### PR TITLE
[codex] Add embedded Python interop ad hoc phase

### DIFF
--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -36,10 +36,11 @@ If an existing Sifr subsystem is not ready for one of these contracts, this phas
 - Every Python boundary operation is fallible and returns a Sifr `Result`.
 - Python calls are synchronous from Sifr's perspective and classified as `@blocking_io`.
 - `py.Object` is not `Send` by default and cannot cross Sifr task/thread boundaries without an explicit audited bridge.
-- Zero-copy support is first-class in this phase: `Py_buffer`, Arrow PyCapsule, DLPack, and strict array-interface compatibility are all part of the contract.
+- Zero-copy support is first-class in this phase: `Py_buffer`, Arrow PyCapsule, DLPack, and the `__array_interface__`/`__array_struct__`/`__cuda_array_interface__` protocols are all part of the contract.
 - Python-to-Sifr callbacks are first-class and have explicit local/threadsafe lifetime modes.
 - Python imports and native Python extensions are trusted in-process code.
 - No subprocess, worker, or IPC-isolated Python mode is part of this phase.
+- No backward-compatibility shims, legacy compatibility layers, fallback paths, or degraded modes are in scope; this phase designs the correct production contract directly.
 - No silent fallback from zero-copy APIs to copying is allowed.
 - No transitive Python import scanner is required or allowed as a correctness dependency; uv owns transitive Python dependency resolution.
 
@@ -307,7 +308,7 @@ Automatic conversion is conservative.
 | Python `int` | exact `int` | fixed-width `py.to[int32]`/etc. is checked and fallible |
 | bytearray, memoryview, buffers | `py.Object` | `py.zero_copy_as[py.BufferView[T]]`, `py.copy_as[bytes]` |
 | list, tuple, dict | `py.Object` | `py.to[list[T]]`, `py.to[dict[str, T]]`, record conversion |
-| numpy arrays | `py.Object` | `py.BufferView`, array-interface compatibility, DLPack where available, explicit copy |
+| numpy arrays | `py.Object` | `py.BufferView`, array-interface protocols, DLPack where available, explicit copy |
 | torch/tensorflow tensors | `py.Object` | DLPack or explicit copy |
 | pandas/polars/pyarrow dataframes | `py.Object` | Arrow PyCapsule/stream or explicit copy |
 | arbitrary Python object | `py.Object` | explicit protocol-specific conversion only |
@@ -475,7 +476,7 @@ Rules:
 
 ### Array Interface
 
-Support `__array_interface__`, `__array_struct__`, and `__cuda_array_interface__` as compatibility paths only.
+Support `__array_interface__`, `__array_struct__`, and `__cuda_array_interface__` as additional zero-copy interchange protocols.
 
 Rules:
 
@@ -891,7 +892,7 @@ verification/python_interop/run.sh --group callbacks
 - `py.Object` operations are opaque, fallible, non-`Any`, and non-Send by default.
 - Python calls obey `@blocking_io`/offload rules.
 - Python-to-Sifr callbacks support local and threadsafe modes.
-- `Py_buffer`, Arrow PyCapsule, DLPack, and strict array-interface paths are implemented with no silent zero-copy fallback to copying.
+- `Py_buffer`, Arrow PyCapsule, DLPack, and array-interface protocols are implemented with no silent zero-copy fallback to copying.
 - Tier 1 package certification passes in the full Python interop gate.
 - Verification reports exist under `verification/python_interop/reports/`.
 - Public and internal docs describe the exact production contract.

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -366,7 +366,7 @@ Supported cleanup APIs:
 try py.close(obj)
 try py.call_attr(obj, "close", [], [])
 try py.with(obj, lambda entered: ...)
-let coro = try py.call_attr(obj, "aclose", [], [])
+coro = try py.call_attr(obj, "aclose", [], [])
 try py.run_coroutine_blocking(coro)
 try callback.close()
 try buffer.release()

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -522,7 +522,7 @@ Required package patterns:
 
 - confluent-kafka polling and background-thread callbacks;
 - Google Pub/Sub scheduler thread-pool callbacks;
-- boto3/botocore SQS long polling, SNS publish/subscribe, paginators, retries, and credential refresh;
+- boto3/botocore refreshable-credentials callbacks and transfer-manager progress callbacks;
 - CFFI callbacks;
 - Pika message callbacks;
 - Python code invoking Sifr handlers while Sifr is blocked in Python;
@@ -556,6 +556,8 @@ Sifr should support any CPython-compatible package installed in the selected uv 
 These packages must pass at the full Python interop gate because they exercise the core embedded, native, conversion, zero-copy, and production-client surfaces: `pydantic`, `pydantic-core`, `httpx`, `requests`, `cryptography`, `cffi`, `numpy`, `pandas`, `pyarrow`, `polars`, `torch` CPU, `psycopg`, `sqlalchemy`, `redis`, `confluent-kafka`, `boto3`, `botocore`, `openai`, `google-genai`, `biip`, `schwifty`.
 
 ### Tier 1b: Ecosystem Certification Gate
+
+Packages already covered by Tier 1a may reappear here when they anchor a Tier 1b category; the Tier 1a gate is authoritative.
 
 - Runtime/package loading: `pip`, `setuptools`, `wheel`, `build`, `hatchling`, `poetry-core`, `uv-build`, `pyproject-hooks`, `packaging`, `pkginfo`, `importlib-metadata`, `zipp`, `platformdirs`, `appdirs`, `typing-extensions`, `exceptiongroup`.
 - Data validation/structured objects: `pydantic`, `pydantic-core`, `pydantic-extra-types`, `annotated-types`, `attrs`, `marshmallow`, `cerberus`, `jsonpickle`, `deepdiff`, `protobuf`, `proto-plus`, `pyyaml`, `toml`, `tomli`, `python-dotenv`.
@@ -654,8 +656,8 @@ Verification groups:
 - `dataframes`: pandas/polars/pyarrow dataframe interop.
 - `tensors`: NumPy/torch/tensorflow tensor interop.
 - `databases`: SQLAlchemy, psycopg, asyncpg, pymongo, motor, redis.
-- `brokers`: confluent-kafka, aiokafka, kafka-python, SQS long polling, SNS-to-SQS delivery, Pub/Sub-style callbacks.
-- `cloud`: boto3/botocore SQS/SNS clients/resources/stubbers, Google/Azure/AWS auth/import surfaces, without requiring live credentials in the default gate.
+- `brokers`: confluent-kafka, aiokafka, kafka-python, SQS long polling, SNS-to-SQS delivery, Pub/Sub-style callbacks. `brokers` covers messaging semantics; SDK surface is covered by `cloud`.
+- `cloud`: boto3/botocore SQS/SNS clients/resources/stubbers, Google/AWS auth/import surfaces, without requiring live credentials in the default gate.
 - `web`: FastAPI/Starlette/Django/Sanic import and in-process smoke fixtures.
 - `cleanup`: close/context-manager/callback release/leak diagnostics.
 
@@ -673,7 +675,7 @@ Validation profiles:
 
 - Fast gate: environment probe, core embedded runtime, pure imports, pydantic/httpx/cryptography/cffi/pandas/pyarrow smoke.
 - Full Python interop gate: all Tier 1 packages, native extension probes, zero-copy checks, callback/threading checks, local service-backed tests.
-- External integration gate: Kafka, Postgres, Redis, AWS SQS/SNS via LocalStack/moto-style emulation or live credentials, Pub/Sub, RabbitMQ, cloud SDK auth, and other service-backed tests.
+- External integration gate: Kafka, Postgres, Redis, AWS SQS/SNS via moto in-process mocking, LocalStack service emulation, or live AWS credentials, Pub/Sub, RabbitMQ, cloud SDK auth, and other service-backed tests.
 
 ## Milestones
 

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -522,6 +522,7 @@ Required package patterns:
 
 - confluent-kafka polling and background-thread callbacks;
 - Google Pub/Sub scheduler thread-pool callbacks;
+- boto3/botocore SQS long polling, SNS publish/subscribe, paginators, retries, and credential refresh;
 - CFFI callbacks;
 - Pika message callbacks;
 - Python code invoking Sifr handlers while Sifr is blocked in Python;
@@ -552,7 +553,7 @@ Sifr should support any CPython-compatible package installed in the selected uv 
 
 ### Tier 1a: Core Interop Certification Gate
 
-These packages must pass at the full Python interop gate because they exercise the core embedded, native, conversion, zero-copy, and production-client surfaces: `pydantic`, `pydantic-core`, `httpx`, `requests`, `cryptography`, `cffi`, `numpy`, `pandas`, `pyarrow`, `polars`, `torch` CPU, `psycopg`, `sqlalchemy`, `redis`, `confluent-kafka`, `openai`, `google-genai`, `biip`, `schwifty`.
+These packages must pass at the full Python interop gate because they exercise the core embedded, native, conversion, zero-copy, and production-client surfaces: `pydantic`, `pydantic-core`, `httpx`, `requests`, `cryptography`, `cffi`, `numpy`, `pandas`, `pyarrow`, `polars`, `torch` CPU, `psycopg`, `sqlalchemy`, `redis`, `confluent-kafka`, `boto3`, `botocore`, `openai`, `google-genai`, `biip`, `schwifty`.
 
 ### Tier 1b: Ecosystem Certification Gate
 
@@ -561,7 +562,7 @@ These packages must pass at the full Python interop gate because they exercise t
 - HTTP/async/networking: `requests`, `urllib3`, `httpx`, `httpcore`, `aiohttp`, `anyio`, `async-timeout`, `sniffio`, `h11`, `httptools`, `websockets`, `uvicorn`, `uvloop`.
 - Web frameworks: `fastapi`, `starlette`, `starlette-context`, `django`, `sanic`, `sanic-routing`, `sanic-testing`, `webargs`, `webargs-sanic`, `jinja2`, `markupsafe`, `python-multipart`.
 - Databases/queues/brokers: `sqlalchemy`, `sqlalchemy-utils`, `alembic`, `psycopg`, `psycopg2`, `psycopg2-binary`, `asyncpg`, `pymongo`, `motor`, `mongoengine`, `redis`, `fakeredis`, `hiredis`, `valkey`, `aiokafka`, `confluent-kafka`, `kafka-python`, `python-schema-registry-client`.
-- Cloud/AI clients: `openai`, `google-genai`, `google-api-core`, `google-api-python-client`, `google-auth`, `google-auth-httplib2`, `google-auth-oauthlib`, `google-cloud-core`, `google-cloud-storage`, `google-cloud-firestore`, `google-cloud-aiplatform`, `firebase-admin`, `kubernetes`, `pinecone-client`, `gspread`, `gspread-asyncio`.
+- Cloud/AI clients: `boto3`, `botocore`, `openai`, `google-genai`, `google-api-core`, `google-api-python-client`, `google-auth`, `google-auth-httplib2`, `google-auth-oauthlib`, `google-cloud-core`, `google-cloud-storage`, `google-cloud-firestore`, `google-cloud-aiplatform`, `firebase-admin`, `kubernetes`, `pinecone-client`, `gspread`, `gspread-asyncio`.
 - Security/crypto/native loading: `cryptography`, `cffi`, `pycparser`, `certifi`, `idna`, `charset-normalizer`, `chardet`, `oauthlib`, `requests-oauthlib`, `python-jose`, `rsa`, `pyasn1`, `pyasn1-modules`.
 - Data/binary/parser: `pandas`, `pyarrow`, `openpyxl`, `lxml`, `bleach`, `defusedxml`, `nh3`, `regex`, `ujson`, `fastavro`, `avro`, `avro-python3`, `google-crc32c`, `tiktoken`.
 - Observability/production infra: `opentelemetry-api`, `opentelemetry-semantic-conventions`, `opentracing`, `sentry-sdk`, `sentry-asgi`, `datadog`, `structlog`, `logstash-formatter`.
@@ -614,6 +615,9 @@ verification/python_interop/
     redis/
     kafka/
     pubsub/
+    aws_sqs/
+    aws_sns/
+    aws_sns_sqs_subscription/
     pandas_arrow/
     polars_arrow/
     pyarrow_capsule/
@@ -650,8 +654,8 @@ Verification groups:
 - `dataframes`: pandas/polars/pyarrow dataframe interop.
 - `tensors`: NumPy/torch/tensorflow tensor interop.
 - `databases`: SQLAlchemy, psycopg, asyncpg, pymongo, motor, redis.
-- `brokers`: confluent-kafka, aiokafka, kafka-python, Pub/Sub-style callbacks.
-- `cloud`: Google/Azure/AWS/client auth/import surfaces without requiring live credentials in the default gate.
+- `brokers`: confluent-kafka, aiokafka, kafka-python, SQS long polling, SNS-to-SQS delivery, Pub/Sub-style callbacks.
+- `cloud`: boto3/botocore SQS/SNS clients/resources/stubbers, Google/Azure/AWS auth/import surfaces, without requiring live credentials in the default gate.
 - `web`: FastAPI/Starlette/Django/Sanic import and in-process smoke fixtures.
 - `cleanup`: close/context-manager/callback release/leak diagnostics.
 
@@ -669,7 +673,7 @@ Validation profiles:
 
 - Fast gate: environment probe, core embedded runtime, pure imports, pydantic/httpx/cryptography/cffi/pandas/pyarrow smoke.
 - Full Python interop gate: all Tier 1 packages, native extension probes, zero-copy checks, callback/threading checks, local service-backed tests.
-- External integration gate: Kafka, Postgres, Redis, cloud SDK auth, Pub/Sub/SQS/SNS, RabbitMQ, and other service-backed tests.
+- External integration gate: Kafka, Postgres, Redis, AWS SQS/SNS via LocalStack/moto-style emulation or live credentials, Pub/Sub, RabbitMQ, cloud SDK auth, and other service-backed tests.
 
 ## Milestones
 

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -4,17 +4,25 @@
 
 ## Objective
 
-Deliver production-grade in-process CPython interoperability so Sifr programs can smoothly use Python code and Python ecosystem packages from uv-created environments while preserving Sifr's safety, error, ownership, diagnostics, and local-verification guarantees.
+Deliver production-grade in-process CPython interoperability so Sifr programs can call into Python code and Python ecosystem packages from uv-created environments while preserving Sifr's safety, error, ownership, diagnostics, and local-verification guarantees.
 
 Python interop is a separate lane from Rust-backed Sifr packages and raw C ABI interop. It is not a Deno-style generic `dlopen` layer and must not be collapsed into the Rust/C FFI model.
 
-## Depends On
+## Self-Contained Scope
 
-- Phase 32 async/offload semantics for foreign blocking diagnostics.
-- Phase 37 Cargo-backed package coordination for root package ownership, metadata, and trust policy shape.
-- Phase 40 typed model/validation where Sifr typed conversion helpers intersect with Python model/data validation.
-- Phase 42 data/ML planning for package-facing dataframes, tensors, arrays, and zero-copy data interchange.
-- Phase 43 interop planning for the separate Rust/C interop lane and shared fixed-width integer/bytes representation constraints.
+This phase owns the complete embedded Python implementation surface required for production use. It may reuse existing Sifr compiler, package, async/offload, validation, diagnostics, runtime, and verification infrastructure, but it does not depend on Phase 42, Phase 43, or any separate interop/data-science phase being implemented first.
+
+The phase must implement every Python-specific contract it relies on:
+
+- root application Python environment ownership and verification;
+- compiler metadata and build-plan plumbing for Python interop;
+- trust policy for Python imports and native Python extension modules;
+- `@blocking_io` diagnostics for Python calls in async Sifr code;
+- typed Python object handles, primitive conversion, callback, cleanup, and error semantics;
+- fixed-width integer, bytes, buffer, tensor, dataframe, and Arrow/DLPack interchange rules required by Python interop;
+- package certification and verification infrastructure for the supported Python package tiers.
+
+If an existing Sifr subsystem is not ready for one of these contracts, this phase includes the required implementation work inside the Python interop milestone sequence rather than waiting for another phase.
 
 ## Core Decisions
 
@@ -26,7 +34,7 @@ Python interop is a separate lane from Rust-backed Sifr packages and raw C ABI i
 - Multiple `.venv` environments in one binary/process are rejected.
 - `py.Object` is an opaque foreign object, not `Any`.
 - Every Python boundary operation is fallible and returns a Sifr `Result`.
