### PR TITLE
[codex] Add audience guide learning paths

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -141,11 +141,19 @@
             ]
           },
           {
-            "group": "Audience Paths",
+            "group": "Python Developer Guide",
             "icon": "map",
             "pages": [
               "guides/python-developers/index",
-              "guides/rust-developers/index"
+              "guides/python-developers/mental-model"
+            ]
+          },
+          {
+            "group": "Rust Developer Guide",
+            "icon": "refresh-cw",
+            "pages": [
+              "guides/rust-developers/index",
+              "guides/rust-developers/rust-concepts"
             ]
           }
         ]

--- a/docs/from-python.mdx
+++ b/docs/from-python.mdx
@@ -73,20 +73,20 @@ else:
     Use `from sifr.collections import Counter`, not `import collections`. Supported stdlib-style modules live under `sifr.*`; see the [collections import example](/stdlib/collections#importing).
   </Accordion>
   <Accordion title="Mutation is explicit">
-    Use `mut` when a function should mutate a borrowed parameter, and `own mut` when it should take ownership and mutate the value before returning or dropping it.
+    Use `mut` when a function should mutate a borrowed parameter, and `own mut` when it should take ownership and mutate the value.
   </Accordion>
 </AccordionGroup>
 
 ## Where To Go Next
 
 <CardGroup cols={2}>
+  <Card title="Mental Model Shift" icon="route" href="/guides/python-developers/mental-model">
+    Follow the practical path from Python habits to Sifr's compile-time model.
+  </Card>
   <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
     Learn `mut`, `own`, and borrow-by-default rules.
   </Card>
   <Card title="Error Handling" icon="triangle-alert" href="/language/error-handling">
     See how `Result` and `try`/`except` replace recoverable exceptions.
-  </Card>
-  <Card title="Python Developers" icon="map" href="/guides/python-developers">
-    Follow a guided path written for Python developers.
   </Card>
 </CardGroup>

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Guides
-description: Practical walkthroughs for common Sifr workflows.
+description: Practical learning paths for Python and Rust developers coming to Sifr.
 contextual: false
 mode: center
 ---
 
-## Featured
+Guides are written as paths, not reference pages. Use them when you want to build the right mental model before diving into individual language or API details.
 
 <CardGroup>
   <Card

--- a/docs/guides/python-developers/index.mdx
+++ b/docs/guides/python-developers/index.mdx
@@ -1,12 +1,15 @@
 ---
-title: "Sifr for Python Developers"
-sidebarTitle: "Python Developers"
-description: "A guided path for Python developers learning Sifr's compile-time types, errors, imports, ownership, and packages."
+title: "Python Developer Guide"
+sidebarTitle: "Overview"
+description: "A guided path for Python developers learning Sifr's compile-time types, errors, imports, ownership, async model, and packages."
 ---
 
-If you know Python, Sifr lets you keep much of the syntax while changing the contract around errors, missing values, mutation, and imports. Start with the compatibility bridge, then follow task-focused guides as they are added.
+If you know Python, Sifr lets you keep much of the syntax while changing the contract around errors, missing values, mutation, imports, and async work. Start with the compact bridge, then use this guide path to replace runtime habits with compile-time guarantees.
 
 <CardGroup cols={2}>
+  <Card title="Mental Model Shift" icon="route" href="/guides/python-developers/mental-model">
+    Learn the surprises to remove first: hints, exceptions, `None`, imports, and mutation.
+  </Card>
   <Card title="From Python" icon="map" href="/from-python">
     See what carries over and what Sifr checks at compile time.
   </Card>
@@ -21,12 +24,16 @@ If you know Python, Sifr lets you keep much of the syntax while changing the con
   </Card>
 </CardGroup>
 
-## Guide Sequence
+## Learning Sequence
 
-The detailed guide pages below are planned follow-ups. Use the linked cards above for the current path through the docs.
+1. Build the mental model: [what changes from Python](/guides/python-developers/mental-model).
+2. Compile a first program: [Quickstart](/quickstart).
+3. Learn everyday values: [Values and Collections](/language/values-and-collections).
+4. Handle failure intentionally: [Error Handling](/language/error-handling).
+5. Make mutation explicit: [Ownership and Mutability](/language/ownership).
+6. Use the Sifr namespace: [Standard Library](/stdlib/overview) and [Module Index](/stdlib/module-index).
+7. Move from scripts to packages: [Packages and Workspaces](/cli/packages-workspaces).
 
-1. Write your first Sifr program.
-2. Handle errors the Sifr way.
-3. Use typed values and collections.
-4. Import Sifr modules.
-5. Move from script to package.
+<Tip>
+If you only read one language page after this guide, read [Ownership and Mutability](/language/ownership). It explains why Sifr can look like Python while still compiling to safe Rust-backed binaries.
+</Tip>

--- a/docs/guides/python-developers/mental-model.mdx
+++ b/docs/guides/python-developers/mental-model.mdx
@@ -1,0 +1,115 @@
+---
+title: "What Changes From Python"
+sidebarTitle: "Mental Model"
+description: "A practical guide for Python developers learning which instincts transfer to Sifr and which runtime habits need to change."
+---
+
+Python knowledge helps you read Sifr quickly. The main adjustment is not syntax. It is where failure is allowed to live.
+
+In Python, many mistakes wait until a specific line executes. In Sifr, the compiler asks you to make those cases explicit before a binary exists.
+
+## Keep These Instincts
+
+You still write familiar control flow and data shapes:
+
+```python
+def describe(value: int | str) -> str:
+    if isinstance(value, int):
+        return f"number: {value}"
+    return f"text: {value}"
+```
+
+`def`, `class`, `if`, `for`, `match`, f-strings, lists, dictionaries, and `async def` all remain recognizable. Use that familiarity to move quickly through examples.
+
+## Change These Assumptions
+
+| Python habit | Sifr contract |
+| --- | --- |
+| Type hints document intent | Type annotations are checked |
+| Exceptions carry recoverable failure | `Result[T, E]` carries recoverable failure |
+| Missing keys raise later | Missing lookups return `T | None` |
+| Imports mirror CPython names | Standard-library imports use `sifr.*` |
+| Any parameter can be mutated locally | Parameter mutation needs `mut` |
+| Background async tasks can detach | Tasks live in structured scopes |
+
+## Missing Values Are Typed
+
+Sifr does not let a missing value hide inside a normal value.
+
+```python
+scores: dict[str, int] = {"ada": 10}
+score: int | None = scores["grace"]
+
+if score is not None:
+    print(score + 1)
+else:
+    print("not found")
+```
+
+<Info>
+If you expected `KeyError`, read [Values and Collections](/language/values-and-collections). Safe lookup is one of the first differences Python developers notice.
+</Info>
+
+## Errors Are Values
+
+Recoverable failures use `Result`, not stack unwinding.
+
+```python
+class ConfigError(Error):
+    message: str
+
+def read_port(text: str) -> Result[int, ConfigError]:
+    if text == "":
+        raise ConfigError("missing port")
+    return int(text)
+
+try:
+    port: int = read_port("8080")
+except ConfigError as e:
+    print(e.message)
+```
+
+`raise` inside a `Result`-returning function builds the error branch. The compiler requires the call site to handle it.
+
+## Mutation Is A Contract
+
+Sifr borrows by default. Use `mut` when a function should mutate the caller's value.
+
+```python
+def add_default(mut values: list[str]) -> None:
+    values.append("default")
+```
+
+Use `own` when a function consumes a value. Use `own mut` when it consumes and mutates the value.
+
+<Tip>
+Read `mut` as part of the function's public API. It tells the caller that the call may change their value.
+</Tip>
+
+## Imports Use Sifr Modules
+
+Use explicit Sifr modules:
+
+```python
+from sifr.math import sqrt
+from sifr.json import loads
+```
+
+Bare CPython module names are not aliases. `from math import sqrt` is rejected with [`SIFR-IMPORT-0008`](/errors/SIFR-IMPORT-0008) when no real project module named `math` exists.
+
+## Where To Go Next
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="zap" href="/quickstart">
+    Compile and run a first program.
+  </Card>
+  <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
+    Learn `mut`, `own`, and borrow-by-default.
+  </Card>
+  <Card title="Error Handling" icon="triangle-alert" href="/language/error-handling">
+    Understand `Result` and typed `try`/`except`.
+  </Card>
+  <Card title="Module Index" icon="library" href="/stdlib/module-index">
+    Browse the `sifr.*` standard-library namespace.
+  </Card>
+</CardGroup>

--- a/docs/guides/rust-developers/index.mdx
+++ b/docs/guides/rust-developers/index.mdx
@@ -1,12 +1,15 @@
 ---
-title: "Sifr for Rust Developers"
-sidebarTitle: "Rust Developers"
-description: "A guided path for Rust developers learning how Sifr exposes ownership, Result, Option, generated Rust, and native builds."
+title: "Rust Developer Guide"
+sidebarTitle: "Overview"
+description: "A guided path for Rust developers learning how Sifr exposes ownership, Result, Option, generated Rust, and native builds through Python-shaped syntax."
 ---
 
-If you know Rust, Sifr's safety model will feel familiar, but the source language keeps Python-shaped syntax. Use this path to map ownership, typed errors, generated Rust, and native binaries back to the Rust concepts you already know.
+If you know Rust, Sifr's safety model will feel familiar, but the source language keeps Python-shaped syntax. Use this path to map ownership, typed errors, generated Rust, and native binaries back to concepts you already know.
 
 <CardGroup cols={2}>
+  <Card title="Rust Concepts in Sifr" icon="route" href="/guides/rust-developers/rust-concepts">
+    Translate `Option`, `Result`, borrowing, mutation, and generated Rust into Sifr's source model.
+  </Card>
   <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
     Map `mut`, `own`, and borrow-by-default to Sifr's source model.
   </Card>
@@ -21,12 +24,15 @@ If you know Rust, Sifr's safety model will feel familiar, but the source languag
   </Card>
 </CardGroup>
 
-## Guide Sequence
+## Learning Sequence
 
-The detailed guide pages below are planned follow-ups. Use the linked cards above for the current path through the docs.
+1. Build the mapping: [Rust Concepts in Sifr](/guides/rust-developers/rust-concepts).
+2. Inspect generated code: [Check and Emit](/cli/check-emit).
+3. Learn source-level ownership: [Ownership and Mutability](/language/ownership).
+4. Review typed failures: [Error Handling](/language/error-handling).
+5. Understand structured async: [Concurrency Overview](/language/concurrency).
+6. Ship a binary: [Build and Run](/cli/build-run).
 
-1. Map Rust patterns to Sifr.
-2. Ownership in Sifr terms.
-3. Results and optional values.
-4. Inspect generated Rust.
-5. Build a native binary.
+<Note>
+Sifr is not a Rust macro language. The generated Rust is an implementation target you can inspect, while the Sifr source model remains the language contract.
+</Note>

--- a/docs/guides/rust-developers/rust-concepts.mdx
+++ b/docs/guides/rust-developers/rust-concepts.mdx
@@ -1,0 +1,127 @@
+---
+title: "Rust Concepts in Sifr"
+sidebarTitle: "Rust Concepts"
+description: "Map Rust ownership, Result, Option, async structure, and native builds to Sifr's Python-shaped source model."
+---
+
+Sifr compiles to Rust, but Sifr source is not Rust with different punctuation. The compiler maps a smaller, Python-shaped surface onto Rust-backed ownership, typed errors, and native code generation.
+
+Use Rust as the safety model, not as the syntax model.
+
+## Concept Map
+
+| Rust concept | Sifr source shape |
+| --- | --- |
+| Borrow by reference | Plain parameter, such as `items: list[int]` |
+| Mutable borrow | `mut items: list[int]` |
+| Move ownership | `own items: list[int]` |
+| Owned mutable value | `own mut items: list[int]` |
+| `Option<T>` | `T | None` |
+| `Result<T, E>` | `Result[T, E]` plus `raise` and `try`/`except` |
+| `async` tasks | Structured `sifr.task` scopes and handles |
+| Cargo-backed binary | `sifr build` native executable |
+
+## Ownership Is Spelled For The Caller
+
+Most Sifr function parameters borrow by default:
+
+```python
+def length(items: list[int]) -> int:
+    return len(items)
+```
+
+Reach for `own` only when the function's contract is consumption:
+
+```python
+def consume(own items: list[int]) -> int:
+    return len(items)
+```
+
+Reach for `mut` when the function mutates caller-owned state:
+
+```python
+def push(mut items: list[int], value: int) -> None:
+    items.append(value)
+```
+
+<Note>
+There are no lifetime annotations in Sifr source. The compiler still enforces the lifetime and move constraints before emitting Rust.
+</Note>
+
+## Option And Result Stay Visible
+
+Sifr uses union syntax for optional values:
+
+```python
+values: list[int] = [10, 20, 30]
+first: int | None = values[0]
+```
+
+Fallible functions use `Result[T, E]`:
+
+```python
+class ReadError(Error):
+    message: str
+
+def load(path: str) -> Result[str, ReadError]:
+    if path == "":
+        raise ReadError("missing path")
+    return "contents"
+```
+
+At the call site, `try`/`except` is the source-level pattern for consuming a `Result`:
+
+```python
+try:
+    text: str = load("config.sifr")
+except ReadError as e:
+    text = ""
+```
+
+## Inspect The Rust When You Need To
+
+Use `sifr emit` to inspect generated Rust:
+
+```bash
+sifr emit app.sifr
+```
+
+Use this for debugging, auditing, or learning how a construct lowers. Do not rely on generated Rust layout as the public source-level contract.
+
+## Async Is Structured
+
+Sifr's async model does not expose a global event loop as the unit of design. Tasks belong to scopes, and scopes wait for children to finish or cancel.
+
+```python
+async def load_one() -> int:
+    await task.sleep(0.0)
+    return 1
+
+async def load_two() -> int:
+    await task.sleep(0.0)
+    return 2
+
+async with task.scope() as scope:
+    first = scope.spawn(load_one())
+    second = scope.spawn(load_two())
+    values: list[int] = await task.gather([first, second])
+```
+
+If you think in Rust terms, prefer "scoped task ownership" over "detached background work."
+
+## Where To Go Next
+
+<CardGroup cols={2}>
+  <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
+    See the complete source-level ownership table.
+  </Card>
+  <Card title="Check and Emit" icon="file-code" href="/cli/check-emit">
+    Use `sifr check` and `sifr emit` during development.
+  </Card>
+  <Card title="Concurrency Overview" icon="workflow" href="/language/concurrency">
+    Learn scoped tasks, cancellation, and task-boundary ownership.
+  </Card>
+  <Card title="Build and Run" icon="terminal" href="/cli/build-run">
+    Compile and run native binaries.
+  </Card>
+</CardGroup>

--- a/docs/language/error-handling.mdx
+++ b/docs/language/error-handling.mdx
@@ -151,3 +151,12 @@ Reserve `assert` for internal correctness checks. Use `Result` and custom error 
 | Consume a result | `try` / `except MyError as e` |
 | Discard a result | `_ = fallible_call()` |
 | Invariant check | `assert condition` |
+
+<CardGroup cols={2}>
+  <Card title="Python Developer Guide" icon="map" href="/guides/python-developers/mental-model">
+    See why recoverable exceptions become typed values in Sifr.
+  </Card>
+  <Card title="Rust Developer Guide" icon="refresh-cw" href="/guides/rust-developers/rust-concepts">
+    Map Sifr's `Result[T, E]` syntax to Rust's `Result<T, E>` model.
+  </Card>
+</CardGroup>

--- a/docs/language/ownership.mdx
+++ b/docs/language/ownership.mdx
@@ -15,7 +15,7 @@ Sifr gives you Rust's memory-safety guarantees without making every call site lo
 | `own items: list[int]` | Owned immutable binding | No | No, unless copied into a mutable local |
 | `own mut items: list[int]` | Owned mutable binding | No | Yes |
 
-This table is the core model. A bare heap parameter is borrowed immutably. `mut` lets the function update the caller's value during the call. `own` moves the value into the function. `own mut` moves it and lets the function change it before returning or dropping it.
+This table is the core model. A bare heap parameter is borrowed immutably. `mut` lets the function update the caller's value during the call. `own` moves the value into the function. `own mut` moves it and lets the function change it.
 
 ## Borrow By Default
 
@@ -76,7 +76,7 @@ def main():
     # values is moved here
 ```
 
-Use `own mut` when the function consumes a value and needs to mutate it before returning or dropping it.
+Use `own mut` when the function consumes a value and needs to mutate it.
 
 ```python
 def append_zero(own mut values: list[int]) -> list[int]:

--- a/docs/language/type-system.mdx
+++ b/docs/language/type-system.mdx
@@ -153,3 +153,14 @@ The compiler instantiates a separate, fully-typed version of the function for ea
 <Note>
 Scalar values such as `int`, `float`, and `bool` have value semantics at the source level. Passing them to a function does not create use-after-move friction for the caller.
 </Note>
+
+## Learning Paths
+
+<CardGroup cols={2}>
+  <Card title="Coming from Python?" icon="map" href="/guides/python-developers/mental-model">
+    Translate type hints, missing values, and runtime checks into Sifr's static model.
+  </Card>
+  <Card title="Coming from Rust?" icon="refresh-cw" href="/guides/rust-developers/rust-concepts">
+    Map `T | None`, `Result[T, E]`, and source-level narrowing back to Rust concepts.
+  </Card>
+</CardGroup>

--- a/docs/language/values-and-collections.mdx
+++ b/docs/language/values-and-collections.mdx
@@ -122,6 +122,9 @@ Truthiness is a convenience for branching. It does not replace typed `None` hand
   <Card title="Iteration" icon="repeat" href="/language/iteration">
     Learn loops, comprehensions, and safe iteration patterns.
   </Card>
+  <Card title="Python Developer Guide" icon="map" href="/guides/python-developers/mental-model">
+    See why missing dictionary keys return `None` instead of raising `KeyError`.
+  </Card>
   <Card title="Collections" icon="boxes" href="/stdlib/collections">
     Use `Counter`, `deque`, and set helpers from `sifr.collections`.
   </Card>

--- a/plans/issues/active/ad-hoc-documentation-learning-path.md
+++ b/plans/issues/active/ad-hoc-documentation-learning-path.md
@@ -23,7 +23,8 @@ Implementation status:
 
 - Wave 1: Merged in PR #2656. Scope: navigation foundation, `From Python`, `Status`, `Ownership and Mutability`, Slice 0 semantic fixes, and audience guide route placeholders. Validation: `cd docs && npx mint@latest validate` passed.
 - Wave 2: Merged in PR #2657. Scope: core data model pages and dedicated Concurrency concept section. Validation: `cd docs && npx mint@latest validate` passed.
-- Wave 3: Ready for PR after Sonnet review. Scope: standard-library module inventory, CLI package/workspace reference, and published one-page-per-code error reference. Validation: `cd docs && npx mint@latest validate` passed with Node 24.
+- Wave 3: Merged in PR #2658. Scope: standard-library module inventory, CLI package/workspace reference, and published one-page-per-code error reference. Validation: `cd docs && npx mint@latest validate` passed with Node 24.
+- Wave 4: Ready for PR after Sonnet review. Scope: Python/Rust developer guide paths and language-doc wayfinding. Validation: `cd docs && npx mint@latest validate` passed with Node 24.
 
 ## Objective
 

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-4-sonnet-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-4-sonnet-review-pass-1.md
@@ -1,0 +1,68 @@
+---
+
+## Wave 4 Review
+
+**PR-ready: Yes, with the cleanup items below addressed first.**
+
+---
+
+### Blockers
+
+**B1 — Stale duplicate file: `docs/errors/SIFR-IMPORT-0008.md`**
+
+Wave 4 added `SIFR-IMPORT-0008.mdx` (Jun 18) but left the older `.md` (Jun 17) in place. The build validator passed, but the duplicate is a cleanup hazard — Mintlify conventions favor `.mdx` and the stale `.md` will confuse anyone editing the errors directory. Remove `SIFR-IMPORT-0008.md` before merging. (This is the only error page with both extensions; all others have just `.md`.)
+
+---
+
+### Important improvements
+
+**I1 — Undefined `values` in `rust-concepts.mdx:54`**
+
+Under "Option And Result Stay Visible":
+```python
+first: int | None = values[0]
+```
+`values` is never declared. For a guide aimed at Rust developers already skeptical of the Python surface, a dangling identifier is an immediate trust hit. One context line fixes it:
+```python
+values: list[int] = [10, 20, 30]
+first: int | None = values[0]
+```
+
+**I2 — `guides/index.mdx` has duplicate path cards (lines 10–46)**
+
+The top `<CardGroup>` already shows all three entry points (quickstart + both guide paths). The `## Paths` section immediately below repeats the Python and Rust guide cards verbatim. Cut the `## Paths` section entirely, or replace it with something the top group doesn't cover (e.g., a "New to compiled languages?" card pointing to the quickstart rationale). As written it reads like a copy-paste accident.
+
+---
+
+### Optional polish
+
+**P1 — `from-python.mdx:83` card title/target mismatch**
+
+The card is titled "Python Developer Guide" but `href="/guides/python-developers/mental-model"` bypasses the guide overview and links directly to the sub-page. Either rename it "Mental Model Shift" (which is how the guide's own index titles it) or point it at `/guides/python-developers`.
+
+**P2 — `mental-model.mdx:82-83` — `own mut` description has a trailing qualifier that confuses**
+
+> "Use `own mut` when it consumes and mutates the value before returning or dropping it."
+
+"before returning or dropping it" is awkward — it implies mutation after return is somehow intended, or that dropping is a notable event the reader should think about. The other docs handle this more cleanly. Simplify to: "Use `own mut` when it consumes and mutates the value."
+
+**P3 — `guides/rust-developers/rust-concepts.mdx:98` — `task.gather` return type assertion**
+
+```python
+values: list[int] = await task.gather([first, second])
+```
+`first` and `second` are handles from `load_one()` and `load_two()`, which aren't defined. The `list[int]` annotation is asserted without basis. Not wrong if you assume `int`-returning tasks, but readers may wonder whether `gather` always returns `list[int]`. Adding a comment or changing to `list[str]` with correspondingly named `load_one/load_two` bodies would prevent the question. Low priority since this is a structural illustration.
+
+---
+
+### Answers to the five inspection questions
+
+1. **Useful and concise for their audiences?** Yes. `mental-model.mdx` nails the Python-developer orientation: the comparison table, the per-section "here's the single thing that changed" structure, and the Info callout linking to Values & Collections on the `KeyError` surprise are all well-targeted. `rust-concepts.mdx` is equally tight — the concept map table is genuinely the first thing a Rust developer needs and it delivers that immediately.
+
+2. **Code examples accurate?** Broadly yes. The `Result`/`raise`/`try`/`except` examples, ownership annotations (`mut`, `own`), and imports (`sifr.math`, `sifr.json`) all match the error-handling and values docs. The one exception is the undefined `values[0]` snippet (I1 above).
+
+3. **Cross-links smooth and not spammy?** Yes. Wayfinding cards appear only at page endings or within `<Info>`/`<Tip>` callouts addressing a specific concept. The language pages (type-system, error-handling, values-and-collections) each add exactly two guide links at the bottom — proportionate for pages that will be read by both audiences.
+
+4. **Sidebar shape correct?** Yes. The docs.json groups now read "Python Developer Guide" / "Rust Developer Guide" with the index page first and the substantive page second in each group. Clean and matches the user's intent.
+
+5. **Copywriting quality?** High. The opening lines of both guide pages ("Python knowledge helps you read Sifr quickly. The main adjustment is not syntax. It is where failure is allowed to live." and "Use Rust as the safety model, not as the syntax model.") are the best-quality prose in the docs so far — clear orientation with no throat-clearing. The note in `rust-developers/index.mdx` ("Sifr is not a Rust macro language. The generated Rust is an implementation target...") preempts the most common Rust-developer misconception precisely. No changes needed to voice or tone.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-4-sonnet-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-4-sonnet-review-pass-2.md
@@ -1,0 +1,20 @@
+All checks pass. Here's the verdict:
+
+**Wave 4 is reviewer-satisfied — PR-ready.**
+
+**B1 rationale confirmed correct.** The three source references verify it:
+- `cli_model_and_entrypoint.rs:664` reads `docs/errors/<CODE>.md` at runtime for `sifr --explain`
+- `registry.rs:513` macro stamps `docs_path` as `docs/errors/<ID>.md`
+- `registry_tests.rs:60` asserts that path matches
+- `.mintignore:2` hides `errors/*.md` from Mintlify — the `.md` files are a CLI/registry artifact, not a web route
+
+Removing `SIFR-IMPORT-0008.md` would break `sifr --explain SIFR-IMPORT-0008` and the registry test. The decision not to remove it is correct.
+
+**All five fixes verified in the diff:**
+- **I1** — `values: list[int] = [10, 20, 30]` on line 56, `values[0]` on line 57 — declaration precedes use
+- **I2** — `guides/index.mdx` has no Paths section; only the description prose uses "paths"
+- **P1** — `from-python.mdx` card title is "Mental Model Shift" linking to `/guides/python-developers/mental-model`
+- **P2** — `own mut` sentence in `from-python.mdx` reads cleanly ("Use `own mut` when it should take ownership and mutate the value before returning or dropping it")
+- **P3** — `rust-concepts.mdx` async example defines `load_one() -> int` and `load_two() -> int` before use, with `task.gather` typed correctly
+
+No new blockers introduced by the follow-up pass.

--- a/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-4-sonnet-review-pass-3.md
+++ b/plans/reviews/active/ad-hoc-documentation-learning-path-implementation-wave-4-sonnet-review-pass-3.md
@@ -1,0 +1,9 @@
+Wave 4 remains **PR-ready**. No blockers introduced.
+
+The two cleanup changes are clean:
+
+- **`docs/from-python.mdx:76`** — "Use `mut` when a function should mutate a borrowed parameter, and `own mut` when it should take ownership and mutate the value." Concise, accurate, consistent with the ownership page's contract table.
+
+- **`docs/language/ownership.mdx:79`** — "Use `own mut` when the function consumes a value and needs to mutate it." Direct parallel to the `own` sentence on line 66 ("Use `own` when a function consumes a value."). The removed "before returning or dropping it" phrase was redundant given the code example immediately below.
+
+Both sentences are technically correct, stylistically tighter than before, and introduce no inconsistencies with the rest of the ownership model documentation.


### PR DESCRIPTION
## Summary
- Add Python and Rust developer guide sections with one substantive guide page each.
- Rework the Guides landing page and sidebar groups around audience learning paths.
- Add smooth wayfinding from language pages into the guide paths and clean adjacent ownership wording.

## Review
- Claude Sonnet medium pass 1 found guide cleanup issues; fixed.
- Claude Sonnet medium pass 2 confirmed Wave 4 PR-ready and verified the diagnostic .md retention rationale.
- Claude Sonnet medium pass 3 confirmed final wording cleanup remained PR-ready.

## Validation
- `export PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH"; cd docs && npx mint@latest validate`

No Rust tests run per request.