### PR TITLE
Close codegen verification wave 2.4

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests/performance_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/performance_codegen_tests.rs
@@ -368,7 +368,11 @@ def compute(values: list[int]) -> list[int]:
     );
 
     assert!(
-        generated.contains("let Some(mut pair) = pair else"),
+        generated.contains("let Some(pair) = pair else"),
+        "{generated}"
+    );
+    assert!(
+        !generated.contains("let Some(mut pair) = pair else"),
         "{generated}"
     );
     assert!(

--- a/crates/sifr_codegen/src/lower_stmt/condition_lowering.rs
+++ b/crates/sifr_codegen/src/lower_stmt/condition_lowering.rs
@@ -15,10 +15,10 @@ pub(super) fn try_lower_simple_if_stmt(
     ctx: SimpleStmtLoweringCtx<'_>,
 ) -> Option<Vec<RustStmt>> {
     let option_binding_pattern = |name: &str| {
-        if bindings.borrowed_params.contains(name) {
-            format!("Some({name})")
-        } else {
+        if bindings.mutated_vars.contains(name) {
             format!("Some(mut {name})")
+        } else {
+            format!("Some({name})")
         }
     };
     if elif_clauses.is_empty() && maybe_else_body.is_none() && codegen_body_always_exits(then_body)
@@ -108,10 +108,10 @@ pub(super) fn try_lower_simple_if_clause(
     ctx: SimpleStmtLoweringCtx<'_>,
 ) -> Option<RustStmt> {
     let option_binding_pattern = |name: &str| {
-        if bindings.borrowed_params.contains(name) {
-            format!("Some({name})")
-        } else {
+        if bindings.mutated_vars.contains(name) {
             format!("Some(mut {name})")
+        } else {
+            format!("Some({name})")
         }
     };
     let lowered_then_body = try_lower_simple_stmt_block(

--- a/crates/sifr_codegen/src/lower_stmt/core_and_tuple_tests.rs
+++ b/crates/sifr_codegen/src/lower_stmt/core_and_tuple_tests.rs
@@ -258,6 +258,21 @@ fn does_not_lower_field_assign_with_non_leaf_value() {
 }
 
 #[test]
+fn does_not_lower_field_assign_with_mismatched_value_type() {
+    let stmt = HirStmt::FieldAssign {
+        object: "node".to_string(),
+        field: "value".to_string(),
+        field_ty: Type::Union(vec![Type::Int, Type::None]),
+        value: HirExpr::Name {
+            name: "next_value".to_string(),
+            ty: Type::Int,
+        },
+    };
+
+    assert!(try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new()).is_none());
+}
+
+#[test]
 fn lowers_simple_tuple_unpack_stmt() {
     let tuple_unpack = HirStmt::TupleUnpack {
         targets: vec![

--- a/crates/sifr_codegen/src/lower_stmt/return_and_assignment_values.rs
+++ b/crates/sifr_codegen/src/lower_stmt/return_and_assignment_values.rs
@@ -157,13 +157,27 @@ pub(super) fn try_lower_simple_assign_value(
 }
 
 pub(super) fn try_lower_simple_field_assign_stmt(
-    _object: &str,
-    _field: &str,
-    _value: &HirExpr,
+    object: &str,
+    field: &str,
+    field_ty: &Type,
+    value: &HirExpr,
 ) -> Option<Vec<RustStmt>> {
-    // Keep field assignments on the structured path so class/recursive storage
-    // adaptations (boxing and option handling) are consistently applied.
-    None
+    if object == "self" {
+        // Keep self-field assignments on the structured path so class/recursive
+        // storage adaptations (boxing and option handling) are consistently applied.
+        return None;
+    }
+    if resolve_alias_type(field_ty) != resolve_alias_type(value.ty()) {
+        return None;
+    }
+    let lowered_value = try_lower_leaf_or_name_expr(value)?;
+    Some(vec![RustStmt::Assign {
+        target: RustExpr::Field {
+            expr: Box::new(RustExpr::Ident(object.to_string())),
+            field: field.to_string(),
+        },
+        value: lowered_value,
+    }])
 }
 
 pub(super) fn try_lower_simple_aug_assign_value(op: &str, value: &HirExpr) -> Option<RustExpr> {

--- a/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
+++ b/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
@@ -106,9 +106,9 @@ pub(crate) fn try_lower_simple_stmt_with_ctx_and_bindings(
         HirStmt::FieldAssign {
             object,
             field,
+            field_ty,
             value,
-            ..
-        } => try_lower_simple_field_assign_stmt(object, field, value),
+        } => try_lower_simple_field_assign_stmt(object, field, field_ty, value),
         HirStmt::NestedFieldAssign { .. } => None,
         HirStmt::Return { value: None } => {
             if ctx.in_display_impl {

--- a/crates/sifr_codegen/src/stmt_support_emitter/condition_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/condition_lowering.rs
@@ -142,12 +142,10 @@ impl RustEmitter {
     }
 
     pub(crate) fn option_binding_pattern_for_ir(&self, option_var: &str) -> String {
-        let is_borrowed_param = self.borrowed_params.contains(option_var)
-            || self.mut_borrowed_params.contains(option_var);
-        if is_borrowed_param {
-            format!("Some({option_var})")
-        } else {
+        if self.mutated_vars.contains(option_var) {
             format!("Some(mut {option_var})")
+        } else {
+            format!("Some({option_var})")
         }
     }
 

--- a/plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md
+++ b/plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md
@@ -1,6 +1,6 @@
 # Ad Hoc Phase: World-Class Verification Standard and Gate Closure
 
-Status: in progress; Wave 0, Wave 1, Wave 2.0, Wave 2.1, and Wave 2.2 merged; Wave 2.3 codegen obsolete architecture guard retargeting in progress
+Status: in progress; Wave 0, Wave 1, Wave 2.0, Wave 2.1, Wave 2.2, and Wave 2.3 merged; Wave 2.4 structured lowering compiler-bug repairs locally validated and under review
 Owner: compiler-verification
 Context: Follow-on verification phase after Phase 29; based on local Sifr verification audit against TypeScript, TypeScript-Go, Rust, CPython, and Bun
 
@@ -365,7 +365,7 @@ Implementation re-check started 2026-06-14.
 
 ### Wave 2.3 Implementation Notes
 
-- Status: implemented locally; review and PR pending.
+- Status: merged in PR `https://github.com/sifr-lang/sifr/pull/2564`.
 - Scope: close all 6 obsolete architecture guard rows assigned to `proposed_pr_slice: 2.3` in the `sifr_codegen` red-blocker inventory.
 - Changes: retargeted stale source-text guards from retired wrapper/helper locations to the current owner modules after decomposition: registry strict/recursive/result helpers, entrypoint body-item assembly, module body/constants emission, generator-init statement output, and structured statement orchestration in `lib_emitter_state.rs`.
 - Validation:
@@ -380,6 +380,26 @@ Implementation re-check started 2026-06-14.
 - Artifacts:
   - `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`: `red_blocker.failure_count` updated to 10, `test_result` updated to 697/10/707, and all 6 Wave 2.3 rows marked `closed`.
   - `plans/issues/active/codegen-test-triage.md`: current Wave 2.3 state and remaining open-row count documented.
+
+### Wave 2.4 Implementation Notes
+
+- Status: locally validated and approved by second review; PR pending.
+- Scope: close all 6 structured lowering compiler-bug rows assigned to `proposed_pr_slice: 2.4` in the `sifr_codegen` red-blocker inventory.
+- Changes: restored simple lowering for non-`self` field assignments when field/value types already match, kept `self` field assignments and mismatched typed field assignments on the structured path for class/recursive storage adaptations, and made option unwrapping patterns mutation-aware in both simple lowering and the structured emitter path. Updated the related break-guard regression to assert the non-`mut` option pattern when the unwrapped value is not mutated.
+- Validation:
+  - Six previously failing Wave 2.4 exact tests: pass.
+  - `cargo test -p sifr_codegen lib_codegen_tests::performance_codegen_tests::break_guard_unwraps_optional_tuple_before_indexing -- --exact --nocapture`: pass after assertion update for the mutation-aware option pattern.
+  - `cargo test -p sifr_codegen -- --nocapture`: expected failure; improved from 697 passed / 10 failed / 707 total to 704 passed / 4 failed / 708 total, closing exactly the 6 Wave 2.4 rows while leaving Wave 2.5 red and adding one field-assignment guard regression.
+  - `cargo fmt --check`: pass after formatting.
+  - `python3 scripts/check_file_size_guardrails.py`: pass.
+  - `uv run --project verification --locked python -m sifr_verify areas run --area core_language`: pass after both the initial and post-review `create-pr` attempts hit the same two transient 10s audit-fixture timeouts.
+  - `scripts/run_all_tests.sh --profile create-pr`: pass after the post-review focused core-language rerun; wall time 198.88s with the existing warm-budget advisory and 100% e2e cache hit rate.
+- Review:
+  - `plans/reviews/active/ad-hoc-world-class-verification-wave-2-4-review-pass-1.md`: approved with nits and no blocking issues; the non-self field assignment type-adaptation nit was addressed by guarding the simple path on matching resolved field/value types and adding a mismatched type regression.
+  - `plans/reviews/active/ad-hoc-world-class-verification-wave-2-4-review-pass-2.md`: approved with no blocking issues; reviewer confirmed Wave 2.4 is ready for PR/merge.
+- Artifacts:
+  - `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`: `red_blocker.failure_count` updated to 4, `test_result` updated to 704/4/708, and all 6 Wave 2.4 rows marked `closed`.
+  - `plans/issues/active/codegen-test-triage.md`: current Wave 2.4 state and remaining open-row count documented.
 
 ## Full Discovery Snapshot
 

--- a/plans/issues/active/codegen-test-triage.md
+++ b/plans/issues/active/codegen-test-triage.md
@@ -1,6 +1,6 @@
 # Codegen Test Triage
 
-Status: Wave 2.3 obsolete architecture guard retargeting in progress; Wave 2.0 inventory merged in PR https://github.com/sifr-lang/sifr/pull/2561, Wave 2.1 merged in PR https://github.com/sifr-lang/sifr/pull/2562, and Wave 2.2 merged in PR https://github.com/sifr-lang/sifr/pull/2563.
+Status: Wave 2.4 structured lowering compiler-bug repairs locally validated and under review; Wave 2.0 inventory merged in PR https://github.com/sifr-lang/sifr/pull/2561, Wave 2.1 merged in PR https://github.com/sifr-lang/sifr/pull/2562, Wave 2.2 merged in PR https://github.com/sifr-lang/sifr/pull/2563, and Wave 2.3 merged in PR https://github.com/sifr-lang/sifr/pull/2564.
 
 Reproduction command:
 
@@ -8,7 +8,7 @@ Reproduction command:
 cargo test -p sifr_codegen -- --nocapture
 ```
 
-Observed Wave 2.0 result on 2026-06-14: `655 passed; 52 failed; 707 total`. After Wave 2.1 stale expectation repairs, the result was `675 passed; 32 failed; 707 total`. After Wave 2.2 stale source-fixture repairs, the result was `691 passed; 16 failed; 707 total`. After Wave 2.3 obsolete architecture guard retargeting, the current local result is `697 passed; 10 failed; 707 total`. The saved local Wave 2.0 log is `target/wave2/sifr_codegen_nocapture.log`; the checked-in machine-readable inventory is `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`.
+Observed Wave 2.0 result on 2026-06-14: `655 passed; 52 failed; 707 total`. After Wave 2.1 stale expectation repairs, the result was `675 passed; 32 failed; 707 total`. After Wave 2.2 stale source-fixture repairs, the result was `691 passed; 16 failed; 707 total`. After Wave 2.3 obsolete architecture guard retargeting, the result was `697 passed; 10 failed; 707 total`. After Wave 2.4 structured lowering repairs plus a field-assignment guard regression, the current local result is `704 passed; 4 failed; 708 total`. The saved local Wave 2.0 log is `target/wave2/sifr_codegen_nocapture.log`; the checked-in machine-readable inventory is `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`.
 
 The JSON inventory records closure with `closes_in_wave: 2` and `closes_in_subwave` for each row. `proposed_pr_slice` below is the human-readable repair slice label.
 
@@ -19,7 +19,7 @@ Classification counts from the Wave 2.0 inventory:
 - `compiler-bug`: 10.
 - `production-bug`: 0; no unresolved production sentinel rows in Wave 2.0.
 
-Wave 2.1 closes the 20 `proposed_pr_slice: 2.1` rows by refreshing stale literal, final-return, render snapshot, and iterator materialization expectations to the current generated-Rust contract. Wave 2.2 closes the 16 `proposed_pr_slice: 2.2` rows by making parser, async-effect, and explicit-encoding fixtures policy-compliant while preserving their codegen assertions. Wave 2.3 closes the 6 `proposed_pr_slice: 2.3` rows by retargeting obsolete architecture guards to their current owner modules after decomposition/refactors. The remaining 10 open rows stay assigned to Waves 2.4 and 2.5.
+Wave 2.1 closes the 20 `proposed_pr_slice: 2.1` rows by refreshing stale literal, final-return, render snapshot, and iterator materialization expectations to the current generated-Rust contract. Wave 2.2 closes the 16 `proposed_pr_slice: 2.2` rows by making parser, async-effect, and explicit-encoding fixtures policy-compliant while preserving their codegen assertions. Wave 2.3 closes the 6 `proposed_pr_slice: 2.3` rows by retargeting obsolete architecture guards to their current owner modules after decomposition/refactors. Wave 2.4 closes the 6 `proposed_pr_slice: 2.4` rows by restoring non-self field assignment lowering and mutation-aware option unwrapping. The remaining 4 open rows stay assigned to Wave 2.5.
 
 Proposed PR slices:
 

--- a/plans/reviews/active/ad-hoc-world-class-verification-wave-2-4-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-world-class-verification-wave-2-4-review-pass-1.md
@@ -1,0 +1,42 @@
+I have enough context. Now I'll write the review.
+
+---
+
+# Wave 2.4 Codegen Review — Pass 1
+
+**Verdict: approved with nits**
+
+The six Wave 2.4 rows are correctly closed by tightly scoped changes. Root behavior is right for the targeted contracts, the inventory and tracking docs are internally consistent, and the four remaining `proposed_pr_slice: 2.5` rows stay `open` with `closes_in_subwave: 5`. No blocking issues found.
+
+## Blocking findings
+None.
+
+## Non-blocking nits
+
+1. **Non-self simple field-assign lowering lacks a field/value-type guard** — `crates/sifr_codegen/src/lower_stmt/return_and_assignment_values.rs:159-177`. The new `try_lower_simple_field_assign_stmt` accepts any `object != "self"` and lowers `object.field = <leaf-or-name>` raw. If a non-self field carries a codegen-only storage adaptation (e.g. recursive `Box<T>` or option-wrapping on the field), the simple path would emit `node.field = value` without the corresponding `Box::new(...)` / `Some(...)` wrap. The Wave 2.4 regression at `lower_stmt/core_and_tuple_tests.rs:208-230` only covers `Type::Int → Type::Int`, and the full suite stays green, so this is plausibly unreachable from user code today — but the asymmetry (self path defers to structured emitter for exactly this reason per the inline comment) is worth either documenting or guarding on `field_ty == value.ty()` before a future recursive non-self field case lands.
+
+2. **Pattern-mut heuristic dropped borrowed-param negative guard** — `lower_stmt/condition_lowering.rs:17-23,110-116` and `stmt_support_emitter/condition_lowering.rs:144-150`. The new predicate is purely `mutated_vars.contains(name)`. If a borrowed `&Option<T>` param ever lands in `mutated_vars` (e.g. local rebinding of the param name), the emitted pattern becomes `Some(mut x)` applied to a scrutinee that goes through `.as_ref()` (`option_binding_value_expr_for_ir` at `condition_lowering.rs:129-142` is unchanged). That still compiles — `mut x: &T` is sound — but it is a behavior change from the prior "borrowed ⇒ never mut" invariant; worth a short note in the wave summary.
+
+3. **Performance-test assertion pair is good, but the negative assertion is redundant once `Some(pair)` is asserted** — `lib_codegen_tests/performance_codegen_tests.rs:370-377`. `generated.contains("let Some(pair) = pair else") && !generated.contains("let Some(mut pair) = pair else")` is belt-and-suspenders; the positive check is a strict substring so it already excludes the `mut` form. Not wrong, just extra. Leaving it does cleanly document the regression intent (no spurious `mut`), so OK to keep.
+
+4. **Plan-doc PR link for Wave 2.3 references `pull/2564`, while `codegen-test-triage.md` also lists `pull/2564` for Wave 2.3** — consistent within this diff, but worth double-checking the actual merged PR number against GitHub before merging Wave 2.4 (this diff alone doesn't expose a mismatch).
+
+## Review-question answers
+
+1. **Scope correctness.** `jq` confirms exactly 6 rows with `proposed_pr_slice == "2.4"` flipped to `closed` (`closes_in_subwave: "4"`) and 4 rows with `proposed_pr_slice == "2.5"` remaining `open` (`closes_in_subwave: "5"`). Totals: 48 closed / 4 open / 52 total. No misclassification.
+
+2. **Field-assignment behavior.** `object == "self"` still returns `None` to keep the structured emitter responsible for boxing/option adaptations; this matches the unchanged regression `does_not_lower_field_assign_on_self_target` at `core_and_tuple_tests.rs:233-242`. Non-self path uses `try_lower_leaf_or_name_expr` (rejects non-leaf RHS — confirmed by `does_not_lower_field_assign_with_non_leaf_value` at line 244-258). Correct for the targeted contract; see Nit 1 for the type-adaptation caveat.
+
+3. **Mutation-aware option pattern.** Both simple (`lower_stmt/condition_lowering.rs:17-23,110-116`) and structured (`stmt_support_emitter/condition_lowering.rs:144-150`) paths now key off `mutated_vars`. `collect_mutated_vars` in `hir_analysis/queries/queries_impl.rs:300-461` covers Assign / AugAssign / mutating method calls / Subscript/Field assigns / Delete / async-with — comprehensive enough to be a sound proxy for "needs `mut` on the unwrapped binding." For the `break_guard_unwraps_optional_tuple_before_indexing` fixture, `pair` is introduced via `HirStmt::Let` (not `Assign`) and only read via `pair[1]`, so it correctly stays out of `mutated_vars` and the new `Some(pair)` pattern is emitted.
+
+4. **Performance-test assertion update.** Correct. In the Wave 2.4 source the unwrapped `pair` is read-only (`previous_index = pair[1]`); the prior `Some(mut pair)` was a spurious mut from the inverse-of-borrowed heuristic. The new assertion pins both the desired shape and the absence of `mut`, which is the actual non-weakening (Nit 3 notes the redundancy but not weakening).
+
+5. **Inventory and tracking docs.** `red_blocker.failure_count: 4` and `test_result: 703/4/707` match the reported local run. Wave 2.3 status moved to "merged in PR #2564" and Wave 2.4 added with `locally validated; review and PR pending`. `codegen-test-triage.md` updates the running per-wave progression consistently. The phase plan's prose ("close all 6 structured lowering compiler-bug rows") matches the JSON closure pattern.
+
+## Verification notes
+
+- `git diff --stat` matches the seven files declared in scope; no collateral edits.
+- `jq` over `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`: 6 closed at `proposed_pr_slice == "2.4"`, 4 open at `proposed_pr_slice == "2.5"`, totals 48/4/52 — consistent with the updated `red_blocker.failure_count` and `test_result`.
+- Spot-checked all six Wave 2.4 regression sites (`lowers_simple_field_assign_for_non_self_target`, the five `return_assert_if_tests` option-narrowing tests) against the new lowering paths — assertions align with what the modified code now emits given empty `mutated_vars` / `borrowed_params`.
+- Did not re-run cargo tests or the verification harness; relied on the user-supplied local run logs (six target tests pass, suite at 703/4/707, `create-pr` profile green after transient timeout).
+- Untracked `plans/reviews/active/ad-hoc-world-class-verification-wave-2-4-review-pass-1.md` is a zero-length placeholder — not part of this scope, no action needed.

--- a/plans/reviews/active/ad-hoc-world-class-verification-wave-2-4-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-world-class-verification-wave-2-4-review-pass-2.md
@@ -1,0 +1,54 @@
+I have enough context. Here is the review.
+
+---
+
+# Wave 2.4 Codegen Review — Pass 2
+
+**Verdict: approved**
+
+The pass-1 nit on non-self simple field assignment has been correctly addressed by a resolved-type equality guard plus a new regression at `crates/sifr_codegen/src/lower_stmt/core_and_tuple_tests.rs:260-273`. The six Wave 2.4 rows are closed, the four Wave 2.5 rows remain `open` with `closes_in_subwave: "5"`, and the inventory/docs match the new 704/4/708 result. Ready for PR/merge from a code-review perspective.
+
+## Blocking findings
+
+None.
+
+## Non-blocking nits
+
+1. **Mutation-aware pattern still drops the historical "borrowed ⇒ never mut" invariant** — `crates/sifr_codegen/src/lower_stmt/condition_lowering.rs:17-23,110-116` and `crates/sifr_codegen/src/stmt_support_emitter/condition_lowering.rs:144-150`. Both predicates are now strictly `mutated_vars.contains(name)`; the prior negative guard on borrowed params is gone in the structured emitter too. `collect_mutated_vars` is reliable today, and `option_binding_value_expr_for_ir` at `stmt_support_emitter/condition_lowering.rs:129-142` still adds `.as_ref()` for borrowed params so the resulting `Some(mut x) = x.as_ref()` is well-typed (`mut x: &T`). Carried over from pass-1 — still worth a one-line comment near both predicates documenting why borrowed params are intentionally not negative-guarded anymore.
+
+2. **Resolved-type equality is a structural compare across the full HIR `Type` shape** — `crates/sifr_codegen/src/lower_stmt/return_and_assignment_values.rs:170-172`. `resolve_alias_type(field_ty) != resolve_alias_type(value.ty())` works for the targeted cases (Option vs non-Option, Union shapes), but the check is conservative on intent and broad on cost: every non-self field assignment now performs a deep `Type` comparison. For Wave 2.4 scale this is fine, but if the simple field-assign path widens later, consider replacing the structural compare with an explicit predicate like `field_carries_storage_adaptation(field_ty, value.ty())`. Not a blocker; the current code's intent is documented by the inline comment.
+
+3. **Redundant positive/negative assertion pair in the perf regression** — `crates/sifr_codegen/src/lib_codegen_tests/performance_codegen_tests.rs:370-377`. The `!generated.contains("let Some(mut pair) = pair else")` is strictly entailed by the positive `generated.contains("let Some(pair) = pair else")`. Pass-1 already noted this; kept for documentation intent. OK to leave.
+
+## Review-question answers
+
+1. **Scope correctness.** `jq` confirms exactly 6 rows with `proposed_pr_slice == "2.4"` are `closed` (`closes_in_subwave: "4"`) and 4 rows with `proposed_pr_slice == "2.5"` remain `open` (`closes_in_subwave: "5"`). Inventory totals: 48 closed / 4 open / 52 total. The four open rows are codegen-red-0012, -0029, -0037, -0045 — all `compiler-bug`, none mislabeled or hidden.
+
+2. **Field/value type guard sufficiency.** The added check `resolve_alias_type(field_ty) != resolve_alias_type(value.ty())` at `return_and_assignment_values.rs:170-172` is sufficient for the targeted storage-adaptation cases:
+   - Option-of-class field with non-Option leaf value → resolved types differ (Union vs Class) → simple path correctly defers, so the structured emitter handles `Some(Box::new(...))`.
+   - Same-type Option-of-class field and value → resolved types match, so the simple path runs; this is fine because the Rust storage representation is identical on both sides (`Option<Box<Node>>` ↔ `Option<Box<Node>>`) and a plain move-assign type-checks.
+   - The new `does_not_lower_field_assign_with_mismatched_value_type` regression at `core_and_tuple_tests.rs:260-273` pins the `Union(Int, None)` field vs `Int` value case, which is the canonical storage-adaptation mismatch the pass-1 nit called out.
+   The combination of (a) `object != "self"`, (b) resolved-type equality, and (c) `try_lower_leaf_or_name_expr` (rejects non-leaf RHS via `does_not_lower_field_assign_with_non_leaf_value` at `core_and_tuple_tests.rs:244-258`) keeps the simple path correctly scoped.
+
+3. **Mutation-aware option pattern.** Correct in both paths.
+   - Simple lowering: `lower_stmt/condition_lowering.rs:17-23,110-116` keys patterns off `mutated_vars`.
+   - Structured emitter: `stmt_support_emitter/condition_lowering.rs:144-150` mirrors the same predicate, and `option_binding_value_expr_for_ir` at `stmt_support_emitter/condition_lowering.rs:129-142` still wraps borrowed scrutinees with `.as_ref()`, so `let Some(mut x) = x.as_ref() else ...` would be `mut x: &T` (sound) if a borrowed param ever ends up in `mutated_vars`. For the `break_guard_unwraps_optional_tuple_before_indexing` fixture, `pair` is introduced via `HirStmt::Let` (not `Assign`) and only read via `pair[1]`, so `collect_mutated_vars` correctly excludes it and the new `Some(pair)` pattern is emitted.
+
+4. **Inventory/docs consistency.** Verified:
+   - `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json:5-10` reports `passed: 704, failed: 4, total: 708`, matching the local cargo run.
+   - `red_blocker.failure_count: 4` at line 16.
+   - All six Wave 2.4 rows show `status: "closed"`, `closes_in_subwave: "4"`.
+   - All four Wave 2.5 rows show `status: "open"`, `closes_in_subwave: "5"`.
+   - `plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md:384-401` Wave 2.4 notes correctly describe 704/4/708, reference pass-1 review, and document the mismatched-type guard regression.
+   - `plans/issues/active/codegen-test-triage.md:3,11,22` consistently reports 704/4/708 and the Wave 2.4 → 2.5 progression.
+   - Delta math checks out: previously 697/10/707 → 704/4/708 = +6 passes from row closures, -6 failures, +1 total from the new mismatched-type regression test.
+
+5. **PR/merge readiness.** Yes, from a code-review perspective. The change is tightly scoped, the targeted contracts are well-covered by tests, no Wave 2.5 work bleeds in, and pass-1's only material nit has been addressed at the root cause.
+
+## Verification notes
+
+- `git status` and `git diff --stat` match the seven declared in-scope files plus the two untracked review notes; no collateral edits.
+- `jq` over the inventory confirmed: 6 closed at `proposed_pr_slice == "2.4"`, 4 open at `proposed_pr_slice == "2.5"`, all four `compiler-bug` classification, totals 48 closed / 4 open / 52 total.
+- `git diff` against HEAD on the test file confirms exactly one new test was added (`does_not_lower_field_assign_with_mismatched_value_type`); the other three field-assign tests already existed in HEAD (one of which — `lowers_simple_field_assign_for_non_self_target` — is the Wave 2.4 row codegen-red-0046 being closed).
+- Cross-checked the structured emitter's `option_binding_value_expr_for_ir` to confirm it still wraps borrowed scrutinees with `.as_ref()`, which is what makes the new mutation-aware pattern sound even if `mutated_vars` ever overlaps `borrowed_params`.
+- Did not re-run cargo tests or the verification harness; relied on the user-supplied local run logs (six target tests pass, suite at 704/4/708, `create-pr` profile green after the transient core_language rerun, fmt and file-size guardrails green).

--- a/verification/areas/generated_code_quality/codegen_red_blocker_inventory.json
+++ b/verification/areas/generated_code_quality/codegen_red_blocker_inventory.json
@@ -3,17 +3,17 @@
   "generated_from": "cargo test -p sifr_codegen -- --nocapture",
   "captured_on": "2026-06-14",
   "test_result": {
-    "passed": 697,
-    "failed": 10,
+    "passed": 704,
+    "failed": 4,
     "ignored": 0,
-    "total": 707
+    "total": 708
   },
   "red_blocker": {
     "profile_suite_id": "sifr_codegen",
     "package": "sifr_codegen",
     "status": "red-blocker",
     "owner": "codegen",
-    "failure_count": 10,
+    "failure_count": 4,
     "triage_file": "plans/issues/active/codegen-test-triage.md",
     "issue": "plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md",
     "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
@@ -760,7 +760,7 @@
       "current_output": "Internal simple-stmt lowering no longer handles non-self field assignment.",
       "panic": "field assign lowered",
       "expected_output_or_snapshot": "Restore/replace structured field assignment lowering and add regression for non-self target assignment.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "4"
     },
@@ -776,7 +776,7 @@
       "current_output": "Internal simple-stmt lowering no longer emits expected IfLet for option truthiness in elif.",
       "panic": "assertion failed: matches!(else_body[0], RustStmt::IfLet { pattern: ref p, expr: RustExpr::Ident(ref n), else_body: Some(_), .. } if p == \"Some(maybe_x)\" && n == \"maybe_x\")",
       "expected_output_or_snapshot": "Fix option-truthiness elif lowering or update to an equivalent safe Rust IR shape with regression.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "4"
     },
@@ -792,7 +792,7 @@
       "current_output": "Option-is-none exiting-body optimization no longer emits expected LetElse without unwrap.",
       "panic": "assertion failed: matches!(lowered[0], RustStmt::LetElse { pattern: ref p, value: RustExpr::Ident(ref name), ref else_body, } if p == \"Some(maybe_x)\" && name == \"maybe_x\" && !else_body.is_empty())",
       "expected_output_or_snapshot": "Restore safe LetElse lowering or replace with equivalent no-unwrap codegen regression.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "4"
     },
@@ -808,7 +808,7 @@
       "current_output": "Alias option truthiness no longer lowers to expected IfLet shape.",
       "panic": "assertion failed: matches!(lowered[0], RustStmt::IfLet { pattern: ref p, expr: RustExpr::Ident(ref n), else_body: Some(_), .. } if p == \"Some(maybe_x)\" && n == \"maybe_x\")",
       "expected_output_or_snapshot": "Fix alias-aware option narrowing or assert equivalent generated no-unwrap behavior.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "4"
     },
@@ -824,7 +824,7 @@
       "current_output": "Option `is not None` compare no longer lowers to expected IfLet shape.",
       "panic": "assertion failed: matches!(lowered[0], RustStmt::IfLet { ref pattern, expr: RustExpr::Ident(ref name), .. } if pattern == \"Some(maybe_x)\" && name == \"maybe_x\")",
       "expected_output_or_snapshot": "Fix option compare narrowing or replace with equivalent no-unwrap regression.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "4"
     },
@@ -840,7 +840,7 @@
       "current_output": "Option truthiness no longer lowers to expected IfLet shape with else body.",
       "panic": "assertion failed: matches!(lowered[0], RustStmt::IfLet { pattern: ref p, expr: RustExpr::Ident(ref n), else_body: Some(_), .. } if p == \"Some(maybe_x)\" && n == \"maybe_x\")",
       "expected_output_or_snapshot": "Fix option truthiness lowering or assert equivalent safe generated Rust shape.",
-      "status": "open",
+      "status": "closed",
       "reproduction_command": "cargo test -p sifr_codegen -- --nocapture",
       "closes_in_subwave": "4"
     },


### PR DESCRIPTION
## Summary
- Close the six Wave 2.4 structured-lowering red-blocker rows in the codegen inventory.
- Restore simple non-self field assignment lowering only when resolved field/value types match, leaving self and storage-adaptation cases on the structured path.
- Make option narrowing patterns mutation-aware in simple lowering and the structured emitter, and refresh the related break-guard regression.
- Update codegen triage/phase docs and add two Opus review artifacts.

## Validation
- Focused Wave 2.4 exact tests: pass.
- Focused field assignment regressions: pass, including `does_not_lower_field_assign_with_mismatched_value_type`.
- `cargo test -p sifr_codegen lib_codegen_tests::performance_codegen_tests::break_guard_unwraps_optional_tuple_before_indexing -- --exact --nocapture`: pass.
- `cargo test -p sifr_codegen -- --nocapture`: expected red, now `704 passed / 4 failed / 708 total`; remaining four failures are Wave 2.5 rows.
- `cargo fmt --check`: pass.
- `python3 scripts/check_file_size_guardrails.py`: pass.
- Inventory jq check: `failure_count=4`, `test_result=704/4/708`, `closed_24=6`, `open_rows=4`.
- `uv run --project verification --locked python -m sifr_verify areas run --area core_language`: pass after transient audit-fixture timeout.
- `scripts/run_all_tests.sh --profile create-pr`: pass after focused core-language rerun; wall time `198.88s`, 100% E2E cache hit rate, existing warm wall-time advisory.

## Reviews
- `plans/reviews/active/ad-hoc-world-class-verification-wave-2-4-review-pass-1.md`: approved with nits; material nit addressed.
- `plans/reviews/active/ad-hoc-world-class-verification-wave-2-4-review-pass-2.md`: approved; ready for PR/merge.
