### PR TITLE
Add CI preview release trigger

### DIFF
--- a/.cursor/commands/create-new-version.md
+++ b/.cursor/commands/create-new-version.md
@@ -16,6 +16,14 @@ Optional input:
 
 ## Examples
 
+Trigger the CI-native preview release workflow:
+
+```bash
+scripts/distribution/trigger_preview_release.sh \
+  --channel beta \
+  --version 0.1.0-beta.5
+```
+
 Dry-run:
 
 ```bash
@@ -36,6 +44,12 @@ scripts/distribution/create_new_version.sh \
 ```
 
 Production real-runs must keep `--mutation-mode github` once release assets are ready to publish. Local validation uses `--mutation-mode local` to exercise the same plan and file mutations without publishing GitHub Release assets.
+
+Use `trigger_preview_release.sh` for production preview releases when the release
+artifacts should be built on native GitHub-hosted runners. The script dispatches
+`.github/workflows/preview-release.yml`, which validates the preview inputs,
+builds each target on the matching runner family, and publishes a draft GitHub
+prerelease with the generated archives and checksum files.
 
 ## Safety Rules
 

--- a/.cursor/commands/create-new-version.md
+++ b/.cursor/commands/create-new-version.md
@@ -48,7 +48,7 @@ Production real-runs must keep `--mutation-mode github` once release assets are 
 Use `trigger_preview_release.sh` for production preview releases when the release
 artifacts should be built on native GitHub-hosted runners. The script dispatches
 `.github/workflows/preview-release.yml`, which validates the preview inputs,
-builds each target on the matching runner family, and publishes a draft GitHub
+builds each target on the matching runner family, and publishes a GitHub
 prerelease with the generated archives and checksum files.
 
 ## Safety Rules

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,4 +1,5 @@
 name: preview-release
+run-name: Preview release ${{ inputs.version }} (${{ inputs.channel }})
 
 on:
   workflow_dispatch:
@@ -187,6 +188,7 @@ jobs:
             gh release create "${VERSION}" \
               --repo "${GITHUB_REPOSITORY}" \
               --prerelease \
+              --draft \
               --latest=false \
               --title "Sifr ${VERSION}" \
               --notes-file "${notes_file}"

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -181,6 +181,7 @@ jobs:
             gh release edit "${VERSION}" \
               --repo "${GITHUB_REPOSITORY}" \
               --prerelease \
+              --draft=false \
               --latest=false \
               --title "Sifr ${VERSION}" \
               --notes-file "${notes_file}"
@@ -188,7 +189,6 @@ jobs:
             gh release create "${VERSION}" \
               --repo "${GITHUB_REPOSITORY}" \
               --prerelease \
-              --draft \
               --latest=false \
               --title "Sifr ${VERSION}" \
               --notes-file "${notes_file}"

--- a/scripts/distribution/trigger_preview_release.sh
+++ b/scripts/distribution/trigger_preview_release.sh
@@ -138,8 +138,8 @@ find_dispatched_run() {
     --workflow "${WORKFLOW}" \
     --event workflow_dispatch \
     --limit 20 \
-    --json databaseId,displayTitle,url \
-    --jq ".[] | select(.displayTitle == \"${title}\") | [.databaseId, .url] | @tsv" \
+    --json createdAt,databaseId,displayTitle,url \
+    --jq ".[] | select(.displayTitle == \"${title}\" and .createdAt >= \"${DISPATCH_STARTED_AT}\") | [.databaseId, .url] | @tsv" \
     | head -n 1
 }
 
@@ -181,6 +181,7 @@ if [[ "${DRY_RUN}" -eq 1 ]]; then
   exit 0
 fi
 
+DISPATCH_STARTED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 "${dispatch_command[@]}"
 
 cat <<EOF

