### PR TITLE
build: add verification runner foundation

### DIFF
--- a/.github/workflows/local-first-validation.yml
+++ b/.github/workflows/local-first-validation.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  SIFR_MIN_UV_VERSION: "0.9.28"
+
 jobs:
   lint-and-format:
     name: lint-and-format
@@ -34,6 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.SIFR_MIN_UV_VERSION }}
       - name: Run local-first profile
         run: bash scripts/run_all_tests.sh --profile "${{ matrix.profile }}"
 

--- a/plans/issues/active/ad-hoc-repository-architecture-and-verification-surface-cleanup.md
+++ b/plans/issues/active/ad-hoc-repository-architecture-and-verification-surface-cleanup.md
@@ -189,7 +189,33 @@ Long review transcripts may be retained under `plans/reviews/archive/` when they
 | PR 2 Cargo Lock Policy | Merged | <https://github.com/sifr-lang/sifr/pull/2507> |
 | PR 3 Cursor Portability Cleanup | Merged | <https://github.com/sifr-lang/sifr/pull/2508> |
 | PR 4 Review Tree Normalization | Merged | <https://github.com/sifr-lang/sifr/pull/2509> |
-| PR 5 Planning Tree Normalization | In progress | This branch |
+| PR 5 Planning Tree Normalization | Merged | <https://github.com/sifr-lang/sifr/pull/2510> |
+| PR 6 Verification Runner Foundation | In progress | This branch |
+
+## Verification Migration Status
+
+This table is the required source of truth while legacy validation surfaces and
+the new `sifr_verify` runner coexist. `scripts/run_all_tests.sh` remains the
+authoritative public facade until the facade cutover PR.
+
+| Area | Legacy path | New area path | Current authoritative gate | Equivalence evidence | Cutover status |
+| --- | --- | --- | --- | --- | --- |
+| Runner foundation | `scripts/run_all_tests.sh`, `scripts/validation_lane.py`, `scripts/validation_lane_report.py` | `verification/runner/sifr_verify/`, `verification/schemas/`, `verification/policy/`, `verification/pyproject.toml`, `verification/uv.lock` | Legacy facade plus new runner foundation self-tests | `uv lock --project verification --check`; `uv run --project verification --locked python -m sifr_verify --self-test`; `scripts/run_all_tests.sh --profile create-pr` | Foundation introduced; no legacy runner behavior migrated |
+| Profiles | `verification/validation_lanes/manifest.json`, `verification/validation_lanes/*_e2e_manifest.json` | `verification/profiles/*.json` | Legacy lane manifest | Pending PR 7 profile schema validation and shell-export equivalence | Not started |
+| `diagnostics` | `verification/suites/manifest.json`, diagnostic guardrail scripts, `crates/sifr/tests/verification/diagnostics/` | `verification/areas/diagnostics/` | Legacy facade and hardening scripts | Pending area migration PR | Not started |
+| `project_workspace` | `verification/suites/manifest.json`, project contract matrix, `crates/sifr/tests/verification/project/` | `verification/areas/project_workspace/` | Legacy facade and contract matrix | Pending area migration PR | Not started |
+| `core_language` | `scripts/run_e2e_pass.sh`, `verification/validation_lanes/*_e2e_manifest.json`, core contract rows | `verification/areas/core_language/` | Legacy e2e runner and contract matrix | Pending area migration PR | Not started |
+| `regression` | `verification/fixedbugs/index.json`, `verification/crashes/index.json` | `verification/areas/regression/` | Legacy hardening runner | Pending area migration PR | Not started |
+| `fuzz_property` | `verification/fuzz_property/`, `scripts/run_smoke_fuzz_property.sh` | `verification/areas/fuzz_property/` | Legacy smoke/property scripts | Pending area migration PR | Not started |
+| `generated_code_quality` | `verification/generated_code_quality/` | `verification/areas/generated_code_quality/` | Legacy generated-code shell helpers | Pending area migration PR | Not started |
+| `performance` | `verification/performance/`, `verification/perf/`, performance scripts | `verification/areas/performance/` | Legacy performance budget scripts | Pending area migration PR | Not started |
+| `developer_tooling` | `verification/tooling/`, LSP corpus submodule | `verification/areas/developer_tooling/` | Legacy tooling scripts | Pending area migration PR | Not started |
+| `runtime_platform` | `verification/platform/`, `scripts/run_platform_golden.sh` | `verification/areas/runtime_platform/` | Legacy platform golden runner | Pending area migration PR | Not started |
+| `distribution_release` | `verification/distribution/`, `scripts/run_distribution_validation.sh` | `verification/areas/distribution_release/` | Legacy distribution validation script | Pending area migration PR | Not started |
+| `package_management` | `verification/package_management/` | `verification/areas/package_management/` | Legacy package guardrails and facade | Pending area migration PR | Not started |
+| `stdlib_parity` | `verification/stdlib/`, stdlib corpus scripts | `verification/areas/stdlib_parity/` | Legacy stdlib scripts and facade | Pending area migration PR | Not started |
+| `algorithmic_compatibility` | LeetCode audit/subrepo material and corpus taxonomy scripts | `verification/areas/algorithmic_compatibility/` | Legacy audit/corpus tooling | Pending area migration PR | Not started |
+| `ecosystem_compatibility` | `verification/oss/` | `verification/areas/ecosystem_compatibility/` | Legacy hardening runner | Pending area migration PR | Not started |
 
 ## Cursor Cleanup
 

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -21,7 +21,7 @@ This roadmap is the authoritative execution plan for the current hardening and e
 ## Global Rules (from Phase 15 onward)
 - Sequential execution only (one phase at a time).
 - Local-first validation is authoritative; CI mirrors local commands/gates exactly.