-- Python calls are synchronous from Sifr's perspective and classified as `foreign_blocking`.
+- Python calls are synchronous from Sifr's perspective and classified as `@blocking_io`.
 - `py.Object` is not `Send` by default and cannot cross Sifr task/thread boundaries without an explicit audited bridge.
 - Zero-copy support is first-class in this phase: `Py_buffer`, Arrow PyCapsule, DLPack, and strict array-interface compatibility are all part of the contract.
 - Python-to-Sifr callbacks are first-class and have explicit local/threadsafe lifetime modes.
@@ -55,11 +63,10 @@ The root application owns the Python environment:
 
 ```toml
 [python]
-enabled = true
 venv = ".venv"
 pyproject = "pyproject.toml"
 lock = "uv.lock"
-interpreter = ".venv/bin/python"
+interpreter = ".venv/bin/python" # optional; if omitted, Sifr resolves from venv per platform
 allow-imports = ["torch", "polars", "pandas", "pyarrow"]
 
 [trust]
@@ -80,7 +87,9 @@ Rules:
 - If no selected environment is available, Sifr reports a deterministic environment diagnostic before codegen/build.
 - If multiple packages require incompatible Python import roots, uv dependency resolution is the user's responsibility; Sifr verifies the final environment.
 - If two packages attempt to select different `.venv` roots, Sifr rejects the build.
-- Applications may use `python = ["*"]` and `python-native = ["*"]` trust during local control. Published libraries must not use wildcards.
+- `allow-imports` defines the root modules Sifr code may request; `trust.python` authorizes executing those roots; `trust.python-native` separately authorizes roots that load extension modules.
+- Applications may use `python = ["*"]` and `python-native = ["*"]` during local control. Published libraries using wildcards are rejected by package publish/check gates and package-graph loading.
+- Static string imports are checked in HIR against `allow-imports` and trust. Dynamic import names are rejected unless the call site uses an explicit unsafe `@trust_python_dynamic` annotation, in which case runtime trust checks still gate the resolved root.
 - Sifr gates declared/root imports only. Transitive Python imports remain uv's responsibility.
 
 ## Environment Probe
@@ -124,6 +133,14 @@ Validation rules:
 - Treat the live interpreter probe as the source of truth. `uv.lock` digests are cache/diagnostic inputs, not correctness proof that the environment is synced.
 - If lock/env state appears stale, report "run `uv sync`" guidance without invoking uv automatically.
 
+## Build and Link Contract
+
+- Generated binaries use the selected venv/interpreter probe as build metadata and cache input.
+- Cache invalidates on interpreter path, CPython major/minor, SOABI, extension suffix set, pointer width, platform, `libpython` path when linked, `pyproject.toml` digest, `uv.lock` digest, declared imports, or trust config changes.
+- Runtime resolution must prefer the configured interpreter/venv. No host-global Python fallback is allowed.
+- PyO3 is built for embedding CPython, not for producing a Python extension module.
+- If dynamic `libpython` linking is required on a target, generated Cargo metadata records the link path and runtime loader requirements; missing loader resolution is a build/probe diagnostic, not a runtime surprise.
+
 ## Runtime Lifecycle
 
 `sifr_runtime::python` owns embedded CPython lifecycle.
@@ -162,21 +179,26 @@ pub mod python {
     }
 
     pub struct PythonRuntime;
+    pub struct PyGilScope;
+    pub enum PyValue;
     pub struct PyObjectHandle;
     pub struct PyBufferView;
     pub struct PyArrowCapsule;
     pub struct PyDlpackCapsule;
     pub struct PyCallbackHandle;
 
+    // Generic wrappers specialize into Sifr-level ArrowArray, ArrowStream, and ArrowSchema handles.
+
     pub fn initialize(config: PythonConfig) -> Result<(), PythonInitError>;
     pub fn import_module(name: &str) -> Result<PyObjectHandle, PythonError>;
+    pub fn with_gil<T>(f: impl FnOnce(PyGilScope) -> Result<T, PythonError>) -> Result<T, PythonError>;
     pub fn getattr(obj: &PyObjectHandle, name: &str) -> Result<PyObjectHandle, PythonError>;
     pub fn getitem(obj: &PyObjectHandle, key: PyValue) -> Result<PyObjectHandle, PythonError>;
     pub fn call(callable: &PyObjectHandle, args: &[PyValue], kwargs: &[(&str, PyValue)]) -> Result<PyObjectHandle, PythonError>;
 }
 ```
 
-Implementation should use PyO3 or a PyO3-compatible ownership model unless a later implementation review records a stronger reason to use raw CPython APIs directly.
+Implementation uses PyO3 for interpreter, GIL, owned-reference, exception, and ordinary object-operation safety. It uses `pyo3-ffi` or narrowly wrapped CPython C APIs only where PyO3 does not expose the required production surface, including `Py_buffer`, capsule validation, Arrow PyCapsule names, DLPack capsules, and low-level environment initialization details.
 
 ## Sifr Object Model
 
@@ -221,8 +243,8 @@ from sifr import python as py
 
 def main() -> Result[None, py.PythonError]:
     torch = try py.import_module("torch")
-    x = try py.call_attr(torch, "tensor", [[1.0, 2.0], [3.0, 4.0]])
-    y = try py.call_attr(torch, "matmul", [x, x])
+    x = try py.call_attr(torch, "tensor", [[1.0, 2.0], [3.0, 4.0]], [])
+    y = try py.call_attr(torch, "matmul", [x, x], [])
     text = try py.to_str(y)
     print(text)
     return None
@@ -241,6 +263,7 @@ try py.call_attr(obj, "method", args, kwargs)
 try py.to[T](obj)
 try py.to_str(obj)
 try py.to_bytes(obj)
+try py.scope(lambda gil: ...)
 try py.close(obj)
 try py.with(obj, lambda entered: ...)
 try py.run_coroutine_blocking(coro)
@@ -261,13 +284,16 @@ but it must lower to the same fallible operations and must not execute Python im
 | --- | --- |
 | `py.import_module("torch")` | `Result[py.Module, py.PythonError]` |
 | `py.get_attr(obj, "name")` | `Result[py.Object, py.PythonError]` |
-| `py.call_attr(obj, "method", args)` | `Result[py.Object, py.PythonError]` |
+| `py.call_attr(obj, "method", args, kwargs)` | `Result[py.Object, py.PythonError]` |
 | `py.call(callable, args, kwargs)` | `Result[py.Object, py.PythonError]` |
 | `py.get_item(obj, key)` | `Result[py.Object, py.PythonError]` |
 | `py.to[T](obj)` | `Result[T, py.TypeConversionError]` |
+| `py.zero_copy_as[T](obj)` | `Result[T, py.ZeroCopyError]`; never copies |
+| `py.copy_as[T](obj)` | `Result[T, py.TypeConversionError]`; explicit copy |
+| `py.scope(fn)` | `Result[T, py.PythonError]`; holds the GIL for batched operations |
 | `py.close(obj)` | `Result[None, py.PythonError]` |
 | `py.with(obj, fn)` | `Result[T, py.PythonError]` |
-| `py.run_coroutine_blocking(coro)` | `Result[py.Object, py.PythonError]`, classified `foreign_blocking` |
+| `py.run_coroutine_blocking(coro)` | `Result[py.Object, py.PythonError]`, classified `@blocking_io` |
 
 Outside a `try`/`Result` handling context, fallible Python operations are compile-time errors.
 
@@ -275,25 +301,16 @@ Outside a `try`/`Result` handling context, fallible Python operations are compil
 
 Automatic conversion is conservative.
 
-| Python value | Sifr value |
-| --- | --- |
-| `None` | `None` |
-| `bool` | `bool` |
-| Python `int` | Sifr exact `int`; fixed-width conversion is checked and fallible |
-| Python `float` | `float` |
-| Python `str` | `str` |
-| Python `bytes` | `bytes` |
-| Python `bytearray` | `py.Object` by default; explicit buffer/copy conversion required |
-| Python `memoryview` | `py.Object` by default; explicit buffer/copy conversion required |
-| Python `list` | `py.Object` by default; explicit typed conversion required |
-| Python `tuple` | `py.Object` by default; explicit typed conversion required |
-| Python `dict` | `py.Object` by default; explicit typed conversion required |
-| `numpy.ndarray` | `py.Object` by default; explicit buffer/array conversion required |
-| `torch.Tensor` | `py.Object` by default; explicit DLPack/copy conversion required |
-| `tensorflow.Tensor` | `py.Object` by default; explicit DLPack/copy conversion required |
-| `pandas.DataFrame` | `py.Object` by default; explicit Arrow/copy conversion required |
-| `polars.DataFrame` | `py.Object` by default; explicit Arrow/copy conversion required |
-| arbitrary Python object | `py.Object` |
+| Python value | Default Sifr type | Explicit conversion API |
+| --- | --- | --- |
+| `None`, bool, float, str, bytes | matching Sifr value | `py.to[T]`, `py.copy_as[T]` when needed |
+| Python `int` | exact `int` | fixed-width `py.to[int32]`/etc. is checked and fallible |
+| bytearray, memoryview, buffers | `py.Object` | `py.zero_copy_as[py.BufferView[T]]`, `py.copy_as[bytes]` |
+| list, tuple, dict | `py.Object` | `py.to[list[T]]`, `py.to[dict[str, T]]`, record conversion |
+| numpy arrays | `py.Object` | `py.BufferView`, array-interface compatibility, DLPack where available, explicit copy |
+| torch/tensorflow tensors | `py.Object` | DLPack or explicit copy |
+| pandas/polars/pyarrow dataframes | `py.Object` | Arrow PyCapsule/stream or explicit copy |
+| arbitrary Python object | `py.Object` | explicit protocol-specific conversion only |
 
 Rules:
 
@@ -331,12 +348,13 @@ Sifr waits until Python returns control.
 
 Rules:
 
-- Every Python call is classified as `foreign_blocking`.
+- Every Python call is classified as `@blocking_io`.
 - Direct Python calls in async Sifr code are compile-time errors unless explicitly offloaded.
-- `py.blocking` or the existing task offload primitive must run Python work in a blocking-safe region.
+- The existing Sifr blocking task/offload primitive is the only async escape hatch. There is no Python-specific `py.blocking` alias.
+- User-defined Sifr wrappers around Python work inherit or declare `@blocking_io`.
 - `py.Object` values cannot cross async task/thread boundaries by default.
 - Python cancellation is cooperative only. Sifr cannot safely kill embedded Python execution mid-call.
-- `py.run_coroutine_blocking` is allowed only as an explicitly blocking operation and should run the coroutine using Python-owned event-loop mechanics.
+- `py.run_coroutine_blocking` is `@blocking_io`, creates or reuses a runtime-owned per-thread Python event loop, rejects reentry into an already running loop on that thread, respects installed loop policies such as uvloop, and returns only after the coroutine finishes.
 
 ## Resource Cleanup
 
@@ -346,9 +364,10 @@ Supported cleanup APIs:
 
 ```sifr
 try py.close(obj)
-try py.call_method(obj, "close", [])
+try py.call_attr(obj, "close", [], [])
 try py.with(obj, lambda entered: ...)
-try py.run_coroutine_blocking(try py.call_attr(obj, "aclose", []))
+let coro = try py.call_attr(obj, "aclose", [], [])
+try py.run_coroutine_blocking(coro)
 try callback.close()
 try buffer.release()
 ```
@@ -357,6 +376,7 @@ Rules:
 
 - Do not rely on Python `__del__` for correctness.
 - Context-manager helpers must call `__enter__` and `__exit__` and preserve Python traceback on failure.
+- `py.with(obj, fn)` is scoped: `entered` cannot escape the lambda, the lambda returns generic `T`, and Python `__exit__(exc_type, exc, tb)` receives Sifr/Python failure context before the final `Result` is produced.
 - Async context managers require a Python wrapper or explicit `py.run_coroutine_blocking`.
 - Callback handles, buffer views, Arrow capsules, and DLPack capsules are resource handles with deterministic close/release semantics.
 - Double close/release is either idempotent by design or reports a deterministic resource-state error; the decision must be documented per resource type.
@@ -377,6 +397,7 @@ Rules:
 - Zero-copy APIs never silently copy.
 - Copying APIs never claim view semantics.
 - Every view tracks the Python owner/resource needed to keep memory valid.
+- `py.BufferView`, `py.ArrowArray`, `py.ArrowStream`, `py.ArrowSchema`, and `py.DlpackTensor` are non-`Send` by default. A view becomes transferable only through an explicit audited bridge that proves owner lifetime, device/stream sync, mutability, and thread-safety constraints.
 - Writable views require both Python exporter writeability and Sifr-side exclusivity/borrow rules.
 - Non-contiguous data is represented with strides when the target type supports strides; contiguity-required targets reject non-contiguous sources.
 
@@ -406,6 +427,8 @@ Used for:
 - suboffsets;
 - contiguity class;
 - requested flags.
+
+It is acquired via `try py.zero_copy_as[py.BufferView[T]](obj)`.
 
 Drop/release must call `PyBuffer_Release` exactly once while holding the GIL.
 
@@ -475,6 +498,7 @@ py.ThreadsafeCallback
 `py.LocalCallback`:
 
 - valid only during the active Sifr-to-Python call;
+- non-`Send`;
 - same-thread/same-stack reentry only;
 - may borrow scoped Sifr values;
 - cannot be stored by Python beyond the active call;
@@ -486,6 +510,9 @@ py.ThreadsafeCallback
 - may be called from Python-created threads, native extension callback threads, thread pools, or event-loop schedulers;
 - must own or clone captured state;
 - requires Send-like Sifr constraints on captured values;
+- is the explicit audited bridge exception to non-`Send` `py.Object` defaults;
+- stores Python callable references only inside the runtime registry, reacquires the GIL before dispatch, and never exposes those references as Send Sifr values;
+- dispatches non-Sifr-thread calls through the Sifr runtime scheduler unless the callback is explicitly marked same-thread reentrant;
 - is registered in a runtime callback registry;
 - has explicit `close`/`cancel`;
 - converts Sifr errors into Python exceptions;
@@ -513,6 +540,7 @@ Rules:
 - Native Python extensions are trusted in-process code.
 - Sifr cannot sandbox native extensions in embedded mode.
 - Native crashes can terminate the process.
+- Sifr's no-user-triggerable-runtime-panic guarantee applies to Sifr-attributable paths. `[trust].python-native` is an explicit opt-in boundary where process-abort safety is delegated to the trusted extension.
 - Native extensions may release the GIL.
 - Native extensions may create background threads.
 - Native extensions may call back into Python/Sifr from non-Sifr threads.
@@ -522,47 +550,22 @@ Rules:
 
 Sifr should support any CPython-compatible package installed in the selected uv environment. Certification is a verification promise for representative package surfaces, not a package whitelist.
 
-### Tier 1: Interop Certification Gate
+### Tier 1a: Core Interop Certification Gate
 
-Core runtime/package loading:
+These packages must pass at the full Python interop gate because they exercise the core embedded, native, conversion, zero-copy, and production-client surfaces: `pydantic`, `pydantic-core`, `httpx`, `requests`, `cryptography`, `cffi`, `numpy`, `pandas`, `pyarrow`, `polars`, `torch` CPU, `psycopg`, `sqlalchemy`, `redis`, `confluent-kafka`, `openai`, `google-genai`, `biip`, `schwifty`.
 
-- `pip`, `setuptools`, `wheel`, `build`, `hatchling`, `poetry-core`, `uv-build`, `pyproject-hooks`, `packaging`, `pkginfo`, `importlib-metadata`, `zipp`, `platformdirs`, `appdirs`, `typing-extensions`, `exceptiongroup`.
+### Tier 1b: Ecosystem Certification Gate
 
