### PR TITLE
[codex] Implement docs learning path foundation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,11 +69,12 @@
               "index",
               "introduction",
               "installation",
-              "quickstart"
+              "quickstart",
+              "from-python"
             ]
           },
           {
-            "group": "Core Language",
+            "group": "Learn Sifr",
             "icon": "braces",
             "pages": [
               "language/type-system",
@@ -85,29 +86,7 @@
             ]
           },
           {
-            "group": "Commands",
-            "icon": "square-terminal",
-            "pages": [
-              "cli/overview",
-              "cli/build-run",
-              "cli/check-emit",
-              "cli/fmt-lint",
-              "cli/test",
-              "cli/lsp"
-            ]
-          },
-          {
-            "group": "Package management",
-            "icon": "package",
-            "pages": [
-              "packages/overview",
-              "packages/manifest",
-              "packages/dependencies",
-              "packages/publishing"
-            ]
-          },
-          {
-            "group": "Modules",
+            "group": "Standard Library",
             "icon": "book-open",
             "pages": [
               "stdlib/overview",
@@ -119,11 +98,20 @@
             ]
           },
           {
-            "group": "Compiler errors",
-            "icon": "scan-search",
+            "group": "Package Management",
+            "icon": "package",
             "pages": [
-              "diagnostics/overview",
-              "diagnostics/error-codes"
+              "packages/overview",
+              "packages/manifest",
+              "packages/dependencies",
+              "packages/publishing"
+            ]
+          },
+          {
+            "group": "Project",
+            "icon": "circle-dot",
+            "pages": [
+              "status"
             ]
           }
         ]
