### PR TITLE
[codex] Add repository surface cleanup plan

### DIFF
--- a/issues/ad-hoc-repository-architecture-and-verification-surface-cleanup.md
+++ b/issues/ad-hoc-repository-architecture-and-verification-surface-cleanup.md
@@ -1,6 +1,6 @@
 # Ad Hoc Repository Architecture And Verification Surface Cleanup
 
-status: draft
+status: implementation-ready
 
 ## Objective
 
@@ -81,6 +81,8 @@ The top-level tree should contain only intentional, load-bearing entries:
 ```text
 .github/
 .cursor/
+.gitignore
+.gitmodules
 crates/
 demos/
 docs/
@@ -108,6 +110,8 @@ Every tracked top-level entry must be classified in the first implementation PR 
 - `archive-external`: valuable process history, not active tree material
 - `delete`: obsolete or generated
 - `generate`: produced by a script and should not be committed unless it is a baseline
+
+Implementation rule: every tracked file or directory move must use `git mv`, followed by the intended content/reference edits, validation, and an explicit commit for that PR slice. Do not move tracked files with plain filesystem commands and leave Git to infer renames later.
 
 ## Planning, Issues, And Reviews Structure
 
@@ -277,6 +281,8 @@ Rules:
 - `schemas` answer what shape committed verification data must have.
 - `runner` answers how verification is executed.
 - `policy` answers machine-facing operational rules for baselines, artifacts, flakes, retention, and schema governance.
+- `toolchain` steps are runner-executed cargo/rustfmt/clippy/test steps selected by profiles through schema-defined names. Toolchain step names are an enum in `profile.schema.json`, not a separate registry. They cover workspace build and Rust test gates without making raw shell commands part of profile data.
+- `guardrail` steps are runner-executed entries selected by profiles through a committed registry at `verification/policy/guardrails.json`. The registry maps stable guardrail names to `scripts/` entrypoints, arguments, timeout policy, and expected report shape.
 - Suites are area-local groupings, not a competing top-level taxonomy. A suite may live under `verification/areas/<area>/suites/` or inside the area manifest.
 - Cases are area-owned. A profile may select a subset of an area or suite, but it never owns fixtures directly.
 - A case is the unit of verification: a manifest or suite entry plus the fixture files and expected outputs it references. A fixture is on-disk input material only; fixtures are never executed except as part of a case.
@@ -327,6 +333,8 @@ verification/profiles/<profile>.json
 Profile files may define:
 
 - selected areas or area-local suites
+- selected toolchain step sets
+- selected guardrail step sets
 - warm and cold time budgets
 - resource policy
 - resource classes such as network, large-memory, platform-specific, long-running, or external-corpus
@@ -342,12 +350,20 @@ Profile files may not define:
 - expected diagnostic text
 - baselines
 - area ownership
-- one-off shell commands
+- raw shell commands or one-off command strings
 
 Naming convention:
 
 - Profile names are kebab-case because they are CLI-facing, such as `--profile create-pr`.
 - Area and suite names are snake_case because they are identifier-facing: directories, manifest keys, and Python modules.
+
+Canonical runner invocation:
+
+```bash
+uv run --project verification python -m sifr_verify --profile create-pr
+```
+
+`verification/pyproject.toml` owns package discovery for `verification/runner/sifr_verify/`, pins `requires-python`, and declares any needed verification dependencies. `verification/README.md` documents the minimum supported `uv` version. `scripts/run_all_tests.sh` fail-fasts with an actionable message when `uv` is missing or below that minimum. CI may install the pinned `uv` version before invoking the same local validation facade; the test behavior itself must remain identical between local and CI execution.
 
 Permanent verification areas:
 
@@ -380,6 +396,8 @@ There is no permanent `audits` area. Existing audit material must move into the 
 
 Boundary rule: a check that gates first-party source or repo hygiene and needs no compiled artifact is a guardrail in `scripts/`; a check that executes or inspects compiler behavior, generated output, diagnostics, or binaries is verification and belongs to an area.
 
+Guardrails remain implemented in `scripts/`, but the end-state validation runner invokes them through `verification/policy/guardrails.json` so `scripts/run_all_tests.sh` can stay a thin dispatcher while profiles avoid raw shell commands.
+
 Keep in `scripts/`:
 
 - `run_all_tests.sh` as the only public validation facade
@@ -391,8 +409,8 @@ Keep in `scripts/`:
 Move into `verification/areas/*`:
 
 - e2e pass runner -> `core_language`
-- validation contract matrices -> owning area, usually `core_language`, `project_workspace`, or `diagnostics`
-- hardening runner -> `regression`, `fuzz_property`, and `ecosystem_compatibility` as appropriate
+- validation contract matrices -> owning areas listed in the discovered verification disposition table: `core_language` and `project_workspace`
+- hardening runner -> split into `regression`, `fuzz_property`, `ecosystem_compatibility`, and runner self-tests
 - platform golden checks -> `runtime_platform`
 - generated-code quality checks -> `generated_code_quality`
 - performance budget checks -> `performance`
@@ -431,7 +449,8 @@ Stay in `scripts/` as public facades, repo guardrails, repo maintenance, code ge
 - `scripts/check_file_size_guardrails.py`, `scripts/check_hir_maintainability_guardrails.py`, `scripts/check_sifr_driver_maintainability_guardrails.py`, `scripts/check_source_crate_dependency_direction.py` -> keep as source/repo guardrails.
 - `scripts/check_codegen_rawcode_gate.sh` -> keep as a source guardrail unless it grows generated-output inspection; if it does, move the generated-output portion to `generated_code_quality`.
 - `scripts/check_diagnostic_cancel_usage.py`, `scripts/check_diagnostic_transport_cleanup.py` -> keep as diagnostics source hygiene guardrails.
-- `scripts/check_integer_dtype_contract.py`, `scripts/check_package_manager_guardrails.py` -> keep as source/repo guardrails unless the inventory proves they execute compiler behavior; then move to `core_language` or `package_management`.
+- `scripts/check_integer_dtype_contract.py` -> move to `core_language`; it validates the active integer dtype contract sentinel under verification data.
+- `scripts/check_package_manager_guardrails.py` -> move to `package_management`; it validates package-manager source boundaries and package-management verification matrices together.
 - `scripts/clone_subrepos.sh` -> keep as repository maintenance.
 - `scripts/generate_unicode_tables.py` -> keep as a code generator.
 - `scripts/distribution/build_preview_artifacts.sh`, `scripts/distribution/create_new_version.sh`, `scripts/distribution/generate_dispatchers.sh`, `scripts/distribution/generate_version_installer.sh` -> keep as release tooling.
@@ -442,24 +461,25 @@ Move into verification areas or runner-owned policy:
 - `scripts/run_validation_contract_matrix.sh` -> split by contract ownership: `core_language`, `project_workspace`, and `diagnostics`; shared harness pieces belong in `verification/runner/`.
 - `scripts/run_phase23_graph_isolation_matrix.sh` -> `project_workspace`.
 - `scripts/run_phase24_hir_analysis_consolidation_matrix.sh`, `scripts/run_phase25_cfg_flow_activation_matrix.sh` -> `core_language`.
-- `scripts/run_frontend_mode_parity_matrix.sh` -> `developer_tooling` unless inventory proves it is a compiler project/workspace contract.
+- `scripts/run_frontend_mode_parity_matrix.sh` -> `project_workspace`; it is a wrapper over the validation contract matrix for project/compiler frontend mode parity.
 - `scripts/run_platform_golden.sh` -> `runtime_platform`.
 - `scripts/run_smoke_fuzz_property.sh` -> `fuzz_property`.
-- `scripts/run_integer_model_closure_perf.py`, `scripts/ci_e2e_throughput.sh`, `scripts/check_codegen_binary_size.sh` -> `performance` with explicit budget/profile policy.
-- `scripts/check_codegen_binary_size.sh` may split generated-artifact assertions into `generated_code_quality` if inventory shows it is testing codegen quality rather than performance budget.
+- `scripts/run_integer_model_closure_perf.py`, `scripts/ci_e2e_throughput.sh` -> `performance` with explicit budget/profile policy.
+- `scripts/check_codegen_binary_size.sh` -> `performance`; binary size is treated as an explicit performance budget.
 - `scripts/check_diagnostic_baseline_hygiene.py`, `scripts/check_diagnostic_code_coverage.py`, `scripts/check_diagnostic_docs_sync.py`, `scripts/check_diagnostic_schema_sync.py` -> `diagnostics`.
 - `scripts/run_distribution_validation.sh`, `scripts/distribution/validate_self_update_metadata.sh` -> `distribution_release` if used as validation gates; keep only release-mutating operations in `scripts/distribution/`.
 - `scripts/run_stdlib_namespace_corpus_validation.py`, `scripts/check_phase30_complexity_resource_inventory.py` -> `stdlib_parity`.
-- `scripts/build_full_corpus_failure_taxonomy.py` -> `algorithmic_compatibility` or `ecosystem_compatibility`, depending on whether the taxonomy is for scored algorithm corpora or broader OSS signal.
+- `scripts/build_full_corpus_failure_taxonomy.py` -> `algorithmic_compatibility`; it builds failure taxonomy artifacts for full algorithmic corpus result JSON.
 - `scripts/generate_concurrency_runtime_inventory.py` -> `stdlib_parity` as an area-local data generator if the output is verification inventory.
 - `scripts/run_verification_hardening.py` and `scripts/run_verification_hardening/` -> split across `regression`, `fuzz_property`, `ecosystem_compatibility`, and runner self-tests; do not keep a generic hardening runner after areas own the suites.
 - `scripts/check_e2e_report_determinism.sh`, `scripts/check_e2e_sequential_parallel_equivalence.sh` -> `verification/runner/` self-tests and `verification/policy/` evidence.
-- `scripts/validation_lane.py`, `scripts/validation_lane_report.py` -> replace with `verification/runner/sifr_verify/profiles.py` and profile report handling; delete old names after PR 7.
+- `scripts/validation_lane.py`, `scripts/validation_lane_report.py` -> replace with `verification/runner/sifr_verify/profiles.py` and profile report handling; delete old names in PR 7.
 
 Delete or replace after references are removed:
 
 - `scripts/__pycache__/` and `scripts/run_verification_hardening/__pycache__/` -> delete and guard against tracked Python bytecode.
-- `scripts/validate_phase15_backlog.py`, `scripts/phase_contract_gate_check.py` -> delete or replace with current `plans/` guardrails only if the inventory proves they still protect active planning data.
+- `scripts/validate_phase15_backlog.py` -> delete; it protects a historical phase-15 backlog path and should not survive the planning-tree move.
+- `scripts/phase_contract_gate_check.py` -> replace with a current `plans/phases/index.md` consistency guardrail if still useful; delete the phase-numbered path assumptions.
 - `scripts/archive_issues.sh`, `scripts/archive_reviews.sh`, `scripts/archive_reviews_and_issues.sh` -> update for `plans/issues/{active,completed,archive}` and `plans/reviews/{active,archive}` if still needed; otherwise delete in favor of direct `git mv` during planning PRs.
 
 ## Audits Cleanup
@@ -472,7 +492,7 @@ Initial disposition:
 | --- | --- |
 | `audits/.DS_Store` | Delete. |
 | `audits/run_audit.sh`, `audits/run_audit_fast.sh`, `audits/run_borrowing_audit.sh` | Delete after equivalent verification area manifests and runners exist. Do not keep wrappers. |
-| `audits/lint_panic_patterns.sh` | Delete or replace with an owned guardrail/verification check under `generated_code_quality` or `scripts/` depending on whether it scans generated output or source. |
+| `audits/lint_panic_patterns.sh` | Replace under `generated_code_quality`; it enforces user-facing generated-code panic policy for `sifr_codegen` and should be owned with the other generated-code quality gates. |
 | `audits/STDLIB_PARITY_MASTER_REPORT.md` | Archive or delete after any current state is reflected in `stdlib_parity` manifests/data. It must not remain an active report. |
 | `audits/*/REPORT.md`, `audits/*/POST_HARDENING_REPORT.md` | Archive or delete. Keep only concise current state in area manifests, area README files, or `plans/` if the history matters. |
 | `audits/stdlib/cpython_parity_fixture_format.md` | Keep as a convention, but move to the owning location: `internal_docs/verification/` if it is a human convention, or `verification/areas/stdlib_parity/README.md` if it is area-specific runner guidance. |
@@ -552,9 +572,15 @@ Shape `internal_docs/` around a small set of durable topics:
 - `sifr_workspace_design.md`
 - `structured_runtime_work_model.md`
 - `dependency_policy.md`
+- `diagnostic_codes.md`
 - `generated_code_quality.md`
+- `hir_maintainability_guardrails.md`
 - `performance_budgets.md`
+- `sifr_driver_maintainability_guardrails.md`
 - `lsp_server.md`
+- `tooling_analysis.md`
+- `tooling_reuse_strategy.md`
+- `tooling_verification.md`
 - `editor_integrations.md`
 - `vscode_extension.md`
 - `distribution_pipeline.md`
@@ -637,6 +663,130 @@ Add repo-hygiene guardrails for:
 
 The personal-path guardrail must allow intentional example paths in tests when they are explicitly part of fixture data.
 
+## Discovered Current-State Disposition
+
+This phase is implementation-ready only if the current surfaces have an explicit destination before the first move PR. The following inventory is the source of truth for the cleanup PRs.
+
+Tracked top-level entries discovered:
+
+| Current entry | Tracked state | Final disposition |
+| --- | ---: | --- |
+| `.cursor/` | 19 files | Keep as portable workflow assets after deleting `.cursor/.rules/` and extra Claude skill variants. |
+| `.github/` | 2 files | Keep; retarget validation vocabulary from lane to profile. |
+| `.gitignore` | 1 file | Keep; edit for `Cargo.lock`, bytecode/cache/editor-state hygiene, and generated-artifact exclusions. |
+| `.gitmodules` | 1 file | Keep; update atomically with submodule moves. |
+| `AGENTS.md`, `CLAUDE.md`, `README.md` | 3 files | Keep; update planning, verification, and profile paths atomically with moves. |
+| `Cargo.toml`, `sifr.toml`, `LICENSE.md`, `logo.webp` | 4 files | Keep. |
+| `Cargo.lock` | ignored/untracked now | Track in the dedicated Cargo lock PR. |
+| `crates/`, `demos/`, `docs/`, `lib/`, `third_party/`, `editor_integrations/` | active trees | Keep; only update references and submodule metadata required by moves. |
+| `internal_docs/` | 96 files | Keep only current architecture, design state, and conventions; move phases/roadmap/planning and runner policy out. |
+| `issues/` | active root issue plus archive | Move under `plans/issues/{active,completed,archive}`. |
+| `reviews/` | active root review artifacts plus archive | Move retained artifacts under `plans/reviews/{active,archive}`; delete logs and transcripts without planning value. |
+| `audits/` | audit fixtures, reports, scripts, and LeetCode submodule | Remove as a top-level system; promote fixtures/corpora into verification areas or delete/archive reports. |
+| `scripts/` | 54 tracked files | Keep only public facade, repo guardrails, release tooling, generators, and maintenance utilities. Move verification implementation into areas. |
+| `verification/` | 303 tracked files | Rebuild into `runner`, `schemas`, `profiles`, `areas`, and `policy`. |
+
+Ignored local/generated top-level material discovered and not to be tracked:
+
+| Current entry | Final disposition |
+| --- | --- |
+| `.DS_Store`, `.claude/`, `.claude.log`, `.obsidian/`, `.sifr_cache/`, `sifr_output/`, `target/`, `tmp/`, `tmp_*` | Delete locally when encountered; keep ignored. |
+| `scripts/__pycache__/`, `verification/**/__pycache__/`, `*.pyc` | Delete locally when encountered; guard against tracking. |
+
+Cursor exact disposition:
+
+| Current path | Final disposition |
+| --- | --- |
+| `.cursor/.rules/architecture-overview.mdc` | Delete; no `.cursor/.rules/` tree remains. |
+| `.cursor/commands/*.md` | Keep and retarget from `issues/`, `reviews/`, and `internal_docs/phases/` to `plans/...` after the planning tree exists. |
+| `.cursor/references/*.md` | Keep only portable templates/references; remove local path assumptions. |
+| `.cursor/skills/project-workflow/`, `.cursor/skills/phase-closure-loop/`, `.cursor/skills/sifr-demo-authoring/` | Keep after replacing personal paths and old planning paths. |
+| `.cursor/skills/talk-to-claude-opus/` | Keep as the single Claude/Fable review workflow; make output default to `plans/reviews/active/`. |
+| `.cursor/skills/talk-to-claude-default/`, `.cursor/skills/talk-to-claude-gui-review/` | Delete after folding any useful wording into `talk-to-claude-opus`. |
+| `.cursor/plans/.obsidian/` and other local state | Delete; no embedded Obsidian or local planning state is tracked. |
+
+Verification exact disposition by current path:
+
+| Current path | Final owner |
+| --- | --- |
+| `verification/validation_lanes/manifest.json` | Convert to `verification/profiles/{create-pr,merge,nightly,release}.json`; field names become profile-oriented. |
+| `verification/validation_lanes/create_pr_e2e_manifest.json`, `verification/validation_lanes/merge_e2e_manifest.json` | Convert to area-owned suite/case selections, primarily `core_language`, with profiles selecting suites instead of owning fixture lists. |
+| `verification/suites/manifest.json` | Dissolve into area manifests and profiles; no top-level suite taxonomy remains. |
+| `verification/validation_contracts/manifest.json` | Split suites by contract owner: `frontend_mode_parity` and `phase23_graph_isolation` to `project_workspace`; `integer_dtype_contract`, `phase24_hir_analysis`, and `phase25_cfg_flow` to `core_language`. |
+| `verification/validation_contracts/integer_dtype_contract.md` | Move to `verification/areas/core_language/data/integer_dtype_contract.md`; the runner validates sentinel text there. |
+| `verification/crashes/index.json` | Move to `verification/areas/regression/data/crashes.json`. |
+| `verification/fixedbugs/index.json` | Move to `verification/areas/regression/data/fixedbugs.json`. |
+| `verification/determinism/manifest.json` | Split into runner determinism self-tests and `verification/policy/`; do not create a `determinism` area. |
+| `verification/flake/quarantine.json` | Move to `verification/policy/flake_quarantine.json`. |
+| `verification/fuzz_property/*` | Move to `verification/areas/fuzz_property/`; `sustained_lane.md` becomes profile/policy language using profile vocabulary. |
+| `verification/generated_code_quality/*` | Move to `verification/areas/generated_code_quality/`; shell helpers become Python area runner helpers unless shell behavior itself is under test. |
+| `verification/perf/sifr_int_loop.sifr` | Move to `verification/areas/performance/fixtures/sifr_int_loop.sifr`. |
+| `verification/performance/*` | Move to `verification/areas/performance/`. |
+| `verification/platform/*` | Move to `verification/areas/runtime_platform/`; platform golden material becomes `kind: "golden"` cases or a `platform_contract` suite. |
+| `verification/distribution/*` | Move validation cases and schemas to `verification/areas/distribution_release/`; keep only release-mutating tools under `scripts/distribution/`. |
+| `verification/oss/*` | Move to `verification/areas/ecosystem_compatibility/`; curated and broader manifests become profile-selected suites. |
+| `verification/package_management/*` | Move to `verification/areas/package_management/`; demo repository submodules remain area-owned corpora/fixtures. |
+| `verification/tooling/*` | Move to `verification/areas/developer_tooling/`. |
+| `verification/sifr-large-lsp-verification/`, `verification/sifr_large_lsp_verification.md` | Move submodule and its current README/manifest wrapper to `verification/areas/developer_tooling/corpora/sifr-large-lsp-verification/`. |
+| `verification/stdlib/*` | Move to `verification/areas/stdlib_parity/`; consumed JSON inventories remain data, while traceability markdown becomes generated reports, compact runbooks, or deleted history. |
+| `verification/integer_model_*.md` | Move current integer-model contract material into `core_language` data or `internal_docs/integer_model.md`; delete point-in-time implementation inventories after current state is represented. |
+
+Crate-local verification fixture disposition:
+
+| Current path | Final owner |
+| --- | --- |
+| `crates/sifr/tests/verification/crashes/` | `verification/areas/regression/fixtures/crashes/`. |
+| `crates/sifr/tests/verification/diagnostics/` | `verification/areas/diagnostics/fixtures/` plus diagnostic baselines where expected output is contractual. |
+| `crates/sifr/tests/verification/package/` | `verification/areas/package_management/fixtures/`. |
+| `crates/sifr/tests/verification/project/` | `verification/areas/project_workspace/fixtures/`. |
+| Current crate-private exemptions | None. Every current `crates/sifr/tests/verification/` fixture moves to an owning verification area. |
+
+Audits exact disposition by current directory:
+
+| Current audit material | Count/shape | Final owner |
+| --- | ---: | --- |
+| `audits/borrowing/` | 50 `.sifr` plus report | `core_language/fixtures/ownership/`; delete report. |
+| `audits/lexical_and_syntax/` | 7 `.sifr` plus reports | `core_language/fixtures/syntax/`; delete reports. |
+| `audits/type_inference/` | 30 `.sifr` plus reports | `core_language/fixtures/type_inference/`; delete reports. |
+| `audits/type_system/` | 41 `.sifr` plus reports | `core_language/fixtures/type_system/`; delete reports. |
+| `audits/modules_and_imports/` | 5 `.sifr` plus reports | `project_workspace/fixtures/imports/`; delete reports. |
+| `audits/iteration_protocol/` | 5 `.sifr` plus reports | Split by contract into `core_language`, `stdlib_parity`, or `regression`; delete reports after manifest coverage. |
+| `audits/object_model/` | 6 `.sifr` plus reports | Split by contract into `core_language`, `stdlib_parity`, or `regression`; delete reports after manifest coverage. |
+| `audits/python_basics/` | 45 `.sifr` plus reports | Split by contract into `core_language`, `stdlib_parity`, or `regression`; delete duplicates after manifest coverage. |
+| `audits/stdlib/` | 10 `.sifr`, CPython convention doc, reports | Fixtures to `stdlib_parity`; CPython convention to `verification/areas/stdlib_parity/README.md`; reports delete/archive. |
+| `audits/leetcode/` | submodule corpus | `verification/areas/algorithmic_compatibility/corpora/leetcode/` with `.gitmodules` updated. |
+| `audits/STDLIB_PARITY_MASTER_REPORT.md`, `audits/*/REPORT.md`, `audits/*/POST_HARDENING_REPORT.md` | historical markdown | Delete from active tree after current state is represented by manifests/data/docs. |
+
+Internal docs exact disposition:
+
+| Current path/group | Final disposition |
+| --- | --- |
+| `internal_docs/roadmap.md` | Move to `plans/roadmap.md` and update links. |
+| `internal_docs/phases/*.md` | Move flat into `plans/phases/`; create `plans/phases/index.md`. Preserve existing filenames; the duplicate phase-27 numbering is shown as two indexed phase-27 entries rather than renamed during this cleanup. |
+| `internal_docs/verification/artifact_schema_and_retention.md` | Move to `verification/policy/artifact_schema_and_retention.md`. |
+| `internal_docs/verification/baseline_governance.md` | Move to `verification/policy/baseline_governance.md`. |
+| `internal_docs/verification/deterministic_sharding_and_flake_policy.md` | Move to `verification/policy/deterministic_sharding_and_flake_policy.md`. |
+| `internal_docs/verification/fuzz_property_policy.md` | Move to `verification/policy/fuzz_property.md` and update lane wording to profile wording. |
+| `internal_docs/verification/oss_gate_policy.md` | Move to `verification/policy/ecosystem_compatibility.md`. |
+| `internal_docs/verification/regression_corpus_policy.md` | Move to `verification/policy/regression_corpus.md`. |
+| `internal_docs/verification/suite_taxonomy.md` | Delete after the new area/profile README and schemas replace it. |
+| `internal_docs/validation_lane_policy.md` | Move to `verification/policy/profile_policy.md` with lane vocabulary removed. |
+| `internal_docs/compiler_pipeline.html` | Stop linking as the canonical compiler overview; either regenerate from source into `target/` or move public visualizer material to `docs/`. `README.md` currently links to this file and must be updated in the same PR. |
+| `internal_docs/typescript_go_architecture_transfer_m*.md` | Consolidate current accepted state into the existing current-state docs (`frontend_query_architecture.md`, `lsp_server.md`, `tooling_analysis.md`, `tooling_verification.md`, `editor_integrations.md`, `vscode_extension.md`) and delete milestone transfer notes from active `internal_docs/`. |
+| `internal_docs/diagnostic_emission_inventory.md` | Keep in `internal_docs/` as current diagnostic emission state after removing validation ledgers and stale milestone prose. |
+| `internal_docs/tooling_verification.md` | Keep as current human-facing tooling verification convention if rewritten without validation ledgers; runner-consumed checks move to `verification/areas/developer_tooling/`. |
+
+Stale reference cleanup discovered:
+
+| Reference family | Required update |
+| --- | --- |
+| `validation_lane`, `validation_lanes`, and user-facing `lane` validation wording in `.github/`, `scripts/`, `README.md`, `AGENTS.md`, `internal_docs/`, and `verification/` | Replace with `profile` vocabulary except where `lane` refers to compiler/LSP worker lanes. |
+| `internal_docs/phases/` references in `AGENTS.md`, `README.md`, Cursor commands, scripts, and phase gate checks | Retarget to `plans/phases/`. |
+| Root `issues/` references in roadmap, Cursor commands, archive scripts, and active docs | Retarget to `plans/issues/{active,completed,archive}`. |
+| Root `reviews/` references and `.claude.log` paths | Retarget retained summaries to `plans/reviews/`; delete log/transcript references that are not retained artifacts. |
+| `/Users/yaseralnajjar/...` references in `.cursor/skills/*` and `verification/distribution/common.sh` | Replace with environment variables or repo-relative paths; fail guardrail on future personal paths. |
+| `verification/validation_lanes/*` references in scripts and inventories | Replace with `verification/profiles/*` and area-owned suite references. |
+
 ## Proposed PR Sequence
 
 ### PR 1: Repository Surface And Relevance Inventory
@@ -685,6 +835,7 @@ Remove local-machine assumptions from `.cursor/` without retargeting commands to
 Scope:
 
 - remove personal absolute paths
+- replace the external `talk-to-claude` absolute path with `TALK_TO_CLAUDE_PROJECT` and a fail-fast message when unset
 - remove `.cursor/.rules/`
 - remove `.DS_Store`, Obsidian state, and local editor artifacts
 - consolidate Claude/Fable review workflow into `.cursor/skills/talk-to-claude-opus/`
@@ -700,6 +851,8 @@ Validation:
 ### PR 4: Review Tree Normalization
 
 Move intentionally retained review artifacts under `plans/reviews/active/` or `plans/reviews/archive/`. Delete review artifacts that have no ongoing planning value and replace direct transcript ledgers in active docs with concise summaries.
+
+This PR creates `plans/reviews/{active,archive}/` and retargets `.cursor/skills/talk-to-claude-opus/` to write new review artifacts to `plans/reviews/active/` before deleting the root `reviews/` tree.
 
 Validation:
 
@@ -726,7 +879,9 @@ Add the `uv`-managed verification runner, schemas, area discovery, and result fo
 
 No existing runner migration yet.
 
-Also add the migration-status table used while old and new verification surfaces temporarily coexist. The table must track area, legacy path, new area path, current authoritative gate, equivalence evidence, and cutover status.
+Also add the migration-status table used while old and new verification surfaces temporarily coexist. The table lives in this issue plan after it moves to `plans/issues/active/`. It must track area, legacy path, new area path, current authoritative gate, equivalence evidence, and cutover status.
+
+This PR also pins `requires-python`, documents the minimum supported `uv` version, adds the `uv` availability/version fail-fast to the facade, updates CI to install the pinned `uv` version before running the same facade, and defines the profile schema entries for selected areas, toolchain step sets, and guardrail step sets.
 
 Validation:
 
@@ -741,6 +896,14 @@ Validation:
 
 Split profile configuration into `verification/profiles/*.json` and validate with schemas.
 
+Scope:
+
+- convert `verification/validation_lanes/manifest.json` into `verification/profiles/*.json`
+- rewrite facade profile resolution so `scripts/run_all_tests.sh` obtains shell exports from `uv run --project verification python -m sifr_verify profiles shell --profile <profile>`
+- move report summarization from `scripts/validation_lane_report.py` into `sifr_verify` profile report handling
+- delete `scripts/validation_lane.py`, `scripts/validation_lane_report.py`, and `verification/validation_lanes/manifest.json`
+- keep the rest of the facade orchestration body as legacy bash until the facade cutover PR
+
 Validation:
 
 - all profiles schema-valid
@@ -753,7 +916,7 @@ Migrate one verification area per PR into `verification/areas/<area>/`.
 
 The migration order intentionally starts with smaller manifest-backed areas before `core_language`, because `core_language` has the largest fixture and snapshot blast radius.
 
-Candidate order:
+Migration order:
 
 1. `diagnostics`
 2. `project_workspace`
@@ -775,6 +938,7 @@ Validation for each area migration:
 - area manifest schema-valid
 - moved fixtures are owned by exactly one area
 - crate-local `crates/sifr/tests/verification/` fixtures are moved or explicitly exempted according to the crate-fixture disposition rule
+- legacy facade dispatch is updated atomically with moved paths
 - shell verification helpers rewritten to Python under the verification `uv` project unless shell is the artifact under test
 - old verification script names deleted, not wrapped
 - runner can execute the area
@@ -806,11 +970,9 @@ Validation:
 - affected area runner executes
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### PR N+3: Scripts Verification Migration
+### PR N+3: Scripts Verification Sweep
 
-Move remaining verification implementation out of `scripts/` and into verification areas.
-
-Delete old entrypoints. Do not add compatibility wrappers.
+Prove no verification implementation remains in `scripts/` after the area migrations and add the guardrail that keeps it that way. Delete any missed old entrypoints. Do not add compatibility wrappers.
 
 Validation:
 
@@ -900,3 +1062,9 @@ This plan was reviewed with the Fable high model. The main findings incorporated
 - runner determinism and sequential/parallel equivalence belong to runner self-tests and policy data, not a permanent verification area
 - the phase should borrow reference compiler invariants from TypeScript, typescript-go, Rust, Bun, and CPython: first-class baselines, mode-specific suites, resource-aware runners, distinct benchmark policy, and current-state internal docs
 - verification execution selectors should be called `profiles`, not `lanes`, because the public facade already uses `--profile` and `lane` has a separate compiler/SIMD meaning
+- the top-level contract must include `.gitignore` and `.gitmodules`
+- profile normalization must rewrite facade profile resolution before deleting the legacy validation-lane manifest
+- the verification runner needs schema-level `toolchain` and `guardrail` step kinds so cargo tests, fmt/clippy, and repo guardrails stay in validation without raw shell in profiles
+- `uv` needs explicit bootstrap, minimum-version, Python-version, and CI installation policy
+- review-tree normalization must retarget `talk-to-claude-opus` before deleting the root `reviews/` tree
+- final Fable review pass 4 returned `PASS` after these blockers were incorporated

--- a/issues/ad-hoc-repository-architecture-and-verification-surface-cleanup.md
+++ b/issues/ad-hoc-repository-architecture-and-verification-surface-cleanup.md
@@ -36,7 +36,7 @@ The desired result is a repo where a new contributor can quickly answer:
 - No test coverage reduction.
 - No CI-only validation behavior.
 - No compatibility shims for moved script paths.
-- No duplicate old and new verification layouts.
+- No duplicate old and new verification layouts in the end state. Transitional coexistence during migration is allowed only when tracked by an explicit migration-status table.
 - No archive-in-place that leaves the active tree visually noisy.
 - No tracking of point-in-time validation logs.
 - No broad rewrite of compiler crates unless required by path or fixture ownership.
@@ -48,10 +48,31 @@ The desired result is a repo where a new contributor can quickly answer:
 - Machines consume schemas, manifests, fixtures, and baselines.
 - Generated reports live under `target/` and are not committed.
 - Each fixture has one owning verification area.
-- Lanes select verification areas; lanes do not own fixtures.
+- Profiles select verification areas; profiles do not own fixtures.
 - Public validation has one entrypoint.
 - Repo hygiene is enforced by guardrails, not convention.
 - Historical material is either deleted, moved to git history, or placed in a separate archive outside the active tree.
+
+## Reference Compiler Lessons
+
+This cleanup should learn from mature compiler and runtime repositories without copying their exact folder names. The useful lesson is the ownership invariant behind each layout.
+
+Reference observations:
+
+- TypeScript keeps compiler cases and baselines as first-class test assets under `tests/cases/` and `tests/baselines/reference/`, with harness code separated from the cases. Sifr should keep fixtures and baselines area-owned and reviewable, not hidden in scripts or markdown reports.
+- typescript-go uses a strong split between compiler implementation, repo tools, and `testdata/` compatibility baselines. Sifr should preserve the same conceptual split through `crates/`, `scripts/`, and `verification/areas/`, rather than creating a generic top-level `testdata/` tree.
+- Rust separates compiler implementation, standard library, test runner tooling, and behavior-mode test families such as UI, codegen, run-make, incremental, rustdoc, and debuginfo. Sifr should let areas own suites by execution mode when useful, instead of forcing every case into one flat pass/fail bucket.
+- Bun separates tests, integration fixtures, regression material, and benchmarks. Sifr should keep performance validation distinct from correctness verification and avoid mixing benchmark artifacts with regular create-PR gates.
+- CPython separates public docs, maintainer-facing internal docs, test runner implementation, resource-heavy tests, platform data, and tools. Sifr should keep `internal_docs/` as current maintainer knowledge and make profile resource policy explicit in the verification runner.
+
+Sifr-specific conclusions:
+
+- Keep `verification/` as the top-level validation contract rather than adding a generic `tests/` or `testdata/` tree.
+- Keep `plans/` separate from `internal_docs/`; mature repos do not make active execution plans look like compiler architecture.
+- Treat baselines as source-controlled contracts only when they are intentional expected outputs. Generated run logs still belong under `target/`.
+- Support area-local case directives or metadata when they make a single fixture self-describing, but the area manifest remains the ownership source of truth.
+- Resource classes, flake policy, retry policy, shard policy, and resume behavior belong in profiles and runner policy, not in one-off scripts.
+- Benchmarks and performance budgets should have their own area and profile policy so normal validation stays deterministic and appropriately fast.
 
 ## Target Top-Level Contract
 
@@ -98,7 +119,7 @@ plans/
   roadmap.md
 
   phases/
-    roadmap.md
+    index.md
     01_language_foundations.md
     02_type_system_power.md
     ...
@@ -122,9 +143,9 @@ internal_docs/
 Rules:
 
 - `plans/roadmap.md` is the high-level execution roadmap.
-- `plans/phases/roadmap.md` indexes phase status.
+- `plans/phases/index.md` indexes phase status.
 - Phase files stay flat under `plans/phases/` so phase numbers remain stable and easy to find.
-- Phase status lives in each phase header and in `plans/phases/roadmap.md`; phases do not need active/completed/archive directories.
+- Phase status lives in each phase header and in `plans/phases/index.md`; phases do not need active/completed/archive directories.
 - Active ad hoc issue plans live in `plans/issues/active/`.
 - Completed ad hoc issue plans move to `plans/issues/completed/`.
 - Superseded, abandoned, or purely historical issue plans move to `plans/issues/archive/`.
@@ -173,12 +194,13 @@ Rules:
 - No local-machine paths such as `/Users/yaseralnajjar/...`.
 - No embedded Obsidian state.
 - No tracked `.DS_Store` or local editor files.
-- Commands target the new `plans/issues/active/`, `plans/phases/`, and `plans/reviews/active/` layout.
+- Commands target the new `plans/issues/active/`, `plans/phases/`, and `plans/reviews/active/` layout only after the planning tree exists.
 - Review skills write to `plans/reviews/active/` by default.
 - Keep `.cursor/skills/talk-to-claude-opus/` as the single Claude/Fable review workflow.
 - Remove the other Claude review skill variants once their useful instructions are folded into `talk-to-claude-opus`.
-- Skill names should describe workflow intent, not a transient model brand, unless the model is itself the workflow contract.
+- Do not introduce additional model-branded review skill variants; `talk-to-claude-opus` remains the existing workflow contract.
 - Remove `.cursor/.rules/`.
+- Move useful `.cursor/plans/` content into `plans/`; delete embedded Obsidian/local state and obsolete workflow notes.
 
 Add a Cursor hygiene guardrail that checks:
 
@@ -195,14 +217,16 @@ Target verification shape:
 ```text
 verification/
   README.md
+  pyproject.toml          # uv-managed verification tooling project
+  uv.lock                 # tracked verification tooling lockfile
   policy/                 # runner/data policy, not human conventions
   schemas/
-    lane.schema.json
+    profile.schema.json
     area.schema.json
     suite.schema.json
     case.schema.json
     result.schema.json
-  lanes/
+  profiles/
     create-pr.json
     merge.json
     nightly.json
@@ -210,7 +234,7 @@ verification/
   runner/
     sifr_verify/
       __main__.py
-      lanes.py
+      profiles.py
       areas.py
       scheduler.py
       results.py
@@ -227,7 +251,6 @@ verification/
     project_workspace/
     regression/
     fuzz_property/
-    determinism/
     generated_code_quality/
     performance/
     developer_tooling/
@@ -242,35 +265,42 @@ verification/
 Rules:
 
 - `verification/README.md` is the single human entrypoint for validation architecture.
-- The verification runner is stdlib-only Python.
-- No `pyproject.toml`, `uv`, or external Python package dependency is required for local validation.
+- Python verification tooling is managed by `uv`.
+- The runner should keep dependencies small and explicit. If verification needs Python packages, they are declared in `verification/pyproject.toml`, locked in `verification/uv.lock`, and invoked through `uv run --project verification`.
+- No ad hoc `pip install`, unmanaged virtualenv, user-site package, or machine-local Python package assumption is allowed.
+- Schemas are a committed data contract, and the runner validates only an explicit supported subset: object shape, required keys, primitive scalar types, arrays of objects or strings, enums, and repo-relative path strings. No `$ref`, `allOf`, `anyOf`, `patternProperties`, or unreviewed schema feature expansion is allowed.
+- The runner must reject any committed schema that uses keywords outside the supported subset. Silent ignoring of unsupported schema features is forbidden.
 - The runner discovers areas by `verification/areas/*/manifest.json`.
-- The top-level verification concepts are only `runner`, `schemas`, `lanes`, `areas`, and `policy`.
+- The top-level verification concepts are only `runner`, `schemas`, `profiles`, `areas`, and `policy`.
 - `areas` answer what is verified and who owns it.
-- `lanes` answer when verification runs and with what resource budget.
+- `profiles` answer when verification runs and with what resource budget. The name deliberately matches the public `--profile` flag of `scripts/run_all_tests.sh`; the flag value resolves directly to `verification/profiles/<name>.json`.
 - `schemas` answer what shape committed verification data must have.
 - `runner` answers how verification is executed.
 - `policy` answers machine-facing operational rules for baselines, artifacts, flakes, retention, and schema governance.
 - Suites are area-local groupings, not a competing top-level taxonomy. A suite may live under `verification/areas/<area>/suites/` or inside the area manifest.
-- Cases are area-owned. A lane may select a subset of an area or suite, but it never owns fixtures directly.
+- Cases are area-owned. A profile may select a subset of an area or suite, but it never owns fixtures directly.
+- A case is the unit of verification: a manifest or suite entry plus the fixture files and expected outputs it references. A fixture is on-disk input material only; fixtures are never executed except as part of a case.
+- A golden fixture is not a separate top-level material kind. It is a case whose purpose is to protect a stable, cross-cutting expected behavior contract. Golden cases live inside their owning area as ordinary cases with `kind: "golden"` or an area-local `golden` suite.
 - Each area owns its fixtures, baselines, runner code, manifests, and area-local data.
 - Each area manifest declares owner, suites, fixtures, baselines, resources, parallel safety, expected outputs, timeout policy, and result contract.
-- Lane files select areas or area-local suites and define execution policy; they do not duplicate fixture lists.
+- Area-local fixture directives are allowed when they make compiler expectations readable next to the source file, but manifests remain the ownership and discovery source of truth.
+- An area `runner.py` implements only the schema-defined adapter interface: discover, execute, and report results for its cases. Scheduling, parallelism, retries, resource classes, and report generation belong exclusively to `sifr_verify`; area adapters may not implement their own framework.
+- Profile files select areas or area-local suites and define execution policy; they do not duplicate fixture lists.
 - Generated reports go to `target/verification_reports/`.
 - Markdown under `verification/` is limited to `README.md`, policy, and runbooks.
 - Gate inputs are JSON, schemas, baselines, or fixtures.
 - Parallelism is explicit per area.
 - Performance-sensitive or shared-state areas must declare `parallel_safe: false`.
-- Sequential/parallel equivalence is a runner self-check, not an ad hoc shell script.
-- Determinism evidence is generated and schema-validated.
+- Sequential/parallel equivalence is a runner self-check, not an ad hoc shell script or permanent verification area.
+- Runner determinism, report-signature checks, and profile equivalence live under `verification/runner/` self-tests and `verification/policy/` data.
 
 Area-local shape:
 
 ```text
 verification/areas/<area>/