--- a/scripts/distribution/trigger_preview_release.sh
+++ b/scripts/distribution/trigger_preview_release.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/distribution/trigger_preview_release.sh --channel alpha|beta --version <preview> [options]
+
+Trigger the GitHub Actions preview-release workflow.
+
+Required:
+  --channel alpha|beta       Preview channel to publish
+  --version <preview>        Semver prerelease version, for example 0.1.0-beta.5
+
+Options:
+  --base-ref <ref>           Ref to build and release (default: main)
+  --workflow-ref <ref>       Ref containing the workflow file (default: --base-ref)
+  --repo <owner/repo>        GitHub repository (default: detected from origin)
+  --workflow <file>          Workflow file name (default: preview-release.yml)
+  --watch                    Watch the dispatched run until completion (default)
+  --no-watch                 Dispatch only
+  --dry-run                  Print the dispatch command without running it
+  --help                     Show this help
+EOF
+}
+
+CHANNEL=""
+VERSION=""
+BASE_REF="main"
+WORKFLOW_REF=""
+REPO=""
+WORKFLOW="preview-release.yml"
+WATCH=1
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel)
+      CHANNEL="${2:-}"
+      shift 2
+      ;;
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --base-ref)
+      BASE_REF="${2:-}"
+      shift 2
+      ;;
+    --workflow-ref)
+      WORKFLOW_REF="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --workflow)
+      WORKFLOW="${2:-}"
+      shift 2
+      ;;
+    --watch)
+      WATCH=1
+      shift
+      ;;
+    --no-watch)
+      WATCH=0
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+fail() {
+  echo "trigger-preview-release: $*" >&2
+  exit 2
+}
+
+preview_channel_for_version() {
+  local version="$1"
+  if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
+    return 1
+  fi
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+quote_arg() {
+  printf "%q" "$1"
+}
+
+print_command() {
+  local arg
+  for arg in "$@"; do
+    quote_arg "${arg}"
+    printf ' '
+  done
+  printf '\n'
+}
+
+detect_repo() {
+  local remote_url
+  remote_url="$(git config --get remote.origin.url || true)"
+  [[ -n "${remote_url}" ]] || return 1
+
+  case "${remote_url}" in
+    git@github.com:*)
+      remote_url="${remote_url#git@github.com:}"
+      ;;
+    https://github.com/*)
+      remote_url="${remote_url#https://github.com/}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  remote_url="${remote_url%.git}"
+  [[ "${remote_url}" == */* ]] || return 1
+  printf '%s\n' "${remote_url}"
+}
+
+find_dispatched_run() {
+  local title="Preview release ${VERSION} (${CHANNEL})"
+  gh run list \
+    --repo "${REPO}" \
+    --workflow "${WORKFLOW}" \
+    --event workflow_dispatch \
+    --limit 20 \
+    --json databaseId,displayTitle,url \
+    --jq ".[] | select(.displayTitle == \"${title}\") | [.databaseId, .url] | @tsv" \
+    | head -n 1
+}
+
+[[ "${CHANNEL}" == "alpha" || "${CHANNEL}" == "beta" ]] || fail "--channel must be alpha or beta"
+[[ -n "${VERSION}" ]] || fail "--version is required"
+[[ -n "${BASE_REF}" ]] || fail "--base-ref must not be empty"
+if [[ -z "${WORKFLOW_REF}" ]]; then
+  WORKFLOW_REF="${BASE_REF}"
+fi
+[[ -n "${WORKFLOW_REF}" ]] || fail "--workflow-ref must not be empty"
+
+if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  fail "stable-looking versions are disabled until a stable channel is supported: ${VERSION}"
+fi
+
+version_channel="$(preview_channel_for_version "${VERSION}")" || \
+  fail "version must be a semver prerelease using -alpha.N, -beta.N, or -rc.N: ${VERSION}"
+[[ "${version_channel}" == "${CHANNEL}" ]] || fail "version ${VERSION} belongs to ${version_channel}, not ${CHANNEL}"
+
+command -v gh >/dev/null 2>&1 || fail "gh is required"
+
+if [[ -z "${REPO}" ]]; then
+  REPO="$(detect_repo)" || fail "--repo is required when remote.origin.url is not a GitHub repository"
+fi
+
+dispatch_command=(
+  gh workflow run "${WORKFLOW}"
+  --repo "${REPO}"
+  --ref "${WORKFLOW_REF}"
+  -f "channel=${CHANNEL}"
+  -f "version=${VERSION}"
+  -f "base_ref=${BASE_REF}"
+)
+
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  printf 'dry_run=1\n'
+  printf 'dispatch_command='
+  print_command "${dispatch_command[@]}"
+  exit 0
+fi
+
+"${dispatch_command[@]}"
+
+cat <<EOF
+dispatched=1
+repo=${REPO}
+workflow=${WORKFLOW}
+channel=${CHANNEL}
+version=${VERSION}
+base_ref=${BASE_REF}
+workflow_ref=${WORKFLOW_REF}
+EOF
+
+if [[ "${WATCH}" -eq 0 ]]; then
+  exit 0
+fi
+
+run_info=""
+for _ in {1..12}; do
+  run_info="$(find_dispatched_run || true)"
+  if [[ -n "${run_info}" ]]; then
+    break
+  fi
+  sleep 5
+done
+
+[[ -n "${run_info}" ]] || fail "workflow was dispatched, but the run was not found in GitHub run listings"
+
+run_id="${run_info%%$'\t'*}"
+run_url="${run_info#*$'\t'}"
+printf 'run_id=%s\n' "${run_id}"
+printf 'run_url=%s\n' "${run_url}"
+
+gh run watch "${run_id}" --repo "${REPO}" --exit-status


### PR DESCRIPTION
## Summary
- add a manually-triggered preview release dispatcher script
- document CI-native preview release publishing
- make the preview release workflow publish prereleases and update existing releases out of draft state
- make the local watcher attach to the run created after dispatch

## Validation
- bash -n scripts/distribution/trigger_preview_release.sh
- scripts/distribution/trigger_preview_release.sh --channel beta --version 0.1.0-beta.5 --base-ref main --workflow-ref codex/preview-release-ci-trigger --repo sifr-lang/sifr --dry-run
- parsed .github/workflows/preview-release.yml with PyYAML
- python3 scripts/check_file_size_guardrails.py
- GitHub Actions preview-release run 27737938855 succeeded
- verified 0.1.0-beta.5 isDraft=false, isPrerelease=true, 8 assets uploaded