-Data validation/structured objects:
-
-- `pydantic`, `pydantic-core`, `pydantic-extra-types`, `annotated-types`, `attrs`, `marshmallow`, `cerberus`, `jsonpickle`, `deepdiff`, `protobuf`, `proto-plus`, `pyyaml`, `toml`, `tomli`, `python-dotenv`.
-
-HTTP/async/networking:
-
-- `requests`, `urllib3`, `httpx`, `httpcore`, `aiohttp`, `anyio`, `async-timeout`, `sniffio`, `h11`, `httptools`, `websockets`, `uvicorn`, `uvloop`.
-
-Web frameworks:
-
-- `fastapi`, `starlette`, `starlette-context`, `django`, `sanic`, `sanic-routing`, `sanic-testing`, `webargs`, `webargs-sanic`, `jinja2`, `markupsafe`, `python-multipart`.
-
-Databases/queues/brokers:
-
-- `sqlalchemy`, `sqlalchemy-utils`, `alembic`, `psycopg`, `psycopg2`, `psycopg2-binary`, `asyncpg`, `pymongo`, `motor`, `mongoengine`, `redis`, `fakeredis`, `hiredis`, `valkey`, `aiokafka`, `confluent-kafka`, `kafka-python`, `python-schema-registry-client`.
-
-Cloud/AI clients:
-
-- `openai`, `google-genai`, `google-api-core`, `google-api-python-client`, `google-auth`, `google-auth-httplib2`, `google-auth-oauthlib`, `google-cloud-core`, `google-cloud-storage`, `google-cloud-firestore`, `google-cloud-aiplatform`, `firebase-admin`, `kubernetes`, `pinecone-client`, `gspread`, `gspread-asyncio`.
-
-Security/crypto/native loading:
-
-- `cryptography`, `cffi`, `pycparser`, `certifi`, `idna`, `charset-normalizer`, `chardet`, `oauthlib`, `requests-oauthlib`, `python-jose`, `rsa`, `pyasn1`, `pyasn1-modules`.
-
-Data/binary/parser:
-
-- `pandas`, `pyarrow`, `openpyxl`, `lxml`, `bleach`, `defusedxml`, `nh3`, `regex`, `ujson`, `fastavro`, `avro`, `avro-python3`, `google-crc32c`, `tiktoken`.
-
-Observability/production infra:
-
-- `opentelemetry-api`, `opentelemetry-semantic-conventions`, `opentracing`, `sentry-sdk`, `sentry-asgi`, `datadog`, `structlog`, `logstash-formatter`.
-
-Domain examples:
-
-- `biip`, `schwifty`, `pycountry`, `babel`, `holidays`, `dateparser`, `pendulum`, `python-dateutil`, `pytz`, `tzdata`, `uuid-utils`, `rank-bm25`.
+- Runtime/package loading: `pip`, `setuptools`, `wheel`, `build`, `hatchling`, `poetry-core`, `uv-build`, `pyproject-hooks`, `packaging`, `pkginfo`, `importlib-metadata`, `zipp`, `platformdirs`, `appdirs`, `typing-extensions`, `exceptiongroup`.
+- Data validation/structured objects: `pydantic`, `pydantic-core`, `pydantic-extra-types`, `annotated-types`, `attrs`, `marshmallow`, `cerberus`, `jsonpickle`, `deepdiff`, `protobuf`, `proto-plus`, `pyyaml`, `toml`, `tomli`, `python-dotenv`.
+- HTTP/async/networking: `requests`, `urllib3`, `httpx`, `httpcore`, `aiohttp`, `anyio`, `async-timeout`, `sniffio`, `h11`, `httptools`, `websockets`, `uvicorn`, `uvloop`.
+- Web frameworks: `fastapi`, `starlette`, `starlette-context`, `django`, `sanic`, `sanic-routing`, `sanic-testing`, `webargs`, `webargs-sanic`, `jinja2`, `markupsafe`, `python-multipart`.
+- Databases/queues/brokers: `sqlalchemy`, `sqlalchemy-utils`, `alembic`, `psycopg`, `psycopg2`, `psycopg2-binary`, `asyncpg`, `pymongo`, `motor`, `mongoengine`, `redis`, `fakeredis`, `hiredis`, `valkey`, `aiokafka`, `confluent-kafka`, `kafka-python`, `python-schema-registry-client`.
+- Cloud/AI clients: `openai`, `google-genai`, `google-api-core`, `google-api-python-client`, `google-auth`, `google-auth-httplib2`, `google-auth-oauthlib`, `google-cloud-core`, `google-cloud-storage`, `google-cloud-firestore`, `google-cloud-aiplatform`, `firebase-admin`, `kubernetes`, `pinecone-client`, `gspread`, `gspread-asyncio`.
+- Security/crypto/native loading: `cryptography`, `cffi`, `pycparser`, `certifi`, `idna`, `charset-normalizer`, `chardet`, `oauthlib`, `requests-oauthlib`, `python-jose`, `rsa`, `pyasn1`, `pyasn1-modules`.
+- Data/binary/parser: `pandas`, `pyarrow`, `openpyxl`, `lxml`, `bleach`, `defusedxml`, `nh3`, `regex`, `ujson`, `fastavro`, `avro`, `avro-python3`, `google-crc32c`, `tiktoken`.
+- Observability/production infra: `opentelemetry-api`, `opentelemetry-semantic-conventions`, `opentracing`, `sentry-sdk`, `sentry-asgi`, `datadog`, `structlog`, `logstash-formatter`.
+- Domain examples: `biip`, `schwifty`, `pycountry`, `babel`, `holidays`, `dateparser`, `pendulum`, `python-dateutil`, `pytz`, `tzdata`, `uuid-utils`, `rank-bm25`.
 
 ### Tier 2: Broad Smoke Gate
 
@@ -652,7 +655,7 @@ Verification groups:
 - `web`: FastAPI/Starlette/Django/Sanic import and in-process smoke fixtures.
 - `cleanup`: close/context-manager/callback release/leak diagnostics.
 
-Runner shape:
+Runner shape: `run.sh` is canonical; it validates environment prerequisites and delegates to `runner/run.py`.
 
 ```bash
 verification/python_interop/run.sh --group env
@@ -678,6 +681,7 @@ Scope:
 - Land this full phase contract.
 - Create `verification/python_interop/` scaffold and package matrix files.
 - Define diagnostic families for Python environment/import/call/conversion/resource/zero-copy errors.
+- Reserve diagnostic families: `SIFR-PYENV`, `SIFR-PYIMP`, `SIFR-PYCALL`, `SIFR-PYCONV`, `SIFR-PYRES`, `SIFR-PYZC`, `SIFR-PYCB`, `SIFR-PYTRUST`.
 - Record package certification policy and host-dependent test policy.
 
 Definition of done:
@@ -737,9 +741,9 @@ Definition of done:
 ### milestone_py_5: Async/Blocking Integration
 
 Scope:
-- Classify Python calls as `foreign_blocking`.
+- Classify Python calls as `@blocking_io`.
 - Reject direct Python calls in async Sifr code unless offloaded.
-- Implement `py.blocking` or integrate with the existing blocking task primitive.
+- Integrate with the existing blocking task primitive; do not add `py.blocking`.
 - Implement `py.run_coroutine_blocking` as an explicitly blocking operation.
 - Enforce non-Send default behavior for `py.Object`.
 
@@ -831,12 +835,11 @@ Definition of done:
 Entry criteria:
 
 - Existing local validation gates remain green before implementation starts.
-- Phase 27 non-regression baseline is green.
 - Python phase contract is linked from phase index and roadmap docs.
 
 Global invariants:
 
-- No user-triggerable compiler or runtime panics.
+- No user-triggerable compiler or runtime panics in Sifr-attributable paths; trusted Python native extensions are the explicit in-process trust boundary exception.
 - No data-dependent emitted `.unwrap()`, `.expect()`, or `panic!` in user runtime paths.
 - Python errors are `Result` values with structured diagnostics.
 - Python calls in async Sifr code require explicit blocking/offload.
@@ -880,10 +883,10 @@ verification/python_interop/run.sh --group callbacks
 - Root app environment ownership, trust, and probing are enforced.
 - CPython lifecycle, GIL/refcount handling, and resource cleanup are deterministic.
 - `py.Object` operations are opaque, fallible, non-`Any`, and non-Send by default.
-- Python calls obey foreign-blocking/offload rules.
+- Python calls obey `@blocking_io`/offload rules.
 - Python-to-Sifr callbacks support local and threadsafe modes.
 - `Py_buffer`, Arrow PyCapsule, DLPack, and strict array-interface paths are implemented with no silent zero-copy fallback to copying.
 - Tier 1 package certification passes in the full Python interop gate.
 - Verification reports exist under `verification/python_interop/reports/`.
 - Public and internal docs describe the exact production contract.
-- Phase 27 non-regression contract remains green.
+- Existing non-regression contracts remain green.

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -49,7 +49,7 @@ If an existing Sifr subsystem is not ready for one of these contracts, this phas
 - Do not introduce a Sifr-owned Python package manager.
 - Do not run `uv sync` automatically during ordinary `sifr build`, `sifr run`, or `sifr check`.
 - Do not support PyPy, GraalPy, MicroPython, or non-CPython implementations.
-- Do not support free-threaded CPython until a future audited phase explicitly enables it.
+- Do not support free-threaded CPython in this phase.
 - Do not support multiple Python interpreters or multiple virtual environments in one process.
 - Do not support CPython subinterpreters.
 - Do not expose Python objects as Sifr `Any`.
@@ -125,7 +125,7 @@ The probe must produce canonical JSON with:
 Validation rules:
 
 - Reject non-CPython implementations.
-- Reject free-threaded CPython unless an explicit future audit enables it.
+- Reject free-threaded CPython.
 - Reject a configured `.venv` whose interpreter does not report `sys.prefix` inside that `.venv`.
 - Reject missing `site-packages` for the selected environment.
 - Reject missing declared imports.
@@ -181,7 +181,7 @@ pub mod python {
 
     pub struct PythonRuntime;
     pub struct PyGilScope;
-    pub enum PyValue;
+    pub enum PyValue<'a> { None_, Bool(bool), IntExact(SifrExactInt), IntFixed(SifrFixedInt), Float(f64), Str(&'a str), Bytes(&'a [u8]), Object(&'a PyObjectHandle) }
     pub struct PyObjectHandle;
     pub struct PyBufferView;
     pub struct PyArrowCapsule;
@@ -270,14 +270,7 @@ try py.with(obj, lambda entered: ...)
 try py.run_coroutine_blocking(coro)
 ```
 
-Future syntax sugar may exist:
-
-```sifr
-import python torch
-import python polars as pl
-```
-
-but it must lower to the same fallible operations and must not execute Python imports during `sifr check`.
+This phase does not introduce `import python <name>` syntax sugar; explicit `py.*` operations are the only user-facing surface.
 
 ## Operation Lowering
 
@@ -320,6 +313,7 @@ Rules:
 - Do not assume Python sequences are finite, cheap, or pure.
 - Typed conversion of lists/dicts/records must validate every element and fail with path-rich diagnostics.
 - `bytes` conversion copies into owned immutable Sifr bytes unless an explicit zero-copy buffer view is requested.
+- Sifr-to-Python call arguments accept `None`, bool, exact/fixed-width integers, float, str, bytes, and existing `py.Object` handles. Sifr containers and records require explicit Python object construction; overflow or unsupported argument packing returns `py.TypeConversionError`.
 
 ## Error Model
 
@@ -727,11 +721,13 @@ Scope:
 - Implement `py.import_module`, attribute/item access, calls, kwargs, and explicit close/context-manager helpers.
 - Add structured `py.PythonError` families with traceback capture.
 - Enforce `Result` handling in lowering/type checking.
+- Enforce `allow-imports`, `[trust] python`, `[trust] python-native`, wildcard rejection, and `@trust_python_dynamic` runtime root checks with `SIFR-PYTRUST` diagnostics.
 - Keep `py.Object` distinct from `Any`.
 
 Definition of done:
 - Positive fixtures cover import, attr, item, call, kwargs, close, and context manager behavior.
 - Negative fixtures cover import failure, attr failure, call failure, wrong args, conversion failure, and unhandled `Result`.