-- Local testing runs in parallel lanes (`create-pr`, `merge`, `release`) with deterministic output.
+- Local testing runs in parallel profiles (`create-pr`, `merge`, `release`) with deterministic output.
 - Every bug fix includes a regression test before phase closure.
 - `check` remains hard-separated from codegen/runtime.
 - Parse/lower/type-check/semantic-diagnostic logic must flow through one canonical frontend API; tool-specific semantic reimplementation is forbidden.

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -9,16 +9,16 @@ usage() {
   cat <<'EOF'
 Usage: scripts/run_all_tests.sh [options]
 
-Run local-first validation for the selected lane.
+Run local-first validation for the selected profile.
 
-Lanes:
+Profiles:
   create-pr Fast local create-PR signal.
   merge     Authoritative merge gate (default).
   nightly Broad hardening and full-corpus signal.
   release Highest-confidence local qualification gate.
 
 Options:
-  --profile <create-pr|merge|nightly|release>  Validation lane (default: merge)
+  --profile <create-pr|merge|nightly|release>  Validation profile (default: merge)
   --help                         Show this help
 
 Any remaining arguments are forwarded to scripts/run_e2e_pass.sh.
@@ -27,6 +27,7 @@ EOF
 
 PROFILE="${SIFR_TEST_PROFILE:-merge}"
 FORWARD_ARGS=()
+MIN_UV_VERSION="${SIFR_MIN_UV_VERSION:-0.9.28}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -44,6 +45,48 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+version_gte() {
+  python3 - "$1" "$2" <<'PY'
+import re
+import sys
+
+
+def parse(value: str) -> tuple[int, ...]:
+    parts = [int(part) for part in re.findall(r"\d+", value)]
+    return tuple(parts)
+
+
+actual = parse(sys.argv[1])
+minimum = parse(sys.argv[2])
+width = max(len(actual), len(minimum))
+actual += (0,) * (width - len(actual))
+minimum += (0,) * (width - len(minimum))
+raise SystemExit(0 if actual >= minimum else 1)
+PY
+}
+
+require_uv() {
+  if ! command -v uv >/dev/null 2>&1; then
+    cat >&2 <<EOF
+error: uv ${MIN_UV_VERSION} or newer is required for verification tooling.
+Install uv and re-run this facade; see verification/README.md.
+EOF
+    exit 2
+  fi
+
+  local uv_version
+  uv_version="$(uv --version | awk '{print $2}')"
+  if ! version_gte "${uv_version}" "${MIN_UV_VERSION}"; then
+    cat >&2 <<EOF
+error: uv ${MIN_UV_VERSION} or newer is required for verification tooling; found ${uv_version}.
+Upgrade uv and re-run this facade; see verification/README.md.
+EOF
+    exit 2
+  fi
+}
+
+require_uv
 
 if [[ -z "${SIFR_LANE_REPORT_CAPTURED:-}" ]]; then
   REPORT_DIR="${SCRIPT_DIR}/../target/validation_lane_reports"
@@ -287,6 +330,12 @@ run_verification_hardening_self_tests() {
   python3 "${SCRIPT_DIR}/run_verification_hardening.py" --self-test
 }
 
