### PR TITLE
Use sifr VS Code Marketplace publisher

### DIFF
--- a/verification/areas/developer_tooling/check_vscode_extension_rules.py
+++ b/verification/areas/developer_tooling/check_vscode_extension_rules.py
@@ -71,8 +71,8 @@ def extension_repo_path(rules: dict[str, Any]) -> Path | None:
 def validate_rules(rules: dict[str, Any]) -> list[str]:
     failures: list[str] = []
     extension = rules.get("extension", {})
-    if extension.get("extension_id") != "sifr-lang.sifr-vscode":
-        failures.append("extension id must be sifr-lang.sifr-vscode")
+    if extension.get("extension_id") != "sifr.sifr-vscode":
+        failures.append("extension id must be sifr.sifr-vscode")
     if extension.get("language_id") != "sifr":
         failures.append("language id must be sifr")
     if ".sifr" not in extension.get("extensions", []):
@@ -158,7 +158,7 @@ def run_self_test() -> None:
     rules = read_json(RULES_PATH)
     package_json = {
         "name": "sifr-vscode",
-        "publisher": "sifr-lang",
+        "publisher": "sifr",
         "engines": {"vscode": "^1.90.0"},
         "contributes": {
             "languages": [{"id": "sifr", "extensions": [".sifr"]}],

--- a/verification/areas/developer_tooling/vscode_extension_rules.json
+++ b/verification/areas/developer_tooling/vscode_extension_rules.json
@@ -13,9 +13,9 @@
     "boundary": "separate-repository"
   },
   "extension": {
-    "publisher": "sifr-lang",
+    "publisher": "sifr",
     "name": "sifr-vscode",
-    "extension_id": "sifr-lang.sifr-vscode",
+    "extension_id": "sifr.sifr-vscode",
     "display_name": "Sifr",
     "language_id": "sifr",
     "extensions": [".sifr"],


### PR DESCRIPTION
## Summary
- advance editor_integrations to the merged VS Code publisher update
- update VS Code extension rules to expect Marketplace publisher sifr and extension id sifr.sifr-vscode

## Validation
- npm run package
- npm audit --json
- python3 verification/areas/developer_tooling/check_vscode_extension_rules.py
- python3 verification/areas/developer_tooling/check_vscode_extension.py
- scripts/run_all_tests.sh --profile create-pr

Note: the first create-pr run hit core-language audit fixture timeouts. A rerun passed. The passing run reported a warm wall-time advisory because the e2e cache was cold.