### PR TITLE
[codex] Expand language and concurrency docs

### DIFF
--- a/docs/concurrency/async-and-await.mdx
+++ b/docs/concurrency/async-and-await.mdx
@@ -1,0 +1,81 @@
+---
+title: "Async and Await"
+sidebarTitle: "Async and Await"
+description: "Define async functions, await real suspension points, and handle typed async errors in Sifr."
+---
+
+Use `async def` for functions that suspend. Use `await` to wait for an async operation inside another async context.
+
+```python
+async def one() -> int:
+    await task.sleep(0.0)
+    return 1
+```
+
+<Note>
+  The `task` namespace is available in async Sifr programs for core task operations such as `task.sleep`, `task.scope`, `task.gather`, and `task.TaskGroup`.
+</Note>
+
+Sifr tracks whether async code performs real suspension. An async function that never reaches a suspension point is rejected because it does not need to be async.
+
+## Typed Errors
+
+Async functions can return `Result[T, E]` just like synchronous functions. `raise` produces the error value, and callers handle it with `try`/`except`.
+
+```python
+async def fail_fast() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("group child failed")
+```
+
+## Awaiting Work
+
+You can await a direct async call, a task handle, or an async API from the standard library.
+
+```python
+async def main() -> Result[None, Error]:
+    value: int = await one()
+    print(value)
+    return None
+```
+
+For async subprocess I/O, use the async process APIs rather than blocking calls.
+
+```python
+from sifr.process import Command, Stdio, async_spawn
+
+async def run_child() -> None:
+    command: Command = Command(["cat"])
+    command.stdin(Stdio.piped())
+    command.stdout(Stdio.piped())
+
+    child = await async_spawn(command)
+    stdin = child.stdin()
+    stdout = child.stdout()
+    await stdin.write_all(b"ping")
+    response: bytes = await stdout.read_all()
+```
+
+## What Is Different From `asyncio`
+
+Sifr has no exposed event-loop object. You do not call `get_event_loop`, mutate loop policy, or detach work into a global registry. Async work belongs to scopes, and the compiler verifies ownership at the boundary.
+
+## Blocking And CPU-Heavy Work
+
+Do not run blocking I/O or CPU-heavy functions directly inside async code. Sifr reports this as an async diagnostic because blocking the runtime would prevent other tasks from making progress.
+
+Use async APIs for I/O, and use `sifr.parallel` for CPU-heavy maps over owned data.
+
+```python
+from sifr.parallel import map as parallel_map
+
+def heavy(value: int) -> int:
+    return value * value
+
+def run_cpu_work(values: list[int]) -> list[int]:
+    return parallel_map(values, heavy)
+```
+
+<Tip>
+  If the next thing you want is "run two things at once", continue with [Structured Tasks](/concurrency/structured-tasks).
+</Tip>

--- a/docs/concurrency/cancellation-and-timeouts.mdx
+++ b/docs/concurrency/cancellation-and-timeouts.mdx
@@ -1,0 +1,73 @@
+---
+title: "Cancellation and Timeouts"
+sidebarTitle: "Cancellation and Timeouts"
+description: "Bound async work with timeouts, cancellation, cleanup, and structured task failure rules."
+---
+
+Sifr treats cancellation as part of structured concurrency. A cancelled child does not keep running in the background, and cleanup runs before cancellation or timeout evidence is observed by the caller.
+
+## Timeout
+
+Use `task.timeout` to bound the runtime of an awaitable operation.
+
+```python
+async def main() -> Result[None, Error]:
+    async with task.timeout(1.0):
+        await task.sleep(0.0)
+    return None
+```
+
+When the timeout expires, the block is cancelled and the caller handles typed timeout evidence.
+
+## Cleanup Runs First
+
+Cleanup in `finally` runs before the timeout is observed outside the block.
+
+```python
+from sifr.io import write_text
+
+async def main() -> Result[None, Error]:
+    try:
+        async with task.timeout(0.0):
+            try:
+                await task.sleep(10.0)
+            finally:
+                _written: None = write_text("/tmp/sifr-cleanup.txt", "cleanup")
+    except TimeoutError:
+        _timed_out: bool = True
+    return None
+```
+
+This keeps resource cleanup deterministic even when work is cancelled.
+
+## Manual Cancellation
+
+Task handles can be cancelled explicitly.
+
+```python
+async with task.scope() as scope:
+    slow = scope.spawn(slow_worker())
+    slow.cancel()
+    cancelled = await slow
+```
+
+The handle still has one owner and one observation path.
+
+## Sibling Cancellation
+
+`TaskGroup` cancels unfinished siblings when one child fails. Use this for all-or-cancel groups where partial completion should not leak beyond the group.
+
+<Warning>
+  Do not use task cancellation as a hidden control-flow side channel. Treat timeout and cancellation as typed evidence that the caller must handle.
+</Warning>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Structured Tasks" icon="workflow" href="/concurrency/structured-tasks">
+    Learn how child task scopes own and clean up spawned work.
+  </Card>
+  <Card title="Error Handling" icon="triangle-alert" href="/language/error-handling">
+    Review how typed errors flow through Sifr programs.
+  </Card>
+</CardGroup>