+run_verification_runner_foundation_checks() {
+  echo "Running verification runner foundation checks"
+  uv lock --project "${SCRIPT_DIR}/../verification" --check
+  uv run --project "${SCRIPT_DIR}/../verification" --locked python -m sifr_verify --self-test
+}
+
 run_distribution_checks() {
   if [[ "${DISTRIBUTION_MODE}" == "none" ]]; then
     echo "Skipping distribution validation for lane ${PROFILE}"
@@ -467,6 +516,7 @@ timed_step frontend_syntax_guardrails run_frontend_syntax_guardrails
 timed_step developer_tooling_checks run_developer_tooling_checks
 timed_step performance_budget_checks run_performance_budget_checks
 timed_step verification_hardening_self_tests run_verification_hardening_self_tests
+timed_step verification_runner_foundation run_verification_runner_foundation_checks
 timed_step distribution_validation run_distribution_checks
 
 if [[ "${GENERATED_CODE_QUALITY_MODE}" != "none" ]]; then

--- a/verification/README.md
+++ b/verification/README.md
@@ -1,0 +1,37 @@
+# Sifr Verification
+
+`verification/` owns runner mechanics, schemas, profiles, policy, and area-owned
+verification data.
+
+Python verification tooling is managed by `uv` through this directory:
+
+```bash
+uv run --project verification python -m sifr_verify --self-test
+uv lock --project verification --check
+```
+
+Minimum supported `uv` version: `0.9.28`.
+
+The public validation entrypoint remains:
+
+```bash
+scripts/run_all_tests.sh --profile create-pr
+```
+
+During the migration, `scripts/run_all_tests.sh` is still the authoritative
+facade for local and CI validation. It fail-fasts when `uv` is missing or below
+the minimum version so the runner foundation and lockfile stay reproducible
+before profile execution is cut over to `sifr_verify`.
+
+## Layout
+
+- `runner/sifr_verify/` contains runner code and self-tests.
+- `schemas/` contains the supported committed data contracts.
+- `profiles/` will contain profile JSON files after profile normalization.
+- `areas/` will contain area-owned manifests, fixtures, baselines, and adapters
+  as each area migrates.
+- `policy/` contains machine-facing runner policy such as guardrail mappings.
+
+Schemas intentionally support only a small subset: object shape, required keys,
+primitive scalar types, arrays of objects or strings, enums, booleans, integers,
+and repo-relative path strings. Unsupported schema keywords are rejected.

--- a/verification/policy/guardrails.json
+++ b/verification/policy/guardrails.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "guardrails": [
+    {
+      "name": "hir-maintainability",
+      "entrypoint": "scripts/check_hir_maintainability_guardrails.py",
+      "args": [],
+      "timeout_seconds": 60,
+      "report": "stdout"
+    },
+    {
+      "name": "file-size",
+      "entrypoint": "scripts/check_file_size_guardrails.py",
+      "args": [],
+      "timeout_seconds": 60,
+      "report": "stdout"
+    },
+    {
+      "name": "cursor-hygiene",
+      "entrypoint": "scripts/check_cursor_hygiene.py",
+      "args": ["--self-test"],
+      "timeout_seconds": 60,
+      "report": "stdout"
+    },
+    {
+      "name": "source-crate-dependency-direction",
+      "entrypoint": "scripts/check_source_crate_dependency_direction.py",
+      "args": ["--self-test"],
+      "timeout_seconds": 60,
+      "report": "stdout"
+    },
+    {
+      "name": "driver-maintainability",
+      "entrypoint": "scripts/check_sifr_driver_maintainability_guardrails.py",
+      "args": [],
+      "timeout_seconds": 60,
+      "report": "stdout"
+    },
+    {
+      "name": "package-manager",
+      "entrypoint": "scripts/check_package_manager_guardrails.py",
+      "args": [],
+      "timeout_seconds": 60,
+      "report": "stdout"
+    }
+  ]
+}

--- a/verification/pyproject.toml
+++ b/verification/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "sifr-verification"
+version = "0.0.0"
+description = "Sifr verification runner and profile tooling"
+requires-python = ">=3.11"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["runner/sifr_verify"]
+
+[tool.uv]
+package = true