-  manifest.json           # owner, suites, resources, lane selectors, result contract
+  manifest.json           # only mandatory area file
   README.md               # short area runbook only when needed
-  runner.py               # optional area adapter called by the stdlib-only runner
+  runner.py               # optional area adapter called by the verification runner
   suites/                 # optional suite manifests for large areas
   fixtures/               # first-party source inputs and minimized cases
   corpora/                # external corpora and submodules owned by this area
@@ -278,31 +308,50 @@ verification/areas/<area>/
   data/                   # machine-readable inventories consumed by this area
 ```
 
-Lane-local shape:
+Area subdirectories are created only on first use. Small areas should not carry empty ceremony.
+
+Golden fixture normalization:
+
+- The word `golden` is allowed because it is established testing vocabulary, but it must describe case intent, not folder ownership outside the area model.
+- A golden case still has one owning area, one manifest entry, declared expected output or baseline references, and normal profile selection.
+- Full expected stdout/stderr/diagnostic snapshots belong in `baselines/`; compact assertions such as expected exit code and required output substrings may live in the case manifest.
+- Current platform golden fixtures move from `verification/platform/golden/` into `verification/areas/runtime_platform/` as a `platform_contract` or `golden` suite.
+- `scripts/run_platform_golden.sh` is deleted after the `runtime_platform` area runner and selected profiles execute the same cases.
+
+Profile-local shape:
 
 ```text
