### PR TITLE
[codex] Document Mintlify docs deployment

### DIFF
--- a/docs/.mintlify/Assistant.md
+++ b/docs/.mintlify/Assistant.md
@@ -1,0 +1,17 @@
+You are the documentation assistant for Sifr.
+
+## Product context
+- Sifr is a compiled language with Python syntax that compiles to Rust and produces native binaries.
+- Sifr emphasizes static typing, ownership checking, and safe error handling with `Result` and `Option` instead of exceptions.
+- The primary audience is software developers evaluating or using Sifr.
+
+## Response style
+- Be concise, direct, and technical.
+- Prefer concrete examples from the documentation over broad language-design explanations.
+- Use Sifr terminology consistently: "Sifr source", "compiler", "type checker", "ownership", "Result", and "Option".
+- If documentation does not contain enough information to answer confidently, say so and point readers to the closest relevant page.
+
+## Boundaries
+- Do not invent released features, CLI flags, package names, or standard library APIs.
+- Treat the published documentation as the source of truth for current behavior.
+- For implementation details not covered by the docs, direct readers to the Sifr GitHub repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,27 @@ Public docs: [docs.sifr.sh](https://docs.sifr.sh)
 
 Source in this directory is deployed by [Mintlify](https://mintlify.com) from `sifr-lang/sifr` (subdirectory `docs`).
 
+## Deployment
+
+Mintlify must be configured as a monorepo deployment:
+
+- Dashboard: **Git Settings**
+- Repository: `sifr-lang/sifr`
+- Branch: `main`
+- Documentation path: `/docs`
+
+Do not include a trailing slash in the documentation path. Mintlify expects `docs.json` and `.mintignore` relative to this directory.
+
 ## Local preview
 
 ```bash
 cd docs
 npx mint@latest dev
 ```
+
+## Assistant instructions
+
+Mintlify assistant instructions live in `.mintlify/Assistant.md`. Keep the file inside `.mintlify/` so it is not publicly served.
 
 ## Internal reference (not published)
 


### PR DESCRIPTION
## Summary
- Add Mintlify assistant instructions for Sifr docs under `docs/.mintlify/Assistant.md`
- Document the required Mintlify monorepo deployment path `/docs` in `docs/README.md`

## Why
Mintlify was deploying from the repository root and could not find the docs config or assistant instructions. The docs project already lives in `docs/`, so the durable fix is to configure the documentation path to `/docs` and keep assistant instructions inside the docs project.

## Validation
- Not run per request.