+- Trust fixtures cover static imports, dynamic imports, native roots, wildcard rejection, and package-graph load failures.
 
 ### milestone_py_4: Primitive and Typed Conversion
 

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -1,0 +1,889 @@
+# Ad Hoc Phase: Embedded Python Interop
+
+> Status: draft planning lock. This phase is intentionally scoped as a complete design contract, not an MVP. Implementation may be delivered in milestones, but the design decisions below are binding for the whole Python interop surface.
+
+## Objective
+
+Deliver production-grade in-process CPython interoperability so Sifr programs can smoothly use Python code and Python ecosystem packages from uv-created environments while preserving Sifr's safety, error, ownership, diagnostics, and local-verification guarantees.
+
+Python interop is a separate lane from Rust-backed Sifr packages and raw C ABI interop. It is not a Deno-style generic `dlopen` layer and must not be collapsed into the Rust/C FFI model.
+
+## Depends On
+
+- Phase 32 async/offload semantics for foreign blocking diagnostics.
+- Phase 37 Cargo-backed package coordination for root package ownership, metadata, and trust policy shape.
+- Phase 40 typed model/validation where Sifr typed conversion helpers intersect with Python model/data validation.
+- Phase 42 data/ML planning for package-facing dataframes, tensors, arrays, and zero-copy data interchange.
+- Phase 43 interop planning for the separate Rust/C interop lane and shared fixed-width integer/bytes representation constraints.
+
+## Core Decisions
+
+- Python interop is embedded CPython only.
+- The root Sifr application selects exactly one uv-created Python environment for the final process.
+- Sifr consumes and verifies the Python environment; Sifr does not resolve, install, or sync Python packages by default.
+- CPython is initialized once per process, uses the main interpreter only, and is not finalized during normal shutdown.
+- Subinterpreters are not supported in this phase.
+- Multiple `.venv` environments in one binary/process are rejected.
+- `py.Object` is an opaque foreign object, not `Any`.
+- Every Python boundary operation is fallible and returns a Sifr `Result`.
+- Python calls are synchronous from Sifr's perspective and classified as `foreign_blocking`.
+- `py.Object` is not `Send` by default and cannot cross Sifr task/thread boundaries without an explicit audited bridge.
+- Zero-copy support is first-class in this phase: `Py_buffer`, Arrow PyCapsule, DLPack, and strict array-interface compatibility are all part of the contract.
+- Python-to-Sifr callbacks are first-class and have explicit local/threadsafe lifetime modes.
+- Python imports and native Python extensions are trusted in-process code.
+- No subprocess, worker, or IPC-isolated Python mode is part of this phase.
+- No silent fallback from zero-copy APIs to copying is allowed.
+- No transitive Python import scanner is required or allowed as a correctness dependency; uv owns transitive Python dependency resolution.
+
+## Non-Goals
+
+- Do not introduce a Sifr-owned Python package manager.
+- Do not run `uv sync` automatically during ordinary `sifr build`, `sifr run`, or `sifr check`.
+- Do not support PyPy, GraalPy, MicroPython, or non-CPython implementations.
+- Do not support free-threaded CPython until a future audited phase explicitly enables it.
+- Do not support multiple Python interpreters or multiple virtual environments in one process.
+- Do not support CPython subinterpreters.
+- Do not expose Python objects as Sifr `Any`.
+- Do not implicitly deep-convert Python lists, dicts, tuples, arrays, tensors, or dataframes.
+- Do not let Python exceptions, Rust panics, or native extension failures cross into Sifr user code as panics.
+- Do not rely on Python `__del__` for correctness-critical resource cleanup.
+- Do not treat Arrow export, pandas conversion, memoryview creation, or Python dataframe conversion as inherently zero-copy.
+
+## Configuration Model
+
+The root application owns the Python environment:
+
+```toml
+[python]
+enabled = true
+venv = ".venv"
+pyproject = "pyproject.toml"
+lock = "uv.lock"
+interpreter = ".venv/bin/python"
+allow-imports = ["torch", "polars", "pandas", "pyarrow"]
+
+[trust]
+python = ["torch", "polars", "pandas", "pyarrow"]
+python-native = ["numpy", "torch", "polars", "pyarrow", "cryptography"]
+```
+
+Library packages may declare required Python import roots but do not select the interpreter, Python version, virtual environment, lockfile, or package resolver:
+
+```toml
+[python]
+requires-imports = ["polars"]
+```
+
+Rules:
+
+- The final application must provide one selected Python environment if any reachable package requires Python.
+- If no selected environment is available, Sifr reports a deterministic environment diagnostic before codegen/build.
+- If multiple packages require incompatible Python import roots, uv dependency resolution is the user's responsibility; Sifr verifies the final environment.
+- If two packages attempt to select different `.venv` roots, Sifr rejects the build.
+- Applications may use `python = ["*"]` and `python-native = ["*"]` trust during local control. Published libraries must not use wildcards.
+- Sifr gates declared/root imports only. Transitive Python imports remain uv's responsibility.
+
+## Environment Probe
+
+Sifr must probe the selected interpreter before any Python-enabled generated binary is considered valid.
+
+Probe command shape:
+
+```text
+<venv>/bin/python        # Unix/macOS
+<venv>\Scripts\python.exe # Windows
+```
+
+The probe must produce canonical JSON with:
+
+- implementation name and version;
+- CPython version tuple;
+- executable path;
+- `sys.prefix` and `sys.base_prefix`;
+- site-packages paths;
+- normalized `sys.path`;
+- SOABI;
+- extension suffixes;
+- pointer width;
+- platform and machine;
+- `libpython` path when discoverable;
+- free-threaded/GIL-disabled status;
+- import metadata for declared roots;
+- import/load results for declared native-extension roots;
+- `pyproject.toml` and `uv.lock` digests when configured.
+
+Validation rules:
+
+- Reject non-CPython implementations.
+- Reject free-threaded CPython unless an explicit future audit enables it.
+- Reject a configured `.venv` whose interpreter does not report `sys.prefix` inside that `.venv`.
+- Reject missing `site-packages` for the selected environment.
+- Reject missing declared imports.
+- Reject native extension import/load failures for trusted native Python roots.
+- Add `pyproject.toml`, `uv.lock`, interpreter path, probe JSON, and declared import roots to cache keys.
+- Treat the live interpreter probe as the source of truth. `uv.lock` digests are cache/diagnostic inputs, not correctness proof that the environment is synced.
+- If lock/env state appears stale, report "run `uv sync`" guidance without invoking uv automatically.
+
+## Runtime Lifecycle
+
+`sifr_runtime::python` owns embedded CPython lifecycle.
+
+Rules:
+
+- Initialize CPython once per process.
+- Use the main interpreter only.
+- Do not call `Py_FinalizeEx` during normal program shutdown.
+- Track initialization state and reject attempts to reinitialize with a different environment.
+- Store the selected `PythonConfig` for diagnostics.
+- Acquire the GIL for every CPython C API operation that requires it.
+- Acquire the GIL before decref in `py.Object` destruction.
+- Track outstanding `py.Object`, buffer, Arrow, DLPack, and callback resources for leak diagnostics and verification.
+
+Rationale:
+
+- CPython finalization is fragile with native extensions, background threads, callbacks, and `PyGILState_*`.
+- Subinterpreters are incompatible with common extension-module and `PyGILState_*` assumptions.
+- Python native packages are trusted process-local code, not sandboxed code.
+
+## Conceptual Runtime API
+
+The Rust runtime surface should be explicit and small:
+
+```rust
+pub mod python {
+    pub struct PythonConfig {
+        pub venv_root: PathBuf,
+        pub executable: PathBuf,
+        pub site_packages: Vec<PathBuf>,
+        pub sys_path: Vec<PathBuf>,
+        pub imports: Vec<String>,
+        pub native_imports: Vec<String>,
+        pub probe: PythonEnvironmentProbe,
+    }
+
+    pub struct PythonRuntime;
+    pub struct PyObjectHandle;
+    pub struct PyBufferView;
+    pub struct PyArrowCapsule;
+    pub struct PyDlpackCapsule;
+    pub struct PyCallbackHandle;
+
+    pub fn initialize(config: PythonConfig) -> Result<(), PythonInitError>;
+    pub fn import_module(name: &str) -> Result<PyObjectHandle, PythonError>;
+    pub fn getattr(obj: &PyObjectHandle, name: &str) -> Result<PyObjectHandle, PythonError>;
+    pub fn getitem(obj: &PyObjectHandle, key: PyValue) -> Result<PyObjectHandle, PythonError>;
+    pub fn call(callable: &PyObjectHandle, args: &[PyValue], kwargs: &[(&str, PyValue)]) -> Result<PyObjectHandle, PythonError>;
+}
+```
+
+Implementation should use PyO3 or a PyO3-compatible ownership model unless a later implementation review records a stronger reason to use raw CPython APIs directly.
+
+## Sifr Object Model
+
+Conceptual Sifr types:
+
+```sifr
+py.Object
+py.Module
+py.Callable
+py.BufferView[T]
+py.ArrowArray
+py.ArrowStream
+py.ArrowSchema
+py.DlpackTensor
+py.LocalCallback
+py.ThreadsafeCallback
+py.PythonError
+py.ImportError
+py.AttributeError
+py.CallError
+py.TypeConversionError
+py.BufferError
+py.ZeroCopyError
+py.EnvironmentError
+```
+
+Rules:
+
+- `py.Object` is opaque and foreign.
+- `py.Object` is not `Any`.
+- `py.Object` is not `Send` by default.
+- `py.Object` cannot be pattern-matched or structurally typed as a Sifr class.
+- Operations on `py.Object` are only allowed through Python interop APIs or compiler-approved Python syntax sugar.
+- Every operation that may touch Python returns `Result`.
+
+## User-Facing API
+
+The canonical surface is explicit:
+
+```sifr
+from sifr import python as py
+
+def main() -> Result[None, py.PythonError]:
+    torch = try py.import_module("torch")
+    x = try py.call_attr(torch, "tensor", [[1.0, 2.0], [3.0, 4.0]])
+    y = try py.call_attr(torch, "matmul", [x, x])
+    text = try py.to_str(y)
+    print(text)
+    return None
+```
+
+Core operations:
+
+```sifr
+try py.import_module("module.name")
+try py.get_attr(obj, "name")
+try py.set_attr(obj, "name", value)
+try py.get_item(obj, key)
+try py.set_item(obj, key, value)
+try py.call(callable, args, kwargs)
+try py.call_attr(obj, "method", args, kwargs)
+try py.to[T](obj)
+try py.to_str(obj)
+try py.to_bytes(obj)
+try py.close(obj)
+try py.with(obj, lambda entered: ...)
+try py.run_coroutine_blocking(coro)
+```
+
+Future syntax sugar may exist:
+
+```sifr
+import python torch
+import python polars as pl
+```
+
+but it must lower to the same fallible operations and must not execute Python imports during `sifr check`.
+
+## Operation Lowering
+
+| Sifr operation | Semantic lowering |
+| --- | --- |
+| `py.import_module("torch")` | `Result[py.Module, py.PythonError]` |
+| `py.get_attr(obj, "name")` | `Result[py.Object, py.PythonError]` |
+| `py.call_attr(obj, "method", args)` | `Result[py.Object, py.PythonError]` |
+| `py.call(callable, args, kwargs)` | `Result[py.Object, py.PythonError]` |
+| `py.get_item(obj, key)` | `Result[py.Object, py.PythonError]` |
+| `py.to[T](obj)` | `Result[T, py.TypeConversionError]` |
+| `py.close(obj)` | `Result[None, py.PythonError]` |
+| `py.with(obj, fn)` | `Result[T, py.PythonError]` |
+| `py.run_coroutine_blocking(coro)` | `Result[py.Object, py.PythonError]`, classified `foreign_blocking` |
+
+Outside a `try`/`Result` handling context, fallible Python operations are compile-time errors.
+
+## Conversion Rules
+
+Automatic conversion is conservative.
+
+| Python value | Sifr value |
+| --- | --- |
+| `None` | `None` |
+| `bool` | `bool` |
+| Python `int` | Sifr exact `int`; fixed-width conversion is checked and fallible |
+| Python `float` | `float` |
+| Python `str` | `str` |
+| Python `bytes` | `bytes` |
+| Python `bytearray` | `py.Object` by default; explicit buffer/copy conversion required |
+| Python `memoryview` | `py.Object` by default; explicit buffer/copy conversion required |
+| Python `list` | `py.Object` by default; explicit typed conversion required |
+| Python `tuple` | `py.Object` by default; explicit typed conversion required |
+| Python `dict` | `py.Object` by default; explicit typed conversion required |
+| `numpy.ndarray` | `py.Object` by default; explicit buffer/array conversion required |
+| `torch.Tensor` | `py.Object` by default; explicit DLPack/copy conversion required |
+| `tensorflow.Tensor` | `py.Object` by default; explicit DLPack/copy conversion required |
+| `pandas.DataFrame` | `py.Object` by default; explicit Arrow/copy conversion required |
+| `polars.DataFrame` | `py.Object` by default; explicit Arrow/copy conversion required |
+| arbitrary Python object | `py.Object` |
+
+Rules:
+
+- Do not eagerly convert Python containers.
+- Do not silently narrow Python integers to fixed-width Sifr integers.
+- Do not assume Python sequences are finite, cheap, or pure.
+- Typed conversion of lists/dicts/records must validate every element and fail with path-rich diagnostics.
+- `bytes` conversion copies into owned immutable Sifr bytes unless an explicit zero-copy buffer view is requested.
+
+## Error Model
+
+Every Python boundary failure returns a structured `py.PythonError` family value. It must preserve:
+
+- Python exception type;
+- message;
+- traceback;
+- module/function/attribute/item context;
+- argument conversion context;
+- return conversion context;
+- dtype/shape/stride/device metadata for data interchange failures;
+- environment and interpreter metadata for environment failures;
+- whether the failure happened during import, call, callback dispatch, conversion, resource cleanup, or zero-copy export.
+
+No Python exception crosses into Sifr as a panic. No CPython/PyO3 unwrap/expect/panic may be emitted in user-triggerable runtime paths.
+
+## Async and Blocking Semantics
+
+Python execution is synchronous from Sifr's perspective:
+
+```text
+Sifr calls Python.
+Python may run threads, event loops, async code, native kernels, or callbacks internally.
+Sifr waits until Python returns control.
+```
+
+Rules:
+
+- Every Python call is classified as `foreign_blocking`.
+- Direct Python calls in async Sifr code are compile-time errors unless explicitly offloaded.
+- `py.blocking` or the existing task offload primitive must run Python work in a blocking-safe region.
+- `py.Object` values cannot cross async task/thread boundaries by default.
+- Python cancellation is cooperative only. Sifr cannot safely kill embedded Python execution mid-call.
+- `py.run_coroutine_blocking` is allowed only as an explicitly blocking operation and should run the coroutine using Python-owned event-loop mechanics.
+
+## Resource Cleanup
+
+Python resource cleanup must be explicit and ergonomic.
+
+Supported cleanup APIs:
+
+```sifr
+try py.close(obj)
+try py.call_method(obj, "close", [])
+try py.with(obj, lambda entered: ...)
+try py.run_coroutine_blocking(try py.call_attr(obj, "aclose", []))
+try callback.close()
+try buffer.release()
+```
+
+Rules:
+
+- Do not rely on Python `__del__` for correctness.
+- Context-manager helpers must call `__enter__` and `__exit__` and preserve Python traceback on failure.
+- Async context managers require a Python wrapper or explicit `py.run_coroutine_blocking`.
+- Callback handles, buffer views, Arrow capsules, and DLPack capsules are resource handles with deterministic close/release semantics.
+- Double close/release is either idempotent by design or reports a deterministic resource-state error; the decision must be documented per resource type.
+
+## Zero-Copy Data Interchange
+
+Zero-copy support is required in this phase.
+
+Sifr exposes two families:
+
+```sifr
+try py.zero_copy_as[T](obj)  # rejects if zero-copy cannot be proven
+try py.copy_as[T](obj)       # explicit copy
+```
+
+Rules:
+
+- Zero-copy APIs never silently copy.
+- Copying APIs never claim view semantics.
+- Every view tracks the Python owner/resource needed to keep memory valid.
+- Writable views require both Python exporter writeability and Sifr-side exclusivity/borrow rules.
+- Non-contiguous data is represented with strides when the target type supports strides; contiguity-required targets reject non-contiguous sources.
+
+### `Py_buffer`
+
+Used for:
+
+- bytes-like objects;
+- `memoryview`;
+- NumPy arrays;
+- psycopg/pymongo/aio buffers;
+- Pillow/aiokafka buffers;
+- general CPython buffer protocol producers.
+
+`py.BufferView[T]` owns:
+
+- exporter owner object;
+- `Py_buffer`;
+- pointer;
+- length;
+- readonly flag;
+- item size;
+- PEP 3118 format string;
+- ndim;
+- shape;
+- strides;
+- suboffsets;
+- contiguity class;
+- requested flags.
+
+Drop/release must call `PyBuffer_Release` exactly once while holding the GIL.
+
+### Arrow PyCapsule
+
+Used for:
+
+- pyarrow;
+- polars;
+- pandas Arrow export;
+- Pillow Arrow images;
+- dataframe/columnar interop.
+
+Supported protocols:
+
+- `__arrow_c_array__`;
+- `__arrow_c_stream__`;
+- `__arrow_c_schema__`.
+
+Rules:
+
+- Validate capsule names: `arrow_array`, `arrow_array_stream`, `arrow_schema`.
+- Preserve capsule ownership and release callbacks.
+- Distinguish real zero-copy exports from conversions that may copy.
+- pandas Arrow export may copy through pyarrow; Sifr must not label it zero-copy unless the producer path proves that.
+- Polars Arrow stream export is the preferred dataframe zero-copy target.
+
+### DLPack
+
+Used for:
+
+- torch;
+- tensorflow;
+- NumPy DLPack support;
+- future tensor libraries.
+
+Rules:
+
+- DLPack capsules are one-shot. Mark consumed capsules and reject double consumption.
+- Track dtype, shape, strides, device, byte offset, deleter, and stream/device synchronization requirements.
+- Handle CPU and device tensors explicitly.
+- Reject unsupported DLPack dtypes/devices with typed errors.
+- Do not hide synchronization/copy requirements behind a zero-copy API.
+
+### Array Interface
+
+Support `__array_interface__`, `__array_struct__`, and `__cuda_array_interface__` as compatibility paths only.
+
+Rules:
+
+- Retain the owner object.
+- Validate pointer, dtype, shape, strides, readonly flag, version, and device metadata.
+- Reject malformed or unsupported metadata.
+- Prefer `Py_buffer`, Arrow, or DLPack when available.
+
+## Python-to-Sifr Callbacks
+
+Callbacks are first-class and explicitly resource-managed.
+
+Two callback kinds:
+
+```sifr
+py.LocalCallback
+py.ThreadsafeCallback
+```
+
+`py.LocalCallback`:
+
+- valid only during the active Sifr-to-Python call;
+- same-thread/same-stack reentry only;
+- may borrow scoped Sifr values;
+- cannot be stored by Python beyond the active call;
+- runtime detects escape attempts when possible and reports deterministic errors.
+
+`py.ThreadsafeCallback`:
+
+- may be called later;
+- may be called from Python-created threads, native extension callback threads, thread pools, or event-loop schedulers;
+- must own or clone captured state;
+- requires Send-like Sifr constraints on captured values;
+- is registered in a runtime callback registry;
+- has explicit `close`/`cancel`;
+- converts Sifr errors into Python exceptions;
+- converts Python callback-dispatch failures back into Sifr `Result` when control returns.
+
+Required package patterns:
+
+- confluent-kafka polling and background-thread callbacks;
+- Google Pub/Sub scheduler thread-pool callbacks;
+- CFFI callbacks;
+- Pika message callbacks;
+- Python code invoking Sifr handlers while Sifr is blocked in Python;
+- async client callback schedulers that call user handlers from Python-managed event loops.
+
+## Native Extension Trust Boundary
+
+Many supported Python packages load native code:
+
+- NumPy, pandas, scipy, pyarrow, torch, tensorflow, scikit-learn, xgboost;
+- cryptography, cffi, grpcio, google-crc32c, lxml, pydantic-core, tiktoken, uvloop, httptools, hiredis, fastavro, ujson, psutil;
+- psycopg, psycopg2, pymongo, Pillow, confluent-kafka, aiokafka extensions.
+
+Rules:
+
+- Native Python extensions are trusted in-process code.
+- Sifr cannot sandbox native extensions in embedded mode.
+- Native crashes can terminate the process.
+- Native extensions may release the GIL.
+- Native extensions may create background threads.
+- Native extensions may call back into Python/Sifr from non-Sifr threads.
+- Trust diagnostics must name the import root, extension module, selected interpreter, extension suffix, and load error.
+
+## Package Certification Matrix
+
+Sifr should support any CPython-compatible package installed in the selected uv environment. Certification is a verification promise for representative package surfaces, not a package whitelist.
+
+### Tier 1: Interop Certification Gate
+
+Core runtime/package loading:
+
+- `pip`, `setuptools`, `wheel`, `build`, `hatchling`, `poetry-core`, `uv-build`, `pyproject-hooks`, `packaging`, `pkginfo`, `importlib-metadata`, `zipp`, `platformdirs`, `appdirs`, `typing-extensions`, `exceptiongroup`.
+
+Data validation/structured objects:
+
+- `pydantic`, `pydantic-core`, `pydantic-extra-types`, `annotated-types`, `attrs`, `marshmallow`, `cerberus`, `jsonpickle`, `deepdiff`, `protobuf`, `proto-plus`, `pyyaml`, `toml`, `tomli`, `python-dotenv`.
+
+HTTP/async/networking:
+
+- `requests`, `urllib3`, `httpx`, `httpcore`, `aiohttp`, `anyio`, `async-timeout`, `sniffio`, `h11`, `httptools`, `websockets`, `uvicorn`, `uvloop`.
+
+Web frameworks:
+
+- `fastapi`, `starlette`, `starlette-context`, `django`, `sanic`, `sanic-routing`, `sanic-testing`, `webargs`, `webargs-sanic`, `jinja2`, `markupsafe`, `python-multipart`.
+
+Databases/queues/brokers:
+
+- `sqlalchemy`, `sqlalchemy-utils`, `alembic`, `psycopg`, `psycopg2`, `psycopg2-binary`, `asyncpg`, `pymongo`, `motor`, `mongoengine`, `redis`, `fakeredis`, `hiredis`, `valkey`, `aiokafka`, `confluent-kafka`, `kafka-python`, `python-schema-registry-client`.
+
+Cloud/AI clients:
+
+- `openai`, `google-genai`, `google-api-core`, `google-api-python-client`, `google-auth`, `google-auth-httplib2`, `google-auth-oauthlib`, `google-cloud-core`, `google-cloud-storage`, `google-cloud-firestore`, `google-cloud-aiplatform`, `firebase-admin`, `kubernetes`, `pinecone-client`, `gspread`, `gspread-asyncio`.
+
+Security/crypto/native loading:
+
+- `cryptography`, `cffi`, `pycparser`, `certifi`, `idna`, `charset-normalizer`, `chardet`, `oauthlib`, `requests-oauthlib`, `python-jose`, `rsa`, `pyasn1`, `pyasn1-modules`.
+
+Data/binary/parser:
+
+- `pandas`, `pyarrow`, `openpyxl`, `lxml`, `bleach`, `defusedxml`, `nh3`, `regex`, `ujson`, `fastavro`, `avro`, `avro-python3`, `google-crc32c`, `tiktoken`.
+
+Observability/production infra:
+
+- `opentelemetry-api`, `opentelemetry-semantic-conventions`, `opentracing`, `sentry-sdk`, `sentry-asgi`, `datadog`, `structlog`, `logstash-formatter`.
+
+Domain examples:
+
+- `biip`, `schwifty`, `pycountry`, `babel`, `holidays`, `dateparser`, `pendulum`, `python-dateutil`, `pytz`, `tzdata`, `uuid-utils`, `rank-bm25`.
+
+### Tier 2: Broad Smoke Gate
+
+- `click`, `typer`, `rich`, `pygments`, `tqdm`, `colorama`, `decorator`, `deprecated`, `backoff`, `backoff-utils`, `tenacity`, `ratelimit`, `cachetools`, `cachecontrol`, `aiocache`, `aiofiles`, `asgi-lifespan`, `basicauth`, `faker`, `freezegun`, `time-machine`, `testfixtures`, `responses`, `requests-mock`, `pytest-httpx`, `sortedcontainers`, `more-itertools`, `inflect`, `text-unidecode`, `python-slugify`, `pyhumps`, `parse`, `docopt`, `argh`, `commonmark`, `markdown`, `markdown-it-py`, `mdurl`, `pymdown-extensions`, `docutils`, `readme-renderer`, `rfc3986`, `uritemplate`, `webencodings`, `wrapt`, `wcwidth`.
+
+### Tier 3: Dev/Tooling Compatibility Gate
+
+- `pytest`, `pytest-asyncio`, `pytest-bdd`, `pytest-cov`, `pytest-mock`, `pytest-env`, `pytest-freezegun`, `pytest-redis`, `pytest-postgresql`, `pytest-pgsql`, `pytest-sugar`, `coverage`, `tox`, `pre-commit`, `black`, `flake8`, `flake8-black`, `flake8-isort`, `flake8-eradicate`, `flake8-pyprojecttoml`, `isort`, `mypy`, `mypy-extensions`, `pycodestyle`, `pyflakes`, `mccabe`, `bandit`, `eradicate`, `yapf`, `reno`, `sphinx`, `mkdocs`, `mkdocs-material`, `mkdocs-material-extensions`, `ghp-import`, `twine`, `pep517`, `setuptools-scm`, `cython`.
+
+### Tier 4: Host-Dependent Compatibility Gate
+
+- `gunicorn`, `uvicorn-worker`, `testcontainers`, `pyngrok`, `wmctrl`, `watchdog`, `psutil`, `pexpect`, `ptyprocess`, `sh`, `keyring`, `secretstorage`, `jeepney`, `keyrings-google-artifactregistry-auth`, `ipython`, `ipykernel`, `ipdb`, `pdbpp`, `pdbp`, `pdbr`, `fancycompleter`, `jedi`, `parso`, `prompt-toolkit`, `pyrepl`, `asttokens`, `executing`, `pure-eval`, `stack-data`, `traitlets`.
+
+### Version-Conditional/Static Typing Artifacts
+
+These should install/import when applicable but do not need special runtime certification unless dependency resolution pulls them into a tested environment:
+
+- `enum34`, `typing`, `funcsigs`, `aiocontextvars`, `backports-tarfile`, `types-*`, `pandas-stubs`.
+
+## Verification Area
+
+Create a dedicated verification area:
+
+```text
+verification/python_interop/
+  README.md
+  pyproject.toml
+  uv.lock
+  packages/
+    tier1.toml
+    tier2.toml
+    tier3.toml
+    tier4.toml
+    native.toml
+    async.toml
+    data.toml
+    cloud.toml
+    brokers.toml
+  fixtures/
+    simple_import/
+    primitive_conversion/
+    pydantic_models/
+    async_http/
+    fastapi_app/
+    sqlalchemy_psycopg/
+    redis/
+    kafka/
+    pubsub/
+    pandas_arrow/
+    polars_arrow/
+    pyarrow_capsule/
+    numpy_buffer/
+    torch_dlpack/
+    tensorflow_dlpack/
+    cffi_callback/
+    cryptography_tls/
+    resource_cleanup/
+  runner/
+    run.py
+    env.py
+    import_matrix.py
+    smoke_matrix.py
+    native_probe.py
+    callback_probe.py
+    zero_copy_probe.py
+    resource_probe.py
+    report.py
+  reports/
+    .gitkeep
+```
+
+Verification groups:
+
+- `env`: interpreter, venv, ABI, platform, lock/env freshness.
+- `imports`: root imports and native extension load diagnostics.
+- `native`: trusted native Python package load/use smoke.
+- `async`: Python event-loop/client behavior under Sifr blocking semantics.
+- `callbacks`: local and threadsafe callback behavior.
+- `buffers`: `Py_buffer` ownership, contiguity, readonly/writable, dtype/format.
+- `arrow`: Arrow PyCapsule schema/array/stream, zero-copy-vs-copy diagnostics.
+- `dlpack`: one-shot tensor capsules, dtype/device/stride handling.
+- `dataframes`: pandas/polars/pyarrow dataframe interop.
+- `tensors`: NumPy/torch/tensorflow tensor interop.
+- `databases`: SQLAlchemy, psycopg, asyncpg, pymongo, motor, redis.
+- `brokers`: confluent-kafka, aiokafka, kafka-python, Pub/Sub-style callbacks.
+- `cloud`: Google/Azure/AWS/client auth/import surfaces without requiring live credentials in the default gate.
+- `web`: FastAPI/Starlette/Django/Sanic import and in-process smoke fixtures.
+- `cleanup`: close/context-manager/callback release/leak diagnostics.
+
+Runner shape:
+
+```bash
+verification/python_interop/run.sh --group env
+verification/python_interop/run.sh --tier tier1
+verification/python_interop/run.sh --group native
+verification/python_interop/run.sh --group data
+verification/python_interop/run.sh --package pandas
+```
+
+Validation profiles:
+
+- Fast gate: environment probe, core embedded runtime, pure imports, pydantic/httpx/cryptography/cffi/pandas/pyarrow smoke.
+- Full Python interop gate: all Tier 1 packages, native extension probes, zero-copy checks, callback/threading checks, local service-backed tests.
+- External integration gate: Kafka, Postgres, Redis, cloud SDK auth, Pub/Sub/SQS/SNS, RabbitMQ, and other service-backed tests.
+
+## Milestones
+
+Milestones are delivery order only. They do not reduce the design scope.
+
+### milestone_py_0: Planning Lock and Verification Scaffold
+
+Scope:
+- Land this full phase contract.
+- Create `verification/python_interop/` scaffold and package matrix files.
+- Define diagnostic families for Python environment/import/call/conversion/resource/zero-copy errors.
+- Record package certification policy and host-dependent test policy.
+
+Definition of done:
+- Phase design is reviewed and accepted.
+- Verification area exists with documented runner contract and empty/initial package matrices.
+- No implementation milestone may start until this phase contract is linked from roadmap/index docs.
+
+### milestone_py_1: Environment Discovery and Probe
+
+Scope:
+- Add Python config parsing for root packages and library package `requires-imports`.
+- Implement selected interpreter discovery and canonical probe JSON.
+- Validate CPython, `.venv`, site-packages, ABI, extension suffix, pointer width, platform, lock/env digests, and declared root imports.
+- Reject unsupported interpreters, missing envs, stale envs, missing imports, native load failures, free-threaded CPython, and multiple venv selections.
+
+Definition of done:
+- Positive and negative fixtures cover every validation rule.
+- Probe output is deterministic and part of build cache keys.
+- Sifr never runs uv implicitly.
+
+### milestone_py_2: Embedded Runtime Lifecycle
+
+Scope:
+- Add optional Python runtime feature and generated build metadata.
+- Initialize CPython once with selected environment configuration.
+- Implement GIL attach/detach discipline and owned `py.Object` refcount management.
+- Add runtime diagnostics for reinitialization with a different environment and outstanding resource tracking.
+
+Definition of done:
+- Runtime lifecycle tests cover init, repeated init with same config, rejected conflicting init, GIL-bound destruction, and shutdown diagnostics.
+- No user-triggerable panic paths exist.
+
+### milestone_py_3: Opaque Object Operations and Errors
+
+Scope:
+- Implement `py.import_module`, attribute/item access, calls, kwargs, and explicit close/context-manager helpers.
+- Add structured `py.PythonError` families with traceback capture.
+- Enforce `Result` handling in lowering/type checking.
+- Keep `py.Object` distinct from `Any`.
+
+Definition of done:
+- Positive fixtures cover import, attr, item, call, kwargs, close, and context manager behavior.
+- Negative fixtures cover import failure, attr failure, call failure, wrong args, conversion failure, and unhandled `Result`.
+
+### milestone_py_4: Primitive and Typed Conversion
+
+Scope:
+- Implement conservative conversions for `None`, bool, exact int, fixed-width checked ints, float, str, bytes.
+- Implement explicit typed conversions for lists, tuples, dicts, and records.
+- Preserve path-rich diagnostics for nested conversion failures.
+
+Definition of done:
+- Deep conversion is never implicit.
+- Fixed-width conversion overflow/underflow is rejected with typed diagnostics.
+- Large containers are not copied unless an explicit conversion requests copying.
+
+### milestone_py_5: Async/Blocking Integration
+
+Scope:
+- Classify Python calls as `foreign_blocking`.
+- Reject direct Python calls in async Sifr code unless offloaded.
+- Implement `py.blocking` or integrate with the existing blocking task primitive.
+- Implement `py.run_coroutine_blocking` as an explicitly blocking operation.
+- Enforce non-Send default behavior for `py.Object`.
+
+Definition of done:
+- Async negative fixtures catch direct Python calls, object crossing, and unclassified blocking.
+- Positive fixtures cover offloaded Python calls and Python-owned event loops returning results to Sifr.
+
+### milestone_py_6: Resource Cleanup and Leak Diagnostics
+
+Scope:
+- Implement `py.close`, `py.with`, callback close, buffer release, Arrow/DLPack release tracking, and leak diagnostics.
+- Define idempotence/error behavior for double close/release per resource.
+
+Definition of done:
+- Fixtures cover close success/failure, context manager success/failure, callback closure, buffer release, double release, and outstanding-resource diagnostics.
+
+### milestone_py_7: `Py_buffer` Zero-Copy Core
+
+Scope:
+- Implement `py.BufferView[T]` using `PyObject_GetBuffer` and `PyBuffer_Release`.
+- Track owner, pointer, length, readonly, itemsize, format, ndim, shape, strides, suboffsets, and contiguity.
+- Implement `zero_copy_as` vs `copy_as` behavior for buffer producers.
+
+Definition of done:
+- Positive fixtures cover bytes-like, memoryview, NumPy, psycopg/mongo-style buffers, and readonly views.
+- Negative fixtures cover unsupported format, wrong dtype, non-contiguous target, writable request on readonly data, and use-after-release prevention.
+
+### milestone_py_8: Arrow PyCapsule Interop
+
+Scope:
+- Support `__arrow_c_array__`, `__arrow_c_stream__`, and `__arrow_c_schema__`.
+- Validate capsule names and release callbacks.
+- Distinguish zero-copy export from conversion paths that may copy.
+- Cover pyarrow, polars, pandas, and Pillow Arrow paths.
+
+Definition of done:
+- Polars and pyarrow zero-copy paths are verified.
+- pandas paths are marked copy-possible unless proven otherwise.
+- Malformed capsule and double-release paths are rejected deterministically.
+
+### milestone_py_9: DLPack Tensor Interop
+
+Scope:
+- Support DLPack capsule import/export and one-shot consumption semantics.
+- Track dtype, shape, strides, device, byte offset, deleter, and stream/device sync requirements.
+- Cover NumPy, torch, and tensorflow paths.
+
+Definition of done:
+- Positive fixtures cover CPU tensors and supported dtypes.
+- Negative fixtures cover double consumption, unsupported dtype, unsupported device, invalid capsule name, and sync/copy-required rejection in zero-copy APIs.
+
+### milestone_py_10: Python-to-Sifr Callbacks
+
+Scope:
+- Implement `py.LocalCallback` and `py.ThreadsafeCallback`.
+- Add runtime callback registry, close/cancel, reentrancy tracking, and callback error conversion.
+- Support Python callback invocation from same-stack calls, Python background threads, native extension callback threads, and Python scheduler/thread-pool callbacks.
+
+Definition of done:
+- Fixtures cover local callback success, local callback escape rejection, threadsafe callback success, callback close, callback after close, captured-state constraints, and Python exception mapping.
+- Kafka/PubSub/CFFI-style callback examples pass.
+
+### milestone_py_11: Package Certification Matrix
+
+Scope:
+- Implement Tier 1 certification fixtures and Tier 2/Tier 3 smoke gates.
+- Add host-dependent Tier 4 policy and skip/evidence format.
+- Add representative app fixtures combining web, data, DB, broker, cloud/AI, and observability clients.
+
+Definition of done:
+- Tier 1 package certification is green in the full Python interop gate.
+- Tier 2/Tier 3 smoke gates are deterministic.
+- Host-dependent skips are explicit and reported.
+
+### milestone_py_12: Documentation, Diagnostics, and Closeout
+
+Scope:
+- Publish public docs for Python interop configuration, trust, runtime semantics, error handling, blocking/offload, callbacks, resources, and zero-copy.
+- Publish internal architecture docs for runtime lifecycle, GIL/refcount ownership, environment probes, and verification gates.
+- Add final examples for biip/schwifty, FastAPI, Kafka, pandas/pyarrow/polars, torch/tensorflow DLPack, and cloud/AI clients.
+
+Definition of done:
+- Docs match implemented semantics exactly.
+- Every diagnostic has stable code, URL, structured JSON fields, and positive/negative tests.
+- Phase exit gate evidence is recorded.
+
+## Quality Contract
+
+Entry criteria:
+
+- Existing local validation gates remain green before implementation starts.
+- Phase 27 non-regression baseline is green.
+- Python phase contract is linked from phase index and roadmap docs.
+
+Global invariants:
+
+- No user-triggerable compiler or runtime panics.
+- No data-dependent emitted `.unwrap()`, `.expect()`, or `panic!` in user runtime paths.
+- Python errors are `Result` values with structured diagnostics.
+- Python calls in async Sifr code require explicit blocking/offload.
+- `py.Object` is not `Any` and is not `Send` by default.
+- Zero-copy APIs never silently copy.
+- Native Python extension trust is explicit.
+- uv remains the Python package manager; Sifr verifies and consumes the environment.
+- All behavior is deterministic except explicitly host/service-dependent gates, which must report structured skip/evidence.
+
+Validation requirements:
+
+- Every milestone must include at least one positive-path and one negative-path fixture mapped to its definition of done.
+- Every resource-owning milestone must include leak/double-release/error-path tests.
+- Every data-interchange milestone must include copy-vs-zero-copy tests.
+- Every callback milestone must include callback-after-close and cross-thread behavior tests.
+- Every package-certification milestone must update verification reports.
+
+Local validation before PRs:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
+cargo test -p sifr -- --skip test_e2e_pass
+scripts/check_hir_maintainability_guardrails.py
+scripts/run_all_tests.sh --profile create-pr
+```
+
+Python interop gates, once implemented:
+
+```bash
+verification/python_interop/run.sh --group env
+verification/python_interop/run.sh --tier tier1
+verification/python_interop/run.sh --group native
+verification/python_interop/run.sh --group data
+verification/python_interop/run.sh --group callbacks
+```
+
+## Exit Gate
+
+- Embedded Python interop is usable end-to-end from Sifr with a uv-created `.venv`.
+- Root app environment ownership, trust, and probing are enforced.
+- CPython lifecycle, GIL/refcount handling, and resource cleanup are deterministic.
+- `py.Object` operations are opaque, fallible, non-`Any`, and non-Send by default.
+- Python calls obey foreign-blocking/offload rules.
+- Python-to-Sifr callbacks support local and threadsafe modes.
+- `Py_buffer`, Arrow PyCapsule, DLPack, and strict array-interface paths are implemented with no silent zero-copy fallback to copying.
+- Tier 1 package certification passes in the full Python interop gate.
+- Verification reports exist under `verification/python_interop/reports/`.
+- Public and internal docs describe the exact production contract.
+- Phase 27 non-regression contract remains green.

--- a/plans/phases/index.md
+++ b/plans/phases/index.md
@@ -50,3 +50,4 @@ Phase status remains authoritative in each phase file header and is mirrored her
 | 41 | Phase 41: Web Framework and Platform Expansion | unspecified | [41_web_framework_and_platform_expansion.md](./41_web_framework_and_platform_expansion.md) |
 | 42 | Phase 42: Data Science and ML | unspecified | [42_data_science_ml.md](./42_data_science_ml.md) |
 | 43 | Phase 43: Interoperability | unspecified | [43_interoperability.md](./43_interoperability.md) |
+| 43.1 | Ad Hoc Embedded Python Interop | draft | [../issues/active/ad-hoc-embedded-python-interop.md](../issues/active/ad-hoc-embedded-python-interop.md) |

--- a/plans/phases/index.md
+++ b/plans/phases/index.md
@@ -50,4 +50,4 @@ Phase status remains authoritative in each phase file header and is mirrored her
 | 41 | Phase 41: Web Framework and Platform Expansion | unspecified | [41_web_framework_and_platform_expansion.md](./41_web_framework_and_platform_expansion.md) |
 | 42 | Phase 42: Data Science and ML | unspecified | [42_data_science_ml.md](./42_data_science_ml.md) |
 | 43 | Phase 43: Interoperability | unspecified | [43_interoperability.md](./43_interoperability.md) |
-| 43.1 | Ad Hoc Embedded Python Interop | draft | [../issues/active/ad-hoc-embedded-python-interop.md](../issues/active/ad-hoc-embedded-python-interop.md) |
+| PY-1 | Ad Hoc Embedded Python Interop | draft, sequence-independent | [../issues/active/ad-hoc-embedded-python-interop.md](../issues/active/ad-hoc-embedded-python-interop.md) |

--- a/plans/reviews/active/embedded-python-interop-implementation-readiness-review-10.md
+++ b/plans/reviews/active/embedded-python-interop-implementation-readiness-review-10.md
@@ -1,0 +1,58 @@
+I read the round-10 file and rounds 1–9. Rounds 5–9 all closed with "ready," and round 10's primary file is 899/900 lines. As an implementation owner about to assign engineers, three real gaps and one wording bullet still stand out — small but enough to cause divergent interpretations.
+
+## 1. Blocking implementation-readiness gaps
+
+**(a) Sifr→Python argument conversion is unspecified.** Conversion Rules (lines 301–323) and the table at lines 305–314 cover Python→Sifr only. But the canonical example at line 247 — `py.call_attr(torch, "tensor", [[1.0, 2.0], [3.0, 4.0]], [])` — assumes Sifr→Python conversion for nested literal arg lists. milestone_py_3 (call surface) and milestone_py_4 (conversion) have ambiguous ownership of this rule today.
+
+Concrete replacement, added as a paragraph at the end of "Conversion Rules" (~line 323):
+
+> Sifr-to-Python argument conversion is the symmetric contract. `None`, bool, exact `int`, fixed-width Sifr integers (checked into Python `int`), float, str, bytes, and existing `py.Object` handles are accepted as call arguments and `kwargs`. Sifr lists, tuples, dicts, and records are not implicitly converted; the caller must construct the corresponding `py.Object` via the explicit Python interop API. Fixed-width integer overflow into the target Python type is a `py.TypeConversionError`.
+
+**(b) `PyValue` variants are a placeholder.** Line 184 has `pub enum PyValue;` with no variants, yet `PyValue` is the entire argument-passing universe (lines 196, 197). Engineers implementing milestone_py_3 cannot cleanly define `call` / `getitem` without knowing what values may be packed.
+
+Concrete replacement at line 184:
+
+> ```rust
+>     pub enum PyValue {
+>         None_, Bool(bool), IntExact(i128), IntFixed(IntFixedWidth),
+>         Float(f64), Str(&'a str), Bytes(&'a [u8]), Object(&'a PyObjectHandle),
+>     }
+> ```
+
+**(c) Trust enforcement has no milestone owner.** Lines 92–94 specify the HIR-static trust check, the `@trust_python_dynamic` annotation, the runtime root check on resolved dynamic imports, and the wildcard publish/load rejection. No milestone scope claims any of these. milestone_py_1 only validates the probe; milestone_py_3 implements `import_module` operationally but doesn't mention gating.
+
+Concrete replacement, adding one line to milestone_py_3 Scope (after line 729):
+
+> - Enforce `allow-imports` and `[trust] python` / `[trust] python-native` at HIR for static import strings, reject wildcards at package publish/check and package-graph load, and gate `@trust_python_dynamic` resolved roots at runtime; emit `SIFR-PYTRUST` diagnostics.
+
+## 2. Deferral/optionality wording in conflict with self-contained scope
+
+**Lines 273–280 ("Future syntax sugar may exist…").** This block leaves the `import python torch` surface neither in nor out of this phase — the "may exist" is exactly the optionality the no-backward-compat / no-deferral policy at line 43 forbids. Round-9 didn't flag it; under round-10's stricter lens it conflicts.
+
+Concrete replacement of lines 273–280 (8 lines) with a single decisive line:
+
+> This phase does not introduce `import python <name>` syntax sugar; the explicit `py.*` operations above are the only user-facing surface. Any later sugar must be designed in its own phase and is not part of this contract.
+
+(Minor secondary polish, not blocking: "until a future audited phase explicitly enables it" at line 53 and "unless an explicit future audit enables it" at line 128 leak the same shape; tightening to "in this phase" matches the no-deferral framing but isn't required.)
+
+## 3. Milestone sequencing gaps
+
+One real sequencing gap: trust enforcement (1c above) currently has no DoD bullet anywhere. Adding it to milestone_py_3 scope (and an accompanying DoD bullet — "Static and dynamic trust gating fixtures cover allow-imports, trust.python, trust.python-native, wildcard rejection, and `@trust_python_dynamic` runtime root check") makes the gate exhaustive.
+
+Everything else sequences correctly: py_0 → py_1 (probe) → py_2 (runtime) → py_3 (ops + trust gating) → py_4 (conversion both directions) → py_5–10 → py_11 (Tier 1 gate) → py_12 (docs/closeout). py_11 transitively requires py_1–py_10, which is what the phase says.
+
+## 4. Smallest edit set (line-neutral overall)
+
+| Edit | Location | Net lines |
+|---|---|---|
+| Replace "Future syntax sugar" block with one decisive line | Lines 273–280 | −7 |
+| Add Sifr→Python conversion paragraph | After line 323 | +3 |
+| Replace `pub enum PyValue;` placeholder with sketched variants | Line 184 | +3 |
+| Add HIR trust + `@trust_python_dynamic` + wildcard gate bullet | milestone_py_3 Scope (after line 729) | +1 |
+| Add a matching DoD bullet for the trust gate | milestone_py_3 DoD (after line 734) | +1 |
+
+Total: **+1 line → 900**, still at the cap. To buy headroom, also trim the two "until a future audited phase" clauses (lines 53, 128) to remove "until a future audited phase explicitly enables it" / "unless an explicit future audit enables it" — that gives back 1–2 lines and aligns the wording with the no-deferral policy.
+
+## 5. Verdict
+
+Not quite ready as-is. The three gaps in §1 plus the §2 wording would cause two engineers to ship divergent implementations of the call surface, the trust gate, and the import-sugar story. With the §4 edits applied (≤5 small touches, net ≤+1 line), the phase is implementation-ready, self-contained, and elegant.

--- a/plans/reviews/active/embedded-python-interop-implementation-readiness-review-11.md
+++ b/plans/reviews/active/embedded-python-interop-implementation-readiness-review-11.md
@@ -1,0 +1,45 @@
+I read the current plan (895 lines, under the 900 cap) and the round-10 review. Here's the round-11 readout.
+
+## 1. Round-10 blocking gaps — resolved?
+
+| Round-10 gap | Status |
+|---|---|
+| Sifr→Python argument conversion rule (Conversion Rules) | ✅ Added as a bullet at line 316. Covers `None`/bool/int/float/str/bytes/`py.Object`, rejects implicit container conversion, routes overflow to `py.TypeConversionError`. |
+| Trust enforcement owner & DoD | ✅ milestone_py_3 scope (line 724) + DoD fixtures bullet (line 730). |
+| `import python <name>` future-sugar block deleted | ✅ Replaced with single decisive line at 273. |
+| Free-threaded CPython language | ✅ Both line 52 (Non-Goals) and line 130 (probe validation) are clean — no deferral language left. |
+| `PyValue` placeholder | ⚠️ Variants added at line 184, but introduced one new minor ambiguity — see §2. |
+
+## 2. New ambiguity from the PyValue/conversion wording
+
+One small issue worth fixing before commit:
+
+**Line 184:** `pub enum PyValue<'a> { None_, Bool(bool), Int(PyInt), Float(f64), Str(&'a str), Bytes(&'a [u8]), Object(&'a PyObjectHandle) }`
+
+- `PyInt` is not defined anywhere else in the document (grep confirms zero other references). The Conversion Rules at lines 300–301 distinguish "exact `int`" from "fixed-width `py.to[int32]` etc.", so a single `Int(PyInt)` collapses a distinction the contract makes elsewhere. An implementer reading this cold cannot tell whether `PyInt` is arb-precision, fixed-width, or a sum of both.
+
+Smallest fix (line-neutral): split into the two variants the contract already commits to —
+
+```rust
+Int(i128), IntFixed(PyIntFixedWidth),
+```
+
+Or, keep `Int(PyInt)` and add one sentence below the block defining `PyInt` as "an internal packer that holds either an exact Python `int` or a checked fixed-width Sifr integer." The two-variant form is cleaner because it mirrors the conversion contract directly.
+
+Minor, non-blocking: the enum is declared `PyValue<'a>` but the function signatures at lines 197–198 use bare `PyValue` (readers can infer the elided lifetime). And the new argument-conversion bullet at line 316 says "call arguments" without naming `kwargs` — but `kwargs: &[(&str, PyValue)]` on line 198 transitively binds the same rule, so this reads fine.
+
+## 3. Trust enforcement — right milestone & DoD?
+
+Yes. milestone_py_3 owns both static HIR enforcement and the runtime `@trust_python_dynamic` root check, with `SIFR-PYTRUST` diagnostics, and DoD fixtures cover static imports, dynamic imports, native roots, wildcard rejection, and package-graph load failures. Optional polish: the DoD bullet says "dynamic imports" — could be tightened to "`@trust_python_dynamic` runtime root check" to mirror the scope phrase exactly, but not required.
+
+## 4. Remaining blockers under no-fallback/no-deferral
+
+The PyInt clarification in §2 is the only outstanding item. Everything else surveys clean:
+
+- `grep -i "future\|may exist\|deferred\|TBD"` — the only "future" hit is "future tensor libraries" at line 461 describing DLPack's reach (descriptive, not a deferral).
+- All `fallback` mentions are policy constraints ("no fallback allowed"), not escape hatches.
+- No "audited future phase" / "until a future audit" remnants.
+
+## 5. Verdict
+
+Almost ready — one small definitional touch on `PyInt` (line 184) is the only thing standing between the current draft and commit-ready. With that fix, the phase is implementation-ready, self-contained, and aligned with the no-fallback / no-deferral policy. **Not yet ready to commit — apply the PyInt clarification first.**

