### PR TITLE
[codex] Add serious build output planning notes

### DIFF
--- a/issues/ad-hoc-serious-build-output-and-phase-timings.md
+++ b/issues/ad-hoc-serious-build-output-and-phase-timings.md
@@ -1,0 +1,260 @@
+# Ad Hoc Phase: Serious Build Output and Phase Timings
+
+Status: planning
+Owner: unassigned
+Context: CLI polish phase for `sifr build` output, timing visibility, and compiler progress reporting
+
+## Problem
+
+`sifr build` currently succeeds with a single generic line:
+
+```text
+compiled successfully: ./sifr_output/target/release/sifr_output
+```
+
+That line is technically correct but undersells the compiler and gives users no useful sense of what happened. The adjacent `sifr trace` command already exposes deterministic compiler-service internals, but `trace` is debugging-oriented and too detailed for normal build feedback.
+
+The gap is not cosmetic color or icons. The gap is that build output does not communicate:
+
+- what input shape was built: single file, project, or package project
+- whether the compiler completed frontend semantic work before native compilation
+- which major build boundary failed when failures happen
+- how long meaningful phases took
+- where the final binary is and, when cheap to measure, how large it is
+
+This phase designs and implements a serious compiler-style build output contract: terse by default, explicit under `--verbose`, truthful to actual compiler boundaries, stable in non-interactive contexts, and compatible with existing diagnostic formats.
+
+## Current Implementation Facts
+
+- `sifr build` only accepts `<FILE>`, `-o/--output`, global `--config`, and global `--isolated`; there is no verbosity flag today.
+- `cmd_build` renders successful builds as `compiled successfully: {binary_path}` on stderr.
+- Build execution currently goes through `compile_entrypoint`, resolves single-file vs project mode, builds a rooted entrypoint plan, emits frontend diagnostics, converts the plan to a generated Rust binary project, materializes files, and runs `cargo build --release`.
+- Single-file builds parse one source and call `compile_single_frontend_module_with_source_and_options`.
+- Project and package-project builds parse an import closure and call `collect_project_hir_source_modules`.
+- Materialization writes `Cargo.toml`, `src/main.rs`, support modules, namespace modules, then invokes Cargo.
+- `sifr trace` already owns detailed compiler-service trace vocabulary such as parse, lower, type_check, ownership, and flow; normal build output should not duplicate that full debugging surface.
+
+## Design Principles
+
+- **Truth over theater.** Output names must correspond to measured implementation boundaries, not aspirational compiler phases.
+- **Quiet default.** Successful default output should remain short enough for scripts and normal terminal use.
+- **Useful verbosity.** Verbose output should explain major work boundaries and durations without becoming a trace dump.
+- **Diagnostics stay canonical.** Human build progress must not pollute JSON or compact diagnostic output.
+- **TTY-aware presentation.** Color and alignment are allowed only when appropriate; output must remain readable with color disabled and when redirected.
+- **No symbolic status gimmicks.** Use words such as `Compiling`, `Analyzing`, `Generating`, `Building`, `Finished`, `Binary`, `error`, and `warning`, not emoji or decorative glyphs.
+- **Failure-first quality.** Each phase boundary must produce useful context on failure without hiding the existing diagnostic renderer or Cargo stderr.
+
+## Output Streams and Machine Formats
+
+- Human progress lines are emitted to stderr only. Stdout remains reserved for command surfaces that intentionally print program output, generated code, or machine-readable content.
+- When `--diagnostic-format` is `json` or `compact`, no human progress lines are emitted on either stream, regardless of `--verbose`. Only diagnostics flow through the diagnostic renderer.
+- Human progress text is not a stable public API. Scripts must use `--diagnostic-format=json` or `--diagnostic-format=compact` and parse the structured diagnostic stream instead of grepping `Finished`, `Binary`, or phase labels.
+- If color is added, it is enabled only when stderr is a terminal and `NO_COLOR` is not set. Non-TTY output has no ANSI sequences.
+- If paths contain whitespace, render them with stable shell-style quoting in human output.
+
+## Proposed User-Facing Contract
+
+Default successful build:
+
+```text
+   Compiling main.sifr
+    Finished release build in 42 ms
+     Binary: ./main
+```
+
+Verbose successful build:
+
+```text
+sifr v0.1.0
+input:  main.sifr
+mode:   project
+target: release native
+
+   Loading Sifr standard library          8 ms
+   Parsing import closure (4 modules)     3 ms
+   Analyzing types, ownership, and flow   12 ms
+   Generating Rust project                4 ms
+   Materializing Cargo project            1 ms
+   Building release binary                26 ms
+
+Finished release build in 54 ms
+Binary: ./main
+Size:   1.4 MB
+```
+
+When the compiler can cheaply report module counts, prefer count-aware labels:
+
+```text
+   Parsing import closure (4 modules)
+   Analyzing 4 modules
+```
+
+For normal output, do not claim detailed sub-phases unless they are separately instrumented. `Analyzing types, ownership, and flow` is acceptable as one frontend semantic boundary only when the timer covers that combined semantic stage. Splitting it into `Checked types`, `Resolved lifetimes`, and `Verified ownership` is not acceptable until those timings are measured independently.
+
+## Decisions
+
+- The flag is `--verbose`. Do not add a separate `--timings` flag in this phase; verbose mode shows timings.
+- Default successful `sifr build` output includes `Compiling <path>`, `Finished release build in <duration>`, and `Binary: <path>`.
+- Human progress is stderr-only. Stdout is untouched by `sifr build` success rendering.
+- Binary size appears only in `--verbose`, and only when readable. A size read failure must not fail or warn after a successful build.
+- In `--diagnostic-format=json` and `--diagnostic-format=compact`, successful builds emit no human progress lines.
+- `sifr run` prints build progress only on cache miss, suppresses the final `Binary:` line because program output follows, and prints no build progress on cache hit.
+- Cache hits in `sifr build` print a concise cached success form: `Finished release build in <duration> (cached)` plus `Binary: <path>`. The duration is the current command's cache lookup and reporting time, not a stored historical compile time.
+- Non-verbose native builds pass `--quiet` to Cargo so Cargo progress does not collide with Sifr progress. Verbose native builds do not pass `--quiet`.
+
+## Scope
+
+This phase owns:
+
+- adding the explicit `--verbose` build output mode
+- introducing a build progress/timing data model in the driver or CLI boundary
+- reporting elapsed time for major build stages
+- reporting build mode and target shape in verbose output
+- reporting binary path in all success modes
+- reporting binary size in verbose mode when the final binary exists and metadata is cheap to read
+- preserving current diagnostic behavior for errors and warnings
+- documenting output stability rules for scripts and snapshots
+
+This phase does not own:
+
+- changing generated Rust semantics
+- changing release/debug compilation policy beyond labeling the current release build accurately
+- replacing `sifr trace`
+- exposing compiler-service trace internals in normal build output
+- changing package manager behavior
+- hiding Cargo errors or rewriting rustc diagnostics
+- implementing a general telemetry framework
+
+## Implementation Plan
+
+### Wave 0: Output Contract Lock
+
+- Add tests that capture the intended default success output shape.
+- Add tests for `--verbose` help text.
+- Add accepted fixture baselines for default success, verbose success, JSON-format success with no progress text, compact-format success with no progress text, and cache-hit success.
+- Add the scripting-stability statement to user-facing CLI docs.
+- Record the `sifr run` cache-hit and cache-miss output contract before touching shared build paths.
+
+Exit criteria:
+
+- The accepted text contract is present in tests or fixture baselines.
+- The flag, stream, machine-format, cache, and `sifr run` policies are documented in this issue before implementation proceeds.
+
+### Wave 1: Build Stage Instrumentation
+
+- Introduce a small `BuildReport` / `BuildStageReport` data model in the driver that records:
+  - entrypoint path
+  - compilation mode: single-file, project, package-project
+  - target profile: currently release native
+  - binary path
+  - optional binary size
+  - total elapsed time
+  - stage elapsed times
+- Instrument real boundaries:
+  - stdlib load/compile
+  - source parsing/import closure, split from semantic analysis when project mode currently bundles the work too tightly
+  - frontend semantic checking and HIR/flow production
+  - Rust project generation
+  - Cargo project materialization
+  - native Cargo build
+- Avoid micro-phase claims unless the implementation times them directly.
+
+Exit criteria:
+
+- Build code returns the same binary path as before.
+- Timing collection can be disabled or ignored without changing build semantics.
+- Internal stage names are stable enough for tests but not overexposed as public API unless explicitly documented.
+
+### Wave 2: CLI Rendering
+
+- Replace the existing `compiled successfully: ...` success line with the new default output.
+- In default mode, right-align the leading verbs in the Cargo style used by the accepted fixture.
+- Add verbose rendering with aligned text in human mode: left-align labels, right-align durations, and compute spacing from the longest label.
+- Keep JSON and compact diagnostic modes free of human progress decorations.
+- Make color TTY-aware and respect `NO_COLOR` if color is added.
+- Ensure output remains readable without color.
+- Pass `--quiet` to Cargo in non-verbose native builds, while preserving Cargo/rustc error output.
+
+Exit criteria:
+
+- Default output is concise.
+- Verbose output is phase-aware and measurable.
+- Non-human diagnostic formats remain parseable and unaffected by progress banners.
+
+### Wave 3: Failure Surface Hardening
+
+- Verify frontend diagnostics still render exactly through the diagnostic renderer.
+- Verify Cargo failure output still includes actionable Cargo/rustc stderr.
+- Verify Cargo failure output does not gain a redundant `Finished` or `Binary` footer and does not double-render an error summary already present in diagnostics.
+- Add tests for failures at:
+  - invalid input path or entrypoint resolution
+  - frontend diagnostic failure
+  - project materialization failure where feasible
+  - Cargo build failure where feasible
+- Ensure failed builds do not print a misleading final `Finished` or `Binary` line.
+
+Exit criteria:
+
+- Every failure boundary has either existing diagnostics or a targeted build-stage context line.
+- No failure path double-renders diagnostics.
+- Exit codes remain compatible with the current CLI contract.
+
+## Preferred Text Vocabulary
+
+Use:
+
+- `Compiling <path>`
+- `Loading Sifr standard library`
+- `Parsing import closure`
+- `Analyzing types, ownership, and flow`
+- `Generating Rust project`
+- `Materializing Cargo project`
+- `Building release binary`
+- `Finished release build in <duration>`
+- `Binary: <path>`
+- `Size: <size>`
+
+Avoid:
+
+- `optimized Rust source`, unless Sifr itself adds and measures an optimization pass
+- `resolved lifetimes`, unless the compiler exposes that as a real separately measured pass
+- `executed native compilation`, because it is less clear than `Building release binary`
+- `Compiling` for the native build step, because Cargo also uses `Compiling` for generated crates
+- emoji, symbolic checkmarks, and decorative glyphs
+- trace-internal labels in ordinary build output
+- mixed unit styles such as `42ms` beside `1.4 MB`; use `42 ms` and `1.4 MB`
+
+## Testing and Validation
+
+Minimum focused validation for implementation PRs:
+
+```bash
+cargo test -p sifr build_output
+cargo run -q -p sifr -- build demos/own_mut_appends/main.sifr
+cargo run -q -p sifr -- build --verbose demos/own_mut_appends/main.sifr
+cargo run -q -p sifr -- --diagnostic-format json build demos/own_mut_appends/main.sifr
+cargo run -q -p sifr -- --diagnostic-format compact build demos/own_mut_appends/main.sifr
+cargo run -q -p sifr -- run demos/own_mut_appends/main.sifr
+cargo run -q -p sifr -- build --verbose demos/own_mut_appends/main.sifr 2>&1 | cat
+NO_COLOR=1 cargo run -q -p sifr -- build --verbose demos/own_mut_appends/main.sifr
+cargo run -q -p sifr -- trace demos/own_mut_appends/main.sifr
+python3 scripts/check_hir_maintainability_guardrails.py
+cargo fmt --check
+```
+
+Authoritative pre-PR gate remains:
+
+```bash
+scripts/run_all_tests.sh --profile create-pr
+```
+
+Merge gate remains:
+
+```bash
+scripts/run_all_tests.sh
+```
+
+## Review Log
+
+- Claude Opus planning review pass 1: requested measured-boundary wording, explicit machine-format suppression, `sifr run` and cache-hit decisions, verbose-only best-effort binary size, Cargo `--quiet` policy, and unit-style cleanup.
+- Claude Opus planning review pass 2: implementation-ready; only minor wording polish requested for default alignment, verbose Cargo quiet policy, and cached duration semantics.