@@ -137,6 +125,40 @@
             "icon": "globe",
             "pages": [
               "guides/index"
+            ]
+          },
+          {
+            "group": "Audience Paths",
+            "icon": "map",
+            "pages": [
+              "guides/python-developers/index",
+              "guides/rust-developers/index"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Reference",
+        "icon": "library",
+        "groups": [
+          {
+            "group": "CLI",
+            "icon": "square-terminal",
+            "pages": [
+              "cli/overview",
+              "cli/build-run",
+              "cli/check-emit",
+              "cli/fmt-lint",
+              "cli/test",
+              "cli/lsp"
+            ]
+          },
+          {
+            "group": "Error Codes",
+            "icon": "scan-search",
+            "pages": [
+              "diagnostics/overview",
+              "diagnostics/error-codes"
             ]
           }
         ]

--- a/docs/from-python.mdx
+++ b/docs/from-python.mdx
@@ -1,0 +1,92 @@
+---
+title: "From Python to Sifr"
+sidebarTitle: "From Python"
+description: "A compact guide for Python developers: what carries over, what changes at compile time, and where to go next."
+---
+
+Sifr uses Python-shaped syntax, but it is not Python with a faster runtime. It is a compiled language with static types, ownership, and typed errors. The syntax should feel familiar; the contract is stricter.
+
+## Same Shape, Different Contract
+
+If you know Python, start by keeping the surface model and changing the failure model. Sifr tries to make illegal states visible before a binary is built: missing values are typed, fallible calls return `Result`, and values crossing ownership or task boundaries must be explicit.
+
+| Python concept | Sifr shape | Difference |
+| --- | --- | --- |
+| Type hints | Type annotations | Enforced by the compiler, not optional metadata |
+| Exceptions | `Result[T, E]` plus `try`/`except` | Recoverable errors are values, not stack unwinds |
+| Missing values | `T | None` | You must check `None` before using the inner value |
+| Imports | `sifr.*` modules and packages | Bare CPython stdlib names are not aliases |
+| Integers | Exact `int` plus explicit fixed-width types | Ordinary arithmetic stays simple; representation-sensitive widths are explicit |
+| Bytes | First-class `bytes` | Encode and decode at typed boundaries; do not rely on platform-default text behavior |
+| Async | `async def`, `await`, `sifr.task` | Structured scopes, typed cancellation evidence, no global event loop |
+| Function calls | Borrow by default | Heap values are not moved unless `own` is used |
+| Mutation | `mut` and `own mut` | Parameter mutation is explicit |
+| `assert` | Assertion | Programmer invariant, not recoverable control flow |
+
+## What Carries Over
+
+You still write `def`, `class`, `if`, `for`, list and dict literals, comprehensions, f-strings, `match`, `async def`, and `await`. The goal is not to make you learn a new surface grammar before you can write useful programs.
+
+```python
+def describe(value: int | str) -> str:
+    if isinstance(value, int):
+        return f"number: {value}"
+    return f"text: {value}"
+```
+
+The difference is that annotations are part of the program. If `describe` promises `str`, every path must return `str`.
+
+## What Changes At Compile Time
+
+Sifr turns several Python runtime surprises into compile-time obligations:
+
+- a dictionary lookup that might miss returns `V | None`;
+- a fallible function returns `Result[T, E]`;
+- a parameter is immutable unless marked `mut`;
+- a value is borrowed by default unless a function asks for `own`;
+- a spawned task can only capture values that are owned and sendable.
+
+```python
+users: dict[str, int] = {"alice": 30}
+age: int | None = users["bob"]
+
+if age is not None:
+    print(age + 1)
+else:
+    print("user not found")
+```
+
+<Note>
+  Sifr docs are the source of truth for Sifr semantics. Python references are useful for syntax vocabulary, but they do not define Sifr's type, ownership, error, or package model.
+</Note>
+
+## Common Surprises
+
+<AccordionGroup>
+  <Accordion title="Type hints are not hints">
+    Sifr annotations are checked before the program runs. Treat them as part of the language, not as documentation for a separate runtime.
+  </Accordion>
+  <Accordion title="Exceptions do not unwind normal errors">
+    `raise` inside a `Result`-returning function produces an error value. `try`/`except` handles that value explicitly.
+  </Accordion>
+  <Accordion title="Imports use the Sifr namespace">
+    Use `from sifr.collections import Counter`, not `import collections`. Supported stdlib-style modules live under `sifr.*`; see the [collections import example](/stdlib/collections#importing).
+  </Accordion>
+  <Accordion title="Mutation is explicit">
+    Use `mut` when a function should mutate a borrowed parameter, and `own mut` when it should take ownership and mutate the value before returning or dropping it.
+  </Accordion>
+</AccordionGroup>
+
+## Where To Go Next
+
+<CardGroup cols={2}>
+  <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
+    Learn `mut`, `own`, and borrow-by-default rules.
+  </Card>
+  <Card title="Error Handling" icon="triangle-alert" href="/language/error-handling">
+    See how `Result` and `try`/`except` replace recoverable exceptions.
+  </Card>
+  <Card title="Python Developers" icon="map" href="/guides/python-developers">
+    Follow a guided path written for Python developers.
+  </Card>
+</CardGroup>

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -16,4 +16,20 @@ mode: center
   >
     Install the toolchain, run a Sifr file, and build a native binary.
   </Card>
+  <Card
+    icon="map"
+    title="Sifr for Python Developers"
+    href="/guides/python-developers"
+    cta="Follow the path"
+  >
+    Transfer Python syntax knowledge without carrying Python runtime assumptions.
+  </Card>
+  <Card
+    icon="refresh-cw"
+    title="Sifr for Rust Developers"
+    href="/guides/rust-developers"
+    cta="Map the concepts"
+  >
+    Connect Sifr ownership, typed errors, and generated Rust to Rust concepts.
+  </Card>
 </CardGroup>

--- a/docs/guides/python-developers/index.mdx
+++ b/docs/guides/python-developers/index.mdx
@@ -1,0 +1,32 @@
+---
+title: "Sifr for Python Developers"
+sidebarTitle: "Python Developers"
+description: "A guided path for Python developers learning Sifr's compile-time types, errors, imports, ownership, and packages."
+---
+
+If you know Python, Sifr lets you keep much of the syntax while changing the contract around errors, missing values, mutation, and imports. Start with the compatibility bridge, then follow task-focused guides as they are added.
+
+<CardGroup cols={2}>
+  <Card title="From Python" icon="map" href="/from-python">
+    See what carries over and what Sifr checks at compile time.
+  </Card>
+  <Card title="Quickstart" icon="zap" href="/quickstart">
+    Write, run, and build your first Sifr program.
+  </Card>
+  <Card title="Error Handling" icon="triangle-alert" href="/language/error-handling">
+    Learn how `Result` and `try`/`except` replace recoverable exceptions.
+  </Card>
+  <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
+    Learn `mut`, `own`, and borrow-by-default calls.
+  </Card>
+</CardGroup>
+
+## Guide Sequence
+
+The detailed guide pages below are planned follow-ups. Use the linked cards above for the current path through the docs.
+
+1. Write your first Sifr program.
+2. Handle errors the Sifr way.
+3. Use typed values and collections.
+4. Import Sifr modules.
+5. Move from script to package.

--- a/docs/guides/rust-developers/index.mdx
+++ b/docs/guides/rust-developers/index.mdx
@@ -1,0 +1,32 @@
+---
+title: "Sifr for Rust Developers"
+sidebarTitle: "Rust Developers"
+description: "A guided path for Rust developers learning how Sifr exposes ownership, Result, Option, generated Rust, and native builds."
+---
+
+If you know Rust, Sifr's safety model will feel familiar, but the source language keeps Python-shaped syntax. Use this path to map ownership, typed errors, generated Rust, and native binaries back to the Rust concepts you already know.
+
+<CardGroup cols={2}>
+  <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
+    Map `mut`, `own`, and borrow-by-default to Sifr's source model.
+  </Card>
+  <Card title="Error Handling" icon="triangle-alert" href="/language/error-handling">
+    See how `Result` appears in Sifr syntax.
+  </Card>
+  <Card title="Check and Emit" icon="file-code" href="/cli/check-emit">
+    Inspect generated Rust with `sifr emit`.
+  </Card>
+  <Card title="Build and Run" icon="terminal" href="/cli/build-run">
+    Compile Sifr into native binaries.
+  </Card>
+</CardGroup>
+
+## Guide Sequence
+
+The detailed guide pages below are planned follow-ups. Use the linked cards above for the current path through the docs.
+
+1. Map Rust patterns to Sifr.
+2. Ownership in Sifr terms.
+3. Results and optional values.
+4. Inspect generated Rust.
+5. Build a native binary.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,6 +14,14 @@ mode: center
     Types, ownership, Result types, and the compiler model behind Sifr.
   </Card>
   <Card
+    icon="map"
+    title="From Python"
+    href="/from-python"
+    cta="Transfer your model"
+  >
+    What carries over from Python and what Sifr checks at compile time.
+  </Card>
+  <Card
     icon="terminal"
     title="CLI"
     href="/cli/overview"
@@ -51,6 +59,9 @@ New to Sifr? Install the toolchain and compile your first program.
   </Card>
   <Card icon="zap" title="Quickstart" href="/quickstart">
     Write, run, and build a small program end to end.
+  </Card>
+  <Card icon="map" title="From Python" href="/from-python">
+    See the compact compatibility bridge for Python developers.
   </Card>
 </CardGroup>
 

--- a/docs/language/ownership.mdx
+++ b/docs/language/ownership.mdx
@@ -1,156 +1,140 @@
 ---
-title: "Sifr Ownership: Borrow by Default and the own Keyword"
-sidebarTitle: "Ownership"
-description: "Learn Sifr's borrow-by-default model: args borrow automatically, own transfers ownership, and the compiler catches use-after-move. No lifetime annotations."
+title: "Ownership and Mutability in Sifr"
+sidebarTitle: "Ownership and Mutability"
+description: "Learn Sifr's borrow-by-default model, explicit mutability with mut, ownership transfer with own, and owned mutable parameters with own mut."
 ---
 
-Sifr gives you Rust's memory-safety guarantees without requiring you to write lifetime annotations. The key insight is that most function calls do not need ownership of their arguments — they just need to read them. Sifr makes borrowing the default, so you can pass a value to a function and still use it afterwards, exactly as you would expect in Python, but with compile-time safety.
+Sifr gives you Rust's memory-safety guarantees without making every call site look like Rust. Function parameters borrow by default, parameter mutation is explicit, and ownership transfer is opt-in. Most code starts with a plain parameter and reaches for `mut`, `own`, or `own mut` only when the function's contract needs it.
 
-## Borrow by Default
+## Parameter Conventions
 
-When you pass a value to a function, Sifr borrows it by default. The function receives the value as an immutable borrow, and the caller retains ownership. The variable is still usable after the call.
+| Parameter style | Meaning | Caller keeps value? | Callee can mutate? |
+| --- | --- | --- | --- |
+| `items: list[int]` | Immutable borrow | Yes | No |
+| `mut items: list[int]` | Mutable borrow | Yes | Yes, during the call |
+| `own items: list[int]` | Owned immutable binding | No | No, unless copied into a mutable local |
+| `own mut items: list[int]` | Owned mutable binding | No | Yes |
+
+This table is the core model. A bare heap parameter is borrowed immutably. `mut` lets the function update the caller's value during the call. `own` moves the value into the function. `own mut` moves it and lets the function change it before returning or dropping it.
+
+## Borrow By Default
+
+When you pass a heap value to a function, Sifr borrows it by default. The function can read the value, and the caller keeps ownership.
 
 ```python
 def get_length(items: list[int]) -> int:
-    # items is borrowed — the caller keeps ownership
     return len(items)
 
 def main():
-    my_list: list[int] = [10, 20, 30]
-    length: int = get_length(my_list)
-    print(length)   # 3
-    print(my_list)  # [10, 20, 30] — still yours
+    values: list[int] = [10, 20, 30]
+    length: int = get_length(values)
+    print(length)
+    print(values)  # still usable
 ```
 
-This applies to any heap-allocated type: lists, strings, dictionaries, and class instances.
+Bare parameters are immutable. The callee cannot reassign the parameter name or mutate the object behind it.
 
 ```python
-def get_first_char(s: str) -> str:
-    # s is borrowed — the caller keeps ownership
-    result: str | None = s[0]
-    if result is not None:
-        return result
-    return ""
-
-def main():
-    greeting: str = "Hello, Sifr!"
-    first: str = get_first_char(greeting)
-    print(first)    # H
-    print(greeting) # Hello, Sifr! — still usable
+def count_items(items: list[int]) -> int:
+    # items.append(0) would be rejected
+    return len(items)
 ```
 
-## Copy Types
+## `mut` For Mutable Borrows
 
-Primitive scalars — `int`, `float`, and `bool` — are **Copy** types. When you pass them to a function, the compiler copies the value automatically. There is no borrowing or ownership transfer involved.
+Use `mut` when the function should update the caller's value in place.
 
 ```python
-def add(x: int, y: int) -> int:
-    # x and y are Copy types — passed by value
-    return x + y
-
-def is_positive(n: float) -> bool:
-    return n > 0.0
+def append_all(mut target: list[bool], values: list[bool]) -> None:
+    for value in values:
+        target.append(value)
 
 def main():
-    result: int = add(10, 20)
-    print(result)  # 30
-
-    pi: float = 3.14
-    print(is_positive(pi))  # True
-    print(pi)               # 3.14 — still usable
+    checks: list[bool] = []
+    append_all(checks, [True, False])
+    print(checks)  # [True, False]
 ```
 
-## Transferring Ownership with `own`
+`mut` is required both for rebinding a parameter name and for mutating through a heap parameter. Rebinding a mutable borrowed parameter to another value still does not make the borrowed value owned.
 
-When a function genuinely needs to take ownership of an argument — for example, to store it inside a data structure or to ensure it is dropped at a specific point — annotate the parameter with `own`.
+<Warning>
+  A mutable borrow cannot escape. `mut items: list[int]` can update the caller's list during the call, but it cannot return `items` or store it as an owned value. Use `own`, `own mut`, or `items.clone()` depending on whether the function should consume, mutate, or copy the value.
+</Warning>
+
+## `own` And `own mut`
+
+Use `own` when a function consumes a value. After the call, the caller cannot use the moved value.
 
 ```python
 def consume_and_count(own items: list[int]) -> int:
-    # items is owned — ownership transferred from caller
     return len(items)
 
 def main():
-    owned_list: list[int] = [1, 2, 3, 4, 5]
-    count: int = consume_and_count(owned_list)
-    print(count)  # 5
-    # owned_list is now moved — cannot use it after this point
+    values: list[int] = [1, 2, 3]
+    count: int = consume_and_count(values)
+    print(count)
+    # values is moved here
 ```
 
-<Warning>
-After passing a value to an `own` parameter, the compiler treats that variable as moved. Any subsequent read or write of the moved variable is a compile-time error.
-</Warning>
-
-## The `longest` Example
-
-The classic ownership puzzle — returning a reference to the longer of two strings — requires no lifetime annotations in Sifr. The function borrows its input, clones the winning value to give the caller an owned `str`, and the compiler verifies everything is sound.
+Use `own mut` when the function consumes a value and needs to mutate it before returning or dropping it.
 
 ```python
-def longest(items: list[str]) -> str:  # items is borrowed, not moved
-    best: str = ""
-    for s in items:
-        if len(s) > len(best):
-            best = s.clone()
-    return best
+def append_zero(own mut values: list[int]) -> list[int]:
+    values.append(0)
+    return values
 
 def main():
-    names: list[str] = ["alice", "bob", "charlie"]
-    print(longest(names))  # charlie
-    print(names)           # ["alice", "bob", "charlie"] — still yours
+    updated: list[int] = append_zero([2, 3, 4])
+    print(updated)  # [2, 3, 4, 0]
 ```
-
-<Note>
-`s.clone()` creates an owned copy of the borrowed string slice so the function can return it. Without `.clone()`, the compiler would reject the return because you cannot return a borrow that might outlive the caller.
-</Note>
-
-## Borrowing in Loops
-
-Borrow-by-default makes it natural to pass the same collection into a function multiple times without copying.
-
-```python
-def sum_multiple_times(items: list[int], times: int) -> int:
-    total: int = 0
-    for i in range(times):
-        total = total + get_length(items)
-    return total
-
-def main():
-    items: list[int] = [10, 20, 30]
-    loop_total: int = sum_multiple_times(items, 3)
-    print(loop_total)  # 9 (3 × 3)
-    print(items)       # [10, 20, 30] — still usable
-```
-
-## Callables and Borrow Convention
-
-When you pass a collection to a higher-order function via a `Callable` parameter, the same borrow-by-default rule applies. The callable borrows the argument, and the caller keeps ownership.
-
-```python
-from typing import Callable
-
-def apply_and_return(f: Callable[[list[int]], int], items: list[int]) -> int:
-    return f(items)
-
-def compute_sum(nums: list[int]) -> int:
-    total: int = 0
-    for n in nums:
-        total = total + n
-    return total
-
-def main():
-    nums: list[int] = [5, 10, 15]
-    sum_result: int = apply_and_return(compute_sum, nums)
-    print(sum_result)  # 30
-    print(nums)        # [5, 10, 15] — still usable
-```
-
-## Ownership Rules at a Glance
-
-| Parameter style | What the callee receives | Caller retains ownership? |
-|-----------------|--------------------------|--------------------------|
-| `items: list[int]` (default) | Immutable borrow | ✅ Yes |
-| `own items: list[int]` | Owned value | ❌ No — value is moved |
-| `x: int` (Copy type) | Copy of the value | ✅ Yes — value is copied |
 
 <Tip>
-Start with the default borrow convention. Reach for `own` only when the function's rules genuinely requires ownership — such as spawning a task, storing a value in a struct, or explicitly dropping a resource.
+  `own mut` is the canonical spelling. The formatter rewrites `mut own` to `own mut`.
 </Tip>
+
+## Scalars And Immutable Values
+
+Scalar values such as `int`, `float`, and `bool` behave like ordinary values at the source level. A `mut n: int` parameter permits local rebinding inside the function, but it does not create an observable heap borrow or ownership transfer.
+
+```python
+def increment(mut n: int) -> int:
+    n = n + 1
+    return n
+```
+
+Some types are immutable by design. For example, `mut` does not make `bytes` subscript assignment legal.
+
+## Across `await`
+
+Mutable borrows cannot remain live across an `await` point. End the mutation before awaiting, move owned data into a task, or wrap shared state in an explicit synchronization primitive.
+
+```python
+def append_before_await(mut items: list[int]) -> None:
+    items.append(1)
+
+async def main() -> None:
+    values: list[int] = []
+    append_before_await(values)
+    await task.sleep(0.0)
+```
+
+For the task-boundary model, see [Concurrency](/language/concurrency).
+
+## Rules At A Glance
+
+| Need | Use |
+| --- | --- |
+| Read a value without taking it | `items: list[int]` |
+| Update the caller's value during the call | `mut items: list[int]` |
+| Consume a value | `own items: list[int]` |
+| Consume and mutate a value | `own mut items: list[int]` |
+| Keep a borrowed value after the call | `.clone()` or change the boundary to `own` |
+
+<CardGroup cols={2}>
+  <Card title="Coming from Python?" href="/guides/python-developers">
+    Follow a path through mutation, typed errors, imports, and packages.
+  </Card>
+  <Card title="Coming from Rust?" href="/guides/rust-developers">
+    Map `mut`, `own`, and borrow-by-default rules back to Rust concepts.
+  </Card>
+</CardGroup>

--- a/docs/language/type-system.mdx
+++ b/docs/language/type-system.mdx
@@ -92,7 +92,7 @@ def find_value(x: int | None, target: int) -> str:
     return "not found"
 
 def is_positive(x: int | None) -> bool:
-    if x > 0:
+    if x is not None and x > 0:
         return True
     return False
 ```
@@ -144,12 +144,12 @@ The compiler instantiates a separate, fully-typed version of the function for ea
 
 | Sifr type | Description |
 |-----------|------------|
-| `int`     | 64-bit signed integer |
+| `int`     | Exact integer for ordinary arithmetic |
 | `float`   | 64-bit IEEE 754 double |
 | `bool`    | `True` / `False` |
 | `str`     | UTF-8 string |
 | `None`    | Absence of value |
 
 <Note>
-Primitive types (`int`, `float`, `bool`) are **Copy** types. Passing them to a function does not move or borrow them — the compiler copies the value automatically.
+Scalar values such as `int`, `float`, and `bool` have value semantics at the source level. Passing them to a function does not create use-after-move friction for the caller.
 </Note>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -130,6 +130,12 @@ All three guarantees are enforced at compile time. If your program compiles, non
     description="Go deeper on union types, literal types, and how type narrowing works across complex expressions."
   />
   <Card
+    title="From Python"
+    icon="map"
+    href="/from-python"
+    description="Transfer Python syntax knowledge without carrying runtime assumptions into Sifr."
+  />
+  <Card
     title="CLI Overview"
     icon="terminal"
     href="/cli/overview"

--- a/docs/status.mdx
+++ b/docs/status.mdx
@@ -1,0 +1,74 @@
+---
+title: "Sifr Status"
+sidebarTitle: "Status"
+description: "Current project status, supported surfaces, and practical boundaries for using Sifr today."
+---
+
+Sifr is in preview. The language, compiler, CLI, and standard library are usable for experimentation and early projects, but the public surface is still being tightened. This page sets expectations so you can decide what to try next.
+
+## Preview Channels
+
+Use the installer from the [Installation](/installation) page to get the current toolchain. Preview releases may adjust syntax, diagnostics, standard-library APIs, and package workflows as the compiler hardens.
+
+## Language Surface
+
+The core language currently focuses on:
+
+- Python-shaped functions, classes, expressions, and control flow;
+- static type annotations, unions, narrowing, and `None`;
+- `Result`-based recoverable errors;
+- ownership, borrow-by-default calls, `mut`, `own`, and `own mut`;
+- structured async tasks and task-boundary ownership.
+
+<Tip>
+  Start with [Quickstart](/quickstart), then read [From Python](/from-python) if you are bringing Python assumptions with you.
+</Tip>
+
+## Standard Library Surface
+
+Public docs cover the most important `sifr.*` areas today: collections, I/O and filesystem, networking, concurrency, and text/encoding. The shipped namespace is broader than the currently detailed pages, so the module index work will make availability easier to scan.
+
+Sifr docs define Sifr behavior even when a module mirrors a Python standard-library idea. Do not assume CPython module parity unless a Sifr page documents it.
+
+## Tooling Surface
+
+The CLI supports the core local loop:
+
+- `sifr run`
+- `sifr build`
+- `sifr check`
+- `sifr emit`
+- `sifr fmt`
+- `sifr lint`
+- `sifr test`
+- `sifr lsp`
+
+More package, repair, tracing, and self-update commands exist and need fuller reference coverage.
+
+## Practical Boundaries
+
+Use Sifr today when you want to explore:
+
+- native binaries from Python-shaped source;
+- compile-time type and ownership checks;
+- typed errors instead of runtime exception paths;
+- structured concurrency without fire-and-forget tasks.
+
+Be cautious when you need broad CPython library compatibility, mature third-party package ecosystems, or long-term API stability across preview releases.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Installation" icon="download" href="/installation">
+    Install the preview toolchain.
+  </Card>
+  <Card title="Standard Library" icon="library" href="/stdlib/overview">
+    Browse documented `sifr.*` modules.
+  </Card>
+  <Card title="Diagnostics" icon="scan-search" href="/diagnostics/error-codes">
+    Look up compiler diagnostic families.
+  </Card>
+  <Card title="Packages" icon="package" href="/packages/overview">
+    Learn project layout and dependency basics.
+  </Card>
+</CardGroup>

--- a/docs/stdlib/collections.mdx
+++ b/docs/stdlib/collections.mdx
@@ -43,7 +43,13 @@ scores: dict[str, int] = {"alice": 42, "bob": 17}
 doubled: dict[str, int] = {k: v * 2 for k, v in scores.items()}
 ```
 
-Safe access via `.get(key)` returns `Option[V]` (either the value or `None`). Direct `scores["missing"]` is a compile-time checked operation that produces a typed error if the key might be absent.
+Safe access via `.get(key)` returns `Option[V]` (either the value or `None`). Direct indexing uses the same panic-free contract: `scores["missing"]` returns `None` instead of raising `KeyError`.
+
+```python
+maybe_score: int | None = scores["charlie"]
+if maybe_score is not None:
+    print(maybe_score)
+```
 
 ## Sets
 

--- a/plans/issues/active/ad-hoc-documentation-learning-path.md
+++ b/plans/issues/active/ad-hoc-documentation-learning-path.md
@@ -16,6 +16,12 @@ Review artifacts:
 - `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-mutability-review-pass-2.md`
 - `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-concurrency-review-pass-1.md`
 - `plans/reviews/active/ad-hoc-documentation-learning-path-sonnet-concurrency-review-pass-2.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-1-sonnet-review-pass-2.md`
+- `plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-1-sonnet-review-pass-3.md`
+
+Implementation status:
+
+- Wave 1: Ready for PR after Sonnet review. Scope: navigation foundation, `From Python`, `Status`, `Ownership and Mutability`, Slice 0 semantic fixes, and audience guide route placeholders. Validation: `cd docs && npx mint@latest validate` passed.
 
 ## Objective
 

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-1-sonnet-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-1-sonnet-review-pass-2.md
@@ -1,0 +1,72 @@
+I now have a full picture. Let me synthesize the review.
+
+---
+
+## Wave 1 Review
+
+### BLOCKERS
+
+**1. Missing import link — explicit Slice 1 acceptance criterion**
+
+`from-python.mdx` Slice 1 criterion says: "The imports row in `From Python` links to a concrete worked import example, either in `Quickstart`, `cli/overview.mdx`, or another existing page chosen during Slice 1."
+
+The current page has an inline accordion that says `from sifr.collections import Counter` but no hyperlink from the imports section to a worked example page. The accordion title is "Imports use the Sifr namespace" with prose description only. This acceptance item is unmet.
+
+Fix: add a link to `stdlib/collections.mdx` (or `quickstart.mdx`) from the imports accordion.
+
+---
+
+**2. `language/concurrency.mdx` orphaned from navigation**
+
+The previous `docs.json` had concurrency under Core Language. The new one removes it entirely — it's not in "Learn Sifr" or anywhere else. It won't be restored until Slice 3. If this PR merges, every user who navigates the sidebar will find no path to the concurrency page. That's a regression. Slice 3 is unscheduled.
+
+Fix: either keep `language/concurrency` in "Learn Sifr" for now, or mark this PR as draft until the Concurrency group ships alongside it.
+
+---
+
+### HIGH-VALUE ISSUES (not blockers)
+
+**3. `from-python.mdx` "Where To Go Next" sends the reader backward**
+
+The sidebar places `from-python` after `quickstart`. The first card in the "Where To Go Next" section is Quickstart — pointing readers backwards in the learning path. Cards should point forward: Ownership and Mutability, Error Handling, Type System, or the Python Developers guide. The Quickstart card belongs on `introduction.mdx` or `index.mdx`, not `from-python`.
+
+---
+
+**4. Tab order is inverted from the plan**
+
+Current: Documentation → **Reference** → Guides  
+Issue spec (§9): Documentation → **Guides** → Reference
+
+Guides is learning-oriented; Reference is catalog-shaped. A newcomer scanning the top nav will see Reference before Guides, which inverts the intended priority. This is a one-line reorder in `docs.json`.
+
+---
+
+**5. Package Management sits before Standard Library**
+
+The issue's proposed sidebar shape (§9) puts Standard Library before Packages. A newcomer cares more about `sifr.collections`, `sifr.io`, and similar modules before they need manifest and publishing details. The current order reverses this.
+
+---
+
+**6. Audience guide sequence steps are unlinked (by design, but needs callout)**
+
+Both `guides/python-developers/index.mdx` and `guides/rust-developers/index.mdx` list a numbered 5-step guide sequence as plain text, with no links. This is expected for Wave 1 placeholders, but readers who arrive here will see no clickable content after the initial cards. The PR description or issue should call this out explicitly so reviewers don't flag it as broken — and so Slice 8 has a clear marker to resolve it.
+
+---
+
+### CLEAN — no issues found
+
+- **`ownership.mdx` rewrite**: excellent. The four-row convention table is the right anchor. `mut`/`own`/`own mut`/borrow-by-default are all covered. The Warning callout about borrowed values not escaping is exactly right. Scalar treatment is accurate. The "Across `await`" section is appropriately brief. Both audience cards at the bottom are correct. This is the strongest piece in the wave.
+- **`type-system.mdx` Slice 0 fixes**: `int` no longer says "64-bit signed"; the scalar note uses "value semantics" not "Copy"; the `find_value` equality comparison on `int | None` is a valid pattern (equality doesn't require narrowing, only arithmetic/string operations do); `is_positive` correctly demonstrates the narrowing pattern.
+- **`collections.mdx` Slice 0 fix**: the direct-indexing contract now correctly says `scores["missing"]` returns `None`, matching the architecture doc. The example is clean.
+- **`status.mdx`**: concise and honest. The stdlib availability section correctly avoids implying undocumented modules are unsupported. "Practical Boundaries" works better than the issue's "Known limits" label.
+- **`from-python.mdx` table and structure**: table-first, not duplicating Introduction prose, all prescribed rows present (including the "Missing values" row now that Slice 0 is done), accordion structure is appropriate. One small prose nit: the "Bytes" row says "Encode and decode at typed boundaries" which is correct but the `status.mdx`-level reader may benefit from the fuller note from the issue ("do not rely on platform-default text behavior").
+- **`docs.json` foundation**: Documentation/Reference/Guides three-tab split is correct in principle; CLI and diagnostics correctly moved to Reference; Project group with Status at the bottom is correct; from-python in Get Started after quickstart matches the spec.
+- **`docs/index.mdx`**: wayfinding is present — From Python card appears in both the hero and the "Get Started" section alongside Quickstart. Criterion met.
+- **`guides/index.mdx`**: clean single-purpose wayfinding page, no concept creep.
+- **Mint validate**: passed per the issue.
+
+---
+
+### Summary
+
+Two blockers: missing import link (explicit acceptance criterion), and concurrency page orphaned from nav (content regression). Four high-value suggestions that are low-effort to address before merging. The ownership rewrite and the Slice 0 semantic corrections are solid and ready.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-1-sonnet-review-pass-3.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-1-sonnet-review-pass-3.md
@@ -1,0 +1,21 @@
+I've read all the changed files. Here's my assessment:
+
+**Previously-fixed blockers — all confirmed resolved:**
+
+- `/stdlib/collections#importing` anchor link in `from-python.mdx` → `## Importing` section exists in `collections.mdx` ✓
+- `language/concurrency` present in the Learn Sifr nav group in `docs.json` ✓
+- Tab order: Documentation → Guides → Reference ✓
+- Standard Library group before Package Management in docs.json ✓
+- No backward Quickstart card in `from-python.mdx` next steps ✓
+- Audience path index pages (`guides/python-developers/index.mdx`, `guides/rust-developers/index.mdx`) both carry the "planned follow-ups" note ✓
+- Bytes row present and expanded in the `from-python.mdx` comparison table ✓
+
+**Cross-link audit — no broken hrefs found:**
+
+- `ownership.mdx` → `/guides/python-developers` and `/guides/rust-developers`: Mintlify serves `index` pages at the directory URL, so these resolve correctly.
+- `from-python.mdx` → `/language/ownership`, `/language/error-handling`, `/guides/python-developers` ✓
+- `quickstart.mdx` → `/language/type-system`, `/from-python`, `/cli/overview` ✓
+- `status.mdx` → `/installation`, `/stdlib/overview`, `/diagnostics/error-codes`, `/packages/overview` ✓
+- Both audience-path index pages link only to pages in the confirmed nav ✓
+
+**No remaining blockers found. Wave 1 is ready for PR.**


### PR DESCRIPTION
## Summary
- Add the From Python and Status pages and wire them into Documentation.
- Split top-level navigation into Documentation, Guides, and Reference, with lightweight Python/Rust audience guide indexes.
- Retitle and rewrite Ownership as Ownership and Mutability, and fix Slice 0 type/indexing docs contradictions.

## Review
- Claude Sonnet medium reviewed Wave 1.
- Follow-up review confirmed blockers resolved and Wave 1 ready for PR.

## Validation
- cd docs && npx mint@latest validate