--- a/plans/reviews/active/embedded-python-interop-implementation-readiness-review-12.md
+++ b/plans/reviews/active/embedded-python-interop-implementation-readiness-review-12.md
@@ -1,0 +1,9 @@
+Read line 184 (the updated `PyValue` enum) and line 316 (the Sifr-to-Python arguments paragraph).
+
+1. **Resolved.** `IntExact(SifrExactInt)` and `IntFixed(SifrFixedInt)` cleanly remove the `PyInt` placeholder and mirror the established Python-to-Sifr terminology in the Conversion Rules table (line 301: "exact `int`" vs "fixed-width `py.to[int32]`/etc."). The two integer flavors are now explicit on both directions of the boundary. No new implementation ambiguity — `SifrExactInt`/`SifrFixedInt` are recognizable references to the Sifr integer kinds already named in this phase, and this is the conceptual runtime surface (line 169), not the final type signature.
+
+2. **Yes.** The phase is implementation-ready and self-contained: lines 11–25 enumerate the contracts this phase owns without deferring, lines 43–45 forbid fallback/legacy/degraded modes, lines 850 and 891 reassert no silent zero-copy fallback, and the milestone DoDs each carry positive + negative fixtures with explicit gates. Trust, blocking, callbacks, zero-copy, cleanup, and certification all have binding rules plus a concrete verification surface.
+
+3. None required.
+
+4. **Ready to commit.**