--- a/reviews/ad-hoc-serious-build-output-and-phase-timings-claude-review-pass-1.md
+++ b/reviews/ad-hoc-serious-build-output-and-phase-timings-claude-review-pass-1.md
@@ -1,0 +1,145 @@
+Here is the structured planning review. I have not modified any files.
+
+# Review: Serious Build Output and Phase Timings
+
+**Verdict:** Approve with revisions. The phase is well-shaped, the vocabulary is honest, and the scope/anti-scope split is clean. Three issues need to be fixed before implementation: (1) the verbose breakdown promises a `Checking types, ownership, and flow` timing that the driver cannot independently measure today, (2) the contract is silent on stdout vs stderr and `--diagnostic-format json|compact` even though the success line currently bypasses the renderer, and (3) `sifr run` is left as an open question even though it shares the exact same build path and will visibly inherit the new output. A handful of smaller tightening edits below.
+
+## 1. Truthfulness and elegance of wording
+
+**Strengths.** `Compiling`, `Finished`, `Binary`, `Loading Sifr standard library`, `Generating Rust project`, `Building release binary` are all real boundaries in the current driver (`RootedEntrypointPlan::from_entrypoint` in `crates/sifr_driver/src/build/entrypoint.rs`, plus materialization and `cargo build --release`). The "Preferred Text Vocabulary" / "Avoid" section is the strongest part of the issue — it directly heads off the most common failure mode (aspirational phase names).
+
+**Problem — `Checking types, ownership, and flow` is not a real boundary today.** Frontend lowering, typecheck, ownership, and flow are all bundled inside `collect_project_hir_source_modules` (and the single-file equivalent). The issue tries to defend itself with "Splitting into `Checked types`, `Resolved lifetimes`… is not acceptable until those timings are measured independently" — but the *combined* label is also a claim, and it is mixed in with `Parsing source modules` which today is *also* inside the same call for the project path. Either:
+
+  - Coalesce parsing+frontend into one line, e.g. `Analyzing 4 modules` or `Checking 4 modules`, until parsing is split out at the driver boundary, **or**
+  - Add a Wave 1 subtask that explicitly splits the parse step from the lower/typecheck/ownership/flow step so the two lines reflect reality.
+
+Pick one and commit. Right now the verbose example implies two timings that share a single timer.
+
+**Minor wording polish:**
+- `Finished release build in 42ms` reads slightly awkward. Cargo says `Finished \`release\` profile [optimized]`. I'd use `Finished release build (53ms)` or `Finished release build in 53 ms` (space before unit per SI; Cargo does this too).
+- `Binary ./main` is fine, but `Binary: ./main` (with colon, as in the verbose block) reads better and matches the other key-value lines. Pick one style for both default and verbose so the default isn't a one-off.
+- "Size" without a colon in the vocabulary list but `Size:   1.4 MB` in the example. Same colon-or-not decision needed.
+
+## 2. Phase scope — implementation-ready?
+
+Scope split is good. One overreach and one underreach:
+
+**Overreach — binary size.** "Reporting binary size when the final binary exists and metadata is cheap to read" sounds cheap but `std::fs::metadata` after `cargo build --release` is racy on some filesystems and on package builds the artifact isn't always where the driver thinks (it's resolved through `cargo metadata`/target dir). Move binary size to verbose-only and make it tolerant of "size unavailable" — do not let a size read failure regress the success path. The "Open Decisions" item already hints at this; resolve it as **verbose only, best-effort, omit on error**.
+
+**Underreach — `sifr run`.** `cmd_run_file` and the package equivalent go through the exact same `build_cached_*_binary` driver functions. That means the new output appears in `sifr run` automatically. The Open Decisions question "Should `sifr run` reuse the same build report?" is really three questions:
+
+  - Does `sifr run` print the build report at all? (If not, you need to *suppress* it, which is a new requirement.)
+  - If yes, does it print on cache hit, or only on cache miss?
+  - Does it print the `Finished` / `Binary` footer when the user's intent is "run", or only `Compiling` while building and then nothing?
+
+Decide this in Wave 0 alongside the flag policy, not as an open decision. A reasonable default: `sifr run` shows progress only when it actually compiles (cache miss), suppresses the final `Binary` line (since the program output follows immediately), and never shows it on cache hit.
+
+## 3. Implementation waves and validation gates
+
+The waves are reasonable but a few gates are thin.
+
+**Wave 0 gap — output-stream contract.** The wave mentions deciding "stderr only vs split between stderr and stdout" and "the contract for `--diagnostic-format=json` and `--diagnostic-format=compact`," but the *current* implementation prints `compiled successfully` directly to stderr without going through `render_diagnostics`. That means today, JSON consumers piping `--diagnostic-format json` already get a stray human line on stderr. The new contract should *explicitly fix this regression* rather than preserve it. Recommend:
+
+  - In `--diagnostic-format=json` or `--diagnostic-format=compact`, **suppress all human progress lines entirely** on both streams, regardless of `--verbose`. The flag is the user saying "I am a machine consumer."
+  - Add a Wave 0 acceptance test: `sifr build --diagnostic-format json demos/own_mut_appends/main.sifr 2>/tmp/err >/tmp/out` → `/tmp/err` contains only valid JSON (or is empty if no diagnostics), `/tmp/out` is empty.
+
+**Wave 1 gap — timer model and lock-step with vocabulary.** "Avoid micro-phase claims unless the implementation times them directly" is the right principle but the wave doesn't say *how* timing is recorded. A small concrete subtask: introduce a `PhaseTimer`/`PhaseReport` in `sifr_driver` that the existing `RootedEntrypointPlan::from_entrypoint` updates at the four real boundaries (stdlib, parse closure, frontend, codegen) plus materialization and Cargo. The CLI renders from that report. Without this, Wave 2 implementers will reach into the driver ad-hoc.
+
+**Wave 2 gap — alignment math.** "Aligned text in human mode" is doing a lot of work. State the rule: right-align durations, left-align labels, fixed gap, computed from the longest label. Otherwise reviewers will argue about it in PR.
+
+**Wave 3 gap — failure not double-rendered.** Good gate, but missing a concrete case: when `cargo build` fails, what does Sifr print after Cargo's stderr? Today nothing, because we abort before `compiled successfully`. After the change, ensure there is no `Finished` / `Binary` epilogue and that we don't add a redundant `error: cargo build failed` on top of Cargo's existing message. Add an explicit test for this.
+
+**Validation list — missing items.**
+- Add a test/check for the `NO_COLOR` env var path (Wave 2 says "respect `NO_COLOR` if color is added" but `if` should be "yes" if any color is added at all; otherwise drop color from the contract).
+- Add `cargo run -q -p sifr -- build --verbose demos/own_mut_appends/main.sifr 2>&1 | cat` to confirm output is sane when stderr is redirected (no ANSI residue, no progress spinner).
+- Add `sifr run` to the validation list since it inherits this output.
+- Add a Cargo-failure fixture (e.g., a demo crafted to trigger codegen of code that rustc rejects) so the failure surface is tested end-to-end, not just in unit tests.
+
+## 4. Cross-cutting concerns the issue under-addresses
+
+**TTY/color.** "Color and alignment are allowed only when appropriate" is vague. Recommended explicit rule: detect `stderr.is_terminal()`; if `NO_COLOR` is set or stderr is not a TTY, emit no ANSI. If colors are used, color only the leading verb (`Compiling`, `Finished`, `Binary`), Cargo-style — never the path or duration.
+
+**Scripting stability.** The issue says "stable in non-interactive contexts" but does not commit to a stability promise. Recommend wording: *"Human progress output is best-effort and may change between versions. Scripts must use `--diagnostic-format=json|compact` and parse the structured stream; do not grep `Finished` or `Binary`."* Otherwise you will be locked into the text forever after the first user pipeline.
+
+**Cargo interop.** Two real concerns the issue misses:
+
+  - **Cargo already prints `Compiling sifr_output v0.1.0`.** If we don't suppress Cargo's progress (we shouldn't), the user sees Sifr's `Compiling main.sifr` and Cargo's `Compiling sifr_output v0.1.0` interleaved on stderr. Decide: pass `--quiet` to `cargo build --release` by default in non-verbose mode (Cargo still prints errors with `--quiet`), and drop `--quiet` in `--verbose`. Document this in Wave 2.
+  - **Cache hits.** When the cached binary is reused (no rebuild), what does the output look like? Today `compiled successfully:` still prints. Under the new contract, do we still print `Compiling main.sifr`+`Finished release build` for a no-op? Better: print only `Finished` with a duration near zero (or a `(cached)` suffix). Add to Open Decisions or, better, decide now.
+
+**Diagnostic-format JSON.** Already covered above — promote it from "record the contract" to "machine-format suppresses human progress, full stop."
+
+**Path quoting.** `Binary ./main` is fine until the binary path contains spaces. Decide whether to quote (`Binary "./My App"`) — recommend yes when the path contains whitespace, never otherwise.
+
+## 5. Concrete edits to the issue text
+
+Below are the most useful targeted replacements. I have not applied them — only proposed.
+
+**Replace the second verbose-output block (lines 65–74)** with a version that reflects current driver granularity:
+
+```text
+sifr v0.1.0
+input:  main.sifr
+mode:   project
+target: release native
+
+   Loading Sifr standard library          8 ms
+   Parsing import closure (4 modules)     3 ms
+   Analyzing types, ownership, and flow   12 ms
+   Generating Rust project                4 ms
+   Materializing Cargo project            1 ms
+   Building release binary                26 ms
+
+Finished release build in 54 ms
+Binary: ./main
+Size:   1.4 MB
+```
+
+Rationale: matches the six measurable boundaries in `RootedEntrypointPlan::from_entrypoint` + materialize + cargo, swaps the misleading `Parsing source modules` for the actual `parse_import_closure_source_modules` boundary, uses `Analyzing` instead of `Checking` to avoid colliding with Cargo's `Checking` (which means `cargo check`).
+
+**Add a new subsection after "Design Principles"** named **"Output Streams and Machine Formats"**:
+
+> - Human progress lines are emitted to stderr only. Stdout is reserved for machine-readable surfaces.
+> - When `--diagnostic-format` is `json` or `compact`, no human progress lines are emitted on either stream regardless of `--verbose`. Only diagnostics flow through the renderer.
+> - Human progress text is not a stable public API. Scripts must consume `--diagnostic-format=json|compact`. This stability rule is documented in the user-facing CLI docs.
+
+**Replace the "Open Decisions" section** with concrete decisions:
+
+> ## Decisions
+> - Flag is `--verbose` (single flag). `--timings` is not added; verbose mode already shows timings.
+> - Default output includes `Compiling <path>`, `Finished …`, and `Binary …`. Three lines, all on stderr.
+> - Successful build progress is stderr-only. Stdout is untouched.
+> - Binary size appears only in `--verbose`, and only when readable; missing size is silently omitted.
+> - `sifr run` prints `Compiling <path>` on cache miss only, suppresses the final `Binary` line (program output follows immediately), and prints nothing on cache hit.
+> - Cache hits in `sifr build` print a single `Finished release build (cached)` line and the `Binary` line; no `Compiling` line.
+> - In non-verbose mode the driver passes `--quiet` to `cargo build --release`; in verbose mode it does not.
+
+**Tighten Wave 0 exit criteria** to:
+
+> - Wave 0 PR includes accepted fixture baselines for: default success, verbose success, JSON-format build (no progress text on either stream), compact-format build (same), and cache-hit success.
+> - Stability statement is added to the user-facing `sifr build` CLI docs in the same PR.
+
+**Add to Wave 3** an explicit failure-output rule:
+
+> - On Cargo failure, Sifr emits no additional summary line and no `Finished` / `Binary` footer; Cargo's stderr is passed through unchanged. A single Sifr line of context is allowed only when it points to the failing phase (e.g., `error: failed during: Generating Rust project`) and is not duplicated by an existing diagnostic.
+
+**Append to "Avoid" list:**
+
+> - `Compiling` for the native build step — that label belongs to the Sifr source step, since Cargo also prints `Compiling` for the generated crate and we should not collide.
+> - Mixed unit styles (`42ms` vs `1.4 MB`). Use SI: `42 ms`, `1.4 MB`, space between number and unit.
+
+## Findings summary
+
+| # | Severity | Finding |
+|---|----------|---------|
+| 1 | **Must-fix** | `Checking types, ownership, and flow` and `Parsing source modules` cannot both be timed independently today. Either split the driver boundary or coalesce the labels. |
+| 2 | **Must-fix** | `--diagnostic-format=json\|compact` interaction is left as "to be recorded"; today the success line leaks plain text into JSON consumers. Specify: machine formats suppress all human progress. |
+| 3 | **Must-fix** | `sifr run` shares the build path verbatim. Decide and document its output behavior in Wave 0, not as an open decision. |
+| 4 | Should-fix | Cargo's own `Compiling sifr_output` will appear alongside Sifr's progress. Pass `cargo build --quiet` by default; drop in `--verbose`. |
+| 5 | Should-fix | Cache-hit behavior is undefined for both `sifr build` and `sifr run`. Specify a `(cached)` variant. |
+| 6 | Should-fix | Binary size read is best-effort and verbose-only; cannot regress the success path on read failure. |
+| 7 | Should-fix | Add stability disclaimer: human progress is not a stable API; scripts use `--diagnostic-format`. |
+| 8 | Nit | Inconsistent punctuation: `Binary ./main` vs `Binary: ./main`; `42ms` vs `1.4 MB`. Pick one and apply everywhere. |
+| 9 | Nit | "Aligned text" needs a stated rule (right-align durations, computed gap). |
+| 10 | Nit | Wave 1 should name a concrete `PhaseReport` struct in `sifr_driver` so the CLI doesn't reach into private internals. |
+
+Net assessment: the issue is one revision pass away from being implementation-ready. The current text is already markedly better than the existing `compiled successfully:` line and the design principles section is genuinely good — just needs the three must-fix items resolved and the open-decisions list converted into actual decisions before Wave 0 starts.

--- a/reviews/ad-hoc-serious-build-output-and-phase-timings-claude-review-pass-2.md
+++ b/reviews/ad-hoc-serious-build-output-and-phase-timings-claude-review-pass-2.md
@@ -1,0 +1,37 @@
+I read the revised issue and the pass-1 review. Going through each pass-1 item against the current text:
+
+## Pass-1 items resolved
+
+1. **Measured-boundary wording (Must-fix #1)** — Resolved. Verbose example now uses `Parsing import closure (4 modules)` + `Analyzing types, ownership, and flow`, and Wave 1 explicitly commits to splitting parsing from semantic analysis at the driver boundary (`crates/sifr_driver` work). The "acceptable as one frontend semantic boundary only when the timer covers that combined semantic stage" gate is the right shape.
+
+2. **Machine-format suppression (Must-fix #2)** — Resolved in the "Output Streams and Machine Formats" subsection: no human progress on either stream when `--diagnostic-format` is `json` or `compact`, regardless of `--verbose`. Wave 0 fixtures explicitly include this.
+
+3. **`sifr run` decision (Must-fix #3)** — Resolved in `Decisions`: progress on cache miss only, no `Binary:` footer, nothing on cache hit. Recorded in Wave 0 before touching shared paths.
+
+4. **Cargo `--quiet` (Should #4)** — Resolved in `Decisions` and Wave 2.
+
+5. **Cache-hit behavior (Should #5)** — Resolved in `Decisions`: `Finished release build in <duration> (cached)` + `Binary: <path>`, no `Compiling` line. `sifr run` cache hit prints nothing.
+
+6. **Verbose-only best-effort size (Should #6)** — Resolved in `Decisions` and Scope: size is verbose-only, omitted on read failure, never warns after a successful build.
+
+7. **Stability disclaimer (Should #7)** — Resolved: "Human progress text is not a stable public API…", with Wave 0 requiring it in CLI docs.
+
+8. **Punctuation/units (Nit #8)** — Resolved: `Binary:` and `Size:` both use colons throughout; SI spacing (`42 ms`, `1.4 MB`) is in the Avoid list.
+
+9. **Alignment math (Nit #9)** — Resolved for verbose: "left-align labels, right-align durations, compute spacing from the longest label" in Wave 2.
+
+10. **PhaseReport struct (Nit #10)** — Resolved: Wave 1 names `BuildReport` / `BuildStageReport`.
+
+## Remaining (non-blocking) wording observations
+
+- **Wave 2 alignment rule covers verbose only.** The default example uses Cargo-style *right-aligned verbs* (`   Compiling`, `    Finished`, `     Binary:` — padded to 12 chars). The stated Wave 2 rule ("left-align labels, right-align durations") describes the verbose block but doesn't say how the default's leading-verb indent is computed. A one-line addendum like "In default mode, leading verbs are right-aligned to the longest verb (Cargo-style)" would close the ambiguity. Not a blocker; reviewers can pin it down in the PR.
+
+- **Verbose Cargo policy uses soft "may".** `Decisions` says "Verbose mode may allow Cargo progress through." Given Pass 1's intent ("drop `--quiet` in `--verbose`"), tightening to "does not pass `--quiet`" removes interpretive room. Minor.
+
+- **Cached `<duration>` semantics.** "`Finished release build in <duration> (cached)`" is unambiguous if `<duration>` is the wall-clock of the command (cache check + I/O). If it's intended to be the *original* compile duration, that needs storing in cache metadata. Worth a half-sentence clarification, but not blocking — implementer will pick the obvious wall-clock reading.
+
+- **Verbose header punctuation.** The verbose top block has `sifr v0.1.0` (no colon) above `input: / mode: / target:` (with colons). Minor visual inconsistency; either drop the header entry or render it as `sifr:   v0.1.0`. Cosmetic.
+
+## Verdict
+
+**Implementation-ready.** All three must-fixes and all four should-fixes from pass 1 are resolved with concrete decisions, not deferred. The remaining items above are wording polish that an implementer can settle in the Wave 0 fixtures PR; none of them change the design, scope, or measured-boundary contract. Proceed to Wave 0.


### PR DESCRIPTION
## Summary

Adds an ad hoc planning issue for serious `sifr build` output and phase timing behavior.

Includes two Claude review notes documenting the initial design review and follow-up readiness check.

## Impact

Documentation-only planning work. No compiler, CLI, CI, or validation behavior changes are included.

## Validation

- `git diff --cached --check`
- Full test suites intentionally not run because this PR only adds Markdown planning/review files.
