### PR TITLE
[codex] Plan documentation redesign

### DIFF
--- a/plans/issues/active/ad-hoc-documentation-learning-path.md
+++ b/plans/issues/active/ad-hoc-documentation-learning-path.md
@@ -1,0 +1,1003 @@
+# Ad Hoc: Documentation Learning Path and Python Compatibility Narrative
+
+Status: draft
+Owner: Codex
+Review artifacts:
+
+- `plans/reviews/active/ad-hoc-documentation-learning-path-review-pass-1.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-review-pass-2.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-review-pass-1.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-review-pass-2.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-reference-review-pass-1.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-reference-review-pass-2.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-guides-review-pass-1.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-guides-review-pass-2.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-mutability-review-pass-1.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-mutability-review-pass-2.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-concurrency-review-pass-1.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-concurrency-review-pass-2.md`
+
+## Objective
+
+Redesign the `Documentation` tab so a developer who is new to Sifr can build the right mental model quickly:
+
+1. what Sifr is and when to use it;
+2. how to install, run, check, and build a first program;
+3. how Sifr maps familiar Python syntax onto a compiled, Rust-backed execution model;
+4. which Python concepts carry over directly;
+5. which Python concepts intentionally behave differently so programs stay panic-free and statically checked.
+
+The finished docs should stay concise and polished. The current writing style is a strength: short sections, focused examples, card groups, steps, callouts, comparison tables, and practical snippets. The redesign should preserve that style instead of turning the docs into a dense language specification.
+
+## Current State
+
+The Mintlify docs currently expose one `Documentation` tab with these sidebar groups:
+
+- Get Started: `index`, `introduction`, `installation`, `quickstart`
+- Core Language: type system, error handling, ownership, classes, pattern matching, concurrency
+- Commands: CLI reference pages
+- Package management: project and package reference
+- Modules: standard library overviews and module references
+- Compiler errors: diagnostics overview and code reference
+
+The existing pages are visually strong and individually useful, especially:
+
+- `docs/introduction.mdx`: clear product thesis and core examples.
+- `docs/quickstart.mdx`: concrete end-to-end walkthrough with `Steps`.
+- `docs/language/type-system.mdx`: solid union/narrowing overview.
+- `docs/language/error-handling.mdx`: strong explanation of `Result` and `try`/`except`.
+- `docs/language/ownership.mdx`: readable borrow-by-default explanation, but it does not yet teach `mut` as clearly as `own`.
+- `docs/language/concurrency.mdx`: strong structured-concurrency introduction, but large enough that it should become the overview for a dedicated Concurrency section.
+- `docs/stdlib/concurrency.mdx`: useful API/reference material for `sifr.task`, `sifr.sync`, `sifr.parallel`, process, signal, runtime, and cleanup helpers.
+- CLI and package pages: good command/reference coverage.
+
+The gap is not presentation quality. The gap is sequencing, scope calibration, compatibility framing, and a small number of semantic contradictions that should be resolved before new learning pages are added.
+
+## Codebase Scan Findings
+
+The second scan covered `lib/sifr`, CLI sources under `crates/sifr/src`, verification inventories, and internal architecture docs. It changes the plan in several ways:
+
+### Shipped standard library surface is broader than current docs
+
+Current public stdlib docs cover only a representative subset:
+
+- collections;
+- I/O and filesystem;
+- networking;
+- concurrency;
+- text and encoding.
+
+The shipped `lib/sifr` namespace is much broader. It includes modules such as:
+
+- Data and text: `json`, `csv`, `tomllib`, `configparser`, `html`, `textwrap`, `string`, `re`, `unicode`, `encoding`, `i18n`.
+- Files and archives: `pathlib`, `os`, `shutil`, `tempfile`, `zipfile`, `gzip`.
+- Algorithms and utilities: `math`, `statistics`, `random`, `secrets`, `hashlib`, `base64`, `heapq`, `bisect`, `itertools`, `functools`, `operator`, `difflib`, `fnmatch`, `glob`, `graphlib`, `ipaddress`, `uuid`.
+- System and process: `sys`, `env`, `platform`, `time`, `datetime`, `calendar`, `process`, `signal`, `resource`, `runtime`, `ipc`, `timeit`.
+- Developer-facing utilities: `argparse`, `logging`, `test`.
+- Concurrency and parallelism: `task`, `sync`, `parallel`.
+- Network substrate: `net`, `tls`, `url`, `http`.
+
+This does not mean every module needs a full page immediately. It does mean the docs need a public module index or status matrix so users do not infer that only the currently documented modules exist.
+
+### Core semantics from internal docs must be reflected carefully
+
+Important source-of-truth concepts from `internal_docs` and verification inventories:
+
+- `int` is intended to be exact/arbitrary precision, with explicit fixed-width integer types for storage, binary protocols, FFI, and dtype-sensitive work.
+- Safe indexing and missing-key behavior must consistently use `Option`/`None` semantics where the compiler contract says they do.
+- `Result`/`Option` handling is mandatory; ignoring fallible results is not normal control flow.
+- `assert` is the intentional panic escape hatch for programmer invariants.
+- Function parameters are immutable borrows by default. `mut` opts into a mutable borrow, `own` transfers ownership, and `own mut` transfers ownership while allowing local mutation.
+- Bare CPython module imports are not aliases for `sifr.*`; supported stdlib imports live under `sifr.*`.
+- Async has one canonical public story: `async def`, `await`, `sifr.task`, `sifr.sync`, structured scopes, explicit offload, typed cancellation evidence.
+- Bytes are a first-class source type and need a clear place in the learning path once data-model docs expand.
+
+### CLI docs have reference gaps
+
+Current CLI docs cover build/run/check/emit/fmt/lint/test/lsp well, but the CLI source also exposes:
+
+- `init`
+- `fetch`
+- `repair`
+- `tree`
+- `package`
+- `publish`
+- `vendor`
+- `self update` / `self version`
+- `trace`
+
+Some package commands are covered indirectly in package pages, but the `CLI Reference` group should eventually make the full command inventory discoverable. The first learning-path slice should not absorb this, but the issue should track it as a follow-up reference cleanup.
+
+### Demos are useful content source material
+
+The `demos/` tree is rich enough to seed guides and examples without inventing toy code. Particularly useful topics:
+
+- `borrow_by_default`
+- `error_handling`
+- `indexing_rules`
+- `integer_safety`
+- `imports`, `local_imports`, `module_assembly`
+- `io_safety`, `binary_files`, `bytes_*`
+- `json`, `csv`, `config_json_csv`
+- `network_tcp_echo`, `network_http_substrate`
+- `async_*`, `blocking_offload_demo`, `cancellation_cleanup_demo`
+- `package` and manifest-related demos
+
+Future guide pages should mine these demos instead of writing examples from scratch.
+
+### Concurrency docs already have strong source material
+
+The current concurrency pages and demos are enough to support a dedicated conceptual section:
+
+- `docs/language/concurrency.mdx`: structured tasks, `async def`, `await`, scopes, `gather`, `select`, `TaskGroup`, channels, shared state, and parallel maps.
+- `docs/stdlib/concurrency.mdx`: reference-shaped API coverage for `sifr.task`, `sifr.sync`, `sifr.parallel`, `sifr.process`, `sifr.signal`, `sifr.runtime`, and `sifr.resource`.
+- `demos/structured_concurrency_demo/main.sifr`: gather, select, TaskGroup, cancellation behavior.
+- `demos/task_core_demo/main.sifr`: timeout and task basics.
+- `demos/cancellation_cleanup_demo/main.sifr`: cancellation and cleanup.
+- `demos/ownership_concurrency_demo/main.sifr`: ownership and task-boundary examples.
+- `demos/async_subprocess_pipeline_demo/main.sifr`: async process I/O.
+
+The implementation should split and reshape this material rather than inventing a second concurrency narrative.
+
+## Audience Perspectives
+
+These perspectives should inform the learning docs, but they should not all live inside `Documentation`. The audience-specific, task-shaped material belongs in `Guides`, where readers can choose the path that matches their background.
+
+### Python Developer Evaluating Sifr
+
+Questions they need answered:
+
+- Is this "Python with a compiler", a Python subset, or a separate language with Python syntax?
+- Can I use normal Python idioms?
+- What breaks if I paste a Python file into Sifr?
+- Where do exceptions, `None`, indexing, imports, classes, and async differ?
+- Do I need to learn Rust to use Sifr?
+
+### Python Developer Starting a First Project
+
+Questions they need answered:
+
+- What file layout should I use?
+- What does `main()` mean?
+- How do imports and packages work?
+- What type annotations are required?
+- How do I install dependencies?
+- What do I do when the compiler reports a type, ownership, or `Result` error?
+
+### Rust-Curious Systems Developer
+
+Questions they need answered:
+
+- What safety guarantees does Sifr inherit from Rust?
+- How does borrow-by-default map to Rust ownership?
+- When do I need `own` or `.clone()`?
+- What runtime is produced, and what is not included?
+- Can I inspect the generated Rust?
+
+### Tooling, CI, and Production User
+
+Questions they need answered:
+
+- Which CLI commands belong in the local loop vs CI?
+- How do diagnostics format for editors and automation?
+- How do `fmt`, `lint`, LSP, and editor integration fit into the local loop?
+- What are the preview/stability limits?
+- What is safe to deploy today?
+
+## Guide Tracks
+
+### Sifr for Python Developers
+
+Recommended route:
+
+- `docs/guides/python-developers/index.mdx`
+- Sidebar title: `Python Developers`
+
+Purpose: help Python developers transfer syntax knowledge while replacing Python runtime assumptions with Sifr's compile-time contract.
+
+This should be a guided track, not a second compatibility reference. It should answer:
+
+- what parts of Python syntax transfer directly;
+- where type hints become enforced types;
+- how `None`, `Result`, `try`/`except`, and missing values work;
+- why imports use `sifr.*` instead of bare CPython module names;
+- how borrow-by-default differs from Python object references;
+- how to structure a first package and run the CLI loop.
+
+Recommended first guide pages:
+
+- `Write your first Sifr program`
+- `Handle errors the Sifr way`
+- `Use typed values and collections`
+- `Import Sifr modules`
+- `Move from script to package`
+
+Scope boundary:
+
+- `docs/from-python.mdx`: compatibility bridge. It is table-first, focused on semantic differences, and should not contain task walkthroughs.
+- `docs/guides/python-developers/index.mdx`: audience-track index. It gives one paragraph of orientation, a card or step list of guide pages, and a link back to `From Python` for the compatibility table. It should not explain compatibility row by row.
+- First Python guide page: task walkthrough. It should help a Python developer write and run a first Sifr program using familiar habits carefully. It should not become a prose version of `From Python`.
+
+### Sifr for Rust Developers
+
+Recommended route:
+
+- `docs/guides/rust-developers/index.mdx`
+- Sidebar title: `Rust Developers`
+
+For both audience tracks, use the short sidebar label in navigation and the full page title in the page itself: `Sifr for Python Developers` and `Sifr for Rust Developers`.
+
+Purpose: help Rust developers understand which Rust safety ideas are visible in Sifr and which details Sifr intentionally hides behind Python-shaped syntax.
+
+This title is better than `Rust Developer Guide` because the guide is not teaching Rust; it is orienting Rust developers inside Sifr.
+
+This should answer:
+
+- how Sifr's borrow-by-default model maps to Rust ownership and borrowing;
+- when `own` and `.clone()` are needed;
+- how `Result` and `Option` appear in source code;
+- what generated Rust is for, and when to inspect it with `sifr emit`;
+- which Rust concepts are not part of the Sifr user model;
+- what runtime, package, and deployment assumptions differ from a normal Rust crate.
+
+Recommended first guide pages:
+
+- `Map Rust patterns to Sifr`
+- `Ownership in Sifr terms`
+- `Results and optional values`
+- `Inspect generated Rust`
+- `Build a native binary`
+
+### Linking from Language Docs
+
+Language pages should remain concept-first. They should not start with audience routing, but they can end with lightweight wayfinding.
+
+Use one of these patterns:
+
+- A short `Next steps` card group at the end of major language pages.
+- One restrained `<Tip>` near a concept where audience context prevents confusion.
+- A `Related guides` section after the page's primary explanation.
+
+Examples:
+
+- `language/type-system.mdx`: link to `Sifr for Python Developers` from the type-hints discussion and to `Sifr for Rust Developers` from `Result`/`Option` vocabulary.
+- `language/error-handling.mdx`: link Python readers to the guide page on replacing exceptions, and Rust readers to the guide page on Sifr's `Result` surface.
+- `language/ownership.mdx`: after it is renamed to `Ownership and Mutability`, link Python readers from borrow-by-default vs object references, and Rust readers from `mut`, `own`, and `own mut` mapping.
+- `language/pattern-matching.mdx`: add a small Python-oriented note around exhaustiveness and link to the Python guide track if the page needs more migration context.
+- `language/concurrency.mdx`: link Python readers from async/cancellation differences and Rust readers from structured task/runtime notes.
+
+The links should be phrased as continuation paths, not warnings:
+
+```mdx
+<CardGroup cols={2}>
+  <Card title="Coming from Python?" href="/guides/python-developers">
+    Follow a guided path through your first program, typed errors, imports, ownership, and packages.
+  </Card>
+  <Card title="Coming from Rust?" href="/guides/rust-developers">
+    Map ownership, `Result`, and generated Rust back to the Rust concepts you already know.
+  </Card>
+</CardGroup>
+```
+
+Do not add these cards to every page. Use them where the reader is likely to carry a strong Python or Rust assumption into Sifr. If icons are added during implementation, verify them against the project's configured Mintlify icon library before using them in MDX.
+
+## Documentation Gaps
+
+### 1. Missing "From Python to Sifr" bridge
+
+There is no page that explicitly says: "If you know Python, here is what carries over, what changes, and why."
+
+Add a short bridge page near the top of the `Get Started` group. It should be written as a compatibility orientation, not a warning dump.
+
+Recommended page:
+
+- `docs/from-python.mdx`
+- Sidebar title: `From Python`
+- Purpose: help Python developers transfer knowledge without being surprised.
+- Sidebar placement: after `Quickstart`, not before it. A reader should see Sifr compile and enforce a real program before they read the differences table.
+
+Core sections:
+
+- "Same shape, different contract"
+- "What carries over"
+- "What changes at compile time"
+- "Common surprises"
+- "Where to go next"
+
+Use a compact, table-first layout:
+
+| Python concept | Sifr shape | Difference |
+| --- | --- | --- |
+| Type hints | Type annotations | Enforced by the compiler, not optional metadata |
+| Exceptions | `Result[T, E]` plus `try`/`except` | No stack unwinding for recoverable errors |
+| Imports | Sifr modules/packages | No arbitrary CPython runtime import surface |
+| Integers | Exact `int` plus explicit fixed-width types | Ordinary arithmetic should be Python-simple; representation-sensitive widths are visible |
+| Bytes | First-class `bytes` | Encode/decode boundaries are explicit typed operations; do not rely on platform-default text behavior |
+| Async | `async def`, `await`, `sifr.task` | Structured task scopes; cancellation is typed evidence, not an ambient exception |
+| Function calls | Borrow by default | Heap values are not moved unless `own` is used |
+| `assert` | Assertion | Programmer invariant, not recoverable control flow |
+
+After Slice 0 corrects the indexing and optional-value docs, add a "Missing values" row that cites the finalized language and stdlib pages rather than restating low-level rules inline.
+
+### 2. Missing first-hour learning flow
+
+The current `Core Language` pages are useful but reference-shaped. A newcomer needs a clear first-hour flow, but that should not be a new `Language Tour` page in the first slice. `Quickstart` already acts as the guided walkthrough, and adding another evolving-example page would duplicate it.
+
+Instead:
+
+- keep `Quickstart` as the workflow-shaped tour;
+- make `From Python` the compatibility bridge after Quickstart;
+- use `docs/index.mdx` cards to point readers into that path;
+- if a non-CLI tour is still needed later, fold it into `introduction.mdx` as a compact "Tour at a glance" section with sequential sections or accordions, not `Steps`.
+
+### 3. Missing current status and compatibility boundaries
+
+The introduction says Sifr is in preview, but there is no clear "what works today" boundary for developers evaluating whether to try it.
+
+Add a concise status page:
+
+- `docs/status.mdx`
+- Sidebar title: `Status`
+- Sidebar placement: a bottom "Project" group or other low-priority location, not the initial `Get Started` sequence.
+
+Sections:
+
+- "Preview channels"
+- "Supported platforms"
+- "Language surface"
+- "Standard library surface"
+- "Tooling surface"
+- "Known limits"
+- "Stability expectations"
+
+This page should avoid apology language. It should give practical boundaries and link to installation, stdlib, and diagnostics.
+
+### 4. Missing core data model pages
+
+The docs explain type system, ownership, and stdlib modules, but they do not yet explain the core everyday data model as a developer would search for it:
+
+- numbers and bools;
+- strings and indexing;
+- lists, dicts, tuples, and sets;
+- iteration and comprehensions;
+- functions and callables;
+- modules and imports.
+
+Some of this appears indirectly in `stdlib/collections.mdx` or demos, but it should be findable in `Core Language` without duplicating stdlib reference pages.
+
+Recommended follow-up pages:
+
+- `language/values-and-collections.mdx`
+- `language/iteration.mdx`
+- later: `language/bytes-and-text.mdx` only when it can bridge core `bytes` semantics without duplicating `stdlib/text-encoding.mdx`
+
+Do not add all at once if that would produce noise. The first implementation slice should add only the bridge pages that unlock the learning path:
+
+1. `From Python`
+2. `Status`
+
+Defer `strings-and-bytes`, `functions`, and a standalone `modules-and-imports` page until there is content that does not already belong in the existing stdlib, ownership, type-system, package, or CLI pages.
+
+Then expand the data model pages as content-backed follow-up work.
+
+### 5. Missing "different from Python" callouts inside existing pages
+
+Existing pages mention differences, but the signal is scattered. Add consistent callout patterns:
+
+- `<Note>` for "If you know Python..."
+- `<Warning>` only for real surprises or unsafe assumptions.
+- `<Tip>` for migration ergonomics.
+
+Examples:
+
+- Type system page: Python type hints are optional runtime metadata; Sifr annotations are compile-time obligations.
+- Error handling page: `raise` in Sifr does not unwind; it maps to `Err` inside `Result` functions.
+- Ownership page: Python passes object references; Sifr borrows by default and may require `own` or `.clone()`.
+- Ownership and Mutability page: Python permits ordinary parameter rebinding and mutation; Sifr requires `mut` or `own mut` when a parameter should be changed.
+- Pattern matching page: Sifr uses exhaustiveness and type narrowing; Python `match` does not enforce the same compile-time completeness.
+- Stdlib overview: Sifr does not expose arbitrary bare CPython module names; supported modules live under `sifr.*`.
+- IO page: `open()` without explicit encoding is rejected; this avoids platform-dependent text behavior.
+
+### 6. Ownership page should become "Ownership and Mutability"
+
+The current `docs/language/ownership.mdx` explains borrow-by-default and `own`, but it does not give `mut` equal treatment. That leaves a major surprise for both Python and Rust readers:
+
+- Python readers expect parameter rebinding and list/dict mutation to be ordinary local behavior.
+- Rust readers expect a clear distinction between shared borrow, mutable borrow, move, and owned mutable binding.
+
+Rename the page in navigation and frontmatter:
+
+- File can remain `docs/language/ownership.mdx` to preserve the existing route.
+- Page title: `Ownership and Mutability`
+- Sidebar title: `Ownership and Mutability`
+- Description: mention borrow-by-default, `mut`, `own`, and `own mut`.
+
+The page should teach the four parameter conventions together:
+
+| Parameter style | Meaning | Caller keeps value? | Callee can mutate? |
+| --- | --- | --- | --- |
+| `items: list[int]` | immutable borrow | yes | no |
+| `mut items: list[int]` | mutable borrow | yes | yes, during the call |
+| `own items: list[int]` | owned immutable binding | no | no, unless copied into a mutable local |
+| `own mut items: list[int]` | owned mutable binding | no | yes |
+
+Primary sections to add or reshape:
+
+- "Immutable by default": bare parameters cannot be reassigned or mutated.
+- "`mut` for mutable borrows": use when the function should update the caller's value in place.
+- "`own mut` for consuming and changing a value": use when the function takes ownership and mutates before returning or dropping the value.
+
+Rules and callouts to include without turning them into large sections:
+
+- `<Warning>` for "Borrowed values cannot escape": `mut items: list[int]` can mutate the caller's list during the call, but it cannot be returned or stored as an owned value. Use `own`, `own mut`, or `.clone()` depending on intent.
+- "Reassignment vs mutation": `mut` is required both when rebinding a parameter name and when mutating through a heap parameter. Rebinding `mut items` to another list still does not let the borrowed value escape.
+- "Scalar parameters": `mut n: int`, `mut x: float`, and `mut ok: bool` permit local rebinding, but they do not represent an observable heap borrow or ownership transfer.
+- "Formatter convention": `own mut` is canonical; the formatter rewrites `mut own` to `own mut`.
+- "Bytes are immutable": `mut` does not make `bytes` subscript assignment legal. Keep this as a one-sentence note, not a full section.
+- "Across `await`": mutable borrows cannot remain live across an await point; link to concurrency docs rather than explaining async borrowing deeply here.
+
+Good source material:
+
+- `internal_docs/architecture.md` parameter convention section.
+- `demos/own_mut_appends/main.sifr`.
+- `demos/string/main.sifr` and `demos/collections/main.sifr` for `mut target: list[bool]`.
+- `crates/sifr_lowering/src/lower/own_mut_semantics_tests.rs` for rejected immutable parameter mutation/reassignment.
+- `SIFR-OWN-0005`, `SIFR-OWN-0006`, `SIFR-OWN-0007`, `SIFR-OWN-0008`, and `SIFR-OWN-0009` diagnostics.
+
+The page should stay elegant: lead with the mental model and a single strong table, then show one mutable-borrow example and one `own mut` example. Keep Rust lowering details out of the main flow; put them in a short note for Rust readers or link to the Rust guide track.
+
+### 7. Missing Python docs reference strategy
+
+The docs should reference Python documentation when it helps transfer familiar syntax, but Sifr docs must remain the source of truth for semantics.
+
+Use Python references for:
+
+- basic syntax vocabulary (`def`, `class`, `if`, `for`, expressions);
+- structural pattern matching terminology;
+- Python typing vocabulary such as union syntax and `TypeVar`;
+- common library concepts where Sifr intentionally mirrors a Python-shaped surface, such as `pathlib`, text encodings, `async`/`await`, or `match`.
+
+Do not rely on Python docs for:
+
+- Sifr type enforcement;
+- Sifr ownership and borrow rules;
+- `Result` / `Option` behavior;
+- panic-free indexing;
+- package layout and `sifr.toml`;
+- Sifr stdlib availability;
+- generated Rust or deployment behavior.
+
+Recommended pattern:
+
+```mdx
+<Note>
+  If you know Python's `match`/`case` from [PEP 634](https://peps.python.org/pep-0634/), the syntax should look familiar. Sifr adds compile-time exhaustiveness for typed unions, so every possible variant must be handled.
+</Note>
+```
+
+Reference links should be sparse and intentional. Put them near the concept they clarify, not in a large external-reference appendix. Prefer stable Python PEP links when the concept is defined by a PEP:
+
+- PEP 484 for type hints and typing vocabulary.
+- PEP 604 for `X | Y` union syntax.
+- PEP 634 for structural pattern matching.
+
+Use `docs.python.org` links for tutorial-level syntax or library concepts only when the Sifr page needs to say "this syntax should look familiar." Avoid meta copy such as "Python's documentation explains the syntax shape"; say the product difference directly.
+
+### 8. Concurrency deserves its own conceptual section
+
+Concurrency is big enough to be more than a single `Learn Sifr` page. It crosses language syntax, ownership, typed errors, cancellation, runtime behavior, synchronization primitives, CPU parallelism, subprocesses, and networking. A newcomer should not have to learn all of that from one long page or from a stdlib API reference.
+
+Best shape:
+
+1. Keep `docs/language/concurrency.mdx` as the stable conceptual overview route, but rewrite it as `Concurrency Overview`.
+2. Add a dedicated `Concurrency` group under the `Documentation` tab, between `Learn Sifr` and `Standard Library`.
+3. Keep `docs/stdlib/concurrency.mdx` as the API reference for modules and methods, but label it `Concurrency API` in the sidebar to avoid colliding with the conceptual section.
+4. Use guides for task-shaped workflows such as building a server, adding timeouts, or doing CPU-heavy work.
+
+The route asymmetry is intentional: the overview keeps the existing `docs/language/concurrency.mdx` path for stability, while new sibling pages can live under `docs/concurrency/`.
+
+Recommended `Documentation > Concurrency` sidebar:
+
+1. `Overview`
+   - Structured concurrency in Sifr.
+   - No fire-and-forget tasks.
+   - No global event-loop object.
+   - Every task belongs to a scope.
+2. `Async and Await`
+   - `async def`
+   - `await`
+   - real suspension requirement
+   - async functions returning `Result[T, E]`
+   - Python `asyncio` differences at a high level
+3. `Structured Tasks`
+   - `task.scope()`
+   - `scope.spawn`
+   - `TaskHandle` as a linear value
+   - `gather`
+   - `select`
+   - `TaskGroup`
+4. `Cancellation and Timeouts`
+   - cancellation evidence
+   - `task.timeout`
+   - `deadline`
+   - cleanup before cancellation is observed
+   - sibling cancellation behavior
+5. `Ownership Across Tasks`
+   - values crossing task boundaries must be owned and sendable
+   - borrowed values and lock guards do not cross task boundaries
+   - mutable borrows cannot cross `await`
+   - link back to `Ownership and Mutability`
+6. `Channels and Shared State`
+   - ownership transfer through channels
+   - bounded channels and backpressure
+   - `Shared[T]`
+   - `Lock[T]`, `RwLock[T]`, `Semaphore`, `Notify`
+   - keep details below API-reference depth
+7. `Parallel Work`
+   - when to use `sifr.parallel` instead of async tasks
+   - `parallel.map`, `try_map`, `Pool`
+   - CPU-heavy work and worker-boundary ownership
+8. `Processes and Signals`
+   - async subprocesses at a concept level
+   - structured shutdown and signal streams
+   - link to stdlib/process/signal reference material
+
+Initial implementation should not create all eight pages at once. Start with:
+
+- `Concurrency Overview`
+- `Async and Await`
+- `Structured Tasks`
+- `Cancellation and Timeouts`
+- `Ownership Across Tasks`
+
+Defer `Channels and Shared State`, `Parallel Work`, and `Processes and Signals` if they would mostly copy `docs/stdlib/concurrency.mdx`. Those can begin as sections inside the overview and split out once the content is strong enough.
+
+Content disposition:
+
+| Existing material | Destination |
+| --- | --- |
+| Opening structured-concurrency guarantee from `language/concurrency.mdx` | Stays in `Concurrency Overview` |
+| `Async Functions` examples | Move to `Async and Await`; expand with demo-sourced suspension examples from `async_generator_comprehension_demo`, `async_subprocess_pipeline_demo`, and `blocking_offload_demo` |
+| `task.scope and Scoped Spawn`, `task.select`, `TaskGroup` | Move to `Structured Tasks` |
+| Timeout, deadline, cancellation, cleanup, sibling cancellation | `Cancellation and Timeouts`; this is mostly demo-sourced net-new writing |
+| Sendability, owned task-boundary captures, borrowed values, mutable borrow across `await` | `Ownership Across Tasks` |
+| `sifr.sync` tabs | Remain brief in overview or defer; API details stay in `Concurrency API` |
+| `sifr.parallel` section | Remain brief in overview or defer; API details stay in `Concurrency API` |
+| Module table | Overview wayfinding cards plus links to `Concurrency API` |
+
+`Concurrency Overview` should not remain a long all-in-one tutorial after sub-pages exist. It should become a mental-model entry point: structured-concurrency guarantees, common differences from Python `asyncio`, a small "which page should I read next?" card group, and links into the stdlib API reference.
+
+`Async and Await` owns the Python `asyncio` comparison at the syntax/model level. Once that page exists, the warning in `docs/stdlib/concurrency.mdx` should be trimmed to a short cross-reference instead of carrying the conceptual explanation.
+
+Boundary rules:
+
+- Concept pages explain the mental model, core guarantees, and common surprises.
+- Stdlib reference pages list APIs, parameters, return types, module coverage, and edge-case behavior.
+- Guides show end-to-end tasks and should pull from demos.
+- Diagnostics pages explain individual compiler errors such as `SIFR-ASYNC-*` and `SIFR-OWN-0009`.
+
+The concurrency section should link smoothly to:
+
+- `Ownership and Mutability` for `mut`, `own`, `own mut`, and borrowed-value escape rules.
+- `Error Handling` for `Result` in async functions and task failures.
+- `Networking` for async TCP/HTTP/TLS examples.
+- `Stdlib > Concurrency` for API detail.
+- `Reference > Error Codes` for async/ownership diagnostics.
+
+### 9. Need clearer split between learning docs and reference docs
+
+The redesigned site should keep the top navigation small while making the left sidebar do more of the information-architecture work.
+
+Proposed top navigation:
+
+- Documentation
+- Guides
+- Reference
+- Blog
+- Website
+- Install Sifr
+
+`Documentation` and `Guides` should sit on the left side of the header. Search should remain centered. `Blog`, `Website`, and `Install Sifr` should sit on the right side.
+
+`Documentation` should focus on the learning path and conceptual docs. It can still include compact references where they are part of learning Sifr, but deeper catalogs should move to `Reference`.
+
+Proposed sidebar shape:
+
+1. Get Started
+   - Welcome
+   - Introduction
+   - Install
+   - Quickstart
+   - From Python
+2. Learn Sifr
+   - Types and Narrowing
+   - Error Handling
+   - Ownership and Mutability
+   - Values and Collections
+   - Iteration
+   - Classes
+   - Pattern Matching
+3. Concurrency
+   - Overview
+   - Async and Await
+   - Structured Tasks
+   - Cancellation and Timeouts
+   - Ownership Across Tasks
+   - Channels and Shared State
+   - Parallel Work
+   - Processes and Signals
+4. Standard Library
+   - Overview
+   - Module Index
+   - Collections
+   - I/O and Filesystem
+   - Networking
+   - Concurrency API
+   - Text and Encoding
+5. Packages
+   - Overview
+   - Manifest
+   - Dependencies
+   - Publishing
+6. Project
+   - Status
+
+`Reference` should hold catalog-shaped material:
+
+1. CLI
+   - Overview
+   - Build and Run
+   - Check and Emit
+   - Format and Lint
+   - Test
+   - LSP
+2. Error Codes
+   - Overview
+   - one page per diagnostic code
+
+This keeps `Documentation` approachable for a newcomer while giving experienced users a predictable reference tab.
+
+The CLI list above is the initial shape. Slice 4 should expand it to the full public command inventory once the current CLI gaps are documented.
+
+### 10. Missing Reference tab and per-code diagnostic pages
+
+The current `docs/diagnostics/error-codes.mdx` page is useful as a family index, but it does not yet give each diagnostic a stable, searchable explanation page. A developer who sees `SIFR-TYPE-0002` or `SIFR-RESULT-0001` should be able to open a direct URL and learn exactly what happened, why it happened, and what a fixed program looks like.
+
+Rust's error index is the right product shape to study: short per-code pages with an erroneous example, a plain explanation, and a corrected example. Sifr should follow that shape without copying Rust's content or making the pages feel like compiler internals.
+
+Current source material:
+
+- `crates/sifr_diagnostics/src/codes/registry.rs` is the registry source of truth.
+- `verification/areas/diagnostics/data/code_catalog.json` maps codes to metadata, owners, severity, stability, representative fixtures, and generated docs links.
+- `docs/errors/*.md` already contains generated per-code metadata, but `docs/.mintignore` excludes `errors/` and the pages are not publication-ready. They are metadata inputs, not public docs.
+- `docs/diagnostics/error-codes.mdx` includes family descriptions and the published index, but some fix guidance needs a semantic audit before it is reused. For example, `SIFR-RESULT-0001` currently mentions `unwrap()` and `?` syntax; that should only remain if those are validated as public Sifr mechanisms.
+
+Recommended public structure:
+
+- Keep `docs/diagnostics/error-codes.mdx` as the existing discoverable index route, and make each row link to the corresponding per-code page.
+- Add a `Reference` top-level tab in `docs/docs.json`.
+- Add a single `Reference > Error Codes` group with a public overview/index and per-code pages.
+- Preserve the compiler-emitted diagnostic URL contract as the canonical route for individual codes: `https://sifr.sh/docs/errors/<CODE>`.
+- Publish the pages from `docs/errors/<CODE>.mdx`, register them under the `Reference > Error Codes` group, and remove or narrow the `errors/` entry in `docs/.mintignore` only after generated `.md` metadata has been replaced with reader-facing MDX.
+- Treat the existing `/diagnostics/error-codes` route as a compatibility entry point. It can either remain the canonical index or redirect readers clearly to the `Reference` index, but it should not become stale.
+
+Each everyday source-level per-code page should use a consistent, skimmable structure:
+
+1. `# SIFR-XXXX-0000`
+2. One-sentence summary
+3. `## Erroneous example`
+4. `## What went wrong`
+5. `## How to fix it`
+6. `## Fixed example`
+7. `## Related`
+
+The examples should be reader-scale, not raw compiler-test fixtures. Representative fixtures from the catalog should seed the example, but the final code should be edited for documentation clarity. For project, package, backend, or formatter diagnostics where a single `.sifr` snippet is not the clearest form, use the smallest realistic file tree, command, manifest, or terminal example instead.
+
+Do not force the full code-example template onto every diagnostic. Tier the pages by how developers encounter them:
+
+- Tier 1: full treatment with erroneous code, explanation, fix, and fixed code for everyday programming diagnostics such as `TYPE`, `NAME`, `CALL`, `RESULT`, `MATCH`, `FLOW`, `OWN`, `ASYNC`, `IMPORT`, and `PARSE`.
+- Tier 2: focused treatment with explanation and a minimal example for source-level but specialized diagnostics such as `INT`, `DECIMAL`, `IO`, `ENCODING`, `CLASS`, `PROTO`, `FMT`, and `LINT`.
+- Tier 3: brief treatment with what happened and what to do next for environment, package, workspace, build, stdlib, and internal diagnostics. Use file trees, manifests, commands, or terminal output when that is clearer than source snippets.
+
+`CODEGEN` currently has no active codes, so it should remain listed as having no active codes rather than gaining an empty page. `SIFR-INTERNAL-0002` is informational note output, so it should not use the erroneous/fixed template.
+
+The index should remain compact:
+
+- group by family;
+- show severity and a one-line description;
+- link every stable active code to its page;
+- include a short note about `sifr --explain <CODE>`;
+- avoid repeating each page's full explanation.
+
+## Content Principles
+
+1. Prefer one strong example over many tiny fragments.
+2. Use comparison tables where Python developers would otherwise infer the wrong thing; do not make every difference a table row.
+3. Keep paragraphs short; let code and callouts carry the detail.
+4. Use `Steps` for workflow pages, not concept pages.
+5. Use cards for wayfinding at the end of pages.
+6. Every page should answer "what do I do next?"
+7. Mention Python when it helps orientation; do not frame Sifr as a Python compatibility clone.
+8. State differences as product decisions, not caveats.
+9. Avoid exhaustive spec language in first-pass learning pages.
+10. Move spec-level detail to diagnostics, CLI references, or architecture docs; learning pages link to those instead of inlining them.
+11. Diagnostic reference pages should lead with the fix path. Do not bury the corrected example below internal compiler detail.
+12. Error-code docs should describe the user-facing program shape that caused the diagnostic, not the internal pass that emitted it.
+
+## Proposed Implementation Slices
+
+### Slice 0: Semantic Consistency Audit
+
+Files:
+
+- `docs/introduction.mdx`
+- `docs/quickstart.mdx`
+- `docs/language/type-system.mdx`
+- `docs/stdlib/collections.mdx`
+- relevant compiler demos/tests/source areas that pin indexing, missing-key, and optional-value behavior
+
+Acceptance:
+
+- Correct the current dictionary/indexing contradiction before new pages are added:
+  - `internal_docs/architecture.md` already defines the contract: where CPython raises `KeyError`, Sifr returns `Option[V]`; `dict["missing"]` returns `None`.
+  - `docs/stdlib/collections.mdx` currently contradicts this by saying direct `scores["missing"]` produces a typed error if the key might be absent.
+  - Update `collections.mdx` to match the architecture contract and align `introduction.mdx`, `quickstart.mdx`, `type-system.mdx`, and future `From Python` copy around the same rule.
+- Verify the actual contract against existing compiler behavior and cite the demo, test, or source area that pins it.
+- Write the resolved contract into `docs/language/type-system.mdx` and `docs/stdlib/collections.mdx` so Slice 1 can cite stable anchors instead of deciding semantics while drafting `From Python`.
+- Fix `docs/language/type-system.mdx` "None Safety" examples so every `int | None` value is checked or intentionally narrowed before numeric/string operations.
+- Fix `docs/language/type-system.mdx` built-in scalar table: `int` must not be described as a 64-bit signed integer; align it with the exact/arbitrary-precision source-level `int` design.
+- Fix `docs/language/type-system.mdx` Copy-type note: `float` and `bool` are Copy-like, but source-level exact `int` should be described as value-semantic rather than Rust-`Copy`.
+- Keep the panic-free/safe-indexing pitch precise and implementation-backed.
+
+### Slice 1: Learning Path Skeleton
+
+Files:
+
+- `docs/docs.json`
+- `docs/from-python.mdx`
+- `docs/status.mdx`
+- `docs/language/ownership.mdx`
+- targeted edits to `docs/index.mdx`, `docs/introduction.mdx`, and `docs/quickstart.mdx`
+
+Acceptance:
+
+- After reading `Introduction`, `Quickstart`, and `From Python`, a Python developer can state:
+  - what Sifr does that Python does not;
+  - which familiar Python idioms have different semantics;
+  - what command they should run next.
+- Sidebar group names distinguish learning pages from reference pages.
+- `From Python` is table-first and does not duplicate the value-proposition prose from `Introduction`.
+- `Introduction` is trimmed or reshaped where necessary so it states the product thesis once and lets `From Python` own the detailed compatibility table.
+- `docs/index.mdx` wayfinding points at the learning path: at minimum, one top card should point to `Quickstart` and one should point to `From Python`.
+- `Status` lives outside the main Get Started learning sequence.
+- `docs/language/ownership.mdx` is retitled in frontmatter and sidebar as `Ownership and Mutability` while keeping the file path stable.
+- `Ownership and Mutability` teaches `mut`, `own`, and `own mut` together, with a compact convention table and examples sourced from existing demos/tests.
+- The page explains that bare parameters are immutable by default, `mut` permits mutation through a borrow, `own` moves the value, and `own mut` moves the value while permitting local mutation.
+- The page explains that mutable borrowed parameters cannot be returned or stored as owned values without `own`, `own mut`, or `.clone()`.
+- The page notes that `mut` on scalar parameters permits local rebinding but does not involve observable heap borrowing or ownership transfer.
+- The page avoids becoming a Rust lowering spec; Rust-specific mapping is a note or link to the Rust guide track.
+- The imports row in `From Python` links to a concrete worked import example, either in `Quickstart`, `cli/overview.mdx`, or another existing page chosen during Slice 1.
+- `Status` includes a short standard-library availability section that points to `stdlib/overview.mdx` and does not imply undocumented modules are unsupported.
+- `npx mint@latest validate` passes from `docs/`.
+
+### Slice 2: Core Data Model
+
+Files:
+
+- `docs/language/values-and-collections.mdx`
+- `docs/language/iteration.mdx`
+- targeted links from stdlib pages to the language pages.
+
+Acceptance:
+
+- Core language docs cover everyday values before module-level stdlib docs.
+- Python differences around indexing, truthiness, iteration, and mutation are easy to find.
+- Existing demos are used as source material where possible.
+- `language/values-and-collections.mdx` covers scalars, exact `int`, explicit fixed-width integer types at a high level, list/dict/tuple/set basics, truthiness, and mutation rules.
+- `stdlib/collections.mdx` remains the home for `Counter`, `deque`, and module-level helpers.
+
+### Slice 3: Concurrency Section
+
+Files:
+
+- `docs/docs.json`
+- `docs/language/concurrency.mdx`
+- optional new conceptual pages under `docs/concurrency/`, such as:
+  - `docs/concurrency/async-and-await.mdx`
+  - `docs/concurrency/structured-tasks.mdx`
+  - `docs/concurrency/cancellation-and-timeouts.mdx`
+  - `docs/concurrency/ownership-across-tasks.mdx`
+- targeted links from `docs/stdlib/concurrency.mdx`, `docs/stdlib/networking.mdx`, `docs/language/ownership.mdx`, and `docs/language/error-handling.mdx`
+
+Acceptance:
+
+- `Documentation` has a dedicated `Concurrency` sidebar group between `Learn Sifr` and `Standard Library`.
+- `docs/language/concurrency.mdx` remains the stable conceptual overview route and is retitled `Concurrency Overview`.
+- The first implementation creates or reshapes only the concept pages that have enough content:
+  - `Overview`
+  - `Async and Await`
+  - `Structured Tasks`
+  - `Cancellation and Timeouts`
+  - `Ownership Across Tasks`
+- `Channels and Shared State`, `Parallel Work`, and `Processes and Signals` are either concise sections in the overview or deferred pages; they should not be split out if doing so only duplicates the stdlib reference.
+- Concept pages explain the mental model, guarantees, and common surprises. They do not list every method on `sifr.task`, `sifr.sync`, or `sifr.parallel`.
+- `docs/stdlib/concurrency.mdx` remains the API reference and links back to the conceptual overview for learning material.
+- `docs/stdlib/concurrency.mdx` uses the sidebar label `Concurrency API`, not `Concurrency`, to avoid competing with the conceptual group.
+- The implementation follows the content disposition table above so existing `language/concurrency.mdx` material is moved, summarized, or linked rather than duplicated.
+- `Concurrency Overview` is rewritten as a concise mental-model entry point with navigation cards; it is not merely the old long page with a new title.
+- `Async and Await` and `Cancellation and Timeouts` are treated as partly net-new writing sourced from demos, not just extracted sections.
+- The section makes Python `asyncio` differences explicit without framing Sifr as an `asyncio` clone.
+- The section links to:
+  - `Ownership and Mutability` for `mut`, `own`, `own mut`, sendability, and borrowed values across `await`;
+  - `Error Handling` for `Result` in async functions and task failures;
+  - `Networking` for async networking examples;
+  - `Reference > Error Codes` for `SIFR-ASYNC-*` and `SIFR-OWN-0009`.
+- Examples are sourced from existing demos, especially `structured_concurrency_demo`, `task_core_demo`, `cancellation_cleanup_demo`, and `ownership_concurrency_demo`.
+- `npx mint@latest validate` passes from `docs/`.
+
+### Slice 4: Standard Library Module Index
+
+Files:
+
+- `docs/stdlib/overview.mdx`
+- optional `docs/stdlib/module-index.mdx`
+- `docs/docs.json`
+
+Acceptance:
+
+- Users can discover the shipped `sifr.*` modules without needing to read `lib/sifr`.
+- The module index groups modules by purpose and marks detailed docs as "available" vs "planned" without overpromising parity.
+- The index can also mark small modules as available without a dedicated page when a full page would add noise.
+- The index links to existing pages for collections, I/O, networking, concurrency reference, and text/encoding.
+- The index explicitly states that Sifr docs own Sifr semantics even when a module mirrors a Python standard-library concept.
+
+### Slice 5: CLI Reference Inventory
+
+Files:
+
+- `docs/cli/overview.mdx`
+- package pages as needed
+- optional targeted CLI pages for `init`, `fetch/tree/vendor`, `repair`, `self`, and `trace`
+
+Acceptance:
+
+- The CLI overview lists every public command exposed by `sifr`.
+- The CLI overview covers global `--diagnostic-format` and `--explain <CODE>` flags alongside subcommands.
+- Commands are grouped by workflow concern, not as a flat alphabetical list.
+- Commands that already have deeper pages link to them.
+- Package-management commands do not get duplicated prose if the package pages already explain them.
+- `self update` and `trace` are discoverable, with status/preview caveats where appropriate.
+
+### Slice 6: Reference Tab and Error Code Pages
+
+Files:
+
+- `docs/docs.json`
+- `docs/diagnostics/error-codes.mdx`
+- rewritten public `docs/errors/<CODE>.mdx` pages for stable active diagnostic codes
+- optional validation script or docs fixture that compares public pages with `verification/areas/diagnostics/data/code_catalog.json`
+
+Acceptance:
+
+- A `Reference` top-level tab exists.
+- `Reference` includes diagnostics and error-code material without crowding the `Documentation` learning path.
+- The existing `/diagnostics/error-codes` route links to the per-code pages and does not become a dead or stale duplicate.
+- Individual error-code pages keep the compiler-emitted `https://sifr.sh/docs/errors/<CODE>` URL contract unless the implementation intentionally updates `DiagnosticCode::docs_url()` and every checked diagnostic baseline in the same slice.
+- Every stable active code in `verification/areas/diagnostics/data/code_catalog.json` has a public page or an explicitly documented reason it is not published yet.
+- No public page is generated from `docs/errors/*.md` without rewriting the content into reader-facing MDX.
+- Tier 1 pages explain what the code indicates, show an erroneous example, explain the fix, and show a fixed example.
+- Tier 2 and Tier 3 pages use the smaller documented templates where the full source-code template would be noisy or misleading.
+- Examples are sourced from representative fixtures where possible, but edited down to documentation-scale examples.
+- The page template handles non-source diagnostics such as package, workspace, backend, formatter, and lint diagnostics with file tree, manifest, command, or terminal examples when code snippets would be misleading.
+- No `CODEGEN` stub page is created while that family has no active codes.
+- `SIFR-INTERNAL-0002` is treated as an informational note page, not as an erroneous/fixed-code tutorial.
+- The `SIFR-RESULT-0001` guidance is audited before publication so it does not recommend mechanisms that are not part of Sifr's current public syntax.
+- The index copy is cleaned up while it moves: remove internal commentary such as "largest family" wording and avoid migration-history phrasing unless it helps the user decide what to do next.
+- A docs validation step reads `verification/areas/diagnostics/data/code_catalog.json`, checks `stability == "stable"` entries, catches missing pages for active codes, and checks the reverse direction so public error pages do not outlive removed codes.
+- The validation step runs from the normal local facade, preferably through `scripts/run_all_tests.sh` under the docs/profile path rather than as a separate one-off command.
+- `npx mint@latest validate` passes from `docs/`.
+
+### Slice 7: Python Reference Callouts
+
+Files:
+
+- existing language and stdlib pages.
+
+Acceptance:
+
+- Each page that uses Python-shaped syntax has at most one or two purposeful Python reference callouts.
+- No page delegates Sifr semantics to Python docs.
+- Differences from Python are consistently signposted.
+- Initial callout targets are type system, error handling, ownership and mutability, stdlib overview, and I/O.
+- Do not add a generic Python callout to pattern matching unless it clarifies a concrete rule not already explained.
+
+### Slice 8: Guides Expansion Plan
+
+Files:
+
+- `docs/guides/index.mdx`
+- `docs/guides/python-developers/index.mdx`
+- `docs/guides/rust-developers/index.mdx`
+- future guide pages.
+
+Acceptance:
+
+- Guides remain how-to oriented, not concept reference.
+- The Guides sidebar includes audience tracks:
+  - `Sifr for Python Developers`
+  - `Sifr for Rust Developers`
+- The two audience guide indexes explain what the reader needs to know from their background without duplicating the language reference pages.
+- Track index pages contain only:
+  - a one-paragraph orientation;
+  - the guide sequence as cards or numbered steps;
+  - pointers to the relevant background reference, such as `From Python` for Python readers and `language/ownership.mdx` or `cli/check-emit.mdx` for Rust readers.
+- Track index pages do not contain concept explanations, compatibility matrices, or comparison tables.
+- `From Python`, `Sifr for Python Developers`, and the first Python guide page have distinct jobs:
+  - `From Python` is the compatibility table.
+  - `Sifr for Python Developers` is the route through the guide track.
+  - The first Python guide page is a task walkthrough.
+- Language docs link into the audience guides only where background assumptions are likely to matter.
+- Cross-links from language pages use `Next steps`, `Related guides`, or a single focused tip/card group; they do not interrupt the main explanation.
+- The guide track names stay reader-centered and clear. Prefer `Sifr for Python Developers` and `Sifr for Rust Developers` over generic titles such as `Python Developer Guide`.
+- Guide pages that share a topic with a language page must be distinguishable by task orientation. A reviewer should not be able to summarize a guide page as only "explains concept X."
+- General guide pages live under `docs/guides/*.mdx` unless a later slice deliberately introduces a deeper grouping. First general guide set should likely be:
+  - "Build a CLI tool"
+  - "Read and write files safely"
+  - "Typed error handling"
+  - "Create a package"
+  - "Use Sifr from CI"
+- Python developer guide seed pages should likely be:
+  - "Write your first Sifr program"
+  - "Handle errors the Sifr way"
+  - "Use typed values and collections"
+  - "Import Sifr modules"
+  - "Move from script to package"
+- Rust developer guide seed pages should likely be:
+  - "Map Rust patterns to Sifr"
+  - "Ownership in Sifr terms"
+  - "Results and optional values"
+  - "Inspect generated Rust"
+- `Typed error handling` is the general how-to guide. `Handle errors the Sifr way` is the Python-audience guide that starts from exception habits and walks through the Sifr workflow.
+- `Results and optional values` is the Rust-audience guide that starts from Rust `Result`/`Option` assumptions and maps them to Sifr syntax and workflow. It should not duplicate the general typed-error guide.
+- Guide examples should be sourced from existing demos when possible.
+
+## Open Questions
+
+- Should "Status" live in Get Started, or in a separate "Project" group?
+- Should `From Python` come before or after Quickstart?
+- How explicit should the docs be about unsupported CPython runtime features before the compatibility matrix exists?
+- Should the first data model page be a single "Values and Collections" page or several smaller pages?
+- Should we add a short "Generated Rust" page for Rust-curious users, or keep that in CLI `emit` docs?
+
+Current answers after Claude review pass 1:
+
+- `Status` should not live in Get Started; use a bottom Project group or equivalent low-priority placement.
+- `From Python` should come after Quickstart.
+- The bridge page should link to `stdlib/overview.mdx` for supported `sifr.*` modules and avoid promising arbitrary CPython module compatibility.
+- Start with `Values and Collections` plus `Iteration`, not six separate data-model pages.
+- Do not add a separate Generated Rust page yet; `Quickstart` and `cli/check-emit.mdx` cover the current need.
+
+## Non-Goals
+
+- Do not rewrite every existing docs page in one PR.
+- Do not add root-level Mintlify shims.
+- Do not create a separate Python compatibility promise broader than Sifr can support.
+- Do not claim CPython module parity unless the implementation and tests support it.
+- Do not move internal compiler reference docs into public docs as part of this task.
+- Do not treat existing internal `.md` files under `docs/` as Mintlify pages unless a later slice explicitly migrates them to MDX and adds them to `docs.json`.
+
+## Validation Plan
+
+For future implementation PRs:
+
+```bash
+cd docs
+npx mint@latest validate
+```
+
+For content review:
+
+- Manually preview the docs and inspect the left sidebar order.
+- Check pages at desktop and mobile widths.
+- Confirm "Ask Assistant" still appears in the expected Mintlify header/panel location.
+- Ask Claude Opus to review the issue and proposed content structure before implementation.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-review-pass-1.md
@@ -1,0 +1,94 @@
+I have enough context to produce the review. Here are my findings.
+
+## Review: ad-hoc-documentation-learning-path
+
+### Overall verdict
+
+The direction is sound — the sequencing/calibration gap is real. But several proposed pages duplicate existing content, the central "panic-free indexing" pitch is inconsistent across current docs in a way the issue does not flag, and Slice 2 is sized too large.
+
+### Findings
+
+**1. The dict-indexing semantics are inconsistent in the existing docs, and the proposed `From Python` table cements one side without resolving it. — blocking**
+
+- `docs/introduction.mdx:39` and `docs/quickstart.mdx:26` show `users["charlie"]` returning `int | None` for a missing key.
+- `docs/stdlib/collections.mdx:46` says: "Direct `scores["missing"]` is a compile-time checked operation that produces a typed error if the key might be absent."
+- The issue's bridge table at line 114 picks the first reading ("Missing keys / indexes → `T | None`") without flagging the contradiction.
+
+This is the central claim of the language. Resolve it (either `[]` returns `T | None` *or* `[]` is rejected and `.get()` returns `T | None`) and update the introduction/quickstart/collections pages in lockstep with the bridge page. Without this, `From Python` will ship contradicting collections.
+
+**2. `docs/language/type-system.mdx` "None Safety" example contradicts the panic-free pitch — blocking**
+
+Lines 88-98 show `if x > 0:` and `x == target` directly on `x: int | None` with no None check first. Either the compiler narrows numeric comparison against an `Option` (then say so explicitly), or the example is wrong. A redesign whose top selling point is "missing values cannot crash" cannot leave this in place. The bridge work needs to include an audit of existing pages, not only additions. Add this to Slice 1 acceptance.
+
+**3. `Language Tour` duplicates Quickstart — important**
+
+Quickstart already uses `Steps`, an evolving example (dict lookup → `Result` → `isinstance` narrowing), and ends with "what you just did". Adding a parallel "evolving example" Language Tour produces two walkthroughs covering nearly the same surface. Replacement: drop `language/tour.mdx`. Move tour-shaped content into a slimmed-down Quickstart and let `Core Language` pages stay reference-flavored. If a non-CLI tour is genuinely wanted, fold it into `introduction.mdx` as a "Tour at a glance" section using `Accordion`/`Tabs`, not `Steps`.
+
+**4. Place `From Python` *after* Quickstart, not before — important**
+
+The issue raises this as an open question. Recommendation: after. A differences page before any code has been seen reads as a warning dump and violates principle #8 ("State differences as product decisions, not caveats"). Once a reader has compiled `greet.sifr` and watched the compiler enforce `try`/`except`, the bridge becomes a memory aid instead of a hedge.
+
+**5. `From Python` content overlaps `introduction.mdx` value props — important**
+
+`introduction.mdx` lines 17-26 already enumerate Python-vs-Sifr deltas in "Key value propositions" prose. If the bridge page repeats the same five differences in prose, both pages decay. Replacement: make `from-python.mdx` table-first (the comparison table at issue line 110 is already the strongest section), keep "Common surprises" as the only prose section, and remove the value-prop paragraphs from `introduction.mdx` (let the example carry them).
+
+**6. Slice 2 is too big and overlaps stdlib — important**
+
+Six new pages (`values-and-types`, `strings-and-bytes`, `collections`, `iteration`, `functions`, `modules-and-imports`) duplicate existing content:
+- `strings-and-bytes` overlaps `stdlib/text-encoding.mdx` and `stdlib/io-filesystem.mdx`.
+- `collections` overlaps `stdlib/collections.mdx` (which already covers lists, dicts, tuples, sets).
+- `functions` overlaps `ownership.mdx` (which covers borrow-by-default for arguments) and `type-system.mdx` (annotations).
+
+Replacement Slice 2: keep two pages only — `language/values-and-collections.mdx` (scalars + list/dict/tuple/set + truthiness + mutation rules) and `language/iteration.mdx` (for/comprehensions/iterators). Link out to `stdlib/collections.mdx` for `Counter`/`deque`. Defer `strings-and-bytes` and `functions` until there is content that does not already live elsewhere.
+
+**7. Sidebar group ordering misplaces Standard Library — important**
+
+The proposed order (Get Started → Learn Sifr → Reference (CLI) → Packages → Standard Library → Diagnostics) hides stdlib behind packaging concerns. Stdlib is part of the learning surface — `sifr.io`, `sifr.collections`, `sifr.task` are everyday tools, not deployment ceremony. Replacement order: Get Started → Learn Sifr → Standard Library → CLI Reference → Packages → Diagnostics.
+
+**8. `Status` does not belong in Get Started — important**
+
+A first-time reader does not need preview-channel and platform-surface tables before Quickstart. Replacement: put `status.mdx` as the last item in its own "Project" group at the bottom of the sidebar, or fold the contents into `introduction.mdx` as a single `<Note>` that links to a Roadmap page. Get Started should be Welcome / Introduction / Install / Quickstart / From Python — five items, not six.
+
+**9. `docs/index.mdx` edits are unspecified and most-load-bearing — important**
+
+The issue says "targeted edits to docs/index.mdx" without naming them. The current four cards point at `/introduction`, `/cli/overview`, `/packages/overview`, `/stdlib/overview` — none of them point at the new learning entry (`Quickstart` → `From Python`). Specify in Slice 1: index card #2 should become "Quickstart" → `/quickstart`, card #4 should become "From Python" → `/from-python`. The bottom card pair can keep `Installation` + `Quickstart`.
+
+**10. The compatibility-matrix open question blocks Slice 1 framing — important**
+
+Open Question #3 asks "How explicit should the docs be about unsupported CPython runtime features before the compatibility matrix exists?" — answer this before drafting `from-python.mdx`. If no matrix is planned, the bridge page must commit to a static list of supported `sifr.*` modules and explicitly say "no other CPython modules are accepted." The current `stdlib/overview.mdx` "What Sifr Does Not Expose" section is the right shape — bridge page should link to it rather than restating.
+
+**11. `Welcome` sidebar entry adds a click without adding content — optional**
+
+`docs/index.mdx` is a card hub. It can be reached via the logo / tab title. Removing "Welcome" from the sidebar drops the click between sidebar selection and `Introduction`. If you keep it, retitle it to "Overview" so the entry signals what it offers.
+
+**12. The proposed Python-references `<Note>` text is meta — optional**
+
+The example at issue line 234 ("Python's documentation explains the syntax shape, while this page explains the Sifr contract") reads as process commentary about documentation, not product copy. Replacement pattern:
+
+> If you know Python's `match`/`case` from [PEP 634], the syntax is the same. Sifr adds compile-time exhaustiveness — every union member must be covered.
+
+Link to PEP numbers (634, 604, 484) rather than `docs.python.org/3/...` pages whose versions drift.
+
+**13. Pattern Matching page does not need a "different from Python" callout — optional**
+
+`docs/language/pattern-matching.mdx` is already framed around exhaustiveness, the actual point of difference. Adding a generic "If you know Python..." callout would dilute the page. Slice 3 should explicitly skip pattern-matching for callouts.
+
+**14. "Generated Rust" page proposal can be declined — optional**
+
+Open Question #5 asks whether to add a Rust-curious page. Recommendation: no. `docs/cli/check-emit.mdx` and the `sifr emit` step in Quickstart already cover it. A separate page introduces audience confusion (the Rust-curious are not the primary newcomer) and the issue's own Non-Goals discourage scope creep.
+
+**15. Acceptance criterion for Slice 1 is unverifiable — optional**
+
+"Newcomer can answer ... within the first four sidebar pages" — with five Get Started entries in the (revised) proposal, "the first four" is ambiguous. Replacement: "After reading `Welcome`, `Introduction`, and `From Python`, a Python developer can state (a) what Sifr does that Python does not, (b) which Python idioms break, (c) what their next command should be." Make the test about content learned, not page count.
+
+### Style preservation
+
+The current snippet-callout-table-cards style is preserved well by the existing concept pages. The risk is that `Language Tour` reaches for `<Steps>` (workflow shape) on a concept page, breaking principle #4 in the issue itself. Tour-shaped content should use `<Accordion>` or sequential sections, not `<Steps>`. (See finding 3.)
+
+### Suggested slice order after the changes above
+
+1. **Slice 0 (new, blocking)**: Resolve dict-indexing semantics and audit `type-system.mdx` None-safety examples; update intro/quickstart/collections to match. No new pages.
+2. **Slice 1**: Add `from-python.mdx` (after Quickstart) and `status.mdx` (bottom group). Update `docs.json` and `index.mdx` card targets. Skip `language/tour.mdx`. Skip `modules-and-imports.mdx` until imports are documented in one place (see finding 6 — it can fold into `values-and-collections.mdx` or stay in `cli/overview.mdx`'s project-mode section).
+3. **Slice 2**: Two pages — `values-and-collections.mdx`, `iteration.mdx`. Link out to stdlib.
+4. **Slice 3**: Callouts on type-system, error-handling, ownership, stdlib overview, io. Skip pattern-matching.
+5. **Slice 4**: Guides — unchanged.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-review-pass-2.md
@@ -1,0 +1,43 @@
+## Review: ad-hoc-documentation-learning-path (pass 2)
+
+The revision picks up most pass-1 corrections cleanly: Slice 0 now exists, Slice 2 is reduced to two pages, `From Python` is moved after Quickstart, the sidebar order puts Standard Library above CLI/Packages, `Status` is demoted to a bottom Project group, `index.mdx` card targets are specified, the CPython-modules question is resolved (link to `stdlib/overview.mdx`), and the Generated Rust page is declined. Slice 1's acceptance is now testable.
+
+A small number of remaining issues:
+
+### Findings
+
+**1. Slice 0 names the contradiction but does not pick a side. — important**
+
+Lines 319-322 leave the resolution as "either A or B." The `From Python` table at line 114 is hedged accordingly (`T | None` *or* a typed diagnostic). The issue therefore tells the Slice 0 implementer "fix the contradiction," then tells the Slice 1 author "write a table that documents whichever resolution Slice 0 chose." That's a real implicit dependency: Slice 1 cannot start until Slice 0 has both decided and recorded the contract somewhere stable. Make this explicit — either commit in this planning artifact to one option (whichever matches current compiler behavior, verifiable from `crates/sifr_hir` or existing tests), or add a Slice 0 acceptance line: "the resolved contract is written into `docs/language/type-system.mdx` and `docs/stdlib/collections.mdx` and the `From Python` table cites those pages by anchor." Without that, the Slice 1 author is the one really resolving it.
+
+**2. Gap section #2 still recommends `Language Tour`, then is countermanded mid-section. — important**
+
+Lines 124-140 keep the original "Missing language tour" recommendation block (`docs/language/tour.mdx`, sidebar title `Language Tour`, evolving example, sections list). Lines 141-143 then say "After review, this page should not be part of the first implementation slice." The artifact reads as if both positions are live. A future implementer skimming for sidebar titles will lift "Language Tour" from line 127. Replacement: either delete the recommendation block entirely (pass-1 #3 said drop the tour), or rewrite the gap as "Tour-shaped content already exists in Quickstart — no new page; if a non-CLI tour is wanted later, fold into `introduction.mdx` with `Accordion`."
+
+**3. The worked Python-reference `<Note>` example demonstrates the wording the revision forbids. — important**
+
+Line 243 adds "Avoid meta copy such as 'Python's documentation explains the syntax shape'; say the product difference directly." Lines 232-235 still print exactly that phrasing as the worked example. The rule and the demo contradict. Replace the code block with something like the pass-1 suggested form, e.g., `If you know Python's match/case from [PEP 634], the syntax is the same. Sifr adds compile-time exhaustiveness — every union member must be covered.` That doubles as a working PEP-link demo (line 240-242 endorses PEPs 484/604/634).
+
+**4. Imports/modules question is under-served by the reduced page set. — optional**
+
+The Python-evaluator persona asks "How do imports and packages work?" (line 60). The reduced Slice 2 (Values and Collections + Iteration) intentionally drops `modules-and-imports`. `From Python` mentions imports in one table row. The Packages group is reference-shaped (manifest/dependencies/publishing), not "here's how `import` works for a Python dev." This is acceptable if Quickstart or `cli/overview.mdx` already shows project-mode imports concretely — pass-1 #6 suggested folding into `cli/overview.mdx`'s project-mode section. The issue does not commit to where this answer lives. Add a one-line note to Slice 1 acceptance: "Quickstart or `cli/overview.mdx` contains a worked `import` example a Python reader can find from the From Python row," or pick a home explicitly.
+
+**5. Slice 1 acceptance constrains only the new page's overlap, not the existing prose. — optional**
+
+Pass-1 #5 asked both: (a) make `from-python.mdx` table-first, and (b) trim the value-prop paragraphs in `introduction.mdx` so the two pages don't decay into duplicates. The revision adopts (a) at line 343 but does not commit to (b). If the value-prop prose in `introduction.mdx` lines 17-26 stays alongside a new table-first bridge page, the duplication risk pass-1 flagged is unresolved. Add a Slice 1 acceptance line about which paragraphs in `introduction.mdx` get trimmed or kept.
+
+**6. Reduced page set is sufficient for a new Python developer otherwise. — optional**
+
+With the caveats above, the path Welcome → Introduction → Install → Quickstart → From Python → (Learn Sifr) → (Standard Library) covers the four personas adequately. Values and Collections plus Iteration as Slice 2 fills the "everyday data model" gap without duplicating stdlib pages. Pattern matching, classes, and error handling already exist. No new finding here — calling it out so it isn't lost.
+
+**7. Slice 0 file list is right; consider naming the verification source. — optional**
+
+Slice 0 lists the four content files but does not say where the implementer should verify the actual contract from (e.g., `crates/sifr_hir/**` lowering rules, a demo, or a specific test). A single line — "verify against existing compile behavior; cite the demo or test that pins the contract" — would prevent Slice 0 from being a doc-only swap that codifies whichever wording feels cleanest.
+
+### Slices are otherwise pragmatic
+
+The 0-1-2-3-4 sequence is small, reviewable, and avoids the "rewrite everything at once" failure mode from the Non-Goals. Slice 1 does five things (new page, status page, sidebar restructure, index card edits, intro/quickstart edits) but they are mechanically coupled — splitting them would create churn. Sidebar ordering matches pass-1 #7 exactly.
+
+### Go / no-go
+
+**Conditional go.** Suitable as the planning artifact once findings 1, 2, and 3 are fixed in the file. They are textual inconsistencies in the issue itself, not strategy errors — a 5-10 minute edit pass. Findings 4 and 5 can be resolved during Slice 1 drafting without blocking adoption.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-concurrency-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-concurrency-review-pass-1.md
@@ -1,0 +1,57 @@
+Here is my evaluation.
+
+---
+
+## Source Material
+
+The plan correctly identifies the right sources: the five demos (`structured_concurrency_demo`, `task_core_demo`, `cancellation_cleanup_demo`, `ownership_concurrency_demo`, `async_subprocess_pipeline_demo`) and both existing docs pages. The instruction to reshape rather than reinvent is right, and the scope boundary between conceptual pages and stdlib reference is stated correctly.
+
+---
+
+## Section Shape and Page Split
+
+The 5-page initial set (Overview, Async and Await, Structured Tasks, Cancellation and Timeouts, Ownership Across Tasks) maps cleanly onto the natural section headings already present in `language/concurrency.mdx`. The split is defensible and the deferral of Channels, Parallel Work, and Processes and Signals is correct: `docs/stdlib/concurrency.mdx` already covers those well at API depth, and splitting them into concept pages now would mostly duplicate that content.
+
+---
+
+## Problems
+
+**1. The Overview reshape is underspecified.**
+The plan says "keep `docs/language/concurrency.mdx` as the conceptual overview route, but retitle it." That understates the work. Once Async and Await, Structured Tasks, Cancellation, and Ownership Across Tasks each have pages, the current overview's sections — `## Async Functions`, `## task.scope and Scoped Spawn`, `## task.select`, `## TaskGroup`, `## sifr.sync`, `## sifr.parallel` — all have better homes. The overview will need to be largely *emptied and replaced* with a mental-model intro and navigation cards, not just retitled. The plan should state that explicitly: existing sections migrate to their corresponding sub-pages; the overview retains only the structured-concurrency guarantee statement, the "no fire-and-forget, no global event loop, every value at task boundaries must be owned" summary, and outbound navigation.
+
+**2. Async and Await has the weakest content sourcing.**
+`language/concurrency.mdx` has exactly two code blocks under `## Async Functions`: a pair of `async def` functions and a `Result`-returning one. `stdlib/concurrency.mdx` covers `task.timeout` and `ContextKey` but not the asyncio comparison. The plan calls for covering `async def`, `await`, real suspension requirement, `Result[T, E]` from async functions, and Python asyncio differences — but most of that is either missing or a two-sentence `<Warning>` in the stdlib page. This is the page most at risk of being written from scratch. The plan should flag it and point to the demos (`async_subprocess_pipeline_demo`) as the primary code source for suspension examples.
+
+**3. Cancellation and Timeouts has good bullet coverage but thin existing prose.**
+The conceptual model — what "cancellation evidence" is, how cleanup runs before the caller observes cancellation, sibling cancellation behavior — is not in either existing page. The demos (`cancellation_cleanup_demo`, `task_core_demo`) are the only source. The Slice 3 acceptance criteria should call this out as net-new writing, not reshaping.
+
+**4. Route asymmetry is unstated.**
+The Overview lives at `docs/language/concurrency.mdx` while the sub-pages live under `docs/concurrency/`. This means the "Concurrency > Overview" sidebar entry links to a file under `language/` while every sibling entry links to a file under `concurrency/`. That's a deliberate route-preservation decision and it's defensible, but it should be stated explicitly in the plan as intentional, not left as an implicit artifact of keeping the existing URL stable.
+
+**5. Sidebar naming collision.**
+The proposed sidebar has a top-level group called "Concurrency" and a Standard Library entry also called "Concurrency Reference." Two distinct "Concurrency" items in the same sidebar will confuse readers. Rename the stdlib entry — "Tasks and Sync" or "Concurrency API" — to distinguish it from the conceptual section. The plan doesn't address this.
+
+---
+
+## What Is Missing
+
+- **A content disposition table** in the Slice 3 acceptance criteria: which existing sections from `language/concurrency.mdx` move to which sub-page, what is net-new, what stays in the overview. Without this, the implementation will either leave duplicated content or hollow out the overview without replacing it.
+- **An explicit asyncio comparison section ownership call.** Both existing pages already have asyncio `<Warning>` blocks. The plan should specify that the "Async and Await" page owns the asyncio comparison prose and the existing stdlib warning should be trimmed or cross-referenced once that page exists.
+
+---
+
+## What Is Over-Specified
+
+Nothing harmful. The cancellation page bullet list is fairly prescriptive, but that is appropriate given it is the page with the least existing source material — more specificity there is the right call.
+
+---
+
+## Verdict
+
+The page count and split are correct. The deferral decisions are right. The main actionable fixes before implementation:
+
+1. Add explicit guidance that the current `language/concurrency.mdx` sections migrate to their sub-pages; the overview retains only the structural-guarantee intro and navigation cards.
+2. Flag "Async and Await" as primarily net-new writing.
+3. Flag "Cancellation and Timeouts" as demo-sourced, not prose-reshaped.
+4. State the `language/` vs `concurrency/` route asymmetry as intentional.
+5. Rename the stdlib sidebar entry to avoid the naming collision with the top-level Concurrency group.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-concurrency-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-concurrency-review-pass-2.md
@@ -1,0 +1,33 @@
+Here is the status against each prior issue:
+
+---
+
+**1. Overview rewrite vs retitle — unresolved inconsistency (blocker-level clarity)**
+
+Section 8's first bullet (line 493) says "retitle it as `Concurrency Overview`," which implies only a heading change. But line 567 within the same section says it "should become a mental-model entry point," and Slice 3 acceptance (line 827) explicitly says it "is rewritten as a concise mental-model entry point with navigation cards; it is not merely the old long page with a new title." The word "retitle" in section 8's opening bullet directly contradicts the Slice 3 acceptance criterion. An implementer reading section 8 top-to-bottom could deliver a renamed page and still satisfy the section 8 spec, but fail the Slice 3 gate. The opening bullet needs to say "rewrite" to match the acceptance criterion.
+
+**2. Async and Await sourcing — partially resolved, not pinned per-page**
+
+The content disposition table (line 558) says "`Async Functions` examples — Move to `Async and Await`; expand with demo-sourced suspension examples." Slice 3 acceptance (line 828) says it is "partly net-new writing sourced from demos." The general demo list (lines 834–835) names `structured_concurrency_demo`, `task_core_demo`, `cancellation_cleanup_demo`, and `ownership_concurrency_demo`. None of those are primarily async/await demos. The codebase scan (line 121) lists `async_*` and `blocking_offload_demo` but those names never appear in the Slice 3 acceptance criteria. The implementer has to independently discover which demos contain suspension-focused content. This is a refinement gap, not a blocker, but it should either name the `async_*` demos explicitly or acknowledge the lookup is required.
+
+**3. Cancellation and Timeouts net-new writing — resolved**
+
+Content disposition (line 561) says "mostly demo-sourced net-new writing." Slice 3 acceptance (line 828) says "partly net-new writing sourced from demos." The phrasing differs slightly ("mostly" vs "partly") but both affirm net-new writing from demos, and the available demos (`task_core_demo`, `cancellation_cleanup_demo`) are named. No conflict, no blocker.
+
+**4. Route asymmetry — resolved**
+
+Section 8 (lines 495–496) explicitly states: "The route asymmetry is intentional: the overview keeps the existing `docs/language/concurrency.mdx` path for stability, while new sibling pages can live under `docs/concurrency/`." Slice 3 (lines 803–808) repeats this cleanly. No ambiguity.
+
+**5. stdlib sidebar naming collision — resolved**
+
+Section 8 (line 493) says to label it `Concurrency API`. The sidebar shape (line 634) shows `Concurrency API` under Standard Library. Slice 3 acceptance (line 824) repeats the requirement explicitly. Consistent throughout.
+
+**6. Content disposition — resolved**
+
+The disposition table (lines 555–566) maps every chunk of existing material to a destination. The rules at lines 574–576 (concept vs reference vs guide vs diagnostics) bound the scope cleanly. No gaps.
+
+---
+
+**Summary**
+
+One blocker remains: the word "retitle" in section 8's opening bullet contradicts the "rewritten" requirement in Slice 3's acceptance criteria. Before implementation, that bullet should be changed to reflect a genuine rewrite. All other prior issues are resolved. The one high-value refinement is naming the `async_*` / `blocking_offload_demo` demos in the Async and Await sourcing note so the implementer does not have to rediscover them.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-guides-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-guides-review-pass-1.md
@@ -1,0 +1,127 @@
+Now I have the full picture. Here's the review.
+
+---
+
+## Review: Guide Tracks, Audience Perspectives handoff, Language Docs linking strategy, and Slice 7
+
+### What's already settled (don't re-litigate)
+
+The prior passes resolved naming, sidebar hierarchy, the CardGroup linking pattern as a concept, and the principle of "guides are task-shaped, not concept reference." All of that is confirmed and correctly carried here. This review addresses only the new guide-specific content.
+
+---
+
+### [critical] The scope boundary between `from-python.mdx` and the Python guide track is undefined
+
+This is the single issue that will cause the most damage if left unresolved.
+
+The plan now has three pages all pointing at the same reader:
+
+1. `docs/from-python.mdx` — table-first bridge in Get Started
+2. `docs/guides/python-developers/index.mdx` — audience track index
+3. `docs/guides/python-developers/start-from-python.mdx` — first guide page
+
+None of these has an explicit scope statement that would prevent an implementer from writing "Start from Python" as a prose version of `from-python.mdx`. The plan gestures at a distinction with "guided track, not a second compatibility reference," but that phrase is not in the Slice 7 acceptance criteria and will not be remembered when the page is being drafted.
+
+The scope split needs to be stated precisely and once:
+
+- `from-python.mdx`: compatibility table only. Every row is a semantic difference. No task walkthroughs, no worked examples. Links out to the guide track for depth.
+- `guides/python-developers/index.mdx`: orientation. "Given Python background, here is the sequence of guides to follow." One paragraph, a card list, and a pointer to `from-python.mdx` for the compatibility table. No compatibility explanations.
+- `guides/python-developers/start-from-python.mdx` (or rename this more clearly — see below): task walkthrough. "Write your first Sifr program starting from Python habits." No comparison tables. No "if you know Python X, Sifr does Y" unless it's embedded in a task step.
+
+Without this pinned in the issue, the implementer will do the natural thing and merge 1 and 3.
+
+---
+
+### [critical] "Handle typed errors" and "Handle errors without exceptions" are listed separately but sound like the same page
+
+Slice 7 lists two groups:
+
+- First guide set includes: `Handle typed errors`
+- Audience seed pages include: `Handle errors without exceptions`
+
+These are almost certainly not the same page (one is in the general how-to track, one is in the Python audience track), but the plan never says this. An implementer reading this will either write them as duplicates or collapse them into one and put it in the wrong location.
+
+Decide: if they're different pages, state the scope difference explicitly. If one is the Python-audience-track version of the other, say that and name them so they don't sound identical (e.g., the Python guide page becomes `Handle errors the Sifr way` and the general guide becomes `Typed error handling`).
+
+---
+
+### [important] The `icon="badge-rust"` in the CardGroup example will fail at render time
+
+`badge-rust` does not exist in Heroicons or FontAwesome, which are the icon sets Mintlify supports. The example as written will produce a broken or missing icon at render time. `snake` (the Python icon) exists in FontAwesome Pro, but not in the free tier, which means it may or may not work depending on the Mintlify plan. The plan should either use verified icon names or strip the icons from the example entirely and add a note: "Icon names must be checked against the project's Mintlify icon registry before use." Leaving an incorrect example invites copy-paste failure.
+
+---
+
+### [important] The card body text for the Python guide links to the wrong thing
+
+The CardGroup example for language-doc links uses this body:
+
+> "See how Sifr changes type hints, exceptions, imports, and object references."
+
+That describes `from-python.mdx` (a compatibility table), not the Python Developers guide track (a task sequence). If this card links to `/guides/python-developers`, a reader who clicks it expecting to understand semantic differences will land on an index of how-to guides. The body should describe what's actually there:
+
+> "Follow a guided learning path designed for Python developers — first program, error handling, ownership, and packages."
+
+The Rust card body is accurate as written.
+
+---
+
+### [important] `Ownership in Sifr terms` and `Results and optional values` (Rust guide) are at high duplication risk with language pages
+
+`language/ownership.mdx` and `language/error-handling.mdx` already exist and cover these concepts. The Rust guide versions of these pages must be task-shaped — not "here is what ownership is" (that's the language page) but "given you know Rust ownership rules, here are the specific Sifr patterns you'll reach for." The distinction is reader assumptions, not topic.
+
+Currently, nothing in the Slice 7 acceptance criteria enforces this. Add something like: "Guide pages that share a topic name with a language page must be distinguishable by task orientation — a reviewer should be able to confirm the guide page cannot be summarized as 'explains concept X.'"
+
+---
+
+### [moderate] `language/pattern-matching.mdx` is missing from the linking examples but is a high-confusion surface for Python developers
+
+The plan lists linking examples for type-system, error-handling, ownership, and concurrency. It omits pattern matching. Sifr adds compile-time exhaustiveness that Python's `match` does not enforce. A Python developer reading the Sifr pattern-matching page will carry the assumption that unhandled cases are a runtime problem, not a compile-time failure. This page needs at least a `<Note>` callout pointing Python readers to the guide — it does not need a two-column CardGroup, but it should appear in the linking strategy list.
+
+---
+
+### [moderate] The audience track index pages have no defined structure
+
+The plan says the index pages "explain what the reader needs to know from their background without duplicating language reference pages." That's a principle, not a structure. Without a defined shape, the index pages will drift into mini-concept pages or compatibility summaries — exactly what `from-python.mdx` is supposed to own.
+
+Add to Slice 7 acceptance: "Track index pages contain: a one-paragraph orientation, the guide sequence as a card list or numbered steps, and a pointer to the relevant reference page for background (`from-python.mdx` for Python, `language/ownership.mdx` for Rust). They do not contain concept explanations or comparison tables."
+
+---
+
+### [minor] "Start from Python" is a weak guide page name — it sounds like `from-python.mdx`
+
+The bridge page in Get Started is called `From Python`. The first guide page is called `Start from Python`. These are close enough to cause navigation confusion when they both appear in search results or sidebar contexts. The guide page should be named for what it does, not where the reader is coming from. Options: `Write your first program`, `First Sifr project`, or `Build a CLI tool as a Python developer`. The audience track establishes the "from Python" framing; the page title can be task-named.
+
+Same concern for `Start from Rust` in the Rust track.
+
+---
+
+### Linking strategy: what's right
+
+The restraint principle ("do not add these cards to every page") is correct and should be honored strictly. The specific page-to-guide mappings (type-system → Python guide from type-hints discussion, ownership → both guides from their respective concepts) are well-targeted. The phrasing guidance ("continuation paths, not warnings") is the right tone. None of that needs revision.
+
+---
+
+### Slice 7 acceptance: what's missing
+
+Three concrete gaps in the acceptance criteria:
+
+1. No criterion defining what the index page must and must not contain (see above).
+2. No criterion for preventing duplication with language reference pages for guide pages that share topic names.
+3. No criterion requiring that "Start from Python" and "Start from Rust" be task-shaped rather than comparison-shaped — which is the single biggest failure mode for those two pages.
+
+The list of first guide pages ("Build a CLI tool", "Read and write files safely", etc.) is good and the demos can seed all of them. These are correctly task-shaped by title.
+
+---
+
+### Summary of required changes
+
+| Priority | Issue | Fix |
+|---|---|---|
+| Critical | `from-python.mdx` vs. `start-from-python.mdx` scope is undefined | Add explicit scope statement for all three Python-facing pages |
+| Critical | "Handle typed errors" and "Handle errors without exceptions" are indistinguishable | Name them differently and state whether they're one or two pages |
+| Important | `badge-rust` icon will fail at render time | Replace with verified icon names or remove icons and flag for verification |
+| Important | Python card body describes the bridge page, not the guide track | Rewrite to describe task content |
+| Important | Rust guide pages `Ownership in Sifr terms` and `Results and optional values` will duplicate language pages without an explicit task-orientation criterion | Add acceptance criterion |
+| Moderate | Pattern matching page missing from linking examples | Add to the list |
+| Moderate | Track index pages have no defined structure | Add structure to Slice 7 acceptance |
+| Minor | `Start from Python` / `Start from Rust` sound like `from-python.mdx` | Rename to task-oriented titles |

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-guides-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-guides-review-pass-2.md
@@ -1,0 +1,28 @@
+Here is the follow-up verdict, issue by issue, then any residual items worth flagging.
+
+---
+
+**Resolved**
+
+- **From Python vs Python guide scope** — The three-way split is now explicit: `From Python` = compatibility table, `Sifr for Python Developers` = route index, first guide page = task walkthrough. The scope boundaries at lines 193–197 are clear.
+- **Duplicate error-guide naming** — Line 727 now explicitly disambiguates: `Typed error handling` is the general guide; `Handle errors the Sifr way` is the Python-audience guide starting from exception habits. Distinct.
+- **Invalid icons** — Line 258 now defers icon decisions to implementation with a mandatory verification step against the configured Mintlify library. Acceptable at plan stage.
+- **Python card body** — The CardGroup example (lines 247–256) now has concrete, task-oriented body copy. Not vague.
+- **Rust guide duplication risk** — Line 712–713 now adds an acceptance criterion: a reviewer must not be able to summarize a guide page as only "explains concept X." Enforces distinction structurally.
+- **Pattern matching link** — Lines 243–244 make the link conditional; Slice 6 criterion (line 684) matches. Consistent.
+- **Track index structure** — Lines 700–706 now define exactly what belongs in a track index and explicitly exclude concept explanations and compatibility matrices.
+- **Weak "Start from Python/Rust" names** — Lines 712–713 mandate `Sifr for Python Developers` and `Sifr for Rust Developers` as the preferred form.
+
+---
+
+**Residual items — not blockers, but worth tightening before implementation**
+
+1. **"Ownership in Sifr terms" audience is unlabeled in Slice 7.** The seed-page list at lines 721–726 mixes Python-oriented and Rust-oriented pages in one unstructured list. `Ownership in Sifr terms` appears in the Rust guide track at line 220, but in the Slice 7 list it sits between two Python-oriented pages with no audience label. An implementer could place it under the wrong track. Fix: split the seed list into two labeled sub-lists, one per audience.
+
+2. **"Results and optional values" (Rust track, line 222) vs "Typed error handling" (general guide, line 718) — no disambiguation analogue.** Line 727 clarifies the Python error-guide distinction, but there is no equivalent sentence for the Rust track. If both a general `Typed error handling` guide and a Rust-track `Results and optional values` guide are built, the distinction in scope and starting audience assumptions should be stated the same way line 727 handles the Python case.
+
+3. **"First guide set" at lines 716–720 has no navigation anchor.** The list is presented under Slice 7 without clarifying whether these pages live at `docs/guides/*.mdx` (top-level general guides) or under an audience sub-path. If they are general guides, the plan should say so explicitly; if they belong under an audience track, they need an owner.
+
+4. **Sidebar label vs page title inconsistency between sections.** Guide Tracks (lines 172, 202) set the sidebar titles as `Python Developers` and `Rust Developers` (short form). Slice 7 acceptance (line 712) mandates `Sifr for Python Developers` and `Sifr for Rust Developers`. This is resolvable by reading "sidebar title" as the truncated nav label and the full form as the page `<h1>`, but the plan does not say that. A single clarifying sentence — "sidebar label is the short form; the page title uses the full form" — removes the ambiguity.
+
+None of these are implementation blockers, but items 1 and 2 are high enough value to resolve before Slice 7 work starts, since they directly affect file placement and page scope decisions.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-mutability-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-mutability-review-pass-1.md
@@ -1,0 +1,74 @@
+Here is a direct assessment of the plan section:
+
+---
+
+## Does `mut` belong on the same page?
+
+Yes, unambiguously. The gap is not that `mut` gets less coverage than `own` — `mut` is entirely absent from the current page. Python readers will assume parameter mutation and rebinding work as in Python. Rust readers need the full four-row picture to map `&T / &mut T / T / mut T` onto Sifr syntax. Combining them on one page is correct.
+
+---
+
+## What the plan gets right
+
+- **The four-row table** is accurate and matches architecture.md lines 430-433 exactly. This is the right anchor for the page.
+- **Source material choices** are good: `own_mut_appends/main.sifr` is minimal and clear. The lowering tests in `own_mut_semantics_tests.rs` cover exactly the right failure cases to draw examples from.
+- **"Formatter rewrites `mut own` to `own mut`"** — this is genuinely non-obvious and easy to miss. Worth a one-line tip.
+- **"Across await" as a cross-link only** — correct. The async borrow rule is complex; this page should not absorb it.
+- **"Avoid becoming a Rust lowering spec"** — the right guardrail. The existing page's style (short paragraph, code, callout) is a good template.
+
+---
+
+## What's missing or wrong
+
+**1. Scalar vs heap asymmetry is unmentioned**
+
+Architecture.md line 434 is explicit:
+
+> `mut` on scalar parameters (`int`, `float`, `bool`) only affects local rebinding/mutation semantics, not observable ownership transfer.
+
+A Python developer writing `def f(mut n: int): n = n + 1` would expect this to work and it does — but for a completely different reason than `mut items: list[int]` (which is a mutable borrow). This asymmetry is likely to confuse both audiences and should be a short callout. The plan currently omits it entirely.
+
+**2. "Borrowed `mut` cannot escape" is the real footgun, not a secondary note**
+
+The tests (`test_mut_borrow_parameter_cannot_escape_via_return`, `test_mut_borrow_parameter_cannot_escape_via_local_binding`) show that `mut items: list[int]` cannot be returned or stored — you get `OWN_BORROWED_PARAMETER_ESCAPES`. This is the constraint that most surprises people: you can mutate through the borrow, but you cannot keep the value. The plan buries this under "Reassignment vs mutation" as if it's the same concept. It isn't. It should be a distinct named rule: **borrowed parameters cannot escape**.
+
+**3. The 7 content areas are not differentiated by weight**
+
+The plan lists these as parallel sections: immutable default, `mut` borrows, `own mut`, reassignment vs mutation, formatter convention, bytes immutability, across await. That's too flat — on a concise page, they cannot all be `##` headings without making the page feel like a spec. The plan should specify which are sections and which are callouts:
+
+- Sections: borrow by default (already exists), `mut` for mutable borrows, `own` and `own mut` for ownership
+- Tips/callouts: formatter canonicalization, bytes caveat, await cross-link, scalar difference
+
+**4. "Bytes are immutable" is a marginal addition**
+
+This is true but niche for a page about parameter conventions. `mut` doesn't make `bytes` subscript assignment legal — correct. But this is a bytes semantics rule, not an ownership rule. If it appears at all it should be a one-sentence `<Note>` inside the `mut` section, not a named content area. The plan over-specifies it.
+
+---
+
+## Acceptance criteria: what's solid and what needs sharpening
+
+**Solid:**
+- Retitle frontmatter and sidebar while keeping the file path — correct, clean.
+- Teach the four conventions together with a compact table — right.
+- Avoid becoming a Rust lowering spec — good constraint.
+- Link Python and Rust readers to guide tracks — appropriate and well-placed.
+
+**Needs sharpening:**
+- The criterion "The page explains that bare parameters are immutable by default, `mut` permits mutation through a borrow, `own` moves the value, and `own mut` moves the value while permitting local mutation" is accurate but omits the escape constraint. Add: **the page explains that `mut` borrows cannot be returned or stored without `.clone()`**.
+- Add: **the page notes that `mut` on scalar types permits local rebinding but does not involve a borrow or move**.
+
+---
+
+## Linking guidance: no issues
+
+The `<CardGroup cols={2}>` pattern shown in the plan is correct. Two cards at the end of the page — one for Python readers, one for Rust readers — is the right weight. Don't add them inline; end-of-page is correct.
+
+---
+
+## Summary
+
+The plan is structurally sound. The table, source material, and elegance constraint are right. Three actionable fixes before writing:
+
+1. Add a callout distinguishing `mut` on scalars from `mut` on heap types.
+2. Elevate "borrowed `mut` cannot escape by return or store" to a named rule — it's the primary footgun.
+3. Flatten the 7 content areas into 3 sections + 4 callouts to prevent the page from reading like a spec.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-mutability-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-mutability-review-pass-2.md
@@ -1,0 +1,47 @@
+Here is the targeted assessment against each previously flagged issue:
+
+---
+
+## Scalar `mut` behavior
+
+**Resolved.** Gap 6 (line 415) now names it explicitly as a callout: "`mut n: int`, `mut x: float`, and `mut ok: bool` permit local rebinding, but do not represent an observable heap borrow or ownership transfer." Slice 1 acceptance criterion line 650 mirrors this exactly. No gap remains.
+
+---
+
+## Borrowed `mut` cannot escape
+
+**Resolved as a named rule.** Line 413 now calls it out by name and specifies the fix paths (`.clone()`, `own`, `own mut`). Acceptance criterion line 649 adds the implementation obligation explicitly. The review's concern about it being buried under "Reassignment vs mutation" is addressed — they are now listed separately.
+
+One high-value refinement remains: the review called this "the primary footgun" suggesting it should be a `<Warning>` callout, not just a plain note. The plan's callout list does not specify callout type. Worth adding `<Warning>` for this one specifically, per the Content Principles (line 368: `<Warning>` is for "real surprises or unsafe assumptions"). Not a blocker, but it would be easy to write this as a `<Note>` during implementation and underemphasize it.
+
+---
+
+## Section/callout weight
+
+**Substantially resolved.** The plan now has a clear two-tier structure:
+- 3 named sections (lines 406–409): immutable default, `mut` mutable borrows, `own mut`
+- "Rules and callouts to include without turning them into large sections" (lines 411–418): 6 items
+
+The review prescribed 3 sections + 4 callouts. The plan has 6 callouts. The two extras are "borrowed values cannot escape" and "reassignment vs mutation." Both are defensible additions, but "reassignment vs mutation" (line 414) is the vaguest entry — it says "reassigning a parameter and mutating the object behind it are both explicit choices" without specifying the callout's actual claim. This could collapse back into the "borrowed cannot escape" concept during writing. Worth either absorbing it into the `mut`-borrow section body or sharpening it to a concrete rule. Low-risk but worth addressing before writing starts.
+
+---
+
+## Bytes caveat
+
+**Resolved.** Line 417 now explicitly says "Keep this as a one-sentence note, not a full section." The review's concern (it was over-specified as a content area) is directly addressed.
+
+---
+
+## Does `mut` belong on the same page?
+
+**Resolved.** The review confirmed unambiguously yes. The plan retitles frontmatter and sidebar, teaches all four conventions via the table, and links to guide tracks from end-of-page cards. No issues here.
+
+---
+
+## Summary
+
+**No blockers.** Two high-value refinements before writing starts:
+
+1. **Specify `<Warning>` for "borrowed `mut` cannot escape"** — the review elevated this to "primary footgun"; the plan's callout list doesn't specify the callout type, leaving it likely to be written as a `<Note>` and underemphasized.
+
+2. **Sharpen or absorb "Reassignment vs mutation"** — as written (line 414) it's the vaguest callout in the list and risks either duplicating or muddying the "borrowed cannot escape" rule. Either give it a concrete claim ("reassigning `mut items` does not prevent the borrow-escape rule from applying") or fold it into the `mut`-borrow section body.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-reference-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-reference-review-pass-1.md
@@ -1,0 +1,121 @@
+I have everything I need. Here is the review.
+
+---
+
+## Review: Reference Tab and Per-Code Diagnostic Error Pages
+
+### What's solid
+
+The existing `error-codes.mdx` index is genuinely strong. Family introductions are concise, table rows are single-line descriptions, and the three inline callouts (IMPORT-0008 note, FMT tip, INTERNAL warning) are exactly the right level of specificity. The IMPORT-0008 note is a model for what inline guidance should look like: one concrete line that tells you exactly what to do. Keep it.
+
+The overall plan shape is right. The idea of a Reference tab, per-code pages seeded from `representative_fixture` paths, and a validation script against `code_catalog.json` is well-conceived.
+
+---
+
+### Issue 1: URL route is already committed in the compiler — this must be resolved before any page is published
+
+`crates/sifr_diagnostics/src/codes/registry.rs:287` emits `https://sifr.sh/docs/errors/<CODE>` as the live `docs_url()` for every diagnostic. The plan proposes `reference/error-codes/sifr-type-0002.mdx`, which would serve at a different path.
+
+This is the highest-priority decision. Options:
+
+- **Keep `/docs/errors/SIFR-TYPE-0002`** as the canonical public route. Remove `errors/` from `.mintignore`, rewrite content as proper `.mdx`, and register pages in `docs.json`. The Reference tab can link to the same pages. No compiler change needed.
+- **Change to `/reference/error-codes/SIFR-TYPE-0002`** and update `docs_url()` in the registry before the first page ships. Any live links in editor output or CI will break until updated.
+
+The plan doesn't resolve this, which means implementation will have to backtrack. Decide route convention now, then lock it.
+
+Either path is fine, but the existing route (`/docs/errors/`) has the advantage of being already committed and zero compiler-change cost.
+
+---
+
+### Issue 2: The sidebar structure has a redundant split
+
+The plan lists:
+
+```
+Reference > Diagnostics > Overview
+Reference > Diagnostics > Error Codes   (← this is the current index)
+Reference > Error Codes > Index         (← this is a new index?)
+Reference > Error Codes > per-code pages
+```
+
+That's two "error codes" groups nested at different levels, and two indexes. Collapse to:
+
+```
+Reference > Error Codes > Overview (= current error-codes.mdx, renamed)
+Reference > Error Codes > SIFR-TYPE-0002 ... (per-code pages)
+```
+
+The family overview text already in `error-codes.mdx` is the right landing page. Give it a sidebar slot; don't duplicate it.
+
+---
+
+### Issue 3: The RESULT-0001 note recommends mechanisms that need auditing first
+
+The current note at `error-codes.mdx:295` reads:
+
+> Use `match`, `unwrap()`, or propagate the result with `?` syntax to resolve it.
+
+The plan already flags this. `unwrap()` reads as Rust-style API. If that isn't the exact public Sifr method name, it will mislead users. The `?` operator also needs confirmation as valid public Sifr syntax before this note goes anywhere near a per-code page. Do not carry this wording forward until the Slice 0 semantic audit resolves it.
+
+---
+
+### Issue 4: 120+ uniform pages is unshippable — tier the coverage
+
+The catalog has ~120 active stable codes across 24 families. Treating them all equally with the full 8-section template would take enormous effort and most of the pages would be rarely visited.
+
+Tier by user-encounter likelihood:
+
+**Tier 1 — full treatment** (erroneous code, explanation, fix, fixed code): TYPE, NAME, CALL, RESULT, MATCH, FLOW, OWN, ASYNC, IMPORT. These are what developers hit doing everyday Sifr programming.
+
+**Tier 2 — focused treatment** (explanation + minimal example): INT, DECIMAL, IO, ENCODING, CLASS, PROTO, FMT, LINT. Specialized but source-code-level.
+
+**Tier 3 — brief treatment** (what happened + what to do, no code example): PACKAGE, WORKSPACE, BUILD, STDLIB, INTERNAL. These are often environment, manifest, or tooling issues — not erroneous-code patterns. A file-tree or terminal example is appropriate, but the full erroneous/fixed source template doesn't fit.
+
+The plan mentions this but doesn't make the tier split explicit. State it in the issue so Slice 5 doesn't stall trying to write a code example for `SIFR-BUILD-0003 (Temporary build workspace creation failed)`.
+
+---
+
+### Issue 5: CODEGEN should not appear as a per-code page
+
+The CODEGEN family has no active codes. The current index handles this cleanly with "(no active codes)". Don't create a `reference/error-codes/codegen-overview.mdx` stub — it will create a dead landing page and confuse users who arrive via search.
+
+---
+
+### Issue 6: INTERNAL-0002 should not get the erroneous/fixed template
+
+`SIFR-INTERNAL-0002` is a `Note`-severity structured summary, not an actionable compiler error. Its page, if it has one, should be a short "what this note means and what to do" paragraph. Do not apply the erroneous-code template to it. INTERNAL-0001 gets a proper page because it asks users to file a bug report — that's actionable. 0002 is informational.
+
+---
+
+### Issue 7: The validation script is the right idea but the spec needs to be tightened
+
+The plan says "a validation step catches missing pages for active codes and stale pages for removed codes." That is correct. But it should also specify:
+
+- The script reads `code_catalog.json` and checks `stability == "stable"` entries
+- For each, it asserts a corresponding `.mdx` exists at the chosen public route
+- It also checks in reverse: every public error page corresponds to an active code in the catalog (catches stale pages)
+- It runs in `scripts/run_all_tests.sh` under the docs profile (not separately)
+
+Without the reverse check, removed codes will accumulate as orphan pages.
+
+---
+
+### Smaller copy notes
+
+- `error-codes.mdx` PACKAGE family description: "The `PACKAGE` family is the largest family" — this is internal narrator commentary. Drop it. The user doesn't care how it ranks. Rewrite as: "The `PACKAGE` family covers the full lifecycle of Sifr packages: manifest validation, dependency resolution, import scope, trust policy, archive integrity, and publish guardrails."
+- WORKSPACE description: "legacy import resolution errors that mirror the `IMPORT` family for workspaces not yet migrated" — "not yet migrated" implies a time-bounded state but gives no timeline. Rewrite or drop the parenthetical: users don't need the migration history.
+- The plan's proposed 8-section template duplicates intent between "What it means" and "Why this fails." Collapse to 6 sections: Summary, Erroneous example, What went wrong (one block, combining the two), How to fix it, Fixed example, Related. Shorter template → more likely to be filled out completely.
+
+---
+
+### Summary of required decisions before implementation
+
+| Decision | Current state | Action needed |
+|---|---|---|
+| Public route for per-code pages | Compiler emits `/docs/errors/<CODE>`, plan proposes `/reference/error-codes/...` | Pick one; update compiler or plan |
+| Sidebar structure | Two overlapping groups | Merge into one `Reference > Error Codes` group |
+| RESULT-0001 `unwrap()`/`?` wording | Unaudited | Do not use until Slice 0 verifies |
+| Coverage tiering | Not explicit | Document tiers in Slice 5 acceptance criteria |
+| Validation script scope | Forward check only | Add reverse check for stale orphan pages |
+
+The plan is otherwise well-structured. The content principles are sound, the catalog is already the right source of truth, and the existing index page is a quality baseline. The per-code page template just needs the tier split and the route decision locked in before anyone writes a line of MDX.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-reference-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-reference-review-pass-2.md
@@ -1,0 +1,55 @@
+Here is the follow-up assessment against every concern raised in the two prior review passes.
+
+---
+
+## Status of Prior Concerns
+
+### Section 7 — Docs/Reference split and sidebar structure
+
+**Duplicate Reference sidebar (sonnet-reference-review-pass-1 Issue 2):** Resolved. The current plan has a single clean group: `Reference > Error Codes > Overview + per-code pages`. The earlier duplicate `Diagnostics > Error Codes` / `Error Codes > Index` split is gone.
+
+**Sidebar CLI count post-Slice-4 (sonnet-review-pass-2):** Still unresolved. The sidebar shape shown in Section 7 lists only 6 CLI entries, but Slice 4 will add `init`, `fetch/tree/vendor`, `repair`, `self`, and `trace`. The plan doesn't note this, so readers of Section 7 will infer an incomplete CLI reference. Worth a one-line note ("expanded to full inventory in Slice 4"), but not a blocker.
+
+---
+
+### Section 8 — Diagnostic route, tiering, and per-code pages
+
+**URL route decision (sonnet-reference-review-pass-1 Issue 1):** Resolved. Section 8 now commits to `/docs/errors/<CODE>` as the canonical public route, preserving the compiler-emitted URL contract. Pages live in `docs/errors/<CODE>.mdx` and are registered under the `Reference > Error Codes` sidebar group in `docs.json`. No compiler change required.
+
+**Per-code page tiering (sonnet-reference-review-pass-1 Issue 4):** Resolved. Tier 1/2/3 split is explicitly defined in Section 8 and reflected in the Slice 5 acceptance criteria. The template correctly uses 6 content sections (summary line + erroneous example + what went wrong + how to fix it + fixed example + related), collapsing the earlier over-specified 8-section draft.
+
+**RESULT-0001 `unwrap()`/`?` wording (Issues 3 and pass-1):** Resolved as a gate condition. Slice 5 acceptance requires auditing before publication; the unsafe wording is not carried forward until Slice 0 verifies the public syntax.
+
+**CODEGEN stub page (sonnet-reference-review-pass-1 Issue 5):** Resolved. Section 8 and Slice 5 both explicitly prohibit a CODEGEN page while that family has no active codes.
+
+**INTERNAL-0002 template misapplication (sonnet-reference-review-pass-1 Issue 6):** Resolved. Section 8 and Slice 5 both call this out as an informational note, not an erroneous/fixed tutorial.
+
+**Validation script — reverse check (sonnet-reference-review-pass-1 Issue 7):** Resolved. Slice 5 acceptance now includes both directions: forward (missing page for stable active code) and reverse (stale orphan page for a removed code). Integration into `scripts/run_all_tests.sh` is also specified.
+
+**Index copy — "largest family" and migration history (sonnet-reference-review-pass-1 copy notes):** Resolved as an implementation gate. Slice 5 acceptance explicitly requires removing "largest family" commentary and avoiding migration-history phrasing. The fix isn't in the plan prose, but it's locked in as a ship condition.
+
+---
+
+### From Python table (sonnet-review-pass-2)
+
+**"Missing values" row containing planning artifact:** Resolved. The row is removed from the table spec. A dependency note now follows the table: "After Slice 0 corrects the indexing and optional-value docs, add a 'Missing values' row citing the finalized language and stdlib pages."
+
+**Async row absent from `From Python` table:** Resolved. The async row is now present: `async def`, `await`, `sifr.task` | structured task scopes, typed cancellation evidence.
+
+---
+
+### Remaining open items
+
+Only three items remain, all flagged optional in the prior reviews:
+
+1. **Content Principles 9 and 10** say the same thing in two halves. Merging them into one rule would tighten the list. Low priority; no implementation risk either way.
+
+2. **Sidebar shape in Section 7** doesn't reflect the post-Slice-4 CLI inventory expansion. Add one sentence noting the shape is incremental. No implementation blocker.
+
+3. **Slices 3 and 4 are parallelizable** once Slice 2 is done. The plan doesn't note this. Useful for delivery velocity if two contributors are working simultaneously, but not a content correctness issue.
+
+---
+
+## Verdict
+
+No blockers. All important concerns from both review passes are resolved in the current plan text. The three remaining items are optional polish that can be picked up during slice work without holding implementation. The plan is ready to implement starting from Slice 0.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-review-pass-1.md
@@ -1,0 +1,104 @@
+I now have everything I need. Let me write the third-pass review.
+
+---
+
+## Review: ad-hoc-documentation-learning-path (pass 3 — codebase scan)
+
+This pass reads the planning artifact after two rounds of correction and validates it directly against the live codebase: `docs/language/type-system.mdx`, `docs/stdlib/collections.mdx`, `docs/introduction.mdx`, `cli_model_and_entrypoint.rs`, `lib/sifr/`, and `internal_docs/architecture.md`.
+
+---
+
+### Summary of the issue state
+
+Pass-2's three conditional blockers are now mostly resolved. Finding 2 (Language Tour section) is gone — the issue no longer proposes `language/tour.mdx`. Finding 3 (the self-contradicting `<Note>` worked example) is fixed — the example now demonstrates clean, direct copy. Finding 1 (Slice 0 doesn't pick a side on dict indexing) is partially addressed but has a more precise resolution available from the architecture source, described below.
+
+---
+
+### Findings
+
+**1. Slice 0 has a false premise: the architecture already picks a side on dict indexing. — blocking**
+
+The planning artifact frames Slice 0 as "resolve the contradiction — either A or B." But `internal_docs/architecture.md` is unambiguous:
+
+> "Where CPython raises `KeyError`, Sifr returns `Option[V]`. Example: `dict["missing"]` raises `KeyError` in CPython; in Sifr it returns `None`."
+
+The confirmed live contradiction is that `docs/stdlib/collections.mdx:46` says "Direct `scores["missing"]` is a compile-time checked operation that produces a typed error if the key might be absent" — which contradicts the architecture, contradicts `introduction.mdx:35`, and contradicts `type-system.mdx:30`. There is no genuine ambiguity to resolve; there is a wrong page to correct.
+
+Slice 0's framing should change from "decide and record which contract applies" to "correct `collections.mdx:46` to match the architecture contract (`[]` returns `T | None`), and confirm the corrected statement against a pinned demo or test." Leaving it as "either A or B" gives the implementer permission to go either way, which could produce a Slice 1 where `from-python.mdx` is drafted against the wrong baseline.
+
+**2. `type-system.mdx` describes `int` as `64-bit signed integer` — blocking**
+
+Line 147 in the live file reads: `| int | 64-bit signed integer |`. The architecture is explicit: `int` is exact, arbitrary-precision, backed by inline-small `SifrInt`. This description will directly mislead Python developers who encounter overflow behavior different from what the docs promised.
+
+The Slice 0 acceptance criterion says "Confirm whether current docs still describe `int` as 64-bit anywhere." This scan confirms they do. The planning artifact should name this file and line explicitly so Slice 0 doesn't treat it as a question to investigate but as a specific edit to make.
+
+**3. `type-system.mdx` "None Safety" examples still use `int | None` without a None check — blocking**
+
+Lines 88–98 (live in the file) show:
+
+```python
+def find_value(x: int | None, target: int) -> str:
+    if x == target:   # x is int | None, no None check
+        return "found"
+
+def is_positive(x: int | None) -> bool:
+    if x > 0:         # same
+```
+
+If the compiler rejects these (as the safety guarantee implies it should), the examples are wrong. If the compiler accepts them via implicit narrowing on equality/comparison, that behavior needs to be documented explicitly, not left implicit. This was flagged in pass 1; it remains live. Slice 0 lists "Audit `int | None` examples" but does not name this specific location. Name it.
+
+**4. `type-system.mdx` claims `int`, `float`, `bool` are Copy types — important**
+
+Line 154 (live): "Primitive types (`int`, `float`, `bool`) are **Copy** types." The architecture is explicit: "`int` is not Rust `Copy`, but codegen owns the borrow/clone/primitive-local optimization." `float` and `bool` are Copy; source-level `int` is value-semantic at the source level but not Rust-`Copy` in codegen. This matters for the `from-python.mdx` borrow row and for any Rust-curious user who reads the emitted Rust. This is Slice 0 audit scope, but the specific sentence is not named.
+
+**5. `parallel` module is missing from the stdlib coverage plan — important**
+
+`lib/sifr/parallel.sifr` is a shipped module. The planning artifact's stdlib scan lists `sifr.task` and `sifr.sync` under concurrency, but never mentions `sifr.parallel`. The architecture and the structured runtime work model both reference `sifr.parallel` as a first-class concurrency surface. The Slice 3 module index will produce a gap if this module is absent from the tracking list. Add it to the "Concurrency" category in the stdlib scan section alongside `task`, `sync`, and `runtime`.
+
+**6. `logging`, `argparse`, and `timeit` are absent from the stdlib scan — important**
+
+`lib/sifr/` contains `logging.sifr`, `argparse.sifr`, and `timeit.sifr`. None of these appear in the planning artifact's module inventory section. `logging` and `argparse` are modules every serious Python developer reaches for immediately. Their absence from the tracked module surface risks the Slice 3 module index omitting them. They belong in a "Developer tooling" or "System utilities" category in the scan section.
+
+**7. CLI inventory plan omits `--explain` and `--diagnostic-format` global flags — optional**
+
+From the CLI source, `--explain <CODE>` and `--diagnostic-format human|json|compact` are global flags on the `sifr` command itself (not subcommands). `--explain` provides inline diagnostic lookup from the terminal — exactly the kind of developer ergonomic detail that a "Tooling, CI, and Production User" persona needs. Slice 4 focuses on subcommands but the global flags are undocumented and not tracked. A single sentence in `cli/overview.mdx` and a note in the Slice 4 acceptance criteria would close this.
+
+**8. Internal `.md` files in `docs/` are not acknowledged — optional**
+
+`docs/` contains eight `.md` files outside the Mintlify navigation: `concurrency_runtime.md`, `formatter.md`, `network_http.md`, `package_management.md`, `self_update.md`, `stdlib_imports.md`, `text_i18n.md`, `cli_command_semantics.md`. These appear to be internal design references. They are not in `docs.json` and will not be published. The planning artifact does not acknowledge them, so a future implementer adding a page with a conflicting name might be confused by their presence. A one-line note in the Non-Goals or in Slice 1 acceptance — "existing internal `.md` files in `docs/` are not part of the Mintlify nav and are not published" — would prevent confusion.
+
+---
+
+### Copywriting and style assessment
+
+The Content Principles section (10 rules) is the right scope and tone, but two are weak:
+
+- Rule 2 ("Use comparison tables only when they reduce surprise") is self-referential. A writer cannot apply it without first knowing what counts as surprising. Rewrite as: "Use comparison tables where Python developers would otherwise infer the wrong thing — not for every difference, and not to be exhaustive." This gives implementers a judgment rule.
+
+- Rule 9 ("Avoid exhaustive spec language in first-pass learning pages") doesn't say what to do with detail that doesn't fit — defer to accordions, deep reference pages, diagnostics docs? The adjacent rules don't answer this. Add a one-sentence pointer: "Move spec-level detail to diagnostics, CLI references, or architecture docs; a learning page links to those rather than inlining them."
+
+The `From Python` table's "Bytes" row ("First-class `bytes` | Binary/text boundaries are explicit and typed") is the weakest cell. The other rows name a concrete behavioral change; this one names a property. Better contrast: `bytes` in Python is sequence-of-int but often treated as opaque; in Sifr, encode/decode boundaries are typed operations that produce explicit errors — there is no platform-dependent default encoding. That fits on one line and tells a Python developer something actionable.
+
+---
+
+### Codebase coverage verdict
+
+The four new audience personas and the six documentation gap sections collectively cover the important developer surfaces. After this scan, the surfaces that remain undiscovered in the plan are:
+
+- `sifr.parallel` (important, missing entirely)
+- `logging`, `argparse`, `timeit` (important for everyday use, missing from module inventory)
+- `--explain` and `--diagnostic-format` global flags (optional, useful for tooling users)
+
+The structural split (Get Started → Learn Sifr → Standard Library → CLI Reference → Packages → Diagnostics → Project) is correct and the Slice ordering (0 → 1 → 2 → 3 → 4) is sound.
+
+---
+
+### Go / no-go
+
+**Conditional go.** The planning artifact is ready to execute with three targeted edits before Slice 0 starts:
+
+1. Change Slice 0's dict-indexing framing from "decide between A or B" to "correct `collections.mdx:46` to match the architecture contract already established in `internal_docs/architecture.md`."
+2. Name `type-system.mdx:147` and `type-system.mdx:154` as specific confirmed edits in the Slice 0 checklist, not as "check whether these need fixing."
+3. Add `sifr.parallel`, `logging`, `argparse`, and `timeit` to the stdlib scan inventory under appropriate category headings.
+
+Findings 7 and 8 can be picked up during Slice 1 and Slice 4 drafting without blocking adoption of the plan.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-review-pass-2.md
@@ -1,0 +1,88 @@
+Now I'll write the review.
+
+---
+
+## Review: ad-hoc-documentation-learning-path (Sonnet pass 2)
+
+### Pass-1 resolution check
+
+All eight pass-1 findings are closed:
+
+- Dict-indexing framing in Slice 0 changed from "decide A or B" to "correct `collections.mdx` to match the established architecture contract." ✓
+- `int` 64-bit and Copy-type sentences in `type-system.mdx` are now named as specific `Fix` directives, not investigation questions. ✓
+- `int | None` None-Safety examples named as a specific fix target. ✓
+- `sifr.parallel` added to the concurrency module list. ✓
+- `logging`, `argparse`, `timeit` present in the module inventory. ✓
+- `--explain` and `--diagnostic-format` global flags added to Slice 4 acceptance. ✓
+- Internal `.md` files called out in Non-Goals. ✓
+- Content Principles rules 2 and 10 rewritten to the suggested forms. ✓
+- Bytes row in the `From Python` table is now behavioral ("encode/decode boundaries are explicit typed operations; do not rely on platform-default text behavior"). ✓
+
+None of the pass-1 findings need revisiting.
+
+---
+
+### New findings
+
+**[important] `From Python` table has a planning artifact embedded in the "Missing values" row**
+
+The row as written:
+
+```
+| Missing values | Contract resolved in Slice 0 | Absence must be handled before use; the bridge page must cite the finalized indexing and optional-value docs |
+```
+
+The "Sifr shape" cell contains planning instruction, not docs content. If an implementer treats this table as copy-ready (which its table-first framing invites), the rendered page would publish "Contract resolved in Slice 0" as visible user-facing text. Since Slice 1 depends on Slice 0 being complete before drafting `From Python`, the correct fix is to omit this row from the table spec entirely and instead add a sentence like: "After Slice 0 resolves the `Option`/`None` indexing contract, add a 'Missing values' row citing the finalized language and stdlib pages." This makes the dependency explicit without risking garbage in the rendered output.
+
+**[important] Async is absent from the `From Python` table**
+
+The issue calls out async as having "one canonical public story" that diverges meaningfully from Python's `asyncio`. A Python developer coming from async Python code will expect `async def` / `await` to work as they know it, but Sifr's model involves `sifr.task`, structured scopes, and typed cancellation evidence — all things that would surprise someone pasting async Python code. There are dedicated demos (`async_*`, `cancellation_cleanup_demo`, `blocking_offload_demo`) and a concurrency page in the sidebar. Yet no row exists in the compatibility table. The omission will make `From Python` feel incomplete to any Python developer who uses async code.
+
+Suggested row:
+
+```
+| async / await | async def, await, sifr.task | Structured task scopes; cancellation is typed evidence, not an exception |
+```
+
+---
+
+### Copywriting and style assessment
+
+The ten Content Principles are well-calibrated for this kind of doc site. Rules 9 and 10 are essentially the same rule stated in two halves (avoid spec language in learning pages; send that detail to reference pages). They read better merged: "Move spec-level detail to diagnostics, CLI references, or architecture docs — learning pages link rather than inline." Losing a rule strengthens the list, but this is a minor polish note.
+
+The proposed sidebar hierarchy (Gap 7) is clean and reads as a learning path first, reference catalog second. One coherence gap: after Slice 4 completes the CLI Reference expansion, the sidebar will have significantly more entries under "CLI Reference" than are shown in the current plan. The sidebar shape in the issue shows only six entries under CLI Reference; Slice 4 will add `init`, `fetch/tree/vendor`, `repair`, `self`, and `trace`. The issue should either update the sidebar shape to reflect the post-Slice-4 state or add a note so future readers understand the plan is incremental.
+
+The overall writing voice across the plan — "state differences as product decisions, not caveats," "written as a compatibility orientation, not a warning dump," "no apology language" — is exactly right for world-class developer docs. The risk is implementation drift, not planning intent. The principles are clear enough to hold that standard if followed.
+
+---
+
+### Module index and CLI inventory dump risk
+
+**Module index (Slice 3):** The grouped-by-purpose structure plus "available vs. planned" status labeling is a real anti-dump mechanism. One gap remains: the plan doesn't say what to do with modules that are small or self-explanatory and may never need a dedicated page. Marking them "planned" indefinitely signals incompleteness; listing them with no status implies work is coming. A third category — "available, no dedicated page needed" or "see Python docs for surface, Sifr semantics are identical" — would let the index be truthful about coverage without creating perpetual "planned" debt. This belongs in the Slice 3 acceptance criteria.
+
+**CLI inventory (Slice 4):** Well-scoped. The acceptance criteria prevent prose duplication across package pages. The one missing piece: the overview should group commands (project lifecycle vs. code quality vs. package management vs. self-management) rather than present a flat alphabetical list. A flat list of 15+ commands is a dump regardless of how well each entry is written. One sentence in the acceptance criteria ("Group commands by workflow concern, not alphabetically") would close this.
+
+---
+
+### Slice order evaluation
+
+After adding Slice 3 (stdlib module index) and Slice 4 (CLI inventory), the sequence is:
+
+0 (audit) → 1 (skeleton) → 2 (data model) → 3 (module index) → 4 (CLI inventory) → 5 (Python callouts) → 6 (guides)
+
+This is pragmatic. Slices 5 (callouts on existing pages) does not strictly depend on Slices 3 or 4, but Slice 1's `status.mdx` needs a meaningful stdlib overview to link to, which makes Slice 3 land before Slice 5 a reasonable default. The real observation: Slices 3 and 4 are independent of each other and can be parallelized once Slice 2 is complete. If two contributors are working simultaneously, the issue should note this to avoid artificial sequencing. Not a blocking concern, but it affects delivery velocity.
+
+---
+
+### Go / no-go
+
+**Go**, with two targeted edits before Slice 1 drafting starts:
+
+1. **[important]** Remove the "Missing values" row from the `From Python` table spec and replace it with an explicit note to add the row after Slice 0 resolves the contract.
+2. **[important]** Add an async row to the `From Python` table spec.
+
+Three optional improvements worth picking up during slice work:
+
+- **[optional]** Slice 3 acceptance: add a third status category for modules that are available but do not need a dedicated doc page.
+- **[optional]** Slice 4 acceptance: add "group commands by workflow concern" to prevent a flat-list dump in `cli/overview.mdx`.
+- **[optional]** Note in Slice 2 or Slice 3 that Slices 3 and 4 are independently executable in parallel.


### PR DESCRIPTION
## Summary
- Add an ad hoc plan for redesigning the Sifr documentation information architecture.
- Capture reviewed plans for Documentation, Guides, Reference/Error Codes, Ownership and Mutability, and Concurrency.
- Include Claude review artifacts from the planning iterations.

## Validation
- Not run, per request.