### PR TITLE
Retarget Wave 2.3 codegen architecture guards

### DIFF
--- a/crates/sifr_codegen/src/intrinsic_method_emitters/narrowing_helpers.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/narrowing_helpers.rs
@@ -34,11 +34,21 @@ mod tests {
 
     #[test]
     fn registry_arg_lowering_avoids_inline_rawcode_paths() {
-        let src = include_str!("../intrinsic_method_emitters.rs");
-        let prod_src = src.split("\n#[cfg(test)]").next().unwrap_or(src);
-        assert!(prod_src.contains("fn try_lower_registry_expr_strict("));
-        assert!(prod_src.contains("fn try_lower_registry_exprs_strict("));
-        assert!(prod_src.contains("fn try_lower_registry_expr_recursive("));
+        let collection_methods_src = include_str!("collection_methods.rs");
+        let recursive_exprs_src = include_str!("recursive_exprs.rs");
+        let field_rewrites_src =
+            include_str!("../expr_render_helpers/field_and_stdlib_rewrites.rs");
+        let prod_src = [
+            collection_methods_src,
+            recursive_exprs_src,
+            field_rewrites_src,
+        ]
+        .join("\n");
+
+        assert!(collection_methods_src.contains("pub(crate) fn try_lower_registry_expr_strict("));
+        assert!(collection_methods_src.contains("pub(crate) fn try_lower_registry_exprs_strict("));
+        assert!(recursive_exprs_src.contains("pub(crate) fn try_lower_registry_expr_recursive("));
+        assert!(field_rewrites_src.contains("pub(crate) fn try_lower_registry_expr_result("));
         let helper_defs = prod_src
             .lines()
             .filter(|line| {
@@ -47,7 +57,7 @@ mod tests {
                     || trimmed.starts_with("pub(crate) fn try_lower_registry_expr")
             })
             .count();
-        assert_eq!(helper_defs, 3, "unexpected registry expr helper set");
+        assert_eq!(helper_defs, 4, "unexpected registry expr helper set");
         assert!(!prod_src.contains("lower_registry_expr_with_string_path"));
         assert!(!prod_src.contains("render_expr_via_string_only("));
     }

--- a/crates/sifr_codegen/src/lib_codegen_tests/async_runtime_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/async_runtime_codegen_tests.rs
@@ -170,7 +170,6 @@ fn test_generate_project_emits_tokio_dependency_when_required() {
 fn test_module_constants_flow_through_assembled_body_items() {
     let module_constants_src = include_str!("../module_constants.rs");
     let entrypoints_src = include_str!("../entrypoints.rs");
-    let lib_src = include_str!("../lib.rs");
 
     assert!(module_constants_src.contains("self.body_items.push(item);"));
     assert!(module_constants_src
@@ -179,38 +178,37 @@ fn test_module_constants_flow_through_assembled_body_items() {
     assert!(!module_constants_src.contains("render_items(&[item])"));
 
     assert!(entrypoints_src.contains("if !emitter.body_items.is_empty() {"));
-    assert!(lib_src.contains("if !emitter.body_items.is_empty() {"));
     assert!(!entrypoints_src.contains("assert_output_drained("));
     assert!(!entrypoints_src.contains("emitter.output"));
-    assert!(!lib_src.contains("emitter.output"));
 }
 
 #[test]
 fn test_module_body_flows_through_assembled_body_items() {
     let module_body_src = include_str!("../module_body.rs");
-    let lib_src = include_str!("../lib.rs");
+    let entrypoints_src = include_str!("../entrypoints.rs");
 
     assert!(!module_body_src.contains("self.drain_emitted_output_items("));
     assert!(!module_body_src.contains("self.push_syn_items_from_source(&emitted"));
     assert!(module_body_src.contains("self.emit_class(class, module, module_public);"));
     assert!(module_body_src.contains("self.emit_function(func, module_public, test_mode);"));
     assert!(!module_body_src.contains("self.output"));
-    assert!(lib_src.contains("if !emitter.body_items.is_empty() {"));
+    assert!(entrypoints_src.contains("if !emitter.body_items.is_empty() {"));
 }
 
 #[test]
 fn test_generator_init_emission_is_structured_only() {
-    let stmt_support_src = include_str!("../stmt_support_emitter.rs");
-    assert!(stmt_support_src.contains("self.lower_stmt_expr_for_ir(value)"));
-    assert!(stmt_support_src.contains("self.try_lower_structured_stmt(stmt)"));
-    assert!(stmt_support_src
+    let emitter_state_src = include_str!("../lib_emitter_state.rs");
+    let statement_output_src = include_str!("../stmt_support_emitter/statement_output.rs");
+    assert!(statement_output_src.contains("self.lower_stmt_expr_for_ir(value)"));
+    assert!(emitter_state_src.contains("self.try_lower_structured_stmt(stmt)"));
+    assert!(statement_output_src
         .contains("structured generator-init expression emission missing for production path"));
-    assert!(stmt_support_src
+    assert!(statement_output_src
         .contains("structured generator-init statement emission missing for production path"));
-    assert!(!stmt_support_src.contains("self.try_emit_expr_string_"));
-    assert!(!stmt_support_src.contains("self.try_emit_stmt_string_"));
-    assert!(!stmt_support_src.contains("self.emit_expr(value);"));
-    assert!(!stmt_support_src.contains("self.emit_stmt(stmt);"));
+    assert!(!statement_output_src.contains("self.try_emit_expr_string_"));
+    assert!(!statement_output_src.contains("self.try_emit_stmt_string_"));
+    assert!(!statement_output_src.contains("self.emit_expr(value);"));
+    assert!(!statement_output_src.contains("self.emit_stmt(stmt);"));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lib_codegen_tests/structured_lowering_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structured_lowering_codegen_tests.rs
@@ -567,6 +567,7 @@ fn test_emit_expr_borrowed_compare_is_structured() {
 #[test]
 fn test_lib_decomposition_guards_keep_stmt_expr_logic_out_of_lib_rs() {
     let lib_src = include_str!("../lib.rs");
+    let emitter_state_src = include_str!("../lib_emitter_state.rs");
 
     assert!(!lib_src.contains("mod stmt_emitter;"));
     assert!(!lib_src.contains("mod expr_emitter;"));
@@ -576,14 +577,16 @@ fn test_lib_decomposition_guards_keep_stmt_expr_logic_out_of_lib_rs() {
     assert!(!lib_src.contains("should_force_expr_string_path"));
     assert!(!lib_src.contains("fn emit_expr(&mut self, expr: &HirExpr) {"));
     assert!(!lib_src.contains("fn try_lower_structured_expr("));
+    assert!(!lib_src.contains("fn emit_stmt(&mut self, stmt: &HirStmt) {"));
 
-    let emit_stmt_start = lib_src
+    let emit_stmt_start = emitter_state_src
         .find("fn emit_stmt(&mut self, stmt: &HirStmt) {")
         .expect("emit_stmt wrapper should exist");
-    let body_contains_yield_start = lib_src
-        .find("pub fn body_contains_yield(stmts: &[HirStmt]) -> bool {")
-        .expect("body_contains_yield should exist");
-    let emit_stmt_wrapper = &lib_src[emit_stmt_start..body_contains_yield_start];
+    let impl_end = emitter_state_src[emit_stmt_start..]
+        .find("\n    }\n}")
+        .map(|offset| emit_stmt_start + offset)
+        .expect("emit_stmt wrapper should end before impl close");
+    let emit_stmt_wrapper = &emitter_state_src[emit_stmt_start..impl_end];
     assert!(emit_stmt_wrapper.contains("structured statement emission missing for production path"));
     assert!(!emit_stmt_wrapper.contains("self.try_emit_stmt_string_"));
     assert!(
@@ -601,14 +604,15 @@ fn test_lib_decomposition_guards_keep_stmt_expr_logic_out_of_lib_rs() {
 #[test]
 fn test_production_lowering_contract_uses_result_helpers_only() {
     let lib_src = include_str!("../lib.rs");
-    let lower_expr_src = include_str!("../lower_expr.rs");
+    let emitter_state_src = include_str!("../lib_emitter_state.rs");
+    let lower_expr_src = include_str!("../lower_expr/leaves_and_plain_calls.rs");
     let module_constants_src = include_str!("../module_constants.rs");
-    let expr_render_helpers_src = include_str!("../expr_render_helpers.rs");
+    let field_rewrites_src = include_str!("../expr_render_helpers/field_and_stdlib_rewrites.rs");
 
-    assert!(lib_src.contains("try_lower_simple_stmt_with_scope_result("));
+    assert!(emitter_state_src.contains("try_lower_simple_stmt_with_scope_result_and_bindings("));
     assert!(lower_expr_src.contains("pub fn try_lower_leaf_expr_result("));
     assert!(module_constants_src.contains("try_lower_simple_module_constant_item_result("));
-    assert!(expr_render_helpers_src.contains("try_lower_registry_expr_result("));
+    assert!(field_rewrites_src.contains("try_lower_registry_expr_result("));
 
     assert!(!lib_src.contains("try_lower_simple_stmt_with_scope("));
     assert!(!lib_src.contains("try_lower_leaf_expr("));

--- a/plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md
+++ b/plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md
@@ -1,6 +1,6 @@
 # Ad Hoc Phase: World-Class Verification Standard and Gate Closure
 
-Status: in progress; Wave 0, Wave 1, Wave 2.0, and Wave 2.1 merged; Wave 2.2 codegen stale source-fixture repairs in progress
+Status: in progress; Wave 0, Wave 1, Wave 2.0, Wave 2.1, and Wave 2.2 merged; Wave 2.3 codegen obsolete architecture guard retargeting in progress
 Owner: compiler-verification
 Context: Follow-on verification phase after Phase 29; based on local Sifr verification audit against TypeScript, TypeScript-Go, Rust, CPython, and Bun
 
@@ -348,7 +348,7 @@ Implementation re-check started 2026-06-14.
 
 ### Wave 2.2 Implementation Notes
 
-- Status: implemented locally; review and PR pending.
+- Status: merged in PR `https://github.com/sifr-lang/sifr/pull/2563`.
 - Scope: close all 16 stale source-fixture rows assigned to `proposed_pr_slice: 2.2` in the `sifr_codegen` red-blocker inventory.
 - Changes: converted parser-invalid `\n\` fixtures to raw multi-line source strings, added real `await task.sleep(0.0)` suspension points to async worker fixtures that must remain async, added explicit encoding to the `open()` fixture, and refreshed secondary normalized-literal / constructor assertions exposed after those fixtures started lowering. The newly reachable literal spelling refreshes are the same current-contract forms covered by Wave 2.1 (`99_i64`, `10_i64`, `77_i64`, and tail-expression `2_i64`).
 - Validation:
@@ -362,6 +362,24 @@ Implementation re-check started 2026-06-14.
 - Artifacts:
   - `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`: `red_blocker.failure_count` updated to 16, `test_result` updated to 691/16/707, and all 16 Wave 2.2 rows marked `closed`.
   - `plans/issues/active/codegen-test-triage.md`: current Wave 2.2 state and remaining open-row count documented.
+
+### Wave 2.3 Implementation Notes
+
+- Status: implemented locally; review and PR pending.
+- Scope: close all 6 obsolete architecture guard rows assigned to `proposed_pr_slice: 2.3` in the `sifr_codegen` red-blocker inventory.
+- Changes: retargeted stale source-text guards from retired wrapper/helper locations to the current owner modules after decomposition: registry strict/recursive/result helpers, entrypoint body-item assembly, module body/constants emission, generator-init statement output, and structured statement orchestration in `lib_emitter_state.rs`.
+- Validation:
+  - Six previously failing Wave 2.3 exact tests: pass.
+  - `cargo test -p sifr_codegen -- --nocapture`: expected failure; improved from 691 passed / 16 failed to 697 passed / 10 failed, closing exactly the 6 Wave 2.3 rows while leaving Waves 2.4 and 2.5 red.
+  - `cargo fmt --check`: pass.
+  - `python3 scripts/check_file_size_guardrails.py`: pass.
+  - `uv run --project verification --locked python -m sifr_verify areas run --area core_language`: pass after the first `create-pr` attempt hit two transient 10s audit-fixture timeouts.
+  - `scripts/run_all_tests.sh --profile create-pr`: pass after the focused core-language rerun; wall time 197.18s with the existing warm-budget advisory and 100% e2e cache hit rate.
+- Review:
+  - `plans/reviews/active/ad-hoc-world-class-verification-wave-2-3-review-pass-1.md`: no blocking issues; reviewer approved Wave 2.3 for PR/merge and left only non-blocking nits.
+- Artifacts:
+  - `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`: `red_blocker.failure_count` updated to 10, `test_result` updated to 697/10/707, and all 6 Wave 2.3 rows marked `closed`.
+  - `plans/issues/active/codegen-test-triage.md`: current Wave 2.3 state and remaining open-row count documented.
 
 ## Full Discovery Snapshot
 

--- a/plans/issues/active/codegen-test-triage.md
+++ b/plans/issues/active/codegen-test-triage.md
@@ -1,6 +1,6 @@
 # Codegen Test Triage
 
-Status: Wave 2.2 stale source-fixture repairs in progress; Wave 2.0 inventory merged in PR https://github.com/sifr-lang/sifr/pull/2561 and Wave 2.1 merged in PR https://github.com/sifr-lang/sifr/pull/2562.
+Status: Wave 2.3 obsolete architecture guard retargeting in progress; Wave 2.0 inventory merged in PR https://github.com/sifr-lang/sifr/pull/2561, Wave 2.1 merged in PR https://github.com/sifr-lang/sifr/pull/2562, and Wave 2.2 merged in PR https://github.com/sifr-lang/sifr/pull/2563.
 
 Reproduction command:
 
@@ -8,7 +8,7 @@ Reproduction command:
 cargo test -p sifr_codegen -- --nocapture
 ```
 
-Observed Wave 2.0 result on 2026-06-14: `655 passed; 52 failed; 707 total`. After Wave 2.1 stale expectation repairs, the result was `675 passed; 32 failed; 707 total`. After Wave 2.2 stale source-fixture repairs, the current local result is `691 passed; 16 failed; 707 total`. The saved local Wave 2.0 log is `target/wave2/sifr_codegen_nocapture.log`; the checked-in machine-readable inventory is `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`.
+Observed Wave 2.0 result on 2026-06-14: `655 passed; 52 failed; 707 total`. After Wave 2.1 stale expectation repairs, the result was `675 passed; 32 failed; 707 total`. After Wave 2.2 stale source-fixture repairs, the result was `691 passed; 16 failed; 707 total`. After Wave 2.3 obsolete architecture guard retargeting, the current local result is `697 passed; 10 failed; 707 total`. The saved local Wave 2.0 log is `target/wave2/sifr_codegen_nocapture.log`; the checked-in machine-readable inventory is `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`.
 
 The JSON inventory records closure with `closes_in_wave: 2` and `closes_in_subwave` for each row. `proposed_pr_slice` below is the human-readable repair slice label.
 
@@ -19,7 +19,7 @@ Classification counts from the Wave 2.0 inventory:
 - `compiler-bug`: 10.
 - `production-bug`: 0; no unresolved production sentinel rows in Wave 2.0.
 
-Wave 2.1 closes the 20 `proposed_pr_slice: 2.1` rows by refreshing stale literal, final-return, render snapshot, and iterator materialization expectations to the current generated-Rust contract. Wave 2.2 closes the 16 `proposed_pr_slice: 2.2` rows by making parser, async-effect, and explicit-encoding fixtures policy-compliant while preserving their codegen assertions. The remaining 16 open rows stay assigned to Waves 2.3, 2.4, and 2.5.
+Wave 2.1 closes the 20 `proposed_pr_slice: 2.1` rows by refreshing stale literal, final-return, render snapshot, and iterator materialization expectations to the current generated-Rust contract. Wave 2.2 closes the 16 `proposed_pr_slice: 2.2` rows by making parser, async-effect, and explicit-encoding fixtures policy-compliant while preserving their codegen assertions. Wave 2.3 closes the 6 `proposed_pr_slice: 2.3` rows by retargeting obsolete architecture guards to their current owner modules after decomposition/refactors. The remaining 10 open rows stay assigned to Waves 2.4 and 2.5.
 
 Proposed PR slices:
 

--- a/plans/reviews/active/ad-hoc-world-class-verification-wave-2-3-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-world-class-verification-wave-2-3-review-pass-1.md
@@ -1,0 +1,26 @@
+## Wave 2.3 External Review
+
+**Verdict: No blockers. Wave 2.3 is approved to open the PR.**
+
+### Findings
+
+All changes are architecture-guard text retargets, not compiler-behavior changes. Each new guard target was verified against live source.
+
+| # | Severity | Location | Note |
+|---|---|---|---|
+| 1 | nit | `crates/sifr_codegen/src/intrinsic_method_emitters/narrowing_helpers.rs:41-46` | `prod_src` joins only the 3 named files. The negative-string assertions (`lower_registry_expr_with_string_path`, `render_expr_via_string_only`) only catch reintroductions inside those 3 files; the original guard scanned the whole parent file. Scope is narrower but matches the new helper ownership boundary — acceptable for an obsolete-test retarget. |
+| 2 | nit | `crates/sifr_codegen/src/lib_codegen_tests/structured_lowering_codegen_tests.rs:585-588` | `emit_stmt` wrapper end is located via `find("\n    }\n}")`, i.e. assumes `emit_stmt` is the last method in its impl block (currently true at `lib_emitter_state.rs:810-836`, impl closes at line 837). If a method is appended after `emit_stmt`, this guard could pick a too-large slice. Not a blocker; consider replacing with a `\n    pub(crate) fn ` next-fn search later. |
+
+No correctness, security, or behavior concerns found.
+
+### Review-question answers
+
+1. **Closes 6 rows without hiding compiler bugs?** Yes. All 6 closed rows are `classification: obsolete-test`. The diff only updates `include_str!` targets and asserted-symbol names to follow the post-decomposition module layout (`collection_methods.rs`, `recursive_exprs.rs`, `expr_render_helpers/field_and_stdlib_rewrites.rs`, `lower_expr/leaves_and_plain_calls.rs`, `lib_emitter_state.rs`, `stmt_support_emitter/statement_output.rs`, `entrypoints.rs`). No compiler source touched; no failing test silenced beyond its retargeted scope. The 10 remaining open rows are all `classification: compiler-bug`, so the Wave 2.4/2.5 compiler-bug surface is preserved.
+
+2. **Are new guards meaningful?** Yes. Verified each guard's referenced text actually exists in the named owner module (`pub(crate) fn try_lower_registry_expr_strict/_exprs_strict` in `collection_methods.rs:641,652`; `_recursive` in `recursive_exprs.rs:7`; `_result` in `field_and_stdlib_rewrites.rs:265`; `fn emit_stmt` wrapper in `lib_emitter_state.rs:810`; `try_lower_simple_stmt_with_scope_result_and_bindings` in `lib_emitter_state.rs:383`; generator-init missing strings in `statement_output.rs:11,25`; `try_lower_leaf_expr_result` in `leaves_and_plain_calls.rs:80`; `if !emitter.body_items.is_empty()` in `entrypoints.rs:96`). The negative assertions on `lib.rs` (now 95 lines) all hold — no banned tokens present.
+
+3. **Inventory internally consistent?** Yes. `red_blocker.failure_count = 10`, `test_result = 697/10/707`, exactly 6 rows with `closes_in_subwave: "3"` flipped to `status: closed`, and the 10 open rows split 6× Wave 2.4 + 4× Wave 2.5, all `classification: compiler-bug`. Matches the user-reported `jq` snapshot exactly.
+
+4. **Docs accurate for closure evidence?** Yes. `plans/issues/active/codegen-test-triage.md` records the 691→697 / 16→10 transition and the Wave 2.2 PR (#2563). `plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md` Wave 2.3 Implementation Notes capture scope (6 rows), the retargeted modules, the validation command set, the two transient core-language audit timeouts, and the `create-pr` 197.18 s wall time. The phase-status header is consistent with Wave 2.2 merged + 2.3 in progress.
+
+5. **Blockers before PR?** None.

--- a/verification/areas/generated_code_quality/codegen_red_blocker_inventory.json
+++ b/verification/areas/generated_code_quality/codegen_red_blocker_inventory.json
@@ -3,8 +3,8 @@
   "generated_from": "cargo test -p sifr_codegen -- --nocapture",
   "captured_on": "2026-06-14",
   "test_result": {
-    "passed": 691,
-    "failed": 16,
+    "passed": 697,
+    "failed": 10,
     "ignored": 0,
     "total": 707
   },
@@ -13,7 +13,7 @@
     "package": "sifr_codegen",
     "status": "red-blocker",
     "owner": "codegen",
-    "failure_count": 16,
+    "failure_count": 10,
     "triage_file": "plans/issues/active/codegen-test-triage.md",
     "issue": "plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md",
     "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
@@ -40,7 +40,7 @@
       "current_output": "Guard expects removed helper names in intrinsic_method_emitters.rs; replace with a current structured-registry boundary check or delete if covered by production no-non-IR-token scan.",
       "panic": "assertion failed: prod_src.contains(\"fn try_lower_registry_expr_strict(\") note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
       "expected_output_or_snapshot": "Current production source should be guarded by token/architecture checks that match the refactored helper names.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "3"
     },
@@ -152,7 +152,7 @@
       "current_output": "Guard looks for old stmt_support_emitter helper text after source decomposition/refactor.",
       "panic": "assertion failed: stmt_support_src.contains(\"self.lower_stmt_expr_for_ir(value)\")",
       "expected_output_or_snapshot": "Replace with a current structured generator-init path guard or map to existing no-non-IR-token scan.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "3"
     },
@@ -168,7 +168,7 @@
       "current_output": "Guard expects assembled body logic in lib.rs even though implementation moved out during decomposition.",
       "panic": "assertion failed: lib_src.contains(\"if !emitter.body_items.is_empty() {\")",
       "expected_output_or_snapshot": "Retarget to the owning module_body/entrypoint source or remove if covered by decomposition guardrails.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "3"
     },
@@ -184,7 +184,7 @@
       "current_output": "Guard expects lib.rs to contain body_items wiring after decomposition moved the responsibility.",
       "panic": "assertion failed: lib_src.contains(\"if !emitter.body_items.is_empty() {\")",
       "expected_output_or_snapshot": "Retarget to current module_constants/entrypoint files with a stable ownership assertion.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "3"
     },
@@ -648,7 +648,7 @@
       "current_output": "Guard expects an `emit_stmt` wrapper in lib.rs after decomposition moved statement lowering out.",
       "panic": "emit_stmt wrapper should exist FAILED",
       "expected_output_or_snapshot": "Retarget decomposition guard to current owner files or rely on maintainability guardrail.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "3"
     },
@@ -664,7 +664,7 @@
       "current_output": "Guard expects old helper names in lib.rs/module files after result-helper refactor.",
       "panic": "assertion failed: lib_src.contains(\"try_lower_simple_stmt_with_scope_result(\")",
       "expected_output_or_snapshot": "Replace with current helper-name contract or delete if no longer meaningful.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "3"
     },


### PR DESCRIPTION
## Summary
- Retarget the 6 Wave 2.3 obsolete codegen architecture guards to current owner modules after decomposition/refactors.
- Update the generated-code red-blocker inventory from 691/16/707 to 697/10/707.
- Record Wave 2.3 validation and Claude Opus review evidence.

## Validation
- Six previously failing Wave 2.3 exact tests: pass
- `cargo test -p sifr_codegen -- --nocapture` expected red: 697 passed / 10 failed / 707 total
- `cargo fmt --check`
- `python3 scripts/check_file_size_guardrails.py`
- `jq empty verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`
- `uv run --project verification --locked python -m sifr_verify areas run --area core_language` pass after first create-pr attempt hit two transient audit-fixture timeouts
- `scripts/run_all_tests.sh --profile create-pr` pass, wall_time=197.18s, existing warm wall-time advisory only

## Review
- `plans/reviews/active/ad-hoc-world-class-verification-wave-2-3-review-pass-1.md`: no blockers; approved for PR/merge with nits only.