--- a/plans/reviews/active/embedded-python-interop-review-1.md
+++ b/plans/reviews/active/embedded-python-interop-review-1.md
@@ -1,0 +1,143 @@
+The review file exists but is empty. Here is my review of the phase contract.
+
+# Review: Ad Hoc Embedded Python Interop
+
+## 1. Blocking design issues
+
+### B1. `foreign_blocking` contradicts the already-merged async classification taxonomy
+Phase 32.1 sealed the async-effect-and-offload contract using `@blocking_io` and `@cpu_heavy` as the *only* valid annotations to authorize a direct blocking call inside async Sifr (`plans/roadmap.md:59`). This phase introduces a third classification keyword, `foreign_blocking`, used both in the Core Decisions (line 38) and the operation lowering table (line 278). Either:
+- `foreign_blocking` is a new synonym, in which case it must be added to the Phase 32.1 taxonomy explicitly (and that's a Phase 32.1 amendment, not self-contained); or
+- Python calls reuse `@blocking_io` (the natural fit), in which case all `foreign_blocking` mentions should be deleted.
+
+As written the document is **incoherent with already-merged async semantics**. Pick one and propagate.
+
+### B2. The `py.blocking` vs offload primitive choice is left open
+Lines 343–344 say "`py.blocking` or the existing task offload primitive must run Python work in a blocking-safe region." Milestone_py_5 (line 750) repeats the same disjunction. A production-grade design contract cannot ship with "or". The async substrate (Ad Hoc 36.4) and Phase 32.1 already provide the offload primitive — commit to it. Introducing a Python-only `py.blocking` wrapper duplicates effect tracking and creates two places where the rule "Python calls require blocking offload in async" can be expressed and disagree.
+
+Recommendation: drop `py.blocking`, declare that the Sifr runtime treats every `py.*` call as `@blocking_io`, and require user-defined wrappers around `py.*` to inherit/declare `@blocking_io`. State this explicitly in the lowering table.
+
+### B3. `ThreadsafeCallback` semantics undercut the "`py.Object` is not Send" guarantee
+- Line 38: `py.Object` is not `Send` by default and cannot cross task/thread boundaries without an explicit audited bridge.
+- Lines 492–500: `ThreadsafeCallback` "may be called from Python-created threads, native extension callback threads, thread pools…" — i.e., the underlying Python callable (a `py.Object`) **is** crossing thread boundaries.
+
+The phase never names the audited bridge or describes its safety contract. A `ThreadsafeCallback` is effectively that bridge, but the document does not say:
+- whether constructing one requires `Send`-bounded captured Sifr state plus GIL re-acquisition on dispatch,
+- what happens when a non-Python thread invokes the callback (does it acquire the GIL and execute Sifr inline? schedule onto a Sifr executor? both?),
+- whether the captured `py.Callable` reference itself counts as a `Send` exception or a `ThreadsafeCallback`-internal owner.
+
+This is the single biggest correctness gap. Without it, milestone_py_10 cannot specify what passes.
+
+### B4. Native-extension crash terminates the process — directly contradicts Sifr's "if it compiles, it works" guarantee
+Line 523: "Native crashes can terminate the process." This is true but it is a *new* failure mode for Sifr binaries and contradicts the AGENTS.md/CLAUDE.md core guarantee that no user-triggerable runtime panics exist. The phase must explicitly carve out the weakened guarantee:
+
+> Sifr's "no user-triggerable runtime panics" guarantee applies only to Sifr-attributable code paths. Loading a trusted Python native extension delegates process-abort safety to that extension. The guarantee is preserved for the Sifr language surface; it is suspended for the in-process trust boundary that the user opted into via `[trust] python-native`.
+
+Without that carve-out, claims of "production-grade" cannot be made.
+
+### B5. Trust enforcement mechanism is unspecified
+The phase introduces `[python] allow-imports`, `[trust] python`, and `[trust] python-native`, plus "Published libraries must not use wildcards" (line 91). It never says:
+- Where wildcards are rejected (publish-time CLI? package-graph load? both?).
+- How `py.import_module("torch")` is gated against `allow-imports` — at HIR static-analysis time? At runtime?
+- What happens for **dynamic** import strings (`py.import_module(name_var)`). Either they are rejected by static analysis, or trust is enforced at runtime — but neither is stated.
+- The relationship between `allow-imports` and `trust.python`. Is one a superset, are they orthogonal, must they match?
+
+This is a security surface. It must be specified before milestone_py_1.
+
+### B6. GIL boundary is invisible in the user API
+The user API has no `py.with_gil(fn) { … }` block. Every `py.call_attr` etc. presumably acquires and releases the GIL on each call. For numeric/tensor loops this destroys perf (and the document boasts zero-copy for tensors). There must be an explicit GIL-scoped batch primitive:
+
+```sifr
+try py.scope(lambda gil: …)   # holds GIL across multiple calls
+```
+
+Otherwise zero-copy tensor pipelines pay GIL ping-pong per op.
+
+### B7. Coroutine bridge semantics are unspecified
+Line 346: `py.run_coroutine_blocking` "should run the coroutine using Python-owned event-loop mechanics." The contract must answer:
+- Does it create a fresh loop per call, or reuse a per-thread loop?
+- Is reentry into a running loop (e.g. when invoked from a `ThreadsafeCallback` dispatched on a Python thread that already runs a loop) an error?
+- uvloop vs stock asyncio: pinned, auto-detected, or user-configured?
+- Is the coroutine guaranteed to run with the GIL held by the Sifr-bound thread, or may it migrate?
+
+Currently every implementer would make a different choice.
+
+### B8. Build/link contract for libpython is missing
+The probe records SOABI, extension suffix, libpython path. The phase never states:
+- Static or dynamic link to libpython.
+- What ABI granularity invalidates the build cache. Minor (3.12→3.13)? Patch? SOABI string change?
+- Whether `pyo3`'s `extension-module`/`auto-initialize` features are used, and whether `sifr build` records the chosen interpreter path into the binary (RPATH/RUNPATH or runtime resolution).
+
+This is part of "verifies and consumes" and is implementation-determining. milestone_py_2 cannot start without it.
+
+### B9. Self-containment claim is undercut by "Phase 27 non-regression baseline"
+Lines 13 and 842 require Phase 27 to remain green. Phase 27 is completed, so this isn't a *blocker* operationally, but the wording reads as a soft dependency. Tighten it to: "Existing baseline gates remain green." Drop the explicit phase number — the phase contract should not name external phase IDs as preconditions if it claims self-containment.
+
+### B10. The 43.1 numbering implies Phase 43 ordering
+`plans/phases/index.md:53` lists this as "43.1 Ad Hoc Embedded Python Interop." The roadmap explicitly lists Phase 43 under *Deferred Planning Drafts (Need Alignment)* (line 121). Numbering 43.1 misrepresents this phase's claim of independence from Phase 42/43. Renumber to a non-43 slot (e.g., the next free 36.x or 37.x) or add a footnote in `plans/phases/index.md` clarifying that 43.1 is sequence-independent.
+
+## 2. Important elegance/coherence improvements
+
+### E1. Object lifetime contract for `BufferView`, `ArrowArray`, `DlpackTensor`
+The phase says `py.Object` is non-`Send` by default. It doesn't say what zero-copy view types are. A `BufferView[T]` is a borrow against a Python exporter — its `Send`/`Sync` story matters for whether you can hand a tensor view to a Rayon-style data pipeline. Add an explicit row per view type stating Send/Sync and the rule (probably: non-Send unless the exporter participates in DLPack stream/device sync).
+
+### E2. The conversion table conflates "default conversion" with "explicit-conversion API"
+Most rows say "`py.Object` by default; explicit … conversion required." That's a sensible policy but the names of the explicit-conversion functions are scattered across other sections (`zero_copy_as`, `copy_as`, `to[T]`, `to_str`, `to_bytes`). Restructure as two columns: *default Sifr type* and *explicit conversion API*. That makes the contract atomic.
+
+### E3. Tier 1 certification gate is too broad to be a single milestone gate
+Tier 1 contains dozens of unrelated production surfaces — Django, FastAPI, SQLAlchemy, psycopg, pymongo, Confluent Kafka, OpenAI/Google clients, cryptography, pandas, pyarrow, opentelemetry. Treating all of these as "the gate" makes milestone_py_11 unbounded. Split Tier 1 into:
+- **Tier 1a — interop primitives** (must pass at milestone exit): pydantic, httpx, cryptography, pandas, pyarrow, polars, numpy, torch (CPU), psycopg, sqlalchemy.
+- **Tier 1b — ecosystem coverage** (must pass with skip evidence allowed where the host can't host the dep): the rest.
+
+This preserves the comprehensive promise without making the gate impossible to hit deterministically.
+
+### E4. `[python]` `enabled = true` is redundant
+The TOML example sets both `enabled = true` and a `venv` path. The presence of `[python]` with `venv`/`interpreter`/`pyproject` should be the activation signal. Drop `enabled`; it invites confusion when libraries declare `requires-imports` against an app with `enabled = false`.
+
+### E5. `py.with` lambda lifetime semantics
+The current shape `try py.with(obj, lambda entered: …)` doesn't say:
+- Whether `entered` escapes the lambda (must not).
+- Whether exceptions thrown inside the lambda are converted via Python `__exit__(exc_type, …)` or just propagate.
+- What return type the lambda has — generic `T`?
+
+Specify these explicitly; "context managers" is the most error-prone seam in PyO3 usage.
+
+### E6. `verification/python_interop/runner/run.py` vs `run.sh`
+Lines 632, 666–670 reference `runner/run.py` and `run.sh` interchangeably. Pick one as canonical; the other is a thin wrapper.
+
+### E7. Reserve diagnostic family codes now
+Phase 31.7 standardized `SIFR-<FAMILY>-dddd`. Reserve `SIFR-PYENV`, `SIFR-PYIMP`, `SIFR-PYCALL`, `SIFR-PYCONV`, `SIFR-PYRES`, `SIFR-PYZC`, `SIFR-PYCB`, `SIFR-PYTRUST` in the design now, so milestones can land diagnostics without re-litigating the taxonomy.
+
+### E8. `[python] interpreter = ".venv/bin/python"` looks like Unix-only
+The probe handles Windows (line 102) but the example never shows a Windows interpreter path. Add a one-line note that `interpreter` is platform-conditional or resolved from `venv` by Sifr; otherwise users will hard-code a Unix path.
+
+## 3. Specific wording / structural changes
+
+- **Line 7 (Objective):** Replace "smoothly use Python code" with "call into Python code and Python ecosystem packages."
+- **Line 38:** Change `foreign_blocking` → `@blocking_io` (or the chosen final term from B1). Apply globally.
+- **Line 278 (lowering table):** Same.
+- **Line 343:** Replace "py.blocking or the existing task offload primitive" with the chosen final primitive (B2).
+- **Line 92 ("Sifr gates declared/root imports only…"):** Add: "Trust enforcement runs at HIR-static-analysis time over statically discoverable import strings; dynamic import strings are rejected unless the call site is annotated `@trust_python_dynamic`." (Or whichever rule is chosen — but pick one.)
+- **Line 132:** Tighten "Treat the live interpreter probe as the source of truth. `uv.lock` digests are cache/diagnostic inputs, not correctness proof that the environment is synced." — good as is, preserve.
+- **Line 154:** "Python native packages are trusted process-local code, not sandboxed code." Add a forward link to the carve-out from B4 in the Quality Contract.
+- **Line 184 (PyObjectHandle in runtime API):** Add `PyGilGuard` so the GIL-scoped batch primitive (B6) has a representation.
+- **Line 286 (conversion table):** Restructure per E2.
+- **Section "Quality Contract" (~line 847):** Add the global invariant: "Sifr's no-user-triggerable-runtime-panic guarantee applies to Sifr-attributable paths; trusted Python native extensions are an explicit opt-in trust boundary that may abort the process."
+- **Index file `plans/phases/index.md:53`:** Renumber (B10) or annotate independence.
+
+## 4. Already strong — preserve as-is
+
+- "Sifr consumes and verifies the Python environment; Sifr does not resolve, install, or sync Python packages by default" (line 31). Clean ownership boundary with uv.
+- "No silent fallback from zero-copy APIs to copying is allowed" (line 43) plus the `zero_copy_as` vs `copy_as` split (lines 379–381). This is the right shape.
+- Refusal to support subinterpreters, free-threaded CPython (without future audit), and multiple venvs per process (lines 32–34, 51–52). These are correct stake-in-the-ground decisions.
+- `py.Object` opaque, foreign, non-`Any`, fallible operations only (lines 36–37, 215–222). Preserves Sifr's safety surface.
+- Conservative conversion policy: no implicit deep conversion of containers/tensors/dataframes (lines 308–309). Right call.
+- DLPack one-shot semantics and explicit dtype/device/stream tracking (lines 453–460). Correct.
+- Per-resource documented double-close/release decision (line 370). Correct discipline.
+- Probe JSON contents and cache-key inclusion (lines 105–131). Solid.
+- The split between `LocalCallback` (scoped, may borrow) and `ThreadsafeCallback` (owned/cloned, registry-managed) as *kinds*, not as flags (lines 478–501). The taxonomy is right; only the Send-boundary mechanics (B3) need filling in.
+- "Verification area" structure (lines 597–643). The fixture/group decomposition mirrors the design exactly and will translate into a real gate.
+- "uv remains the Python package manager; Sifr verifies and consumes the environment" as a Quality Contract invariant (line 854). Keep verbatim.
+
+---
+
+The phase is fundamentally on the right track and the policy decisions are sharper than most ad-hoc phases. The blocking issues are concentrated in three places: the async-classification term mismatch with Phase 32.1, the `ThreadsafeCallback`/`Send` story, and the trust-enforcement mechanism. Once those three are nailed, plus the GIL-scope primitive (B6) and the libpython link contract (B8), this reads as a true design contract rather than a scoped MVP.

--- a/plans/reviews/active/embedded-python-interop-review-2.md
+++ b/plans/reviews/active/embedded-python-interop-review-2.md
@@ -1,0 +1,50 @@
+# Review Round 2: Embedded Python Interop Phase
+
+## 1. Round 1 blocking issues — all resolved
+
+| # | Issue | Status | Where addressed |
+|---|---|---|---|
+| B1 | `foreign_blocking` vs `@blocking_io` | ✅ | `@blocking_io` throughout (lines 22, 39, 291, 348) |
+| B2 | `py.blocking` vs offload primitive | ✅ | "There is no Python-specific `py.blocking` alias" (line 348); milestone_py_5 echoes it (line 738) |
+| B3 | `ThreadsafeCallback` Send story | ✅ | Lines 499–510 name it as the audited bridge; specify registry storage, GIL reacquisition, scheduler dispatch, and no exposure of Python refs as Send |
+| B4 | Native-extension carve-out | ✅ | Line 534 (boundary text) and line 833 (Quality Contract invariant) |
+| B5 | Trust enforcement mechanism | ✅ | HIR static check for static imports + `@trust_python_dynamic` annotation for dynamic + runtime root check (line 92); wildcards rejected at publish/check + package-graph load (line 91); allow-imports vs trust.python vs trust.python-native triad (line 90) |
+| B6 | GIL boundary | ✅ | `py.scope` Sifr API (line 263), `PyGilScope` type (line 186), `with_gil` Rust API (line 191), lowering row (line 288) |
+| B7 | Coroutine semantics | ✅ | Per-thread loop reuse, no-reentry rule, uvloop honored, blocking return (line 352) |
+| B8 | Build/link contract | ✅ | New "Build and Link Contract" section (lines 137–142): probe is build metadata, cache key invalidators enumerated, no host-global fallback, PyO3 embedding not extension mode, dynamic libpython loader requirements recorded |
+| B9 | Self-containment vs Phase 27 | ✅ | No phase-number anchor remains; Entry Criteria says "Existing local validation gates remain green" (line 828) |
+| B10 | `43.1` numbering | ✅ | Renumbered `PY-1`, marked sequence-independent in `plans/phases/index.md:53` |
+| E1 | View Send/Sync | ✅ | All five view types non-`Send` by default; audited-bridge clause (line 394) |
+| E2 | Conversion table split | ✅ | Two-column "default Sifr type" / "explicit conversion API" (lines 299–308) |
+| E3 | Tier 1 too broad | ✅ | Tier 1a core gate vs Tier 1b ecosystem gate (lines 544, 549) |
+| E4 | `enabled=true` redundancy | ✅ | Removed from example |
+| E5 | `py.with` lifetime | ✅ | "`entered` cannot escape", generic `T`, `__exit__(exc_type, exc, tb)` receives failure context (line 373) |
+| E6 | `run.sh` vs `run.py` canonical | ✅ | "`run.sh` is canonical; delegates to `runner/run.py`" (line 649) |
+| E7 | Reserve diagnostic families | ✅ | All eight `SIFR-PY*` families reserved in milestone_py_0 (line 675) |
+| E8 | Unix-only interpreter example | ✅ | Comment now says "Sifr resolves from venv per platform" (line 69) |
+
+## 2. No new blocking issues
+
+I went through every revision-touched section looking for new contradictions, weakened guarantees, or under-specified mechanics. None rise to the level of a blocker:
+
+- The new `@trust_python_dynamic` is a genuine unsafe annotation but it preserves runtime trust checking, so the security surface is intact.
+- The new `py.scope` + `PyGilScope` does not break the per-call GIL discipline rule because every `py.*` op acquires the GIL idempotently inside a held scope (PyO3's `Python<'py>` token model). No statement in the doc requires that to be re-derived.
+- The Tier 1a / Tier 1b split keeps the certification promise intact; nothing in `milestone_py_11` was weakened — both tiers stay inside it.
+- "Audited bridge" is now a defined term for `ThreadsafeCallback`. Views still reference "an explicit audited bridge" (line 394) without naming a concrete type, but that is consistent — the bridge for views is a *future* surface, and the doc correctly defaults views to non-`Send`.
+
+## 3. Final polish (no scope expansion)
+
+These are wording inconsistencies that a reviewer will flag but that don't change a single decision:
+
+1. **`call_attr` signature is inconsistent across the doc.** Example at line 244 uses three args (`obj, "method", positional`); core-operations bullet at line 260 uses four (`obj, "method", args, kwargs`); lowering-table row at line 285 uses three again. Pick `call_attr(obj, name, args, kwargs)` everywhere and let the example pass `[]` for kwargs.
+2. **`py.call_method` appears once (line 362) and is otherwise undefined.** Either add it to the core operations list and lowering table, or drop the line and rely on `call_attr`.
+3. **`PyValue` is used in the Rust API (lines 193–194) but not listed in the module struct block (lines 171–188).** Add `PyValue` to that block (or `enum PyValue { … }`).
+4. **`py.zero_copy_as[T]` and `py.copy_as[T]` are missing from the operation lowering table** (lines 281–292) even though they are first-class user-facing operations introduced in the Zero-Copy section. Add two rows.
+5. **`PyArrowCapsule` in the Rust API vs three Sifr types (`py.ArrowArray`, `py.ArrowStream`, `py.ArrowSchema`)** — either rename the Rust struct to indicate it is the generic capsule wrapper that the three Sifr types specialize, or expose three Rust types. One sentence of mapping resolves it.
+6. **`LocalCallback`'s `Send` status is not stated explicitly.** It is implied by "same-thread/same-stack reentry only" (line 491), but for symmetry with the view-type clause (line 394), add "non-`Send`" to its bullet list.
+7. **Conversion-rules row "bytearray, memoryview, buffers"** suggests `py.zero_copy_as[py.BufferView[T]]` as the default explicit API but the Buffer subsection talks about `Py_buffer` ownership and never gives the user-facing call signature. One sentence in the BufferView subsection ("Acquired via `try py.zero_copy_as[py.BufferView[T]](obj)`") would close the loop.
+8. **`py.run_coroutine_blocking` argument convention** is shown in the resource-cleanup example (line 364) as `py.run_coroutine_blocking(try py.call_attr(obj, "aclose", []))`. The doubled `try` is parseable but awkward; consider `let coro = try py.call_attr(obj, "aclose", [], []); try py.run_coroutine_blocking(coro)`.
+
+## 4. Verdict
+
+**The document is ready after the small polish in §3.** All round-1 blockers are closed, no new blockers were introduced, and the remaining items are signature/wording consistency fixes that do not touch a single design decision.

--- a/plans/reviews/active/embedded-python-interop-review-3.md
+++ b/plans/reviews/active/embedded-python-interop-review-3.md
@@ -1,0 +1,12 @@
+1. **No remaining blockers.** All polish items confirmed in place:
+   - `call_attr(obj, "name", args, kwargs)` signature is consistent at lines 248, 262, 287, 369, 372.
+   - `PyValue` declared in the runtime API sketch (line 184) and referenced by `call`/`getitem` (lines 196-197).
+   - `zero_copy_as`/`copy_as` rows present in the lowering table (lines 291-292).
+   - Arrow Rust↔Sifr mapping noted at line 190 ("Generic wrappers specialize into Sifr-level ArrowArray, ArrowStream, and ArrowSchema handles").
+   - `LocalCallback` explicitly non-`Send` (line 502).
+   - `BufferView` acquisition named at line 431.
+   - Coroutine cleanup split into two clear steps (lines 369-370).
+
+2. **One low-signal nit, not worth blocking:** the conceptual Rust block uses `pub enum PyValue;` (line 184), which isn't literal valid Rust — but the surrounding `pub struct PyObjectHandle;` lines use the same illustrative shorthand, and the section is titled "Conceptual Runtime API". Consistent within the block; leave as-is.
+
+3. **Ready to commit.**

--- a/plans/reviews/active/embedded-python-interop-review-4.md
+++ b/plans/reviews/active/embedded-python-interop-review-4.md
@@ -1,0 +1,57 @@
+# Review Round 4: Embedded Python Interop
+
+## 1. AWS/SQS/SNS additions — blockers/gaps
+
+**No blockers, but three precision issues:**
+
+- **Callback bullet mis-categorizes most boto3 patterns (line 525).** "SQS long polling, SNS publish/subscribe, paginators, retries" are not Python-to-Sifr *callbacks* — they're blocking RPC calls and internal iterators. Only `credential refresh` (and arguably S3 transfer `Callback=`) actually invokes Sifr code from boto3. The other items belong in the verification cloud/brokers groups (where they already live) or in a generic "production client patterns" section, not under the Callbacks contract. As written, milestone_py_10 fixtures would inherit a misleading scope.
+
+- **"Google/Azure/AWS auth/import surfaces" (line 658)** dangles Azure: no Azure SDK appears in any tier or fixture set. Drop "Azure/" or add a representative Azure SDK (e.g., `azure-identity`, `azure-storage-blob`) to Tier 1b Cloud/AI.
+
+- **"LocalStack/moto-style emulation" (line 676)** lumps two different mechanisms. moto is an in-process Python monkey-patch library; LocalStack is an out-of-process service emulator. The conflation will make the integration gate ambiguous about which artifact is being exercised.
+
+**Minor (non-blocking):** boto3 and botocore appear in both Tier 1a and Tier 1b Cloud/AI. This matches the pre-existing pattern (pydantic, pyarrow, sqlalchemy, etc. also dual-listed), but it's never declared as intentional anywhere.
+
+## 2. Overall phase — blockers/gaps after round 4
+
+No new blockers. Rounds 1–3 closed the substantive design gaps. Phase reads as self-contained; no Phase 42/43 dependency remains. File is at 896/900 lines — net-zero edits required to preserve headroom.
+
+## 3. Smallest concrete wording edits
+
+1. **Line 525** — replace
+   > boto3/botocore SQS long polling, SNS publish/subscribe, paginators, retries, and credential refresh;
+
+   with
+   > boto3/botocore refreshable-credentials callbacks and transfer-manager progress callbacks;
+
+   (Long polling, publish/subscribe, paginators, retries already live in the verification groups; the Callbacks section should only list genuine Python-to-Sifr callback patterns.)
+
+2. **Line 658** — replace
+   > Google/Azure/AWS auth/import surfaces
+
+   with
+   > Google/AWS auth/import surfaces
+
+   (Removes the dangling Azure reference; no Azure SDK is certified.)
+
+3. **Line 676** — replace
+   > AWS SQS/SNS via LocalStack/moto-style emulation or live credentials
+
+   with
+   > AWS SQS/SNS via moto in-process mocking, LocalStack service emulation, or live AWS credentials
+
+4. **Start of Tier 1b (line 558, after the heading)** — add one line:
+   > Packages already covered by Tier 1a may reappear here when they anchor a Tier 1b category; the Tier 1a gate is authoritative.
+
+   (Net +1 line; resolves the dual-listing ambiguity once for the whole tier matrix without renaming any package.)
+
+5. **Line 657** — append after `Pub/Sub-style callbacks`:
+   > `brokers` covers messaging semantics; SDK surface for AWS/GCP messaging clients is covered by `cloud`.
+
+   (Net +1 line; disambiguates the brokers/cloud overlap created by SQS appearing in both groups. Optional — drop if line budget is tight.)
+
+Net change: +1 to +2 lines if edits 4 and 5 land; 0 if only 1–3 land. Stays under the 900-line cap.
+
+## 4. Verdict
+
+**Ready** after edits 1–3 (minimal, ~3 line touches), with 4–5 as optional clarifiers. The four points above are pure wording; no design decision shifts. The phase is production-grade as a contract.

--- a/plans/reviews/active/embedded-python-interop-review-5.md
+++ b/plans/reviews/active/embedded-python-interop-review-5.md
@@ -1,0 +1,13 @@
+I read the full file. It is 899 lines, sits under the guardrail, and all the round-4 fixes landed cleanly.
+
+**1. Blockers/design gaps:** None. The contract is internally consistent — root ownership, probe, lifecycle, error model, blocking/offload, callbacks (local vs threadsafe), zero-copy families (`Py_buffer` / Arrow PyCapsule / DLPack / array interface), trust split (`python` vs `python-native`), and the certification tiers all line up. Milestones cover every contract item.
+
+**2. Wording fixes to apply before commit:** None required. The previously raised items are all addressed:
+- Callbacks (line 525-529) name real boto3 patterns (refreshable-credentials, transfer-manager progress) plus Pub/Sub scheduler threads, confluent-kafka polling, CFFI, Pika, async client schedulers — all genuine.
+- No Azure reference remains.
+- External integration gate (line 678) distinguishes moto (in-process mocking) from LocalStack (service emulation) from live AWS credentials.
+- Tier 1a/1b overlap is explicit (line 560: "Tier 1a gate is authoritative").
+- brokers/cloud split is stated (line 659: "brokers covers messaging semantics; SDK surface is covered by cloud").
+- Fixtures include `aws_sqs`, `aws_sns`, `aws_sns_sqs_subscription`.
+
+**3. Ready to commit.**

--- a/plans/reviews/active/embedded-python-interop-review-6.md
+++ b/plans/reviews/active/embedded-python-interop-review-6.md
@@ -1,0 +1,29 @@
+## Review (round 6)
+
+**1. New policy clarity (line 43): strong.**
+
+The Core Decisions bullet is well-placed, names the four forbidden patterns (back-compat shims, legacy compat layers, fallback paths, degraded modes), and gives the positive framing ("correct production contract directly"). It pairs cleanly with the existing no-fallback rules at lines 44, 142, and 895.
+
+**2. Conflict scan — one wording fix needed.**
+
+| Phrase | Location | Conflict? | Reasoning |
+|---|---|---|---|
+| "as compatibility paths only" | line 479 (Array Interface) | **Yes** | "compatibility paths only" reads as "legacy-only fallback," which contradicts the new bullet. The intent is "interchange protocol for producers that don't expose Py_buffer/Arrow/DLPack" — a peer protocol, not a legacy/degraded mode. |
+| "CPython-compatible packages" | line 553 | No | Means *compatible with CPython*, not Sifr back-compat. |
+| "No host-global Python fallback" | line 142 | No | Forbids a fallback — reinforces the new bullet. |
+| "No silent fallback from zero-copy…" | line 44 | No | Same — explicit "no fallback" rule. |
+| "no silent zero-copy fallback to copying" | line 895 | No | Same — exit-gate reinforcement. |
+
+**3. Recommended one-line change before commit.**
+
+Line 479 — drop "as compatibility paths only" and re-frame as a peer protocol; preference is already stated separately at line 486 ("Prefer `Py_buffer`, Arrow, or DLPack when available.").
+
+```
+Support `__array_interface__`, `__array_struct__`, and `__cuda_array_interface__` as additional zero-copy interchange protocols.
+```
+
+Same line count (file stays at 899 lines, well under 900).
+
+**4. Status: not ready to commit yet.**
+
+Make the line 479 rewording, then commit. Everything else is consistent with the new policy and the wording at line 43 is clear and strong.

--- a/plans/reviews/active/embedded-python-interop-review-7.md
+++ b/plans/reviews/active/embedded-python-interop-review-7.md
@@ -1,0 +1,7 @@
+Reviewed the file. Brief answers:
+
+1. **No conflict with no-fallback/no-backward-compat policy.** The line 479 wording ("additional zero-copy interchange protocols") reads as peer protocols alongside `Py_buffer`/Arrow/DLPack, not as a compatibility shim or fallback path. The "no silent fallback from zero-copy APIs to copying" rule (line 44) and the explicit "no silent zero-copy fallback to copying" at line 895 remain consistent.
+
+2. **One optional consistency polish (not a conflict).** Line 39 still reads "…DLPack, and strict array-interface compatibility are all part of the contract." The word "compatibility" there overlaps with the policy phrase "legacy compatibility layers" at line 43. Round 6's peer-protocol framing was applied at line 479 but not at line 39 or line 895 ("strict array-interface paths"). For full consistency you could phrase line 39 as "…DLPack, and the `__array_interface__`/`__array_struct__`/`__cuda_array_interface__` protocols are all part of the contract." This is a polish, not a blocker.
+
+3. **Ready to commit** as-is. The semantic contract is sound; the line 39 phrasing is the only spot where wording consistency could be tightened in a follow-up if you want.

--- a/plans/reviews/active/embedded-python-interop-review-8.md
+++ b/plans/reviews/active/embedded-python-interop-review-8.md
@@ -1,0 +1,7 @@
+I reviewed the round-8 file.
+
+1. **Backward-compat/fallback conflicts:** None. The policy at line 43 ("No backward-compatibility shims, legacy compatibility layers, fallback paths, or degraded modes") is consistent with line 44 (no silent zero-copy fallback), line 142 (no host-global Python fallback), line 354 (no `py.blocking` alias), and the Exit Gate's "no silent zero-copy fallback to copying." Nothing contradicts.
+
+2. **Wording:** One minor leftover — the Conversion Rules table at line 311 still says "array-interface compatibility" for numpy arrays, while Core Decisions (line 39) and Exit Gate (line 895) now name the protocols precisely. For full parity you could replace it with `__array_interface__`/`__array_struct__`/`__cuda_array_interface__` (or just "array-interface protocols"). Optional, not blocking.
+
+3. **Otherwise: ready to commit.**

--- a/plans/reviews/active/embedded-python-interop-review-9.md
+++ b/plans/reviews/active/embedded-python-interop-review-9.md
@@ -1,0 +1,5 @@
+1. No remaining conflict with the policy. The document is consistent: line 43 declares no backward-compat/fallback/degraded modes, line 44 forbids silent zero-copy fallback, line 142 forbids host-global Python fallback, line 895 reiterates no silent zero-copy fallback. The "Prefer `Py_buffer`, Arrow, or DLPack when available" on line 486 is protocol preference order among zero-copy options, not a degraded fallback, so it doesn't conflict.
+
+2. No remaining high-signal wording issues. The Tier 1a/1b split is clear, brokers-vs-cloud scope is disambiguated (line 660), `py.with` semantics are precise, callback registry rules are tight, and the array-interface wording is now consistent with the other protocol entries.
+
+3. Ready to commit.

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -121,3 +121,4 @@ flowchart LR
 - Phase 42 and Phase 43 are intentionally excluded from the main execution table until post-Phase-41 planning lock.
 - [42_data_science_ml.md](./phases/42_data_science_ml.md) (needs more planning)
 - [43_interoperability.md](./phases/43_interoperability.md) (needs more planning)
+- [ad-hoc-embedded-python-interop.md](./issues/active/ad-hoc-embedded-python-interop.md) (draft planning lock for the separate embedded CPython/uv interop lane)


### PR DESCRIPTION
## Summary

- Adds a full ad hoc phase for embedded CPython interop under `plans/issues/active`.
- Makes the Python interop phase sequence-independent from Phase 42 and Phase 43.
- Captures the Claude review rounds and final confirmation artifacts under `plans/reviews/active`.

## Design Scope

The phase covers uv-created environment verification, embedded CPython lifecycle, trust policy, `@blocking_io` semantics, opaque `py.Object` handling, callbacks, native-extension trust boundaries, zero-copy buffer/Arrow/DLPack interop, package certification, and the planned `verification/python_interop` area.

## Validation

Not run per request; this is a markdown-only planning PR.
