### PR TITLE
[codex] Redesign Mintlify docs navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -44,6 +44,11 @@
         "icon": "globe"
       },
       {
+        "label": "Blog",
+        "href": "https://sifr.sh/blog",
+        "icon": "newspaper"
+      },
+      {
         "label": "Install Sifr",
         "href": "/installation",
         "icon": "download",
@@ -54,8 +59,8 @@
   "navigation": {
     "tabs": [
       {
-        "tab": "Language",
-        "icon": "code",
+        "tab": "Documentation",
+        "icon": "book-open",
         "groups": [
           {
             "group": "Get Started",
@@ -78,13 +83,7 @@
               "language/pattern-matching",
               "language/concurrency"
             ]
-          }
-        ]
-      },
-      {
-        "tab": "CLI",
-        "icon": "terminal",
-        "groups": [
+          },
           {
             "group": "Commands",
             "icon": "square-terminal",
@@ -96,13 +95,7 @@
               "cli/test",
               "cli/lsp"
             ]
-          }
-        ]
-      },
-      {
-        "tab": "Projects",
-        "icon": "folder-kanban",
-        "groups": [
+          },
           {
             "group": "Package management",
             "icon": "package",
@@ -112,13 +105,7 @@
               "packages/dependencies",
               "packages/publishing"
             ]
-          }
-        ]
-      },
-      {
-        "tab": "Standard Library",
-        "icon": "library",
-        "groups": [
+          },
           {
             "group": "Modules",
             "icon": "book-open",
@@ -130,13 +117,7 @@
               "stdlib/concurrency",
               "stdlib/text-encoding"
             ]
-          }
-        ]
-      },
-      {
-        "tab": "Diagnostics",
-        "icon": "triangle-alert",
-        "groups": [
+          },
           {
             "group": "Compiler errors",
             "icon": "scan-search",
@@ -148,9 +129,17 @@
         ]
       },
       {
-        "tab": "Blog",
-        "icon": "newspaper",
-        "href": "https://sifr.sh/blog"
+        "tab": "Guides",
+        "icon": "map",
+        "groups": [
+          {
+            "group": "Overview",
+            "icon": "globe",
+            "pages": [
+              "guides/index"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -1,0 +1,19 @@
+---
+title: Guides
+description: Practical walkthroughs for common Sifr workflows.
+contextual: false
+mode: center
+---
+
+## Featured
+
+<CardGroup>
+  <Card
+    icon="zap"
+    title="Compile your first Sifr program"
+    href="/quickstart"
+    cta="View guide"
+  >
+    Install the toolchain, run a Sifr file, and build a native binary.
+  </Card>
+</CardGroup>

--- a/docs/style.css
+++ b/docs/style.css
@@ -16,3 +16,41 @@ pre.shiki {
   line-height: 1.45rem;
   font-size: 0.825rem;
 }
+
+@media (min-width: 1024px) {
+  #navbar div.hidden.lg\:flex.items-center.h-12 {
+    position: relative;
+    gap: 1rem;
+  }
+
+  #navbar div.hidden.lg\:flex.items-center.h-12 > div.flex-1:first-child {
+    flex: 0 0 auto !important;
+    width: auto;
+  }
+
+  #navbar div.hidden.lg\:flex.items-center.h-12 > nav {
+    flex: 0 0 auto;
+    justify-content: flex-start !important;
+  }
+
+  #navbar .topbar-right-container {
+    flex: 1 1 auto !important;
+    min-width: 0;
+  }
+
+  #navbar .topbar-right-container > div:has(#search-bar-entry) {
+    position: absolute !important;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(24rem, calc(100vw - 44rem));
+    min-width: 14rem;
+    justify-content: center !important;
+  }
+
+  #navbar #search-bar-entry {
+    width: 100% !important;
+    justify-content: space-between !important;
+    padding-left: 0.875rem !important;
+    padding-right: 0.75rem !important;
+  }
+}


### PR DESCRIPTION
## Summary

- Collapse the Mintlify docs top navigation into `Documentation` and `Guides` tabs.
- Move `Blog` into the right-side navbar links next to `Website` and `Install Sifr`.
- Add a Guides landing page with the initial quickstart-style guide card.
- Adjust desktop header CSS so the primary docs tabs sit on the left and search stays centered.

## Validation

- `cd docs && npx mint@latest validate`
- Local Mintlify preview at `http://localhost:3333`, verified header layout and Guides route in browser.