--- a/verification/runner/sifr_verify/__init__.py
+++ b/verification/runner/sifr_verify/__init__.py
@@ -1,0 +1,7 @@
+"""Sifr verification runner foundation."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.0.0"

--- a/verification/runner/sifr_verify/__main__.py
+++ b/verification/runner/sifr_verify/__main__.py
@@ -1,0 +1,58 @@
+"""Command line entrypoint for the Sifr verification runner foundation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from .areas import discover_areas
+from .errors import VerificationError
+from .selftest import run_all
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="Run runner foundation self-tests.")
+    parser.add_argument("--list-areas", action="store_true", help="List discovered verification areas as JSON.")
+    parser.add_argument("--profile", help="Reserved profile selector for the facade cutover.")
+    parser.add_argument("--case", help="Reserved case selector for failure reproduction.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.self_test:
+            for name in run_all():
+                print(f"verification runner self-test: {name}: pass")
+            return 0
+        if args.list_areas:
+            areas = [
+                {
+                    "name": area.name,
+                    "owner": area.owner,
+                    "manifest": str(area.manifest_path),
+                    "parallel_safe": area.parallel_safe,
+                    "resource_classes": list(area.resource_classes),
+                }
+                for area in discover_areas()
+            ]
+            print(json.dumps({"schema_version": 1, "areas": areas}, indent=2, sort_keys=True))
+            return 0
+        if args.profile:
+            print(
+                "profile execution has not migrated to sifr_verify yet; "
+                "use scripts/run_all_tests.sh as the authoritative facade",
+                file=sys.stderr,
+            )
+            return 2
+        print("nothing to do; pass --self-test or --list-areas", file=sys.stderr)
+        return 2
+    except VerificationError as exc:
+        print(f"sifr_verify: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/runner/sifr_verify/areas.py
+++ b/verification/runner/sifr_verify/areas.py
@@ -1,0 +1,59 @@
+"""Verification area discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .errors import DiscoveryError
+from .paths import AREAS_DIR, REPO_ROOT
+from .schemas import load_json, load_schema, validate_data
+
+
+@dataclass(frozen=True)
+class Area:
+    name: str
+    owner: str
+    manifest_path: Path
+    parallel_safe: bool
+    resource_classes: tuple[str, ...]
+
+
+def discover_areas(areas_dir: Path = AREAS_DIR) -> list[Area]:
+    if not areas_dir.exists():
+        return []
+    if not areas_dir.is_dir():
+        raise DiscoveryError(f"areas path is not a directory: {areas_dir}")
+
+    schema = load_schema("area.schema.json")
+    areas: list[Area] = []
+    seen: set[str] = set()
+    for manifest_path in sorted(areas_dir.glob("*/manifest.json")):
+        payload = load_json(manifest_path)
+        source = _display_path(manifest_path)
+        validate_data(payload, schema, source=source)
+        name = payload["name"]
+        if name in seen:
+            raise DiscoveryError(f"duplicate verification area name: {name}")
+        if manifest_path.parent.name != name:
+            raise DiscoveryError(
+                f"area manifest name '{name}' must match directory '{manifest_path.parent.name}'"
+            )
+        seen.add(name)
+        areas.append(
+            Area(
+                name=name,
+                owner=payload["owner"],
+                manifest_path=manifest_path,
+                parallel_safe=payload["parallel_safe"],
+                resource_classes=tuple(payload.get("resource_classes", [])),
+            )
+        )
+    return areas
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)

--- a/verification/runner/sifr_verify/errors.py
+++ b/verification/runner/sifr_verify/errors.py
@@ -1,0 +1,15 @@
+"""Typed verification runner errors."""
+
+from __future__ import annotations
+
+
+class VerificationError(RuntimeError):
+    """Base error for runner-controlled validation failures."""
+
+
+class SchemaError(VerificationError):
+    """Schema contract or data validation failed."""
+
+
+class DiscoveryError(VerificationError):
+    """Area discovery failed."""

--- a/verification/runner/sifr_verify/paths.py
+++ b/verification/runner/sifr_verify/paths.py
@@ -1,0 +1,12 @@
+"""Repository path helpers for verification tooling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parent
+VERIFICATION_ROOT = PACKAGE_ROOT.parents[1]
+REPO_ROOT = VERIFICATION_ROOT.parent
+SCHEMAS_DIR = VERIFICATION_ROOT / "schemas"
+AREAS_DIR = VERIFICATION_ROOT / "areas"

--- a/verification/runner/sifr_verify/profiles.py
+++ b/verification/runner/sifr_verify/profiles.py
@@ -1,0 +1,25 @@
+"""Profile policy helpers for the verification runner."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def selected_resource_classes(profile: dict[str, Any]) -> set[str]:
+    classes: set[str] = set()
+    resource_policy = profile.get("resource_policy", {})
+    if isinstance(resource_policy, dict):
+        raw_classes = resource_policy.get("classes", [])
+        if isinstance(raw_classes, list):
+            classes.update(item for item in raw_classes if isinstance(item, str))
+    for selection in profile.get("selected_areas", []):
+        if not isinstance(selection, dict):
+            continue
+        raw_classes = selection.get("resource_classes", [])
+        if isinstance(raw_classes, list):
+            classes.update(item for item in raw_classes if isinstance(item, str))
+    return classes
+
+
+def failure_reproduction_command(profile_name: str, case_id: str) -> str:
+    return f"uv run --project verification python -m sifr_verify --profile {profile_name} --case {case_id}"

--- a/verification/runner/sifr_verify/results.py
+++ b/verification/runner/sifr_verify/results.py
@@ -1,0 +1,36 @@
+"""Result document construction for verification reports."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from .profiles import failure_reproduction_command
+
+
+def build_result(
+    *,
+    profile: str,
+    status: str,
+    cases: list[dict[str, Any]],
+    elapsed_ms: int,
+) -> dict[str, Any]:
+    failures = []
+    for case in cases:
+        if case.get("status") != "pass":
+            case_id = str(case.get("id", "unknown"))
+            failures.append(
+                {
+                    "case_id": case_id,
+                    "reproduce": failure_reproduction_command(profile, case_id),
+                }
+            )
+    return {
+        "schema_version": 1,
+        "profile": profile,
+        "status": status,
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        "elapsed_ms": elapsed_ms,
+        "cases": cases,
+        "failures": failures,
+    }

--- a/verification/runner/sifr_verify/schemas.py
+++ b/verification/runner/sifr_verify/schemas.py
@@ -1,0 +1,150 @@
+"""Small, explicit schema subset for committed verification data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .errors import SchemaError
+from .paths import REPO_ROOT, SCHEMAS_DIR
+
+SUPPORTED_SCHEMA_KEYS = {
+    "$schema",
+    "title",
+    "description",
+    "type",
+    "required",
+    "properties",
+    "items",
+    "enum",
+    "additionalProperties",
+    "format",
+}
+SUPPORTED_TYPES = {"object", "array", "string", "integer", "number", "boolean"}
+SUPPORTED_FORMATS = {"repo-relative-path"}
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_schema(name: str) -> dict[str, Any]:
+    path = SCHEMAS_DIR / name
+    payload = load_json(path)
+    if not isinstance(payload, dict):
+        raise SchemaError(f"schema must be a JSON object: {path}")
+    validate_schema_contract(payload, path)
+    return payload
+
+
+def validate_all_committed_schemas(schema_dir: Path = SCHEMAS_DIR) -> list[str]:
+    checked: list[str] = []
+    for path in sorted(schema_dir.glob("*.schema.json")):
+        payload = load_json(path)
+        if not isinstance(payload, dict):
+            raise SchemaError(f"schema must be a JSON object: {path}")
+        validate_schema_contract(payload, path)
+        checked.append(str(path.relative_to(REPO_ROOT)))
+    return checked
+
+
+def validate_schema_contract(schema: dict[str, Any], path: Path) -> None:
+    _validate_schema_node(schema, path, "$")
+
+
+def _validate_schema_node(node: Any, path: Path, location: str) -> None:
+    if not isinstance(node, dict):
+        raise SchemaError(f"{path}:{location}: schema nodes must be objects")
+    for key, value in node.items():
+        if key not in SUPPORTED_SCHEMA_KEYS:
+            raise SchemaError(f"{path}:{location}: unsupported schema keyword '{key}'")
+        if key == "type":
+            if value not in SUPPORTED_TYPES:
+                raise SchemaError(f"{path}:{location}: unsupported type {value!r}")
+        elif key == "required":
+            if not _is_string_list(value):
+                raise SchemaError(f"{path}:{location}: required must be a string array")
+        elif key == "properties":
+            if not isinstance(value, dict):
+                raise SchemaError(f"{path}:{location}: properties must be an object")
+            for prop, child in value.items():
+                if not isinstance(prop, str) or not prop:
+                    raise SchemaError(f"{path}:{location}: property names must be non-empty strings")
+                _validate_schema_node(child, path, f"{location}.properties.{prop}")
+        elif key == "items":
+            _validate_schema_node(value, path, f"{location}.items")
+        elif key == "enum":
+            if not isinstance(value, list) or not value:
+                raise SchemaError(f"{path}:{location}: enum must be a non-empty array")
+            if not all(isinstance(item, str | int | bool) for item in value):
+                raise SchemaError(f"{path}:{location}: enum values must be primitive scalars")
+        elif key == "additionalProperties":
+            if not isinstance(value, bool):
+                raise SchemaError(f"{path}:{location}: additionalProperties must be boolean")
+        elif key == "format":
+            if value not in SUPPORTED_FORMATS:
+                raise SchemaError(f"{path}:{location}: unsupported format {value!r}")
+        elif key in {"$schema", "title", "description"} and not isinstance(value, str):
+            raise SchemaError(f"{path}:{location}: {key} must be a string")
+
+
+def validate_data(data: Any, schema: dict[str, Any], *, source: str) -> None:
+    _validate_data_node(data, schema, source, "$")
+
+
+def _validate_data_node(data: Any, schema: dict[str, Any], source: str, location: str) -> None:
+    expected_type = schema.get("type")
+    if expected_type == "object":
+        if not isinstance(data, dict):
+            raise SchemaError(f"{source}:{location}: expected object")
+        required = schema.get("required", [])
+        assert isinstance(required, list)
+        for key in required:
+            if key not in data:
+                raise SchemaError(f"{source}:{location}: missing required key '{key}'")
+        properties = schema.get("properties", {})
+        assert isinstance(properties, dict)
+        if schema.get("additionalProperties") is False:
+            extra = sorted(set(data) - set(properties))
+            if extra:
+                raise SchemaError(f"{source}:{location}: unsupported keys: {', '.join(extra)}")
+        for key, child_schema in properties.items():
+            if key in data:
+                _validate_data_node(data[key], child_schema, source, f"{location}.{key}")
+    elif expected_type == "array":
+        if not isinstance(data, list):
+            raise SchemaError(f"{source}:{location}: expected array")
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(data):
+                _validate_data_node(item, item_schema, source, f"{location}[{index}]")
+    elif expected_type == "string":
+        if not isinstance(data, str):
+            raise SchemaError(f"{source}:{location}: expected string")
+        if schema.get("format") == "repo-relative-path":
+            _validate_repo_relative_path(data, source, location)
+    elif expected_type == "integer":
+        if not isinstance(data, int) or isinstance(data, bool):
+            raise SchemaError(f"{source}:{location}: expected integer")
+    elif expected_type == "number":
+        if not isinstance(data, int | float) or isinstance(data, bool):
+            raise SchemaError(f"{source}:{location}: expected number")
+    elif expected_type == "boolean":
+        if not isinstance(data, bool):
+            raise SchemaError(f"{source}:{location}: expected boolean")
+
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and data not in enum_values:
+        allowed = ", ".join(str(value) for value in enum_values)
+        raise SchemaError(f"{source}:{location}: expected one of: {allowed}")
+
+
+def _validate_repo_relative_path(value: str, source: str, location: str) -> None:
+    path = Path(value)
+    if not value or path.is_absolute() or ".." in path.parts:
+        raise SchemaError(f"{source}:{location}: expected repo-relative path, got {value!r}")
+
+
+def _is_string_list(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) and item for item in value)

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -1,0 +1,122 @@
+"""Self-tests for the verification runner foundation."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from .areas import discover_areas
+from .profiles import failure_reproduction_command, selected_resource_classes
+from .results import build_result
+from .schemas import load_schema, validate_all_committed_schemas, validate_data, validate_schema_contract
+
+
+def run_all() -> list[str]:
+    checks = [
+        ("schema self-tests", _schema_self_test),
+        ("runner discovery self-test", _discovery_self_test),
+        ("resource class selection self-test", _resource_class_self_test),
+        ("resume/failure-reproduction self-test", _failure_reproduction_self_test),
+    ]
+    passed: list[str] = []
+    for name, check in checks:
+        check()
+        passed.append(name)
+    return passed
+
+
+def _schema_self_test() -> None:
+    committed = validate_all_committed_schemas()
+    required = {
+        "verification/schemas/profile.schema.json",
+        "verification/schemas/area.schema.json",
+        "verification/schemas/suite.schema.json",
+        "verification/schemas/case.schema.json",
+        "verification/schemas/result.schema.json",
+    }
+    missing = required - set(committed)
+    if missing:
+        raise AssertionError(f"missing schema self-test coverage: {sorted(missing)}")
+    try:
+        validate_schema_contract({"type": "object", "oneOf": []}, Path("bad.schema.json"))
+    except Exception as exc:
+        if "unsupported schema keyword 'oneOf'" not in str(exc):
+            raise
+    else:
+        raise AssertionError("unsupported schema keyword was accepted")
+
+    area_schema = load_schema("area.schema.json")
+    invalid_area = {
+        "schema_version": 1,
+        "name": "core_language",
+        "description": "Missing owner and wrong parallel_safe type.",
+        "parallel_safe": "yes",
+        "resource_classes": ["default-local"],
+        "timeout_seconds": 60,
+        "suites": [],
+    }
+    try:
+        validate_data(invalid_area, area_schema, source="invalid area self-test")
+    except Exception as exc:
+        if "missing required key 'owner'" not in str(exc):
+            raise
+    else:
+        raise AssertionError("invalid area manifest data was accepted")
+
+
+def _discovery_self_test() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        areas_dir = Path(tmp) / "areas"
+        demo_dir = areas_dir / "core_language"
+        demo_dir.mkdir(parents=True)
+        (demo_dir / "manifest.json").write_text(
+            """
+{
+  "schema_version": 1,
+  "name": "core_language",
+  "owner": "compiler/core",
+  "description": "Temporary discovery fixture.",
+  "parallel_safe": true,
+  "resource_classes": ["default-local"],
+  "timeout_seconds": 60,
+  "suites": []
+}
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        areas = discover_areas(areas_dir)
+    if [area.name for area in areas] != ["core_language"]:
+        raise AssertionError(f"unexpected discovery result: {areas}")
+
+
+def _resource_class_self_test() -> None:
+    profile = {
+        "resource_policy": {"classes": ["default-local", "network"]},
+        "selected_areas": [
+            {"area": "core_language", "resource_classes": ["default-local"]},
+            {"area": "ecosystem_compatibility", "resource_classes": ["external-corpus"]},
+        ],
+    }
+    expected = {"default-local", "network", "external-corpus"}
+    actual = selected_resource_classes(profile)
+    if actual != expected:
+        raise AssertionError(f"resource class selection mismatch: {actual}")
+
+
+def _failure_reproduction_self_test() -> None:
+    command = failure_reproduction_command("create-pr", "case-001")
+    expected = "uv run --project verification python -m sifr_verify --profile create-pr --case case-001"
+    if command != expected:
+        raise AssertionError(f"unexpected reproduction command: {command}")
+    result = build_result(
+        profile="create-pr",
+        status="fail",
+        elapsed_ms=7,
+        cases=[{"id": "case-001", "status": "fail", "elapsed_ms": 7}],
+    )
+    schema = load_schema("result.schema.json")
+    validate_data(result, schema, source="self-test result")
+    failures = result.get("failures")
+    if failures != [{"case_id": "case-001", "reproduce": expected}]:
+        raise AssertionError(f"unexpected failure reproduction data: {failures}")

--- a/verification/schemas/area.schema.json
+++ b/verification/schemas/area.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://sifr-lang.local/verification/area.schema.json",
+  "title": "Sifr verification area manifest",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "name",
+    "owner",
+    "description",
+    "parallel_safe",
+    "resource_classes",
+    "timeout_seconds",
+    "suites"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "enum": [1]
+    },
+    "name": {
+      "type": "string"
+    },
+    "owner": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "parallel_safe": {
+      "type": "boolean"
+    },
+    "resource_classes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "default-local",
+          "network",
+          "large-memory",
+          "platform-specific",
+          "long-running",
+          "external-corpus"
+        ]
+      }
+    },
+    "timeout_seconds": {
+      "type": "integer"
+    },
+    "suites": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "kind", "cases"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["manifest", "golden", "adapter"]
+          },
+          "cases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/verification/schemas/case.schema.json
+++ b/verification/schemas/case.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://sifr-lang.local/verification/case.schema.json",
+  "title": "Sifr verification case",
+  "type": "object",
+  "required": ["schema_version", "id", "area", "kind", "fixture", "expected"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "enum": [1]
+    },
+    "id": {
+      "type": "string"
+    },
+    "area": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["compile", "run", "check", "golden", "policy"]
+    },
+    "fixture": {
+      "type": "string",
+      "format": "repo-relative-path"
+    },
+    "expected": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    }
+  }
+}

--- a/verification/schemas/profile.schema.json
+++ b/verification/schemas/profile.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://sifr-lang.local/verification/profile.schema.json",
+  "title": "Sifr verification profile",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "name",
+    "description",
+    "budgets",
+    "resource_policy",
+    "selected_areas",
+    "toolchain_steps",
+    "guardrail_steps",
+    "retry_policy",
+    "shard_policy",
+    "resume_policy",
+    "report"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "enum": [1]
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "budgets": {
+      "type": "object",
+      "required": ["warm_wall_time_minutes", "cold_wall_time_minutes"],
+      "additionalProperties": false,
+      "properties": {
+        "warm_wall_time_minutes": {
+          "type": "integer"
+        },
+        "cold_wall_time_minutes": {
+          "type": "integer"
+        }
+      }
+    },
+    "resource_policy": {
+      "type": "object",
+      "required": ["classes", "max_parallel"],
+      "additionalProperties": false,
+      "properties": {
+        "classes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "default-local",
+              "network",
+              "large-memory",
+              "platform-specific",
+              "long-running",
+              "external-corpus"
+            ]
+          }
+        },
+        "max_parallel": {
+          "type": "integer"
+        }
+      }
+    },
+    "selected_areas": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["area", "suites", "resource_classes"],
+        "additionalProperties": false,
+        "properties": {
+          "area": {
+            "type": "string"
+          },
+          "suites": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "resource_classes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "default-local",
+                "network",
+                "large-memory",
+                "platform-specific",
+                "long-running",
+                "external-corpus"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "toolchain_steps": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "cargo-build-release",
+          "cargo-fmt-check",
+          "cargo-clippy-workspace",
+          "cargo-test-sifr-smoke",
+          "cargo-test-sifr-full",
+          "cargo-test-workspace"
+        ]
+      }
+    },
+    "guardrail_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "retry_policy": {
+      "type": "object",
+      "required": ["max_attempts", "retry_flaky_only"],
+      "additionalProperties": false,
+      "properties": {
+        "max_attempts": {
+          "type": "integer"
+        },
+        "retry_flaky_only": {
+          "type": "boolean"
+        }
+      }
+    },
+    "shard_policy": {
+      "type": "object",
+      "required": ["strategy", "shards"],
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["none", "deterministic"]
+        },
+        "shards": {
+          "type": "integer"
+        }
+      }
+    },
+    "resume_policy": {
+      "type": "object",
+      "required": ["enabled", "failure_reproduction"],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "failure_reproduction": {
+          "type": "string",
+          "enum": ["profile-and-case"]
+        }
+      }
+    },
+    "report": {
+      "type": "object",
+      "required": ["format", "output_dir"],
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": ["json-v1"]
+        },
+        "output_dir": {
+          "type": "string",
+          "format": "repo-relative-path"
+        }
+      }
+    }
+  }
+}

--- a/verification/schemas/result.schema.json
+++ b/verification/schemas/result.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://sifr-lang.local/verification/result.schema.json",
+  "title": "Sifr verification result report",
+  "type": "object",
+  "required": ["schema_version", "profile", "status", "generated_at", "elapsed_ms", "cases", "failures"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "enum": [1]
+    },
+    "profile": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "fail"]
+    },
+    "generated_at": {
+      "type": "string"
+    },
+    "elapsed_ms": {
+      "type": "integer"
+    },
+    "cases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "status", "elapsed_ms"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pass", "fail", "skip"]
+          },
+          "elapsed_ms": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["case_id", "reproduce"],
+        "additionalProperties": false,
+        "properties": {
+          "case_id": {
+            "type": "string"
+          },
+          "reproduce": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/verification/schemas/suite.schema.json
+++ b/verification/schemas/suite.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://sifr-lang.local/verification/suite.schema.json",
+  "title": "Sifr verification area suite",
+  "type": "object",
+  "required": ["schema_version", "name", "description", "cases"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "enum": [1]
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "cases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "kind", "fixture", "expected"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["compile", "run", "check", "golden", "policy"]
+          },
+          "fixture": {
+            "type": "string",
+            "format": "repo-relative-path"
+          },
+          "expected": {
+            "type": "string",
+            "enum": ["pass", "fail"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/verification/uv.lock
+++ b/verification/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "sifr-verification"
+version = "0.0.0"
+source = { editable = "." }


### PR DESCRIPTION
## Summary

- add the `uv`-managed `sifr_verify` runner foundation, schema subset validator, area discovery, result helpers, and self-tests
- add committed verification schemas, guardrail policy data, `verification/pyproject.toml`, `verification/uv.lock`, and verification README bootstrap guidance
- add `uv` availability/version fail-fast plus lock/self-test checks to the existing `scripts/run_all_tests.sh` facade, and install pinned `uv` in CI before running the same facade
- update the phase plan with the required verification migration-status table and PR6 progress

## Validation

- `bash -n scripts/run_all_tests.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/local-first-validation.yml")'`
- `uv lock --project verification --check`
- `uv run --project verification --locked python -m sifr_verify --self-test`
- `uv run --project verification --locked python -m sifr_verify --list-areas`
- `SIFR_MIN_UV_VERSION=99.0.0 bash scripts/run_all_tests.sh --profile create-pr` negative gate check exits 2 with the expected uv error
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`
- `scripts/run_all_tests.sh --profile create-pr` PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisory only: warm wall-time budget exceeded

## Reviews

- Opus pass 1: PASS, low nits only; useful nits applied
- Opus pass 2: PASS; ready to ship