--- a/docs/concurrency/ownership-across-tasks.mdx
+++ b/docs/concurrency/ownership-across-tasks.mdx
@@ -1,0 +1,80 @@
+---
+title: "Ownership Across Tasks"
+sidebarTitle: "Ownership Across Tasks"
+description: "Understand owned task-boundary inputs, sendability, shared state, and why mutable borrows cannot cross await."
+---
+
+Concurrency boundaries are ownership boundaries. A spawned task may outlive the current line of code, so values captured by that task must be owned and safe to send.
+
+## Owned Inputs
+
+Pass owned values into spawned tasks.
+
+```python
+async def count_items(own items: list[int]) -> int:
+    await task.sleep(0.0)
+    return len(items)
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        handle = scope.spawn(count_items([1, 2, 3]))
+        result = await handle
+    return None
+```
+
+The child owns its input. The parent observes the task through the handle.
+
+## Shared Read Access
+
+Use explicit synchronization primitives for values shared across tasks.
+
+```python
+from sifr.sync import Shared
+
+async def read_shared(own shared: Shared[int]) -> int:
+    await task.sleep(0.0)
+    return shared.get()
+```
+
+`Shared[T]` is for concurrent read access. Mutable shared state uses explicit lock types from `sifr.sync`.
+
+## Mutable Borrows And Await
+
+Mutable borrows must end before an `await`.
+
+This shape is rejected because the mutable borrow remains live when the function reaches `await`:
+
+```python
+async def rejected(mut items: list[int]) -> None:
+    items.append(1)
+    await task.sleep(0.0)
+```
+
+End the mutation before awaiting by moving the mutation into a synchronous helper.
+
+```python
+def append_before_await(mut items: list[int]) -> None:
+    items.append(2)
+    return None
+
+async def main() -> Result[None, ScopeFailure]:
+    values: list[int] = [1]
+    append_before_await(values)
+    await task.sleep(0.0)
+    return None
+```
+
+<Warning>
+  Lock guards, borrowed references, and mutable borrows cannot cross task or await boundaries. Move owned values, clone when copying is intended, or use `sifr.sync` primitives.
+</Warning>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
+    Review `mut`, `own`, `own mut`, and borrowed-value escape rules.
+  </Card>
+  <Card title="Concurrency API" icon="library" href="/stdlib/concurrency">
+    Browse channels, locks, shared values, and task APIs.
+  </Card>
+</CardGroup>

--- a/docs/concurrency/structured-tasks.mdx
+++ b/docs/concurrency/structured-tasks.mdx
@@ -1,0 +1,82 @@
+---
+title: "Structured Tasks"
+sidebarTitle: "Structured Tasks"
+description: "Use task scopes, spawned handles, gather, select, and TaskGroup in Sifr."
+---
+
+Spawned tasks live inside a scope. The scope owns the children and waits for them before the block exits.
+
+## Scoped Spawn
+
+```python
+async def one() -> int:
+    await task.sleep(0.0)
+    return 1
+
+async def two() -> int:
+    await task.sleep(0.0)
+    return 2
+
+async def main() -> Result[None, Error]:
+    async with task.scope() as scope:
+        first = scope.spawn(one())
+        second = scope.spawn(two())
+        values = await task.gather([first, second])
+    return None
+```
+
+`task.gather` returns results in the order the handles were passed.
+
+## Linear Handles
+
+`TaskHandle[T, E]` values are linear. Awaiting or joining a handle consumes it. The compiler rejects using the same handle twice.
+
+<Note>
+  This is the task version of Sifr's ownership model: a handle represents a live child task, so there is exactly one path that observes it.
+</Note>
+
+## Select
+
+Use `task.select` when two tasks race and the first result wins. The losing child is cancelled before the scope exits.
+
+```python
+async def fast() -> int:
+    await task.sleep(0.0)
+    return 10
+
+async def slow() -> int:
+    await task.sleep(0.20)
+    return 20
+
+async with task.scope() as scope:
+    selected: int = await task.select(
+        first=scope.spawn(fast()),
+        second=scope.spawn(slow()),
+    )
+```
+
+## TaskGroup
+
+Use `task.TaskGroup` when a group of tasks should run together and you need to observe individual results.
+
+```python
+async with task.TaskGroup() as group:
+    slow = group.spawn(slow())
+    failing = group.spawn(fail_fast())
+    failure = await failing
+```
+
+<Warning>
+  `TaskGroup` cancels unfinished siblings when any child fails. Do not rely on sibling work completing after another child has returned an error.
+</Warning>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Cancellation and Timeouts" icon="clock-alert" href="/concurrency/cancellation-and-timeouts">
+    Bound the lifetime of async work.
+  </Card>
+  <Card title="Concurrency API" icon="library" href="/stdlib/concurrency">
+    See the full `sifr.task` API reference.
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -80,9 +80,21 @@
               "language/type-system",
               "language/error-handling",
               "language/ownership",
+              "language/values-and-collections",
+              "language/iteration",
               "language/classes",
