### PR TITLE
Promote codegen suite into merge gate

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests/recursive_node_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/recursive_node_codegen_tests.rs
@@ -107,6 +107,46 @@ def walk(own root: TreeNode | None) -> list[int]:
 }
 
 #[test]
+fn test_recursive_option_let_else_binding_is_mutable_for_child_moves() {
+    let rust_code = generate_rust_from_source(
+        r#"class Expr:
+    value: int
+    term: Term | None
+
+    def __init__(self, value: int, term: Term | None):
+        self.value = value
+        self.term = term
+
+class Term:
+    factor: int
+    expr: Expr | None
+
+    def __init__(self, factor: int, expr: Expr | None):
+        self.factor = factor
+        self.expr = expr
+
+def measure(expr: Expr | None) -> int:
+    if not expr:
+        return 0
+    term: Term | None = expr.term
+    if not term:
+        return expr.value
+    parent: Expr | None = term.expr
+    return expr.value + term.factor + measure(parent)
+"#,
+    );
+
+    assert!(
+        rust_code.contains("let Some(mut term) = term else"),
+        "recursive option narrowing must bind mutable locals when later field reads use .take():\n{rust_code}"
+    );
+    assert!(
+        rust_code.contains("term.expr.take().map(|__sifr_boxed_recursive_value|"),
+        "owned recursive option field reads should still move boxed children:\n{rust_code}"
+    );
+}
+
+#[test]
 fn test_borrowed_optional_wrapper_clones_recursive_node() {
     let rust_code = generate_rust_from_source(
         r#"class TreeNode:

--- a/crates/sifr_codegen/src/stmt_support_emitter/condition_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/condition_lowering.rs
@@ -142,11 +142,34 @@ impl RustEmitter {
     }
 
     pub(crate) fn option_binding_pattern_for_ir(&self, option_var: &str) -> String {
-        if self.mutated_vars.contains(option_var) {
+        if self.option_binding_requires_mut_for_ir(option_var) {
             format!("Some(mut {option_var})")
         } else {
             format!("Some({option_var})")
         }
+    }
+
+    fn option_binding_requires_mut_for_ir(&self, option_var: &str) -> bool {
+        if self.mutated_vars.contains(option_var) {
+            return true;
+        }
+        if self.borrowed_params.contains(option_var)
+            || self.mut_borrowed_params.contains(option_var)
+        {
+            return false;
+        }
+        let Some(option_ty) = self.local_binding_types.get(option_var) else {
+            return false;
+        };
+        let Some(inner_ty) = Self::option_inner_type_for_ir(option_ty) else {
+            return false;
+        };
+        let Type::Class { name, .. } = crate::resolve_alias_type_for_plain_call(inner_ty) else {
+            return false;
+        };
+        self.recursive_fields
+            .iter()
+            .any(|(class_name, _)| class_name == name)
     }
 
     pub(crate) fn try_lower_collection_truthiness_condition_for_ir(

--- a/crates/sifr_stdlib/tests/ipc_process_pipe_fixture.rs
+++ b/crates/sifr_stdlib/tests/ipc_process_pipe_fixture.rs
@@ -9,6 +9,9 @@ use sifr_stdlib::{
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::{Mutex, MutexGuard};
+
+static WORKER_STARTUP_LOCK: Mutex<()> = Mutex::new(());
 
 fn sample_schema() -> IpcWireSchema {
     IpcWireSchema {
@@ -24,10 +27,14 @@ struct WorkerProcess {
     child: Child,
     stdin: ChildStdin,
     stdout: ChildStdout,
+    startup_lock: Option<MutexGuard<'static, ()>>,
 }
 
 impl WorkerProcess {
     fn spawn() -> Self {
+        let startup_lock = WORKER_STARTUP_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let repo_root = manifest_dir
             .parent()
@@ -59,7 +66,12 @@ impl WorkerProcess {
             child,
             stdin,
             stdout,
+            startup_lock: Some(startup_lock),
         }
+    }
+
+    fn release_startup_lock(&mut self) {
+        drop(self.startup_lock.take());
     }
 
     fn finish(self) {
@@ -89,6 +101,7 @@ fn connect(worker: &mut WorkerProcess) -> IpcConnectionState {
     let ready = read_frame(&mut worker.stdout, IPC_DEFAULT_MAX_FRAME_BYTES)
         .expect("read worker bootstrap frame")
         .expect("worker emits bootstrap frame");
+    worker.release_startup_lock();
     connection
         .accept_worker_bootstrap(&ready)
         .expect("worker ready is accepted");

--- a/plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md
+++ b/plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md
@@ -1,6 +1,6 @@
 # Ad Hoc Phase: World-Class Verification Standard and Gate Closure
 
-Status: in progress; Wave 0, Wave 1, Wave 2.0, Wave 2.1, Wave 2.2, Wave 2.3, and Wave 2.4 merged; Wave 2.5 final codegen red rows locally green
+Status: in progress; Wave 0, Wave 1, Wave 2.0, Wave 2.1, Wave 2.2, Wave 2.3, Wave 2.4, and Wave 2.5 merged; Wave 2.final codegen merge-gate promotion locally validated
 Owner: compiler-verification
 Context: Follow-on verification phase after Phase 29; based on local Sifr verification audit against TypeScript, TypeScript-Go, Rust, CPython, and Bun
 
@@ -403,7 +403,7 @@ Implementation re-check started 2026-06-14.
 
 ### Wave 2.5 Implementation Notes
 
-- Status: implemented locally; review and PR pending.
+- Status: merged in PR https://github.com/sifr-lang/sifr/pull/2566.
 - Scope: close the final 4 Wave 2 codegen red-blocker rows assigned to `proposed_pr_slice: 2.5`.
 - Changes: reinspection showed the generated Rust already preserved the intended async cleanup, generator else-branch, self-field clone suppression, and string-index guard behavior. Refreshed the four stale assertions to current generated-Rust spelling and tail-expression/char-cache output contracts; the string-index assertion now validates the current `Vec<char>` cache plus let-else guard shape rather than the older direct `chars().nth(...)` spelling.
 - Validation:
@@ -418,6 +418,16 @@ Implementation re-check started 2026-06-14.
 - Review:
   - `plans/reviews/active/ad-hoc-world-class-verification-wave-2-5-review-pass-1.md`: approved with nits and no blocking issues; the string-index assertion/doc honesty nits were addressed.
   - `plans/reviews/active/ad-hoc-world-class-verification-wave-2-5-review-pass-2.md`: approved with no blocking issues; reviewer confirmed Wave 2.5 is ready to merge and Wave 2.final promotion is unblocked.
+
+### Wave 2.final Implementation Notes
+
+- Status: implemented and locally validated; review and PR pending.
+- Scope: promote `sifr_codegen` from planned red-blocker membership to executed merge membership after the suite reached 708 passed / 0 failed / 708 total in Wave 2.5.
+- Changes: profile membership for `create-pr`, `merge`, `nightly`, and `release` now marks `sifr_codegen` as `blocking` with `executed_in_merge: true`; the verification runner self-test now requires codegen to be blocking/executed across all four profiles; cargo metadata target classification now assigns `sifr_codegen` to `merge`; the coverage matrix no longer carries a `red-blocker` row for the generated-Rust contract; baseline governance now records `sifr_codegen` snapshot bless requirements.
+- Post-promotion repair: the first full merge run after profile promotion executed `sifr_codegen` but then exposed a real e2e regression in `recursive_mutual_classes_runtime.sifr`; structured option let-else bindings for recursive class values now emit `Some(mut value)` when later child moves require `.take()`, covered by a new codegen regression. The same validation pass also exposed a parallel IPC fixture startup race in `sifr_stdlib`; worker startup is now serialized only through the cargo-run/bootstrap handoff.
+- Baseline comparison: Wave 1 full merge baseline was 986.72s with cold e2e cache while `sifr_codegen` was logged as a planned Wave 2.final red-blocker. The first post-promotion merge run reached 848.99s and failed e2e because it caught the recursive option mutability bug. The final post-review full merge run passed in 726.99s with `sifr_codegen` executed as blocking, 51/51 e2e cache hits, and only the existing group-skew advisory.
+- Validation: `cargo test -p sifr_codegen` passed with 709 passed / 0 failed / 709 total; `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/recursive_mutual_classes_runtime.sifr` passed; `scripts/run_all_tests.sh --profile merge --emit-plan` passed and showed `sifr_codegen` as blocking/executed; `scripts/run_all_tests.sh --profile merge` passed in 726.99s; `scripts/run_all_tests.sh --profile create-pr` passed in 189.46s with a non-blocking warm wall-time advisory and 44/44 e2e cache hits; `cargo test -p sifr_stdlib --test ipc_process_pipe_fixture -- --nocapture` passed; `cargo clippy --workspace -- -D warnings` passed; `python3 scripts/check_hir_maintainability_guardrails.py` passed.
+- Review: `plans/reviews/active/ad-hoc-world-class-verification-wave-2-final-review-pass-1.md` found one blocker: stale cargo metadata still labeled `sifr_codegen` as `merge-red-blocker`. The blocker was fixed by assigning the target to `merge`; non-blocking follow-ups accepted in this PR broadened the selftest across all profiles, renamed the generated-Rust matrix row and shipped-guarantee reference to `codegen_merge_blocking`, added an inventory post-Wave-2.final timestamp, and made the IPC startup lock poison-tolerant.
 
 ## Full Discovery Snapshot
 
@@ -463,7 +473,7 @@ Cargo workspace packages and notable targets/features currently observed:
 | --- | --- | --- |
 | `sifr` | bin plus integration tests `e2e`, `validation_contracts`, `build_output_contracts` | keep existing CLI tests; profile membership becomes explicit |
 | `sifr_analysis` | lib | already in current hard-coded crate path; keep explicit |
-| `sifr_codegen` | lib; currently red by review/re-check | `red-blocker` until Wave 2.final |
+| `sifr_codegen` | lib; 709 passed / 0 failed after Wave 2.final regression coverage | merge-blocking as of Wave 2.final |
 | `sifr_diagnostics` | lib plus bins `gen-diagnostic-schema`, `gen-error-docs` | bins are internal release-engineering tools; Wave 1 assigns internal tool smoke or explicit internal-no-run classification |
 | `sifr_driver` | lib plus bin `diagnostic_contract_harness` | bin is internal diagnostics harness; Wave 1 assigns internal tool smoke or explicit internal-no-run classification |
 | `sifr_format` | lib | merge crate test membership required |

--- a/plans/issues/active/codegen-test-triage.md
+++ b/plans/issues/active/codegen-test-triage.md
@@ -1,6 +1,6 @@
 # Codegen Test Triage
 
-Status: Wave 2.5 final codegen red rows locally green; Wave 2.0 inventory merged in PR https://github.com/sifr-lang/sifr/pull/2561, Wave 2.1 merged in PR https://github.com/sifr-lang/sifr/pull/2562, Wave 2.2 merged in PR https://github.com/sifr-lang/sifr/pull/2563, Wave 2.3 merged in PR https://github.com/sifr-lang/sifr/pull/2564, and Wave 2.4 merged in PR https://github.com/sifr-lang/sifr/pull/2565.
+Status: Wave 2.5 final codegen red rows are green and merged; Wave 2.0 inventory merged in PR https://github.com/sifr-lang/sifr/pull/2561, Wave 2.1 merged in PR https://github.com/sifr-lang/sifr/pull/2562, Wave 2.2 merged in PR https://github.com/sifr-lang/sifr/pull/2563, Wave 2.3 merged in PR https://github.com/sifr-lang/sifr/pull/2564, Wave 2.4 merged in PR https://github.com/sifr-lang/sifr/pull/2565, and Wave 2.5 merged in PR https://github.com/sifr-lang/sifr/pull/2566. Wave 2.final promotes `sifr_codegen` from planned red-blocker membership to blocking merge membership.
 
 Reproduction command:
 
@@ -8,7 +8,7 @@ Reproduction command:
 cargo test -p sifr_codegen -- --nocapture
 ```
 
-Observed Wave 2.0 result on 2026-06-14: `655 passed; 52 failed; 707 total`. After Wave 2.1 stale expectation repairs, the result was `675 passed; 32 failed; 707 total`. After Wave 2.2 stale source-fixture repairs, the result was `691 passed; 16 failed; 707 total`. After Wave 2.3 obsolete architecture guard retargeting, the result was `697 passed; 10 failed; 707 total`. After Wave 2.4 structured lowering repairs plus a field-assignment guard regression, the result was `704 passed; 4 failed; 708 total`. After Wave 2.5 final assertion refreshes, the current local result is `708 passed; 0 failed; 708 total`. The saved local Wave 2.0 log is `target/wave2/sifr_codegen_nocapture.log`; the checked-in machine-readable inventory is `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`.
+Observed Wave 2.0 result on 2026-06-14: `655 passed; 52 failed; 707 total`. After Wave 2.1 stale expectation repairs, the result was `675 passed; 32 failed; 707 total`. After Wave 2.2 stale source-fixture repairs, the result was `691 passed; 16 failed; 707 total`. After Wave 2.3 obsolete architecture guard retargeting, the result was `697 passed; 10 failed; 707 total`. After Wave 2.4 structured lowering repairs plus a field-assignment guard regression, the result was `704 passed; 4 failed; 708 total`. After Wave 2.5 final assertion refreshes, the result was `708 passed; 0 failed; 708 total`. Wave 2.final added a recursive option let-else mutability regression after the merge gate exposed the e2e failure; the current local result is `709 passed; 0 failed; 709 total`. The saved local Wave 2.0 log is `target/wave2/sifr_codegen_nocapture.log`; the checked-in machine-readable inventory is `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json`.
 
 The JSON inventory records closure with `closes_in_wave: 2` and `closes_in_subwave` for each row. `proposed_pr_slice` below is the human-readable repair slice label.
 
@@ -19,7 +19,7 @@ Final classification counts after Wave 2.5 reinspection:
 - `compiler-bug`: 6.
 - `production-bug`: 0; no unresolved production sentinel rows in Wave 2.0.
 
-Wave 2.1 closes the 20 `proposed_pr_slice: 2.1` rows by refreshing stale literal, final-return, render snapshot, and iterator materialization expectations to the current generated-Rust contract. Wave 2.2 closes the 16 `proposed_pr_slice: 2.2` rows by making parser, async-effect, and explicit-encoding fixtures policy-compliant while preserving their codegen assertions. Wave 2.3 closes the 6 `proposed_pr_slice: 2.3` rows by retargeting obsolete architecture guards to their current owner modules after decomposition/refactors. Wave 2.4 closes the 6 `proposed_pr_slice: 2.4` rows by restoring non-self field assignment lowering and mutation-aware option unwrapping. Wave 2.5 closes the final 4 rows after reinspection showed the current generated Rust already preserved the intended behavior and only the assertions were stale. The string-index row now validates the current `Vec<char>` cache plus let-else guard shape rather than the older direct `chars().nth(...)` spelling.
+Wave 2.1 closes the 20 `proposed_pr_slice: 2.1` rows by refreshing stale literal, final-return, render snapshot, and iterator materialization expectations to the current generated-Rust contract. Wave 2.2 closes the 16 `proposed_pr_slice: 2.2` rows by making parser, async-effect, and explicit-encoding fixtures policy-compliant while preserving their codegen assertions. Wave 2.3 closes the 6 `proposed_pr_slice: 2.3` rows by retargeting obsolete architecture guards to their current owner modules after decomposition/refactors. Wave 2.4 closes the 6 `proposed_pr_slice: 2.4` rows by restoring non-self field assignment lowering and mutation-aware option unwrapping. Wave 2.5 closes the final 4 rows after reinspection showed the current generated Rust already preserved the intended behavior and only the assertions were stale. The string-index row now validates the current `Vec<char>` cache plus let-else guard shape rather than the older direct `chars().nth(...)` spelling. Wave 2.final keeps the red-blocker rows closed, promotes the suite, and adds a post-promotion regression for recursive `Option[T]` let-else bindings whose narrowed class value must be mutable for recursive child moves.
 
 Proposed PR slices:
 
@@ -28,7 +28,7 @@ Proposed PR slices:
 - `2.3`: obsolete architecture guard tests after source decomposition/refactors.
 - `2.4`: internal structured lowering defects around field assignment and option narrowing.
 - `2.5`: final stale assertions for async cleanup ordering, generator else preservation, self-field clone suppression, and string-index guard output.
-- `2.final`: promote `sifr_codegen` into merge only after all rows are closed and `cargo test -p sifr_codegen` passes.
+- `2.final`: promote `sifr_codegen` into merge after all rows are closed and `cargo test -p sifr_codegen` passes.
 
 | # | test id | failure summary | classification | proposed PR slice | owner | replacement or regression target |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/plans/reviews/active/ad-hoc-world-class-verification-wave-2-final-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-world-class-verification-wave-2-final-review-pass-1.md
@@ -1,0 +1,68 @@
+# Wave 2.final Review — Sifr Verification Standard Closure
+
+## Blocking findings
+
+### B1. `cargo_metadata_classification.json` still labels `sifr_codegen` as `merge-red-blocker`
+
+`verification/areas/coverage_matrix/data/cargo_metadata_classification.json:25` still has:
+
+```json
+{"name": "sifr_codegen", "kind": "lib", "classification": "first_party_compiler", "profile_assignment": "merge-red-blocker"}
+```
+
+This is the *only* surviving red-blocker label for the codegen surface and it directly contradicts the documented profile policy. `verification/policy/profile_policy.md:47-48` is explicit:
+
+> Targets and features use `merge-red-blocker` **only for a suite that is planned for merge membership but intentionally not executed until its red-blocker closes**.
+
+After this wave the suite is `status: blocking`, `executed_in_merge: true` in all four profiles, so the documented precondition for `merge-red-blocker` no longer holds. This is exactly the red-blocker metadata the phase commits to retiring at gate closure (question 1). The reason the matrix checker doesn't flag it is incidental: `validate_targets` (`verification/areas/coverage_matrix/checks/coverage_matrix.py:454-456`) only verifies the value is in `VALID_PROFILE_ASSIGNMENTS` and never cross-checks against the merge membership row, and `validate_cargo_metadata_classification` (lines 380-397) is satisfied as long as *either* `executed_in_merge=true` *or* a `red-blocker` membership exists. Neither catches the stale label.
+
+Fix: change `profile_assignment` to `"merge"` in this row. The phase's "no remaining codegen red-blocker in profile/matrix semantics" promise isn't honored until this is updated. (Optional follow-up: add a `validate_targets` cross-check so `merge-red-blocker` is only accepted when the matching merge membership is actually `red-blocker`/`executed_in_merge=false`.)
+
+## Non-blocking findings
+
+### N1. Selftest only guards the `merge` profile
+
+`verification/runner/sifr_verify/selftest.py:86,104-108` loads only `load_all_profiles()["merge"]` and checks `sifr_codegen` status/execution there. Demoting `sifr_codegen` back to `red-blocker` in `create-pr`, `nightly`, or `release` would pass selftest, schema, `validate_crate_test_membership`, and the matrix checker, because the matrix only inspects merge memberships (`coverage_matrix.py:361-397`). Given the four profiles are intentionally kept in lockstep on this row, a tiny loop iterating all of `("create-pr","merge","nightly","release")` would close this gap. Not blocking — the merge profile is the gate the user explicitly asked about — but the protection is narrower than it looks.
+
+### N2. `option_binding_requires_mut_for_ir` is structural, not use-driven
+
+`condition_lowering.rs:152-173` emits `Some(mut option_var)` whenever the local's type is `Option<Class>` and the class is anywhere in `recursive_fields`. This catches the e2e shape correctly, but it also binds `mut` for any narrowed recursive option even when the narrowed body only reads fields — i.e. it can emit `unused_mut` shapes. This is consistent with the existing local-class binding behavior asserted by `test_local_recursive_node_binding_is_mutable_for_child_moves`, so it isn't regressing precedent, and the test suite proves no current fixture trips a warning. Worth filing a follow-up to drive `mut` off actual `.take()` use rather than a class-recursion heuristic; not blocking for this wave.
+
+### N3. Regression test asserts on rendered strings only
+
+`recursive_node_codegen_tests.rs:139-146` asserts that the generated Rust contains `let Some(mut term) = term else` and `term.expr.take().map(...)`. That catches the binding-shape regression the e2e exposed and matches the rest of the file's test style, but it does not compile-check the produced Rust. If a future change keeps the `mut` prefix but breaks the surrounding let-else/closure scope, this test would still pass while the e2e regresses. The e2e `recursive_mutual_classes_runtime.sifr` run is the real safety net here — make sure that fixture stays referenced in the codegen merge membership, since the codegen unit test alone isn't a complete proof of the fix.
+
+### N4. IPC fixture lock poisons cascade on test panic
+
+`crates/sifr_stdlib/tests/ipc_process_pipe_fixture.rs:14,35-37,69-75,104`. Scope is correct — the lock serializes only the cargo-run/bootstrap handoff (which shares `target/ipc_process_pipe_fixture_worker` and the cargo build lock) and is dropped right after the worker emits its bootstrap frame, so it does not mask runtime-level product bugs in `IpcConnectionState`. But because the guard is held across `spawn` + `read_frame`, a panic in either path (e.g. cargo build failure, worker exiting early) poisons the static `Mutex`, and the subsequent `.lock().expect("IPC fixture startup lock is not poisoned")` turns the next test's failure into a misleading expect-message instead of the real spawn error. Consider `.lock().unwrap_or_else(|e| e.into_inner())` so the first failing test surfaces the actual cause rather than being shadowed by poison cascades.
+
+### N5. Stale `surface_id: codegen_red_blocker`
+
+`compiler_surface_matrix.json:140` keeps the row id `codegen_red_blocker` even though the row is now plain `blocking` with no red-blocker fields. The name is misleading; rename to e.g. `codegen_merge_blocking` is a low-risk cleanup. Cross-refs are limited to the matrix file itself.
+
+### N6. Validation evidence is missing two AGENTS.md required commands
+
+The evidence list covers `cargo test -p sifr_codegen`, the targeted e2e, `--profile merge`/`--profile create-pr`, `cargo fmt --check`, `check_file_size_guardrails.py`, and `git diff --check`. It does **not** include the two other commands AGENTS.md lists as guardrails:
+
+- `cargo clippy --workspace -- -D warnings`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+
+`run_all_tests.sh` likely invokes both internally — but the explicit local-validation manifest in the phase doc and the user's evidence summary should call them out, otherwise reviewers can't tell whether they ran. Add them to the Wave 2.final implementation-notes "Validation" line for parity with the other waves' bookkeeping.
+
+### N7. Inventory `captured_on` vs. count
+
+`codegen_red_blocker_inventory.json` keeps `captured_on: 2026-06-14` but the `test_result` block now reports `709/0/709` — a Wave 2.final number. Since the same date covered every wave in this run, it's not factually wrong, but a reader sees a date that matches the *original* capture and counts that don't. A short note like `"updated_on": "2026-06-14 (post-Wave-2.final)"` or simply moving the count into a `closure_snapshot` block would make the inventory unambiguous.
+
+## Answers to the specific questions
+
+1. **Profile promotion honesty:** Profiles + selftest + matrix row + governance text are correct. The hold-out is **B1** — the cargo classification still carries the red-blocker label and contradicts the profile policy text. Until that is updated, the promotion is not yet honest end-to-end.
+2. **Selftest demotion protection:** Correct for `merge` (the asked-about gate). See **N1** for the gap across the other three profiles.
+3. **Condition-lowering fix correctness/scope:** Correct and minimally scoped. It honors borrowed-param paths (no spurious mut on `&Option<T>`), falls back to the existing `mutated_vars` short-circuit, and only widens to recursive class locals. See **N2** for the "structural vs. use-driven" caveat.
+4. **Regression meaningful enough:** Yes for the shape that broke (binding-mutability + child-move). It is not a full compile-check though; the e2e `recursive_mutual_classes_runtime.sifr` is what proves the end-to-end shape — keep both. See **N3**.
+5. **IPC fixture lock:** Correctly scoped to the cargo-run/bootstrap handoff and released before runtime semantics begin, so it does not mask product issues in `IpcConnectionState`. Resilience nit only — see **N4**.
+6. **Doc/inventory honesty:** The 708 → 709 transition is described correctly in both the triage doc and the phase doc; the merge timing (780.24s post-fix vs. 848.99s catch-the-bug vs. Wave 1 986.72s baseline) and the remaining advisories (warm-cache rebuild on create-pr, group-skew on merge) are stated. Caveats: `inventory.json` `captured_on` reads as a Wave-2.0 date (**N7**), the matrix `surface_id` still says `codegen_red_blocker` (**N5**), and the cargo classification still says `merge-red-blocker` (**B1**).
+7. **Missing validation:** Add `cargo clippy --workspace -- -D warnings` and `python3 scripts/check_hir_maintainability_guardrails.py` to the validation list (**N6**). Also worth one more `uv run … profiles check` after fixing **B1** to confirm the matrix-strict path still passes once the cargo classification flips to `merge`.
+
+## Recommendation
+
+Hold for **B1**: flip `cargo_metadata_classification.json`'s `sifr_codegen` row to `profile_assignment: "merge"`, rerun `uv run --project verification --locked python -m sifr_verify profiles check` and `scripts/run_all_tests.sh --profile merge --emit-plan`. The remaining items are non-blocking and can ride in follow-ups.

--- a/plans/reviews/active/ad-hoc-world-class-verification-wave-2-final-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-world-class-verification-wave-2-final-review-pass-2.md
@@ -1,0 +1,22 @@
+## Review pass 2 — Wave 2.final
+
+Verified the four follow-up changes against the working tree (no edits made):
+
+- `verification/areas/coverage_matrix/data/cargo_metadata_classification.json:25` — `sifr_codegen` lib target now `profile_assignment: "merge"`. No remaining row uses `merge-red-blocker`.
+- `verification/areas/coverage_matrix/compiler_surface_matrix.json:140` — `surface_id` is `codegen_merge_blocking`.
+- `verification/areas/coverage_matrix/shipped_guarantees.json:49` — `merge_surface: "codegen_merge_blocking"` cross-references the renamed matrix row.
+- `verification/runner/sifr_verify/selftest.py:105-115` — loops all four profiles (`create-pr`, `merge`, `nightly`, `release`) and asserts `sifr_codegen` is present in full-mode `crate_test_membership` with `status="blocking"` and `executed_in_merge=true`.
+- `verification/areas/generated_code_quality/codegen_red_blocker_inventory.json:5` — `updated_on: "2026-06-14 (post-Wave-2.final)"`.
+- `crates/sifr_stdlib/tests/ipc_process_pipe_fixture.rs:37` — `WORKER_STARTUP_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())`. Standard poison recovery; safe because the guarded state is `()` (pure mutual exclusion), so an upstream panic can't leave corrupted data behind.
+
+Remaining `merge-red-blocker` mentions live only in (a) the vocabulary enum `coverage_matrix.py`, (b) `verification/policy/profile_policy.md` wording, and (c) historical plan/review notes. None are data rows assigning the value to a real target — the vocabulary is kept available for future suites, which matches the documented policy.
+
+### Answers
+
+1. **B1 fixed end-to-end?** Yes. Cargo classification, compiler surface matrix, and shipped-guarantee `merge_surface` are all aligned on `codegen_merge_blocking`/`merge`. No data file still labels `sifr_codegen` as `merge-red-blocker`.
+
+2. **Selftest + profile metadata prevent stale red-blocker semantics?** Yes. The new four-profile loop in `selftest.py` makes any future regression that demotes `sifr_codegen` to non-executed/red-blocker fail self-test in all four profiles, not just `merge`. Combined with the `updated_on` timestamp on the inventory, the post-closure semantics are pinned.
+
+3. **New blocking issues introduced?** None. Selftest expansion is additive and consistent with prior assertions; the matrix/guarantee rename is a pure relabel cross-checked by both files; the inventory date is metadata-only; the IPC poison handler uses the canonical pattern over a unit-typed mutex.
+
+4. **Wave 2.final is approved for PR/merge.**

--- a/verification/areas/coverage_matrix/compiler_surface_matrix.json
+++ b/verification/areas/coverage_matrix/compiler_surface_matrix.json
@@ -137,22 +137,15 @@
       "expiry": "2026-09-30"
     },
     {
-      "surface_id": "codegen_red_blocker",
+      "surface_id": "codegen_merge_blocking",
       "guarantee_id": "codegen-generated-rust-contract",
       "support_status": "stable",
       "owner": "compiler/codegen",
-      "status": "red-blocker",
+      "status": "blocking",
       "merge_suite": "sifr_codegen:cargo-test",
       "nightly_release_suite": "generated_code_quality:full",
       "regression_suite": "regression:fixedbugs",
-      "reproduction_command": "cargo test -p sifr_codegen",
-      "command": "cargo test -p sifr_codegen",
-      "current_failure_count": 52,
-      "triage_file": "plans/issues/active/codegen-test-triage.md",
-      "issue": "plans/issues/active/ad-hoc-world-class-verification-standard-and-gate-closure.md#Wave-2",
-      "closes_in_wave": "2",
-      "closes_in_subwave": "final",
-      "expiry": "2026-09-30"
+      "reproduction_command": "cargo test -p sifr_codegen"
     },
     {
       "surface_id": "generated_rust_toolchain_survival",

--- a/verification/areas/coverage_matrix/data/cargo_metadata_classification.json
+++ b/verification/areas/coverage_matrix/data/cargo_metadata_classification.json
@@ -22,7 +22,7 @@
     {
       "name": "sifr_codegen",
       "classification": "first_party_compiler",
-      "targets": [{"name": "sifr_codegen", "kind": "lib", "classification": "first_party_compiler", "profile_assignment": "merge-red-blocker"}],
+      "targets": [{"name": "sifr_codegen", "kind": "lib", "classification": "first_party_compiler", "profile_assignment": "merge"}],
       "features": []
     },
     {

--- a/verification/areas/coverage_matrix/shipped_guarantees.json
+++ b/verification/areas/coverage_matrix/shipped_guarantees.json
@@ -46,7 +46,7 @@
       "support_status": "stable",
       "public_doc_path": "internal_docs/architecture.md",
       "owner": "compiler/codegen",
-      "merge_surface": "codegen_red_blocker",
+      "merge_surface": "codegen_merge_blocking",
       "nightly_release_surface": "generated_rust_toolchain_survival",
       "regression_surface": "regression_fixedbugs",
       "unsupported_behavior_policy": "Generated Rust must not rely on nightly-only behavior unless the source surface is experimental or internal."

--- a/verification/areas/generated_code_quality/codegen_red_blocker_inventory.json
+++ b/verification/areas/generated_code_quality/codegen_red_blocker_inventory.json
@@ -2,11 +2,12 @@
   "schema_version": 1,
   "generated_from": "cargo test -p sifr_codegen -- --nocapture",
   "captured_on": "2026-06-14",
+  "updated_on": "2026-06-14 (post-Wave-2.final)",
   "test_result": {
-    "passed": 708,
+    "passed": 709,
     "failed": 0,
     "ignored": 0,
-    "total": 708
+    "total": 709
   },
   "red_blocker": {
     "profile_suite_id": "sifr_codegen",

--- a/verification/policy/baseline_governance.md
+++ b/verification/policy/baseline_governance.md
@@ -20,6 +20,8 @@ Only explicit `--bless` updates checked-in baseline files.
 - Exit-code behavior
 - Selected multi-file project behavior
 - Machine-readable suite result summaries
+- `sifr_codegen` insta snapshots and generated-Rust assertion baselines owned by
+  `crates/sifr_codegen/src/**`
 
 ## Normalization Rules
 
@@ -46,6 +48,8 @@ Baseline comparison and bless write-path use canonical normalization:
 - Baseline diffs are first-class review artifacts.
 - Incidental baseline updates are not allowed.
 - Any baseline change must be justified by an intentional contract change.
+- `sifr_codegen` snapshot blesses must be reviewed with the corresponding generated-Rust
+  contract change, and `cargo test -p sifr_codegen` must pass before the bless is accepted.
 
 ## Suggestion/Autofix Boundary (Phase 29)
 

--- a/verification/profiles/create-pr.json
+++ b/verification/profiles/create-pr.json
@@ -57,7 +57,7 @@
       {"id": "sifr_cli_bin", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr"], "modes": ["smoke"], "status": "blocking", "executed_in_merge": false},
       {"id": "sifr_cli_full", "package": "sifr", "command": ["test", "-p", "sifr", "--", "--skip", "test_e2e_pass"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_driver_lib", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib"], "modes": ["smoke", "full"], "status": "blocking", "executed_in_merge": true},
-      {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "red-blocker", "executed_in_merge": false, "must_be_executed_by": "Wave 2.final", "reason": "Known red suite tracked by codegen red-blocker inventory until Wave 2.final."}
+      {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "blocking", "executed_in_merge": true}
     ]
   },
   "selected_areas": [

--- a/verification/profiles/merge.json
+++ b/verification/profiles/merge.json
@@ -57,7 +57,7 @@
       {"id": "sifr_cli_bin", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr"], "modes": ["smoke"], "status": "blocking", "executed_in_merge": false},
       {"id": "sifr_cli_full", "package": "sifr", "command": ["test", "-p", "sifr", "--", "--skip", "test_e2e_pass"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_driver_lib", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib"], "modes": ["smoke", "full"], "status": "blocking", "executed_in_merge": true},
-      {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "red-blocker", "executed_in_merge": false, "must_be_executed_by": "Wave 2.final", "reason": "Known red suite tracked by codegen red-blocker inventory until Wave 2.final."}
+      {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "blocking", "executed_in_merge": true}
     ]
   },
   "selected_areas": [

--- a/verification/profiles/nightly.json
+++ b/verification/profiles/nightly.json
@@ -59,7 +59,7 @@
       {"id": "sifr_cli_bin", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr"], "modes": ["smoke"], "status": "blocking", "executed_in_merge": false},
       {"id": "sifr_cli_full", "package": "sifr", "command": ["test", "-p", "sifr", "--", "--skip", "test_e2e_pass"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_driver_lib", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib"], "modes": ["smoke", "full"], "status": "blocking", "executed_in_merge": true},
-      {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "red-blocker", "executed_in_merge": false, "must_be_executed_by": "Wave 2.final", "reason": "Known red suite tracked by codegen red-blocker inventory until Wave 2.final."}
+      {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "blocking", "executed_in_merge": true}
     ]
   },
   "selected_areas": [

--- a/verification/profiles/release.json
+++ b/verification/profiles/release.json
@@ -59,7 +59,7 @@
       {"id": "sifr_cli_bin", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr"], "modes": ["smoke"], "status": "blocking", "executed_in_merge": false},
       {"id": "sifr_cli_full", "package": "sifr", "command": ["test", "-p", "sifr", "--", "--skip", "test_e2e_pass"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_driver_lib", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib"], "modes": ["smoke", "full"], "status": "blocking", "executed_in_merge": true},
-      {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "red-blocker", "executed_in_merge": false, "must_be_executed_by": "Wave 2.final", "reason": "Known red suite tracked by codegen red-blocker inventory until Wave 2.final."}
+      {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "blocking", "executed_in_merge": true}
     ]
   },
   "selected_areas": [

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -83,7 +83,8 @@ def _profile_schema_self_test() -> None:
 
 
 def _crate_membership_self_test() -> None:
-    merge = load_all_profiles()["merge"]
+    profiles = load_all_profiles()
+    merge = profiles["merge"]
     full_suites = crate_test_suites_for_mode(merge, "full")
     by_id = {str(suite.get("id")): suite for suite in full_suites}
     expected_executed = {
@@ -101,13 +102,17 @@ def _crate_membership_self_test() -> None:
         if suite.get("status") != "blocking" or suite.get("executed_in_merge") is not True:
             raise AssertionError(f"merge crate suite is not blocking/executed: {suite_id}")
 
-    codegen = by_id.get("sifr_codegen")
-    if not isinstance(codegen, dict):
-        raise AssertionError("sifr_codegen red-blocker missing from merge crate membership")
-    if codegen.get("status") != "red-blocker" or codegen.get("executed_in_merge") is not False:
-        raise AssertionError(f"sifr_codegen red-blocker has invalid execution status: {codegen}")
-    if not codegen.get("must_be_executed_by"):
-        raise AssertionError("sifr_codegen red-blocker has no execution deadline")
+    for profile_name in ("create-pr", "merge", "nightly", "release"):
+        profile = profiles[profile_name]
+        profile_full_suites = crate_test_suites_for_mode(profile, "full")
+        profile_by_id = {str(suite.get("id")): suite for suite in profile_full_suites}
+        codegen = profile_by_id.get("sifr_codegen")
+        if not isinstance(codegen, dict):
+            raise AssertionError(f"sifr_codegen missing from {profile_name} crate membership")
+        if codegen.get("status") != "blocking" or codegen.get("executed_in_merge") is not True:
+            raise AssertionError(
+                f"sifr_codegen is not blocking/executed in {profile_name}: {codegen}",
+            )
 
     duplicate_profile = {
         "name": "self-test",


### PR DESCRIPTION
## Summary
- promote `sifr_codegen` from planned red-blocker membership to blocking/executed membership in `create-pr`, `merge`, `nightly`, and `release`
- align coverage matrix, cargo metadata classification, shipped guarantees, baseline governance, and verification selftests with the closed codegen gate
- fix the post-promotion recursive `Option[T]` let-else mutability regression and add codegen coverage for recursive child moves
- serialize only the IPC fixture worker cargo-run/bootstrap handoff to remove the parallel startup race exposed by create-pr validation

## Reviews
- `plans/reviews/active/ad-hoc-world-class-verification-wave-2-final-review-pass-1.md`: one blocker found for stale cargo metadata classification
- `plans/reviews/active/ad-hoc-world-class-verification-wave-2-final-review-pass-2.md`: blocker fixed; reviewer approved Wave 2.final for PR/merge

## Local validation
- `cargo test -p sifr_codegen`: 709 passed / 0 failed / 709 total
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/recursive_mutual_classes_runtime.sifr`: passed
- `cargo test -p sifr_stdlib --test ipc_process_pipe_fixture -- --nocapture`: passed
- `uv run --project verification --locked python -m sifr_verify profiles check`: passed
- `scripts/run_all_tests.sh --profile merge --emit-plan`: passed; `sifr_codegen` is blocking/executed
- `scripts/run_all_tests.sh --profile create-pr`: passed in 189.46s with non-blocking warm wall-time advisory and 44/44 e2e cache hits
- `scripts/run_all_tests.sh --profile merge`: passed in 726.99s with `sifr_codegen` executed as blocking, e2e 145/145, 51/51 cache hits, only existing group-skew advisory
- `cargo clippy --workspace -- -D warnings`: passed
- `cargo fmt --check`: passed
- `python3 scripts/check_hir_maintainability_guardrails.py`: passed
- `python3 scripts/check_file_size_guardrails.py`: passed
- `git diff --check`: passed