-verification/lanes/<lane>.json
+verification/profiles/<profile>.json
 ```
 
-Lane files may define:
+Profile files may define:
 
 - selected areas or area-local suites
 - warm and cold time budgets
 - resource policy
+- resource classes such as network, large-memory, platform-specific, long-running, or external-corpus
 - shard policy
 - retry and flake policy
+- resume and failure-reproduction policy
 - parallelism limits
 - generated report requirements
 
-Lane files may not define:
+Profile files may not define:
 
 - fixture paths directly
 - expected diagnostic text
 - baselines
-- domain ownership
+- area ownership
 - one-off shell commands
 
+Naming convention:
+
+- Profile names are kebab-case because they are CLI-facing, such as `--profile create-pr`.
+- Area and suite names are snake_case because they are identifier-facing: directories, manifest keys, and Python modules.
+
 Permanent verification areas:
+
+Ownership follows the contract being asserted, not the feature being exercised. A fixture asserting CPython-observable behavior belongs to `stdlib_parity`; a fixture asserting compile-time Sifr semantics belongs to `core_language`; a minimized fixed bug belongs to `regression`; an external project compatibility signal belongs to `ecosystem_compatibility`.
 
 | Area | Owns |
 | --- | --- |
@@ -311,7 +360,6 @@ Permanent verification areas:
 | `project_workspace` | Multi-file project behavior, imports, module graph, workspace resolution, graph isolation, cache identity, and project-mode command semantics. |
 | `regression` | Fixed bugs, minimized crash reproducers, invariant failures, and promoted sentinel cases. |
 | `fuzz_property` | Deterministic property tests, fuzz smoke seeds, sustained fuzz corpus metadata, minimization conventions, and seed provenance. |
-| `determinism` | Deterministic report signatures, sequential/parallel equivalence, sharding behavior, flake/quarantine data, and runner determinism self-checks. |
 | `generated_code_quality` | Emitted Rust quality, rustfmt/clippy/panic scans, generated-code determinism, generated binary-size checks, and codegen quality corpora. |
 | `performance` | Benchmark manifests, budgets, waivers, baselines, performance fixtures, and budget-check runners. |
 | `developer_tooling` | Formatter, linter, LSP, editor assets, editor query snapshots, completion quality, and tooling split-brain checks. |
@@ -324,9 +372,13 @@ Permanent verification areas:
 
 There is no permanent `audits` area. Existing audit material must move into the owning area above or be deleted/archived according to the audit cleanup rules.
 
+`crates/sifr/tests/verification/` is repo-level verification material unless a fixture is truly private to a crate unit test. Repo-level fixtures currently under that path move into the owning `verification/areas/<area>/fixtures/`; Rust test harnesses may remain under `crates/sifr/tests/` but should reference area-owned fixtures. Crate-local unit-test fixtures may remain next to crate tests only when the crate test itself owns the data and no repo-level manifest references it.
+
 ## Scripts Cleanup
 
 `scripts/` becomes repo operations and developer ergonomics only. It must not own verification implementation.
+
+Boundary rule: a check that gates first-party source or repo hygiene and needs no compiled artifact is a guardrail in `scripts/`; a check that executes or inspects compiler behavior, generated output, diagnostics, or binaries is verification and belongs to an area.
 
 Keep in `scripts/`:
 
@@ -348,8 +400,7 @@ Move into `verification/areas/*`:
 - distribution validation cases -> `distribution_release`
 - stdlib namespace and corpus validation -> `stdlib_parity`
 - fuzz and property checks -> `fuzz_property`
-- determinism checks -> `determinism`
-- sequential/parallel equivalence checks -> `determinism`
+- report determinism and sequential/parallel equivalence checks -> `verification/runner/` self-tests and `verification/policy/` data
 
 Rules:
 
@@ -358,9 +409,10 @@ Rules:
 - No compatibility wrapper remains for an old script name after migration.
 - `AGENTS.md`, CI workflows, README, internal docs, and Cursor commands update atomically with script moves.
 - Shell is allowed only for tiny public facades or release scripts where POSIX shell is the artifact under test.
-- Verification scripts moved out of `scripts/` should be rewritten as stdlib-only Python area runners unless the checked artifact is itself POSIX shell.
+- Verification scripts moved out of `scripts/` should be rewritten as Python area runners managed by the verification `uv` project unless the checked artifact is itself POSIX shell.
 - Shell-to-Python rewrites must preserve command semantics, exit-code behavior, timeout behavior, output normalization, and generated report shape.
 - Rewrites must land with side-by-side equivalence evidence before the shell implementation is deleted.
+- `run_all_tests.sh` is a facade, not a second runner. During migration it may dispatch to both legacy and new implementations only when the migration-status table says which path is authoritative. In the end state it must be a thin profile dispatcher over `sifr_verify`.
 
 Script migration classification:
 
@@ -370,6 +422,45 @@ Script migration classification:
 - `verification-runner`: move to `verification/areas/<area>/` and rewrite in Python
 - `verification-case`: move to the owning area as a fixture, manifest row, or area-local helper
 - `obsolete-phase-tool`: delete after proving no active reference remains
+
+Initial script disposition:
+
+Stay in `scripts/` as public facades, repo guardrails, repo maintenance, code generators, or release tooling:
+
+- `scripts/run_all_tests.sh` -> keep as the only public validation facade; end state is a thin profile dispatcher over `sifr_verify`.
+- `scripts/check_file_size_guardrails.py`, `scripts/check_hir_maintainability_guardrails.py`, `scripts/check_sifr_driver_maintainability_guardrails.py`, `scripts/check_source_crate_dependency_direction.py` -> keep as source/repo guardrails.
+- `scripts/check_codegen_rawcode_gate.sh` -> keep as a source guardrail unless it grows generated-output inspection; if it does, move the generated-output portion to `generated_code_quality`.
+- `scripts/check_diagnostic_cancel_usage.py`, `scripts/check_diagnostic_transport_cleanup.py` -> keep as diagnostics source hygiene guardrails.
+- `scripts/check_integer_dtype_contract.py`, `scripts/check_package_manager_guardrails.py` -> keep as source/repo guardrails unless the inventory proves they execute compiler behavior; then move to `core_language` or `package_management`.
+- `scripts/clone_subrepos.sh` -> keep as repository maintenance.
+- `scripts/generate_unicode_tables.py` -> keep as a code generator.
+- `scripts/distribution/build_preview_artifacts.sh`, `scripts/distribution/create_new_version.sh`, `scripts/distribution/generate_dispatchers.sh`, `scripts/distribution/generate_version_installer.sh` -> keep as release tooling.
+
+Move into verification areas or runner-owned policy:
+
+- `scripts/run_e2e_pass.sh` -> `verification/areas/core_language/` as an area suite runner or delete after the `create-pr` profile owns the same cases.
+- `scripts/run_validation_contract_matrix.sh` -> split by contract ownership: `core_language`, `project_workspace`, and `diagnostics`; shared harness pieces belong in `verification/runner/`.
+- `scripts/run_phase23_graph_isolation_matrix.sh` -> `project_workspace`.
+- `scripts/run_phase24_hir_analysis_consolidation_matrix.sh`, `scripts/run_phase25_cfg_flow_activation_matrix.sh` -> `core_language`.
+- `scripts/run_frontend_mode_parity_matrix.sh` -> `developer_tooling` unless inventory proves it is a compiler project/workspace contract.
+- `scripts/run_platform_golden.sh` -> `runtime_platform`.
+- `scripts/run_smoke_fuzz_property.sh` -> `fuzz_property`.
+- `scripts/run_integer_model_closure_perf.py`, `scripts/ci_e2e_throughput.sh`, `scripts/check_codegen_binary_size.sh` -> `performance` with explicit budget/profile policy.
+- `scripts/check_codegen_binary_size.sh` may split generated-artifact assertions into `generated_code_quality` if inventory shows it is testing codegen quality rather than performance budget.
+- `scripts/check_diagnostic_baseline_hygiene.py`, `scripts/check_diagnostic_code_coverage.py`, `scripts/check_diagnostic_docs_sync.py`, `scripts/check_diagnostic_schema_sync.py` -> `diagnostics`.
+- `scripts/run_distribution_validation.sh`, `scripts/distribution/validate_self_update_metadata.sh` -> `distribution_release` if used as validation gates; keep only release-mutating operations in `scripts/distribution/`.
+- `scripts/run_stdlib_namespace_corpus_validation.py`, `scripts/check_phase30_complexity_resource_inventory.py` -> `stdlib_parity`.
+- `scripts/build_full_corpus_failure_taxonomy.py` -> `algorithmic_compatibility` or `ecosystem_compatibility`, depending on whether the taxonomy is for scored algorithm corpora or broader OSS signal.
+- `scripts/generate_concurrency_runtime_inventory.py` -> `stdlib_parity` as an area-local data generator if the output is verification inventory.
+- `scripts/run_verification_hardening.py` and `scripts/run_verification_hardening/` -> split across `regression`, `fuzz_property`, `ecosystem_compatibility`, and runner self-tests; do not keep a generic hardening runner after areas own the suites.
+- `scripts/check_e2e_report_determinism.sh`, `scripts/check_e2e_sequential_parallel_equivalence.sh` -> `verification/runner/` self-tests and `verification/policy/` evidence.
+- `scripts/validation_lane.py`, `scripts/validation_lane_report.py` -> replace with `verification/runner/sifr_verify/profiles.py` and profile report handling; delete old names after PR 7.
+
+Delete or replace after references are removed:
+
+- `scripts/__pycache__/` and `scripts/run_verification_hardening/__pycache__/` -> delete and guard against tracked Python bytecode.
+- `scripts/validate_phase15_backlog.py`, `scripts/phase_contract_gate_check.py` -> delete or replace with current `plans/` guardrails only if the inventory proves they still protect active planning data.
+- `scripts/archive_issues.sh`, `scripts/archive_reviews.sh`, `scripts/archive_reviews_and_issues.sh` -> update for `plans/issues/{active,completed,archive}` and `plans/reviews/{active,archive}` if still needed; otherwise delete in favor of direct `git mv` during planning PRs.
 
 ## Audits Cleanup
 
@@ -389,8 +480,8 @@ Initial disposition:
 | `audits/lexical_and_syntax/*.sifr` | Promote into `verification/areas/core_language/fixtures/syntax/` or delete duplicates once covered by syntax/parser suites. |
 | `audits/type_inference/*.sifr` | Promote into `verification/areas/core_language/fixtures/type_inference/` or delete duplicates once covered by type-system suites. |
 | `audits/type_system/*.sifr` | Promote into `verification/areas/core_language/fixtures/type_system/` or delete duplicates once covered by type-system suites. |
-| `audits/iteration_protocol/*.sifr` | Promote into `verification/areas/core_language/fixtures/iteration/` unless a case is specifically stdlib parity. |
-| `audits/object_model/*.sifr` | Promote into `verification/areas/core_language/fixtures/object_model/` unless a case is specifically stdlib parity. |
+| `audits/iteration_protocol/*.sifr` | Promote according to the asserted contract: compile-time iteration semantics to `core_language`, CPython-observable behavior to `stdlib_parity`, fixed bugs to `regression`. |
+| `audits/object_model/*.sifr` | Promote according to the asserted contract: compile-time object-model semantics to `core_language`, CPython-observable behavior to `stdlib_parity`, fixed bugs to `regression`. |
 | `audits/modules_and_imports/*.sifr` | Promote into `verification/areas/project_workspace/fixtures/imports/`. |
 | `audits/python_basics/*.sifr` | Split by ownership: syntax/type/control-flow cases to `core_language`; stdlib behavior to `stdlib_parity`; redundant smoke examples delete after coverage proof. |
 | `audits/stdlib/*.sifr` | Promote into `verification/areas/stdlib_parity/fixtures/`. |
@@ -424,7 +515,8 @@ Classify every existing file under `verification/` before moving it:
 - `area-fixture`: move under the owning area's fixtures or cases
 - `area-baseline`: move under the owning area's baselines
 - `area-manifest`: convert to the new area manifest schema
-- `lane-policy`: move under `verification/lanes/`
+- `golden-case`: convert to an area-owned case with `kind: "golden"` or an area-local `golden` suite
+- `profile-policy`: move under `verification/profiles/`
 - `global-policy`: move under `verification/policy/`
 - `schema`: move under `verification/schemas/`
 - `generated-report`: delete from active tree and regenerate under `target/`
@@ -434,7 +526,8 @@ Classify every existing file under `verification/` before moving it:
 Rules:
 
 - `verification/` should not contain loose domain files at the root after cleanup.
-- Domain material must live under one area, policy, schema, lane, or runner owner.
+- Verification material must live under one area, policy, schema, profile, or runner owner.
+- No `golden/` directory may remain outside an owning area.
 - Point-in-time markdown inventories must either become generated reports or compact policy docs.
 - JSON inventories are retained only when a gate consumes them or a current design doc references them as canonical data.
 - Any retained markdown in `verification/` must explain a stable policy or runbook, not record a past result.
@@ -481,7 +574,7 @@ Clean up docs in place instead of over-classifying them:
 - remove stale status sections once the current state is described elsewhere
 - rewrite procedural "how to implement" sections into state/contract descriptions, or move them to `plans/`
 - keep verification conventions in `internal_docs/verification/` when they describe human-facing conventions
-- move runner mechanics, schemas, lane data, baseline retention, and generated-artifact policy under `verification/`
+- move runner mechanics, schemas, profile data, baseline retention, and generated-artifact policy under `verification/`
 
 Rules:
 
@@ -492,7 +585,7 @@ Rules:
 - Absolute personal reference paths must become environment-variable based references, repo-relative references, or explicit external-reference notes.
 - Docs that describe planned work but not accepted design belong under `plans/`, not `internal_docs/`.
 - Verification convention docs may live in `internal_docs/verification/` when they describe human-facing conventions.
-- Verification docs that are part of runner mechanics, schema contracts, lane data, baseline retention, or generated-artifact policy belong under `verification/policy/`, `verification/schemas/`, or a verification area.
+- Verification docs that are part of runner mechanics, schema contracts, profile data, baseline retention, or generated-artifact policy belong under `verification/policy/`, `verification/schemas/`, or a verification area.
 
 ## Submodule Policy
 
@@ -511,18 +604,19 @@ Rules:
 - Every submodule has one owning top-level area.
 - Submodule moves update `.gitmodules`, scripts, CI, docs, and manifests in the same PR.
 - A corpus is either a submodule or restored by a clone script, not both.
-- Optional heavy corpora are excluded from default create-pr validation unless explicitly selected by lane policy.
+- Optional heavy corpora are excluded from default create-pr validation unless explicitly selected by profile policy.
 
 ## Cargo Lock Policy
 
-`Cargo.lock` is a load-bearing file for this binary-producing compiler workspace and should be tracked.
+`Cargo.lock` is a load-bearing file for this binary-producing compiler workspace and must begin being tracked.
 
 Cleanup must:
 
 - remove any ignore rule that conflicts with tracking `Cargo.lock`
-- keep `Cargo.lock` in the root tracked set
+- add `Cargo.lock` to the root tracked set
 - document why the compiler workspace tracks the lockfile
 - validate that CI and local builds use the same dependency graph
+- document that lockfile diffs are contributor-visible dependency changes and must be reviewed intentionally
 
 This policy should land as its own PR or isolated commit because it affects every contributor.
 
@@ -545,9 +639,9 @@ The personal-path guardrail must allow intentional example paths in tests when t
 
 ## Proposed PR Sequence
 
-### PR 1: Repository Surface Contract
+### PR 1: Repository Surface And Relevance Inventory
 
-Add the full tracked-entry disposition tables:
+Add the full tracked-entry disposition tables and relevance audit. No moves, rewrites, or deletions in this PR.
 
 - top-level entries
 - `scripts/` entries
@@ -558,23 +652,6 @@ Add the full tracked-entry disposition tables:
 - Cursor workflow files
 - plan, issue, phase, and review artifact locations
 
-No moves in this PR.
-
-Validation:
-
-- `git diff --check`
-- `python3 scripts/check_file_size_guardrails.py`
-
-### PR 1B: Relevance Audit
-
-Produce reviewable keep/move/rewrite/delete tables for stale or outdated material before any deletion-heavy PR:
-
-- `audits/`
-- `verification/`
-- `internal_docs/`
-- `scripts/`
-- `.cursor/`
-
 Each row must include:
 
 - current path
@@ -583,16 +660,18 @@ Each row must include:
 - whether a gate consumes it
 - whether a current doc references it
 - validation required after changing it
+- reference-compiler lesson when one applies
 
 Validation:
 
 - `git diff --check`
+- `python3 scripts/check_file_size_guardrails.py`
 - no file moves
 - no deletions
 
 ### PR 2: Cargo Lock Policy
 
-Make `Cargo.lock` tracking explicit and fix ignore rules.
+Begin tracking `Cargo.lock` and fix ignore rules.
 
 Validation:
 
@@ -601,7 +680,16 @@ Validation:
 
 ### PR 3: Cursor Portability Cleanup
 
-Remove local-machine assumptions from `.cursor/` and update commands for the planned `plans/` layout.
+Remove local-machine assumptions from `.cursor/` without retargeting commands to paths that do not exist yet.
+
+Scope:
+
+- remove personal absolute paths
+- remove `.cursor/.rules/`
+- remove `.DS_Store`, Obsidian state, and local editor artifacts
+- consolidate Claude/Fable review workflow into `.cursor/skills/talk-to-claude-opus/`
+- remove the other Claude review skill variants after folding in useful instructions
+- disposition `.cursor/plans/` content as move-later inventory or delete-obsolete local state
 
 Validation:
 
@@ -623,7 +711,7 @@ Validation:
 
 ### PR 5: Planning Tree Normalization
 
-Move active, completed, and archived phase and issue docs into the new lifecycle directories.
+Move active, completed, and archived phase and issue docs into the new lifecycle directories. Retarget AGENTS and Cursor commands atomically with the new paths.
 
 Validation:
 
@@ -634,29 +722,36 @@ Validation:
 
 ### PR 6: Verification Runner Foundation
 
-Add the stdlib-only verification runner, schemas, area discovery, and result format.
+Add the `uv`-managed verification runner, schemas, area discovery, and result format.
 
 No existing runner migration yet.
+
+Also add the migration-status table used while old and new verification surfaces temporarily coexist. The table must track area, legacy path, new area path, current authoritative gate, equivalence evidence, and cutover status.
 
 Validation:
 
 - schema self-tests
 - runner discovery self-test
+- `uv` lockfile/check workflow
+- resource class selection self-test
+- resume/failure-reproduction self-test
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### PR 7: Verification Lane Normalization
+### PR 7: Verification Profile Normalization
 
-Split lane configuration into `verification/lanes/*.json` and validate with schemas.
+Split profile configuration into `verification/profiles/*.json` and validate with schemas.
 
 Validation:
 
-- all lanes schema-valid
-- old lane manifest removed
+- all profiles schema-valid
+- old validation manifest removed
 - `scripts/run_all_tests.sh --profile create-pr`
 
 ### PR 8-N: Verification Area Corpus Migration
 
-Migrate one verification domain per PR into `verification/areas/<area>/`.
+Migrate one verification area per PR into `verification/areas/<area>/`.
+
+The migration order intentionally starts with smaller manifest-backed areas before `core_language`, because `core_language` has the largest fixture and snapshot blast radius.
 
 Candidate order:
 
@@ -665,29 +760,41 @@ Candidate order:
 3. `core_language`
 4. `regression`
 5. `fuzz_property`
-6. `determinism`
-7. `generated_code_quality`
-8. `performance`
-9. `developer_tooling`
-10. `runtime_platform`
-11. `distribution_release`
-12. `package_management`
-13. `stdlib_parity`
-14. `algorithmic_compatibility`
-15. `ecosystem_compatibility`
+6. `generated_code_quality`
+7. `performance`
+8. `developer_tooling`
+9. `runtime_platform`
+10. `distribution_release`
+11. `package_management`
+12. `stdlib_parity`
+13. `algorithmic_compatibility`
+14. `ecosystem_compatibility`
 
 Validation for each area migration:
 
 - area manifest schema-valid
 - moved fixtures are owned by exactly one area
-- shell verification helpers rewritten to stdlib-only Python unless shell is the artifact under test
+- crate-local `crates/sifr/tests/verification/` fixtures are moved or explicitly exempted according to the crate-fixture disposition rule
+- shell verification helpers rewritten to Python under the verification `uv` project unless shell is the artifact under test
 - old verification script names deleted, not wrapped
 - runner can execute the area
-- determinism check for affected area
+- compiler-output determinism check for affected area
 - sequential/parallel equivalence where applicable
+- snapshot stability verified after fixture moves, including declaration-order expectations
+- migration-status table updated
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### PR N+1: Submodule Normalization
+### PR N+1: Verification Facade Cutover
+
+Rewrite `scripts/run_all_tests.sh` into a thin public facade over `sifr_verify`.
+
+Validation:
+
+- side-by-side equivalence evidence per profile: checks executed, exit-code behavior, timeout behavior, output normalization, and report shape
+- `scripts/run_all_tests.sh --profile create-pr`
+- `scripts/run_all_tests.sh --profile merge`
+
+### PR N+2: Submodule Normalization
 
 Resolve submodule ownership and move any submodule paths that belong under verification areas.
 
@@ -699,7 +806,7 @@ Validation:
 - affected area runner executes
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### PR N+2: Scripts Verification Migration
+### PR N+3: Scripts Verification Migration
 
 Move remaining verification implementation out of `scripts/` and into verification areas.
 
@@ -712,7 +819,7 @@ Validation:
 - `scripts/run_all_tests.sh --profile create-pr`
 - `scripts/run_all_tests.sh --profile merge`
 
-### PR N+3: Audits Normalization
+### PR N+4: Audits Normalization
 
 Promote retained audit fixtures into verification manifests and remove historical report markdown from the active tree.
 
@@ -723,7 +830,7 @@ Validation:
 - audit area executes through the runner
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### PR N+4: Internal Docs Relevance Cleanup
+### PR N+5: Internal Docs Relevance Cleanup
 
 Move, consolidate, or delete outdated internal docs according to the relevance audit.
 
@@ -735,7 +842,7 @@ Validation:
 - no active internal doc contains long validation transcript ledgers
 - `git diff --check`
 
-### PR N+5: Docs And Guardrails Closeout
+### PR N+6: Docs And Guardrails Closeout
 
 Update public docs, internal docs, AGENTS, Cursor commands, and CI docs to reflect the final structure.
 
@@ -761,10 +868,10 @@ Validation:
 - No active verification implementation remains in `scripts/`.
 - Every verification area has a schema-valid manifest.
 - Every retained fixture has exactly one owning area manifest.
-- Lane files reference areas instead of duplicating fixture ownership.
+- Profile files reference areas instead of duplicating fixture ownership.
 - No committed validation result logs exist outside explicit baselines.
 - Markdown under `verification/` is limited to README, policy, and runbooks.
-- CI and local validation use the same runner and lane files.
+- CI and local validation use the same runner and profile files.
 - Migration PRs prove determinism and sequential/parallel equivalence where applicable.
 - Final closeout passes local merge validation.
 
@@ -773,17 +880,23 @@ Validation:
 - Moving fixtures can reorder e2e discovery or invalidate snapshots.
 - Removing review transcripts can break historical issue references unless summaries replace them.
 - Moving submodules requires atomic `.gitmodules`, script, CI, docs, and manifest updates.
-- A Python runner can drift if it gains external dependencies; keep it stdlib-only.
+- A Python runner can drift if dependencies grow casually; require every dependency to be declared, locked, reviewed, and justified by verification value.
 - Parallel scheduling can hide resource contention unless every area declares resource policy.
 - Historical docs may contain the only explanation for a design decision; archive by value, not by age.
 
 ## Review Notes
 
-This plan was reviewed with the Fable high model before being written. The main findings incorporated here were:
+This plan was reviewed with the Fable high model. The main findings incorporated here were:
 
 - the top-level contract must include load-bearing entries such as `lib/`, `.github/`, `sifr.toml`, and `logo.webp`
 - corpus migration and submodule migration must be explicit PRs, not risks hidden inside script movement
 - the personal-path guardrail must distinguish workflow/code leaks from intentional test fixture paths
 - `Cargo.lock` tracking deserves its own policy step
-- the runner should commit to stdlib-only Python
+- Python verification tooling should be managed by `uv`, with dependencies declared and locked when needed
 - `internal_docs/verification/` should move to `verification/policy/` instead of remaining as a temporary half-state
+- `run_all_tests.sh` needs an explicit facade-cutover PR with profile-by-profile equivalence evidence
+- `crates/sifr/tests/verification/` must be dispositioned as area-owned repo verification or crate-local unit fixture data
+- schema validation must be an explicit supported subset, not an implied full JSON Schema implementation
+- runner determinism and sequential/parallel equivalence belong to runner self-tests and policy data, not a permanent verification area
+- the phase should borrow reference compiler invariants from TypeScript, typescript-go, Rust, Bun, and CPython: first-class baselines, mode-specific suites, resource-aware runners, distinct benchmark policy, and current-state internal docs
+- verification execution selectors should be called `profiles`, not `lanes`, because the public facade already uses `--profile` and `lane` has a separate compiler/SIMD meaning

--- a/issues/ad-hoc-repository-architecture-and-verification-surface-cleanup.md
+++ b/issues/ad-hoc-repository-architecture-and-verification-surface-cleanup.md
@@ -1,0 +1,789 @@
+# Ad Hoc Repository Architecture And Verification Surface Cleanup
+
+status: draft
+
+## Objective
+
+Make the Sifr repository present as a serious, production-grade compiler codebase by giving every major repo surface a clear ownership contract: compiler source, public docs, internal architecture, planning, verification, workflow automation, release tooling, and external corpora.
+
+This is an architectural cleanup phase, not a cosmetic sweep. The end state must be clean, explicit, and uncompromising: no fallback paths, no compatibility wrappers for old script names, no half-migrated folder layouts, no tracked process exhaust, and no machine-specific workflow assumptions.
+
+## Problem
+
+Sifr has strong compiler infrastructure, but the repository surface has accumulated historical artifacts from rapid milestone execution:
+
+- planning docs, closed issues, and phase ledgers are not separated by lifecycle
+- review transcripts and process history have been treated as active repo material
+- Cursor workflows contain local-machine assumptions and model-specific command paths
+- verification logic is split across `scripts/`, `verification/`, `audits/`, `crates/sifr/tests/verification/`, and internal docs
+- some active script names encode stale phase numbers instead of stable compiler concerns
+- audit fixtures and audit reports share one namespace even though they have different lifecycles
+- verification inputs, inventories, reports, and policy docs are not consistently separated
+- top-level repo intent is less obvious than the underlying compiler quality
+
+The desired result is a repo where a new contributor can quickly answer:
+
+1. Where is the compiler?
+2. How do I validate it?
+3. Which docs are current?
+4. Which plans are active?
+5. Which corpora are executable verification assets?
+6. Which files are generated or historical and therefore not active engineering surface?
+
+## Non-Goals
+
+- No compiler feature work.
+- No test coverage reduction.
+- No CI-only validation behavior.
+- No compatibility shims for moved script paths.
+- No duplicate old and new verification layouts.
+- No archive-in-place that leaves the active tree visually noisy.
+- No tracking of point-in-time validation logs.
+- No broad rewrite of compiler crates unless required by path or fixture ownership.
+
+## Core Principles
+
+- Active tree shows the product, not the process history.
+- Humans read short, current docs and issue plans.
+- Machines consume schemas, manifests, fixtures, and baselines.
+- Generated reports live under `target/` and are not committed.
+- Each fixture has one owning verification area.
+- Lanes select verification areas; lanes do not own fixtures.
+- Public validation has one entrypoint.
+- Repo hygiene is enforced by guardrails, not convention.
+- Historical material is either deleted, moved to git history, or placed in a separate archive outside the active tree.
+
+## Target Top-Level Contract
+
+The top-level tree should contain only intentional, load-bearing entries:
+
+```text
+.github/
+.cursor/
+crates/
+demos/
+docs/
+editor_integrations/
+internal_docs/
+lib/
+plans/
+scripts/
+third_party/
+verification/
+AGENTS.md
+CLAUDE.md
+Cargo.lock
+Cargo.toml
+LICENSE.md
+README.md
+logo.webp
+sifr.toml
+```
+
+Every tracked top-level entry must be classified in the first implementation PR as one of:
+
+- `keep`: active, intentional top-level surface
+- `move`: active, but belongs under another owner
+- `archive-external`: valuable process history, not active tree material
+- `delete`: obsolete or generated
+- `generate`: produced by a script and should not be committed unless it is a baseline
+
+## Planning, Issues, And Reviews Structure
+
+Target planning shape:
+
+```text
+plans/
+  README.md
+  roadmap.md
+
+  phases/
+    roadmap.md
+    01_language_foundations.md
+    02_type_system_power.md
+    ...
+    43_interoperability.md
+
+  issues/
+    active/
+    completed/
+    archive/
+
+  reviews/
+    active/
+    archive/
+
+internal_docs/
+  architecture.md
+  architecture/
+  decisions/
+```
+
+Rules:
+
+- `plans/roadmap.md` is the high-level execution roadmap.
+- `plans/phases/roadmap.md` indexes phase status.
+- Phase files stay flat under `plans/phases/` so phase numbers remain stable and easy to find.
+- Phase status lives in each phase header and in `plans/phases/roadmap.md`; phases do not need active/completed/archive directories.
+- Active ad hoc issue plans live in `plans/issues/active/`.
+- Completed ad hoc issue plans move to `plans/issues/completed/`.
+- Superseded, abandoned, or purely historical issue plans move to `plans/issues/archive/`.
+- Active review artifacts live in `plans/reviews/active/`.
+- Completed or historical review artifacts move to `plans/reviews/archive/`.
+- Review archives are allowed under `plans/reviews/archive/`; they should not sit at the repository root.
+- Issue files may include concise review summaries and PR links. Long transcript references should point into `plans/reviews/` only when the transcript is intentionally retained.
+- Point-in-time validation logs are never committed.
+- `internal_docs/` is reserved for durable architecture, accepted design decisions, and current technical references. It should not own execution planning.
+
+## Review Artifact Policy
+
+The main repository should not contain `reviews/` as a top-level tracked tree. Review artifacts belong under `plans/reviews/`.
+
+Allowed review references in active docs:
+
+- reviewer name or model family when relevant
+- pass/fail summary
+- concise actionable findings
+- PR link
+- final disposition
+
+Disallowed active-tree material:
+
+- per-pass review logs
+- `.claude.log` files
+- stale transcript path lists
+- validation evidence copied as long prose when a generated report exists
+
+Long review transcripts may be retained under `plans/reviews/archive/` when they have ongoing planning value. Otherwise they should be deleted from the active tree and left to git history.
+
+## Cursor Cleanup
+
+Target `.cursor/` shape:
+
+```text
+.cursor/
+  commands/
+  references/
+  skills/
+```
+
+Rules:
+
+- No personal absolute paths.
+- No local-machine paths such as `/Users/yaseralnajjar/...`.
+- No embedded Obsidian state.
+- No tracked `.DS_Store` or local editor files.
+- Commands target the new `plans/issues/active/`, `plans/phases/`, and `plans/reviews/active/` layout.
+- Review skills write to `plans/reviews/active/` by default.
+- Keep `.cursor/skills/talk-to-claude-opus/` as the single Claude/Fable review workflow.
+- Remove the other Claude review skill variants once their useful instructions are folded into `talk-to-claude-opus`.
+- Skill names should describe workflow intent, not a transient model brand, unless the model is itself the workflow contract.
+- Remove `.cursor/.rules/`.
+
+Add a Cursor hygiene guardrail that checks:
+
+- forbidden personal paths
+- tracked local editor state
+- tracked review-output paths
+- stale issue or phase path references
+- workflow commands that write generated artifacts into tracked locations
+
+## Verification Architecture
+
+Target verification shape:
+
+```text
+verification/
+  README.md
+  policy/                 # runner/data policy, not human conventions
+  schemas/
+    lane.schema.json
+    area.schema.json
+    suite.schema.json
+    case.schema.json
+    result.schema.json
+  lanes/
+    create-pr.json
+    merge.json
+    nightly.json
+    release.json
+  runner/
+    sifr_verify/
+      __main__.py
+      lanes.py
+      areas.py
+      scheduler.py
+      results.py
+      schemas.py
+  areas/
+    core_language/
+      manifest.json
+      suites/
+      fixtures/
+      baselines/
+      data/
+      runner.py
+    diagnostics/
+    project_workspace/
+    regression/
+    fuzz_property/
+    determinism/
+    generated_code_quality/
+    performance/
+    developer_tooling/
+    runtime_platform/
+    stdlib_parity/
+    algorithmic_compatibility/
+    ecosystem_compatibility/
+    package_management/
+    distribution_release/
+```
+
+Rules:
+
+- `verification/README.md` is the single human entrypoint for validation architecture.
+- The verification runner is stdlib-only Python.
+- No `pyproject.toml`, `uv`, or external Python package dependency is required for local validation.
+- The runner discovers areas by `verification/areas/*/manifest.json`.
+- The top-level verification concepts are only `runner`, `schemas`, `lanes`, `areas`, and `policy`.
+- `areas` answer what is verified and who owns it.
+- `lanes` answer when verification runs and with what resource budget.
+- `schemas` answer what shape committed verification data must have.
+- `runner` answers how verification is executed.
+- `policy` answers machine-facing operational rules for baselines, artifacts, flakes, retention, and schema governance.
+- Suites are area-local groupings, not a competing top-level taxonomy. A suite may live under `verification/areas/<area>/suites/` or inside the area manifest.
+- Cases are area-owned. A lane may select a subset of an area or suite, but it never owns fixtures directly.
+- Each area owns its fixtures, baselines, runner code, manifests, and area-local data.
+- Each area manifest declares owner, suites, fixtures, baselines, resources, parallel safety, expected outputs, timeout policy, and result contract.
+- Lane files select areas or area-local suites and define execution policy; they do not duplicate fixture lists.
+- Generated reports go to `target/verification_reports/`.
+- Markdown under `verification/` is limited to `README.md`, policy, and runbooks.
+- Gate inputs are JSON, schemas, baselines, or fixtures.
+- Parallelism is explicit per area.
+- Performance-sensitive or shared-state areas must declare `parallel_safe: false`.
+- Sequential/parallel equivalence is a runner self-check, not an ad hoc shell script.
+- Determinism evidence is generated and schema-validated.
+
+Area-local shape:
+
+```text
+verification/areas/<area>/
+  manifest.json           # owner, suites, resources, lane selectors, result contract
+  README.md               # short area runbook only when needed
+  runner.py               # optional area adapter called by the stdlib-only runner
+  suites/                 # optional suite manifests for large areas
+  fixtures/               # first-party source inputs and minimized cases
+  corpora/                # external corpora and submodules owned by this area
+  baselines/              # checked-in expected outputs
+  data/                   # machine-readable inventories consumed by this area
+```
+
+Lane-local shape:
+
+```text
+verification/lanes/<lane>.json
+```
+
+Lane files may define:
+
+- selected areas or area-local suites
+- warm and cold time budgets
+- resource policy
+- shard policy
+- retry and flake policy
+- parallelism limits
+- generated report requirements
+
+Lane files may not define:
+
+- fixture paths directly
+- expected diagnostic text
+- baselines
+- domain ownership
+- one-off shell commands
+
+Permanent verification areas:
+
+| Area | Owns |
+| --- | --- |
+| `core_language` | Broad compiler behavior fixtures for syntax, lowering, type checking, ownership, control flow, and pass/fail language behavior that is not more specifically owned elsewhere. |
+| `diagnostics` | Diagnostic codes, renderer behavior, JSON/compact/human diagnostic contracts, docs/schema sync fixtures, and diagnostic presentation baselines. |
+| `project_workspace` | Multi-file project behavior, imports, module graph, workspace resolution, graph isolation, cache identity, and project-mode command semantics. |
+| `regression` | Fixed bugs, minimized crash reproducers, invariant failures, and promoted sentinel cases. |
+| `fuzz_property` | Deterministic property tests, fuzz smoke seeds, sustained fuzz corpus metadata, minimization conventions, and seed provenance. |
+| `determinism` | Deterministic report signatures, sequential/parallel equivalence, sharding behavior, flake/quarantine data, and runner determinism self-checks. |
+| `generated_code_quality` | Emitted Rust quality, rustfmt/clippy/panic scans, generated-code determinism, generated binary-size checks, and codegen quality corpora. |
+| `performance` | Benchmark manifests, budgets, waivers, baselines, performance fixtures, and budget-check runners. |
+| `developer_tooling` | Formatter, linter, LSP, editor assets, editor query snapshots, completion quality, and tooling split-brain checks. |
+| `runtime_platform` | Host/platform contracts, platform golden fixtures, process/runtime/IO/network host behavior that is platform substrate rather than stdlib parity. |
+| `stdlib_parity` | CPython-adapted stdlib behavior, stdlib namespace contracts, complexity/resource parity, dependency snapshots, and stdlib parity evidence. |
+| `algorithmic_compatibility` | Algorithmic compatibility corpora such as LeetCode, algorithmic scorecards, and external algorithm fixture projections. |
+| `ecosystem_compatibility` | Curated OSS and broader ecosystem compatibility manifests, pinned external project outcomes, and non-blocking ecosystem signal. |
+| `package_management` | Package graph, package demo repositories, package CLI alignment matrices, workspace/package fixtures, and package publishing/vendoring validation. |
+| `distribution_release` | Installer, self-update, release-channel, artifact checksum, generated dispatcher, and preview/stable release validation. |
+
+There is no permanent `audits` area. Existing audit material must move into the owning area above or be deleted/archived according to the audit cleanup rules.
+
+## Scripts Cleanup
+
+`scripts/` becomes repo operations and developer ergonomics only. It must not own verification implementation.
+
+Keep in `scripts/`:
+
+- `run_all_tests.sh` as the only public validation facade
+- source and repository guardrails
+- code generators
+- release and publishing tools
+- repository maintenance utilities
+
+Move into `verification/areas/*`:
+
+- e2e pass runner -> `core_language`
+- validation contract matrices -> owning area, usually `core_language`, `project_workspace`, or `diagnostics`
+- hardening runner -> `regression`, `fuzz_property`, and `ecosystem_compatibility` as appropriate
+- platform golden checks -> `runtime_platform`
+- generated-code quality checks -> `generated_code_quality`
+- performance budget checks -> `performance`
+- tooling and LSP verification checks -> `developer_tooling`
+- distribution validation cases -> `distribution_release`
+- stdlib namespace and corpus validation -> `stdlib_parity`
+- fuzz and property checks -> `fuzz_property`
+- determinism checks -> `determinism`
+- sequential/parallel equivalence checks -> `determinism`
+
+Rules:
+
+- No active script filename may encode stale phase numbers.
+- No duplicate entrypoints for the same gate.
+- No compatibility wrapper remains for an old script name after migration.
+- `AGENTS.md`, CI workflows, README, internal docs, and Cursor commands update atomically with script moves.
+- Shell is allowed only for tiny public facades or release scripts where POSIX shell is the artifact under test.
+- Verification scripts moved out of `scripts/` should be rewritten as stdlib-only Python area runners unless the checked artifact is itself POSIX shell.
+- Shell-to-Python rewrites must preserve command semantics, exit-code behavior, timeout behavior, output normalization, and generated report shape.
+- Rewrites must land with side-by-side equivalence evidence before the shell implementation is deleted.
+
+Script migration classification:
+
+- `repo-guardrail`: stays in `scripts/`
+- `code-generator`: stays in `scripts/`
+- `release-tool`: stays in `scripts/` unless it is only a validation case
+- `verification-runner`: move to `verification/areas/<area>/` and rewrite in Python
+- `verification-case`: move to the owning area as a fixture, manifest row, or area-local helper
+- `obsolete-phase-tool`: delete after proving no active reference remains
+
+## Audits Cleanup
+
+`audits/` should not survive as a top-level test system. Verification is the new home for executable audit value.
+
+Initial disposition:
+
+| Current path | Disposition |
+| --- | --- |
+| `audits/.DS_Store` | Delete. |
+| `audits/run_audit.sh`, `audits/run_audit_fast.sh`, `audits/run_borrowing_audit.sh` | Delete after equivalent verification area manifests and runners exist. Do not keep wrappers. |
+| `audits/lint_panic_patterns.sh` | Delete or replace with an owned guardrail/verification check under `generated_code_quality` or `scripts/` depending on whether it scans generated output or source. |
+| `audits/STDLIB_PARITY_MASTER_REPORT.md` | Archive or delete after any current state is reflected in `stdlib_parity` manifests/data. It must not remain an active report. |
+| `audits/*/REPORT.md`, `audits/*/POST_HARDENING_REPORT.md` | Archive or delete. Keep only concise current state in area manifests, area README files, or `plans/` if the history matters. |
+| `audits/stdlib/cpython_parity_fixture_format.md` | Keep as a convention, but move to the owning location: `internal_docs/verification/` if it is a human convention, or `verification/areas/stdlib_parity/README.md` if it is area-specific runner guidance. |
+| `audits/borrowing/*.sifr` | Promote into `verification/areas/core_language/fixtures/ownership/` or delete duplicates once coverage is proven elsewhere. |
+| `audits/lexical_and_syntax/*.sifr` | Promote into `verification/areas/core_language/fixtures/syntax/` or delete duplicates once covered by syntax/parser suites. |
+| `audits/type_inference/*.sifr` | Promote into `verification/areas/core_language/fixtures/type_inference/` or delete duplicates once covered by type-system suites. |
+| `audits/type_system/*.sifr` | Promote into `verification/areas/core_language/fixtures/type_system/` or delete duplicates once covered by type-system suites. |
+| `audits/iteration_protocol/*.sifr` | Promote into `verification/areas/core_language/fixtures/iteration/` unless a case is specifically stdlib parity. |
+| `audits/object_model/*.sifr` | Promote into `verification/areas/core_language/fixtures/object_model/` unless a case is specifically stdlib parity. |
+| `audits/modules_and_imports/*.sifr` | Promote into `verification/areas/project_workspace/fixtures/imports/`. |
+| `audits/python_basics/*.sifr` | Split by ownership: syntax/type/control-flow cases to `core_language`; stdlib behavior to `stdlib_parity`; redundant smoke examples delete after coverage proof. |
+| `audits/stdlib/*.sifr` | Promote into `verification/areas/stdlib_parity/fixtures/`. |
+| `audits/leetcode/` | Move to `verification/areas/algorithmic_compatibility/corpora/leetcode/` and make it either a submodule or clone-restored corpus, not both. |
+
+Migration rules:
+
+- `fixture-corpus`: promote into the owning verification area
+- `external-corpus`: move under the owning verification area and resolve submodule ownership
+- `historical-report`: delete from active tree or archive externally
+- `obsolete-experiment`: delete
+- `policy-spec`: move to `verification/policy/` or an area runbook
+
+Rules:
+
+- No audit report markdown remains active unless it is a timeless policy or spec.
+- Every retained audit fixture is referenced by exactly one owning area manifest.
+- Each promoted fixture must either become a manifest-owned verification case or be deleted as duplicate/obsolete.
+- Stale fixtures should be updated to current Sifr syntax and expected behavior before promotion.
+- Duplicate fixtures should be deleted only after the coverage map shows the behavior is already owned by another verification area.
+- The LeetCode corpus must have one ownership model: submodule or clone script, not both.
+- The LeetCode corpus belongs under `verification/areas/algorithmic_compatibility/corpora/leetcode/`.
+- Audit fixtures must be executable by the verification runner.
+- Audit output reports are generated under `target/`, not committed.
+
+## Verification Material Cleanup
+
+Classify every existing file under `verification/` before moving it:
+
+- `area-runner`: move under `verification/areas/<area>/runner` or equivalent area-owned code
+- `area-fixture`: move under the owning area's fixtures or cases
+- `area-baseline`: move under the owning area's baselines
+- `area-manifest`: convert to the new area manifest schema
+- `lane-policy`: move under `verification/lanes/`
+- `global-policy`: move under `verification/policy/`
+- `schema`: move under `verification/schemas/`
+- `generated-report`: delete from active tree and regenerate under `target/`
+- `historical-inventory`: convert to JSON if consumed by a gate, otherwise archive externally or delete
+- `obsolete`: delete
+
+Rules:
+
+- `verification/` should not contain loose domain files at the root after cleanup.
+- Domain material must live under one area, policy, schema, lane, or runner owner.
+- Point-in-time markdown inventories must either become generated reports or compact policy docs.
+- JSON inventories are retained only when a gate consumes them or a current design doc references them as canonical data.
+- Any retained markdown in `verification/` must explain a stable policy or runbook, not record a past result.
+
+## Internal Docs Cleanup
+
+`internal_docs/` is only for decided technical state and conventions. It should describe how Sifr works now, the contracts the implementation currently upholds, accepted engineering conventions, and accepted architecture/decision records.
+
+It should not contain implementation instructions, execution planning, active issues, review transcripts, validation ledgers, phase checklists, or point-in-time status reports.
+
+Shape `internal_docs/` around a small set of durable topics:
+
+- `architecture.md`
+- `syntax_architecture.md`
+- `integer_model.md`
+- `async_concurrency_model.md`
+- `network_http_architecture.md`
+- `text_i18n_architecture.md`
+- `frontend_query_architecture.md`
+- `frontend_cache_invalidation.md`
+- `narrowing_flow_facts_design.md`
+- `sifr_workspace_design.md`
+- `structured_runtime_work_model.md`
+- `dependency_policy.md`
+- `generated_code_quality.md`
+- `performance_budgets.md`
+- `lsp_server.md`
+- `editor_integrations.md`
+- `vscode_extension.md`
+- `distribution_pipeline.md`
+
+Move execution material out of `internal_docs/`:
+
+- `roadmap.md` -> `plans/roadmap.md`
+- `phases/*.md` -> `plans/phases/`
+- phase checklists and execution ledgers -> `plans/`
+- active or future implementation instructions -> `plans/`
+- repeated validation evidence -> generated reports under `target/`
+- review transcript references -> `plans/reviews/`
+
+Clean up docs in place instead of over-classifying them:
+
+- consolidate scattered docs when one current design document would be clearer
+- remove stale status sections once the current state is described elsewhere
+- rewrite procedural "how to implement" sections into state/contract descriptions, or move them to `plans/`
+- keep verification conventions in `internal_docs/verification/` when they describe human-facing conventions
+- move runner mechanics, schemas, lane data, baseline retention, and generated-artifact policy under `verification/`
+
+Rules:
+
+- Internal docs should explain current architecture, accepted decisions, implemented behavior, durable state, and accepted engineering conventions.
+- Internal docs should not tell contributors how to implement a future change. Those instructions belong in `plans/`.
+- Internal docs should not contain long validation transcripts, repeated pass/fail logs, or AI-review path ledgers.
+- Phase-numbered architecture-transfer notes should either consolidate into a small design narrative or move to an archive directory.
+- Absolute personal reference paths must become environment-variable based references, repo-relative references, or explicit external-reference notes.
+- Docs that describe planned work but not accepted design belong under `plans/`, not `internal_docs/`.
+- Verification convention docs may live in `internal_docs/verification/` when they describe human-facing conventions.
+- Verification docs that are part of runner mechanics, schema contracts, lane data, baseline retention, or generated-artifact policy belong under `verification/policy/`, `verification/schemas/`, or a verification area.
+
+## Submodule Policy
+
+Submodules inside a move zone require dedicated handling.
+
+Known submodule categories:
+
+- parser and compiler reference dependencies under `third_party/`
+- editor integration repositories
+- verification demo repositories
+- large verification corpora
+- LeetCode or external audit corpora
+
+Rules:
+
+- Every submodule has one owning top-level area.
+- Submodule moves update `.gitmodules`, scripts, CI, docs, and manifests in the same PR.
+- A corpus is either a submodule or restored by a clone script, not both.
+- Optional heavy corpora are excluded from default create-pr validation unless explicitly selected by lane policy.
+
+## Cargo Lock Policy
+
+`Cargo.lock` is a load-bearing file for this binary-producing compiler workspace and should be tracked.
+
+Cleanup must:
+
+- remove any ignore rule that conflicts with tracking `Cargo.lock`
+- keep `Cargo.lock` in the root tracked set
+- document why the compiler workspace tracks the lockfile
+- validate that CI and local builds use the same dependency graph
+
+This policy should land as its own PR or isolated commit because it affects every contributor.
+
+## Guardrails
+
+Add repo-hygiene guardrails for:
+
+- personal absolute paths in active workflow/code surfaces
+- tracked local editor artifacts
+- tracked generated validation reports
+- tracked Python bytecode and cache directories
+- active phase-numbered verification script names
+- verification fixtures not owned by any area manifest
+- verification fixtures owned by more than one area manifest
+- markdown reports under `verification/` that are not README, policy, or runbooks
+- stale references to removed review transcript paths
+- stale references to removed script entrypoints
+
+The personal-path guardrail must allow intentional example paths in tests when they are explicitly part of fixture data.
+
+## Proposed PR Sequence
+
+### PR 1: Repository Surface Contract
+
+Add the full tracked-entry disposition tables:
+
+- top-level entries
+- `scripts/` entries
+- `verification/` entries
+- `audits/` entries
+- `internal_docs/` entries
+- submodules
+- Cursor workflow files
+- plan, issue, phase, and review artifact locations
+
+No moves in this PR.
+
+Validation:
+
+- `git diff --check`
+- `python3 scripts/check_file_size_guardrails.py`
+
+### PR 1B: Relevance Audit
+
+Produce reviewable keep/move/rewrite/delete tables for stale or outdated material before any deletion-heavy PR:
+
+- `audits/`
+- `verification/`
+- `internal_docs/`
+- `scripts/`
+- `.cursor/`
+
+Each row must include:
+
+- current path
+- classification
+- destination or deletion rationale
+- whether a gate consumes it
+- whether a current doc references it
+- validation required after changing it
+
+Validation:
+
+- `git diff --check`
+- no file moves
+- no deletions
+
+### PR 2: Cargo Lock Policy
+
+Make `Cargo.lock` tracking explicit and fix ignore rules.
+
+Validation:
+
+- `cargo check --workspace`
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### PR 3: Cursor Portability Cleanup
+
+Remove local-machine assumptions from `.cursor/` and update commands for the planned `plans/` layout.
+
+Validation:
+
+- Cursor hygiene guardrail
+- `git diff --check`
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### PR 4: Review Tree Normalization
+
+Move intentionally retained review artifacts under `plans/reviews/active/` or `plans/reviews/archive/`. Delete review artifacts that have no ongoing planning value and replace direct transcript ledgers in active docs with concise summaries.
+
+Validation:
+
+- no top-level tracked `reviews/`
+- retained review artifacts live under `plans/reviews/`
+- no active doc depends on review transcript paths
+- `git diff --check`
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### PR 5: Planning Tree Normalization
+
+Move active, completed, and archived phase and issue docs into the new lifecycle directories.
+
+Validation:
+
+- all roadmap links resolve
+- all AGENTS/Cursor references resolve
+- `git diff --check`
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### PR 6: Verification Runner Foundation
+
+Add the stdlib-only verification runner, schemas, area discovery, and result format.
+
+No existing runner migration yet.
+
+Validation:
+
+- schema self-tests
+- runner discovery self-test
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### PR 7: Verification Lane Normalization
+
+Split lane configuration into `verification/lanes/*.json` and validate with schemas.
+
+Validation:
+
+- all lanes schema-valid
+- old lane manifest removed
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### PR 8-N: Verification Area Corpus Migration
+
+Migrate one verification domain per PR into `verification/areas/<area>/`.
+
+Candidate order:
+
+1. `diagnostics`
+2. `project_workspace`
+3. `core_language`
+4. `regression`
+5. `fuzz_property`
+6. `determinism`
+7. `generated_code_quality`
+8. `performance`
+9. `developer_tooling`
+10. `runtime_platform`
+11. `distribution_release`
+12. `package_management`
+13. `stdlib_parity`
+14. `algorithmic_compatibility`
+15. `ecosystem_compatibility`
+
+Validation for each area migration:
+
+- area manifest schema-valid
+- moved fixtures are owned by exactly one area
+- shell verification helpers rewritten to stdlib-only Python unless shell is the artifact under test
+- old verification script names deleted, not wrapped
+- runner can execute the area
+- determinism check for affected area
+- sequential/parallel equivalence where applicable
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### PR N+1: Submodule Normalization
+
+Resolve submodule ownership and move any submodule paths that belong under verification areas.
+
+Validation:
+
+- `.gitmodules` is correct
+- clone/restoration scripts are correct
+- CI checkout still initializes required submodules
+- affected area runner executes
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### PR N+2: Scripts Verification Migration
+
+Move remaining verification implementation out of `scripts/` and into verification areas.
+
+Delete old entrypoints. Do not add compatibility wrappers.
+
+Validation:
+
+- no verification implementation remains in `scripts/`
+- no stale script references remain
+- `scripts/run_all_tests.sh --profile create-pr`
+- `scripts/run_all_tests.sh --profile merge`
+
+### PR N+3: Audits Normalization
+
+Promote retained audit fixtures into verification manifests and remove historical report markdown from the active tree.
+
+Validation:
+
+- no top-level `audits/`
+- every retained audit fixture is manifest-owned
+- audit area executes through the runner
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### PR N+4: Internal Docs Relevance Cleanup
+
+Move, consolidate, or delete outdated internal docs according to the relevance audit.
+
+Validation:
+
+- roadmap links resolve
+- phase roadmap links resolve
+- verification policy docs live under `verification/policy/`
+- no active internal doc contains long validation transcript ledgers
+- `git diff --check`
+
+### PR N+5: Docs And Guardrails Closeout
+
+Update public docs, internal docs, AGENTS, Cursor commands, and CI docs to reflect the final structure.
+
+Add all hygiene guardrails.
+
+Validation:
+
+- guardrails pass
+- `scripts/run_all_tests.sh --profile create-pr`
+- `scripts/run_all_tests.sh --profile merge`
+
+## Acceptance Criteria
+
+- Fresh clone top-level tree matches the top-level contract.
+- No top-level tracked `reviews/` tree exists.
+- Any retained review artifacts live under `plans/reviews/`.
+- No top-level `audits/` tree exists.
+- `.cursor/` contains only portable workflow assets.
+- No active workflow/code surface contains personal `/Users/yaseralnajjar/...` paths.
+- `Cargo.lock` is tracked and intentionally not ignored.
+- `scripts/run_all_tests.sh --profile create-pr` is the only public create-PR validation command.
+- `scripts/run_all_tests.sh` delegates directly to the verification runner.
+- No active verification implementation remains in `scripts/`.
+- Every verification area has a schema-valid manifest.
+- Every retained fixture has exactly one owning area manifest.
+- Lane files reference areas instead of duplicating fixture ownership.
+- No committed validation result logs exist outside explicit baselines.
+- Markdown under `verification/` is limited to README, policy, and runbooks.
+- CI and local validation use the same runner and lane files.
+- Migration PRs prove determinism and sequential/parallel equivalence where applicable.
+- Final closeout passes local merge validation.
+
+## Risks
+
+- Moving fixtures can reorder e2e discovery or invalidate snapshots.
+- Removing review transcripts can break historical issue references unless summaries replace them.
+- Moving submodules requires atomic `.gitmodules`, script, CI, docs, and manifest updates.
+- A Python runner can drift if it gains external dependencies; keep it stdlib-only.
+- Parallel scheduling can hide resource contention unless every area declares resource policy.
+- Historical docs may contain the only explanation for a design decision; archive by value, not by age.
+
+## Review Notes
+
+This plan was reviewed with the Fable high model before being written. The main findings incorporated here were:
+
+- the top-level contract must include load-bearing entries such as `lib/`, `.github/`, `sifr.toml`, and `logo.webp`
+- corpus migration and submodule migration must be explicit PRs, not risks hidden inside script movement
+- the personal-path guardrail must distinguish workflow/code leaks from intentional test fixture paths
+- `Cargo.lock` tracking deserves its own policy step
+- the runner should commit to stdlib-only Python
+- `internal_docs/verification/` should move to `verification/policy/` instead of remaining as a temporary half-state

--- a/reviews/ad-hoc-repository-architecture-and-verification-surface-cleanup-fable-review-pass-1.md
+++ b/reviews/ad-hoc-repository-architecture-and-verification-surface-cleanup-fable-review-pass-1.md
@@ -1,0 +1,83 @@
+I have everything I need. Here is the review.
+
+---
+
+# Review: Ad Hoc Repository Architecture And Verification Surface Cleanup
+
+**Verdict up front: approve with changes.** The core architecture — areas own fixtures, lanes select areas, one public facade, stdlib-only runner, generated reports under `target/` — is sound and genuinely production-grade. But the plan has one missing load-bearing PR (the facade cutover), one internal contradiction it cannot land without resolving (transitional coexistence vs. "no duplicate layouts"), and one named-but-undispositioned surface (`crates/sifr/tests/verification/`). These are fixable in the doc; nothing requires redesigning the shape.
+
+## 1. Severity-ordered findings
+
+### Blocker-level (the plan cannot land as written)
+
+**F1. The `run_all_tests.sh` cutover has no PR.** `run_all_tests.sh` is today a 481-line shell orchestrator that hard-wires dozens of individual check invocations (`scripts/run_all_tests.sh:128-189`) and sources lane config via `scripts/validation_lane.py`. The acceptance criteria demand it "delegates directly to the verification runner," but no PR in the sequence performs that rewiring. PR 6 builds the runner, PR 7 splits lanes, PRs 8–N migrate areas — and at no defined point does the facade stop being the orchestrator and become a thin wrapper over `sifr_verify`. This is the single riskiest change in the whole phase (it redefines the merge gate and CI mirrors it), and it's invisible. Add an explicit **Facade Cutover PR** (logically after the first few area migrations, before PR N+2) with side-by-side equivalence evidence: same checks executed, same exit-code semantics, same report shape, per lane.
+
+**F2. Internal contradiction: "No duplicate old and new verification layouts" (Non-Goals) vs. a 15+ PR incremental migration.** From PR 6 until PR N+2, the repo necessarily contains both the new runner/areas and the legacy `scripts/` + loose `verification/` material — that *is* a duplicate layout. As written, every migration PR violates a stated non-goal. Scope the non-goal to the end state and explicitly authorize transitional coexistence, governed by a migration-status table (which area has cut over, which legacy path still gates). Without this, reviewers of mid-train PRs have no rule to apply.
+
+**F3. `crates/sifr/tests/verification/` is named in the Problem statement and then never dispositioned.** The current `verification/suites/manifest.json` points its case entries at `crates/sifr/tests/verification/diagnostics/...`, `project/...`, `crashes/`, `package/`. The plan's "every retained fixture has exactly one owning area manifest" rule is unsatisfiable while those fixtures live in a crate the plan doesn't mention. Decide explicitly: either (a) crate-local fixtures move into `verification/areas/<area>/fixtures/` and the Rust tests reference them by relative path, or (b) crate-internal unit-test fixtures are formally exempted from area ownership and the suites manifest entries migrate. Either answer is defensible; silence is not.
+
+### High
+
+**F4. Stdlib-only Python vs. JSON Schema validation is an unacknowledged conflict.** The plan commits to five `*.schema.json` files *and* a runner with "no external Python package dependency" — but JSON Schema validation in Python requires the third-party `jsonschema` package. Hand-rolling a full JSON Schema validator is its own project. Resolve in the doc: commit to a small, explicitly enumerated schema subset (required keys, types, enums) validated by hand-written stdlib code, and say so in the schemas section. Otherwise PR 6's "schema self-tests" validation step is undefined.
+
+**F5. PR 3 (Cursor cleanup) targets a `plans/` layout that doesn't exist until PR 5.** PR 3 says Cursor commands are updated "for the planned `plans/` layout," leaving commands pointing at nonexistent paths for two PRs — and PR 5's own validation ("all AGENTS/Cursor references resolve") forces a second Cursor edit anyway. Split it: PR 3 becomes portability-only (personal paths, `.DS_Store`, `.obsidian`, `.cursor/.rules/`, skill consolidation); path retargeting moves into PR 5 atomically with the tree move.
+
+**F6. Guardrails-vs-verification boundary is fuzzy and will be litigated in every migration PR.** `scripts/` keeps "source and repository guardrails" while "no verification implementation remains in `scripts/`" — but `check_hir_maintainability_guardrails.py`, `check_diagnostic_docs_sync.py`, `check_source_crate_dependency_direction.py` etc. are verification by any reasonable reading, and several `check_diagnostic_*` scripts map directly to the proposed `diagnostics` area. Add a one-sentence tie-breaker, e.g.: *"A check that gates first-party source/repo hygiene and needs no compiled artifact is a guardrail (`scripts/`); a check that executes or inspects compiler behavior or output is verification (area-owned)."* Then classify the ambiguous diagnostics scripts in PR 1B against that rule.
+
+### Medium
+
+**F7. The `determinism` area conflates two different things.** The plan states "sequential/parallel equivalence is a runner self-check, not an ad hoc shell script" — and then creates an *area* that owns "runner determinism self-checks." Runner self-checks belong to `runner/` (tested like any other code); flake/quarantine data and report-signature baselines are policy-adjacent data. Either fold determinism into `runner/` self-tests plus `policy/` data, or narrow the area's charter to *compiler-output determinism* (deterministic emitted Rust, deterministic diagnostics ordering) and move runner self-verification out of it.
+
+**F8. Repeated ownership hedges signal a missing tie-breaker rule.** "Unless a case is specifically stdlib parity" appears three times in the audit disposition table; `runtime_platform` vs `stdlib_parity` and `regression` vs `core_language` boundaries will generate the same argument repeatedly. Add one rule to the area table: *ownership follows the contract being asserted, not the feature being exercised* — a fixture asserting CPython-observable behavior is `stdlib_parity`; one asserting compile-time semantics is `core_language`; a minimized reproducer of a fixed bug is `regression` regardless of domain.
+
+**F9. PR 1 and PR 1B are the same artifact split bureaucratically.** A "disposition table" (PR 1) and a "keep/move/rewrite/delete relevance audit" (PR 1B) over largely the same surfaces, both no-op PRs, differ only in column count. Merge into one inventory PR with the richer row format. Also drop the "1B" numbering — renumber cleanly.
+
+**F10. Two files named `roadmap.md` with different meanings.** `plans/roadmap.md` (execution roadmap) and `plans/phases/roadmap.md` (phase status index) will be confused in links and in conversation. Rename the latter `plans/phases/index.md`.
+
+**F11. `plans/issues/{active,completed,archive}` has two terminal states; reviews get only two states.** The completed/archive distinction (done vs. superseded) is real but will be misfiled constantly, and the asymmetry with `plans/reviews/{active,archive}` is arbitrary. Collapse issues to `active/` + `archive/` and record `status: completed | superseded | abandoned` in the doc header — the plan already establishes header-status as the mechanism for phases, so reuse it.
+
+**F12. Skill-naming rule contradicts its own example.** "Skill names should describe workflow intent, not a transient model brand" — followed by "Keep `.cursor/skills/talk-to-claude-opus/`." The repo's review flow now runs on Fable, so "opus" is already a stale brand, which is precisely the failure mode the rule targets. Consolidate the three `talk-to-claude-*` variants under an intent name (`ai-review/` or `claude-review/`) in the same PR.
+
+**F13. `.cursor/plans/` is silently dropped.** The current `.cursor/` contains `plans/` (with embedded `.obsidian/` state); the target shape lists only `commands/`, `references/`, `skills/` and the rules never disposition `.cursor/plans/` itself. Add an explicit row — presumably its contents move to `plans/` or are deleted.
+
+**F14. Cargo.lock wording is factually off.** `Cargo.lock` is currently **ignored and untracked** (`git ls-files Cargo.lock` is empty; `.gitignore` lists it). "Keep `Cargo.lock` in the root tracked set" should read "begin tracking `Cargo.lock`" — and PR 2 should note the consequences the current text omits: a large initial commit, and a contributor-visible behavior change (lockfile diffs now appear in PRs and need a review convention).
+
+### Low
+
+**F15. E2E discovery-reorder risk needs a mitigation, not a bullet.** The Risks section notes fixture moves can reorder lexicographic e2e discovery and invalidate snapshots, but no migration-PR validation step addresses it. Add to the PR 8-N checklist: regenerate/verify snapshot stability after each fixture move, with declaration-order expectations re-pinned.
+
+**F16. Area-local ceremony should declare its minimum.** Eight optional subdirectories per area (`suites/ fixtures/ corpora/ baselines/ data/ runner.py README.md`) is fine for `stdlib_parity` and absurd for `package_management` (five submodules and a manifest). State explicitly: only `manifest.json` is mandatory; create subdirectories on first use.
+
+**F17. PR 8-N candidate order is reasonable but unjustified.** Starting with `diagnostics`/`project_workspace` (small, manifest-backed already) before `core_language` (e2e runner, highest blast radius) is the right risk ramp — say so in one sentence, so a future executor doesn't "optimize" the order.
+
+## 2. Specific recommended edits to the phase doc
+
+1. **Add a "Facade Cutover" PR** between the early area migrations and PR N+2: rewrite `run_all_tests.sh` as a thin lane dispatcher over `sifr_verify`, with side-by-side equivalence evidence (checks executed, exit codes, report shape) per lane. Update the acceptance criterion to reference it. (F1)
+2. **Rescope the Non-Goal** to: "No duplicate old/new verification layouts *in the end state*; transitional coexistence during PRs 6–N+2 is tracked in a migration-status table." (F2)
+3. **Add a disposition subsection for `crates/sifr/tests/verification/`** choosing (and justifying) area-migration vs. explicit exemption, and updating the "exactly one owning area manifest" rule accordingly. (F3)
+4. **Amend the Verification Architecture rules**: schemas are validated by a hand-written stdlib validator over an enumerated schema-feature subset; name that subset. (F4)
+5. **Split PR 3** into portability-only; move Cursor path retargeting into PR 5. (F5)
+6. **Add the guardrail/verification tie-breaker sentence** to the Scripts Cleanup section. (F6)
+7. **Narrow or dissolve the `determinism` area**; move runner self-checks under `runner/`. (F7)
+8. **Add the ownership tie-breaker rule** ("ownership follows the asserted contract") above the area table; delete the three "unless stdlib parity" hedges in favor of it. (F8)
+9. **Merge PR 1 and PR 1B**; renumber the sequence. (F9)
+10. **Rename `plans/phases/roadmap.md` → `plans/phases/index.md`.** (F10)
+11. **Collapse `plans/issues/` to `active/` + `archive/`** with header status. (F11)
+12. **Rename the consolidated review skill** to an intent-based name; drop the "keep talk-to-claude-opus" wording. (F12)
+13. **Add an explicit `.cursor/plans/` disposition row.** (F13)
+14. **Fix PR 2 wording** to "begin tracking Cargo.lock" and note the contributor-facing consequences. (F14)
+15. **Add snapshot-stability verification** to every PR 8-N checklist. (F15)
+16. **State that `manifest.json` is the only mandatory area file.** (F16)
+
+## 3. Taxonomy assessment
+
+The areas/lanes/schemas/runner/policy five-concept top level is the right shape — better than the current suites/lanes/loose-domain-dirs mix, and the "lanes select, areas own" invariant is the strongest single idea in the doc. Keep it. Two adjustments to the area table:
+
+- **14 areas, not 15**: fold `determinism` per F7. The remaining 14 map cleanly onto existing directories (`fixedbugs`+`crashes`→`regression`, `oss`→`ecosystem_compatibility`, `tooling`→`developer_tooling`, `perf`+`performance`→`performance`, etc.), which is evidence the taxonomy is descriptive rather than aspirational — good.
+- I considered merging `algorithmic_compatibility` into `ecosystem_compatibility` as a single external-corpora area, but their gating semantics differ (scored blocking corpus vs. non-blocking signal) and lanes select per-area, so keeping them separate is the simpler lane story. No change recommended.
+
+The `plans/` top level alongside `internal_docs/` is the correct split (state vs. execution), and moving `internal_docs/verification/` policy material under `verification/policy/` eliminates a real half-state — the seven policy docs currently there are exactly the machine-adjacent material the plan says they are.
+
+## 4. Final verdict
+
+**Approve with changes.** The architecture and end-state contract are serious and coherent; the audit disposition table is unusually rigorous (per-path, per-rule, with coverage-proof preconditions for deletion — this is the best section of the doc). The required changes are concentrated in execution sequencing: add the facade-cutover PR (F1), resolve the coexistence contradiction (F2), and disposition `crates/sifr/tests/verification/` (F3). Those three are blocking; the rest are doc edits that prevent predictable churn during the ~18-PR train. No structural redesign is warranted.

--- a/reviews/ad-hoc-repository-architecture-and-verification-surface-cleanup-fable-review-pass-3.md
+++ b/reviews/ad-hoc-repository-architecture-and-verification-surface-cleanup-fable-review-pass-3.md
@@ -1,0 +1,78 @@
+# Fable Review — Pass 3: Ad Hoc Repository Architecture And Verification Surface Cleanup
+
+Reviewed file: `issues/ad-hoc-repository-architecture-and-verification-surface-cleanup.md`
+Reviewer: Fable (Claude Fable 5)
+Verdict: **REQUEST CHANGES**
+
+The plan is close. The disposition tables were verified against the live repository and are accurate and complete where they exist: every one of the 55 tracked `scripts/` files has a disposition row, all `verification/` subtrees and loose root files are covered, the four `crates/sifr/tests/verification/` subdirectories match the crate-fixture table, the duplicate phase-27 numbering is real and handled, `internal_docs/verification/` contains exactly the seven files dispositioned, and the personal-path findings in `.cursor/skills/*` and `verification/distribution/common.sh` are confirmed. The area model, the profile vocabulary, the schema-subset rule, and the golden-as-case-kind normalization are all sound.
+
+Five blocking gaps remain. Four are sequencing/ownership holes that an implementation PR would hit mid-flight — exactly the "hidden unknowns" this phase is supposed to eliminate — and one is a contract inconsistency that makes an acceptance criterion unsatisfiable as written.
+
+## 1. Blocking issues
+
+### B1. Target Top-Level Contract omits `.gitignore` and `.gitmodules`
+
+Both are tracked, load-bearing top-level files today (`git ls-files` confirms), and the plan itself depends on both: the Cargo Lock PR edits `.gitignore`, and the Submodule Policy section requires `.gitmodules` correctness. But the contract block in "Target Top-Level Contract" lists neither, while the acceptance criterion says "Fresh clone top-level tree matches the top-level contract." As written, the criterion is unsatisfiable (or perversely demands deleting `.gitmodules` with nine live submodules).
+
+Fix: add `.gitignore` and `.gitmodules` to the contract block, and add a row for each to the "Tracked top-level entries discovered" table (`keep`; `.gitignore` is edited by the Cargo lock PR and the bytecode/editor-state guardrails).
+
+### B2. PR 7 removes the old validation manifest while the legacy facade still reads it
+
+`scripts/run_all_tests.sh` resolves all profile policy by `eval`-ing the output of `python3 scripts/validation_lane.py shell --profile <p>`, which reads `verification/validation_lanes/manifest.json` (verified live: it exports `RESOLVED_PROFILE`, budgets, `CONTRACT_SUITES`, `TOOLING_SUITES`, etc.). PR 7's validation says "old validation manifest removed", but the facade cutover is PR N+1 — many PRs later. Between PR 7 and PR N+1 nothing in the plan states what the still-legacy bash facade reads for profile policy. The script disposition row ("`validation_lane.py` … delete old names after PR 7") hints at the answer but never states it.
+
+Fix: make PR 7's scope explicit. Proposed wording for PR 7:
+
+> Scope: convert `verification/validation_lanes/manifest.json` into `verification/profiles/*.json`; rewrite the facade's profile resolution so `run_all_tests.sh` obtains its shell exports from the new profile files (via `uv run --project verification python -m sifr_verify profiles shell --profile <p>`); delete `scripts/validation_lane.py` and `scripts/validation_lane_report.py` in this PR, with report summarization moving to `sifr_verify` profile report handling. The facade's orchestration body remains legacy bash until PR N+1; only its policy source changes.
+
+(If report handling is too heavy for PR 7, keep `validation_lane_report.py` until PR N+1 — but then say so; the current "after PR 7" is exactly the ambiguity an implementer should not have to resolve.)
+
+### B3. Toolchain gates and repo guardrails have no owner in the end-state execution model
+
+The merge profile today runs, inside `run_all_tests.sh`: `cargo test` across ~12 crates (`run_crate_tests`), plus `run_core_guardrails` (file-size, HIR/driver maintainability, dependency direction, package-manager guardrails — all `scripts/check_*`). The end state requires: (a) `run_all_tests.sh` is "a thin profile dispatcher over `sifr_verify`"; (b) profiles "may not define … one-off shell commands"; (c) the boundary rule says guardrails are *not* verification and stay in `scripts/`; (d) the area table assigns no owner to Rust workspace unit tests, clippy, or fmt. These four constraints are jointly unsatisfiable: after cutover, either crate tests and guardrails silently fall out of the gates (violating the "No test coverage reduction" non-goal) or profiles smuggle them in as the shell commands they are forbidden to define.
+
+Fix: define the missing concept before PR 6, because the profile/area schemas depend on it. Recommended shape, consistent with the existing principles:
+
+- Add two runner-owned step kinds to the profile schema: `toolchain` steps (cargo test/clippy/fmt with declared crate scope, executed by `sifr_verify` itself) and `guardrail` steps (entries resolved from a committed registry such as `verification/policy/guardrails.json` that maps stable guardrail names to `scripts/` entrypoints). Profiles then select guardrail/toolchain step sets by name, the same way they select areas — they still never define raw shell.
+- Update the "Profile files may define" list to include "toolchain step selection" and "guardrail step selection", and add one sentence to the Scripts Cleanup boundary rule: "Guardrails remain implemented in `scripts/`, but are invoked by `sifr_verify` through the guardrail registry so the facade stays a thin dispatcher."
+
+A `workspace_toolchain` pseudo-area is the alternative, but it muddies "areas own fixtures"; the registry/step-kind shape is cleaner.
+
+### B4. uv has no bootstrap, version, or CI availability story
+
+`.github/workflows/local-first-validation.yml` runs only `bash scripts/run_all_tests.sh --profile …`; nothing installs uv. The plan mandates uv everywhere but never states: minimum uv version, `requires-python` pin in `verification/pyproject.toml`, how CI gets uv, or what a developer without uv sees. Given AGENTS.md's "CI mirrors these exact scripts — no CI-only behavior", the availability check must live in the repo, not the workflow.
+
+Fix: add to the Verification Architecture rules and PR 6 scope:
+
+- `verification/pyproject.toml` pins `requires-python` and the repo documents a minimum uv version in `verification/README.md`.
+- The facade fail-fasts with an actionable message when `uv` is missing or below the minimum ("install via `curl -LsSf https://astral.sh/uv/install.sh | sh` or `brew install uv`").
+- PR 6 updates `.github/workflows/local-first-validation.yml` to install the pinned uv version (the one permitted CI-only step is tool installation, which should be stated explicitly so it doesn't read as a violation of the no-CI-only-behavior rule).
+
+### B5. PR 4 deletes top-level `reviews/` while the review skill still writes there
+
+`.cursor/skills/talk-to-claude-opus/SKILL.md` writes review conversations to `${PWD_NOW}/reviews/<file>.md`. PR 3 deliberately avoids retargeting to not-yet-existing paths; PR 4 removes the top-level `reviews/` tree but its scope says nothing about the skill's output path; the Cursor retarget is PR 5. So between PR 4 and PR 5, every review run recreates the banned top-level `reviews/` tree — directly violating a PR 4 acceptance check through the normal workflow.
+
+Fix: PR 4 scope must include "create `plans/reviews/{active,archive}/` and retarget the `talk-to-claude-opus` output path to `plans/reviews/active/` in the same PR" (PR 4 thereby creates the first slice of `plans/`; note that in PR 5's description so the ordering reads intentionally). Relatedly, PR 3 should name the portability contract for this skill explicitly: the skill depends on the external `~/work/talk-to-claude` project, so "remove personal absolute paths" concretely means an environment variable such as `TALK_TO_CLAUDE_PROJECT` with a fail-fast message when unset — say so, or PR 3's author has to invent the contract.
+
+## 2. Non-blocking elegance improvements
+
+- **Duplicate disposition row.** `scripts/check_codegen_binary_size.sh` appears twice in the "Move into verification areas" list (once bundled with the perf scripts, once alone). Merge into the single standalone row.
+- **Migration-status table has no declared location.** PR 6 adds it but never says where it lives. Since it is process state, the cleanest home is a section inside this issue doc (which by then lives in `plans/issues/active/`). Name the location explicitly so area PRs know what file to update.
+- **The internal_docs durable-topic list contradicts the plan's own dispositions.** The "small set of durable topics" list omits `diagnostic_codes.md`, `hir_maintainability_guardrails.md`, `sifr_driver_maintainability_guardrails.md`, `tooling_analysis.md`, `tooling_reuse_strategy.md`, and `tooling_verification.md` — yet the typescript-go consolidation row names `tooling_analysis.md` and `tooling_verification.md` as kept consolidation targets, and the guardrail docs describe active conventions. Either complete the list or mark it "representative, not exhaustive; the PR 1 relevance audit is authoritative per file." Otherwise PR N+5 can read the list as a deletion mandate.
+- **`.claude/` is missing from the ignored-local table.** The table covers `.claude.log` but not the local `.claude/` directory, and `.gitignore` only covers `.claude/worktrees/*`. Add a `.claude/` row (delete-locally/keep-ignored) or extend the ignore rule.
+- **Pin the runner invocation and package layout.** `pyproject.toml` at `verification/` with the package at `verification/runner/sifr_verify/` requires explicit package-dir configuration. State the canonical command once (e.g. `uv run --project verification python -m sifr_verify --profile create-pr`) and the layout choice, so PR 6 doesn't bikeshed it.
+- **PR N+3 is nearly empty by construction.** Each area PR already requires "old verification script names deleted, not wrapped", so by PR N+3 little should remain. Re-scope it honestly as "sweep: prove no verification implementation remains in `scripts/` and add the guardrail enforcing it" or fold it into PR N+6.
+- **Say that area PRs edit the legacy facade.** `run_all_tests.sh` calls `verification/tooling/*.py` and `verification/performance/*.py` checks directly today, so each PR 8-N area migration necessarily edits the facade's dispatch in the same PR. Add one line to the PR 8-N validation list ("legacy facade dispatch updated atomically with moved paths") so it isn't discovered mid-PR.
+- **Plan for the Review Notes section's own afterlife.** Per the plan's review-artifact policy, when this issue moves to `plans/issues/completed/`, "Review Notes" should already be the concise-summary form (it nearly is; just keep it that way rather than appending per-pass logs).
+
+## 3. Vocabulary and folder-structure recommendations
+
+The vocabulary survives challenge; do not churn it. `areas` / `profiles` / `suites` / `cases` / `fixtures` / `baselines` / `corpora` / `policy` maps cleanly onto the reference compilers the plan cites: areas ≈ Rust's behavior-mode test families, baselines ≈ TypeScript's `tests/baselines/reference/`, suites ≈ lit-style area-local groupings, profiles ≈ CI tier selection — and `profiles` over `lanes` is unambiguously right given the public `--profile` flag and the compiler/SIMD meaning of "lane". The golden-as-case-kind normalization (no `golden/` ownership outside areas) is the correct shape and matches how TypeScript treats baselines as ordinary owned assets.
+
+Two specifics:
+
+- `data/` is the weakest term (it means "machine-readable inventories consumed by gates"). `inventories/` would be more self-describing, but the rename buys little and the schema description can carry the definition — keep `data/` and define it in `area.schema.json`.
+- The one structural addition I strongly recommend is the B3 concept: a named, schema-level home for toolchain and guardrail steps (runner-executed step kinds selected by profiles via a committed registry). That is a genuinely missing concept in the model, not vocabulary churn — without it the "thin facade" end state cannot honor the "no coverage reduction" non-goal.
+
+## 4. Verdict
+
+**REQUEST CHANGES.** All five blocking items are document-level fixes — none invalidates the architecture, the PR sequence skeleton, or the disposition tables, which are otherwise complete and verified against the live tree. Resolve B1–B5 (B3 is the only one requiring a real design decision, and it must land before PR 6 because the profile schema depends on it) and the phase is implementation-ready.

--- a/reviews/ad-hoc-repository-architecture-and-verification-surface-cleanup-fable-review-pass-4.md
+++ b/reviews/ad-hoc-repository-architecture-and-verification-surface-cleanup-fable-review-pass-4.md
@@ -1,0 +1,25 @@
+Both files read. Checking each pass-3 blocker against the updated issue doc:
+
+**B1 (top-level contract):** "Target Top-Level Contract" now lists `.gitignore` and `.gitmodules`, and the "Tracked top-level entries discovered" table has a `keep` row for each with the right rationale (lock/bytecode/editor-state edits; atomic submodule updates). Resolved.
+
+**B2 (PR 7 vs legacy facade):** PR 7 now has an explicit scope block: convert the lanes manifest to `verification/profiles/*.json`, rewrite facade profile resolution to `uv run --project verification python -m sifr_verify profiles shell --profile <p>`, move report summarization into `sifr_verify`, delete both `validation_lane*.py` scripts and the old manifest in the same PR, and keep the rest of the facade as legacy bash until PR N+1. The interregnum is fully specified. Resolved.
+
+**B3 (toolchain/guardrail ownership):** Verification Architecture defines runner-executed `toolchain` steps and `guardrail` steps backed by `verification/policy/guardrails.json`; the profile "may define" list adds both step-set selections; the Scripts Cleanup boundary rule gains the registry-invocation sentence; PR 6 scope includes defining the schema entries. This was the only real design decision and it landed in the recommended shape, before PR 6 where the schema needs it. Resolved.
+
+**B4 (uv bootstrap):** The canonical-invocation section now pins `requires-python` in `verification/pyproject.toml`, documents the minimum uv version in `verification/README.md`, requires the facade to fail-fast with an actionable message when uv is missing/old, and explicitly permits CI to install the pinned uv version while keeping test behavior identical. PR 6 scope carries all four. Resolved.
+
+**B5 (PR 4 vs review skill):** PR 4 now explicitly creates `plans/reviews/{active,archive}/` and retargets `talk-to-claude-opus` output before deleting root `reviews/`; PR 3 names the `TALK_TO_CLAUDE_PROJECT` environment variable with a fail-fast when unset. Resolved.
+
+The pass-3 non-blocking items were also swept: the duplicate `check_codegen_binary_size.sh` row is merged, the migration-status table has a declared home (this issue doc under `plans/issues/active/`), the durable internal-docs topic list is completed, `.claude/` is in the ignored-local table, the runner invocation and package layout are pinned, PR N+3 is re-scoped as a sweep+guardrail, and PR 8-N validation includes "legacy facade dispatch is updated atomically with moved paths."
+
+---
+
+## Verdict: **PASS**
+
+No remaining blockers. The five pass-3 gaps are all resolved at the exact points named, and I found no new hidden unknowns: every PR in the sequence now has a defined policy source, ownership target, and ordering rationale an implementer can execute without inventing contracts mid-flight.
+
+Non-blocking notes (minor, fix at will):
+
+1. **"Delete old names after PR 7" wording** — the script disposition row for `validation_lane.py`/`validation_lane_report.py` (Scripts Cleanup, "Move into verification areas" list) still says "delete old names after PR 7," while PR 7's scope deletes them *in* PR 7. PR 7's explicit scope governs, but changing the row to "deleted in PR 7" removes the last trace of the old ambiguity.
+2. **Toolchain step-name registry** — guardrail steps get a committed registry (`verification/policy/guardrails.json`), but toolchain steps are only "schema-defined names." Whether those names are runner-builtin enums or a small registry file is left to PR 6. It's a contained decision (enum in `profile.schema.json` is the obvious answer given the schema-subset rule), so it doesn't block, but one sentence would close it.
+3. The doc header still reads `status: draft`; flip it to ready/approved when this verdict is recorded so `plans/phases`-style status conventions stay honest.

--- a/reviews/ad-hoc-repository-architecture-and-verification-vocabulary-fable-review-pass-2.md
+++ b/reviews/ad-hoc-repository-architecture-and-verification-vocabulary-fable-review-pass-2.md
@@ -1,0 +1,94 @@
+The two prior vocabulary review passes never ran — both files contain only a model-selection error line, so this is effectively pass 1 and I'll review from scratch.
+
+# Verification Vocabulary Review — Decisive Findings
+
+## Verdict
+
+The conceptual architecture is right and should not be restructured. The vocabulary is 6/7 correct. **Rename `lanes` → `profiles`; keep everything else.** Patch the phase doc with the edits below before implementation — they are mechanical and cheap now, expensive after PR 6.
+
+## Q1 — Term-by-term assessment
+
+**`suites`, `cases`** — Universal. Every reference repo you sampled uses both. Keep.
+
+**`runner`** — Keep. It is literal (the directory holds the engine that runs things), and CPython's `libregrtest` — your closest structural analogue, a stdlib-only Python runner with resource policy — is called "the test runner" throughout CPython's docs. No reader will stumble.
+
+**`areas`** — Keep. This is less standard than suite/case but it is *not* invented vocabulary: rust-lang triages with `A-*` labels that literally mean "area," and "ownership area" reads naturally in review comments ("this fixture belongs to the diagnostics area"). The directory form `verification/areas/diagnostics/` is self-explanatory to a new contributor, which is the actual test.
+
+**`schemas`** — Keep. Plain and accurate.
+
+**`policy`** — Keep. Slightly unusual as a directory name, but the doc gives it a crisp contract (machine-facing operational rules) and no standard term does better. "config" would be worse — policy signals *rules*, not knobs.
+
+**`lanes`** — **Rename to `profiles`.** Two independent reasons, either sufficient:
+
+1. **You already shipped the word.** The single public validation facade is `scripts/run_all_tests.sh --profile create-pr` / `--profile merge`. The phase doc's own hygiene standard is one word per concept and no duplicate surfaces for the same gate — yet as written, a contributor types `--profile merge` and the runner reads `lanes/merge.json`. That is exactly the split-brain the phase exists to eliminate. Renaming the public flag instead is worse: the doc commits to the facade being the stable public contract.
+2. **"Lane" has a reserved meaning in compiler engineering.** In Rust, LLVM, and SIMD documentation generally, a *lane* is a vector lane. Sifr compiles to Rust; the day Sifr documents anything about vectorization or portable SIMD, "lane" will mean two unrelated things in the same repo. "Profile" has a mild collision with Cargo build profiles, but that overlap is semantically *aligned* (a named bundle of execution policy), whereas lane-vs-lane is a true homonym.
+
+## Q2/Q3 — Alternatives rejected
+
+- **`domains`** (for areas) — Rejected. More abstract, carries DNS/DDD baggage, and reads academic. "Which domain owns this fixture?" is worse English than "which area owns this fixture?" No reference repo uses it.
+- **`harness`** (for runner) — Rejected. Defensible (TypeScript uses it), but renaming buys nothing over `runner`, and "harness" vaguely connotes the *whole* apparatus including cases. `runner` names exactly what the directory contains: the engine.
+- **`specs`** (for schemas) — **Rejected hard.** In a compiler repository, "spec" means the language specification. A serious compiler repo must keep that word free. This alone disqualifies the `domains/profiles/suites/cases/harness/specs/policy` slate as a package.
+- **Rust-like `modes`** — Rejected as a top-level concept. In compiletest, a mode is an *execution strategy* (ui, run-make, incremental), orthogonal to ownership. Your areas are ownership domains. The doc already gets this right: "areas own suites by execution mode when useful" — mode is a suite-level attribute inside an area, not a taxonomy peer. Promoting it would create the competing-taxonomy problem the doc explicitly forbids.
+- **CPython-like `resources`** — Rejected as a top-level concept for the same reason. CPython's `-u network,largefile` resources are cost classes, and the doc already places resource classes exactly where they belong: inside profile policy. Correct as designed.
+
+## Q4 — Recommended final vocabulary and structure
+
+Top-level concepts (five, as the doc already insists): **`runner`, `schemas`, `profiles`, `areas`, `policy`.** Subordinate, area-local concepts: **`suites`, `cases`** (with `fixtures`, `baselines`, `corpora`, `data` as on-disk material kinds). The 5+2 split in the doc is correct — do not promote suites or cases to top level.
+
+```text
+verification/
+  README.md
+  policy/
+  schemas/
+    profile.schema.json
+    area.schema.json
+    suite.schema.json
+    case.schema.json
+    result.schema.json
+  profiles/
+    create-pr.json
+    merge.json
+    nightly.json
+    release.json
+  runner/
+    sifr_verify/
+      __main__.py
+      profiles.py
+      areas.py
+      scheduler.py
+      results.py
+      schemas.py
+  areas/
+    core_language/
+    ... (14 areas, unchanged)
+```
+
+The end-to-end story becomes one sentence with one vocabulary: *`run_all_tests.sh --profile create-pr` invokes `sifr_verify`, which loads `verification/profiles/create-pr.json`, which selects areas and suites, which own cases.* That sentence is the "serious compiler repo" test, and it now contains zero invented words.
+
+**Keep all 14 areas.** Areas cost one manifest each, the "subdirectories created only on first use" rule kills empty ceremony, and merging `algorithmic_compatibility` into `ecosystem_compatibility` would blur two genuinely different contracts (scored corpus projection vs. pinned non-blocking OSS signal). The `regression`-vs-contract-ownership tension is real but the doc already resolves it explicitly (minimized fixed bug → `regression`), matching Bun and LLVM practice.
+
+## Q5 — Precise doc edits
+
+Patch `issues/ad-hoc-repository-architecture-and-verification-surface-cleanup.md`:
+
+1. **Global rename**, lane → profile, in the verification sections only: `lanes/` → `profiles/`, `lane.schema.json` → `profile.schema.json`, `lanes.py` → `profiles.py`, "Lane files" → "Profile files", "Lane-local shape" → "Profile-local shape", "lane policy" → "profile policy", "thin lane dispatcher" → "thin profile dispatcher", "Verification Lane Normalization" (PR 7) → "Verification Profile Normalization", "lane-by-lane equivalence" → "profile-by-profile equivalence", and the Core Principles line "Lanes select verification areas; lanes do not own fixtures" → "Profiles select verification areas; profiles do not own fixtures."
+
+2. **Replace** the concept-definition bullet:
+   - Old: `` `lanes` answer when verification runs and with what resource budget. ``
+   - New: `` `profiles` answer when verification runs and with what resource budget. The name deliberately matches the public `--profile` flag of `scripts/run_all_tests.sh`; the flag value resolves directly to `verification/profiles/<name>.json`. ``
+
+3. **Add** under Verification Architecture rules (closes a real ambiguity — the doc currently uses "case" and "fixture" interchangeably in places):
+   > A case is the unit of verification: a manifest or suite entry plus the fixture files and expected outputs it references. A fixture is on-disk input material only; fixtures are never executed except as part of a case.
+
+4. **Add** a schema-strictness rule (without it, committed `.schema.json` files can silently drift beyond what the stdlib validator actually checks, and the schemas become false advertising):
+   > The runner must reject, with an error, any committed schema that uses keywords outside the supported subset. Silent ignoring of unsupported schema features is forbidden.
+
+5. **Add** an area-adapter boundary rule (prevents 14 areas growing 14 mini-frameworks — the one real over-engineering risk in this design):
+   > An area `runner.py` implements only the schema-defined adapter interface (discover, execute, report results for its cases). Scheduling, parallelism, retries, resource classes, and report generation belong exclusively to `sifr_verify`; area adapters may not implement their own.
+
+6. **Add** a naming-convention rule so the mixed casing reads as intentional rather than accidental:
+   > Profile names are kebab-case because they are CLI-facing (`--profile create-pr`). Area and suite names are snake_case because they are identifier-facing (directories, manifest keys, Python modules).
+
+**Tradeoff acknowledged for the rename:** "lane" arguably evokes parallel execution streams better than "profile," and Cargo also uses "profile" for build settings. Neither outweighs flag/vocabulary unification plus the SIMD-lane collision. If you reject the rename, the fallback is renaming the public flag to `--lane` — but that breaks the facade-stability commitment and every existing doc reference, so it's strictly worse.
+
+One housekeeping note: both `reviews/ad-hoc-repository-architecture-and-verification-vocabulary-fable-review-pass-{1,2}.md` contain only a model-error line ("There's an issue with the selected model (fable-high)…") — they're dead artifacts and should be deleted or replaced with this pass rather than archived.


### PR DESCRIPTION
## Summary

Adds an ad hoc issue plan for repository architecture and verification surface cleanup.

The plan defines the target top-level repository contract, planning/review artifact locations, verification area ownership, scripts cleanup, audit migration, internal docs cleanup, submodule policy, Cargo.lock policy, guardrails, proposed PR sequence, acceptance criteria, and risks.

## Impact

This is documentation-only planning work. It does not change compiler behavior, validation scripts, CI, or repository layout yet.

## Validation

- `git diff --cached --check`
- Full test suites intentionally not run because this PR only adds a Markdown planning document.