-              "language/pattern-matching",
-              "language/concurrency"
+              "language/pattern-matching"
+            ]
+          },
+          {
+            "group": "Concurrency",
+            "icon": "workflow",
+            "pages": [
+              "language/concurrency",
+              "concurrency/async-and-await",
+              "concurrency/structured-tasks",
+              "concurrency/cancellation-and-timeouts",
+              "concurrency/ownership-across-tasks"
             ]
           },
           {

--- a/docs/language/concurrency.mdx
+++ b/docs/language/concurrency.mdx
@@ -1,237 +1,58 @@
 ---
-title: "Sifr Concurrency: Async Tasks and Structured Scopes"
-sidebarTitle: "Concurrency"
-description: "Write concurrent Sifr programs with sifr.task, sifr.sync, and sifr.parallel. Structured scopes, typed channels, and parallel maps — all ownership-safe."
+title: "Concurrency Overview"
+sidebarTitle: "Overview"
+description: "Understand Sifr's structured concurrency model: scoped tasks, explicit cancellation, ownership at task boundaries, and no global event loop."
 ---
 
-Sifr's concurrency model is built on structured concurrency: every task lives inside an explicit scope, and the scope does not exit until all child tasks have finished or been cancelled. There are no fire-and-forget tasks and no global event loops. The compiler enforces that values crossing task, thread, or process boundaries are owned and sendable — the same ownership rules that apply to the rest of the language.
-
-## Async Functions
-
-Declare an async function with `async def`. Call it with `await` inside another async function or an async scope.
-
-```python
-async def one() -> int:
-    await task.sleep(0.0)
-    return 1
-
-async def two() -> int:
-    await task.sleep(0.0)
-    return 2
-```
-
-Async functions that can fail return `Result[T, E]`:
-
-```python
-async def fail_fast() -> Result[int, ValueError]:
-    await task.sleep(0.0)
-    raise ValueError("group child failed")
-```
-
-## task.scope and Scoped Spawn
-
-Use `task.scope()` as an async context manager to create a structured scope. Spawn child tasks with `scope.spawn(...)`. The scope awaits all children before the `async with` block exits.
-
-```python
-async with task.scope() as scope:
-    gathered = await task.gather([scope.spawn(one()), scope.spawn(two())])
-```
-
-`task.gather` collects results in the order the handles were passed, preserving deterministic output ordering.
-
-<Note>
-Scoped spawn requires an active owner. Values that a spawned task captures must be **owned** and **sendable** across the task boundary. Lock guards, borrowed references, and other non-send resources are rejected at compile time.
-</Note>
-
-## task.select — Racing Tasks
-
-Use `task.select` to race two tasks against each other. The first task to finish wins; the compiler-generated runtime cancels the losing child automatically.
-
-```python
-async def fast() -> int:
-    await task.sleep(0.0)
-    return 10
-
-async def slow_writes_marker() -> int:
-    await task.sleep(0.20)
-    try:
-        _written: None = write_text(marker_path(), "not cancelled")
-    except IOError as e:
-        _message: str = str(e.message)
-    return 20
-
-async with task.scope() as scope:
-    selected = await task.select(
-        first=scope.spawn(fast()),
-        second=scope.spawn(slow_writes_marker()),
-    )
-```
-
-<Tip>
-`task.select` consumes both handles. Whichever child loses is cancelled before the scope exits, so you never observe a dangling task writing to shared state after the race.
-</Tip>
-
-## TaskGroup — Structured Error Propagation
-
-`task.TaskGroup` is the right tool when you want a group of tasks to run concurrently and you need to observe individual results. If one child fails, the `TaskGroup` cancels remaining siblings at scope exit.
-
-```python
-async with task.TaskGroup() as group:
-    slow = group.spawn(slow_writes_marker())
-    failing = group.spawn(fail_fast())
-    failure = await failing
-```
-
-`TaskHandle[T, E]` values are **linear**: awaiting or joining a handle consumes it. Attempting to await the same handle twice is a compile-time ownership error.
-
-<Warning>
-`TaskGroup` cancels unfinished siblings when any child fails. Do not rely on a sibling completing work after another child in the same group has raised an error.
-</Warning>
-
-## A Complete Structured Concurrency Example
-
-```python
-from sifr.io import exists, write_text
-from sifr.os import getpid, remove_file
-
-
-def marker_path() -> str:
-    return "/tmp/sifr_structured_concurrency_demo_" + str(getpid()) + ".txt"
-
-
-async def one() -> int:
-    await task.sleep(0.0)
-    return 1
-
-
-async def two() -> int:
-    await task.sleep(0.0)
-    return 2
-
-
-async def fast() -> int:
-    await task.sleep(0.0)
-    return 10
-
-
-async def slow_writes_marker() -> int:
-    await task.sleep(0.20)
-    try:
-        _written: None = write_text(marker_path(), "not cancelled")
-    except IOError as e:
-        _message: str = str(e.message)
-    return 20
-
-
-async def fail_fast() -> Result[int, ValueError]:
-    await task.sleep(0.0)
-    raise ValueError("group child failed")
-
-
-async def main() -> Result[None, Error]:
-    path: str = marker_path()
-    if exists(path):
-        try:
-            _removed_existing: None = remove_file(path)
-        except IOError as e:
-            _cleanup_message: str = str(e.message)
-
-    # Scoped gather: deterministic input ownership and ordering
-    async with task.scope() as scope:
-        gathered = await task.gather([scope.spawn(one()), scope.spawn(two())])
-
-    # Select: cancels the losing child
-    async with task.scope() as scope:
-        selected = await task.select(
-            first=scope.spawn(fast()),
-            second=scope.spawn(slow_writes_marker()),
-        )
-
-    # TaskGroup: cancels siblings when a child fails
-    async with task.TaskGroup() as group:
-        slow = group.spawn(slow_writes_marker())
-        failing = group.spawn(fail_fast())
-        failure = await failing
-
-    assert not exists(path)
-    return None
-```
-
-## sifr.sync — Shared State and Channels
-
-Use `sifr.sync` for same-process communication between tasks.
-
-<Tabs>
-  <Tab title="Channels">
-    Channels transfer **ownership** of values between tasks. Sending moves the value into the channel; receiving moves it back out.
-
-    ```python
-    from sifr.sync import channel
-
-    sender, receiver = channel()
-
-    async with task.scope() as scope:
-        scope.spawn(sender.send(42))
-        value = await receiver.receive()
-    ```
-
-    Use `bounded_channel(capacity)` for backpressure — sends block when the buffer is full.
-  </Tab>
-  <Tab title="Shared[T]">
-    `Shared[T]` wraps a value for concurrent read access by multiple tasks. Multiple tasks can hold a `Shared[T]` handle simultaneously without violating ownership rules.
-
-    ```python
-    from sifr.sync import Shared
-
-    counter: Shared[int] = Shared(0)
-    ```
-  </Tab>
-  <Tab title="Lock[T]">
-    `Lock[T]` provides exclusive mutable access. A `LockGuard` is returned when the lock is acquired, and it is released when the guard goes out of scope.
-
-    ```python
-    from sifr.sync import Lock
-
-    state: Lock[int] = Lock(0)
-    ```
-
-    Lock guards are scoped resources. Holding a guard across an `await` point is rejected by the compiler's ownership diagnostics.
-  </Tab>
-</Tabs>
-
-## sifr.parallel — CPU-Parallel Work
-
-Use `sifr.parallel` to distribute CPU-heavy work across native worker threads. `parallel.map` preserves output order; `parallel.try_map` returns a typed error when any item fails.
-
-```python
-from sifr.parallel import map as par_map
-
-results = par_map(items, heavy_compute)
-```
-
-<Note>
-Captured values and return values passed to `parallel.map` must satisfy worker-boundary ownership and sendability requirements. The same rules that apply to `task.scope` apply here.
-</Note>
-
-For more control, configure a `Pool` with `PoolConfig`:
-
-```python
-from sifr.parallel import Pool, PoolConfig
-
-config: PoolConfig = PoolConfig(workers=4)
-pool: Pool = Pool(config)
-results = pool.map(items, heavy_compute)
-```
-
-## Concurrency Modules at a Glance
-
-| Module | Purpose |
-|--------|---------|
-| `sifr.task` | Structured async tasks, scopes, gather, select, TaskGroup |
-| `sifr.sync` | Channels, `Shared[T]`, `Lock[T]`, `RwLock[T]`, `Semaphore`, `Notify` |
-| `sifr.parallel` | CPU-parallel `map`, `try_map`, and `Pool` |
-| `sifr.process` | Native subprocess spawning and I/O |
-| `sifr.signal` | Structured shutdown and signal handling |
-| `sifr.runtime` | Structured diagnostic events and observability |
-| `sifr.resource` | Deterministic cleanup helpers (`nullcontext`) |
-| `sifr.ipc` | Typed IPC substrate for future process workers |
+Sifr's concurrency model is structured: every task belongs to an explicit scope, and the scope cannot exit until its children have finished or been cancelled. There are no fire-and-forget tasks, no global event-loop object, and no hidden task registry.
+
+The compiler applies the same safety model at concurrency boundaries that it applies everywhere else. Values crossing task, thread, or process boundaries must be owned and sendable. Mutable borrows and lock guards stay scoped.
+
+## The Mental Model
+
+<CardGroup cols={2}>
+  <Card title="Async and Await" icon="timer" href="/concurrency/async-and-await">
+    Define async functions, await suspension points, and understand how Sifr differs from Python `asyncio`.
+  </Card>
+  <Card title="Structured Tasks" icon="workflow" href="/concurrency/structured-tasks">
+    Use scopes, spawned tasks, `gather`, `select`, and `TaskGroup`.
+  </Card>
+  <Card title="Cancellation and Timeouts" icon="clock-alert" href="/concurrency/cancellation-and-timeouts">
+    Bound work, observe cancellation evidence, and rely on cleanup before cancellation is surfaced.
+  </Card>
+  <Card title="Ownership Across Tasks" icon="shield-check" href="/concurrency/ownership-across-tasks">
+    Learn what can cross task boundaries and why borrowed values cannot escape.
+  </Card>
+</CardGroup>
+
+## What Is Different From Python
+
+Python `asyncio` exposes event loops, detached tasks, and ambient task registries. Sifr does not. Sifr makes the lifetime of concurrent work part of the source program.
+
+| Python habit | Sifr model |
+| --- | --- |
+| Create a background task and forget it | Spawn inside a scope that owns the child |
+| Reach for a global event loop | Use `async def`, `await`, and `sifr.task` scopes |
+| Share mutable objects between tasks | Move owned values, use channels, or use explicit sync primitives |
+| Treat cancellation as ambient | Observe typed cancellation or timeout evidence |
+
+## Where APIs Live
+
+This section explains the concepts. The API reference for `sifr.task`, `sifr.sync`, `sifr.parallel`, process helpers, signals, runtime diagnostics, and cleanup helpers lives in [Concurrency API](/stdlib/concurrency).
+
+## Related Pages
+
+<CardGroup cols={2}>
+  <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
+    Review `mut`, `own`, `own mut`, and borrowed-value escape rules.
+  </Card>
+  <Card title="Error Handling" icon="triangle-alert" href="/language/error-handling">
+    See how async functions report typed errors with `Result`.
+  </Card>
+  <Card title="Networking" icon="radio" href="/stdlib/networking">
+    Use async TCP, HTTP, TLS, and URL helpers.
+  </Card>
+  <Card title="Error Codes" icon="scan-search" href="/diagnostics/error-codes">
+    Look up `SIFR-ASYNC-*` and task-boundary ownership diagnostics.
+  </Card>
+</CardGroup>

--- a/docs/language/iteration.mdx
+++ b/docs/language/iteration.mdx
@@ -1,0 +1,103 @@
+---
+title: "Iteration in Sifr"
+sidebarTitle: "Iteration"
+description: "Use for loops, ranges, comprehensions, and safe collection iteration in Sifr."
+---
+
+Sifr keeps Python's readable loop syntax while enforcing ownership and type rules at compile time. Iteration is usually borrowed: you can loop over a collection without consuming it.
+
+## For Loops
+
+```python
+def total(values: list[int]) -> int:
+    result: int = 0
+    for value in values:
+        result = result + value
+    return result
+```
+
+The loop body sees each `value` as an `int`, and `values` remains usable after the loop.
+
+## Ranges
+
+Use `range` for counted loops.
+
+```python
+def factorial(n: int) -> int:
+    result: int = 1
+    for i in range(1, n + 1):
+        result = result * i
+    return result
+```
+
+Use `enumerate` when you need the index and the value together.
+
+```python
+def label(items: list[str]) -> list[str]:
+    result: list[str] = []
+    for index, item in enumerate(items):
+        result.append(str(index) + ": " + item)
+    return result
+```
+
+## Comprehensions
+
+List and dictionary comprehensions keep their Python shape.
+
+```python
+numbers: list[int] = [1, 2, 3, 4]
+squares: list[int] = [n * n for n in numbers]
+evens: list[int] = [n for n in numbers if n % 2 == 0]
+
+labels: dict[str, int] = {f"n{n}": n for n in numbers}
+```
+
+The result type is checked from the expression and the declared binding.
+
+## Optional Values While Iterating
+
+When a lookup can miss, handle `None` inside the loop before using the value.
+
+```python
+def sum_known(users: list[str], scores: dict[str, int]) -> int:
+    total: int = 0
+    for user in users:
+        score: int | None = scores[user]
+        if score is not None:
+            total = total + score
+    return total
+```
+
+## Mutation While Iterating
+
+Prefer building a new collection when transforming data.
+
+```python
+def positives(values: list[int]) -> list[int]:
+    return [value for value in values if value > 0]
+```
+
+Mutating a collection while iterating over it is a place where ownership rules matter. Keep mutation outside the loop, or write into a separate result collection.
+
+<Note>
+  If you know Python, this is stricter by design. Mutating the collection you are iterating over is an ownership constraint the compiler can reject instead of a runtime surprise.
+</Note>
+
+```python
+def doubled(values: list[int]) -> list[int]:
+    result: list[int] = []
+    for value in values:
+        result.append(value * 2)
+    return result
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Values and Collections" icon="braces" href="/language/values-and-collections">
+    Review the collection types that loops work with.
+  </Card>
+  <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
+    Learn when mutation needs `mut`, `own`, or `own mut`.
+  </Card>
+</CardGroup>

--- a/docs/language/values-and-collections.mdx
+++ b/docs/language/values-and-collections.mdx
@@ -1,0 +1,128 @@
+---
+title: "Values and Collections in Sifr"
+sidebarTitle: "Values and Collections"
+description: "Learn Sifr's everyday values: exact integers, strings, None, lists, dictionaries, tuples, sets, truthiness, and mutation."
+---
+
+Most Sifr programs use familiar Python-shaped values: numbers, strings, `None`, lists, dictionaries, tuples, and sets. The difference is that every value has a compile-time type and every missing-value path is visible in that type.
+
+## Scalars
+
+| Type | Use it for |
+| --- | --- |
+| `int` | Ordinary exact integer arithmetic |
+| `float` | 64-bit floating-point values |
+| `bool` | `True` or `False` |
+| `str` | UTF-8 text |
+| `None` | Absence of a value |
+
+```python
+count: int = 3
+ratio: float = 0.5
+ready: bool = True
+name: str = "sifr"
+missing: None = None
+```
+
+`int` is the source-level integer you reach for by default. Use explicit fixed-width integer types when storage layout, binary protocols, FFI, or dtype-sensitive work requires a specific representation: `int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, `uint64`, `isize`, and `usize`.
+
+## Optional Values
+
+Use `T | None` when a value might be absent. Sifr requires you to check `None` before using the inner value.
+
+```python
+def describe_age(age: int | None) -> str:
+    if age is not None:
+        return f"age: {age}"
+    return "age unknown"
+```
+
+Dictionary and sequence operations that can miss use this same shape.
+
+```python
+scores: dict[str, int] = {"alice": 42}
+maybe_score: int | None = scores["bob"]
+
+if maybe_score is not None:
+    print(maybe_score + 1)
+```
+
+## Lists
+
+Lists are ordered, mutable collections.
+
+```python
+numbers: list[int] = [1, 2, 3]
+first: int | None = numbers[0]
+```
+
+Mutating a list through a function parameter requires `mut`.
+
+```python
+def append_zero(mut values: list[int]) -> None:
+    values.append(0)
+```
+
+For the full parameter model, see [Ownership and Mutability](/language/ownership).
+
+## Dictionaries
+
+Dictionaries map keys to values. Lookup results are typed so a missing key cannot crash later.
+
+```python
+users: dict[str, int] = {"alice": 30, "bob": 25}
+age: int | None = users["charlie"]
+```
+
+<Note>
+  If you know Python, this is an intentional difference: `dict["missing"]` returns `None` in Sifr instead of raising `KeyError`.
+</Note>
+
+When you need module-level helpers such as `Counter` or `deque`, use [Collections](/stdlib/collections).
+
+## Tuples
+
+Tuples group a fixed shape of values.
+
+```python
+point: tuple[int, int] = (10, 20)
+name_and_score: tuple[str, int] = ("alice", 42)
+```
+
+Use a tuple when the position of each value has meaning and the shape is known.
+
+## Sets
+
+Sifr's set helpers live in `sifr.collections` and return deduplicated list values. This keeps ownership straightforward while still giving you set operations.
+
+```python
+from sifr.collections import set_from_list, set_intersection
+
+left: list[int] = set_from_list([1, 2, 2, 3])
+right: list[int] = set_from_list([3, 4])
+common: list[int] = set_intersection(left, right)
+```
+
+## Truthiness
+
+Collections can be checked directly for emptiness.
+
+```python
+def summarize(items: list[str]) -> str:
+    if not items:
+        return "empty"
+    return f"{len(items)} items"
+```
+
+Truthiness is a convenience for branching. It does not replace typed `None` handling when a value is optional.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Iteration" icon="repeat" href="/language/iteration">
+    Learn loops, comprehensions, and safe iteration patterns.
+  </Card>
+  <Card title="Collections" icon="boxes" href="/stdlib/collections">
+    Use `Counter`, `deque`, and set helpers from `sifr.collections`.
+  </Card>
+</CardGroup>

--- a/docs/stdlib/collections.mdx
+++ b/docs/stdlib/collections.mdx
@@ -34,6 +34,8 @@ def append_all(mut target: list[bool], values: list[bool]):
         target.append(value)
 ```
 
+For the core language model behind lists, dictionaries, optional values, and iteration, see [Values and Collections](/language/values-and-collections) and [Iteration](/language/iteration).
+
 ## Dicts and Tuples
 
 `dict[K, V]` and `tuple[T, ...]` are built-in types. Dict literals and comprehensions work exactly as in Python:

--- a/docs/stdlib/concurrency.mdx
+++ b/docs/stdlib/concurrency.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Concurrency Primitives: Tasks, Channels, and Parallelism"
-sidebarTitle: "Concurrency"
+sidebarTitle: "Concurrency API"
 description: "Concurrency API reference for Sifr: structured tasks, typed channels, CPU parallelism, subprocesses, runtime diagnostics, and cleanup helpers."
 ---
 
 Sifr's concurrency modules are a native structured-concurrency substrate that compiles to Rust's async runtime. Unlike CPython's `asyncio`, there is no exposed event-loop object, no global task registry, and no fire-and-forget detachment. Every task belongs to a scope, every value that crosses a task boundary must be owned and sendable, and every error is a typed value you handle explicitly.
 
-This page is the stdlib reference for concurrency. For an introduction to the concepts — ownership at task boundaries, the structured-scope model, and how Sifr's concurrency compares to CPython's — see the Language / Concurrency guide.
+This page is the stdlib reference for concurrency. For the concepts behind scopes, task-boundary ownership, cancellation, and Python `asyncio` differences, start with [Concurrency Overview](/language/concurrency).
 
 ## `sifr.task` — Structured Tasks
 
@@ -33,8 +33,6 @@ async def main() -> None:
 Bound the runtime of any awaitable expression using `task.timeout` (duration-based) or `task.deadline` (absolute time):
 
 ```python
-from sifr.task import TaskGroup
-
 async def fetch_with_timeout(url: str) -> bytes:
     try:
         async with task.timeout(5.0):
@@ -45,14 +43,15 @@ async def fetch_with_timeout(url: str) -> bytes:
 
 ### TaskGroup
 
-`TaskGroup` collects a set of tasks and waits for all of them, propagating the first error:
+`TaskGroup` collects a set of tasks and waits for all of them, propagating the first error. Use it as an async context manager:
 
 ```python
 async def run_all() -> None:
-    group: TaskGroup = TaskGroup()
-    group.spawn(job_one())
-    group.spawn(job_two())
-    await group.join()
+    async with task.TaskGroup() as group:
+        first = group.spawn(job_one())
+        second = group.spawn(job_two())
+        first_result = await first
+        second_result = await second
 ```
 
 ### Context Propagation

--- a/docs/stdlib/networking.mdx
+++ b/docs/stdlib/networking.mdx
@@ -52,7 +52,7 @@ async def echo_server(port: int) -> None:
 ```
 
 <Note>
-Network operations consume Sifr's concurrency runtime for cancellation, deadlines, and backpressure. Use `task.scope()` or `task.timeout()` from `sifr.task` to bound the lifetime of network operations.
+Network operations consume Sifr's concurrency runtime for cancellation, deadlines, and backpressure. Use `task.scope()` or `task.timeout()` from `sifr.task` to bound the lifetime of network operations. See [Concurrency Overview](/language/concurrency) for the structured task model.
 </Note>
 
 ## TLS with `sifr.tls`

--- a/docs/stdlib/overview.mdx
+++ b/docs/stdlib/overview.mdx
@@ -90,7 +90,7 @@ If a real user-defined or third-party top-level module named `math`, `json`, or 
 
 | Module | Description |
 |---|---|
-| `sifr.task` | Structured task management: `TaskGroup`, `TaskHandle[T, E]`, scoped `spawn`, `timeout`, `deadline`, `join`, `race`, and `select`. |
+| `sifr.task` | Structured task management: `TaskGroup`, `TaskHandle[T, E]`, scoped `spawn`, `timeout`, `deadline`, `gather`, and `select`. |
 | `sifr.sync` | Same-process synchronization: `Shared[T]`, `channel`, `bounded_channel`, `Lock`, `RwLock`, `Semaphore`, and `Notify`. |
 | `sifr.parallel` | CPU-parallel map over owned data: `map`, `try_map`, `Pool`, and `PoolConfig`. |
 | `sifr.runtime` | Structured runtime diagnostics: `DiagnosticEvent`, `DiagnosticLevel`, `emit_diagnostic`, and `DiagnosticError`. |

--- a/plans/issues/active/ad-hoc-documentation-learning-path.md
+++ b/plans/issues/active/ad-hoc-documentation-learning-path.md
@@ -21,7 +21,8 @@ Review artifacts:
 
 Implementation status:
 
-- Wave 1: Ready for PR after Sonnet review. Scope: navigation foundation, `From Python`, `Status`, `Ownership and Mutability`, Slice 0 semantic fixes, and audience guide route placeholders. Validation: `cd docs && npx mint@latest validate` passed.
+- Wave 1: Merged in PR #2656. Scope: navigation foundation, `From Python`, `Status`, `Ownership and Mutability`, Slice 0 semantic fixes, and audience guide route placeholders. Validation: `cd docs && npx mint@latest validate` passed.
+- Wave 2: In progress. Scope: core data model pages and dedicated Concurrency concept section.
 
 ## Objective
 

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-2-sonnet-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-2-sonnet-review-pass-1.md
@@ -1,0 +1,115 @@
+Now I have everything I need. Here is the review.
+
+---
+
+## Wave 2 Review
+
+### Slice 2 — Core Data Model
+
+**Pass, with one notable gap.**
+
+`values-and-collections.mdx` and `iteration.mdx` are clean, accurate, and well-placed before the Standard Library group in the sidebar. Information architecture is correct — language pages own the model, stdlib/collections.mdx owns Counter/deque, cross-links are in the right direction.
+
+**Gap: fixed-width integer type names are missing** (`values-and-collections.mdx:27`)
+
+> "Use explicit fixed-width integer types when storage layout, binary protocols, FFI, or dtype-sensitive work requires a specific representation."
+
+The acceptance criteria says "at a high level." This sentence explains *when* but not *what*. A reader who needs `i32` or `u64` for a binary protocol has no idea what to type. Add the type names and a link to wherever they're documented. One sentence, not a section.
+
+**Suggestion: no Python callouts in either new page**
+
+The issue plan (Gap #5, content principle #2) calls for `<Note>` callouts on pages where Python developers would infer the wrong thing. Two places where they'd be valuable:
+- `values-and-collections.mdx` Dictionaries section: "If you know Python, `dict["missing"]` here returns `None` instead of raising `KeyError`." One sentence, no table needed.
+- `iteration.mdx` Mutation While Iterating: "In Python this is undefined behavior; in Sifr it's an ownership constraint the compiler enforces." Not critical, but this is the most surprising difference on the page.
+
+**Suggestion: `iteration.mdx` has no mention of `enumerate`**
+
+It's the most common Python loop pattern after plain `for`. If it's supported, show it. If it's not, a single sentence saying so prevents a common frustration.
+
+---
+
+### Slice 3 — Concurrency Section
+
+**Pass, with one blocker.**
+
+The overall structure is correct: Overview is a concise mental-model entry point, four concept pages stay concept-level, Channels/Parallel/Processes are correctly deferred, the sidebar group sits between Learn Sifr and Standard Library, `sidebarTitle: "Concurrency API"` is in place, and the stdlib reference correctly opens with a back-link to the Overview.
+
+---
+
+#### Blocker: `TaskGroup` API shape conflicts between `stdlib/concurrency.mdx` and the concept page + demo
+
+`structured-tasks.mdx` shows the context-manager form (which matches `demos/structured_concurrency_demo/main.sifr` line 58):
+
+```python
+async with task.TaskGroup() as group:
+    slow = group.spawn(slow_writes_marker())
+    failing = group.spawn(fail_fast())
+    failure = await failing
+```
+
+`stdlib/concurrency.mdx` shows a completely different form:
+
+```python
+group: TaskGroup = TaskGroup()
+group.spawn(job_one())
+group.spawn(job_two())
+await group.join()
+```
+
+One of these is wrong. The demo compiles and runs, so the context-manager form is authoritative. The stdlib page's `group.join()` pattern needs to be reconciled. This inconsistency was pre-existing in the stdlib reference, but it's now directly exposed because the concept page and stdlib page sit next to each other in the same sidebar section.
+
+---
+
+#### Suggestion: `task` namespace needs one explanatory note
+
+The demo confirms `task` is available without an import — `task.sleep`, `task.scope`, `task.gather`, `task.select`, `task.TaskGroup` are all used with no `import` statement in the demo. The concept pages correctly match this. But the stdlib reference shows `from sifr.task import TaskGroup`, which implies explicit import. This confuses the picture.
+
+A single note in `async-and-await.mdx` (the first page where `task.sleep` appears) would close this: "The `task` namespace is available without an import in any async Sifr program." Then the stdlib page showing an explicit import can be disambiguated on the stdlib side.
+
+---
+
+#### Suggestion: `ownership-across-tasks.mdx` Mutable Borrows section shows the permitted case only
+
+The section heading promises a constraint, but the example shows only what compiles:
+
+```python
+def append_before_await(mut items: list[int]) -> None:
+    items.append(2)
+    return None          # borrow ends here
+
+async def main() -> ...:
+    values: list[int] = [1]
+    append_before_await(values)  # fine — borrow is done
+    await task.sleep(0.0)        # await is after the borrow
+```
+
+The teaching moment is what the compiler *rejects* — e.g., holding a `mut` borrow across an `await` or storing a borrowed reference into a spawned task. Show the rejected shape first, then the fix. The current example is accurate but doesn't actually demonstrate the constraint.
+
+---
+
+#### Suggestion: `async-and-await.mdx` is thin; `blocking_offload` concept is absent
+
+The page is 62 lines. The issue plan calls out `blocking_offload_demo` as source material. The most common asyncio mistake Python developers carry over is blocking the runtime with CPU-heavy work. A single section on "offloading CPU work" — pointing to `sifr.parallel` or `task.spawn_blocking` — would close the gap the issue identified and make this page complete enough to stand alone.
+
+---
+
+#### Minor: `structured-tasks.mdx` `select` snippet has no type annotations
+
+The `selected` binding in the `select` example is untyped, inconsistent with the style of every other snippet on the page.
+
+---
+
+### Summary
+
+| Finding | Severity | File |
+|---|---|---|
+| `TaskGroup` API mismatch: stdlib reference contradicts demo/concept page | **Blocker** | `stdlib/concurrency.mdx` |
+| Fixed-width integer type names not given | Gap (AC) | `values-and-collections.mdx:27` |
+| `task` builtin status not stated | Suggestion | `concurrency/async-and-await.mdx` |
+| Mutable Borrows example shows permitted case, not the rejected constraint | Suggestion | `concurrency/ownership-across-tasks.mdx` |
+| Blocking offload concept absent | Suggestion | `concurrency/async-and-await.mdx` |
+| No Python callouts in new language pages | Suggestion | `values-and-collections.mdx`, `iteration.mdx` |
+| `enumerate` not mentioned in iteration page | Suggestion | `iteration.mdx` |
+| `select` snippet missing type annotation | Minor | `concurrency/structured-tasks.mdx` |
+
+The implementation is otherwise well-structured and accurate. The blocker is in the pre-existing stdlib reference page, not in the new concept pages.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-2-sonnet-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-2-sonnet-review-pass-2.md
@@ -1,0 +1,25 @@
+Now I have a complete picture. Here is the review summary:
+
+---
+
+## Wave 2 Review — Findings
+
+### One confirmed blocker
+
+**`docs/stdlib/overview.mdx` line 93** lists `join` and `race` as `sifr.task` APIs. The actual implementations in demos and the concurrency docs use `gather` and `select`. `join` and `race` do not exist anywhere in the codebase. This is a factual error in the stdlib overview that will mislead readers looking for the right function names.
+
+The fix is a one-line correction: replace `join`, `race`, and `select` with `gather` and `select`.
+
+---
+
+### Confirmed non-issues (agent findings that don't hold up)
+
+- **`task.gather` and `task.select` not in stdlib/concurrency.mdx** — these are intentionally documented in the language section (`docs/concurrency/structured-tasks.mdx`), which is the correct home for concept-level API explanations. `stdlib/concurrency.mdx` is the reference page and the `structured-tasks.mdx` page links to it. Not a gap.
+- **`task.sleep` undocumented in stdlib** — `task.sleep` is straightforwardly defined and used in demos; it's an obvious API. Its absence from the stdlib reference page is fine.
+- **`task.deadline` missing an example** — the text covers it descriptively alongside `task.timeout`; this is acceptable for a reference page.
+
+---
+
+### Verdict
+
+**Wave 2 is not yet ready for PR.** There is one blocker: `docs/stdlib/overview.mdx` line 93 claims `task.join` and `task.race` exist — they do not. The correct names are `task.gather` and `task.select`. That single line needs to be corrected before opening the PR.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-2-sonnet-review-pass-3.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-2-sonnet-review-pass-3.md
@@ -1,0 +1,3 @@
+The pass-2 review identified exactly one blocker (`join`/`race` → `gather`/`select` in overview.mdx line 93), which you've confirmed is now fixed. The pass-3 file was created but left empty — that's just a stub artifact, not a pending finding.
+
+**Wave 2 is ready for PR.** The single confirmed blocker has been fixed, validation passed, and the three confirmed non-issues from pass-2 stand. No other blockers remain.


### PR DESCRIPTION
## Summary
- Add core data model pages for values, collections, and iteration.
- Split concurrency into a concept section covering async/await, structured tasks, cancellation, and ownership across tasks.
- Update stdlib cross-links and record Sonnet medium review passes for Wave 2.

## Review
- Claude Sonnet medium review pass 1 found API/style gaps; addressed them.
- Claude Sonnet medium review pass 2 found the stdlib overview task API mismatch; fixed it.
- Claude Sonnet medium review pass 3 marked Wave 2 PR-ready.

## Validation
- `export PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH"; cd docs && npx mint@latest validate`

No Rust tests run per request.