### PR TITLE
[codex] Publish reference and error code docs

### DIFF
--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,5 +1,5 @@
 # Internal compiler reference (not published on docs.sifr.sh yet).
-errors/
+errors/*.md
 schemas/
 cli_command_semantics.md
 concurrency_runtime.md

--- a/docs/cli/packages-workspaces.mdx
+++ b/docs/cli/packages-workspaces.mdx
@@ -1,0 +1,109 @@
+---
+title: "Sifr CLI Package and Workspace Commands"
+sidebarTitle: "Packages and Workspaces"
+description: "Reference for Sifr package, workspace, dependency, publishing, vendoring, and self-update commands."
+---
+
+Sifr's package commands are Cargo-compatible where that matters, but they preserve Sifr's stricter source ownership rules. Use them when you are working with `sifr.toml`, Sifr-aware Cargo metadata, or workspace package selection.
+
+## Dependency and Workspace Commands
+
+| Command | Purpose |
+| --- | --- |
+| `sifr init [PATH]` | Create a new Sifr package in `PATH` or the current directory. |
+| `sifr fetch` | Fetch package dependencies without building. |
+| `sifr repair` | Repair Sifr-managed Cargo projection drift. |
+| `sifr tree` | Print the package dependency tree with Cargo-compatible tree options. |
+| `sifr package` | Assemble and verify a package archive. |
+| `sifr publish` | Publish a Sifr package through Cargo, or validate with `--dry-run`. |
+| `sifr vendor [PATH]` | Vendor dependency sources into `PATH`, defaulting to `vendor`. |
+
+<Tip>
+Use `--locked`, `--offline`, or `--frozen` on dependency-sensitive commands when you need reproducible package behavior.
+</Tip>
+
+## Create a Package
+
+```bash
+sifr init hello --bin
+sifr init math-lib --lib --name math-lib
+```
+
+`sifr init` creates missing Sifr-owned package files. Pass `--force` to create missing owned files without overwriting existing user files.
+
+## Check or Repair Projection Drift
+
+```bash
+sifr repair --check
+sifr repair
+```
+
+`--check` reports drift without writing. Without `--check`, Sifr repairs the Sifr-managed Cargo projection files.
+
+## Select Workspace Packages
+
+Commands such as `check`, `package`, `publish`, and `run` accept Cargo-shaped package selection:
+
+```bash
+sifr check --workspace
+sifr check -p app
+sifr package --workspace --exclude experimental
+sifr publish -p math-lib --dry-run
+```
+
+<Warning>
+Sifr rejects ambiguous package selections and duplicate Sifr package names. Fix the workspace metadata instead of relying on implicit selection.
+</Warning>
+
+## Package and Publish
+
+```bash
+sifr package --list
+sifr package --no-verify --allow-dirty
+sifr publish --dry-run
+```
+
+`sifr package` validates the archive shape before publishing. `sifr publish --dry-run` runs the publish path without uploading.
+
+## Vendor Dependencies
+
+```bash
+sifr vendor vendor
+sifr vendor vendor --sync other/Cargo.toml --versioned-dirs
+```
+
+Vendoring delegates dependency source collection to Cargo while preserving Sifr's package diagnostics and lock-mode flags.
+
+## Self Update
+
+```bash
+sifr self version
+sifr self version --short
+sifr self version --format json
+
+sifr self update
+sifr self update --dry-run
+sifr self update --dry-run --format json
+sifr self update --channel nightly
+sifr self update --version 0.4.0-preview.2 --force
+```
+
+`sifr self update --dry-run` prints the resolved plan without running the installer. Use `--channel` to resolve the latest preview for a channel, `--version` for one immutable preview version, and `--force` for an intentional reinstall, downgrade, or channel switch.
+
+<Note>
+`--format json` is accepted for `sifr self update` only with `--dry-run`. `sifr self version --short` cannot be combined with `--format json`.
+</Note>
+
+The standalone installer records an update receipt. If that receipt is missing or outside the install rules, Sifr reports a build-family diagnostic instead of guessing which files are safe to modify.
+
+## Global Diagnostic Flags
+
+Every command accepts the global diagnostic controls:
+
+```bash
+sifr --diagnostic-format compact check src/main.sifr
+sifr --diagnostic-format json check --workspace
+sifr --explain SIFR-IMPORT-0008
+```
+
+See [Diagnostics](/diagnostics/overview) and [Error Codes](/diagnostics/error-codes) for renderer behavior and per-code references.

--- a/docs/diagnostics/error-codes.mdx
+++ b/docs/diagnostics/error-codes.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Sifr Diagnostic Code Reference for All Error Families"
 sidebarTitle: "Error Codes"
-description: "A complete reference of all 24 Sifr diagnostic code families, with every active code, its severity, and a concise description of what it means."
+description: "A complete reference for Sifr's 23 active diagnostic code families plus the reserved CODEGEN family."
 ---
 
-Sifr organizes every diagnostic into a named family. Each code follows the format `SIFR-<FAMILY>-dddd`, where the four-digit number is scoped within its family. This page lists all 24 families and every active code in each one. Use `sifr --explain <CODE>` in your terminal to get full detail, message templates, and fix guidance for any specific code.
+Sifr organizes every diagnostic into a named family. Each code follows the format `SIFR-<FAMILY>-dddd`, where the four-digit number is scoped within its family. This page lists every active diagnostic family and links each code to a dedicated reference page. Use `sifr --explain <CODE>` in your terminal to get the exact renderer template and suggestions for your installed compiler version.
 
 <Accordion title="PARSE — Parsing and source syntax">
 
@@ -12,14 +12,14 @@ The `PARSE` family covers errors that the parser encounters before any semantic 
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-PARSE-0002` | Error | Expected token or generic parser recovery failure. |
-| `SIFR-PARSE-0003` | Error | Lexical or interpolated string parser failure. |
-| `SIFR-PARSE-0004` | Error | Indentation or same-line statement layout parser failure. |
-| `SIFR-PARSE-0005` | Error | Invalid assignment, delete, starred, or named-expression target syntax. |
-| `SIFR-PARSE-0006` | Error | Invalid call argument order or unpacking syntax. |
-| `SIFR-PARSE-0007` | Error | Empty or malformed declaration list syntax. |
-| `SIFR-PARSE-0008` | Error | Invalid match-pattern syntax. |
-| `SIFR-PARSE-0009` | Error | Unsupported parser syntax or interactive-only syntax. |
+| [`SIFR-PARSE-0002`](/errors/SIFR-PARSE-0002) | Error | Expected token or generic parser recovery failure. |
+| [`SIFR-PARSE-0003`](/errors/SIFR-PARSE-0003) | Error | Lexical or interpolated string parser failure. |
+| [`SIFR-PARSE-0004`](/errors/SIFR-PARSE-0004) | Error | Indentation or same-line statement layout parser failure. |
+| [`SIFR-PARSE-0005`](/errors/SIFR-PARSE-0005) | Error | Invalid assignment, delete, starred, or named-expression target syntax. |
+| [`SIFR-PARSE-0006`](/errors/SIFR-PARSE-0006) | Error | Invalid call argument order or unpacking syntax. |
+| [`SIFR-PARSE-0007`](/errors/SIFR-PARSE-0007) | Error | Empty or malformed declaration list syntax. |
+| [`SIFR-PARSE-0008`](/errors/SIFR-PARSE-0008) | Error | Invalid match-pattern syntax. |
+| [`SIFR-PARSE-0009`](/errors/SIFR-PARSE-0009) | Error | Unsupported parser syntax or interactive-only syntax. |
 
 </Accordion>
 
@@ -29,12 +29,12 @@ The `NAME` family covers errors that arise when the compiler cannot resolve an i
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-NAME-0001` | Error | Undefined variable. |
-| `SIFR-NAME-0002` | Error | Undefined function or callable. |
-| `SIFR-NAME-0003` | Error | Unknown type or generic type name. |
-| `SIFR-NAME-0004` | Error | Missing module or class member. |
-| `SIFR-NAME-0005` | Error | Duplicate function definition in a module. |
-| `SIFR-NAME-0006` | Error | Variable declaration lacks a required initializer. |
+| [`SIFR-NAME-0001`](/errors/SIFR-NAME-0001) | Error | Undefined variable. |
+| [`SIFR-NAME-0002`](/errors/SIFR-NAME-0002) | Error | Undefined function or callable. |
+| [`SIFR-NAME-0003`](/errors/SIFR-NAME-0003) | Error | Unknown type or generic type name. |
+| [`SIFR-NAME-0004`](/errors/SIFR-NAME-0004) | Error | Missing module or class member. |
+| [`SIFR-NAME-0005`](/errors/SIFR-NAME-0005) | Error | Duplicate function definition in a module. |
+| [`SIFR-NAME-0006`](/errors/SIFR-NAME-0006) | Error | Variable declaration lacks a required initializer. |
 
 </Accordion>
 
@@ -44,15 +44,15 @@ The `IMPORT` family covers errors that occur when resolving `import` and `from �
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-IMPORT-0001` | Error | Forbidden intrinsic import. |
-| `SIFR-IMPORT-0002` | Error | Unknown source module import target. |
-| `SIFR-IMPORT-0003` | Error | Unsupported import statement form. |
-| `SIFR-IMPORT-0004` | Error | Private module member import. |
-| `SIFR-IMPORT-0005` | Error | Ambiguous source module import target. |
-| `SIFR-IMPORT-0006` | Error | Source module namespace and file import collision. |
-| `SIFR-IMPORT-0007` | Error | Circular source module import graph. |
-| `SIFR-IMPORT-0008` | Error | Bare CPython-style stdlib import attempt. |
-| `SIFR-IMPORT-0009` | Error | Unsupported legacy Sifr stdlib module import. |
+| [`SIFR-IMPORT-0001`](/errors/SIFR-IMPORT-0001) | Error | Forbidden intrinsic import. |
+| [`SIFR-IMPORT-0002`](/errors/SIFR-IMPORT-0002) | Error | Unknown source module import target. |
+| [`SIFR-IMPORT-0003`](/errors/SIFR-IMPORT-0003) | Error | Unsupported import statement form. |
+| [`SIFR-IMPORT-0004`](/errors/SIFR-IMPORT-0004) | Error | Private module member import. |
+| [`SIFR-IMPORT-0005`](/errors/SIFR-IMPORT-0005) | Error | Ambiguous source module import target. |
+| [`SIFR-IMPORT-0006`](/errors/SIFR-IMPORT-0006) | Error | Source module namespace and file import collision. |
+| [`SIFR-IMPORT-0007`](/errors/SIFR-IMPORT-0007) | Error | Circular source module import graph. |
+| [`SIFR-IMPORT-0008`](/errors/SIFR-IMPORT-0008) | Error | Bare CPython-style stdlib import attempt. |
+| [`SIFR-IMPORT-0009`](/errors/SIFR-IMPORT-0009) | Error | Unsupported legacy Sifr stdlib module import. |
 
 <Note>
 `SIFR-IMPORT-0008` fires when you write `from math import floor` instead of `from sifr.math import floor`. Sifr's standard library lives under the `sifr.*` namespace.
@@ -66,19 +66,19 @@ The `TYPE` family covers type system violations detected during static analysis 
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-TYPE-0002` | Error | Expected and actual types are incompatible. |
-| `SIFR-TYPE-0003` | Error | If-expression or conditional branches have incompatible types. |
-| `SIFR-TYPE-0004` | Error | A required type annotation is missing. |
-| `SIFR-TYPE-0005` | Error | Unsupported operator or operand types. |
-| `SIFR-TYPE-0006` | Error | Int and bigint are mixed without an explicit conversion. |
-| `SIFR-TYPE-0007` | Error | Invalid type annotation shape. |
-| `SIFR-TYPE-0008` | Error | Container literal elements, keys, or values have conflicting types. |
-| `SIFR-TYPE-0009` | Error | Tuple or list unpacking shape mismatch. |
-| `SIFR-TYPE-0010` | Error | TypeVar constraints are not satisfied by the inferred concrete type. |
-| `SIFR-TYPE-0011` | Error | Unsupported default argument expression. |
-| `SIFR-TYPE-0012` | Error | Unsupported expression form. |
-| `SIFR-TYPE-0901` | Warning | Integer arithmetic may overflow at runtime. |
-| `SIFR-TYPE-0902` | Note | Reveal the inferred static type of an expression. |
+| [`SIFR-TYPE-0002`](/errors/SIFR-TYPE-0002) | Error | Expected and actual types are incompatible. |
+| [`SIFR-TYPE-0003`](/errors/SIFR-TYPE-0003) | Error | If-expression or conditional branches have incompatible types. |
+| [`SIFR-TYPE-0004`](/errors/SIFR-TYPE-0004) | Error | A required type annotation is missing. |
+| [`SIFR-TYPE-0005`](/errors/SIFR-TYPE-0005) | Error | Unsupported operator or operand types. |
+| [`SIFR-TYPE-0006`](/errors/SIFR-TYPE-0006) | Error | Int and bigint are mixed without an explicit conversion. |
+| [`SIFR-TYPE-0007`](/errors/SIFR-TYPE-0007) | Error | Invalid type annotation shape. |
+| [`SIFR-TYPE-0008`](/errors/SIFR-TYPE-0008) | Error | Container literal elements, keys, or values have conflicting types. |
+| [`SIFR-TYPE-0009`](/errors/SIFR-TYPE-0009) | Error | Tuple or list unpacking shape mismatch. |
+| [`SIFR-TYPE-0010`](/errors/SIFR-TYPE-0010) | Error | TypeVar constraints are not satisfied by the inferred concrete type. |
+| [`SIFR-TYPE-0011`](/errors/SIFR-TYPE-0011) | Error | Unsupported default argument expression. |
+| [`SIFR-TYPE-0012`](/errors/SIFR-TYPE-0012) | Error | Unsupported expression form. |
+| [`SIFR-TYPE-0901`](/errors/SIFR-TYPE-0901) | Warning | Integer arithmetic may overflow at runtime. |
+| [`SIFR-TYPE-0902`](/errors/SIFR-TYPE-0902) | Note | Reveal the inferred static type of an expression. |
 
 </Accordion>
 
@@ -88,13 +88,13 @@ The `ASYNC` family covers violations of Sifr's async effect system. Sifr tracks 
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-ASYNC-0001` | Error | Async function body has no real suspension effect. |
-| `SIFR-ASYNC-0002` | Error | Awaited same-task coroutine has no real suspension effect. |
-| `SIFR-ASYNC-0003` | Error | Blocking I/O function called directly from async context. |
-| `SIFR-ASYNC-0004` | Error | CPU-heavy function called directly from async context. |
-| `SIFR-ASYNC-0005` | Error | Blocking offload target is not classified as blocking I/O or CPU-heavy work. |
-| `SIFR-ASYNC-0006` | Error | Synchronous workload annotation applied to async function. |
-| `SIFR-ASYNC-0007` | Error | Shell execution function called directly from async context. |
+| [`SIFR-ASYNC-0001`](/errors/SIFR-ASYNC-0001) | Error | Async function body has no real suspension effect. |
+| [`SIFR-ASYNC-0002`](/errors/SIFR-ASYNC-0002) | Error | Awaited same-task coroutine has no real suspension effect. |
+| [`SIFR-ASYNC-0003`](/errors/SIFR-ASYNC-0003) | Error | Blocking I/O function called directly from async context. |
+| [`SIFR-ASYNC-0004`](/errors/SIFR-ASYNC-0004) | Error | CPU-heavy function called directly from async context. |
+| [`SIFR-ASYNC-0005`](/errors/SIFR-ASYNC-0005) | Error | Blocking offload target is not classified as blocking I/O or CPU-heavy work. |
+| [`SIFR-ASYNC-0006`](/errors/SIFR-ASYNC-0006) | Error | Synchronous workload annotation applied to async function. |
+| [`SIFR-ASYNC-0007`](/errors/SIFR-ASYNC-0007) | Error | Shell execution function called directly from async context. |
 
 </Accordion>
 
@@ -104,14 +104,14 @@ The `DECIMAL` family covers errors in Sifr's `Decimal` and `BigDecimal` numeric 
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-DECIMAL-0001` | Error | Invalid `Decimal` exact literal. |
-| `SIFR-DECIMAL-0002` | Error | Invalid `BigDecimal` exact literal. |
-| `SIFR-DECIMAL-0003` | Error | Float mixed with a decimal numeric type. |
-| `SIFR-DECIMAL-0004` | Error | `Decimal` and `BigDecimal` mixed in one operation. |
-| `SIFR-DECIMAL-0005` | Error | `Decimal` float construction or conversion is forbidden. |
-| `SIFR-DECIMAL-0006` | Error | `BigDecimal` float construction or conversion is forbidden. |
-| `SIFR-DECIMAL-0007` | Error | `Decimal` scale argument is invalid. |
-| `SIFR-DECIMAL-0008` | Error | `BigDecimal` scale or context argument is invalid. |
+| [`SIFR-DECIMAL-0001`](/errors/SIFR-DECIMAL-0001) | Error | Invalid `Decimal` exact literal. |
+| [`SIFR-DECIMAL-0002`](/errors/SIFR-DECIMAL-0002) | Error | Invalid `BigDecimal` exact literal. |
+| [`SIFR-DECIMAL-0003`](/errors/SIFR-DECIMAL-0003) | Error | Float mixed with a decimal numeric type. |
+| [`SIFR-DECIMAL-0004`](/errors/SIFR-DECIMAL-0004) | Error | `Decimal` and `BigDecimal` mixed in one operation. |
+| [`SIFR-DECIMAL-0005`](/errors/SIFR-DECIMAL-0005) | Error | `Decimal` float construction or conversion is forbidden. |
+| [`SIFR-DECIMAL-0006`](/errors/SIFR-DECIMAL-0006) | Error | `BigDecimal` float construction or conversion is forbidden. |
+| [`SIFR-DECIMAL-0007`](/errors/SIFR-DECIMAL-0007) | Error | `Decimal` scale argument is invalid. |
+| [`SIFR-DECIMAL-0008`](/errors/SIFR-DECIMAL-0008) | Error | `BigDecimal` scale or context argument is invalid. |
 
 </Accordion>
 
@@ -121,13 +121,13 @@ The `INT` family covers errors in Sifr's exact integer (`int`) and fixed-width i
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-INT-0001` | Error | Fixed-width integer literal or const expression is out of range. |
-| `SIFR-INT-0003` | Error | Reserved integer width name used before support lands. |
-| `SIFR-INT-0004` | Error | Compile-time integer evaluation budget exceeded. |
-| `SIFR-INT-0005` | Error | Integer division, modulo, or exponentiation requires handling a typed failure. |
-| `SIFR-INT-0006` | Error | Exact integer to float conversion requires handling precision loss. |
-| `SIFR-INT-0007` | Error | Bool and integer comparison requires explicit conversion. |
-| `SIFR-INT-0011` | Warning | Temporary bigint transition alias used. |
+| [`SIFR-INT-0001`](/errors/SIFR-INT-0001) | Error | Fixed-width integer literal or const expression is out of range. |
+| [`SIFR-INT-0003`](/errors/SIFR-INT-0003) | Error | Reserved integer width name used before support lands. |
+| [`SIFR-INT-0004`](/errors/SIFR-INT-0004) | Error | Compile-time integer evaluation budget exceeded. |
+| [`SIFR-INT-0005`](/errors/SIFR-INT-0005) | Error | Integer division, modulo, or exponentiation requires handling a typed failure. |
+| [`SIFR-INT-0006`](/errors/SIFR-INT-0006) | Error | Exact integer to float conversion requires handling precision loss. |
+| [`SIFR-INT-0007`](/errors/SIFR-INT-0007) | Error | Bool and integer comparison requires explicit conversion. |
+| [`SIFR-INT-0011`](/errors/SIFR-INT-0011) | Warning | Temporary bigint transition alias used. |
 
 </Accordion>
 
@@ -137,8 +137,8 @@ The `IO` family covers errors at the boundary between text-mode and binary-mode 
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-IO-0801` | Error | Text-mode `open` requires an explicit encoding. |
-| `SIFR-IO-0802` | Error | Open mode must be statically known. |
+| [`SIFR-IO-0801`](/errors/SIFR-IO-0801) | Error | Text-mode `open` requires an explicit encoding. |
+| [`SIFR-IO-0802`](/errors/SIFR-IO-0802) | Error | Open mode must be statically known. |
 
 </Accordion>
 
@@ -148,7 +148,7 @@ The `ENCODING` family covers errors related to text encoding configuration. Sifr
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-ENCODING-0803` | Error | Encoding error handler must be statically known. |
+| [`SIFR-ENCODING-0803`](/errors/SIFR-ENCODING-0803) | Error | Encoding error handler must be statically known. |
 
 </Accordion>
 
@@ -158,11 +158,11 @@ The `CALL` family covers errors at call sites: wrong argument counts, unexpected
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-CALL-0001` | Error | Wrong positional argument count. |
-| `SIFR-CALL-0002` | Error | Unexpected keyword argument. |
-| `SIFR-CALL-0003` | Error | Duplicate argument from positional and keyword overlap. |
-| `SIFR-CALL-0004` | Error | Missing required argument. |
-| `SIFR-CALL-0005` | Error | Callable arity failure or expression is not callable. |
+| [`SIFR-CALL-0001`](/errors/SIFR-CALL-0001) | Error | Wrong positional argument count. |
+| [`SIFR-CALL-0002`](/errors/SIFR-CALL-0002) | Error | Unexpected keyword argument. |
+| [`SIFR-CALL-0003`](/errors/SIFR-CALL-0003) | Error | Duplicate argument from positional and keyword overlap. |
+| [`SIFR-CALL-0004`](/errors/SIFR-CALL-0004) | Error | Missing required argument. |
+| [`SIFR-CALL-0005`](/errors/SIFR-CALL-0005) | Error | Callable arity failure or expression is not callable. |
 
 </Accordion>
 
@@ -172,19 +172,19 @@ The `OWN` family covers violations of Sifr's ownership and borrow model. Because
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-OWN-0001` | Error | Use after move. |
-| `SIFR-OWN-0002` | Error | Same-call borrow conflict. |
-| `SIFR-OWN-0003` | Error | Borrowed parameter escapes by return or store. |
-| `SIFR-OWN-0004` | Error | Moved value is reused across loop iterations. |
-| `SIFR-OWN-0005` | Error | Immutable parameter is mutated. |
-| `SIFR-OWN-0006` | Error | Immutable parameter is reassigned. |
-| `SIFR-OWN-0007` | Error | Immutable bytes value is mutated. |
-| `SIFR-OWN-0008` | Error | Immutable bytes value is mutated by augmented assignment. |
-| `SIFR-OWN-0009` | Error | Mutable borrow remains live across an `await` point. |
-| `SIFR-OWN-0010` | Error | Non-sendable value crosses a spawned task boundary. |
-| `SIFR-OWN-0011` | Error | Non-sendable value is sent through a channel. |
-| `SIFR-OWN-0012` | Error | Non-share-safe value is wrapped in `sync.Shared`. |
-| `SIFR-OWN-0013` | Error | Non-IPC-serializable value is used as a typed IPC payload. |
+| [`SIFR-OWN-0001`](/errors/SIFR-OWN-0001) | Error | Use after move. |
+| [`SIFR-OWN-0002`](/errors/SIFR-OWN-0002) | Error | Same-call borrow conflict. |
+| [`SIFR-OWN-0003`](/errors/SIFR-OWN-0003) | Error | Borrowed parameter escapes by return or store. |
+| [`SIFR-OWN-0004`](/errors/SIFR-OWN-0004) | Error | Moved value is reused across loop iterations. |
+| [`SIFR-OWN-0005`](/errors/SIFR-OWN-0005) | Error | Immutable parameter is mutated. |
+| [`SIFR-OWN-0006`](/errors/SIFR-OWN-0006) | Error | Immutable parameter is reassigned. |
+| [`SIFR-OWN-0007`](/errors/SIFR-OWN-0007) | Error | Immutable bytes value is mutated. |
+| [`SIFR-OWN-0008`](/errors/SIFR-OWN-0008) | Error | Immutable bytes value is mutated by augmented assignment. |
+| [`SIFR-OWN-0009`](/errors/SIFR-OWN-0009) | Error | Mutable borrow remains live across an `await` point. |
+| [`SIFR-OWN-0010`](/errors/SIFR-OWN-0010) | Error | Non-sendable value crosses a spawned task boundary. |
+| [`SIFR-OWN-0011`](/errors/SIFR-OWN-0011) | Error | Non-sendable value is sent through a channel. |
+| [`SIFR-OWN-0012`](/errors/SIFR-OWN-0012) | Error | Non-share-safe value is wrapped in `sync.Shared`. |
+| [`SIFR-OWN-0013`](/errors/SIFR-OWN-0013) | Error | Non-IPC-serializable value is used as a typed IPC payload. |
 
 </Accordion>
 
@@ -194,15 +194,15 @@ The `FLOW` family covers control-flow correctness: invalid `break`/`continue` pl
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-FLOW-0001` | Error | `break` outside a loop. |
-| `SIFR-FLOW-0002` | Error | `continue` outside a loop. |
-| `SIFR-FLOW-0003` | Error | Invalid `nonlocal` or nested-function flow. |
-| `SIFR-FLOW-0004` | Error | Function may finish without returning a required value. |
-| `SIFR-FLOW-0005` | Error | Control-flow condition has an unsupported type. |
-| `SIFR-FLOW-0006` | Error | Statement form is unsupported by HIR lowering. |
-| `SIFR-FLOW-0007` | Error | Assignment target form is unsupported by HIR lowering. |
-| `SIFR-FLOW-0008` | Error | For-loop iteration form or source is invalid. |
-| `SIFR-FLOW-0901` | Warning | Unreachable statement ignored during lowering. |
+| [`SIFR-FLOW-0001`](/errors/SIFR-FLOW-0001) | Error | `break` outside a loop. |
+| [`SIFR-FLOW-0002`](/errors/SIFR-FLOW-0002) | Error | `continue` outside a loop. |
+| [`SIFR-FLOW-0003`](/errors/SIFR-FLOW-0003) | Error | Invalid `nonlocal` or nested-function flow. |
+| [`SIFR-FLOW-0004`](/errors/SIFR-FLOW-0004) | Error | Function may finish without returning a required value. |
+| [`SIFR-FLOW-0005`](/errors/SIFR-FLOW-0005) | Error | Control-flow condition has an unsupported type. |
+| [`SIFR-FLOW-0006`](/errors/SIFR-FLOW-0006) | Error | Statement form is unsupported by HIR lowering. |
+| [`SIFR-FLOW-0007`](/errors/SIFR-FLOW-0007) | Error | Assignment target form is unsupported by HIR lowering. |
+| [`SIFR-FLOW-0008`](/errors/SIFR-FLOW-0008) | Error | For-loop iteration form or source is invalid. |
+| [`SIFR-FLOW-0901`](/errors/SIFR-FLOW-0901) | Warning | Unreachable statement ignored during lowering. |
 
 </Accordion>
 
@@ -212,7 +212,7 @@ The `FMT` family covers formatting enforcement. It fires when `sifr fmt --check`
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-FMT-0001` | Error | Source formatting drift detected by `sifr fmt --check`. |
+| [`SIFR-FMT-0001`](/errors/SIFR-FMT-0001) | Error | Source formatting drift detected by `sifr fmt --check`. |
 
 <Tip>
 Run `sifr fmt` (without `--check`) to automatically rewrite all files to canonical formatting and resolve `SIFR-FMT-0001`.
@@ -226,14 +226,14 @@ The `LINT` family covers the policy-rule engine (`sifr lint`). These are `Warnin
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-LINT-0001` | Warning | Suppression references an unknown policy rule ID. |
-| `SIFR-LINT-0002` | Warning | Suppression did not suppress any diagnostic. |
-| `SIFR-LINT-0003` | Warning | Suppression must list explicit Sifr policy rule IDs. |
-| `SIFR-LINT-0004` | Warning | Line ends with trailing horizontal whitespace. |
-| `SIFR-LINT-0005` | Warning | Comment contains a tracked TODO or FIXME marker. |
-| `SIFR-LINT-0006` | Warning | Call passes a boolean literal positionally. |
-| `SIFR-LINT-0007` | Warning | Function has more parameters than the policy limit. |
-| `SIFR-LINT-0008` | Warning | Import duplicates a module/name pair already imported in the same source file. |
+| [`SIFR-LINT-0001`](/errors/SIFR-LINT-0001) | Warning | Suppression references an unknown policy rule ID. |
+| [`SIFR-LINT-0002`](/errors/SIFR-LINT-0002) | Warning | Suppression did not suppress any diagnostic. |
+| [`SIFR-LINT-0003`](/errors/SIFR-LINT-0003) | Warning | Suppression must list explicit Sifr policy rule IDs. |
+| [`SIFR-LINT-0004`](/errors/SIFR-LINT-0004) | Warning | Line ends with trailing horizontal whitespace. |
+| [`SIFR-LINT-0005`](/errors/SIFR-LINT-0005) | Warning | Comment contains a tracked TODO or FIXME marker. |
+| [`SIFR-LINT-0006`](/errors/SIFR-LINT-0006) | Warning | Call passes a boolean literal positionally. |
+| [`SIFR-LINT-0007`](/errors/SIFR-LINT-0007) | Warning | Function has more parameters than the policy limit. |
+| [`SIFR-LINT-0008`](/errors/SIFR-LINT-0008) | Warning | Import duplicates a module/name pair already imported in the same source file. |
 
 </Accordion>
 
@@ -243,10 +243,10 @@ The `MATCH` family covers `match` statement correctness. Sifr requires that matc
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-MATCH-0001` | Error | Non-exhaustive match — one or more enum variants are not covered. |
-| `SIFR-MATCH-0002` | Error | Match guard must be `bool`. |
-| `SIFR-MATCH-0003` | Error | Invalid class pattern field. |
-| `SIFR-MATCH-0004` | Error | Invalid or unsupported match pattern form. |
+| [`SIFR-MATCH-0001`](/errors/SIFR-MATCH-0001) | Error | Non-exhaustive match — one or more enum variants are not covered. |
+| [`SIFR-MATCH-0002`](/errors/SIFR-MATCH-0002) | Error | Match guard must be `bool`. |
+| [`SIFR-MATCH-0003`](/errors/SIFR-MATCH-0003) | Error | Invalid class pattern field. |
+| [`SIFR-MATCH-0004`](/errors/SIFR-MATCH-0004) | Error | Invalid or unsupported match pattern form. |
 
 </Accordion>
 
@@ -256,10 +256,10 @@ The `PROTO` family covers violations of Sifr's structural protocol system: itera
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-PROTO-0001` | Error | Protocol bound or conformance failure. |
-| `SIFR-PROTO-0002` | Error | Invalid iterator or reversible protocol signature. |
-| `SIFR-PROTO-0003` | Error | Context-manager protocol is missing (`__enter__` or `__exit__` absent). |
-| `SIFR-PROTO-0004` | Error | Hashable or comparable protocol is required. |
+| [`SIFR-PROTO-0001`](/errors/SIFR-PROTO-0001) | Error | Protocol bound or conformance failure. |
+| [`SIFR-PROTO-0002`](/errors/SIFR-PROTO-0002) | Error | Invalid iterator or reversible protocol signature. |
+| [`SIFR-PROTO-0003`](/errors/SIFR-PROTO-0003) | Error | Context-manager protocol is missing (`__enter__` or `__exit__` absent). |
+| [`SIFR-PROTO-0004`](/errors/SIFR-PROTO-0004) | Error | Hashable or comparable protocol is required. |
 
 </Accordion>
 
@@ -269,12 +269,12 @@ The `CLASS` family covers class-level structural errors: missing field initializ
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-CLASS-0001` | Error | Class fields require an initializer or super initializer. |
-| `SIFR-CLASS-0002` | Error | Required field declared after a defaulted field. |
-| `SIFR-CLASS-0003` | Error | Duplicate enum or class value, or invalid variant. |
-| `SIFR-CLASS-0004` | Error | Missing class field. |
-| `SIFR-CLASS-0005` | Error | Invalid class base. |
-| `SIFR-CLASS-0006` | Error | Unsupported class declaration. |
+| [`SIFR-CLASS-0001`](/errors/SIFR-CLASS-0001) | Error | Class fields require an initializer or super initializer. |
+| [`SIFR-CLASS-0002`](/errors/SIFR-CLASS-0002) | Error | Required field declared after a defaulted field. |
+| [`SIFR-CLASS-0003`](/errors/SIFR-CLASS-0003) | Error | Duplicate enum or class value, or invalid variant. |
+| [`SIFR-CLASS-0004`](/errors/SIFR-CLASS-0004) | Error | Missing class field. |
+| [`SIFR-CLASS-0005`](/errors/SIFR-CLASS-0005) | Error | Invalid class base. |
+| [`SIFR-CLASS-0006`](/errors/SIFR-CLASS-0006) | Error | Unsupported class declaration. |
 
 </Accordion>
 
@@ -284,12 +284,12 @@ The `RESULT` family covers Sifr's checked error-handling model. Sifr requires th
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-RESULT-0001` | Error | Unused `Result` value. |
-| `SIFR-RESULT-0002` | Error | Invalid `Result` error type. |
-| `SIFR-RESULT-0003` | Error | Invalid `raise` expression. |
-| `SIFR-RESULT-0004` | Error | `except` arm references an unknown error type. |
-| `SIFR-RESULT-0005` | Error | `try` body error types are not fully covered by `except` arms. |
-| `SIFR-RESULT-0006` | Error | `except` arm type expression has an unsupported form. |
+| [`SIFR-RESULT-0001`](/errors/SIFR-RESULT-0001) | Error | Unused `Result` value. |
+| [`SIFR-RESULT-0002`](/errors/SIFR-RESULT-0002) | Error | Invalid `Result` error type. |
+| [`SIFR-RESULT-0003`](/errors/SIFR-RESULT-0003) | Error | Invalid `raise` expression. |
+| [`SIFR-RESULT-0004`](/errors/SIFR-RESULT-0004) | Error | `except` arm references an unknown error type. |
+| [`SIFR-RESULT-0005`](/errors/SIFR-RESULT-0005) | Error | `try` body error types are not fully covered by `except` arms. |
+| [`SIFR-RESULT-0006`](/errors/SIFR-RESULT-0006) | Error | `except` arm type expression has an unsupported form. |
 
 <Note>
 `SIFR-RESULT-0001` fires whenever you call a function that returns `Result` and discard the return value without handling it. Use `match`, `unwrap()`, or propagate the result with `?` syntax to resolve it.
@@ -303,9 +303,9 @@ The `STDLIB` family covers errors related to Sifr's embedded standard library. T
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-STDLIB-0001` | Error | Unsupported standard-library constructor, method, or surface. |
-| `SIFR-STDLIB-0003` | Error | Embedded standard-library bootstrap failure. |
-| `SIFR-STDLIB-0004` | Error | Standard-library cache build or reuse failure. |
+| [`SIFR-STDLIB-0001`](/errors/SIFR-STDLIB-0001) | Error | Unsupported standard-library constructor, method, or surface. |
+| [`SIFR-STDLIB-0003`](/errors/SIFR-STDLIB-0003) | Error | Embedded standard-library bootstrap failure. |
+| [`SIFR-STDLIB-0004`](/errors/SIFR-STDLIB-0004) | Error | Standard-library cache build or reuse failure. |
 
 </Accordion>
 
@@ -315,14 +315,14 @@ The `WORKSPACE` family covers errors in workspace configuration: malformed manif
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-WORKSPACE-0001` | Error | Malformed workspace manifest. |
-| `SIFR-WORKSPACE-0002` | Error | Workspace source root escapes the workspace root. |
-| `SIFR-WORKSPACE-0003` | Error | Workspace source root is not a directory. |
-| `SIFR-WORKSPACE-0004` | Error | Workspace source root entry has an invalid shape or path. |
-| `SIFR-WORKSPACE-0101` | Error | Legacy workspace import target could not be resolved. |
-| `SIFR-WORKSPACE-0102` | Error | Legacy workspace import target is ambiguous. |
-| `SIFR-WORKSPACE-0103` | Error | Legacy workspace namespace package collision. |
-| `SIFR-WORKSPACE-0104` | Error | Legacy workspace import graph cycle. |
+| [`SIFR-WORKSPACE-0001`](/errors/SIFR-WORKSPACE-0001) | Error | Malformed workspace manifest. |
+| [`SIFR-WORKSPACE-0002`](/errors/SIFR-WORKSPACE-0002) | Error | Workspace source root escapes the workspace root. |
+| [`SIFR-WORKSPACE-0003`](/errors/SIFR-WORKSPACE-0003) | Error | Workspace source root is not a directory. |
+| [`SIFR-WORKSPACE-0004`](/errors/SIFR-WORKSPACE-0004) | Error | Workspace source root entry has an invalid shape or path. |
+| [`SIFR-WORKSPACE-0101`](/errors/SIFR-WORKSPACE-0101) | Error | Legacy workspace import target could not be resolved. |
+| [`SIFR-WORKSPACE-0102`](/errors/SIFR-WORKSPACE-0102) | Error | Legacy workspace import target is ambiguous. |
+| [`SIFR-WORKSPACE-0103`](/errors/SIFR-WORKSPACE-0103) | Error | Legacy workspace namespace package collision. |
+| [`SIFR-WORKSPACE-0104`](/errors/SIFR-WORKSPACE-0104) | Error | Legacy workspace import graph cycle. |
 
 </Accordion>
 
@@ -332,40 +332,40 @@ The `PACKAGE` family is the largest family and covers the full lifecycle of Sifr
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-PACKAGE-0001` | Error | Missing or invalid Cargo Sifr discovery metadata. |
-| `SIFR-PACKAGE-0002` | Error | Missing or invalid `sifr.toml` package manifest. |
-| `SIFR-PACKAGE-0003` | Error | Unsupported Sifr compiler metadata appears in Cargo metadata. |
-| `SIFR-PACKAGE-0101` | Error | Cargo command invocation failed. |
-| `SIFR-PACKAGE-0102` | Error | A selected Cargo package is Rust-only. |
-| `SIFR-PACKAGE-0103` | Error | Cargo metadata parsing or normalization failed. |
-| `SIFR-PACKAGE-0104` | Error | Package source is unavailable in offline or frozen mode. |
-| `SIFR-PACKAGE-0106` | Error | Rust-only package depends directly on a Sifr source package. |
-| `SIFR-PACKAGE-0201` | Error | Direct package import root resolves to multiple package instances. |
-| `SIFR-PACKAGE-0202` | Error | Package imports a module outside its direct dependency scope. |
-| `SIFR-PACKAGE-0203` | Error | Package imports a private module from another package. |
-| `SIFR-PACKAGE-0204` | Error | Type identity crosses resolved package instances. |
-| `SIFR-PACKAGE-0301` | Error | Backend Rust crate is not allowed by the Sifr trust policy. |
-| `SIFR-PACKAGE-0305` | Error | Trust policy names a backend crate that is not a direct dependency. |
-| `SIFR-PACKAGE-0401` | Error | Cargo package archive is missing required Sifr source. |
-| `SIFR-PACKAGE-0402` | Error | Package publish or archive validation failed. |
-| `SIFR-PACKAGE-0403` | Error | Cargo include/exclude rules omit required Sifr files. |
-| `SIFR-PACKAGE-0404` | Error | Cargo package archive contains an unsafe path. |
-| `SIFR-PACKAGE-0501` | Error | Pure Sifr Rust marker contains implementation. |
-| `SIFR-PACKAGE-0601` | Error | Package selector is ambiguous or invalid. |
-| `SIFR-PACKAGE-0602` | Error | Workspace selection contains duplicate import roots. |
-| `SIFR-PACKAGE-0603` | Error | Changed file could not be mapped to a package. |
-| `SIFR-PACKAGE-0604` | Error | Outdated query cannot inspect this Cargo source. |
-| `SIFR-PACKAGE-0605` | Error | Runnable package target or script selection is missing or ambiguous. |
-| `SIFR-PACKAGE-0606` | Error | Discovered app target name is invalid. |
-| `SIFR-PACKAGE-0607` | Error | Selected workspace members use the same Sifr package name. |
-| `SIFR-PACKAGE-0701` | Error | Production `sifr.toml` uses manifest-level exports. |
-| `SIFR-PACKAGE-0703` | Error | Sifr-managed Cargo projection manifest pointer drift. |
-| `SIFR-PACKAGE-0704` | Error | Sifr-managed Cargo projection include rules omit required package files. |
-| `SIFR-PACKAGE-0709` | Error | Pure package marker is missing from Sifr-managed projection. |
-| `SIFR-PACKAGE-0710` | Error | Explicit Sifr file target is outside the package source root. |
-| `SIFR-PACKAGE-0711` | Error | Production `sifr.toml` uses manifest binary target tables. |
-| `SIFR-PACKAGE-0713` | Error | Public API symbol is exported more than once. |
-| `SIFR-PACKAGE-0714` | Error | Package script expansion attempted to invoke another script. |
+| [`SIFR-PACKAGE-0001`](/errors/SIFR-PACKAGE-0001) | Error | Missing or invalid Cargo Sifr discovery metadata. |
+| [`SIFR-PACKAGE-0002`](/errors/SIFR-PACKAGE-0002) | Error | Missing or invalid `sifr.toml` package manifest. |
+| [`SIFR-PACKAGE-0003`](/errors/SIFR-PACKAGE-0003) | Error | Unsupported Sifr compiler metadata appears in Cargo metadata. |
+| [`SIFR-PACKAGE-0101`](/errors/SIFR-PACKAGE-0101) | Error | Cargo command invocation failed. |
+| [`SIFR-PACKAGE-0102`](/errors/SIFR-PACKAGE-0102) | Error | A selected Cargo package is Rust-only. |
+| [`SIFR-PACKAGE-0103`](/errors/SIFR-PACKAGE-0103) | Error | Cargo metadata parsing or normalization failed. |
+| [`SIFR-PACKAGE-0104`](/errors/SIFR-PACKAGE-0104) | Error | Package source is unavailable in offline or frozen mode. |
+| [`SIFR-PACKAGE-0106`](/errors/SIFR-PACKAGE-0106) | Error | Rust-only package depends directly on a Sifr source package. |
+| [`SIFR-PACKAGE-0201`](/errors/SIFR-PACKAGE-0201) | Error | Direct package import root resolves to multiple package instances. |
+| [`SIFR-PACKAGE-0202`](/errors/SIFR-PACKAGE-0202) | Error | Package imports a module outside its direct dependency scope. |
+| [`SIFR-PACKAGE-0203`](/errors/SIFR-PACKAGE-0203) | Error | Package imports a private module from another package. |
+| [`SIFR-PACKAGE-0204`](/errors/SIFR-PACKAGE-0204) | Error | Type identity crosses resolved package instances. |
+| [`SIFR-PACKAGE-0301`](/errors/SIFR-PACKAGE-0301) | Error | Backend Rust crate is not allowed by the Sifr trust policy. |
+| [`SIFR-PACKAGE-0305`](/errors/SIFR-PACKAGE-0305) | Error | Trust policy names a backend crate that is not a direct dependency. |
+| [`SIFR-PACKAGE-0401`](/errors/SIFR-PACKAGE-0401) | Error | Cargo package archive is missing required Sifr source. |
+| [`SIFR-PACKAGE-0402`](/errors/SIFR-PACKAGE-0402) | Error | Package publish or archive validation failed. |
+| [`SIFR-PACKAGE-0403`](/errors/SIFR-PACKAGE-0403) | Error | Cargo include/exclude rules omit required Sifr files. |
+| [`SIFR-PACKAGE-0404`](/errors/SIFR-PACKAGE-0404) | Error | Cargo package archive contains an unsafe path. |
+| [`SIFR-PACKAGE-0501`](/errors/SIFR-PACKAGE-0501) | Error | Pure Sifr Rust marker contains implementation. |
+| [`SIFR-PACKAGE-0601`](/errors/SIFR-PACKAGE-0601) | Error | Package selector is ambiguous or invalid. |
+| [`SIFR-PACKAGE-0602`](/errors/SIFR-PACKAGE-0602) | Error | Workspace selection contains duplicate import roots. |
+| [`SIFR-PACKAGE-0603`](/errors/SIFR-PACKAGE-0603) | Error | Changed file could not be mapped to a package. |
+| [`SIFR-PACKAGE-0604`](/errors/SIFR-PACKAGE-0604) | Error | Outdated query cannot inspect this Cargo source. |
+| [`SIFR-PACKAGE-0605`](/errors/SIFR-PACKAGE-0605) | Error | Runnable package target or script selection is missing or ambiguous. |
+| [`SIFR-PACKAGE-0606`](/errors/SIFR-PACKAGE-0606) | Error | Discovered app target name is invalid. |
+| [`SIFR-PACKAGE-0607`](/errors/SIFR-PACKAGE-0607) | Error | Selected workspace members use the same Sifr package name. |
+| [`SIFR-PACKAGE-0701`](/errors/SIFR-PACKAGE-0701) | Error | Production `sifr.toml` uses manifest-level exports. |
+| [`SIFR-PACKAGE-0703`](/errors/SIFR-PACKAGE-0703) | Error | Sifr-managed Cargo projection manifest pointer drift. |
+| [`SIFR-PACKAGE-0704`](/errors/SIFR-PACKAGE-0704) | Error | Sifr-managed Cargo projection include rules omit required package files. |
+| [`SIFR-PACKAGE-0709`](/errors/SIFR-PACKAGE-0709) | Error | Pure package marker is missing from Sifr-managed projection. |
+| [`SIFR-PACKAGE-0710`](/errors/SIFR-PACKAGE-0710) | Error | Explicit Sifr file target is outside the package source root. |
+| [`SIFR-PACKAGE-0711`](/errors/SIFR-PACKAGE-0711) | Error | Production `sifr.toml` uses manifest binary target tables. |
+| [`SIFR-PACKAGE-0713`](/errors/SIFR-PACKAGE-0713) | Error | Public API symbol is exported more than once. |
+| [`SIFR-PACKAGE-0714`](/errors/SIFR-PACKAGE-0714) | Error | Package script expansion attempted to invoke another script. |
 
 </Accordion>
 
@@ -385,12 +385,12 @@ The `BUILD` family covers failures in Sifr's build pipeline: file materializatio
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-BUILD-0002` | Error | Build file materialization failed. |
-| `SIFR-BUILD-0003` | Error | Temporary build workspace creation failed. |
-| `SIFR-BUILD-0004` | Error | Cargo manifest generation failed. |
-| `SIFR-BUILD-0005` | Error | Rustc or Cargo execution failed. |
-| `SIFR-BUILD-0006` | Error | Expected build artifact was not produced. |
-| `SIFR-BUILD-0901` | Error | Standalone install receipt is missing or outside the self-update rules. |
+| [`SIFR-BUILD-0002`](/errors/SIFR-BUILD-0002) | Error | Build file materialization failed. |
+| [`SIFR-BUILD-0003`](/errors/SIFR-BUILD-0003) | Error | Temporary build workspace creation failed. |
+| [`SIFR-BUILD-0004`](/errors/SIFR-BUILD-0004) | Error | Cargo manifest generation failed. |
+| [`SIFR-BUILD-0005`](/errors/SIFR-BUILD-0005) | Error | Rustc or Cargo execution failed. |
+| [`SIFR-BUILD-0006`](/errors/SIFR-BUILD-0006) | Error | Expected build artifact was not produced. |
+| [`SIFR-BUILD-0901`](/errors/SIFR-BUILD-0901) | Error | Standalone install receipt is missing or outside the self-update rules. |
 
 </Accordion>
 
@@ -400,8 +400,8 @@ The `INTERNAL` family covers compiler-internal failures that escape the panic bo
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-INTERNAL-0001` | Error | Unclassified compiler panic after a panic boundary. |
-| `SIFR-INTERNAL-0002` | Note | Structured recovery-cap omission summary. |
+| [`SIFR-INTERNAL-0001`](/errors/SIFR-INTERNAL-0001) | Error | Unclassified compiler panic after a panic boundary. |
+| [`SIFR-INTERNAL-0002`](/errors/SIFR-INTERNAL-0002) | Note | Structured recovery-cap omission summary. |
 
 <Warning>
 `SIFR-INTERNAL-0001` always indicates a compiler bug. If you encounter it, please file a report with the Sifr issue tracker and include a minimal reproduction of the failing source file.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -102,6 +102,7 @@
             "icon": "book-open",
             "pages": [
               "stdlib/overview",
+              "stdlib/module-index",
               "stdlib/collections",
               "stdlib/io-filesystem",
               "stdlib/networking",
@@ -162,7 +163,8 @@
               "cli/check-emit",
               "cli/fmt-lint",
               "cli/test",
-              "cli/lsp"
+              "cli/lsp",
+              "cli/packages-workspaces"
             ]
           },
           {

--- a/docs/errors/SIFR-ASYNC-0001.mdx
+++ b/docs/errors/SIFR-ASYNC-0001.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-ASYNC-0001: Async function body has no real suspension effect"
+sidebarTitle: "SIFR-ASYNC-0001"
+description: "Async function body has no real suspension effect"
+---
+
+`SIFR-ASYNC-0001` belongs to the **Async effect and awaitability** diagnostic family. It means: async function body has no real suspension effect.
+
+## Why It Happens
+
+Sifr tracks suspension and blocking effects statically. This diagnostic fires when async code either does not really suspend, awaits work that cannot suspend, or calls blocking/CPU-heavy work without an explicit offload boundary.
+
+<Info>
+Use `sifr --explain SIFR-ASYNC-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+async def cached() -> int:
+    return 1
+```
+
+## How To Fix It
+
+Make the function synchronous when it never suspends, or add a real asynchronous operation if it truly belongs in async code.
+
+## Fixed Code
+
+```python
+def cached() -> int:
+    return 1
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-ASYNC-0001` |
+| Family | `ASYNC` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/async_no_suspend_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0002.mdx
+++ b/docs/errors/SIFR-ASYNC-0002.mdx
@@ -1,0 +1,53 @@
+---
+title: "SIFR-ASYNC-0002: Awaited same-task coroutine has no real suspension effect"
+sidebarTitle: "SIFR-ASYNC-0002"
+description: "Awaited same-task coroutine has no real suspension effect"
+---
+
+`SIFR-ASYNC-0002` belongs to the **Async effect and awaitability** diagnostic family. It means: awaited same-task coroutine has no real suspension effect.
+
+## Why It Happens
+
+Sifr tracks suspension and blocking effects statically. This diagnostic fires when async code either does not really suspend, awaits work that cannot suspend, or calls blocking/CPU-heavy work without an explicit offload boundary.
+
+<Info>
+Use `sifr --explain SIFR-ASYNC-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+async def cached() -> int:
+    return 1
+
+async def main() -> int:
+    return await cached()
+```
+
+## How To Fix It
+
+Do not await a same-task coroutine that cannot suspend. Make the helper synchronous, or move the suspension into the helper.
+
+## Fixed Code
+
+```python
+def cached() -> int:
+    return 1
+
+async def main() -> int:
+    await task.sleep(0.0)
+    return cached()
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-ASYNC-0002` |
+| Family | `ASYNC` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/async_transitive_no_suspend_await_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0003.mdx
+++ b/docs/errors/SIFR-ASYNC-0003.mdx
@@ -1,0 +1,54 @@
+---
+title: "SIFR-ASYNC-0003: Blocking I/O function called directly from async context"
+sidebarTitle: "SIFR-ASYNC-0003"
+description: "Blocking I/O function called directly from async context"
+---
+
+`SIFR-ASYNC-0003` belongs to the **Async effect and awaitability** diagnostic family. It means: blocking i/o function called directly from async context.
+
+## Why It Happens
+
+Sifr tracks suspension and blocking effects statically. This diagnostic fires when async code either does not really suspend, awaits work that cannot suspend, or calls blocking/CPU-heavy work without an explicit offload boundary.
+
+<Info>
+Use `sifr --explain SIFR-ASYNC-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from sifr.io import read_text
+
+async def load() -> str:
+    return read_text("config.txt")
+```
+
+## How To Fix It
+
+Move blocking I/O behind a supported offload helper or call an async API instead of blocking the task directly.
+
+## Fixed Code
+
+```python
+from sifr.io import read_text
+
+@blocking_io
+def read_config() -> str:
+    return read_text("config.txt")
+
+async def load() -> str:
+    return await task.spawn_blocking(read_config)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-ASYNC-0003` |
+| Family | `ASYNC` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/blocking_io_direct_call_in_async_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0004.mdx
+++ b/docs/errors/SIFR-ASYNC-0004.mdx
@@ -1,0 +1,57 @@
+---
+title: "SIFR-ASYNC-0004: CPU-heavy function called directly from async context"
+sidebarTitle: "SIFR-ASYNC-0004"
+description: "CPU-heavy function called directly from async context"
+---
+
+`SIFR-ASYNC-0004` belongs to the **Async effect and awaitability** diagnostic family. It means: cpu-heavy function called directly from async context.
+
+## Why It Happens
+
+Sifr tracks suspension and blocking effects statically. This diagnostic fires when async code either does not really suspend, awaits work that cannot suspend, or calls blocking/CPU-heavy work without an explicit offload boundary.
+
+<Info>
+Use `sifr --explain SIFR-ASYNC-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def crunch(values: list[int]) -> int:
+    total: int = 0
+    for value in values:
+        total = total + value
+    return total
+
+async def main(values: list[int]) -> int:
+    return crunch(values)
+```
+
+## How To Fix It
+
+Keep CPU-heavy work out of the async executor. Use the parallel/offload surface intended for owned CPU work.
+
+## Fixed Code
+
+```python
+from sifr.parallel import map as par_map
+
+def crunch(value: int) -> int:
+    return value * value
+
+async def main(values: list[int]) -> list[int]:
+    return par_map(values, crunch)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-ASYNC-0004` |
+| Family | `ASYNC` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/cpu_heavy_direct_call_in_async_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0005.mdx
+++ b/docs/errors/SIFR-ASYNC-0005.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-ASYNC-0005: Blocking offload target is not classified as blocking I/O or CPU-heavy work"
+sidebarTitle: "SIFR-ASYNC-0005"
+description: "Blocking offload target is not classified as blocking I/O or CPU-heavy work"
+---
+
+`SIFR-ASYNC-0005` belongs to the **Async effect and awaitability** diagnostic family. It means: blocking offload target is not classified as blocking i/o or cpu-heavy work.
+
+## Why It Happens
+
+Sifr tracks suspension and blocking effects statically. This diagnostic fires when async code either does not really suspend, awaits work that cannot suspend, or calls blocking/CPU-heavy work without an explicit offload boundary.
+
+<Info>
+Use `sifr --explain SIFR-ASYNC-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+async def main() -> int:
+    return await task.spawn_blocking(lambda: 42)
+```
+
+## How To Fix It
+
+Only offload functions classified as blocking I/O or CPU-heavy work; otherwise leave ordinary synchronous helpers synchronous.
+
+## Fixed Code
+
+```python
+def blocking_read() -> str:
+    return read_text("config.txt")
+
+async def main() -> str:
+    return await task.spawn_blocking(blocking_read)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-ASYNC-0005` |
+| Family | `ASYNC` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/spawn_blocking_unannotated_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0006.mdx
+++ b/docs/errors/SIFR-ASYNC-0006.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-ASYNC-0006: Synchronous workload annotation applied to async function"
+sidebarTitle: "SIFR-ASYNC-0006"
+description: "Synchronous workload annotation applied to async function"
+---
+
+`SIFR-ASYNC-0006` belongs to the **Async effect and awaitability** diagnostic family. It means: synchronous workload annotation applied to async function.
+
+## Why It Happens
+
+The `@blocking_io` and `@cpu_heavy` annotations describe synchronous workload classes. An `async def` already has its own scheduling contract, so it cannot also be classified as a blocking or CPU-heavy synchronous workload.
+
+<Info>
+Use `sifr --explain SIFR-ASYNC-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+@blocking_io
+async def load() -> str:
+    await task.sleep(0.0)
+    return "done"
+```
+
+## How To Fix It
+
+Apply synchronous workload annotations to synchronous functions, not async functions.
+
+## Fixed Code
+
+```python
+@blocking_io
+def load() -> str:
+    return read_text("config.txt")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-ASYNC-0006` |
+| Family | `ASYNC` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/blocking_io_on_async_def_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0007.mdx
+++ b/docs/errors/SIFR-ASYNC-0007.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-ASYNC-0007: Shell execution function called directly from async context"
+sidebarTitle: "SIFR-ASYNC-0007"
+description: "Shell execution function called directly from async context"
+---
+
+`SIFR-ASYNC-0007` belongs to the **Async effect and awaitability** diagnostic family. It means: shell execution function called directly from async context.
+
+## Why It Happens
+
+Sifr tracks suspension and blocking effects statically. This diagnostic fires when async code either does not really suspend, awaits work that cannot suspend, or calls blocking/CPU-heavy work without an explicit offload boundary.
+
+<Info>
+Use `sifr --explain SIFR-ASYNC-0007` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from sifr.process import shell_output
+
+async def version() -> str:
+    return shell_output("sifr --version")
+```
+
+## How To Fix It
+
+Use the async process API or an explicit offload boundary instead of direct shell execution from async code.
+
+## Fixed Code
+
+```python
+from sifr.process import async_shell_output
+
+async def version() -> str:
+    return await async_shell_output("sifr --version")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-ASYNC-0007` |
+| Family | `ASYNC` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/process_shell_exec_direct_async_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0002.mdx
+++ b/docs/errors/SIFR-BUILD-0002.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-BUILD-0002: Build file materialization failed"
+sidebarTitle: "SIFR-BUILD-0002"
+description: "Build file materialization failed"
+---
+
+`SIFR-BUILD-0002` belongs to the **Build pipeline** diagnostic family. It means: build file materialization failed.
+
+## Why It Happens
+
+Sifr reached the build pipeline but could not create, run, or verify one of the generated build artifacts. The source may be valid; inspect the output path, temporary workspace, Cargo/rustc excerpt, or standalone install receipt named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-BUILD-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```bash
+sifr build app.sifr --output /root/out
+```
+
+## How To Fix It
+
+Check the generated build path, Cargo/rustc output, and whether Sifr can create its temporary workspace and final artifact.
+
+## Fixed Code
+
+```bash
+sifr build app.sifr --output build
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-BUILD-0002` |
+| Family | `BUILD` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0003.mdx
+++ b/docs/errors/SIFR-BUILD-0003.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-BUILD-0003: Temporary build workspace creation failed"
+sidebarTitle: "SIFR-BUILD-0003"
+description: "Temporary build workspace creation failed"
+---
+
+`SIFR-BUILD-0003` belongs to the **Build pipeline** diagnostic family. It means: temporary build workspace creation failed.
+
+## Why It Happens
+
+Sifr reached the build pipeline but could not create, run, or verify one of the generated build artifacts. The source may be valid; inspect the output path, temporary workspace, Cargo/rustc excerpt, or standalone install receipt named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-BUILD-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```bash
+sifr build app.sifr --output /root/out
+```
+
+## How To Fix It
+
+Check the generated build path, Cargo/rustc output, and whether Sifr can create its temporary workspace and final artifact.
+
+## Fixed Code
+
+```bash
+sifr build app.sifr --output build
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-BUILD-0003` |
+| Family | `BUILD` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0004.mdx
+++ b/docs/errors/SIFR-BUILD-0004.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-BUILD-0004: Cargo manifest generation failed"
+sidebarTitle: "SIFR-BUILD-0004"
+description: "Cargo manifest generation failed"
+---
+
+`SIFR-BUILD-0004` belongs to the **Build pipeline** diagnostic family. It means: cargo manifest generation failed.
+
+## Why It Happens
+
+Sifr reached the build pipeline but could not create, run, or verify one of the generated build artifacts. The source may be valid; inspect the output path, temporary workspace, Cargo/rustc excerpt, or standalone install receipt named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-BUILD-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```bash
+sifr build app.sifr --output /root/out
+```
+
+## How To Fix It
+
+Check the generated build path, Cargo/rustc output, and whether Sifr can create its temporary workspace and final artifact.
+
+## Fixed Code
+
+```bash
+sifr build app.sifr --output build
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-BUILD-0004` |
+| Family | `BUILD` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0005.mdx
+++ b/docs/errors/SIFR-BUILD-0005.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-BUILD-0005: Rustc or Cargo execution failed"
+sidebarTitle: "SIFR-BUILD-0005"
+description: "Rustc or Cargo execution failed"
+---
+
+`SIFR-BUILD-0005` belongs to the **Build pipeline** diagnostic family. It means: rustc or cargo execution failed.
+
+## Why It Happens
+
+Sifr reached the build pipeline but could not create, run, or verify one of the generated build artifacts. The source may be valid; inspect the output path, temporary workspace, Cargo/rustc excerpt, or standalone install receipt named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-BUILD-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```bash
+sifr build app.sifr --output /root/out
+```
+
+## How To Fix It
+
+Check the generated build path, Cargo/rustc output, and whether Sifr can create its temporary workspace and final artifact.
+
+## Fixed Code
+
+```bash
+sifr build app.sifr --output build
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-BUILD-0005` |
+| Family | `BUILD` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0006.mdx
+++ b/docs/errors/SIFR-BUILD-0006.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-BUILD-0006: Expected build artifact was not produced"
+sidebarTitle: "SIFR-BUILD-0006"
+description: "Expected build artifact was not produced"
+---
+
+`SIFR-BUILD-0006` belongs to the **Build pipeline** diagnostic family. It means: expected build artifact was not produced.
+
+## Why It Happens
+
+Sifr reached the build pipeline but could not create, run, or verify one of the generated build artifacts. The source may be valid; inspect the output path, temporary workspace, Cargo/rustc excerpt, or standalone install receipt named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-BUILD-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```bash
+sifr build app.sifr --output /root/out
+```
+
+## How To Fix It
+
+Check the generated build path, Cargo/rustc output, and whether Sifr can create its temporary workspace and final artifact.
+
+## Fixed Code
+
+```bash
+sifr build app.sifr --output build
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-BUILD-0006` |
+| Family | `BUILD` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0901.mdx
+++ b/docs/errors/SIFR-BUILD-0901.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-BUILD-0901: Standalone install receipt is missing or outside the self-update install rules"
+sidebarTitle: "SIFR-BUILD-0901"
+description: "Standalone install receipt is missing or outside the self-update install rules"
+---
+
+`SIFR-BUILD-0901` belongs to the **Build pipeline** diagnostic family. It means: standalone install receipt is missing or outside the self-update install rules.
+
+## Why It Happens
+
+Sifr reached the build pipeline but could not create, run, or verify one of the generated build artifacts. The source may be valid; inspect the output path, temporary workspace, Cargo/rustc excerpt, or standalone install receipt named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-BUILD-0901` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```bash
+sifr build app.sifr --output /root/out
+```
+
+## How To Fix It
+
+Check the generated build path, Cargo/rustc output, and whether Sifr can create its temporary workspace and final artifact.
+
+## Fixed Code
+
+```bash
+sifr build app.sifr --output build
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-BUILD-0901` |
+| Family | `BUILD` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr/src/self_update_receipt.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CALL-0001.mdx
+++ b/docs/errors/SIFR-CALL-0001.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-CALL-0001: Wrong positional argument count"
+sidebarTitle: "SIFR-CALL-0001"
+description: "Wrong positional argument count"
+---
+
+`SIFR-CALL-0001` belongs to the **Function and method calls** diagnostic family. It means: wrong positional argument count.
+
+## Why It Happens
+
+The call site does not match the callable signature Sifr inferred or checked. Fix the number of arguments, keyword names, duplicate arguments, or the value being called.
+
+<Info>
+Use `sifr --explain SIFR-CALL-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def greet(name: str) -> str:
+    return "hi " + name
+
+message = greet()
+```
+
+## How To Fix It
+
+Make the call match the function signature: provide required arguments once, use known keyword names, and call only callable values.
+
+## Fixed Code
+
+```python
+def greet(name: str) -> str:
+    return "hi " + name
+
+message = greet("Sifr")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CALL-0001` |
+| Family | `CALL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/stdlib_wrong_arg_count.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CALL-0002.mdx
+++ b/docs/errors/SIFR-CALL-0002.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-CALL-0002: Unexpected keyword argument"
+sidebarTitle: "SIFR-CALL-0002"
+description: "Unexpected keyword argument"
+---
+
+`SIFR-CALL-0002` belongs to the **Function and method calls** diagnostic family. It means: unexpected keyword argument.
+
+## Why It Happens
+
+The call site does not match the callable signature Sifr inferred or checked. Fix the number of arguments, keyword names, duplicate arguments, or the value being called.
+
+<Info>
+Use `sifr --explain SIFR-CALL-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def greet(name: str) -> str:
+    return "hi " + name
+
+message = greet()
+```
+
+## How To Fix It
+
+Make the call match the function signature: provide required arguments once, use known keyword names, and call only callable values.
+
+## Fixed Code
+
+```python
+def greet(name: str) -> str:
+    return "hi " + name
+
+message = greet("Sifr")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CALL-0002` |
+| Family | `CALL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/sorted_unexpected_keyword.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CALL-0003.mdx
+++ b/docs/errors/SIFR-CALL-0003.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-CALL-0003: Duplicate argument from positional and keyword overlap"
+sidebarTitle: "SIFR-CALL-0003"
+description: "Duplicate argument from positional and keyword overlap"
+---
+
+`SIFR-CALL-0003` belongs to the **Function and method calls** diagnostic family. It means: duplicate argument from positional and keyword overlap.
+
+## Why It Happens
+
+The call site does not match the callable signature Sifr inferred or checked. Fix the number of arguments, keyword names, duplicate arguments, or the value being called.
+
+<Info>
+Use `sifr --explain SIFR-CALL-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def greet(name: str) -> str:
+    return "hi " + name
+
+message = greet()
+```
+
+## How To Fix It
+
+Make the call match the function signature: provide required arguments once, use known keyword names, and call only callable values.
+
+## Fixed Code
+
+```python
+def greet(name: str) -> str:
+    return "hi " + name
+
+message = greet("Sifr")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CALL-0003` |
+| Family | `CALL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/keyword_after_positional_error.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CALL-0004.mdx
+++ b/docs/errors/SIFR-CALL-0004.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-CALL-0004: Missing required argument"
+sidebarTitle: "SIFR-CALL-0004"
+description: "Missing required argument"
+---
+
+`SIFR-CALL-0004` belongs to the **Function and method calls** diagnostic family. It means: missing required argument.
+
+## Why It Happens
+
+The call site does not match the callable signature Sifr inferred or checked. Fix the number of arguments, keyword names, duplicate arguments, or the value being called.
+
+<Info>
+Use `sifr --explain SIFR-CALL-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def greet(name: str) -> str:
+    return "hi " + name
+
+message = greet()
+```
+
+## How To Fix It
+
+Make the call match the function signature: provide required arguments once, use known keyword names, and call only callable values.
+
+## Fixed Code
+
+```python
+def greet(name: str) -> str:
+    return "hi " + name
+
+message = greet("Sifr")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CALL-0004` |
+| Family | `CALL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/missing_required_argument.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CALL-0005.mdx
+++ b/docs/errors/SIFR-CALL-0005.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-CALL-0005: Callable arity failure or expression is not callable"
+sidebarTitle: "SIFR-CALL-0005"
+description: "Callable arity failure or expression is not callable"
+---
+
+`SIFR-CALL-0005` belongs to the **Function and method calls** diagnostic family. It means: callable arity failure or expression is not callable.
+
+## Why It Happens
+
+The call site does not match the callable signature Sifr inferred or checked. Fix the number of arguments, keyword names, duplicate arguments, or the value being called.
+
+<Info>
+Use `sifr --explain SIFR-CALL-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def greet(name: str) -> str:
+    return "hi " + name
+
+message = greet()
+```
+
+## How To Fix It
+
+Make the call match the function signature: provide required arguments once, use known keyword names, and call only callable values.
+
+## Fixed Code
+
+```python
+def greet(name: str) -> str:
+    return "hi " + name
+
+message = greet("Sifr")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CALL-0005` |
+| Family | `CALL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/map_callable_arity_mismatch.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0001.mdx
+++ b/docs/errors/SIFR-CLASS-0001.mdx
@@ -1,0 +1,53 @@
+---
+title: "SIFR-CLASS-0001: Class fields require an initializer or super initializer"
+sidebarTitle: "SIFR-CLASS-0001"
+description: "Class fields require an initializer or super initializer"
+---
+
+`SIFR-CLASS-0001` belongs to the **Classes and declarations** diagnostic family. It means: class fields require an initializer or super initializer.
+
+## Why It Happens
+
+The class declaration cannot be lowered into a safe Rust-backed representation. Check field initialization, default ordering, base classes, enum variants, and unsupported declaration shapes.
+
+<Info>
+Use `sifr --explain SIFR-CLASS-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+class User:
+    name: str
+
+user = User()
+```
+
+## How To Fix It
+
+Give class declarations a shape the compiler can lower: initialized fields, valid bases, unique variants, and supported field ordering.
+
+## Fixed Code
+
+```python
+class User:
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+user = User("Ada")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CLASS-0001` |
+| Family | `CLASS` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/auto_init_inheritance_missing_super.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0002.mdx
+++ b/docs/errors/SIFR-CLASS-0002.mdx
@@ -1,0 +1,53 @@
+---
+title: "SIFR-CLASS-0002: Required field declared after a defaulted field"
+sidebarTitle: "SIFR-CLASS-0002"
+description: "Required field declared after a defaulted field"
+---
+
+`SIFR-CLASS-0002` belongs to the **Classes and declarations** diagnostic family. It means: required field declared after a defaulted field.
+
+## Why It Happens
+
+The class declaration cannot be lowered into a safe Rust-backed representation. Check field initialization, default ordering, base classes, enum variants, and unsupported declaration shapes.
+
+<Info>
+Use `sifr --explain SIFR-CLASS-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+class User:
+    name: str
+
+user = User()
+```
+
+## How To Fix It
+
+Give class declarations a shape the compiler can lower: initialized fields, valid bases, unique variants, and supported field ordering.
+
+## Fixed Code
+
+```python
+class User:
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+user = User("Ada")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CLASS-0002` |
+| Family | `CLASS` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/auto_init_required_after_default.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0003.mdx
+++ b/docs/errors/SIFR-CLASS-0003.mdx
@@ -1,0 +1,53 @@
+---
+title: "SIFR-CLASS-0003: Duplicate enum or class value, or invalid variant"
+sidebarTitle: "SIFR-CLASS-0003"
+description: "Duplicate enum or class value, or invalid variant"
+---
+
+`SIFR-CLASS-0003` belongs to the **Classes and declarations** diagnostic family. It means: duplicate enum or class value, or invalid variant.
+
+## Why It Happens
+
+The class declaration cannot be lowered into a safe Rust-backed representation. Check field initialization, default ordering, base classes, enum variants, and unsupported declaration shapes.
+
+<Info>
+Use `sifr --explain SIFR-CLASS-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+class User:
+    name: str
+
+user = User()
+```
+
+## How To Fix It
+
+Give class declarations a shape the compiler can lower: initialized fields, valid bases, unique variants, and supported field ordering.
+
+## Fixed Code
+
+```python
+class User:
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+user = User("Ada")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CLASS-0003` |
+| Family | `CLASS` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/enum_duplicate_value.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0004.mdx
+++ b/docs/errors/SIFR-CLASS-0004.mdx
@@ -1,0 +1,53 @@
+---
+title: "SIFR-CLASS-0004: Missing class field"
+sidebarTitle: "SIFR-CLASS-0004"
+description: "Missing class field"
+---
+
+`SIFR-CLASS-0004` belongs to the **Classes and declarations** diagnostic family. It means: missing class field.
+
+## Why It Happens
+
+The class declaration cannot be lowered into a safe Rust-backed representation. Check field initialization, default ordering, base classes, enum variants, and unsupported declaration shapes.
+
+<Info>
+Use `sifr --explain SIFR-CLASS-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+class User:
+    name: str
+
+user = User()
+```
+
+## How To Fix It
+
+Give class declarations a shape the compiler can lower: initialized fields, valid bases, unique variants, and supported field ordering.
+
+## Fixed Code
+
+```python
+class User:
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+user = User("Ada")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CLASS-0004` |
+| Family | `CLASS` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/missing_field.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0005.mdx
+++ b/docs/errors/SIFR-CLASS-0005.mdx
@@ -1,0 +1,53 @@
+---
+title: "SIFR-CLASS-0005: Invalid class base"
+sidebarTitle: "SIFR-CLASS-0005"
+description: "Invalid class base"
+---
+
+`SIFR-CLASS-0005` belongs to the **Classes and declarations** diagnostic family. It means: invalid class base.
+
+## Why It Happens
+
+The class declaration cannot be lowered into a safe Rust-backed representation. Check field initialization, default ordering, base classes, enum variants, and unsupported declaration shapes.
+
+<Info>
+Use `sifr --explain SIFR-CLASS-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+class User:
+    name: str
+
+user = User()
+```
+
+## How To Fix It
+
+Give class declarations a shape the compiler can lower: initialized fields, valid bases, unique variants, and supported field ordering.
+
+## Fixed Code
+
+```python
+class User:
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+user = User("Ada")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CLASS-0005` |
+| Family | `CLASS` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/class_unknown_parent.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0006.mdx
+++ b/docs/errors/SIFR-CLASS-0006.mdx
@@ -1,0 +1,53 @@
+---
+title: "SIFR-CLASS-0006: Unsupported class declaration"
+sidebarTitle: "SIFR-CLASS-0006"
+description: "Unsupported class declaration"
+---
+
+`SIFR-CLASS-0006` belongs to the **Classes and declarations** diagnostic family. It means: unsupported class declaration.
+
+## Why It Happens
+
+The class declaration cannot be lowered into a safe Rust-backed representation. Check field initialization, default ordering, base classes, enum variants, and unsupported declaration shapes.
+
+<Info>
+Use `sifr --explain SIFR-CLASS-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+class User:
+    name: str
+
+user = User()
+```
+
+## How To Fix It
+
+Give class declarations a shape the compiler can lower: initialized fields, valid bases, unique variants, and supported field ordering.
+
+## Fixed Code
+
+```python
+class User:
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+user = User("Ada")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-CLASS-0006` |
+| Family | `CLASS` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/class_unsupported_field_default.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0001.mdx
+++ b/docs/errors/SIFR-DECIMAL-0001.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-DECIMAL-0001: Invalid Decimal exact literal"
+sidebarTitle: "SIFR-DECIMAL-0001"
+description: "Invalid Decimal exact literal"
+---
+
+`SIFR-DECIMAL-0001` belongs to the **Decimal arithmetic** diagnostic family. It means: invalid decimal exact literal.
+
+## Why It Happens
+
+Sifr keeps decimal values exact. This diagnostic fires when decimal construction, scale handling, or mixed numeric operations would introduce ambiguity or precision loss.
+
+<Info>
+Use `sifr --explain SIFR-DECIMAL-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## How To Fix It
+
+Keep exact decimal values out of binary floating point. Use exact literals or string construction, and do not mix Decimal and BigDecimal in one expression.
+
+## Fixed Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-DECIMAL-0001` |
+| Family | `DECIMAL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/decimal_invalid_literal_string.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0002.mdx
+++ b/docs/errors/SIFR-DECIMAL-0002.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-DECIMAL-0002: Invalid BigDecimal exact literal"
+sidebarTitle: "SIFR-DECIMAL-0002"
+description: "Invalid BigDecimal exact literal"
+---
+
+`SIFR-DECIMAL-0002` belongs to the **Decimal arithmetic** diagnostic family. It means: invalid bigdecimal exact literal.
+
+## Why It Happens
+
+Sifr keeps decimal values exact. This diagnostic fires when decimal construction, scale handling, or mixed numeric operations would introduce ambiguity or precision loss.
+
+<Info>
+Use `sifr --explain SIFR-DECIMAL-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## How To Fix It
+
+Keep exact decimal values out of binary floating point. Use exact literals or string construction, and do not mix Decimal and BigDecimal in one expression.
+
+## Fixed Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-DECIMAL-0002` |
+| Family | `DECIMAL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/bigdecimal_invalid_literal_string.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0003.mdx
+++ b/docs/errors/SIFR-DECIMAL-0003.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-DECIMAL-0003: Float mixed with a decimal numeric type"
+sidebarTitle: "SIFR-DECIMAL-0003"
+description: "Float mixed with a decimal numeric type"
+---
+
+`SIFR-DECIMAL-0003` belongs to the **Decimal arithmetic** diagnostic family. It means: float mixed with a decimal numeric type.
+
+## Why It Happens
+
+Sifr keeps decimal values exact. This diagnostic fires when decimal construction, scale handling, or mixed numeric operations would introduce ambiguity or precision loss.
+
+<Info>
+Use `sifr --explain SIFR-DECIMAL-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## How To Fix It
+
+Keep exact decimal values out of binary floating point. Use exact literals or string construction, and do not mix Decimal and BigDecimal in one expression.
+
+## Fixed Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-DECIMAL-0003` |
+| Family | `DECIMAL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/decimal_float_mixed_arithmetic.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0004.mdx
+++ b/docs/errors/SIFR-DECIMAL-0004.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-DECIMAL-0004: Decimal and BigDecimal mixed in one operation"
+sidebarTitle: "SIFR-DECIMAL-0004"
+description: "Decimal and BigDecimal mixed in one operation"
+---
+
+`SIFR-DECIMAL-0004` belongs to the **Decimal arithmetic** diagnostic family. It means: decimal and bigdecimal mixed in one operation.
+
+## Why It Happens
+
+Sifr keeps decimal values exact. This diagnostic fires when decimal construction, scale handling, or mixed numeric operations would introduce ambiguity or precision loss.
+
+<Info>
+Use `sifr --explain SIFR-DECIMAL-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## How To Fix It
+
+Keep exact decimal values out of binary floating point. Use exact literals or string construction, and do not mix Decimal and BigDecimal in one expression.
+
+## Fixed Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-DECIMAL-0004` |
+| Family | `DECIMAL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/decimal_bigdecimal_mixed_arithmetic.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0005.mdx
+++ b/docs/errors/SIFR-DECIMAL-0005.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-DECIMAL-0005: Decimal float construction or conversion is forbidden"
+sidebarTitle: "SIFR-DECIMAL-0005"
+description: "Decimal float construction or conversion is forbidden"
+---
+
+`SIFR-DECIMAL-0005` belongs to the **Decimal arithmetic** diagnostic family. It means: decimal float construction or conversion is forbidden.
+
+## Why It Happens
+
+Sifr keeps decimal values exact. This diagnostic fires when decimal construction, scale handling, or mixed numeric operations would introduce ambiguity or precision loss.
+
+<Info>
+Use `sifr --explain SIFR-DECIMAL-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## How To Fix It
+
+Keep exact decimal values out of binary floating point. Use exact literals or string construction, and do not mix Decimal and BigDecimal in one expression.
+
+## Fixed Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-DECIMAL-0005` |
+| Family | `DECIMAL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/decimal_constructor_float.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0006.mdx
+++ b/docs/errors/SIFR-DECIMAL-0006.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-DECIMAL-0006: BigDecimal float construction or conversion is forbidden"
+sidebarTitle: "SIFR-DECIMAL-0006"
+description: "BigDecimal float construction or conversion is forbidden"
+---
+
+`SIFR-DECIMAL-0006` belongs to the **Decimal arithmetic** diagnostic family. It means: bigdecimal float construction or conversion is forbidden.
+
+## Why It Happens
+
+Sifr keeps decimal values exact. This diagnostic fires when decimal construction, scale handling, or mixed numeric operations would introduce ambiguity or precision loss.
+
+<Info>
+Use `sifr --explain SIFR-DECIMAL-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## How To Fix It
+
+Keep exact decimal values out of binary floating point. Use exact literals or string construction, and do not mix Decimal and BigDecimal in one expression.
+
+## Fixed Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-DECIMAL-0006` |
+| Family | `DECIMAL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/bigdecimal_constructor_float.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0007.mdx
+++ b/docs/errors/SIFR-DECIMAL-0007.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-DECIMAL-0007: Decimal scale argument is invalid"
+sidebarTitle: "SIFR-DECIMAL-0007"
+description: "Decimal scale argument is invalid"
+---
+
+`SIFR-DECIMAL-0007` belongs to the **Decimal arithmetic** diagnostic family. It means: decimal scale argument is invalid.
+
+## Why It Happens
+
+Sifr keeps decimal values exact. This diagnostic fires when decimal construction, scale handling, or mixed numeric operations would introduce ambiguity or precision loss.
+
+<Info>
+Use `sifr --explain SIFR-DECIMAL-0007` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## How To Fix It
+
+Keep exact decimal values out of binary floating point. Use exact literals or string construction, and do not mix Decimal and BigDecimal in one expression.
+
+## Fixed Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-DECIMAL-0007` |
+| Family | `DECIMAL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/decimal_round_scale_out_of_range.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0008.mdx
+++ b/docs/errors/SIFR-DECIMAL-0008.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-DECIMAL-0008: BigDecimal scale or context argument is invalid"
+sidebarTitle: "SIFR-DECIMAL-0008"
+description: "BigDecimal scale or context argument is invalid"
+---
+
+`SIFR-DECIMAL-0008` belongs to the **Decimal arithmetic** diagnostic family. It means: bigdecimal scale or context argument is invalid.
+
+## Why It Happens
+
+Sifr keeps decimal values exact. This diagnostic fires when decimal construction, scale handling, or mixed numeric operations would introduce ambiguity or precision loss.
+
+<Info>
+Use `sifr --explain SIFR-DECIMAL-0008` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## How To Fix It
+
+Keep exact decimal values out of binary floating point. Use exact literals or string construction, and do not mix Decimal and BigDecimal in one expression.
+
+## Fixed Code
+
+```python
+amount = Decimal("1.25")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-DECIMAL-0008` |
+| Family | `DECIMAL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/bigdecimal_quantize_negative_scale_context.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ENCODING-0803.mdx
+++ b/docs/errors/SIFR-ENCODING-0803.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-ENCODING-0803: Encoding error handler must be statically known"
+sidebarTitle: "SIFR-ENCODING-0803"
+description: "Encoding error handler must be statically known"
+---
+
+`SIFR-ENCODING-0803` belongs to the **Text encoding** diagnostic family. It means: encoding error handler must be statically known.
+
+## Why It Happens
+
+Text conversion behavior must be known at compile time. Use a supported, statically known encoding or error handler.
+
+<Info>
+Use `sifr --explain SIFR-ENCODING-0803` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+text = decode(data, "utf-8", handler_name)
+```
+
+## How To Fix It
+
+Use a statically known encoding error handler so text conversion remains predictable.
+
+## Fixed Code
+
+```python
+text = decode(data, "utf-8", "strict")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-ENCODING-0803` |
+| Family | `ENCODING` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/text_i18n_dynamic_errors_handler.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0001.mdx
+++ b/docs/errors/SIFR-FLOW-0001.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-FLOW-0001: Break outside a loop"
+sidebarTitle: "SIFR-FLOW-0001"
+description: "Break outside a loop"
+---
+
+`SIFR-FLOW-0001` belongs to the **Control flow** diagnostic family. It means: break outside a loop.
+
+## Why It Happens
+
+The control-flow graph cannot satisfy Sifr's static rules. Repair unsupported statements, invalid loop control, non-boolean conditions, missing returns, or unreachable code.
+
+<Info>
+Use `sifr --explain SIFR-FLOW-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+```
+
+## How To Fix It
+
+Repair the control-flow shape: put break/continue inside loops, return on every required path, and use supported loop and assignment forms.
+
+## Fixed Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+    return "zero or negative"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-FLOW-0001` |
+| Family | `FLOW` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/break_outside_loop.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0002.mdx
+++ b/docs/errors/SIFR-FLOW-0002.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-FLOW-0002: Continue outside a loop"
+sidebarTitle: "SIFR-FLOW-0002"
+description: "Continue outside a loop"
+---
+
+`SIFR-FLOW-0002` belongs to the **Control flow** diagnostic family. It means: continue outside a loop.
+
+## Why It Happens
+
+The control-flow graph cannot satisfy Sifr's static rules. Repair unsupported statements, invalid loop control, non-boolean conditions, missing returns, or unreachable code.
+
+<Info>
+Use `sifr --explain SIFR-FLOW-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+```
+
+## How To Fix It
+
+Repair the control-flow shape: put break/continue inside loops, return on every required path, and use supported loop and assignment forms.
+
+## Fixed Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+    return "zero or negative"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-FLOW-0002` |
+| Family | `FLOW` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/continue_outside_loop.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0003.mdx
+++ b/docs/errors/SIFR-FLOW-0003.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-FLOW-0003: Invalid nonlocal or nested-function flow"
+sidebarTitle: "SIFR-FLOW-0003"
+description: "Invalid nonlocal or nested-function flow"
+---
+
+`SIFR-FLOW-0003` belongs to the **Control flow** diagnostic family. It means: invalid nonlocal or nested-function flow.
+
+## Why It Happens
+
+The control-flow graph cannot satisfy Sifr's static rules. Repair unsupported statements, invalid loop control, non-boolean conditions, missing returns, or unreachable code.
+
+<Info>
+Use `sifr --explain SIFR-FLOW-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+```
+
+## How To Fix It
+
+Repair the control-flow shape: put break/continue inside loops, return on every required path, and use supported loop and assignment forms.
+
+## Fixed Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+    return "zero or negative"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-FLOW-0003` |
+| Family | `FLOW` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/nested_function_recursive_nonlocal_unsupported.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0004.mdx
+++ b/docs/errors/SIFR-FLOW-0004.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-FLOW-0004: Function may finish without returning a required value"
+sidebarTitle: "SIFR-FLOW-0004"
+description: "Function may finish without returning a required value"
+---
+
+`SIFR-FLOW-0004` belongs to the **Control flow** diagnostic family. It means: function may finish without returning a required value.
+
+## Why It Happens
+
+The control-flow graph cannot satisfy Sifr's static rules. Repair unsupported statements, invalid loop control, non-boolean conditions, missing returns, or unreachable code.
+
+<Info>
+Use `sifr --explain SIFR-FLOW-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+```
+
+## How To Fix It
+
+Repair the control-flow shape: put break/continue inside loops, return on every required path, and use supported loop and assignment forms.
+
+## Fixed Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+    return "zero or negative"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-FLOW-0004` |
+| Family | `FLOW` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/missing_return_value.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0005.mdx
+++ b/docs/errors/SIFR-FLOW-0005.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-FLOW-0005: Control-flow condition has an unsupported type"
+sidebarTitle: "SIFR-FLOW-0005"
+description: "Control-flow condition has an unsupported type"
+---
+
+`SIFR-FLOW-0005` belongs to the **Control flow** diagnostic family. It means: control-flow condition has an unsupported type.
+
+## Why It Happens
+
+The control-flow graph cannot satisfy Sifr's static rules. Repair unsupported statements, invalid loop control, non-boolean conditions, missing returns, or unreachable code.
+
+<Info>
+Use `sifr --explain SIFR-FLOW-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+```
+
+## How To Fix It
+
+Repair the control-flow shape: put break/continue inside loops, return on every required path, and use supported loop and assignment forms.
+
+## Fixed Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+    return "zero or negative"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-FLOW-0005` |
+| Family | `FLOW` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/if_condition_numeric_truthiness.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0006.mdx
+++ b/docs/errors/SIFR-FLOW-0006.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-FLOW-0006: Statement form is unsupported by HIR lowering"
+sidebarTitle: "SIFR-FLOW-0006"
+description: "Statement form is unsupported by HIR lowering"
+---
+
+`SIFR-FLOW-0006` belongs to the **Control flow** diagnostic family. It means: statement form is unsupported by hir lowering.
+
+## Why It Happens
+
+The control-flow graph cannot satisfy Sifr's static rules. Repair unsupported statements, invalid loop control, non-boolean conditions, missing returns, or unreachable code.
+
+<Info>
+Use `sifr --explain SIFR-FLOW-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+```
+
+## How To Fix It
+
+Repair the control-flow shape: put break/continue inside loops, return on every required path, and use supported loop and assignment forms.
+
+## Fixed Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+    return "zero or negative"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-FLOW-0006` |
+| Family | `FLOW` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/yield_without_value.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0007.mdx
+++ b/docs/errors/SIFR-FLOW-0007.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-FLOW-0007: Assignment target form is unsupported by HIR lowering"
+sidebarTitle: "SIFR-FLOW-0007"
+description: "Assignment target form is unsupported by HIR lowering"
+---
+
+`SIFR-FLOW-0007` belongs to the **Control flow** diagnostic family. It means: assignment target form is unsupported by hir lowering.
+
+## Why It Happens
+
+The control-flow graph cannot satisfy Sifr's static rules. Repair unsupported statements, invalid loop control, non-boolean conditions, missing returns, or unreachable code.
+
+<Info>
+Use `sifr --explain SIFR-FLOW-0007` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+```
+
+## How To Fix It
+
+Repair the control-flow shape: put break/continue inside loops, return on every required path, and use supported loop and assignment forms.
+
+## Fixed Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+    return "zero or negative"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-FLOW-0007` |
+| Family | `FLOW` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/invalid_assignment_target_attribute_base.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0008.mdx
+++ b/docs/errors/SIFR-FLOW-0008.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-FLOW-0008: For-loop iteration form or source is invalid"
+sidebarTitle: "SIFR-FLOW-0008"
+description: "For-loop iteration form or source is invalid"
+---
+
+`SIFR-FLOW-0008` belongs to the **Control flow** diagnostic family. It means: for-loop iteration form or source is invalid.
+
+## Why It Happens
+
+The control-flow graph cannot satisfy Sifr's static rules. Repair unsupported statements, invalid loop control, non-boolean conditions, missing returns, or unreachable code.
+
+<Info>
+Use `sifr --explain SIFR-FLOW-0008` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+```
+
+## How To Fix It
+
+Repair the control-flow shape: put break/continue inside loops, return on every required path, and use supported loop and assignment forms.
+
+## Fixed Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+    return "zero or negative"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-FLOW-0008` |
+| Family | `FLOW` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/for_loop_invalid_iterable.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0901.mdx
+++ b/docs/errors/SIFR-FLOW-0901.mdx
@@ -1,0 +1,49 @@
+---
+title: "SIFR-FLOW-0901: Unreachable statement ignored during lowering"
+sidebarTitle: "SIFR-FLOW-0901"
+description: "Unreachable statement ignored during lowering"
+---
+
+`SIFR-FLOW-0901` belongs to the **Control flow** diagnostic family. It means: unreachable statement ignored during lowering.
+
+## Why It Happens
+
+The control-flow graph cannot satisfy Sifr's static rules. Repair unsupported statements, invalid loop control, non-boolean conditions, missing returns, or unreachable code.
+
+<Info>
+Use `sifr --explain SIFR-FLOW-0901` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+```
+
+## How To Fix It
+
+Repair the control-flow shape: put break/continue inside loops, return on every required path, and use supported loop and assignment forms.
+
+## Fixed Code
+
+```python
+def label(value: int) -> str:
+    if value > 0:
+        return "positive"
+    return "zero or negative"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-FLOW-0901` |
+| Family | `FLOW` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_driver/src/tests/single_file_frontend.rs::test_type_check_source_surfaces_unreachable_statement_as_structured_warning` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FMT-0001.mdx
+++ b/docs/errors/SIFR-FMT-0001.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-FMT-0001: Source formatting drift detected by sifr fmt --check"
+sidebarTitle: "SIFR-FMT-0001"
+description: "Source formatting drift detected by sifr fmt --check"
+---
+
+`SIFR-FMT-0001` belongs to the **Formatting** diagnostic family. It means: source formatting drift detected by sifr fmt --check.
+
+## Why It Happens
+
+The source file differs from canonical Sifr formatter output.
+
+<Info>
+Use `sifr --explain SIFR-FMT-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def main()->int:
+ return 1
+```
+
+## How To Fix It
+
+Run `sifr fmt` to rewrite the file, or make the source match the formatter output before using `sifr fmt --check`.
+
+## Fixed Code
+
+```python
+def main() -> int:
+    return 1
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-FMT-0001` |
+| Family | `FMT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr_format/src/lib.rs::check_reports_formatting_drift` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0001.mdx
+++ b/docs/errors/SIFR-IMPORT-0001.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-IMPORT-0001: Forbidden intrinsic import"
+sidebarTitle: "SIFR-IMPORT-0001"
+description: "Forbidden intrinsic import"
+---
+
+`SIFR-IMPORT-0001` belongs to the **Imports and module resolution** diagnostic family. It means: forbidden intrinsic import.
+
+## Why It Happens
+
+The module graph cannot be resolved safely. Use explicit `sifr.*` imports for standard-library modules, avoid private imports, and remove ambiguous or cyclic import paths.
+
+<Info>
+Use `sifr --explain SIFR-IMPORT-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from math import sqrt
+```
+
+## How To Fix It
+
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+
+## Fixed Code
+
+```python
+from sifr.math import sqrt
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IMPORT-0001` |
+| Family | `IMPORT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/stdlib_intrinsic_direct_import.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0002.mdx
+++ b/docs/errors/SIFR-IMPORT-0002.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-IMPORT-0002: Unknown source module import target"
+sidebarTitle: "SIFR-IMPORT-0002"
+description: "Unknown source module import target"
+---
+
+`SIFR-IMPORT-0002` belongs to the **Imports and module resolution** diagnostic family. It means: unknown source module import target.
+
+## Why It Happens
+
+The module graph cannot be resolved safely. Use explicit `sifr.*` imports for standard-library modules, avoid private imports, and remove ambiguous or cyclic import paths.
+
+<Info>
+Use `sifr --explain SIFR-IMPORT-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from math import sqrt
+```
+
+## How To Fix It
+
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+
+## Fixed Code
+
+```python
+from sifr.math import sqrt
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IMPORT-0002` |
+| Family | `IMPORT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/import_nonexistent_local.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0003.mdx
+++ b/docs/errors/SIFR-IMPORT-0003.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-IMPORT-0003: Unsupported import statement form"
+sidebarTitle: "SIFR-IMPORT-0003"
+description: "Unsupported import statement form"
+---
+
+`SIFR-IMPORT-0003` belongs to the **Imports and module resolution** diagnostic family. It means: unsupported import statement form.
+
+## Why It Happens
+
+The module graph cannot be resolved safely. Use explicit `sifr.*` imports for standard-library modules, avoid private imports, and remove ambiguous or cyclic import paths.
+
+<Info>
+Use `sifr --explain SIFR-IMPORT-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from math import sqrt
+```
+
+## How To Fix It
+
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+
+## Fixed Code
+
+```python
+from sifr.math import sqrt
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IMPORT-0003` |
+| Family | `IMPORT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/unsupported_import_statement.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0004.mdx
+++ b/docs/errors/SIFR-IMPORT-0004.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-IMPORT-0004: Private module member import"
+sidebarTitle: "SIFR-IMPORT-0004"
+description: "Private module member import"
+---
+
+`SIFR-IMPORT-0004` belongs to the **Imports and module resolution** diagnostic family. It means: private module member import.
+
+## Why It Happens
+
+The module graph cannot be resolved safely. Use explicit `sifr.*` imports for standard-library modules, avoid private imports, and remove ambiguous or cyclic import paths.
+
+<Info>
+Use `sifr --explain SIFR-IMPORT-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from math import sqrt
+```
+
+## How To Fix It
+
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+
+## Fixed Code
+
+```python
+from sifr.math import sqrt
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IMPORT-0004` |
+| Family | `IMPORT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_lowering/src/lower/name_import_diagnostics_tests.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0005.mdx
+++ b/docs/errors/SIFR-IMPORT-0005.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-IMPORT-0005: Ambiguous source module import target"
+sidebarTitle: "SIFR-IMPORT-0005"
+description: "Ambiguous source module import target"
+---
+
+`SIFR-IMPORT-0005` belongs to the **Imports and module resolution** diagnostic family. It means: ambiguous source module import target.
+
+## Why It Happens
+
+The module graph cannot be resolved safely. Use explicit `sifr.*` imports for standard-library modules, avoid private imports, and remove ambiguous or cyclic import paths.
+
+<Info>
+Use `sifr --explain SIFR-IMPORT-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from math import sqrt
+```
+
+## How To Fix It
+
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+
+## Fixed Code
+
+```python
+from sifr.math import sqrt
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IMPORT-0005` |
+| Family | `IMPORT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `verification/areas/project_workspace/fixtures/project/workspace_ambiguous_import_canonical` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0006.mdx
+++ b/docs/errors/SIFR-IMPORT-0006.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-IMPORT-0006: Source module namespace and file import collision"
+sidebarTitle: "SIFR-IMPORT-0006"
+description: "Source module namespace and file import collision"
+---
+
+`SIFR-IMPORT-0006` belongs to the **Imports and module resolution** diagnostic family. It means: source module namespace and file import collision.
+
+## Why It Happens
+
+The module graph cannot be resolved safely. Use explicit `sifr.*` imports for standard-library modules, avoid private imports, and remove ambiguous or cyclic import paths.
+
+<Info>
+Use `sifr --explain SIFR-IMPORT-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from math import sqrt
+```
+
+## How To Fix It
+
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+
+## Fixed Code
+
+```python
+from sifr.math import sqrt
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IMPORT-0006` |
+| Family | `IMPORT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `verification/areas/project_workspace/fixtures/project/workspace_namespace_collision_canonical` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0007.mdx
+++ b/docs/errors/SIFR-IMPORT-0007.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-IMPORT-0007: Circular source module import graph"
+sidebarTitle: "SIFR-IMPORT-0007"
+description: "Circular source module import graph"
+---
+
+`SIFR-IMPORT-0007` belongs to the **Imports and module resolution** diagnostic family. It means: circular source module import graph.
+
+## Why It Happens
+
+The module graph cannot be resolved safely. Use explicit `sifr.*` imports for standard-library modules, avoid private imports, and remove ambiguous or cyclic import paths.
+
+<Info>
+Use `sifr --explain SIFR-IMPORT-0007` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from math import sqrt
+```
+
+## How To Fix It
+
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+
+## Fixed Code
+
+```python
+from sifr.math import sqrt
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IMPORT-0007` |
+| Family | `IMPORT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `verification/areas/project_workspace/fixtures/project/import_cycle_source_spans` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0008.mdx
+++ b/docs/errors/SIFR-IMPORT-0008.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-IMPORT-0008: Bare CPython-style stdlib import attempt"
+sidebarTitle: "SIFR-IMPORT-0008"
+description: "Bare CPython-style stdlib import attempt"
+---
+
+`SIFR-IMPORT-0008` belongs to the **Imports and module resolution** diagnostic family. It means: bare cpython-style stdlib import attempt.
+
+## Why It Happens
+
+The module graph cannot be resolved safely. Use explicit `sifr.*` imports for standard-library modules, avoid private imports, and remove ambiguous or cyclic import paths.
+
+<Info>
+Use `sifr --explain SIFR-IMPORT-0008` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from math import sqrt
+```
+
+## How To Fix It
+
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+
+## Fixed Code
+
+```python
+from sifr.math import sqrt
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IMPORT-0008` |
+| Family | `IMPORT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/bare_stdlib_from_math.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0009.mdx
+++ b/docs/errors/SIFR-IMPORT-0009.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-IMPORT-0009: Unsupported legacy Sifr stdlib module import"
+sidebarTitle: "SIFR-IMPORT-0009"
+description: "Unsupported legacy Sifr stdlib module import"
+---
+
+`SIFR-IMPORT-0009` belongs to the **Imports and module resolution** diagnostic family. It means: unsupported legacy sifr stdlib module import.
+
+## Why It Happens
+
+The module graph cannot be resolved safely. Use explicit `sifr.*` imports for standard-library modules, avoid private imports, and remove ambiguous or cyclic import paths.
+
+<Info>
+Use `sifr --explain SIFR-IMPORT-0009` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from math import sqrt
+```
+
+## How To Fix It
+
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+
+## Fixed Code
+
+```python
+from sifr.math import sqrt
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IMPORT-0009` |
+| Family | `IMPORT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/legacy_sifr_asyncio_removed.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0001.mdx
+++ b/docs/errors/SIFR-INT-0001.mdx
@@ -1,0 +1,45 @@
+---
+title: "SIFR-INT-0001: Fixed-width integer literal or const expression is out of range"
+sidebarTitle: "SIFR-INT-0001"
+description: "Fixed-width integer literal or const expression is out of range"
+---
+
+`SIFR-INT-0001` belongs to the **Integer model** diagnostic family. It means: fixed-width integer literal or const expression is out of range.
+
+## Why It Happens
+
+Sifr separates exact integers from fixed-width integers. This diagnostic fires when an integer value, operation, or conversion could overflow, lose precision, or rely on an implicit transition.
+
+<Info>
+Use `sifr --explain SIFR-INT-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+small: int8 = 200
+```
+
+## How To Fix It
+
+Choose an integer type whose range fits the value, and make lossy or fallible numeric conversions explicit.
+
+## Fixed Code
+
+```python
+small: int8 = 127
+wide: int = 200
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-INT-0001` |
+| Family | `INT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_lowering/src/lower/expressions_tests.rs::test_fixed_width_literal_assignment_out_of_range_has_int_code` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0003.mdx
+++ b/docs/errors/SIFR-INT-0003.mdx
@@ -1,0 +1,45 @@
+---
+title: "SIFR-INT-0003: Reserved integer width name used before support lands"
+sidebarTitle: "SIFR-INT-0003"
+description: "Reserved integer width name used before support lands"
+---
+
+`SIFR-INT-0003` belongs to the **Integer model** diagnostic family. It means: reserved integer width name used before support lands.
+
+## Why It Happens
+
+Sifr separates exact integers from fixed-width integers. This diagnostic fires when an integer value, operation, or conversion could overflow, lose precision, or rely on an implicit transition.
+
+<Info>
+Use `sifr --explain SIFR-INT-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+small: int8 = 200
+```
+
+## How To Fix It
+
+Choose an integer type whose range fits the value, and make lossy or fallible numeric conversions explicit.
+
+## Fixed Code
+
+```python
+small: int8 = 127
+wide: int = 200
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-INT-0003` |
+| Family | `INT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/reserved_int128_annotation.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0004.mdx
+++ b/docs/errors/SIFR-INT-0004.mdx
@@ -1,0 +1,45 @@
+---
+title: "SIFR-INT-0004: Compile-time integer evaluation budget exceeded"
+sidebarTitle: "SIFR-INT-0004"
+description: "Compile-time integer evaluation budget exceeded"
+---
+
+`SIFR-INT-0004` belongs to the **Integer model** diagnostic family. It means: compile-time integer evaluation budget exceeded.
+
+## Why It Happens
+
+Sifr separates exact integers from fixed-width integers. This diagnostic fires when an integer value, operation, or conversion could overflow, lose precision, or rely on an implicit transition.
+
+<Info>
+Use `sifr --explain SIFR-INT-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+small: int8 = 200
+```
+
+## How To Fix It
+
+Choose an integer type whose range fits the value, and make lossy or fallible numeric conversions explicit.
+
+## Fixed Code
+
+```python
+small: int8 = 127
+wide: int = 200
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-INT-0004` |
+| Family | `INT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_lowering/src/lower/expressions_tests.rs::test_large_integer_literal_over_budget_has_int_code` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0005.mdx
+++ b/docs/errors/SIFR-INT-0005.mdx
@@ -1,0 +1,45 @@
+---
+title: "SIFR-INT-0005: Integer division, modulo, or exponentiation requires handling a typed failure"
+sidebarTitle: "SIFR-INT-0005"
+description: "Integer division, modulo, or exponentiation requires handling a typed failure"
+---
+
+`SIFR-INT-0005` belongs to the **Integer model** diagnostic family. It means: integer division, modulo, or exponentiation requires handling a typed failure.
+
+## Why It Happens
+
+Sifr separates exact integers from fixed-width integers. This diagnostic fires when an integer value, operation, or conversion could overflow, lose precision, or rely on an implicit transition.
+
+<Info>
+Use `sifr --explain SIFR-INT-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+small: int8 = 200
+```
+
+## How To Fix It
+
+Choose an integer type whose range fits the value, and make lossy or fallible numeric conversions explicit.
+
+## Fixed Code
+
+```python
+small: int8 = 127
+wide: int = 200
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-INT-0005` |
+| Family | `INT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/exact_int_division_requires_handling.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0006.mdx
+++ b/docs/errors/SIFR-INT-0006.mdx
@@ -1,0 +1,45 @@
+---
+title: "SIFR-INT-0006: Exact integer to float conversion requires handling precision loss"
+sidebarTitle: "SIFR-INT-0006"
+description: "Exact integer to float conversion requires handling precision loss"
+---
+
+`SIFR-INT-0006` belongs to the **Integer model** diagnostic family. It means: exact integer to float conversion requires handling precision loss.
+
+## Why It Happens
+
+Sifr separates exact integers from fixed-width integers. This diagnostic fires when an integer value, operation, or conversion could overflow, lose precision, or rely on an implicit transition.
+
+<Info>
+Use `sifr --explain SIFR-INT-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+small: int8 = 200
+```
+
+## How To Fix It
+
+Choose an integer type whose range fits the value, and make lossy or fallible numeric conversions explicit.
+
+## Fixed Code
+
+```python
+small: int8 = 127
+wide: int = 200
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-INT-0006` |
+| Family | `INT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/exact_int_true_division_requires_handling.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0007.mdx
+++ b/docs/errors/SIFR-INT-0007.mdx
@@ -1,0 +1,45 @@
+---
+title: "SIFR-INT-0007: Bool and integer comparison requires explicit conversion"
+sidebarTitle: "SIFR-INT-0007"
+description: "Bool and integer comparison requires explicit conversion"
+---
+
+`SIFR-INT-0007` belongs to the **Integer model** diagnostic family. It means: bool and integer comparison requires explicit conversion.
+
+## Why It Happens
+
+Sifr separates exact integers from fixed-width integers. This diagnostic fires when an integer value, operation, or conversion could overflow, lose precision, or rely on an implicit transition.
+
+<Info>
+Use `sifr --explain SIFR-INT-0007` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+small: int8 = 200
+```
+
+## How To Fix It
+
+Choose an integer type whose range fits the value, and make lossy or fallible numeric conversions explicit.
+
+## Fixed Code
+
+```python
+small: int8 = 127
+wide: int = 200
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-INT-0007` |
+| Family | `INT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/bool_integer_comparison.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0011.mdx
+++ b/docs/errors/SIFR-INT-0011.mdx
@@ -1,0 +1,45 @@
+---
+title: "SIFR-INT-0011: Temporary bigint transition alias used"
+sidebarTitle: "SIFR-INT-0011"
+description: "Temporary bigint transition alias used"
+---
+
+`SIFR-INT-0011` belongs to the **Integer model** diagnostic family. It means: temporary bigint transition alias used.
+
+## Why It Happens
+
+Sifr separates exact integers from fixed-width integers. This diagnostic fires when an integer value, operation, or conversion could overflow, lose precision, or rely on an implicit transition.
+
+<Info>
+Use `sifr --explain SIFR-INT-0011` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+small: int8 = 200
+```
+
+## How To Fix It
+
+Choose an integer type whose range fits the value, and make lossy or fallible numeric conversions explicit.
+
+## Fixed Code
+
+```python
+small: int8 = 127
+wide: int = 200
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-INT-0011` |
+| Family | `INT` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_driver/src/tests/single_file_frontend.rs::test_type_check_source_surfaces_bigint_transition_warning` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INTERNAL-0001.mdx
+++ b/docs/errors/SIFR-INTERNAL-0001.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-INTERNAL-0001: Unclassified compiler panic after a panic boundary"
+sidebarTitle: "SIFR-INTERNAL-0001"
+description: "Unclassified compiler panic after a panic boundary"
+---
+
+`SIFR-INTERNAL-0001` belongs to the **Internal compiler recovery** diagnostic family. It means: unclassified compiler panic after a panic boundary.
+
+## Why It Happens
+
+This diagnostic indicates compiler recovery from an internal invariant failure or missing recovery cap. Preserve the diagnostic code, compiler version, and smallest reproducer for a bug report.
+
+<Info>
+Use `sifr --explain SIFR-INTERNAL-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```text
+compiler emitted SIFR-INTERNAL-0001
+```
+
+## How To Fix It
+
+Do not try to silence an internal diagnostic with user-code workarounds. Reduce the program and report it.
+
+## Fixed Code
+
+```text
+report the smallest reproducer with the Sifr version and diagnostic output
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-INTERNAL-0001` |
+| Family | `INTERNAL` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_driver/src/tests/panic_boundary.rs::planned_internal_0001` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INTERNAL-0002.mdx
+++ b/docs/errors/SIFR-INTERNAL-0002.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-INTERNAL-0002: Structured recovery-cap omission summary"
+sidebarTitle: "SIFR-INTERNAL-0002"
+description: "Structured recovery-cap omission summary"
+---
+
+`SIFR-INTERNAL-0002` belongs to the **Internal compiler recovery** diagnostic family. It means: structured recovery-cap omission summary.
+
+## Why It Happens
+
+This diagnostic indicates compiler recovery from an internal invariant failure or missing recovery cap. Preserve the diagnostic code, compiler version, and smallest reproducer for a bug report.
+
+<Info>
+Use `sifr --explain SIFR-INTERNAL-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```text
+compiler emitted SIFR-INTERNAL-0001
+```
+
+## How To Fix It
+
+Do not try to silence an internal diagnostic with user-code workarounds. Reduce the program and report it.
+
+## Fixed Code
+
+```text
+report the smallest reproducer with the Sifr version and diagnostic output
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-INTERNAL-0002` |
+| Family | `INTERNAL` |
+| Severity | Note |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_driver/src/tests/diagnostics.rs::test_apply_diagnostic_recovery_limits_summarizes_similar_diagnostics` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IO-0801.mdx
+++ b/docs/errors/SIFR-IO-0801.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-IO-0801: Text-mode open requires an explicit encoding"
+sidebarTitle: "SIFR-IO-0801"
+description: "Text-mode open requires an explicit encoding"
+---
+
+`SIFR-IO-0801` belongs to the **File and stream I/O** diagnostic family. It means: text-mode open requires an explicit encoding.
+
+## Why It Happens
+
+Sifr makes file mode and text encoding boundaries explicit. This diagnostic fires when file I/O would depend on runtime-default mode or encoding behavior.
+
+<Info>
+Use `sifr --explain SIFR-IO-0801` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from sifr.io import open
+
+file = open("notes.txt", "r")
+```
+
+## How To Fix It
+
+Make file modes and encodings explicit at compile time, especially at text/binary boundaries.
+
+## Fixed Code
+
+```python
+from sifr.io import open_text
+
+file = open_text("notes.txt", encoding="utf-8")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IO-0801` |
+| Family | `IO` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/text_i18n_open_without_encoding.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IO-0802.mdx
+++ b/docs/errors/SIFR-IO-0802.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-IO-0802: Open mode must be statically known"
+sidebarTitle: "SIFR-IO-0802"
+description: "Open mode must be statically known"
+---
+
+`SIFR-IO-0802` belongs to the **File and stream I/O** diagnostic family. It means: open mode must be statically known.
+
+## Why It Happens
+
+Sifr makes file mode and text encoding boundaries explicit. This diagnostic fires when file I/O would depend on runtime-default mode or encoding behavior.
+
+<Info>
+Use `sifr --explain SIFR-IO-0802` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+from sifr.io import open
+
+file = open("notes.txt", "r")
+```
+
+## How To Fix It
+
+Make file modes and encodings explicit at compile time, especially at text/binary boundaries.
+
+## Fixed Code
+
+```python
+from sifr.io import open_text
+
+file = open_text("notes.txt", encoding="utf-8")
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-IO-0802` |
+| Family | `IO` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/text_i18n_open_dynamic_mode.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0001.mdx
+++ b/docs/errors/SIFR-LINT-0001.mdx
@@ -1,0 +1,52 @@
+---
+title: "SIFR-LINT-0001: Suppression references an unknown policy rule id"
+sidebarTitle: "SIFR-LINT-0001"
+description: "Suppression references an unknown policy rule id"
+---
+
+`SIFR-LINT-0001` belongs to the **Policy linting** diagnostic family. It means: suppression references an unknown policy rule id.
+
+## Why It Happens
+
+A suppressible policy rule fired, or a suppression itself is malformed. Fix the policy issue or make the suppression exact and local.
+
+<Info>
+Use `sifr --explain SIFR-LINT-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+# sifr: ignore
+def f(flag: bool):
+    pass
+
+f(True)
+```
+
+## How To Fix It
+
+Fix the policy issue when possible. If suppression is intentional, list the exact policy rule id and keep it local.
+
+## Fixed Code
+
+```python
+# sifr: ignore SIFR-LINT-0006
+def f(flag: bool):
+    pass
+
+f(flag=True)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-LINT-0001` |
+| Family | `LINT` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr_lint/src/lib.rs::unknown_and_unused_suppressions_are_reported` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0002.mdx
+++ b/docs/errors/SIFR-LINT-0002.mdx
@@ -1,0 +1,52 @@
+---
+title: "SIFR-LINT-0002: Suppression did not suppress any diagnostic"
+sidebarTitle: "SIFR-LINT-0002"
+description: "Suppression did not suppress any diagnostic"
+---
+
+`SIFR-LINT-0002` belongs to the **Policy linting** diagnostic family. It means: suppression did not suppress any diagnostic.
+
+## Why It Happens
+
+A suppressible policy rule fired, or a suppression itself is malformed. Fix the policy issue or make the suppression exact and local.
+
+<Info>
+Use `sifr --explain SIFR-LINT-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+# sifr: ignore
+def f(flag: bool):
+    pass
+
+f(True)
+```
+
+## How To Fix It
+
+Fix the policy issue when possible. If suppression is intentional, list the exact policy rule id and keep it local.
+
+## Fixed Code
+
+```python
+# sifr: ignore SIFR-LINT-0006
+def f(flag: bool):
+    pass
+
+f(flag=True)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-LINT-0002` |
+| Family | `LINT` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr_lint/src/lib.rs::unknown_and_unused_suppressions_are_reported` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0003.mdx
+++ b/docs/errors/SIFR-LINT-0003.mdx
@@ -1,0 +1,52 @@
+---
+title: "SIFR-LINT-0003: Suppression must list explicit Sifr policy rule ids"
+sidebarTitle: "SIFR-LINT-0003"
+description: "Suppression must list explicit Sifr policy rule ids"
+---
+
+`SIFR-LINT-0003` belongs to the **Policy linting** diagnostic family. It means: suppression must list explicit sifr policy rule ids.
+
+## Why It Happens
+
+A suppressible policy rule fired, or a suppression itself is malformed. Fix the policy issue or make the suppression exact and local.
+
+<Info>
+Use `sifr --explain SIFR-LINT-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+# sifr: ignore
+def f(flag: bool):
+    pass
+
+f(True)
+```
+
+## How To Fix It
+
+Fix the policy issue when possible. If suppression is intentional, list the exact policy rule id and keep it local.
+
+## Fixed Code
+
+```python
+# sifr: ignore SIFR-LINT-0006
+def f(flag: bool):
+    pass
+
+f(flag=True)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-LINT-0003` |
+| Family | `LINT` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr_lint/src/lib.rs::blanket_suppression_is_reported` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0004.mdx
+++ b/docs/errors/SIFR-LINT-0004.mdx
@@ -1,0 +1,52 @@
+---
+title: "SIFR-LINT-0004: Line ends with trailing horizontal whitespace"
+sidebarTitle: "SIFR-LINT-0004"
+description: "Line ends with trailing horizontal whitespace"
+---
+
+`SIFR-LINT-0004` belongs to the **Policy linting** diagnostic family. It means: line ends with trailing horizontal whitespace.
+
+## Why It Happens
+
+A suppressible policy rule fired, or a suppression itself is malformed. Fix the policy issue or make the suppression exact and local.
+
+<Info>
+Use `sifr --explain SIFR-LINT-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+# sifr: ignore
+def f(flag: bool):
+    pass
+
+f(True)
+```
+
+## How To Fix It
+
+Fix the policy issue when possible. If suppression is intentional, list the exact policy rule id and keep it local.
+
+## Fixed Code
+
+```python
+# sifr: ignore SIFR-LINT-0006
+def f(flag: bool):
+    pass
+
+f(flag=True)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-LINT-0004` |
+| Family | `LINT` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr_lint/src/lib.rs::suppression_only_suppresses_matching_policy_rule` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0005.mdx
+++ b/docs/errors/SIFR-LINT-0005.mdx
@@ -1,0 +1,52 @@
+---
+title: "SIFR-LINT-0005: Comment contains a tracked TODO or FIXME marker"
+sidebarTitle: "SIFR-LINT-0005"
+description: "Comment contains a tracked TODO or FIXME marker"
+---
+
+`SIFR-LINT-0005` belongs to the **Policy linting** diagnostic family. It means: comment contains a tracked todo or fixme marker.
+
+## Why It Happens
+
+A suppressible policy rule fired, or a suppression itself is malformed. Fix the policy issue or make the suppression exact and local.
+
+<Info>
+Use `sifr --explain SIFR-LINT-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+# sifr: ignore
+def f(flag: bool):
+    pass
+
+f(True)
+```
+
+## How To Fix It
+
+Fix the policy issue when possible. If suppression is intentional, list the exact policy rule id and keep it local.
+
+## Fixed Code
+
+```python
+# sifr: ignore SIFR-LINT-0006
+def f(flag: bool):
+    pass
+
+f(flag=True)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-LINT-0005` |
+| Family | `LINT` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr_lint/src/rules/todo_comment.rs::todo_comment_reports_tracked_marker` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0006.mdx
+++ b/docs/errors/SIFR-LINT-0006.mdx
@@ -1,0 +1,52 @@
+---
+title: "SIFR-LINT-0006: Call passes a boolean literal positionally"
+sidebarTitle: "SIFR-LINT-0006"
+description: "Call passes a boolean literal positionally"
+---
+
+`SIFR-LINT-0006` belongs to the **Policy linting** diagnostic family. It means: call passes a boolean literal positionally.
+
+## Why It Happens
+
+A suppressible policy rule fired, or a suppression itself is malformed. Fix the policy issue or make the suppression exact and local.
+
+<Info>
+Use `sifr --explain SIFR-LINT-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+# sifr: ignore
+def f(flag: bool):
+    pass
+
+f(True)
+```
+
+## How To Fix It
+
+Fix the policy issue when possible. If suppression is intentional, list the exact policy rule id and keep it local.
+
+## Fixed Code
+
+```python
+# sifr: ignore SIFR-LINT-0006
+def f(flag: bool):
+    pass
+
+f(flag=True)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-LINT-0006` |
+| Family | `LINT` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr_lint/src/rules/boolean_positional_argument.rs::boolean_positional_argument_reports_literal_call_arg` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0007.mdx
+++ b/docs/errors/SIFR-LINT-0007.mdx
@@ -1,0 +1,52 @@
+---
+title: "SIFR-LINT-0007: Function has more parameters than the policy limit"
+sidebarTitle: "SIFR-LINT-0007"
+description: "Function has more parameters than the policy limit"
+---
+
+`SIFR-LINT-0007` belongs to the **Policy linting** diagnostic family. It means: function has more parameters than the policy limit.
+
+## Why It Happens
+
+A suppressible policy rule fired, or a suppression itself is malformed. Fix the policy issue or make the suppression exact and local.
+
+<Info>
+Use `sifr --explain SIFR-LINT-0007` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+# sifr: ignore
+def f(flag: bool):
+    pass
+
+f(True)
+```
+
+## How To Fix It
+
+Fix the policy issue when possible. If suppression is intentional, list the exact policy rule id and keep it local.
+
+## Fixed Code
+
+```python
+# sifr: ignore SIFR-LINT-0006
+def f(flag: bool):
+    pass
+
+f(flag=True)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-LINT-0007` |
+| Family | `LINT` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr_lint/src/rules/large_parameter_list.rs::large_parameter_list_reports_hir_function` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0008.mdx
+++ b/docs/errors/SIFR-LINT-0008.mdx
@@ -1,0 +1,52 @@
+---
+title: "SIFR-LINT-0008: Import duplicates a module/name pair already imported in the same source file"
+sidebarTitle: "SIFR-LINT-0008"
+description: "Import duplicates a module/name pair already imported in the same source file"
+---
+
+`SIFR-LINT-0008` belongs to the **Policy linting** diagnostic family. It means: import duplicates a module/name pair already imported in the same source file.
+
+## Why It Happens
+
+A suppressible policy rule fired, or a suppression itself is malformed. Fix the policy issue or make the suppression exact and local.
+
+<Info>
+Use `sifr --explain SIFR-LINT-0008` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+# sifr: ignore
+def f(flag: bool):
+    pass
+
+f(True)
+```
+
+## How To Fix It
+
+Fix the policy issue when possible. If suppression is intentional, list the exact policy rule id and keep it local.
+
+## Fixed Code
+
+```python
+# sifr: ignore SIFR-LINT-0006
+def f(flag: bool):
+    pass
+
+f(flag=True)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-LINT-0008` |
+| Family | `LINT` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr_lint/src/rules/duplicate_import.rs::duplicate_import_reports_repeated_import` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-MATCH-0001.mdx
+++ b/docs/errors/SIFR-MATCH-0001.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-MATCH-0001: Non-exhaustive match"
+sidebarTitle: "SIFR-MATCH-0001"
+description: "Non-exhaustive match"
+---
+
+`SIFR-MATCH-0001` belongs to the **Pattern matching** diagnostic family. It means: non-exhaustive match.
+
+## Why It Happens
+
+The pattern match cannot be proven valid. Check exhaustiveness, guard types, class-pattern fields, and unsupported pattern shapes.
+
+<Info>
+Use `sifr --explain SIFR-MATCH-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+match value:
+    case 0:
+        label = "zero"
+```
+
+## How To Fix It
+
+Make patterns supported, guards boolean, field names valid, and matches exhaustive where required.
+
+## Fixed Code
+
+```python
+match value:
+    case 0:
+        label = "zero"
+    case _:
+        label = "other"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-MATCH-0001` |
+| Family | `MATCH` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/enum_match_non_exhaustive.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-MATCH-0002.mdx
+++ b/docs/errors/SIFR-MATCH-0002.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-MATCH-0002: Match guard must be bool"
+sidebarTitle: "SIFR-MATCH-0002"
+description: "Match guard must be bool"
+---
+
+`SIFR-MATCH-0002` belongs to the **Pattern matching** diagnostic family. It means: match guard must be bool.
+
+## Why It Happens
+
+The pattern match cannot be proven valid. Check exhaustiveness, guard types, class-pattern fields, and unsupported pattern shapes.
+
+<Info>
+Use `sifr --explain SIFR-MATCH-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+match value:
+    case 0:
+        label = "zero"
+```
+
+## How To Fix It
+
+Make patterns supported, guards boolean, field names valid, and matches exhaustive where required.
+
+## Fixed Code
+
+```python
+match value:
+    case 0:
+        label = "zero"
+    case _:
+        label = "other"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-MATCH-0002` |
+| Family | `MATCH` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/match_type_mismatch_guard.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-MATCH-0003.mdx
+++ b/docs/errors/SIFR-MATCH-0003.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-MATCH-0003: Invalid class pattern field"
+sidebarTitle: "SIFR-MATCH-0003"
+description: "Invalid class pattern field"
+---
+
+`SIFR-MATCH-0003` belongs to the **Pattern matching** diagnostic family. It means: invalid class pattern field.
+
+## Why It Happens
+
+The pattern match cannot be proven valid. Check exhaustiveness, guard types, class-pattern fields, and unsupported pattern shapes.
+
+<Info>
+Use `sifr --explain SIFR-MATCH-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+match value:
+    case 0:
+        label = "zero"
+```
+
+## How To Fix It
+
+Make patterns supported, guards boolean, field names valid, and matches exhaustive where required.
+
+## Fixed Code
+
+```python
+match value:
+    case 0:
+        label = "zero"
+    case _:
+        label = "other"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-MATCH-0003` |
+| Family | `MATCH` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/match_invalid_field_name.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-MATCH-0004.mdx
+++ b/docs/errors/SIFR-MATCH-0004.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-MATCH-0004: Invalid or unsupported match pattern form"
+sidebarTitle: "SIFR-MATCH-0004"
+description: "Invalid or unsupported match pattern form"
+---
+
+`SIFR-MATCH-0004` belongs to the **Pattern matching** diagnostic family. It means: invalid or unsupported match pattern form.
+
+## Why It Happens
+
+The pattern match cannot be proven valid. Check exhaustiveness, guard types, class-pattern fields, and unsupported pattern shapes.
+
+<Info>
+Use `sifr --explain SIFR-MATCH-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+match value:
+    case 0:
+        label = "zero"
+```
+
+## How To Fix It
+
+Make patterns supported, guards boolean, field names valid, and matches exhaustive where required.
+
+## Fixed Code
+
+```python
+match value:
+    case 0:
+        label = "zero"
+    case _:
+        label = "other"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-MATCH-0004` |
+| Family | `MATCH` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/match_tuple_pattern_requires_tuple_subject.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0001.mdx
+++ b/docs/errors/SIFR-NAME-0001.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-NAME-0001: Undefined variable"
+sidebarTitle: "SIFR-NAME-0001"
+description: "Undefined variable"
+---
+
+`SIFR-NAME-0001` belongs to the **Name resolution** diagnostic family. It means: undefined variable.
+
+## Why It Happens
+
+A binding, type, function, module, or member name cannot be resolved in the current scope.
+
+<Info>
+Use `sifr --explain SIFR-NAME-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+total = subtotal + tax
+```
+
+## How To Fix It
+
+Declare or import the name before use, and check whether you meant a module member, type name, or local binding.
+
+## Fixed Code
+
+```python
+subtotal: int = 10
+tax: int = 2
+total = subtotal + tax
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-NAME-0001` |
+| Family | `NAME` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/undefined_var.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0002.mdx
+++ b/docs/errors/SIFR-NAME-0002.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-NAME-0002: Undefined function or callable"
+sidebarTitle: "SIFR-NAME-0002"
+description: "Undefined function or callable"
+---
+
+`SIFR-NAME-0002` belongs to the **Name resolution** diagnostic family. It means: undefined function or callable.
+
+## Why It Happens
+
+A binding, type, function, module, or member name cannot be resolved in the current scope.
+
+<Info>
+Use `sifr --explain SIFR-NAME-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+total = subtotal + tax
+```
+
+## How To Fix It
+
+Declare or import the name before use, and check whether you meant a module member, type name, or local binding.
+
+## Fixed Code
+
+```python
+subtotal: int = 10
+tax: int = 2
+total = subtotal + tax
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-NAME-0002` |
+| Family | `NAME` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/undefined_function.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0003.mdx
+++ b/docs/errors/SIFR-NAME-0003.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-NAME-0003: Unknown type or generic type name"
+sidebarTitle: "SIFR-NAME-0003"
+description: "Unknown type or generic type name"
+---
+
+`SIFR-NAME-0003` belongs to the **Name resolution** diagnostic family. It means: unknown type or generic type name.
+
+## Why It Happens
+
+A binding, type, function, module, or member name cannot be resolved in the current scope.
+
+<Info>
+Use `sifr --explain SIFR-NAME-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+total = subtotal + tax
+```
+
+## How To Fix It
+
+Declare or import the name before use, and check whether you meant a module member, type name, or local binding.
+
+## Fixed Code
+
+```python
+subtotal: int = 10
+tax: int = 2
+total = subtotal + tax
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-NAME-0003` |
+| Family | `NAME` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/generic_class_missing_type_arg.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0004.mdx
+++ b/docs/errors/SIFR-NAME-0004.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-NAME-0004: Missing module or class member"
+sidebarTitle: "SIFR-NAME-0004"
+description: "Missing module or class member"
+---
+
+`SIFR-NAME-0004` belongs to the **Name resolution** diagnostic family. It means: missing module or class member.
+
+## Why It Happens
+
+A binding, type, function, module, or member name cannot be resolved in the current scope.
+
+<Info>
+Use `sifr --explain SIFR-NAME-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+total = subtotal + tax
+```
+
+## How To Fix It
+
+Declare or import the name before use, and check whether you meant a module member, type name, or local binding.
+
+## Fixed Code
+
+```python
+subtotal: int = 10
+tax: int = 2
+total = subtotal + tax
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-NAME-0004` |
+| Family | `NAME` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/stdlib_missing_function.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0005.mdx
+++ b/docs/errors/SIFR-NAME-0005.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-NAME-0005: Duplicate function definition in a module"
+sidebarTitle: "SIFR-NAME-0005"
+description: "Duplicate function definition in a module"
+---
+
+`SIFR-NAME-0005` belongs to the **Name resolution** diagnostic family. It means: duplicate function definition in a module.
+
+## Why It Happens
+
+A binding, type, function, module, or member name cannot be resolved in the current scope.
+
+<Info>
+Use `sifr --explain SIFR-NAME-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+total = subtotal + tax
+```
+
+## How To Fix It
+
+Declare or import the name before use, and check whether you meant a module member, type name, or local binding.
+
+## Fixed Code
+
+```python
+subtotal: int = 10
+tax: int = 2
+total = subtotal + tax
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-NAME-0005` |
+| Family | `NAME` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/duplicate_function_definition.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0006.mdx
+++ b/docs/errors/SIFR-NAME-0006.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-NAME-0006: Variable declaration lacks a required initializer"
+sidebarTitle: "SIFR-NAME-0006"
+description: "Variable declaration lacks a required initializer"
+---
+
+`SIFR-NAME-0006` belongs to the **Name resolution** diagnostic family. It means: variable declaration lacks a required initializer.
+
+## Why It Happens
+
+A binding, type, function, module, or member name cannot be resolved in the current scope.
+
+<Info>
+Use `sifr --explain SIFR-NAME-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+total = subtotal + tax
+```
+
+## How To Fix It
+
+Declare or import the name before use, and check whether you meant a module member, type name, or local binding.
+
+## Fixed Code
+
+```python
+subtotal: int = 10
+tax: int = 2
+total = subtotal + tax
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-NAME-0006` |
+| Family | `NAME` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/annotated_variable_requires_initializer.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0001.mdx
+++ b/docs/errors/SIFR-OWN-0001.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0001: Use after move"
+sidebarTitle: "SIFR-OWN-0001"
+description: "Use after move"
+---
+
+`SIFR-OWN-0001` belongs to the **Ownership and borrowing** diagnostic family. It means: use after move.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0001` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/use_after_move.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0002.mdx
+++ b/docs/errors/SIFR-OWN-0002.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0002: Same-call borrow conflict"
+sidebarTitle: "SIFR-OWN-0002"
+description: "Same-call borrow conflict"
+---
+
+`SIFR-OWN-0002` belongs to the **Ownership and borrowing** diagnostic family. It means: same-call borrow conflict.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0002` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/double_mut_borrow.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0003.mdx
+++ b/docs/errors/SIFR-OWN-0003.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0003: Borrowed parameter escapes by return or store"
+sidebarTitle: "SIFR-OWN-0003"
+description: "Borrowed parameter escapes by return or store"
+---
+
+`SIFR-OWN-0003` belongs to the **Ownership and borrowing** diagnostic family. It means: borrowed parameter escapes by return or store.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0003` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/borrow_escape_return.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0004.mdx
+++ b/docs/errors/SIFR-OWN-0004.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0004: Moved value is reused across loop iterations"
+sidebarTitle: "SIFR-OWN-0004"
+description: "Moved value is reused across loop iterations"
+---
+
+`SIFR-OWN-0004` belongs to the **Ownership and borrowing** diagnostic family. It means: moved value is reused across loop iterations.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0004` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/use_after_move_loop.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0005.mdx
+++ b/docs/errors/SIFR-OWN-0005.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0005: Immutable parameter is mutated"
+sidebarTitle: "SIFR-OWN-0005"
+description: "Immutable parameter is mutated"
+---
+
+`SIFR-OWN-0005` belongs to the **Ownership and borrowing** diagnostic family. It means: immutable parameter is mutated.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0005` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/own_parameter_mutation_requires_mut.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0006.mdx
+++ b/docs/errors/SIFR-OWN-0006.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0006: Immutable parameter is reassigned"
+sidebarTitle: "SIFR-OWN-0006"
+description: "Immutable parameter is reassigned"
+---
+
+`SIFR-OWN-0006` belongs to the **Ownership and borrowing** diagnostic family. It means: immutable parameter is reassigned.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0006` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/own_parameter_reassignment_requires_mut.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0007.mdx
+++ b/docs/errors/SIFR-OWN-0007.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0007: Immutable bytes value is mutated"
+sidebarTitle: "SIFR-OWN-0007"
+description: "Immutable bytes value is mutated"
+---
+
+`SIFR-OWN-0007` belongs to the **Ownership and borrowing** diagnostic family. It means: immutable bytes value is mutated.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0007` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0007` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/bytes_subscript_assignment_unsupported.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0008.mdx
+++ b/docs/errors/SIFR-OWN-0008.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0008: Immutable bytes value is mutated by augmented assignment"
+sidebarTitle: "SIFR-OWN-0008"
+description: "Immutable bytes value is mutated by augmented assignment"
+---
+
+`SIFR-OWN-0008` belongs to the **Ownership and borrowing** diagnostic family. It means: immutable bytes value is mutated by augmented assignment.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0008` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0008` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/bytes_augmented_subscript_assignment_unsupported.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0009.mdx
+++ b/docs/errors/SIFR-OWN-0009.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0009: Mutable borrow remains live across an await point"
+sidebarTitle: "SIFR-OWN-0009"
+description: "Mutable borrow remains live across an await point"
+---
+
+`SIFR-OWN-0009` belongs to the **Ownership and borrowing** diagnostic family. It means: mutable borrow remains live across an await point.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0009` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0009` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/borrow_across_await_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0010.mdx
+++ b/docs/errors/SIFR-OWN-0010.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0010: Non-sendable value crosses a spawned task boundary"
+sidebarTitle: "SIFR-OWN-0010"
+description: "Non-sendable value crosses a spawned task boundary"
+---
+
+`SIFR-OWN-0010` belongs to the **Ownership and borrowing** diagnostic family. It means: non-sendable value crosses a spawned task boundary.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0010` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0010` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/spawn_non_send_field_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0011.mdx
+++ b/docs/errors/SIFR-OWN-0011.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0011: Non-sendable value is sent through a channel"
+sidebarTitle: "SIFR-OWN-0011"
+description: "Non-sendable value is sent through a channel"
+---
+
+`SIFR-OWN-0011` belongs to the **Ownership and borrowing** diagnostic family. It means: non-sendable value is sent through a channel.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0011` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0011` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/channel_non_send_element_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0012.mdx
+++ b/docs/errors/SIFR-OWN-0012.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0012: Non-share-safe value is wrapped in sync.Shared"
+sidebarTitle: "SIFR-OWN-0012"
+description: "Non-share-safe value is wrapped in sync.Shared"
+---
+
+`SIFR-OWN-0012` belongs to the **Ownership and borrowing** diagnostic family. It means: non-share-safe value is wrapped in sync.shared.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0012` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0012` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/shared_mut_without_lock_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0013.mdx
+++ b/docs/errors/SIFR-OWN-0013.mdx
@@ -1,0 +1,48 @@
+---
+title: "SIFR-OWN-0013: Non-IPC-serializable value is used as a typed IPC payload"
+sidebarTitle: "SIFR-OWN-0013"
+description: "Non-IPC-serializable value is used as a typed IPC payload"
+---
+
+`SIFR-OWN-0013` belongs to the **Ownership and borrowing** diagnostic family. It means: non-ipc-serializable value is used as a typed ipc payload.
+
+## Why It Happens
+
+The ownership model would be violated. Move values only once, keep borrows scoped, and cross task/channel/IPC boundaries only with owned values that satisfy the required safety traits.
+
+<Info>
+Use `sifr --explain SIFR-OWN-0013` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+items: list[int] = [1, 2]
+taken = own items
+count = len(items)
+```
+
+## How To Fix It
+
+Move ownership only after the last use, keep mutable borrows scoped, and send only owned sendable values across task or channel boundaries.
+
+## Fixed Code
+
+```python
+items: list[int] = [1, 2]
+count = len(items)
+taken = own items
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-OWN-0013` |
+| Family | `OWN` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/ipc_payload_process_resource_rejected.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0001.mdx
+++ b/docs/errors/SIFR-PACKAGE-0001.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0001: Missing or invalid Cargo Sifr discovery metadata"
+sidebarTitle: "SIFR-PACKAGE-0001"
+description: "Missing or invalid Cargo Sifr discovery metadata"
+---
+
+`SIFR-PACKAGE-0001` belongs to the **Package management** diagnostic family. It means: missing or invalid cargo sifr discovery metadata.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0001` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/manifest/metadata.rs::tests` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0002.mdx
+++ b/docs/errors/SIFR-PACKAGE-0002.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0002: Missing or invalid sifr.toml package manifest"
+sidebarTitle: "SIFR-PACKAGE-0002"
+description: "Missing or invalid sifr.toml package manifest"
+---
+
+`SIFR-PACKAGE-0002` belongs to the **Package management** diagnostic family. It means: missing or invalid sifr.toml package manifest.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0002` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/manifest/sifr.rs::tests` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0003.mdx
+++ b/docs/errors/SIFR-PACKAGE-0003.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0003: Unsupported Sifr compiler metadata appears in Cargo metadata"
+sidebarTitle: "SIFR-PACKAGE-0003"
+description: "Unsupported Sifr compiler metadata appears in Cargo metadata"
+---
+
+`SIFR-PACKAGE-0003` belongs to the **Package management** diagnostic family. It means: unsupported sifr compiler metadata appears in cargo metadata.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0003` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/manifest/metadata.rs::tests` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0101.mdx
+++ b/docs/errors/SIFR-PACKAGE-0101.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0101: Cargo command invocation failed; Sifr reports the redacted Cargo excerpt and safe Sifr-owned recovery context"
+sidebarTitle: "SIFR-PACKAGE-0101"
+description: "Cargo command invocation failed; Sifr reports the redacted Cargo excerpt and safe Sifr-owned recovery context"
+---
+
+`SIFR-PACKAGE-0101` belongs to the **Package management** diagnostic family. It means: cargo command invocation failed; sifr reports the redacted cargo excerpt and safe sifr-owned recovery context.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0101` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0101` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/cargo_backend_integration_tests.rs::cargo_failure_mapping_redacts_private_credentials` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0102.mdx
+++ b/docs/errors/SIFR-PACKAGE-0102.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0102: A selected Cargo package is Rust-only"
+sidebarTitle: "SIFR-PACKAGE-0102"
+description: "A selected Cargo package is Rust-only"
+---
+
+`SIFR-PACKAGE-0102` belongs to the **Package management** diagnostic family. It means: a selected cargo package is rust-only.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0102` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0102` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::explicit_rust_only_selection_reports_0102` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0103.mdx
+++ b/docs/errors/SIFR-PACKAGE-0103.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0103: Cargo metadata parsing or normalization failed"
+sidebarTitle: "SIFR-PACKAGE-0103"
+description: "Cargo metadata parsing or normalization failed"
+---
+
+`SIFR-PACKAGE-0103` belongs to the **Package management** diagnostic family. It means: cargo metadata parsing or normalization failed.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0103` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0103` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/cargo/metadata.rs::tests` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0104.mdx
+++ b/docs/errors/SIFR-PACKAGE-0104.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0104: Package source is unavailable in offline or frozen mode"
+sidebarTitle: "SIFR-PACKAGE-0104"
+description: "Package source is unavailable in offline or frozen mode"
+---
+
+`SIFR-PACKAGE-0104` belongs to the **Package management** diagnostic family. It means: package source is unavailable in offline or frozen mode.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0104` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0104` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/cargo_backend_integration_tests.rs::offline_mode_reports_missing_sifr_source_package` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0106.mdx
+++ b/docs/errors/SIFR-PACKAGE-0106.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0106: Rust-only package depends directly on a Sifr source package"
+sidebarTitle: "SIFR-PACKAGE-0106"
+description: "Rust-only package depends directly on a Sifr source package"
+---
+
+`SIFR-PACKAGE-0106` belongs to the **Package management** diagnostic family. It means: rust-only package depends directly on a sifr source package.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0106` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0106` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::rust_only_member_depending_on_sifr_reports_0106` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0201.mdx
+++ b/docs/errors/SIFR-PACKAGE-0201.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0201: Direct package import root resolves to multiple package instances"
+sidebarTitle: "SIFR-PACKAGE-0201"
+description: "Direct package import root resolves to multiple package instances"
+---
+
+`SIFR-PACKAGE-0201` belongs to the **Package management** diagnostic family. It means: direct package import root resolves to multiple package instances.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0201` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0201` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_dependency_scope_tests.rs::duplicate_direct_import_root_in_one_scope_reports_0201` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0202.mdx
+++ b/docs/errors/SIFR-PACKAGE-0202.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0202: Package imports a module outside its direct dependency scope"
+sidebarTitle: "SIFR-PACKAGE-0202"
+description: "Package imports a module outside its direct dependency scope"
+---
+
+`SIFR-PACKAGE-0202` belongs to the **Package management** diagnostic family. It means: package imports a module outside its direct dependency scope.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0202` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0202` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_source_map_tests.rs::transitive_dependency_import_reports_0202` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0203.mdx
+++ b/docs/errors/SIFR-PACKAGE-0203.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0203: Package imports a private module from another package"
+sidebarTitle: "SIFR-PACKAGE-0203"
+description: "Package imports a private module from another package"
+---
+
+`SIFR-PACKAGE-0203` belongs to the **Package management** diagnostic family. It means: package imports a private module from another package.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0203` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0203` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_source_map_tests.rs::private_dependency_module_reports_0203` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0204.mdx
+++ b/docs/errors/SIFR-PACKAGE-0204.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0204: Type identity crosses resolved package instances"
+sidebarTitle: "SIFR-PACKAGE-0204"
+description: "Type identity crosses resolved package instances"
+---
+
+`SIFR-PACKAGE-0204` belongs to the **Package management** diagnostic family. It means: type identity crosses resolved package instances.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0204` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0204` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_dependency_scope_tests.rs::type_identity_mismatch_reports_0204_for_distinct_package_instances` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0301.mdx
+++ b/docs/errors/SIFR-PACKAGE-0301.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0301: Backend Rust crate is not allowed by the Sifr trust policy"
+sidebarTitle: "SIFR-PACKAGE-0301"
+description: "Backend Rust crate is not allowed by the Sifr trust policy"
+---
+
+`SIFR-PACKAGE-0301` belongs to the **Package management** diagnostic family. It means: backend rust crate is not allowed by the sifr trust policy.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0301` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0301` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/cargo_backend_integration_tests.rs::backend_trust_reports_untrusted_direct_backend_crate` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0305.mdx
+++ b/docs/errors/SIFR-PACKAGE-0305.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0305: Trust policy names a backend crate that is not a direct dependency"
+sidebarTitle: "SIFR-PACKAGE-0305"
+description: "Trust policy names a backend crate that is not a direct dependency"
+---
+
+`SIFR-PACKAGE-0305` belongs to the **Package management** diagnostic family. It means: trust policy names a backend crate that is not a direct dependency.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0305` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0305` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/cargo_backend_integration_tests.rs::backend_trust_rejects_stale_non_direct_trust_entry` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0401.mdx
+++ b/docs/errors/SIFR-PACKAGE-0401.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0401: Cargo package archive is missing required Sifr source"
+sidebarTitle: "SIFR-PACKAGE-0401"
+description: "Cargo package archive is missing required Sifr source"
+---
+
+`SIFR-PACKAGE-0401` belongs to the **Package management** diagnostic family. It means: cargo package archive is missing required sifr source.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0401` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0401` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_publish_archive_tests.rs::archive_missing_sifr_source_reports_0401` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0402.mdx
+++ b/docs/errors/SIFR-PACKAGE-0402.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0402: Package publish or archive validation failed"
+sidebarTitle: "SIFR-PACKAGE-0402"
+description: "Package publish or archive validation failed"
+---
+
+`SIFR-PACKAGE-0402` belongs to the **Package management** diagnostic family. It means: package publish or archive validation failed.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0402` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0402` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_publish_archive_tests.rs::publish_validation_failed_reports_0402` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0403.mdx
+++ b/docs/errors/SIFR-PACKAGE-0403.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0403: Cargo include/exclude rules omit required Sifr files"
+sidebarTitle: "SIFR-PACKAGE-0403"
+description: "Cargo include/exclude rules omit required Sifr files"
+---
+
+`SIFR-PACKAGE-0403` belongs to the **Package management** diagnostic family. It means: cargo include/exclude rules omit required sifr files.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0403` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0403` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_publish_archive_tests.rs::archive_missing_required_entry_reports_0403` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0404.mdx
+++ b/docs/errors/SIFR-PACKAGE-0404.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0404: Cargo package archive contains an unsafe path"
+sidebarTitle: "SIFR-PACKAGE-0404"
+description: "Cargo package archive contains an unsafe path"
+---
+
+`SIFR-PACKAGE-0404` belongs to the **Package management** diagnostic family. It means: cargo package archive contains an unsafe path.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0404` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0404` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_publish_archive_tests.rs::archive_traversal_reports_0404` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0501.mdx
+++ b/docs/errors/SIFR-PACKAGE-0501.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0501: Pure Sifr Rust marker contains implementation"
+sidebarTitle: "SIFR-PACKAGE-0501"
+description: "Pure Sifr Rust marker contains implementation"
+---
+
+`SIFR-PACKAGE-0501` belongs to the **Package management** diagnostic family. It means: pure sifr rust marker contains implementation.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0501` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0501` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/source/layout.rs::tests` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0601.mdx
+++ b/docs/errors/SIFR-PACKAGE-0601.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0601: Package selector is ambiguous or invalid"
+sidebarTitle: "SIFR-PACKAGE-0601"
+description: "Package selector is ambiguous or invalid"
+---
+
+`SIFR-PACKAGE-0601` belongs to the **Package management** diagnostic family. It means: package selector is ambiguous or invalid.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0601` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0601` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::ambiguous_filter_reports_0601` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0602.mdx
+++ b/docs/errors/SIFR-PACKAGE-0602.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0602: Workspace selection contains duplicate import roots"
+sidebarTitle: "SIFR-PACKAGE-0602"
+description: "Workspace selection contains duplicate import roots"
+---
+
+`SIFR-PACKAGE-0602` belongs to the **Package management** diagnostic family. It means: workspace selection contains duplicate import roots.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0602` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0602` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::workspace_duplicate_import_roots_report_0602` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0603.mdx
+++ b/docs/errors/SIFR-PACKAGE-0603.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0603: Changed file could not be mapped to a package"
+sidebarTitle: "SIFR-PACKAGE-0603"
+description: "Changed file could not be mapped to a package"
+---
+
+`SIFR-PACKAGE-0603` belongs to the **Package management** diagnostic family. It means: changed file could not be mapped to a package.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0603` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0603` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::changed_file_mapping_reports_0603` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0604.mdx
+++ b/docs/errors/SIFR-PACKAGE-0604.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0604: Outdated query cannot inspect this Cargo source"
+sidebarTitle: "SIFR-PACKAGE-0604"
+description: "Outdated query cannot inspect this Cargo source"
+---
+
+`SIFR-PACKAGE-0604` belongs to the **Package management** diagnostic family. It means: outdated query cannot inspect this cargo source.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0604` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0604` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::outdated_unknown_source_reports_0604` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0605.mdx
+++ b/docs/errors/SIFR-PACKAGE-0605.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0605: Runnable package target or script selection is missing or ambiguous"
+sidebarTitle: "SIFR-PACKAGE-0605"
+description: "Runnable package target or script selection is missing or ambiguous"
+---
+
+`SIFR-PACKAGE-0605` belongs to the **Package management** diagnostic family. It means: runnable package target or script selection is missing or ambiguous.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0605` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0605` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_session_tests.rs::package_session_reports_script_target_ambiguity` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0606.mdx
+++ b/docs/errors/SIFR-PACKAGE-0606.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0606: Discovered app target name is invalid"
+sidebarTitle: "SIFR-PACKAGE-0606"
+description: "Discovered app target name is invalid"
+---
+
+`SIFR-PACKAGE-0606` belongs to the **Package management** diagnostic family. It means: discovered app target name is invalid.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0606` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0606` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_session_tests.rs::package_session_rejects_invalid_nested_target_name` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0607.mdx
+++ b/docs/errors/SIFR-PACKAGE-0607.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0607: Selected workspace members use the same Sifr package name"
+sidebarTitle: "SIFR-PACKAGE-0607"
+description: "Selected workspace members use the same Sifr package name"
+---
+
+`SIFR-PACKAGE-0607` belongs to the **Package management** diagnostic family. It means: selected workspace members use the same sifr package name.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0607` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0607` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::workspace_duplicate_sifr_names_report_0607` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0701.mdx
+++ b/docs/errors/SIFR-PACKAGE-0701.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0701: Production sifr.toml uses manifest-level exports"
+sidebarTitle: "SIFR-PACKAGE-0701"
+description: "Production sifr.toml uses manifest-level exports"
+---
+
+`SIFR-PACKAGE-0701` belongs to the **Package management** diagnostic family. It means: production sifr.toml uses manifest-level exports.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0701` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0701` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_public_api_tests.rs::production_manifest_exports_report_0701` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0703.mdx
+++ b/docs/errors/SIFR-PACKAGE-0703.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0703: Sifr-managed Cargo projection manifest pointer drift"
+sidebarTitle: "SIFR-PACKAGE-0703"
+description: "Sifr-managed Cargo projection manifest pointer drift"
+---
+
+`SIFR-PACKAGE-0703` belongs to the **Package management** diagnostic family. It means: sifr-managed cargo projection manifest pointer drift.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0703` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0703` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_projection_tests.rs::repair_check_reports_missing_manifest_pointer_0703` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0704.mdx
+++ b/docs/errors/SIFR-PACKAGE-0704.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0704: Sifr-managed Cargo projection include rules omit required package files"
+sidebarTitle: "SIFR-PACKAGE-0704"
+description: "Sifr-managed Cargo projection include rules omit required package files"
+---
+
+`SIFR-PACKAGE-0704` belongs to the **Package management** diagnostic family. It means: sifr-managed cargo projection include rules omit required package files.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0704` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0704` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_projection_tests.rs::repair_check_reports_missing_required_include_0704` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0709.mdx
+++ b/docs/errors/SIFR-PACKAGE-0709.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0709: Pure package marker is missing from Sifr-managed projection"
+sidebarTitle: "SIFR-PACKAGE-0709"
+description: "Pure package marker is missing from Sifr-managed projection"
+---
+
+`SIFR-PACKAGE-0709` belongs to the **Package management** diagnostic family. It means: pure package marker is missing from sifr-managed projection.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0709` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0709` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_projection_tests.rs::repair_regenerates_missing_pure_marker` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0710.mdx
+++ b/docs/errors/SIFR-PACKAGE-0710.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0710: Explicit Sifr file target is outside the package source root"
+sidebarTitle: "SIFR-PACKAGE-0710"
+description: "Explicit Sifr file target is outside the package source root"
+---
+
+`SIFR-PACKAGE-0710` belongs to the **Package management** diagnostic family. It means: explicit sifr file target is outside the package source root.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0710` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0710` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_session_tests.rs::package_session_rejects_explicit_file_outside_source_root` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0711.mdx
+++ b/docs/errors/SIFR-PACKAGE-0711.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0711: Production sifr.toml uses manifest binary target tables"
+sidebarTitle: "SIFR-PACKAGE-0711"
+description: "Production sifr.toml uses manifest binary target tables"
+---
+
+`SIFR-PACKAGE-0711` belongs to the **Package management** diagnostic family. It means: production sifr.toml uses manifest binary target tables.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0711` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0711` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_public_api_tests.rs::production_manifest_bin_tables_report_0711` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0713.mdx
+++ b/docs/errors/SIFR-PACKAGE-0713.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0713: Public API symbol is exported more than once"
+sidebarTitle: "SIFR-PACKAGE-0713"
+description: "Public API symbol is exported more than once"
+---
+
+`SIFR-PACKAGE-0713` belongs to the **Package management** diagnostic family. It means: public api symbol is exported more than once.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0713` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0713` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_public_api_tests.rs::duplicate_init_public_symbol_reports_0713` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0714.mdx
+++ b/docs/errors/SIFR-PACKAGE-0714.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PACKAGE-0714: Package script expansion attempted to invoke another script"
+sidebarTitle: "SIFR-PACKAGE-0714"
+description: "Package script expansion attempted to invoke another script"
+---
+
+`SIFR-PACKAGE-0714` belongs to the **Package management** diagnostic family. It means: package script expansion attempted to invoke another script.
+
+## Why It Happens
+
+Sifr package or workspace metadata violates the package model. Inspect `sifr.toml`, Cargo metadata, source roots, trust policy, archive contents, package selectors, or projection files as named by the diagnostic.
+
+<Info>
+Use `sifr --explain SIFR-PACKAGE-0714` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[package]
+name = "demo"
+```
+
+## How To Fix It
+
+Repair the package manifest, workspace selection, projection files, archive rules, or publish options named by the diagnostic.
+
+## Fixed Code
+
+```toml
+[package]
+name = "demo"
+version = "0.1.0"
+
+[sifr]
+source-root = "src"
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PACKAGE-0714` |
+| Family | `PACKAGE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_package/src/package_session_tests.rs::package_session_rejects_nested_script_expansion` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0002.mdx
+++ b/docs/errors/SIFR-PARSE-0002.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-PARSE-0002: Expected token or generic parser recovery failure"
+sidebarTitle: "SIFR-PARSE-0002"
+description: "Expected token or generic parser recovery failure"
+---
+
+`SIFR-PARSE-0002` belongs to the **Parsing** diagnostic family. It means: expected token or generic parser recovery failure.
+
+## Why It Happens
+
+The parser cannot recover a supported Sifr syntax tree from the source. Fix syntax before type, ownership, or package analysis can continue.
+
+<Info>
+Use `sifr --explain SIFR-PARSE-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def main( -> int:
+    return 1
+```
+
+## How To Fix It
+
+Fix the source syntax first. Parser diagnostics happen before Sifr can reason about types, ownership, or package structure.
+
+## Fixed Code
+
+```python
+def main() -> int:
+    return 1
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PARSE-0002` |
+| Family | `PARSE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/parser_expected_token.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0003.mdx
+++ b/docs/errors/SIFR-PARSE-0003.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-PARSE-0003: Lexical or interpolated string parser failure"
+sidebarTitle: "SIFR-PARSE-0003"
+description: "Lexical or interpolated string parser failure"
+---
+
+`SIFR-PARSE-0003` belongs to the **Parsing** diagnostic family. It means: lexical or interpolated string parser failure.
+
+## Why It Happens
+
+The parser cannot recover a supported Sifr syntax tree from the source. Fix syntax before type, ownership, or package analysis can continue.
+
+<Info>
+Use `sifr --explain SIFR-PARSE-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def main( -> int:
+    return 1
+```
+
+## How To Fix It
+
+Fix the source syntax first. Parser diagnostics happen before Sifr can reason about types, ownership, or package structure.
+
+## Fixed Code
+
+```python
+def main() -> int:
+    return 1
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PARSE-0003` |
+| Family | `PARSE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/parser_malformed_string.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0004.mdx
+++ b/docs/errors/SIFR-PARSE-0004.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-PARSE-0004: Indentation or same-line statement layout parser failure"
+sidebarTitle: "SIFR-PARSE-0004"
+description: "Indentation or same-line statement layout parser failure"
+---
+
+`SIFR-PARSE-0004` belongs to the **Parsing** diagnostic family. It means: indentation or same-line statement layout parser failure.
+
+## Why It Happens
+
+The parser cannot recover a supported Sifr syntax tree from the source. Fix syntax before type, ownership, or package analysis can continue.
+
+<Info>
+Use `sifr --explain SIFR-PARSE-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def main( -> int:
+    return 1
+```
+
+## How To Fix It
+
+Fix the source syntax first. Parser diagnostics happen before Sifr can reason about types, ownership, or package structure.
+
+## Fixed Code
+
+```python
+def main() -> int:
+    return 1
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PARSE-0004` |
+| Family | `PARSE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/parser_invalid_layout.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0005.mdx
+++ b/docs/errors/SIFR-PARSE-0005.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-PARSE-0005: Invalid assignment, delete, starred, or named-expression target syntax"
+sidebarTitle: "SIFR-PARSE-0005"
+description: "Invalid assignment, delete, starred, or named-expression target syntax"
+---
+
+`SIFR-PARSE-0005` belongs to the **Parsing** diagnostic family. It means: invalid assignment, delete, starred, or named-expression target syntax.
+
+## Why It Happens
+
+The parser cannot recover a supported Sifr syntax tree from the source. Fix syntax before type, ownership, or package analysis can continue.
+
+<Info>
+Use `sifr --explain SIFR-PARSE-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def main( -> int:
+    return 1
+```
+
+## How To Fix It
+
+Fix the source syntax first. Parser diagnostics happen before Sifr can reason about types, ownership, or package structure.
+
+## Fixed Code
+
+```python
+def main() -> int:
+    return 1
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PARSE-0005` |
+| Family | `PARSE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/parser_invalid_target.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0006.mdx
+++ b/docs/errors/SIFR-PARSE-0006.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-PARSE-0006: Invalid call argument order or unpacking syntax"
+sidebarTitle: "SIFR-PARSE-0006"
+description: "Invalid call argument order or unpacking syntax"
+---
+
+`SIFR-PARSE-0006` belongs to the **Parsing** diagnostic family. It means: invalid call argument order or unpacking syntax.
+
+## Why It Happens
+
+The parser cannot recover a supported Sifr syntax tree from the source. Fix syntax before type, ownership, or package analysis can continue.
+
+<Info>
+Use `sifr --explain SIFR-PARSE-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def main( -> int:
+    return 1
+```
+
+## How To Fix It
+
+Fix the source syntax first. Parser diagnostics happen before Sifr can reason about types, ownership, or package structure.
+
+## Fixed Code
+
+```python
+def main() -> int:
+    return 1
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PARSE-0006` |
+| Family | `PARSE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/parser_invalid_call_arguments.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0007.mdx
+++ b/docs/errors/SIFR-PARSE-0007.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-PARSE-0007: Empty or malformed declaration list syntax"
+sidebarTitle: "SIFR-PARSE-0007"
+description: "Empty or malformed declaration list syntax"
+---
+
+`SIFR-PARSE-0007` belongs to the **Parsing** diagnostic family. It means: empty or malformed declaration list syntax.
+
+## Why It Happens
+
+The parser cannot recover a supported Sifr syntax tree from the source. Fix syntax before type, ownership, or package analysis can continue.
+
+<Info>
+Use `sifr --explain SIFR-PARSE-0007` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def main( -> int:
+    return 1
+```
+
+## How To Fix It
+
+Fix the source syntax first. Parser diagnostics happen before Sifr can reason about types, ownership, or package structure.
+
+## Fixed Code
+
+```python
+def main() -> int:
+    return 1
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PARSE-0007` |
+| Family | `PARSE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/parser_malformed_declaration_list.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0008.mdx
+++ b/docs/errors/SIFR-PARSE-0008.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-PARSE-0008: Invalid match-pattern syntax"
+sidebarTitle: "SIFR-PARSE-0008"
+description: "Invalid match-pattern syntax"
+---
+
+`SIFR-PARSE-0008` belongs to the **Parsing** diagnostic family. It means: invalid match-pattern syntax.
+
+## Why It Happens
+
+The parser cannot recover a supported Sifr syntax tree from the source. Fix syntax before type, ownership, or package analysis can continue.
+
+<Info>
+Use `sifr --explain SIFR-PARSE-0008` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def main( -> int:
+    return 1
+```
+
+## How To Fix It
+
+Fix the source syntax first. Parser diagnostics happen before Sifr can reason about types, ownership, or package structure.
+
+## Fixed Code
+
+```python
+def main() -> int:
+    return 1
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PARSE-0008` |
+| Family | `PARSE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/parser_invalid_match_pattern.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0009.mdx
+++ b/docs/errors/SIFR-PARSE-0009.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-PARSE-0009: Unsupported parser syntax or interactive-only syntax"
+sidebarTitle: "SIFR-PARSE-0009"
+description: "Unsupported parser syntax or interactive-only syntax"
+---
+
+`SIFR-PARSE-0009` belongs to the **Parsing** diagnostic family. It means: unsupported parser syntax or interactive-only syntax.
+
+## Why It Happens
+
+The parser cannot recover a supported Sifr syntax tree from the source. Fix syntax before type, ownership, or package analysis can continue.
+
+<Info>
+Use `sifr --explain SIFR-PARSE-0009` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+def main( -> int:
+    return 1
+```
+
+## How To Fix It
+
+Fix the source syntax first. Parser diagnostics happen before Sifr can reason about types, ownership, or package structure.
+
+## Fixed Code
+
+```python
+def main() -> int:
+    return 1
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PARSE-0009` |
+| Family | `PARSE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/diagnostics` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/parser_unsupported_syntax.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PROTO-0001.mdx
+++ b/docs/errors/SIFR-PROTO-0001.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PROTO-0001: Protocol bound or conformance failure"
+sidebarTitle: "SIFR-PROTO-0001"
+description: "Protocol bound or conformance failure"
+---
+
+`SIFR-PROTO-0001` belongs to the **Protocols** diagnostic family. It means: protocol bound or conformance failure.
+
+## Why It Happens
+
+A value does not satisfy the structural protocol required by the operation, such as iteration, context management, hashing, comparison, or reversible iteration.
+
+<Info>
+Use `sifr --explain SIFR-PROTO-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+for item in NotIterable():
+    pass
+```
+
+## How To Fix It
+
+Implement the required protocol shape, or pass a value that already satisfies the iterator, context-manager, hashable, or comparable requirement.
+
+## Fixed Code
+
+```python
+class Items:
+    def __iter__(self) -> Iterator[int]:
+        return iter([1, 2, 3])
+
+for item in Items():
+    pass
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PROTO-0001` |
+| Family | `PROTO` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/generic_bounds_not_satisfied.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PROTO-0002.mdx
+++ b/docs/errors/SIFR-PROTO-0002.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PROTO-0002: Invalid iterator or reversible protocol signature"
+sidebarTitle: "SIFR-PROTO-0002"
+description: "Invalid iterator or reversible protocol signature"
+---
+
+`SIFR-PROTO-0002` belongs to the **Protocols** diagnostic family. It means: invalid iterator or reversible protocol signature.
+
+## Why It Happens
+
+A value does not satisfy the structural protocol required by the operation, such as iteration, context management, hashing, comparison, or reversible iteration.
+
+<Info>
+Use `sifr --explain SIFR-PROTO-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+for item in NotIterable():
+    pass
+```
+
+## How To Fix It
+
+Implement the required protocol shape, or pass a value that already satisfies the iterator, context-manager, hashable, or comparable requirement.
+
+## Fixed Code
+
+```python
+class Items:
+    def __iter__(self) -> Iterator[int]:
+        return iter([1, 2, 3])
+
+for item in Items():
+    pass
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PROTO-0002` |
+| Family | `PROTO` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/invalid_iter_signature.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PROTO-0003.mdx
+++ b/docs/errors/SIFR-PROTO-0003.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PROTO-0003: Context-manager protocol is missing"
+sidebarTitle: "SIFR-PROTO-0003"
+description: "Context-manager protocol is missing"
+---
+
+`SIFR-PROTO-0003` belongs to the **Protocols** diagnostic family. It means: context-manager protocol is missing.
+
+## Why It Happens
+
+A value does not satisfy the structural protocol required by the operation, such as iteration, context management, hashing, comparison, or reversible iteration.
+
+<Info>
+Use `sifr --explain SIFR-PROTO-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+for item in NotIterable():
+    pass
+```
+
+## How To Fix It
+
+Implement the required protocol shape, or pass a value that already satisfies the iterator, context-manager, hashable, or comparable requirement.
+
+## Fixed Code
+
+```python
+class Items:
+    def __iter__(self) -> Iterator[int]:
+        return iter([1, 2, 3])
+
+for item in Items():
+    pass
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PROTO-0003` |
+| Family | `PROTO` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/with_non_context_manager.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PROTO-0004.mdx
+++ b/docs/errors/SIFR-PROTO-0004.mdx
@@ -1,0 +1,50 @@
+---
+title: "SIFR-PROTO-0004: Hashable or comparable protocol is required"
+sidebarTitle: "SIFR-PROTO-0004"
+description: "Hashable or comparable protocol is required"
+---
+
+`SIFR-PROTO-0004` belongs to the **Protocols** diagnostic family. It means: hashable or comparable protocol is required.
+
+## Why It Happens
+
+A value does not satisfy the structural protocol required by the operation, such as iteration, context management, hashing, comparison, or reversible iteration.
+
+<Info>
+Use `sifr --explain SIFR-PROTO-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+for item in NotIterable():
+    pass
+```
+
+## How To Fix It
+
+Implement the required protocol shape, or pass a value that already satisfies the iterator, context-manager, hashable, or comparable requirement.
+
+## Fixed Code
+
+```python
+class Items:
+    def __iter__(self) -> Iterator[int]:
+        return iter([1, 2, 3])
+
+for item in Items():
+    pass
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-PROTO-0004` |
+| Family | `PROTO` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/unhashable_dict_key.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0001.mdx
+++ b/docs/errors/SIFR-RESULT-0001.mdx
@@ -1,0 +1,47 @@
+---
+title: "SIFR-RESULT-0001: Unused Result value"
+sidebarTitle: "SIFR-RESULT-0001"
+description: "Unused Result value"
+---
+
+`SIFR-RESULT-0001` belongs to the **Result and typed errors** diagnostic family. It means: unused result value.
+
+## Why It Happens
+
+A typed failure path is being ignored or described with an invalid error type. Handle the `Result`, return it, or cover the raised error types explicitly.
+
+<Info>
+Use `sifr --explain SIFR-RESULT-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+read_text("notes.txt")
+```
+
+## How To Fix It
+
+Handle typed failures explicitly. Use `try`/`except`, return the `Result`, or otherwise consume the value so failures cannot be ignored.
+
+## Fixed Code
+
+```python
+try:
+    text = read_text("notes.txt")
+except IOError as e:
+    text = ""
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-RESULT-0001` |
+| Family | `RESULT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/unused_result.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0002.mdx
+++ b/docs/errors/SIFR-RESULT-0002.mdx
@@ -1,0 +1,47 @@
+---
+title: "SIFR-RESULT-0002: Invalid Result error type"
+sidebarTitle: "SIFR-RESULT-0002"
+description: "Invalid Result error type"
+---
+
+`SIFR-RESULT-0002` belongs to the **Result and typed errors** diagnostic family. It means: invalid result error type.
+
+## Why It Happens
+
+A typed failure path is being ignored or described with an invalid error type. Handle the `Result`, return it, or cover the raised error types explicitly.
+
+<Info>
+Use `sifr --explain SIFR-RESULT-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+read_text("notes.txt")
+```
+
+## How To Fix It
+
+Handle typed failures explicitly. Use `try`/`except`, return the `Result`, or otherwise consume the value so failures cannot be ignored.
+
+## Fixed Code
+
+```python
+try:
+    text = read_text("notes.txt")
+except IOError as e:
+    text = ""
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-RESULT-0002` |
+| Family | `RESULT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/error_str_not_allowed.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0003.mdx
+++ b/docs/errors/SIFR-RESULT-0003.mdx
@@ -1,0 +1,47 @@
+---
+title: "SIFR-RESULT-0003: Invalid raise expression"
+sidebarTitle: "SIFR-RESULT-0003"
+description: "Invalid raise expression"
+---
+
+`SIFR-RESULT-0003` belongs to the **Result and typed errors** diagnostic family. It means: invalid raise expression.
+
+## Why It Happens
+
+A typed failure path is being ignored or described with an invalid error type. Handle the `Result`, return it, or cover the raised error types explicitly.
+
+<Info>
+Use `sifr --explain SIFR-RESULT-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+read_text("notes.txt")
+```
+
+## How To Fix It
+
+Handle typed failures explicitly. Use `try`/`except`, return the `Result`, or otherwise consume the value so failures cannot be ignored.
+
+## Fixed Code
+
+```python
+try:
+    text = read_text("notes.txt")
+except IOError as e:
+    text = ""
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-RESULT-0003` |
+| Family | `RESULT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/error_raise_str.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0004.mdx
+++ b/docs/errors/SIFR-RESULT-0004.mdx
@@ -1,0 +1,47 @@
+---
+title: "SIFR-RESULT-0004: Except arm references an unknown error type"
+sidebarTitle: "SIFR-RESULT-0004"
+description: "Except arm references an unknown error type"
+---
+
+`SIFR-RESULT-0004` belongs to the **Result and typed errors** diagnostic family. It means: except arm references an unknown error type.
+
+## Why It Happens
+
+A typed failure path is being ignored or described with an invalid error type. Handle the `Result`, return it, or cover the raised error types explicitly.
+
+<Info>
+Use `sifr --explain SIFR-RESULT-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+read_text("notes.txt")
+```
+
+## How To Fix It
+
+Handle typed failures explicitly. Use `try`/`except`, return the `Result`, or otherwise consume the value so failures cannot be ignored.
+
+## Fixed Code
+
+```python
+try:
+    text = read_text("notes.txt")
+except IOError as e:
+    text = ""
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-RESULT-0004` |
+| Family | `RESULT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/unknown_except_error_type.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0005.mdx
+++ b/docs/errors/SIFR-RESULT-0005.mdx
@@ -1,0 +1,47 @@
+---
+title: "SIFR-RESULT-0005: Try body error types are not fully covered by except arms"
+sidebarTitle: "SIFR-RESULT-0005"
+description: "Try body error types are not fully covered by except arms"
+---
+
+`SIFR-RESULT-0005` belongs to the **Result and typed errors** diagnostic family. It means: try body error types are not fully covered by except arms.
+
+## Why It Happens
+
+A typed failure path is being ignored or described with an invalid error type. Handle the `Result`, return it, or cover the raised error types explicitly.
+
+<Info>
+Use `sifr --explain SIFR-RESULT-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+read_text("notes.txt")
+```
+
+## How To Fix It
+
+Handle typed failures explicitly. Use `try`/`except`, return the `Result`, or otherwise consume the value so failures cannot be ignored.
+
+## Fixed Code
+
+```python
+try:
+    text = read_text("notes.txt")
+except IOError as e:
+    text = ""
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-RESULT-0005` |
+| Family | `RESULT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/try_except_uncovered_error_types.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0006.mdx
+++ b/docs/errors/SIFR-RESULT-0006.mdx
@@ -1,0 +1,47 @@
+---
+title: "SIFR-RESULT-0006: Except arm type expression has an unsupported form"
+sidebarTitle: "SIFR-RESULT-0006"
+description: "Except arm type expression has an unsupported form"
+---
+
+`SIFR-RESULT-0006` belongs to the **Result and typed errors** diagnostic family. It means: except arm type expression has an unsupported form.
+
+## Why It Happens
+
+A typed failure path is being ignored or described with an invalid error type. Handle the `Result`, return it, or cover the raised error types explicitly.
+
+<Info>
+Use `sifr --explain SIFR-RESULT-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+read_text("notes.txt")
+```
+
+## How To Fix It
+
+Handle typed failures explicitly. Use `try`/`except`, return the `Result`, or otherwise consume the value so failures cannot be ignored.
+
+## Fixed Code
+
+```python
+try:
+    text = read_text("notes.txt")
+except IOError as e:
+    text = ""
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-RESULT-0006` |
+| Family | `RESULT` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_lowering/src/lower/statement_diagnostics_tests.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-STDLIB-0001.mdx
+++ b/docs/errors/SIFR-STDLIB-0001.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-STDLIB-0001: Unsupported standard-library constructor, method, or surface"
+sidebarTitle: "SIFR-STDLIB-0001"
+description: "Unsupported standard-library constructor, method, or surface"
+---
+
+`SIFR-STDLIB-0001` belongs to the **Standard library surface** diagnostic family. It means: unsupported standard-library constructor, method, or surface.
+
+## Why It Happens
+
+The selected standard-library surface is not supported in this form. Use the documented `sifr.*` constructor, method, or module path.
+
+<Info>
+Use `sifr --explain SIFR-STDLIB-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+values = defaultdict()
+```
+
+## How To Fix It
+
+Use the supported `sifr.*` surface and constructor shape. Some CPython conveniences are intentionally absent or require explicit arguments.
+
+## Fixed Code
+
+```python
+from sifr.collections import defaultdict
+
+values = defaultdict(lambda: 0)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-STDLIB-0001` |
+| Family | `STDLIB` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/defaultdict_keyword_constructor_unsupported.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-STDLIB-0003.mdx
+++ b/docs/errors/SIFR-STDLIB-0003.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-STDLIB-0003: Embedded standard-library bootstrap failure"
+sidebarTitle: "SIFR-STDLIB-0003"
+description: "Embedded standard-library bootstrap failure"
+---
+
+`SIFR-STDLIB-0003` belongs to the **Standard library surface** diagnostic family. It means: embedded standard-library bootstrap failure.
+
+## Why It Happens
+
+The selected standard-library surface is not supported in this form. Use the documented `sifr.*` constructor, method, or module path.
+
+<Info>
+Use `sifr --explain SIFR-STDLIB-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+values = defaultdict()
+```
+
+## How To Fix It
+
+Use the supported `sifr.*` surface and constructor shape. Some CPython conveniences are intentionally absent or require explicit arguments.
+
+## Fixed Code
+
+```python
+from sifr.collections import defaultdict
+
+values = defaultdict(lambda: 0)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-STDLIB-0003` |
+| Family | `STDLIB` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_driver/src/tests/stdlib_exports.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-STDLIB-0004.mdx
+++ b/docs/errors/SIFR-STDLIB-0004.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-STDLIB-0004: Standard-library cache build or reuse failure"
+sidebarTitle: "SIFR-STDLIB-0004"
+description: "Standard-library cache build or reuse failure"
+---
+
+`SIFR-STDLIB-0004` belongs to the **Standard library surface** diagnostic family. It means: standard-library cache build or reuse failure.
+
+## Why It Happens
+
+The selected standard-library surface is not supported in this form. Use the documented `sifr.*` constructor, method, or module path.
+
+<Info>
+Use `sifr --explain SIFR-STDLIB-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+values = defaultdict()
+```
+
+## How To Fix It
+
+Use the supported `sifr.*` surface and constructor shape. Some CPython conveniences are intentionally absent or require explicit arguments.
+
+## Fixed Code
+
+```python
+from sifr.collections import defaultdict
+
+values = defaultdict(lambda: 0)
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-STDLIB-0004` |
+| Family | `STDLIB` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0002.mdx
+++ b/docs/errors/SIFR-TYPE-0002.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0002: Expected and actual types are incompatible"
+sidebarTitle: "SIFR-TYPE-0002"
+description: "Expected and actual types are incompatible"
+---
+
+`SIFR-TYPE-0002` belongs to the **Static typing** diagnostic family. It means: expected and actual types are incompatible.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0002` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/type_mismatch.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0003.mdx
+++ b/docs/errors/SIFR-TYPE-0003.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0003: If-expression or conditional branches have incompatible types"
+sidebarTitle: "SIFR-TYPE-0003"
+description: "If-expression or conditional branches have incompatible types"
+---
+
+`SIFR-TYPE-0003` belongs to the **Static typing** diagnostic family. It means: if-expression or conditional branches have incompatible types.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0003` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/ternary_type_mismatch.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0004.mdx
+++ b/docs/errors/SIFR-TYPE-0004.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0004: A required type annotation is missing"
+sidebarTitle: "SIFR-TYPE-0004"
+description: "A required type annotation is missing"
+---
+
+`SIFR-TYPE-0004` belongs to the **Static typing** diagnostic family. It means: a required type annotation is missing.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0004` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/missing_type_annotation.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0005.mdx
+++ b/docs/errors/SIFR-TYPE-0005.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0005: Unsupported operator or operand types"
+sidebarTitle: "SIFR-TYPE-0005"
+description: "Unsupported operator or operand types"
+---
+
+`SIFR-TYPE-0005` belongs to the **Static typing** diagnostic family. It means: unsupported operator or operand types.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0005` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0005` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/optional_arithmetic_without_narrowing.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0006.mdx
+++ b/docs/errors/SIFR-TYPE-0006.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0006: Int and bigint are mixed without an explicit conversion"
+sidebarTitle: "SIFR-TYPE-0006"
+description: "Int and bigint are mixed without an explicit conversion"
+---
+
+`SIFR-TYPE-0006` belongs to the **Static typing** diagnostic family. It means: int and bigint are mixed without an explicit conversion.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0006` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0006` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/bigint_int_mixed_arithmetic.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0007.mdx
+++ b/docs/errors/SIFR-TYPE-0007.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0007: Invalid type annotation shape"
+sidebarTitle: "SIFR-TYPE-0007"
+description: "Invalid type annotation shape"
+---
+
+`SIFR-TYPE-0007` belongs to the **Static typing** diagnostic family. It means: invalid type annotation shape.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0007` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0007` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/invalid_type_annotation.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0008.mdx
+++ b/docs/errors/SIFR-TYPE-0008.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0008: Container literal elements, keys, or values have conflicting types"
+sidebarTitle: "SIFR-TYPE-0008"
+description: "Container literal elements, keys, or values have conflicting types"
+---
+
+`SIFR-TYPE-0008` belongs to the **Static typing** diagnostic family. It means: container literal elements, keys, or values have conflicting types.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0008` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0008` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/container_literal_type_conflict.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0009.mdx
+++ b/docs/errors/SIFR-TYPE-0009.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0009: Tuple or list unpacking shape mismatch"
+sidebarTitle: "SIFR-TYPE-0009"
+description: "Tuple or list unpacking shape mismatch"
+---
+
+`SIFR-TYPE-0009` belongs to the **Static typing** diagnostic family. It means: tuple or list unpacking shape mismatch.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0009` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0009` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/tuple_unpack_shape_mismatch.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0010.mdx
+++ b/docs/errors/SIFR-TYPE-0010.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0010: TypeVar constraints are not satisfied by the inferred concrete type"
+sidebarTitle: "SIFR-TYPE-0010"
+description: "TypeVar constraints are not satisfied by the inferred concrete type"
+---
+
+`SIFR-TYPE-0010` belongs to the **Static typing** diagnostic family. It means: typevar constraints are not satisfied by the inferred concrete type.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0010` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0010` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/typevar_constraints_violation.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0011.mdx
+++ b/docs/errors/SIFR-TYPE-0011.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0011: Unsupported default argument expression"
+sidebarTitle: "SIFR-TYPE-0011"
+description: "Unsupported default argument expression"
+---
+
+`SIFR-TYPE-0011` belongs to the **Static typing** diagnostic family. It means: unsupported default argument expression.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0011` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0011` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/unsupported_default_expr_call.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0012.mdx
+++ b/docs/errors/SIFR-TYPE-0012.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0012: Unsupported expression form"
+sidebarTitle: "SIFR-TYPE-0012"
+description: "Unsupported expression form"
+---
+
+`SIFR-TYPE-0012` belongs to the **Static typing** diagnostic family. It means: unsupported expression form.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0012` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0012` |
+| Family | `TYPE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr/tests/e2e/fail/unsupported_yield_expression.sifr` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0901.mdx
+++ b/docs/errors/SIFR-TYPE-0901.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0901: Integer arithmetic may overflow at runtime"
+sidebarTitle: "SIFR-TYPE-0901"
+description: "Integer arithmetic may overflow at runtime"
+---
+
+`SIFR-TYPE-0901` belongs to the **Static typing** diagnostic family. It means: integer arithmetic may overflow at runtime.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0901` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0901` |
+| Family | `TYPE` |
+| Severity | Warning |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_driver/src/tests/single_file_frontend.rs::test_type_check_source_surfaces_arithmetic_overflow_as_structured_warning` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0902.mdx
+++ b/docs/errors/SIFR-TYPE-0902.mdx
@@ -1,0 +1,44 @@
+---
+title: "SIFR-TYPE-0902: Reveal the inferred static type of an expression"
+sidebarTitle: "SIFR-TYPE-0902"
+description: "Reveal the inferred static type of an expression"
+---
+
+`SIFR-TYPE-0902` belongs to the **Static typing** diagnostic family. It means: reveal the inferred static type of an expression.
+
+## Why It Happens
+
+Static types do not line up. Align annotations, inferred expressions, branches, containers, operators, or generic constraints, and convert explicitly where needed.
+
+<Info>
+Use `sifr --explain SIFR-TYPE-0902` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```python
+count: int = "three"
+```
+
+## How To Fix It
+
+Make annotations, inferred values, branch results, container elements, and operator operands agree. Add explicit conversions where the conversion is meaningful.
+
+## Fixed Code
+
+```python
+count: int = 3
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-TYPE-0902` |
+| Family | `TYPE` |
+| Severity | Note |
+| Stability | stable |
+| Owner | `compiler/core-language` |
+| Representative fixture | `crates/sifr_driver/src/tests/single_file_frontend.rs::test_type_check_source_surfaces_reveal_type_as_structured_note` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0001.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0001.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-WORKSPACE-0001: Malformed workspace manifest"
+sidebarTitle: "SIFR-WORKSPACE-0001"
+description: "Malformed workspace manifest"
+---
+
+`SIFR-WORKSPACE-0001` belongs to the **Workspace metadata** diagnostic family. It means: malformed workspace manifest.
+
+## Why It Happens
+
+Workspace metadata does not describe a valid Sifr source layout. Keep source roots inside the workspace and use valid member/source-root shapes.
+
+<Info>
+Use `sifr --explain SIFR-WORKSPACE-0001` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[workspace]
+members = [123]
+```
+
+## How To Fix It
+
+Fix workspace metadata so source roots stay inside the workspace and each entry has the expected string/path shape.
+
+## Fixed Code
+
+```toml
+[workspace]
+members = ["crates/app"]
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-WORKSPACE-0001` |
+| Family | `WORKSPACE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `verification/areas/project_workspace/fixtures/project/workspace_malformed_manifest` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0002.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0002.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-WORKSPACE-0002: Workspace source root escapes the workspace root"
+sidebarTitle: "SIFR-WORKSPACE-0002"
+description: "Workspace source root escapes the workspace root"
+---
+
+`SIFR-WORKSPACE-0002` belongs to the **Workspace metadata** diagnostic family. It means: workspace source root escapes the workspace root.
+
+## Why It Happens
+
+Workspace metadata does not describe a valid Sifr source layout. Keep source roots inside the workspace and use valid member/source-root shapes.
+
+<Info>
+Use `sifr --explain SIFR-WORKSPACE-0002` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[workspace]
+members = [123]
+```
+
+## How To Fix It
+
+Fix workspace metadata so source roots stay inside the workspace and each entry has the expected string/path shape.
+
+## Fixed Code
+
+```toml
+[workspace]
+members = ["crates/app"]
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-WORKSPACE-0002` |
+| Family | `WORKSPACE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_driver/src/tests/discovery_and_workspace.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0003.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0003.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-WORKSPACE-0003: Workspace source root is not a directory"
+sidebarTitle: "SIFR-WORKSPACE-0003"
+description: "Workspace source root is not a directory"
+---
+
+`SIFR-WORKSPACE-0003` belongs to the **Workspace metadata** diagnostic family. It means: workspace source root is not a directory.
+
+## Why It Happens
+
+Workspace metadata does not describe a valid Sifr source layout. Keep source roots inside the workspace and use valid member/source-root shapes.
+
+<Info>
+Use `sifr --explain SIFR-WORKSPACE-0003` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[workspace]
+members = [123]
+```
+
+## How To Fix It
+
+Fix workspace metadata so source roots stay inside the workspace and each entry has the expected string/path shape.
+
+## Fixed Code
+
+```toml
+[workspace]
+members = ["crates/app"]
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-WORKSPACE-0003` |
+| Family | `WORKSPACE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_driver/src/tests/discovery_and_workspace.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0004.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0004.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-WORKSPACE-0004: Workspace source root entry has an invalid shape or path"
+sidebarTitle: "SIFR-WORKSPACE-0004"
+description: "Workspace source root entry has an invalid shape or path"
+---
+
+`SIFR-WORKSPACE-0004` belongs to the **Workspace metadata** diagnostic family. It means: workspace source root entry has an invalid shape or path.
+
+## Why It Happens
+
+Workspace metadata does not describe a valid Sifr source layout. Keep source roots inside the workspace and use valid member/source-root shapes.
+
+<Info>
+Use `sifr --explain SIFR-WORKSPACE-0004` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[workspace]
+members = [123]
+```
+
+## How To Fix It
+
+Fix workspace metadata so source roots stay inside the workspace and each entry has the expected string/path shape.
+
+## Fixed Code
+
+```toml
+[workspace]
+members = ["crates/app"]
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-WORKSPACE-0004` |
+| Family | `WORKSPACE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_driver/src/tests/discovery_and_workspace.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0101.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0101.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-WORKSPACE-0101: Legacy workspace import target could not be resolved; source imports use SIFR-IMPORT-0002"
+sidebarTitle: "SIFR-WORKSPACE-0101"
+description: "Legacy workspace import target could not be resolved; source imports use SIFR-IMPORT-0002"
+---
+
+`SIFR-WORKSPACE-0101` belongs to the **Workspace metadata** diagnostic family. It means: legacy workspace import target could not be resolved; source imports use sifr-import-0002.
+
+## Why It Happens
+
+Workspace metadata does not describe a valid Sifr source layout. Keep source roots inside the workspace and use valid member/source-root shapes.
+
+<Info>
+Use `sifr --explain SIFR-WORKSPACE-0101` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[workspace]
+members = [123]
+```
+
+## How To Fix It
+
+Fix workspace metadata so source roots stay inside the workspace and each entry has the expected string/path shape.
+
+## Fixed Code
+
+```toml
+[workspace]
+members = ["crates/app"]
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-WORKSPACE-0101` |
+| Family | `WORKSPACE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `verification/areas/project_workspace/fixtures/project/workspace_unresolved_import` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0102.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0102.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-WORKSPACE-0102: Legacy workspace import target is ambiguous; source imports use SIFR-IMPORT-0005"
+sidebarTitle: "SIFR-WORKSPACE-0102"
+description: "Legacy workspace import target is ambiguous; source imports use SIFR-IMPORT-0005"
+---
+
+`SIFR-WORKSPACE-0102` belongs to the **Workspace metadata** diagnostic family. It means: legacy workspace import target is ambiguous; source imports use sifr-import-0005.
+
+## Why It Happens
+
+Workspace metadata does not describe a valid Sifr source layout. Keep source roots inside the workspace and use valid member/source-root shapes.
+
+<Info>
+Use `sifr --explain SIFR-WORKSPACE-0102` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[workspace]
+members = [123]
+```
+
+## How To Fix It
+
+Fix workspace metadata so source roots stay inside the workspace and each entry has the expected string/path shape.
+
+## Fixed Code
+
+```toml
+[workspace]
+members = ["crates/app"]
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-WORKSPACE-0102` |
+| Family | `WORKSPACE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `verification/areas/project_workspace/fixtures/project/workspace_ambiguous_import` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0103.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0103.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-WORKSPACE-0103: Legacy workspace namespace package collision; source imports use SIFR-IMPORT-0006"
+sidebarTitle: "SIFR-WORKSPACE-0103"
+description: "Legacy workspace namespace package collision; source imports use SIFR-IMPORT-0006"
+---
+
+`SIFR-WORKSPACE-0103` belongs to the **Workspace metadata** diagnostic family. It means: legacy workspace namespace package collision; source imports use sifr-import-0006.
+
+## Why It Happens
+
+Workspace metadata does not describe a valid Sifr source layout. Keep source roots inside the workspace and use valid member/source-root shapes.
+
+<Info>
+Use `sifr --explain SIFR-WORKSPACE-0103` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[workspace]
+members = [123]
+```
+
+## How To Fix It
+
+Fix workspace metadata so source roots stay inside the workspace and each entry has the expected string/path shape.
+
+## Fixed Code
+
+```toml
+[workspace]
+members = ["crates/app"]
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-WORKSPACE-0103` |
+| Family | `WORKSPACE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_driver/src/tests/discovery_and_workspace.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0104.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0104.mdx
@@ -1,0 +1,46 @@
+---
+title: "SIFR-WORKSPACE-0104: Legacy workspace import graph cycle; source imports use SIFR-IMPORT-0007"
+sidebarTitle: "SIFR-WORKSPACE-0104"
+description: "Legacy workspace import graph cycle; source imports use SIFR-IMPORT-0007"
+---
+
+`SIFR-WORKSPACE-0104` belongs to the **Workspace metadata** diagnostic family. It means: legacy workspace import graph cycle; source imports use sifr-import-0007.
+
+## Why It Happens
+
+Workspace metadata does not describe a valid Sifr source layout. Keep source roots inside the workspace and use valid member/source-root shapes.
+
+<Info>
+Use `sifr --explain SIFR-WORKSPACE-0104` locally to see the renderer's exact message template and any machine-applicable suggestions for the compiler version you are running.
+</Info>
+
+## Erroneous Code
+
+```toml
+[workspace]
+members = [123]
+```
+
+## How To Fix It
+
+Fix workspace metadata so source roots stay inside the workspace and each entry has the expected string/path shape.
+
+## Fixed Code
+
+```toml
+[workspace]
+members = ["crates/app"]
+```
+
+## Details
+
+| Field | Value |
+| --- | --- |
+| Code | `SIFR-WORKSPACE-0104` |
+| Family | `WORKSPACE` |
+| Severity | Error |
+| Stability | stable |
+| Owner | `compiler/frontend` |
+| Representative fixture | `crates/sifr_driver/src/tests/project_graph.rs` |
+
+See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/stdlib/module-index.mdx
+++ b/docs/stdlib/module-index.mdx
@@ -1,0 +1,132 @@
+---
+title: "Sifr Standard Library Module Index"
+sidebarTitle: "Module Index"
+description: "A compact map of every sifr.* module and what it is for."
+---
+
+Sifr standard-library modules live under the `sifr.*` namespace. Import concrete symbols from the module you need:
+
+```python
+from sifr.json import loads
+from sifr.pathlib import join_path
+```
+
+<Note>
+This page is an orientation map. The deeper reference pages cover the modules most developers reach for first, and the compiler rejects bare CPython imports with `SIFR-IMPORT-0008`.
+</Note>
+
+## Choosing a Module
+
+<CardGroup cols={2}>
+  <Card title="Collections" icon="blocks" href="/stdlib/collections">
+    Lists, dictionaries, sets, counters, and safe lookup patterns.
+  </Card>
+  <Card title="I/O and Filesystem" icon="folder-open" href="/stdlib/io-filesystem">
+    Text/binary boundaries, paths, files, and directories.
+  </Card>
+  <Card title="Networking" icon="radio" href="/stdlib/networking">
+    TCP, HTTP, TLS, URLs, and typed network errors.
+  </Card>
+  <Card title="Concurrency API" icon="workflow" href="/stdlib/concurrency">
+    Tasks, channels, locks, pools, process helpers, and signals.
+  </Card>
+</CardGroup>
+
+## Math, Data, and Serialization
+
+| Module | Purpose |
+| --- | --- |
+| `sifr.math` | Mathematical functions and numeric helpers. |
+| `sifr.json` | Typed JSON values, parsing, and serialization. |
+| `sifr.re` | Unicode-aware regular expression matching and substitution. |
+| `sifr.datetime` | Dates, times, durations, and timezone-aware values. |
+| `sifr.random` | Seeded random number generation. |
+| `sifr.statistics` | Mean, median, variance, and related statistics. |
+| `sifr.hashlib` | Hash functions, HMAC construction, and digest objects. |
+| `sifr.uuid` | UUID construction, parsing, and formatting. |
+| `sifr.base64` | Base64 text and byte encoding helpers. |
+| `sifr.tomllib` | TOML value parsing helpers. |
+| `sifr.csv` | CSV dialects, readers, and writers. |
+| `sifr.configparser` | INI-style configuration parsing. |
+
+## Collections and Iteration
+
+| Module | Purpose |
+| --- | --- |
+| `sifr.collections` | Counters, deques, default dictionaries, and set helpers. |
+| `sifr.itertools` | Iterator construction and combinator helpers. |
+| `sifr.functools` | Higher-order function helpers such as `reduce`. |
+| `sifr.operator` | Named operator functions. |
+| `sifr.bisect` | Binary search and insertion helpers for ordered lists. |
+| `sifr.heapq` | Heap queues and priority queue helpers. |
+| `sifr.graphlib` | Topological sorting helpers. |
+
+## Filesystem, Environment, and System
+
+| Module | Purpose |
+| --- | --- |
+| `sifr.io` | Explicit text and binary file I/O. |
+| `sifr.pathlib` | Path construction, joining, and traversal helpers. |
+| `sifr.os` | Filesystem stat helpers. |
+| `sifr.shutil` | Copy, move, and recursive remove helpers. |
+| `sifr.glob` | Filesystem glob expansion. |
+| `sifr.fnmatch` | Shell-style filename pattern matching. |
+| `sifr.tempfile` | Temporary file and directory helpers. |
+| `sifr.env` | Process environment variable access. |
+| `sifr.sys` | Process arguments, exit, version, and platform constants. |
+| `sifr.platform` | Host platform metadata. |
+
+## Text, Encoding, and Internationalization
+
+| Module | Purpose |
+| --- | --- |
+| `sifr.string` | String templating and formatting helpers. |
+| `sifr.textwrap` | Text wrapping, indentation, and whitespace helpers. |
+| `sifr.encoding` | Explicit byte/text conversion with typed encoding errors. |
+| `sifr.unicode` | Unicode data, normalization, names, categories, and segmentation. |
+| `sifr.i18n` | Locale ids, number formatting, plural rules, and translation catalogs. |
+| `sifr.html` | HTML escaping and unescaping. |
+| `sifr.bytes` | Byte construction, search, and UTF-8 conversion helpers. |
+
+## Concurrency and Runtime
+
+| Module | Purpose |
+| --- | --- |
+| `sifr.task` | Task contexts and structured task helpers. |
+| `sifr.sync` | Channels, shared values, locks, semaphores, and notifications. |
+| `sifr.parallel` | CPU-parallel maps and worker pools. |
+| `sifr.process` | Subprocess spawning, output collection, pipes, and async process helpers. |
+| `sifr.signal` | Structured signal and shutdown helpers. |
+| `sifr.runtime` | Structured runtime diagnostic events. |
+| `sifr.resource` | Deterministic cleanup context helpers. |
+| `sifr.ipc` | Typed IPC schema, frame, and backpressure primitives. |
+| `sifr.time` | Wall-clock and calendar time helpers. |
+| `sifr.timeit` | Timing helpers and repeatable benchmark loops. |
+| `sifr.logging` | Structured log levels, formatters, handlers, and emitters. |
+
+## Networking and Archives
+
+| Module | Purpose |
+| --- | --- |
+| `sifr.net` | Async TCP networking primitives. |
+| `sifr.http` | HTTP methods, status codes, headers, bodies, and cookies. |
+| `sifr.tls` | TLS client/server configuration and streams. |
+| `sifr.url` | Typed URL parsing and manipulation. |
+| `sifr.ipaddress` | IPv4 parsing, classification, and conversion. |
+| `sifr.gzip` | Gzip compression and decompression. |
+| `sifr.zipfile` | ZIP archive inspection and read helpers. |
+| `sifr.secrets` | Security-oriented random helpers and constant-time comparison. |
+
+## Testing and CLIs
+
+| Module | Purpose |
+| --- | --- |
+| `sifr.test` | Assertion helpers for Sifr tests. |
+| `sifr.argparse` | Command-line option parsing helpers and typed namespaces. |
+
+## Additional Modules
+
+| Module | Purpose |
+| --- | --- |
+| `sifr.calendar` | Calendar date calculations and text calendar helpers. |
+| `sifr.difflib` | Sequence matching and diff-adjacent helpers. |

--- a/docs/stdlib/overview.mdx
+++ b/docs/stdlib/overview.mdx
@@ -6,6 +6,8 @@ description: "A complete reference to the sifr.* standard library namespace: how
 
 Sifr ships a comprehensive standard library under the `sifr.*` namespace. Every module is designed with Rust-backed safety guarantees — predictable ownership, explicit error types, and no hidden global mutation. Because Sifr compiles to Rust rather than running on the CPython interpreter, the standard library is its own surface; it is not a thin wrapper around CPython's built-in modules.
 
+For a compact inventory of every module currently shipped in `lib/sifr`, see the [Module Index](/stdlib/module-index).
+
 ## How to Import
 
 Use `from sifr.<module> import <symbol>` for every standard library import:

--- a/plans/issues/active/ad-hoc-documentation-learning-path.md
+++ b/plans/issues/active/ad-hoc-documentation-learning-path.md
@@ -22,7 +22,8 @@ Review artifacts:
 Implementation status:
 
 - Wave 1: Merged in PR #2656. Scope: navigation foundation, `From Python`, `Status`, `Ownership and Mutability`, Slice 0 semantic fixes, and audience guide route placeholders. Validation: `cd docs && npx mint@latest validate` passed.
-- Wave 2: In progress. Scope: core data model pages and dedicated Concurrency concept section.
+- Wave 2: Merged in PR #2657. Scope: core data model pages and dedicated Concurrency concept section. Validation: `cd docs && npx mint@latest validate` passed.
+- Wave 3: Ready for PR after Sonnet review. Scope: standard-library module inventory, CLI package/workspace reference, and published one-page-per-code error reference. Validation: `cd docs && npx mint@latest validate` passed with Node 24.
 
 ## Objective
 

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-3-sonnet-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-3-sonnet-review-pass-1.md
@@ -1,0 +1,133 @@
+Now I have everything needed for a thorough review. Here is my assessment.
+
+---
+
+## Wave 3 Documentation Review
+
+**Verdict: NOT PR-READY** — three blockers, two important improvements, and optional polish below.
+
+---
+
+### Blockers
+
+#### B1 — Family-shared examples are wrong for most codes in a family (all 170 pages)
+
+The generator uses one erroneous/fixed pair per family. The result is that the code shown is only accurate for the first or most-prominent code in the family — and actively misleads developers for the rest.
+
+The clearest failure is ASYNC. All seven ASYNC codes (`SIFR-ASYNC-0001` through `SIFR-ASYNC-0007`) render:
+
+```python
+# Erroneous
+async def cached() -> int:
+    return 1
+```
+
+This is the `SIFR-ASYNC-0001` ("no suspension") example. A developer hitting `SIFR-ASYNC-0003` ("blocking I/O called from async context") will see code that has no blocking I/O call at all, and the "fix" (add `await task.sleep(0.0)`) is wrong guidance for their actual problem. The real fixture (`blocking_io_direct_call_in_async_rejected.sifr`) clearly shows what should be there instead.
+
+The same problem spans every family:
+- **PACKAGE** (34 codes): all show `[package]\nname = "demo"` — meaningless for import-scope, trust-policy, archive-integrity, or publish-guard errors
+- **OWN** (13 codes): all show the use-after-move pattern — wrong for borrow-conflict, loop-move, sendability, or IPC codes
+- **TYPE** (13 codes): all show `count: int = "three"` — wrong for TypeVar, overflow, or reveal-type codes
+- **FLOW** (9 codes): all show the missing-return example — wrong for break/continue, for-loop, or unsupported-form codes
+
+This is a blocker because it degrades the key user promise of the per-code reference — that each page tells you what's wrong *for this specific code*. The ASYNC family has real per-code fixtures in the e2e suite; using them is feasible.
+
+**Minimum acceptable bar:** fix ASYNC (7 pages) with per-code examples from the e2e fixtures before merging. Document the remaining families as a known gap with a follow-up ticket.
+
+---
+
+#### B2 — Wrong code fence language on 42 pages
+
+BUILD codes (`SIFR-BUILD-0002` through `SIFR-BUILD-0901`, 6 pages) tag their erroneous/fixed examples as ` ```python ` but the content is a shell invocation:
+
+```python   ← wrong
+sifr build app.sifr --output /root/out
+```
+
+Should be ` ```bash `.
+
+PACKAGE and WORKSPACE codes (34 + 8 pages) tag TOML content as ` ```python `:
+
+```python   ← wrong
+[package]
+name = "demo"
+```
+
+Should be ` ```toml `.
+
+Mintlify renders these with Python syntax highlighting, which is visually confusing and makes the code look broken. The validation pass does not catch language-tag mismatches.
+
+---
+
+#### B3 — "Why It Happens" boilerplate is factually wrong for operational error families
+
+All 170 pages use this identical text:
+
+> Sifr reports this diagnostic when **the program shape would make compilation ambiguous, unsafe, or inconsistent with the language contract**. The compiler stops at this point so the generated Rust does not rely on a hidden runtime fallback.
+
+This is wrong for:
+- **BUILD** codes — these are filesystem, Cargo, or Rustc execution failures entirely unrelated to program shape. `SIFR-BUILD-0002` fires because `--output /root/out` is unwritable, not because the source is ambiguous.
+- **INTERNAL** codes — these are compiler bugs, not user program errors. `SIFR-INTERNAL-0001` explicitly says "indicates a compiler bug" in the `error-codes.mdx` Warning callout, yet the same page then claims the diagnostic fires because "the program shape would make compilation ambiguous." These two statements contradict each other on the same page.
+- **PACKAGE** / **WORKSPACE** codes — these are manifest and configuration errors, not source-language contract violations.
+
+At minimum the INTERNAL pages need the boilerplate replaced (two pages). The BUILD and PACKAGE families need distinct "Why It Happens" text.
+
+---
+
+### Important Improvements
+
+#### I1 — `self update` / `self version` flags are completely undocumented (`cli/packages-workspaces.mdx:78–84`)
+
+The Self Update section shows only:
+
+```bash
+sifr self version
+sifr self update
+```
+
+The actual CLI has significant flags that developers need: `--dry-run`, `--format json`, `--channel`, `--version`, `--force` on `self update`; and `--short`, `--format json` on `self version`. The `--dry-run --format json` output is stable and machine-readable — it's exactly what CI tooling would consume. This section should document at least `--dry-run` and `--channel`.
+
+#### I2 — `error-codes.mdx` description claims "24 families" but the catalog exports 23 (`error-codes.mdx:3`)
+
+The frontmatter reads:
+
+```
+description: "A complete reference of all 24 Sifr diagnostic code families..."
+```
+
+The code catalog (`code_catalog.json`) exports 23 families. CODEGEN is listed in the accordion as "no active codes in the current release." The count is technically defensible (24 registered families), but the description leads developers to expect 24 entries with actionable codes. The fix is either to say "23 active families and 1 reserved" or keep 24 but make "reserved" explicit in the description.
+
+---
+
+### Optional Polish
+
+**P1** — `SIFR-ASYNC-0003` (`docs/errors/SIFR-ASYNC-0003.mdx:7`): the family display name from the `.md` source says "Async effect and awaitability" — the description is correct but the "Why It Happens" body then contradicts the title by describing a "program shape" issue rather than an effect-system violation. Even when the boilerplate is replaced (B3), this family deserves wording specific to the effect-tracking model.
+
+**P2** — `docs/cli/packages-workspaces.mdx:19` — The command table omits `sifr repair` from the summary sentence but includes it below. The table entry for `sifr vendor [PATH]` says the default path is `vendor`; the CLI code at `cli_model_and_entrypoint.rs:241` (`#[arg(default_value = "vendor")]`) confirms this is accurate. No correction needed, just note it's verified.
+
+**P3** — `docs/stdlib/module-index.mdx:119–132` — The CardGroup footer links to `/stdlib/collections`, `/stdlib/io-filesystem`, `/stdlib/networking`, `/stdlib/concurrency`. These pages are registered in `docs.json` under Standard Library, so the routes are valid. However the CardGroup is placed after "Additional Modules," making it read as an afterthought rather than a navigation entry point. Moving it above the categorized tables would improve scan-ability.
+
+**P4** — Per-code pages omit stability from the **title/description** frontmatter even though `stability: stable` is shown in the details table. For future `unstable` codes this will matter for discoverability.
+
+---
+
+### Routing and Mintlify Assessment (Q4)
+
+The per-code pages (`docs/errors/SIFR-*.mdx`) are **not** registered in `docs.json`. Mintlify serves unregistered `.mdx` files as routable pages — they just don't appear in the sidebar. The `.mintignore` correctly exposes `errors/*.mdx` while hiding `errors/*.md`. The `validate` pass confirmed no broken page references. Links in `error-codes.mdx` use `/errors/SIFR-<CODE>` which Mintlify resolves to `docs/errors/SIFR-<CODE>.mdx`. This is structurally sound; the 170 pages will resolve correctly as hidden-from-nav reference pages.
+
+The `sifr --explain <CODE>` path (`cli_model_and_entrypoint.rs:664`) reads `docs/errors/<CODE>.md` (not `.mdx`) — so the new `.mdx` pages do not affect the terminal `--explain` output. Both systems coexist correctly.
+
+---
+
+### Summary
+
+| Issue | Scope | Blocking? |
+|---|---|---|
+| Family-shared examples wrong for most codes | 170 pages | Yes — fix ASYNC at minimum |
+| Wrong code fence language (`python` for bash/toml) | 42 pages | Yes — mechanical fix |
+| "Why It Happens" boilerplate wrong for BUILD/INTERNAL/PACKAGE | ~50 pages | Yes — 2 INTERNAL pages minimum |
+| `self update` flags undocumented | 1 page | Important |
+| "24 families" vs 23 active | 1 page | Important |
+| CardGroup placement, stability | 1–2 pages | Optional |
+
+The nav structure, routing, module-index completeness, CLI flag accuracy for init/repair/vendor/package/publish, and stdlib module coverage are all correct and ready. The blockers are in the generated per-code pages — fixing the ASYNC family examples, the language tags, and the INTERNAL boilerplate would put this in a mergeable state for a Wave 3 that's explicitly scoped as "v1 reference pages with known example gaps."

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-3-sonnet-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-3-sonnet-review-pass-2.md
@@ -1,0 +1,66 @@
+Here is my findings after inspecting all requested files against the source.
+
+---
+
+## Findings
+
+### No hard blockers found. One soft flag.
+
+---
+
+### ASYNC pages (0001–0007)
+
+**Per-code examples**: All seven codes now have distinct, per-code erroneous/fixed examples. That Pass 1 requirement is met.
+
+**"Why It Happens" — soft flag on SIFR-ASYNC-0006**: The text is identical across all seven ASYNC files:
+
+> "Sifr tracks suspension and blocking effects statically. This diagnostic fires when async code either does not really suspend, awaits work that cannot suspend, or calls blocking/CPU-heavy work without an explicit offload boundary."
+
+That sentence is accurate for 0001–0005 and 0007, but **factually misleading for 0006**. SIFR-ASYNC-0006 fires because `@blocking_io` (or `@cpu_heavy`) is applied to an `async def`, which is an annotation-placement constraint — nothing to do with whether the code suspends or calls blocking work. A user reading only 0006 gets a wrong mental model of what triggered the error. The fix and code examples are correct, so this won't mislead on remediation, but the diagnostic explanation is off.
+
+This is not a merge blocker (actionable content is accurate), but it is an inaccuracy in a "was previously broken" section. Worth a one-line fix to 0006 if standards require per-code accuracy.
+
+**Fixture references**: All seven fixture paths match what is in the repo.
+
+---
+
+### SIFR-ASYNC-0003 vs. fixture
+
+The doc's erroneous example calls `read_text("config.txt")` directly from async. The fixture (`blocking_io_direct_call_in_async_rejected.sifr`) calls a `@blocking_io`-annotated function `read_blocking()`. These illustrate the same rule from different angles. The doc example is arguably clearer for end users, and the fixture path listed in Details is correct. Not a blocker.
+
+---
+
+### SIFR-ASYNC-0005 vs. fixture
+
+The doc's erroneous code uses `lambda: 42`; the fixture uses a named unannotated function `compute_value`. Both are unannotated, so the concept is accurate. Minor illustrative divergence, not a blocker.
+
+---
+
+### BUILD, INTERNAL, RESULT, TYPE, ENCODING, PACKAGE, WORKSPACE
+
+All "Why It Happens" text is family-specific and accurate. Code fences are correct (`bash` for BUILD, `toml` for PACKAGE/WORKSPACE, `text` for INTERNAL, `python` for user-code families). No issues.
+
+---
+
+### `docs/cli/packages-workspaces.mdx` vs. source
+
+Every command, flag, and constraint documented was verified against `cli_model_and_entrypoint.rs` and `self_update_cli.rs`:
+
+- `--format json` requires `--dry-run` on `sifr self update` — confirmed (`update_args_diagnostic` enforces it).
+- `sifr self version --short` cannot combine with `--format json` — confirmed (`version_args_diagnostic` enforces it).
+- `--channel` and `--version` are mutually exclusive — confirmed.
+- All `--locked`/`--offline`/`--frozen` flags present on all relevant commands — confirmed.
+
+No inaccuracies.
+
+---
+
+### `docs/stdlib/module-index.mdx`
+
+CardGroup is positioned under "## Choosing a Module" near the top of the page, before the table sections. Correct.
+
+---
+
+## Summary
+
+**Wave 3 is PR-ready.** The one soft flag — SIFR-ASYNC-0006's "Why It Happens" text describing suspension/blocking effects when the actual cause is a decorator placement constraint — is a factual inaccuracy in a secondary explanation section. It does not block merge since the title, erroneous code, fix, and fixed code for 0006 are all correct. If the bar for this wave requires accurate per-code "Why" text (which was a Pass 1 stated goal), fix `docs/errors/SIFR-ASYNC-0006.mdx`'s Why It Happens to something like: *"The `@blocking_io` and `@cpu_heavy` annotations can only be applied to synchronous functions. An async function carries its own scheduling contract and cannot be additionally classified as a blocking or CPU-heavy workload."* Otherwise the PR can merge as-is.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-3-sonnet-review-pass-3.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-3-sonnet-review-pass-3.md
@@ -1,0 +1,7 @@
+Wave 3 is fully PR-ready. The patch resolves the only soft flag from Pass 2:
+
+- **"Why It Happens"** now correctly explains that `@blocking_io`/`@cpu_heavy` describe synchronous workload classes and cannot annotate `async def` because an async function already has its own scheduling contract — no longer generic.
+- The erroneous/fixed code pair is well-chosen: the bad example shows `@blocking_io` on an `async def` with an `await`, the fixed example shows the annotation correctly on a plain `def` with a synchronous I/O call.
+- Structure, frontmatter, Details table, and cross-links all look clean.
+
+No new blockers introduced by this patch.


### PR DESCRIPTION
## Summary
- Add a compact standard-library module index and package/workspace CLI reference.
- Publish one routeable MDX page for every active diagnostic code while keeping legacy generated Markdown hidden.
- Link every code from the Error Codes index without listing all 170 pages in the sidebar.

## Review
- Claude Sonnet medium pass 1 found blockers in generated examples, fence languages, and boilerplate; fixed.
- Claude Sonnet medium pass 2 marked Wave 3 PR-ready with one soft flag; fixed.
- Claude Sonnet medium pass 3 confirmed Wave 3 is fully PR-ready.

## Validation
- `export PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH"; cd docs && npx mint@latest validate`

No Rust tests run per request.