### PR TITLE
Add Python runtime lifecycle milestone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+dependencies = [
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,8 +3024,10 @@ dependencies = [
  "icu_decimal",
  "icu_locale",
  "icu_plurals",
+ "libc",
  "num-bigint",
  "num-traits",
+ "pyo3",
  "rcgen",
  "rustls",
  "rustls-pemfile",
@@ -3179,6 +3213,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,9 +88,11 @@ is-macro = { version = "0.3.7" }
 itertools = { version = "0.14.0" }
 lsp-server = { version = "0.7.8" }
 lsp-types = { version = "0.97.0" }
+libc = { version = "0.2.178" }
 memchr = { version = "2.8.0" }
 once_cell = { version = "1.21.4" }
 postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
+pyo3 = { version = "0.29.0", default-features = false }
 rcgen = { version = "0.14.8" }
 num-bigint = { version = "0.4.6" }
 num-traits = { version = "0.2.19" }

--- a/crates/sifr/src/check_and_package_commands.rs
+++ b/crates/sifr/src/check_and_package_commands.rs
@@ -148,7 +148,7 @@ pub(super) fn package_entrypoint_for_file(
         package_id: context.package_id,
         graph: context.graph,
         source_map: context.source_map,
-        python_probe_digest: context.python_probe_digest,
+        python_runtime: context.python_runtime,
     }))
 }
 
@@ -163,21 +163,20 @@ pub(super) fn package_compiler_context(
     let Some(package_id) = current_session_package_id(session, &context.graph) else {
         return Ok(None);
     };
-    let python_probe_digest =
-        package_python_probe_digest(&context.graph, &package_id, diagnostic_format)?;
+    let python_runtime = package_python_runtime(&context.graph, &package_id, diagnostic_format)?;
     Ok(Some(PackageCompilerContext {
         graph: context.graph,
         source_map: context.source_map,
         package_id,
-        python_probe_digest,
+        python_runtime,
     }))
 }
 
-fn package_python_probe_digest(
+fn package_python_runtime(
     graph: &sifr_package::SifrPackageGraph,
     package_id: &sifr_package::SifrPackageId,
     diagnostic_format: DiagnosticFormat,
-) -> Result<Option<String>, i32> {
+) -> Result<Option<sifr_driver::PackagePythonRuntime>, i32> {
     let resolved = match sifr_package::resolve_python_environment(graph, package_id) {
         Ok(resolved) => resolved,
         Err(errors) => {
@@ -200,9 +199,10 @@ fn package_python_probe_digest(
             return Err(EXIT_USER_DIAGNOSTIC);
         }
     };
-    Ok(Some(
-        sifr_package::digest_python_environment_probe(&request, &probe).hex,
-    ))
+    let digest = sifr_package::digest_python_environment_probe(&request, &probe).hex;
+    Ok(Some(sifr_driver::PackagePythonRuntime::from_probe(
+        &request, &probe, digest,
+    )))
 }
 
 pub(super) fn load_package_graph_context(

--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -317,7 +317,7 @@ pub(super) struct PackageCompilerContext {
     pub(super) graph: sifr_package::SifrPackageGraph,
     pub(super) source_map: sifr_package::PackageSourceMap,
     pub(super) package_id: sifr_package::SifrPackageId,
-    pub(super) python_probe_digest: Option<String>,
+    pub(super) python_runtime: Option<sifr_driver::PackagePythonRuntime>,
 }
 
 pub(super) struct PackageGraphContext {

--- a/crates/sifr/src/diagnostic_rendering_and_run.rs
+++ b/crates/sifr/src/diagnostic_rendering_and_run.rs
@@ -445,7 +445,7 @@ pub(super) fn cmd_run_package_file(
         package_id: context.package_id,
         graph: context.graph,
         source_map: context.source_map,
-        python_probe_digest: context.python_probe_digest,
+        python_runtime: context.python_runtime,
     };
     let result = match run_with_panic_boundary(
         "internal compiler panic during package run command compilation",

--- a/crates/sifr_driver/src/bin/diagnostic_rendering_harness.rs
+++ b/crates/sifr_driver/src/bin/diagnostic_rendering_harness.rs
@@ -388,7 +388,7 @@ fn package_diagnostics(package: &Path) -> Result<Vec<RenderedDiagnostic>, String
         package_id,
         graph,
         source_map,
-        python_probe_digest: None,
+        python_runtime: None,
     };
     Ok(check_package_project(&entrypoint))
 }

--- a/crates/sifr_driver/src/build/entrypoint.rs
+++ b/crates/sifr_driver/src/build/entrypoint.rs
@@ -3,8 +3,10 @@ use super::materialize::{
     materialize_cached_binary_project_with_report,
 };
 use super::project_codegen::{
-    generated_project_binary_project, generated_single_file_binary_project, GeneratedBinaryProject,
+    apply_package_runtime_metadata, generated_project_binary_project,
+    generated_single_file_binary_project, GeneratedBinaryProject,
 };
+use super::python_runtime::PackagePythonRuntime;
 use super::report::{BuildCompilationMode, BuildReport, BuildStageReport};
 use crate::diagnostics::{run_codegen_with_boundary, CompileResult, RenderedDiagnostic};
 use crate::frontend::{parse_source, FrontendCompiled};
@@ -70,7 +72,7 @@ pub struct PackageEntrypoint {
     pub package_id: SifrPackageId,
     pub graph: SifrPackageGraph,
     pub source_map: PackageSourceMap,
-    pub python_probe_digest: Option<String>,
+    pub python_runtime: Option<PackagePythonRuntime>,
 }
 
 pub struct CachedBinaryArtifact {
@@ -92,7 +94,7 @@ pub(crate) struct RootedEntrypointPlan {
     shape: RootedEntrypointShape,
     stdlib: StdlibCompiled,
     project_lowering: ProjectLowering,
-    cache_key_fragment: Option<String>,
+    python_runtime: Option<PackagePythonRuntime>,
 }
 
 fn measure_stage<T>(
@@ -322,7 +324,7 @@ impl RootedEntrypointPlan {
         stages: &mut Vec<BuildStageReport>,
     ) -> Result<(Self, BuildCompilationMode, PathBuf), Vec<RenderedDiagnostic>> {
         let stdlib = measure_stage(stages, "Loading Sifr standard library", compile_stdlib)?;
-        let (shape, project_lowering, cache_key_fragment) = match entrypoint {
+        let (shape, project_lowering, python_runtime) = match entrypoint {
             RootedEntrypoint::SingleFile {
                 source,
                 display_path,
@@ -412,7 +414,7 @@ impl RootedEntrypointPlan {
                 (
                     RootedEntrypointShape::Project,
                     project_lowering,
-                    entrypoint.python_probe_digest.clone(),
+                    entrypoint.python_runtime.clone(),
                 )
             }
         };
@@ -424,7 +426,7 @@ impl RootedEntrypointPlan {
                 shape,
                 stdlib,
                 project_lowering,
-                cache_key_fragment,
+                python_runtime,
             },
             mode,
             entrypoint_path,
@@ -510,8 +512,8 @@ impl RootedEntrypointPlan {
     fn into_generated_binary_project(
         self,
     ) -> Result<GeneratedBinaryProject, Vec<RenderedDiagnostic>> {
-        let cache_key_fragment = self.cache_key_fragment.clone();
-        let mut generated = match self.shape {
+        let python_runtime = self.python_runtime.clone();
+        let generated = match self.shape {
             RootedEntrypointShape::SingleFile => {
                 let codegen_result = self.into_single_file_codegen_result()?;
                 generated_single_file_binary_project(codegen_result)
@@ -520,8 +522,7 @@ impl RootedEntrypointPlan {
                 generated_project_binary_project(&self.stdlib.code, self.project_lowering)?
             }
         };
-        generated.cache_key_fragment = cache_key_fragment;
-        Ok(generated)
+        apply_package_runtime_metadata(generated, python_runtime)
     }
 }
 

--- a/crates/sifr_driver/src/build/materialize.rs
+++ b/crates/sifr_driver/src/build/materialize.rs
@@ -78,12 +78,16 @@ fn materialize_binary_project_at_path(
     project_name: &str,
     generated_project: GeneratedBinaryProject,
 ) -> Result<MaterializedBinaryProject, Vec<RenderedDiagnostic>> {
+    let python_interpreter = generated_project
+        .python_runtime
+        .as_ref()
+        .map(|runtime| runtime.interpreter().to_path_buf());
     let materialize_start = std::time::Instant::now();
     materialize_binary_project_files(project_path, project_name, generated_project)?;
     let materialize_elapsed = materialize_start.elapsed();
 
     let cargo_start = std::time::Instant::now();
-    run_cargo_build(project_path)?;
+    run_cargo_build(project_path, python_interpreter.as_deref())?;
     let cargo_elapsed = cargo_start.elapsed();
 
     Ok(MaterializedBinaryProject {
@@ -163,16 +167,22 @@ fn materialize_binary_project_files(
     Ok(())
 }
 
-fn run_cargo_build(project_path: &Path) -> Result<(), Vec<RenderedDiagnostic>> {
-    let output = Command::new("cargo")
+fn run_cargo_build(
+    project_path: &Path,
+    python_interpreter: Option<&Path>,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let mut command = Command::new("cargo");
+    command
         .args(["build", "--release", "--quiet"])
-        .current_dir(project_path)
-        .output()
-        .map_err(|error| {
-            vec![cargo_build_error(format!(
-                "failed to run cargo build: {error}"
-            ))]
-        })?;
+        .current_dir(project_path);
+    if let Some(python_interpreter) = python_interpreter {
+        command.env("PYO3_PYTHON", python_interpreter);
+    }
+    let output = command.output().map_err(|error| {
+        vec![cargo_build_error(format!(
+            "failed to run cargo build: {error}"
+        ))]
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -270,6 +280,7 @@ mod tests {
             used_stdlib_modules: HashSet::new(),
             required_features: HashSet::new(),
             cache_key_fragment: None,
+            python_runtime: None,
         };
         let mut with_python_probe = GeneratedBinaryProject {
             cache_key_fragment: Some("python-probe-a".to_string()),

--- a/crates/sifr_driver/src/build/mod.rs
+++ b/crates/sifr_driver/src/build/mod.rs
@@ -3,6 +3,7 @@ mod cargo_manifest;
 mod entrypoint;
 mod materialize;
 mod project_codegen;
+mod python_runtime;
 mod report;
 mod workspace;
 
@@ -12,6 +13,7 @@ pub use api::{
     check_package_project, check_project, check_single_file, emit_project,
 };
 pub use entrypoint::{CachedBinaryArtifact, PackageEntrypoint};
+pub use python_runtime::PackagePythonRuntime;
 pub use report::{BuildCompilationMode, BuildReport, BuildStageReport};
 
 pub(crate) use cargo_manifest::generate_dependency_cargo_toml;

--- a/crates/sifr_driver/src/build/project_codegen.rs
+++ b/crates/sifr_driver/src/build/project_codegen.rs
@@ -1,3 +1,4 @@
+use super::python_runtime::{inject_python_runtime_bootstrap, PackagePythonRuntime};
 use crate::diagnostics::{run_codegen_with_boundary, RenderedDiagnostic};
 use crate::project::{
     assemble_project_main_rs, ordered_non_main_module_names, rust_module_file_path, ProjectLowering,
@@ -13,6 +14,7 @@ pub(super) struct GeneratedBinaryProject {
     pub(super) used_stdlib_modules: HashSet<String>,
     pub(super) required_features: HashSet<StdlibFeature>,
     pub(super) cache_key_fragment: Option<String>,
+    pub(super) python_runtime: Option<PackagePythonRuntime>,
 }
 
 impl GeneratedBinaryProject {
@@ -45,6 +47,7 @@ pub(super) fn generated_single_file_binary_project(
         used_stdlib_modules: codegen_result.used_stdlib_modules,
         required_features: codegen_result.required_features,
         cache_key_fragment: None,
+        python_runtime: None,
     }
 }
 
@@ -88,5 +91,79 @@ pub(super) fn generated_project_binary_project(
         used_stdlib_modules: codegen_result.used_stdlib_modules,
         required_features: codegen_result.required_features,
         cache_key_fragment: None,
+        python_runtime: None,
     })
+}
+
+pub(super) fn apply_package_runtime_metadata(
+    mut generated: GeneratedBinaryProject,
+    python_runtime: Option<PackagePythonRuntime>,
+) -> Result<GeneratedBinaryProject, Vec<RenderedDiagnostic>> {
+    if let Some(metadata) = python_runtime {
+        generated
+            .required_features
+            .insert(StdlibFeature::PythonRuntime);
+        generated.main_rs = inject_python_runtime_bootstrap(&generated.main_rs, &metadata)
+            .map_err(|message| {
+                vec![crate::diagnostics::diagnostic_with_code(
+                    message,
+                    sifr_diagnostics::DiagnosticCode::INTERNAL_COMPILER_PANIC,
+                )]
+            })?;
+        generated.cache_key_fragment = Some(metadata.probe_digest().to_string());
+        generated.python_runtime = Some(metadata);
+    }
+    Ok(generated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_project() -> GeneratedBinaryProject {
+        GeneratedBinaryProject {
+            main_rs: "fn main() {\n    println!(\"ok\");\n}\n".to_string(),
+            support_modules: BTreeMap::new(),
+            used_stdlib_modules: HashSet::new(),
+            required_features: HashSet::new(),
+            cache_key_fragment: None,
+            python_runtime: None,
+        }
+    }
+
+    #[test]
+    fn package_python_runtime_metadata_enables_feature_and_bootstrap() {
+        let metadata = PackagePythonRuntime::for_tests("/tmp/sifr-py/bin/python", "digest-a");
+
+        let generated = apply_package_runtime_metadata(base_project(), Some(metadata))
+            .expect("metadata should apply");
+
+        assert!(generated
+            .required_features
+            .contains(&StdlibFeature::PythonRuntime));
+        assert_eq!(generated.cache_key_fragment.as_deref(), Some("digest-a"));
+        assert!(generated
+            .main_rs
+            .contains("__sifr_initialize_python_runtime"));
+        assert!(generated.python_runtime.is_some());
+    }
+
+    #[test]
+    fn package_python_runtime_metadata_requires_main_function() {
+        let mut project = base_project();
+        project.main_rs = "fn helper() {}\n".to_string();
+
+        let result = apply_package_runtime_metadata(
+            project,
+            Some(PackagePythonRuntime::for_tests(
+                "/tmp/sifr-py/bin/python",
+                "digest-a",
+            )),
+        );
+        let Err(errors) = result else {
+            panic!("missing main should fail");
+        };
+
+        assert!(errors[0].message.contains("no main function"));
+    }
 }

--- a/crates/sifr_driver/src/build/python_runtime.rs
+++ b/crates/sifr_driver/src/build/python_runtime.rs
@@ -1,0 +1,188 @@
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PackagePythonRuntime {
+    venv_root: PathBuf,
+    interpreter: PathBuf,
+    executable: String,
+    sys_prefix: String,
+    sys_base_prefix: String,
+    probe_digest: String,
+    implementation_name: String,
+    implementation_version: String,
+    cpython_version_tuple: Vec<u64>,
+    sys_path: Vec<String>,
+    site_packages: Vec<String>,
+}
+
+impl PackagePythonRuntime {
+    #[must_use]
+    pub fn from_probe(
+        request: &sifr_package::PythonEnvironmentProbeRequest,
+        probe: &sifr_package::PythonEnvironmentProbe,
+        probe_digest: String,
+    ) -> Self {
+        Self {
+            venv_root: request.venv_root.clone(),
+            interpreter: request.interpreter.clone(),
+            executable: probe.executable.clone(),
+            sys_prefix: probe.sys_prefix.clone(),
+            sys_base_prefix: probe.sys_base_prefix.clone(),
+            probe_digest,
+            implementation_name: probe.implementation_name.clone(),
+            implementation_version: probe.implementation_version.clone(),
+            cpython_version_tuple: probe.cpython_version_tuple.clone(),
+            sys_path: probe.sys_path.clone(),
+            site_packages: probe.site_packages.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn probe_digest(&self) -> &str {
+        &self.probe_digest
+    }
+
+    #[must_use]
+    pub(crate) fn interpreter(&self) -> &std::path::Path {
+        &self.interpreter
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_tests(interpreter: &str, probe_digest: &str) -> Self {
+        Self {
+            venv_root: PathBuf::from("/tmp/sifr-py"),
+            interpreter: PathBuf::from(interpreter),
+            executable: interpreter.to_string(),
+            sys_prefix: "/tmp/sifr-py".to_string(),
+            sys_base_prefix: "/opt/python".to_string(),
+            probe_digest: probe_digest.to_string(),
+            implementation_name: "cpython".to_string(),
+            implementation_version: "3.13.1".to_string(),
+            cpython_version_tuple: vec![3, 13, 1],
+            sys_path: vec!["/tmp/sifr-py/lib".to_string()],
+            site_packages: vec!["/tmp/sifr-py/site-packages".to_string()],
+        }
+    }
+}
+
+pub(super) fn render_python_runtime_prelude(metadata: &PackagePythonRuntime) -> String {
+    format!(
+        r#"fn __sifr_python_runtime_config() -> sifr_runtime::python::PythonRuntimeConfig {{
+    sifr_runtime::python::PythonRuntimeConfig {{
+        venv_root: {venv_root}.to_string(),
+        interpreter: {interpreter}.to_string(),
+        executable: {executable}.to_string(),
+        sys_prefix: {sys_prefix}.to_string(),
+        sys_base_prefix: {sys_base_prefix}.to_string(),
+        probe_digest: {probe_digest}.to_string(),
+        implementation_name: {implementation_name}.to_string(),
+        implementation_version: {implementation_version}.to_string(),
+        cpython_version_tuple: vec![{version_tuple}],
+        sys_path: vec![{sys_path}],
+        site_packages: vec![{site_packages}],
+    }}
+}}
+
+fn __sifr_initialize_python_runtime() -> Result<(), sifr_runtime::python::PythonRuntimeError> {{
+    sifr_runtime::python::initialize_runtime(__sifr_python_runtime_config()).map(|_| ())
+}}
+
+"#,
+        venv_root = rust_string_literal(&metadata.venv_root.to_string_lossy()),
+        interpreter = rust_string_literal(&metadata.interpreter.to_string_lossy()),
+        executable = rust_string_literal(&metadata.executable),
+        sys_prefix = rust_string_literal(&metadata.sys_prefix),
+        sys_base_prefix = rust_string_literal(&metadata.sys_base_prefix),
+        probe_digest = rust_string_literal(&metadata.probe_digest),
+        implementation_name = rust_string_literal(&metadata.implementation_name),
+        implementation_version = rust_string_literal(&metadata.implementation_version),
+        version_tuple = render_u64_vec(&metadata.cpython_version_tuple),
+        sys_path = render_string_vec(&metadata.sys_path),
+        site_packages = render_string_vec(&metadata.site_packages),
+    )
+}
+
+pub(super) fn inject_python_runtime_bootstrap(
+    main_rs: &str,
+    metadata: &PackagePythonRuntime,
+) -> Result<String, String> {
+    let Some(main_start) = main_rs.find("fn main") else {
+        return Err(
+            "generated package project has Python runtime metadata but no main function"
+                .to_string(),
+        );
+    };
+    let Some(body_offset) = main_rs[main_start..].find('{') else {
+        return Err("generated package project main function has no body".to_string());
+    };
+    let insert_at = main_start + body_offset + 1;
+    let mut with_bootstrap = render_python_runtime_prelude(metadata);
+    with_bootstrap.push_str(&main_rs[..insert_at]);
+    with_bootstrap.push_str(
+        "\n    if let Err(__sifr_python_runtime_error) = __sifr_initialize_python_runtime() {\n        eprintln!(\"Sifr Python runtime initialization failed: {}\", __sifr_python_runtime_error);\n        std::process::exit(1);\n    }\n",
+    );
+    with_bootstrap.push_str(&main_rs[insert_at..]);
+    Ok(with_bootstrap)
+}
+
+fn render_u64_vec(values: &[u64]) -> String {
+    values
+        .iter()
+        .map(u64::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn render_string_vec(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|value| format!("{}.to_string()", rust_string_literal(value)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn rust_string_literal(value: &str) -> String {
+    format!("{value:?}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata() -> PackagePythonRuntime {
+        let mut metadata = PackagePythonRuntime::for_tests("/tmp/sifr py/bin/python", "digest-a");
+        metadata.venv_root = PathBuf::from("/tmp/sifr py");
+        metadata.sys_path = vec!["/tmp/sifr py/lib".to_string()];
+        metadata.site_packages = vec!["/tmp/sifr py/site-packages".to_string()];
+        metadata
+    }
+
+    #[test]
+    fn renders_escaped_runtime_metadata() {
+        let rendered = render_python_runtime_prelude(&metadata());
+
+        assert!(rendered.contains("PythonRuntimeConfig"));
+        assert!(rendered.contains("\"/tmp/sifr py/bin/python\".to_string()"));
+        assert!(rendered.contains("cpython_version_tuple: vec![3, 13, 1]"));
+    }
+
+    #[test]
+    fn injects_runtime_init_as_first_main_statement() {
+        let main_rs = "fn main() {\n    println!(\"ok\");\n}\n".to_string();
+
+        let rendered =
+            inject_python_runtime_bootstrap(&main_rs, &metadata()).expect("main should be patched");
+
+        assert!(rendered.starts_with("fn __sifr_python_runtime_config()"));
+        assert!(rendered.contains("fn main() {\n    if let Err(__sifr_python_runtime_error)"));
+        assert!(rendered.contains("println!(\"ok\")"));
+    }
+
+    #[test]
+    fn rejects_missing_main_function() {
+        let error = inject_python_runtime_bootstrap("fn helper() {}\n", &metadata())
+            .expect_err("missing main should fail");
+
+        assert!(error.contains("no main function"));
+    }
+}

--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -20,7 +20,7 @@ pub use build::{
     build, build_cached_package_project, build_cached_project, build_cached_single_file,
     build_package_project_report, build_project, build_project_report, build_single_file_report,
     check_package_project, check_project, check_single_file, emit_project, BuildCompilationMode,
-    BuildReport, BuildStageReport, CachedBinaryArtifact, PackageEntrypoint,
+    BuildReport, BuildStageReport, CachedBinaryArtifact, PackageEntrypoint, PackagePythonRuntime,
 };
 pub use diagnostics::{
     apply_diagnostic_recovery_limits, diagnostic_label_for_code, diagnostic_label_for_code_str,

--- a/crates/sifr_driver/src/tests/package_project_build_check.rs
+++ b/crates/sifr_driver/src/tests/package_project_build_check.rs
@@ -212,7 +212,7 @@ fn package_entrypoint(
         package_id,
         graph: graph.clone(),
         source_map: source_map.clone(),
-        python_probe_digest: None,
+        python_runtime: None,
     }
 }
 

--- a/crates/sifr_runtime/Cargo.toml
+++ b/crates/sifr_runtime/Cargo.toml
@@ -20,8 +20,10 @@ icu_datetime = { workspace = true, optional = true }
 icu_decimal = { workspace = true, optional = true }
 icu_locale = { workspace = true, optional = true }
 icu_plurals = { workspace = true, optional = true }
+libc = { workspace = true, optional = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
+pyo3 = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 rustls-pemfile = { workspace = true, optional = true }
 rustls-platform-verifier = { workspace = true, optional = true }
@@ -45,6 +47,7 @@ i18n = [
     "dep:icu_plurals",
 ]
 unicode = ["dep:unicode-normalization", "dep:unicode-segmentation", "dep:unicode_names2"]
+python = ["dep:libc", "dep:pyo3"]
 net = ["dep:tokio"]
 tls = [
     "net",

--- a/crates/sifr_runtime/src/lib.rs
+++ b/crates/sifr_runtime/src/lib.rs
@@ -10,6 +10,8 @@ mod int;
 pub mod json;
 #[cfg(feature = "net")]
 pub mod net;
+#[cfg(feature = "python")]
+pub mod python;
 #[cfg(any(feature = "net", feature = "tls", feature = "http", test))]
 mod timeouts;
 #[cfg(feature = "tls")]

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -1,0 +1,696 @@
+#![allow(unsafe_code)]
+
+use pyo3::{ffi, prelude::*, Py, PyAny};
+use std::ffi::{CStr, CString};
+use std::fmt;
+use std::mem::MaybeUninit;
+use std::sync::{Mutex, MutexGuard};
+
+static RUNTIME_STATE: Mutex<RuntimeState> = Mutex::new(RuntimeState::new());
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PythonRuntimeConfig {
+    pub venv_root: String,
+    pub interpreter: String,
+    pub executable: String,
+    pub sys_prefix: String,
+    pub sys_base_prefix: String,
+    pub probe_digest: String,
+    pub implementation_name: String,
+    pub implementation_version: String,
+    pub cpython_version_tuple: Vec<u64>,
+    pub sys_path: Vec<String>,
+    pub site_packages: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PythonRuntimeInitStatus {
+    Initialized,
+    AlreadyInitialized,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PythonRuntimeDiagnostics {
+    pub initialized: bool,
+    pub live_objects: usize,
+    pub leaked_objects: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum PythonRuntimeError {
+    NotInitialized,
+    ConflictingEnvironment {
+        selected_interpreter: String,
+        attempted_interpreter: String,
+    },
+    InterpreterVersionMismatch {
+        expected: String,
+        actual: String,
+    },
+    InterpreterConfigMismatch {
+        field: &'static str,
+        expected: String,
+        actual: String,
+    },
+    PythonOperationFailed(String),
+    OutstandingResources {
+        live_objects: usize,
+        leaked_objects: usize,
+    },
+    StateUnavailable,
+}
+
+impl fmt::Display for PythonRuntimeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotInitialized => write!(f, "Python runtime has not been initialized"),
+            Self::ConflictingEnvironment {
+                selected_interpreter,
+                attempted_interpreter,
+            } => write!(
+                f,
+                "Python runtime was initialized with '{selected_interpreter}' and cannot be reinitialized with '{attempted_interpreter}'"
+            ),
+            Self::InterpreterVersionMismatch { expected, actual } => write!(
+                f,
+                "selected Python environment uses CPython {expected}, but the embedded interpreter is CPython {actual}"
+            ),
+            Self::InterpreterConfigMismatch {
+                field,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "selected Python environment expected {field} '{expected}', but the embedded interpreter reported '{actual}'"
+            ),
+            Self::PythonOperationFailed(message) => {
+                write!(f, "Python runtime operation failed: {message}")
+            }
+            Self::OutstandingResources {
+                live_objects,
+                leaked_objects,
+            } => write!(
+                f,
+                "Python runtime shutdown blocked by {live_objects} live object(s) and {leaked_objects} leaked object(s)"
+            ),
+            Self::StateUnavailable => write!(f, "Python runtime state is unavailable"),
+        }
+    }
+}
+
+impl std::error::Error for PythonRuntimeError {}
+
+#[derive(Debug)]
+pub struct Object {
+    inner: Option<Py<PyAny>>,
+}
+
+impl Object {
+    pub fn new(object: Py<PyAny>) -> Result<Self, PythonRuntimeError> {
+        update_object_count(1)?;
+        Ok(Self {
+            inner: Some(object),
+        })
+    }
+}
+
+impl Drop for Object {
+    fn drop(&mut self) {
+        let Some(object) = self.inner.take() else {
+            return;
+        };
+        let mut pending = Some(object);
+        if Python::try_attach(|_py| {
+            drop(pending.take());
+        })
+        .is_some()
+        {
+            let _ignored = update_object_count(-1);
+            return;
+        }
+        if let Some(leaked) = pending.take() {
+            std::mem::forget(leaked);
+        }
+        let _ignored = record_leaked_object();
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RuntimeState {
+    config: Option<PythonRuntimeConfig>,
+    initialized: bool,
+    live_objects: usize,
+    leaked_objects: usize,
+}
+
+impl RuntimeState {
+    const fn new() -> Self {
+        Self {
+            config: None,
+            initialized: false,
+            live_objects: 0,
+            leaked_objects: 0,
+        }
+    }
+}
+
+pub fn initialize_runtime(
+    config: PythonRuntimeConfig,
+) -> Result<PythonRuntimeInitStatus, PythonRuntimeError> {
+    let mut state = runtime_state()?;
+    if let Some(selected) = &state.config {
+        if selected != &config {
+            return Err(PythonRuntimeError::ConflictingEnvironment {
+                selected_interpreter: selected.interpreter.clone(),
+                attempted_interpreter: config.interpreter,
+            });
+        }
+        if state.initialized {
+            return Ok(PythonRuntimeInitStatus::AlreadyInitialized);
+        }
+    }
+
+    state.config = Some(config.clone());
+    initialize_cpython_with_config(&config)?;
+    configure_interpreter(&config)?;
+    state.initialized = true;
+    Ok(PythonRuntimeInitStatus::Initialized)
+}
+
+pub fn attach<F, R>(f: F) -> Result<R, PythonRuntimeError>
+where
+    F: for<'py> FnOnce(Python<'py>) -> R,
+{
+    ensure_initialized()?;
+    Python::try_attach(f).ok_or(PythonRuntimeError::NotInitialized)
+}
+
+pub fn detach<F, R>(py: Python<'_>, f: F) -> R
+where
+    F: FnOnce() -> R + Send,
+    R: Send,
+{
+    py.detach(f)
+}
+
+pub fn shutdown_diagnostics() -> Result<PythonRuntimeDiagnostics, PythonRuntimeError> {
+    let state = runtime_state()?;
+    Ok(PythonRuntimeDiagnostics {
+        initialized: state.initialized,
+        live_objects: state.live_objects,
+        leaked_objects: state.leaked_objects,
+    })
+}
+
+pub fn validate_shutdown() -> Result<(), PythonRuntimeError> {
+    let diagnostics = shutdown_diagnostics()?;
+    if diagnostics.live_objects == 0 && diagnostics.leaked_objects == 0 {
+        return Ok(());
+    }
+    Err(PythonRuntimeError::OutstandingResources {
+        live_objects: diagnostics.live_objects,
+        leaked_objects: diagnostics.leaked_objects,
+    })
+}
+
+fn configure_interpreter(config: &PythonRuntimeConfig) -> Result<(), PythonRuntimeError> {
+    attach_initialized(|py| {
+        verify_interpreter_version(py, config)?;
+        verify_interpreter_config(py, config)?;
+        let sys = py.import("sys").map_err(|error| py_error(&error))?;
+        let path = sys.getattr("path").map_err(|error| py_error(&error))?;
+        for entry in config
+            .site_packages
+            .iter()
+            .chain(config.sys_path.iter())
+            .rev()
+        {
+            path.call_method1("insert", (0, entry.as_str()))
+                .map_err(|error| py_error(&error))?;
+        }
+        Ok(())
+    })
+}
+
+fn initialize_cpython_with_config(config: &PythonRuntimeConfig) -> Result<(), PythonRuntimeError> {
+    if unsafe { ffi::Py_IsInitialized() } != 0 {
+        return Ok(());
+    }
+
+    let mut raw_config = MaybeUninit::<ffi::PyConfig>::uninit();
+    unsafe {
+        ffi::PyConfig_InitPythonConfig(raw_config.as_mut_ptr());
+    }
+    let mut raw_config = unsafe { raw_config.assume_init() };
+    raw_config.install_signal_handlers = 0;
+    raw_config.parse_argv = 0;
+    raw_config.use_environment = 0;
+    raw_config.user_site_directory = 0;
+    raw_config.module_search_paths_set = 1;
+
+    let configure_result = configure_raw_python_config(&mut raw_config, config);
+    let initialize_result = configure_result.and_then(|()| {
+        py_status_result(
+            unsafe { ffi::Py_InitializeFromConfig(&raw const raw_config) },
+            "initialize CPython",
+        )
+    });
+    unsafe {
+        ffi::PyConfig_Clear(&raw mut raw_config);
+    }
+    initialize_result?;
+    unsafe {
+        ffi::PyEval_SaveThread();
+    }
+    Ok(())
+}
+
+fn configure_raw_python_config(
+    raw_config: &mut ffi::PyConfig,
+    config: &PythonRuntimeConfig,
+) -> Result<(), PythonRuntimeError> {
+    let raw_config_ptr = std::ptr::from_mut(raw_config);
+    set_config_string(
+        raw_config_ptr,
+        std::ptr::addr_of_mut!(raw_config.executable),
+        &config.executable,
+        "set Python executable",
+    )?;
+    set_config_string(
+        raw_config_ptr,
+        std::ptr::addr_of_mut!(raw_config.base_executable),
+        &config.executable,
+        "set Python base executable",
+    )?;
+    set_config_string(
+        raw_config_ptr,
+        std::ptr::addr_of_mut!(raw_config.program_name),
+        &config.interpreter,
+        "set Python program name",
+    )?;
+    set_optional_config_string(
+        raw_config_ptr,
+        std::ptr::addr_of_mut!(raw_config.prefix),
+        &config.sys_prefix,
+        "set Python prefix",
+    )?;
+    set_optional_config_string(
+        raw_config_ptr,
+        std::ptr::addr_of_mut!(raw_config.exec_prefix),
+        &config.sys_prefix,
+        "set Python exec prefix",
+    )?;
+    set_optional_config_string(
+        raw_config_ptr,
+        std::ptr::addr_of_mut!(raw_config.base_prefix),
+        &config.sys_base_prefix,
+        "set Python base prefix",
+    )?;
+    set_optional_config_string(
+        raw_config_ptr,
+        std::ptr::addr_of_mut!(raw_config.base_exec_prefix),
+        &config.sys_base_prefix,
+        "set Python base exec prefix",
+    )?;
+    set_config_argv(raw_config, &config.interpreter)?;
+    for path in &config.sys_path {
+        append_module_search_path(raw_config, path)?;
+    }
+    Ok(())
+}
+
+fn set_optional_config_string(
+    raw_config: *mut ffi::PyConfig,
+    target: *mut *mut libc::wchar_t,
+    value: &str,
+    context: &'static str,
+) -> Result<(), PythonRuntimeError> {
+    if value.is_empty() {
+        return Ok(());
+    }
+    set_config_string(raw_config, target, value, context)
+}
+
+fn set_config_string(
+    raw_config: *mut ffi::PyConfig,
+    target: *mut *mut libc::wchar_t,
+    value: &str,
+    context: &'static str,
+) -> Result<(), PythonRuntimeError> {
+    let value = CString::new(value).map_err(|_| {
+        PythonRuntimeError::PythonOperationFailed(format!("{context}: value contains NUL byte"))
+    })?;
+    py_status_result(
+        unsafe { ffi::PyConfig_SetBytesString(raw_config, target, value.as_ptr()) },
+        context,
+    )
+}
+
+fn set_config_argv(
+    raw_config: &mut ffi::PyConfig,
+    interpreter: &str,
+) -> Result<(), PythonRuntimeError> {
+    let interpreter = CString::new(interpreter).map_err(|_| {
+        PythonRuntimeError::PythonOperationFailed(
+            "set Python argv: value contains NUL byte".to_string(),
+        )
+    })?;
+    let mut argv = [interpreter.as_ptr()];
+    py_status_result(
+        unsafe { ffi::PyConfig_SetBytesArgv(raw_config, 1, argv.as_mut_ptr()) },
+        "set Python argv",
+    )
+}
+
+fn append_module_search_path(
+    raw_config: &mut ffi::PyConfig,
+    path: &str,
+) -> Result<(), PythonRuntimeError> {
+    let wide = wide_string(path);
+    py_status_result(
+        unsafe {
+            ffi::PyWideStringList_Append(&raw mut raw_config.module_search_paths, wide.as_ptr())
+        },
+        "set Python module search path",
+    )
+}
+
+#[cfg(windows)]
+fn wide_string(value: &str) -> Vec<libc::wchar_t> {
+    use std::os::windows::ffi::OsStrExt;
+    std::ffi::OsStr::new(value)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+#[cfg(not(windows))]
+fn wide_string(value: &str) -> Vec<libc::wchar_t> {
+    value
+        .chars()
+        .map(|ch| ch as libc::wchar_t)
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+fn py_status_result(
+    status: ffi::PyStatus,
+    context: &'static str,
+) -> Result<(), PythonRuntimeError> {
+    if unsafe { ffi::PyStatus_Exception(status) } == 0 {
+        return Ok(());
+    }
+    Err(PythonRuntimeError::PythonOperationFailed(format!(
+        "{context}: {}",
+        py_status_message(status)
+    )))
+}
+
+fn py_status_message(status: ffi::PyStatus) -> String {
+    if status.err_msg.is_null() {
+        return format!("status exit code {}", status.exitcode);
+    }
+    unsafe { CStr::from_ptr(status.err_msg) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn verify_interpreter_version(
+    py: Python<'_>,
+    config: &PythonRuntimeConfig,
+) -> Result<(), PythonRuntimeError> {
+    if config.cpython_version_tuple.len() < 2 {
+        return Ok(());
+    }
+    let version = py.version_info();
+    let expected_major = config.cpython_version_tuple[0];
+    let expected_minor = config.cpython_version_tuple[1];
+    if u64::from(version.major) == expected_major && u64::from(version.minor) == expected_minor {
+        return Ok(());
+    }
+    Err(PythonRuntimeError::InterpreterVersionMismatch {
+        expected: format!("{expected_major}.{expected_minor}"),
+        actual: format!("{}.{}", version.major, version.minor),
+    })
+}
+
+fn verify_interpreter_config(
+    py: Python<'_>,
+    config: &PythonRuntimeConfig,
+) -> Result<(), PythonRuntimeError> {
+    let sys = py.import("sys").map_err(|error| py_error(&error))?;
+    verify_sys_attr(&sys, "executable", &config.executable)?;
+    verify_sys_attr(&sys, "prefix", &config.sys_prefix)?;
+    verify_sys_attr(&sys, "base_prefix", &config.sys_base_prefix)
+}
+
+fn verify_sys_attr(
+    sys: &Bound<'_, PyAny>,
+    field: &'static str,
+    expected: &str,
+) -> Result<(), PythonRuntimeError> {
+    if expected.is_empty() {
+        return Ok(());
+    }
+    let actual = sys
+        .getattr(field)
+        .and_then(|value| value.extract::<String>())
+        .map_err(|error| py_error(&error))?;
+    if actual == expected {
+        return Ok(());
+    }
+    Err(PythonRuntimeError::InterpreterConfigMismatch {
+        field,
+        expected: expected.to_string(),
+        actual,
+    })
+}
+
+fn attach_initialized<F, R>(f: F) -> Result<R, PythonRuntimeError>
+where
+    F: for<'py> FnOnce(Python<'py>) -> Result<R, PythonRuntimeError>,
+{
+    Python::try_attach(f).ok_or(PythonRuntimeError::NotInitialized)?
+}
+
+fn ensure_initialized() -> Result<(), PythonRuntimeError> {
+    let state = runtime_state()?;
+    if state.initialized {
+        Ok(())
+    } else {
+        Err(PythonRuntimeError::NotInitialized)
+    }
+}
+
+fn runtime_state() -> Result<MutexGuard<'static, RuntimeState>, PythonRuntimeError> {
+    RUNTIME_STATE
+        .lock()
+        .map_err(|_| PythonRuntimeError::StateUnavailable)
+}
+
+fn update_object_count(delta: isize) -> Result<(), PythonRuntimeError> {
+    let mut state = runtime_state()?;
+    if delta.is_positive() {
+        state.live_objects = state.live_objects.saturating_add(delta.cast_unsigned());
+    } else {
+        state.live_objects = state.live_objects.saturating_sub(delta.unsigned_abs());
+    }
+    Ok(())
+}
+
+fn record_leaked_object() -> Result<(), PythonRuntimeError> {
+    let mut state = runtime_state()?;
+    state.live_objects = state.live_objects.saturating_sub(1);
+    state.leaked_objects = state.leaked_objects.saturating_add(1);
+    Ok(())
+}
+
+fn py_error(error: &PyErr) -> PythonRuntimeError {
+    PythonRuntimeError::PythonOperationFailed(error.to_string())
+}
+
+#[cfg(test)]
+fn reset_runtime_state_for_tests() {
+    let mut state = runtime_state().expect("runtime state should be available");
+    *state = RuntimeState::new();
+}
+
+#[cfg(test)]
+fn test_config(label: &str) -> PythonRuntimeConfig {
+    let mut config = local_python_config();
+    config.probe_digest = format!("digest-{label}");
+    config
+}
+
+#[cfg(test)]
+fn local_python_config() -> PythonRuntimeConfig {
+    let script = r#"
+import os
+import sys
+print(sys.executable)
+print(sys.prefix)
+print(sys.base_prefix)
+print(".".join(str(part) for part in sys.version_info[:3]))
+print(os.pathsep.join(sys.path))
+"#;
+    let output = std::process::Command::new("python3")
+        .args(["-c", script])
+        .output()
+        .expect("python3 should be available for PyO3 runtime tests");
+    assert!(
+        output.status.success(),
+        "python3 probe should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("python3 probe should emit UTF-8");
+    let mut lines = stdout.lines();
+    let executable = lines
+        .next()
+        .expect("python3 probe should emit executable")
+        .to_string();
+    let sys_prefix = lines
+        .next()
+        .expect("python3 probe should emit sys.prefix")
+        .to_string();
+    let sys_base_prefix = lines
+        .next()
+        .expect("python3 probe should emit sys.base_prefix")
+        .to_string();
+    let version = lines
+        .next()
+        .expect("python3 probe should emit version tuple")
+        .split('.')
+        .map(|part| part.parse::<u64>().expect("version part should be numeric"))
+        .collect::<Vec<_>>();
+    let sys_path = lines
+        .next()
+        .unwrap_or_default()
+        .split(if cfg!(windows) { ';' } else { ':' })
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    PythonRuntimeConfig {
+        venv_root: sys_prefix.clone(),
+        interpreter: executable.clone(),
+        executable,
+        sys_prefix,
+        sys_base_prefix,
+        probe_digest: "digest-test".to_string(),
+        implementation_name: "cpython".to_string(),
+        implementation_version: "test".to_string(),
+        cpython_version_tuple: version,
+        sys_path,
+        site_packages: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn test_guard() -> MutexGuard<'static, ()> {
+        TEST_LOCK.lock().expect("test lock should be available")
+    }
+
+    #[test]
+    fn initializes_and_accepts_repeated_same_config() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        let config = test_config("same");
+
+        assert_eq!(
+            initialize_runtime(config.clone()),
+            Ok(PythonRuntimeInitStatus::Initialized)
+        );
+        assert_eq!(
+            initialize_runtime(config),
+            Ok(PythonRuntimeInitStatus::AlreadyInitialized)
+        );
+    }
+
+    #[test]
+    fn rejects_reinitialization_with_different_config() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("first")).expect("first init should succeed");
+
+        let error =
+            initialize_runtime(test_config("second")).expect_err("different config should fail");
+
+        assert!(matches!(
+            error,
+            PythonRuntimeError::ConflictingEnvironment { .. }
+        ));
+    }
+
+    #[test]
+    fn attach_requires_runtime_initialization() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+
+        let result = attach(|py| py.version_info().major);
+
+        assert_eq!(result, Err(PythonRuntimeError::NotInitialized));
+    }
+
+    #[test]
+    fn attach_and_detach_run_under_initialized_runtime() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("detach")).expect("init should succeed");
+
+        let result = attach(|py| detach(py, || 41 + 1));
+
+        assert_eq!(result, Ok(42));
+    }
+
+    #[test]
+    fn owned_object_tracking_is_released_through_gil_bound_drop() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("object")).expect("init should succeed");
+        let object = attach(|py| Object::new(py.None())).expect("attach should succeed");
+        assert!(object.is_ok());
+        assert_eq!(
+            shutdown_diagnostics().expect("diagnostics should be available"),
+            PythonRuntimeDiagnostics {
+                initialized: true,
+                live_objects: 1,
+                leaked_objects: 0,
+            }
+        );
+
+        drop(object);
+
+        assert_eq!(
+            shutdown_diagnostics().expect("diagnostics should be available"),
+            PythonRuntimeDiagnostics {
+                initialized: true,
+                live_objects: 0,
+                leaked_objects: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn shutdown_validation_reports_outstanding_objects() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("shutdown")).expect("init should succeed");
+        let object = attach(|py| Object::new(py.None())).expect("attach should succeed");
+        assert!(object.is_ok());
+
+        let error = validate_shutdown().expect_err("live object should block shutdown");
+
+        assert_eq!(
+            error,
+            PythonRuntimeError::OutstandingResources {
+                live_objects: 1,
+                leaked_objects: 0,
+            }
+        );
+        drop(object);
+    }
+}

--- a/crates/sifr_stdlib/src/features.rs
+++ b/crates/sifr_stdlib/src/features.rs
@@ -29,6 +29,7 @@ pub enum StdlibFeature {
     NumBigint,
     NumTraits,
     PercentEncoding,
+    PythonRuntime,
     Rand,
     RandDistr,
     Rayon,
@@ -83,6 +84,7 @@ impl StdlibFeature {
             Self::NumBigint => "num-bigint",
             Self::NumTraits => "num-traits",
             Self::PercentEncoding => "percent-encoding",
+            Self::PythonRuntime => "sifr_runtime/python",
             Self::Rand => "rand",
             Self::RandDistr => "rand_distr",
             Self::Rayon => "rayon",
@@ -228,6 +230,7 @@ const PERCENT_ENCODING_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDepen
     package: "percent-encoding",
     spec: "percent-encoding = \"2.3.2\"",
 }];
+const PYTHON_RUNTIME_DEPS: &[GeneratedCargoDependency] = SIFR_RUNTIME_DEPS;
 const RAND_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
     package: "rand",
     spec: "rand = \"0.10.1\"",
@@ -429,6 +432,10 @@ pub const STDLIB_FEATURE_SPECS: &[StdlibFeatureSpec] = &[
         cargo_dependencies: PERCENT_ENCODING_DEPS,
     },
     StdlibFeatureSpec {
+        feature: StdlibFeature::PythonRuntime,
+        cargo_dependencies: PYTHON_RUNTIME_DEPS,
+    },
+    StdlibFeatureSpec {
         feature: StdlibFeature::Rand,
         cargo_dependencies: RAND_DEPS,
     },
@@ -550,6 +557,9 @@ pub fn feature_for_codegen_requirement(name: &str) -> Option<StdlibFeature> {
         "num-bigint" => Some(StdlibFeature::NumBigint),
         "num-traits" => Some(StdlibFeature::NumTraits),
         "percent-encoding" | "percent_encoding" => Some(StdlibFeature::PercentEncoding),
+        "sifr_runtime/python" | "sifr-runtime/python" | "python-runtime" => {
+            Some(StdlibFeature::PythonRuntime)
+        }
         "rand" => Some(StdlibFeature::Rand),
         "rand_distr" => Some(StdlibFeature::RandDistr),
         "rayon" => Some(StdlibFeature::Rayon),
@@ -692,6 +702,7 @@ struct RuntimeFeatures {
     http: bool,
     i18n: bool,
     net: bool,
+    python: bool,
     tls: bool,
     unicode: bool,
 }
@@ -705,6 +716,7 @@ impl RuntimeFeatures {
             http: needs_sifr_runtime_http(stdlib_modules, required_features),
             i18n: needs_sifr_runtime_i18n(stdlib_modules, required_features),
             net: needs_sifr_runtime_net(stdlib_modules),
+            python: required_features.contains(&StdlibFeature::PythonRuntime),
             tls: needs_sifr_runtime_tls(stdlib_modules, required_features),
             unicode: needs_sifr_runtime_unicode(stdlib_modules, required_features),
         }
@@ -823,6 +835,9 @@ fn sifr_runtime_dependency_spec(runtime_features: RuntimeFeatures) -> String {
     }
     if runtime_features.net || runtime_features.tls || runtime_features.http {
         features.push("\"net\"");
+    }
+    if runtime_features.python {
+        features.push("\"python\"");
     }
     if runtime_features.tls || runtime_features.http {
         features.push("\"tls\"");

--- a/crates/sifr_stdlib/src/features_tests.rs
+++ b/crates/sifr_stdlib/src/features_tests.rs
@@ -130,3 +130,19 @@ fn runtime_dependency_can_enable_unicode_and_i18n_together() {
     assert!(deps.iter().any(|dep| dep.starts_with("sifr_runtime = ")
         && dep.contains("features = [\"i18n\", \"unicode\"]")));
 }
+
+#[test]
+fn python_runtime_feature_enables_sifr_runtime_python_feature() {
+    let deps = generated_cargo_dependencies(
+        &HashSet::new(),
+        &HashSet::from([StdlibFeature::PythonRuntime]),
+    );
+
+    assert!(deps
+        .iter()
+        .any(|dep| dep.starts_with("sifr_runtime = ") && dep.contains("features = [\"python\"]")));
+    assert_eq!(
+        feature_for_codegen_requirement("python-runtime"),
+        Some(StdlibFeature::PythonRuntime)
+    );
+}

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -17,13 +17,14 @@
   - Added active `SIFR-PYENV-0001` through `SIFR-PYENV-0011` diagnostics and generated docs.
   - Wired package `check`/cached `run` contexts to resolve/probe the root-selected environment and feed the probe digest into generated-artifact cache keys.
   - Promoted `verification/python_interop/run.sh --group env` to live environment evidence with positive and negative fixture coverage.
-- [ ] `milestone_py_2`: Embedded runtime lifecycle.
+- [x] `milestone_py_2`: Embedded runtime lifecycle.
   - Added optional `sifr_runtime/python` feature backed by PyO3 embedding APIs and CPython `PyConfig` initialization.
   - Added generated package runtime metadata carrying the validated probe executable, prefixes, path set, version tuple, and digest into generated binaries.
   - Added generated bootstrap that initializes the Python runtime before user `main` code for Python-enabled package builds.
   - Added `PYO3_PYTHON` build environment wiring so generated package binaries link/configure against the selected interpreter.
   - Added runtime lifecycle state with same-config repeated init, conflicting-config rejection, GIL attach/detach helpers, owned Python object tracking, and shutdown diagnostics.
-  - Added focused runtime, stdlib dependency, and driver bootstrap tests; Opus review approved and local `create-pr` validation passed, PR pending.
+  - Added focused runtime, stdlib dependency, and driver bootstrap tests; Opus review approved and local `create-pr` validation passed.
+  - Merged via PR [#2667](https://github.com/sifr-lang/sifr/pull/2667).
 - [ ] `milestone_py_3`: Opaque object operations and errors.
 - [ ] `milestone_py_4`: Primitive and typed conversion.
 - [ ] `milestone_py_5`: Async/blocking integration.

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -18,6 +18,12 @@
   - Wired package `check`/cached `run` contexts to resolve/probe the root-selected environment and feed the probe digest into generated-artifact cache keys.
   - Promoted `verification/python_interop/run.sh --group env` to live environment evidence with positive and negative fixture coverage.
 - [ ] `milestone_py_2`: Embedded runtime lifecycle.
+  - Added optional `sifr_runtime/python` feature backed by PyO3 embedding APIs and CPython `PyConfig` initialization.
+  - Added generated package runtime metadata carrying the validated probe executable, prefixes, path set, version tuple, and digest into generated binaries.
+  - Added generated bootstrap that initializes the Python runtime before user `main` code for Python-enabled package builds.
+  - Added `PYO3_PYTHON` build environment wiring so generated package binaries link/configure against the selected interpreter.
+  - Added runtime lifecycle state with same-config repeated init, conflicting-config rejection, GIL attach/detach helpers, owned Python object tracking, and shutdown diagnostics.
+  - Added focused runtime, stdlib dependency, and driver bootstrap tests; Opus review approved and local `create-pr` validation passed, PR pending.
 - [ ] `milestone_py_3`: Opaque object operations and errors.
 - [ ] `milestone_py_4`: Primitive and typed conversion.
 - [ ] `milestone_py_5`: Async/blocking integration.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py2-review-1.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py2-review-1.md
@@ -1,0 +1,43 @@
+I've inspected the diff and the relevant source. Here's my review against milestone_py_2.
+
+## Blockers
+
+### 1. Embedded CPython runtime does not honor the selected venv
+
+`crates/sifr_runtime/src/python.rs:153` calls `Python::initialize()` (which dispatches to `Py_InitializeEx` with the default config) and then in `configure_interpreter` (`python.rs:196-212`) only *prepends* `site_packages` and `sys_path` to `sys.path`. Nothing tells CPython to treat the configured `.venv` as its prefix:
+
+- `PythonRuntimeConfig::venv_root` and `PythonRuntimeConfig::interpreter` are stored but never used to set `PyConfig.executable`, `PyConfig.prefix`, `PyConfig.exec_prefix`, `PYTHONHOME`, etc.
+- After init, `sys.executable`, `sys.prefix`, `sys.base_prefix` will reflect whatever libpython `pyo3-build-config` linked at compile time — i.e., the host-global Python — not the probed venv.
+- Native extensions loaded via the prepended `site-packages` will read those mismatched prefixes.
+
+This directly violates the contract in `plans/issues/active/ad-hoc-embedded-python-interop.md:175` ("Runtime resolution must prefer the configured interpreter/venv. No host-global Python fallback is allowed.") and the milestone_py_2 scope line ("Initialize CPython once with selected environment configuration").
+
+**Expected fix:** drive `Python::initialize_with(PyConfig {...})` via `pyo3-ffi` (or set `PYTHONHOME` before `Python::initialize()` as a transitional measure), with `executable`, `prefix`, `exec_prefix`, and the venv path wired from `PythonRuntimeConfig`. The `verify_interpreter_version` check at `python.rs:214-231` should remain as a post-init safety net.
+
+### 2. `cargo build` for the generated package is not parametrized by the selected interpreter
+
+`crates/sifr_driver/src/build/materialize.rs:166-184` runs `cargo build --release --quiet` with no environment overrides. The probe digest is in the cache key, but `pyo3-build-config` chooses libpython at build time from `PYO3_PYTHON` / `PATH` — neither of which is forced to match the selected venv. So the cache key claims "binary X was built against probe Y," but cargo may have actually linked a different libpython.
+
+Combined with blocker #1, this means a binary cached for venv A can be linked to host Python B. The runtime version check is the only thing protecting against the mismatch, and it only checks major/minor.
+
+**Expected fix:** thread the resolved interpreter into `Command::new("cargo")` as `PYO3_PYTHON=<config.interpreter>` (and, for cross-config interpreter resolution, the related `PYO3_CROSS_*` knobs where applicable). The phase contract enumerates `interpreter path` as a cache-invalidation input (`plans/issues/active/...:172`); it should also be a build input.
+
+## Non-blocking concerns
+
+1. **Fragile bootstrap injection** — `python_runtime.rs:89-105` uses `main_rs.find("fn main")` and then `find('{')` from that offset. Any preceding doc comment or unrelated `fn main_*` symbol earlier in `main.rs` would silently mis-target the injection. Today's generated `main.rs` doesn't trip it, but it's an unchecked invariant. Recommend a stricter match (e.g., a regex anchored at line start, or emitting the bootstrap call from codegen instead of textual post-processing).
+
+2. **Bootstrap failure path bypasses Sifr diagnostics** — `python_runtime.rs:101-103` emits `eprintln!` + `std::process::exit(1)` on init failure. That's acceptable for "no panic" but the user sees an unstructured message rather than a `SIFR-PYRUNTIME-*` (or equivalent) coded diagnostic. The milestone_py_0 family list reserved `SIFR-PYENV/PYIMP/PYCALL/PYCONV/PYRES/PYZC/PYCB/PYTRUST` but no runtime-init family. Worth either reusing `SIFR-PYENV-*` at runtime, reserving a new family, or noting this in milestone_py_12 (docs/diagnostics closeout).
+
+3. **No regression test for `InterpreterVersionMismatch`** — `python.rs:283-294` test config sets `cpython_version_tuple: Vec::new()`, which short-circuits version verification at `python.rs:218-220`. The mismatch path is unexercised. Hard to assert against a real interpreter without rebuilding, but a unit test that fakes `version_info` via an injected verifier would close the gap.
+
+4. **State mutex held across `Python::initialize()`** — `python.rs:140-157` holds the `RUNTIME_STATE` mutex while CPython runs site-init. If site.py or an extension import recursively reaches the runtime state (e.g., via a Sifr callback in a later milestone), it deadlocks. Probably moot for milestone_py_2 but worth releasing the lock before `Python::initialize()` and re-acquiring just to write the config back.
+
+5. **Partial-init recovery** — If `configure_interpreter` fails after `Python::initialize()` succeeds (`python.rs:153-156`), `state.config` is never set. A subsequent call with a *different* config will pass the conflict check (because `state.config` is `None`) and silently switch configs, even though CPython has already been initialized. Set `state.config` (or a "pending" sentinel) *before* calling `configure_interpreter`, or eagerly mark the runtime as poisoned on partial failure.
+
+6. **`verify_interpreter_version` only checks major/minor** — Acceptable for libpython ABI, but the probe digest is the real cache key. Worth documenting that the runtime mismatch error is a defense-in-depth check, not an ABI gate.
+
+7. **`run_cargo_build` does not surface clear "PyO3 couldn't find a Python" diagnostics** — Indirectly related to blocker #2: today a missing/wrong `PYO3_PYTHON` produces a generic cargo build failure via `BUILD_RUSTC_OR_CARGO_FAILURE`. Once #2 is fixed by passing the resolved interpreter, this resolves.
+
+## Verdict
+
+**Not approved.** The two blockers above are direct violations of the phase contract's "No host-global Python fallback" and the milestone_py_2 scope sentence "Initialize CPython once with selected environment configuration." The lifecycle state machine, GIL discipline, `Object` GIL-bound drop, conflict rejection, and cache-key plumbing are all correctly shaped — the gap is specifically how the selected venv is wired into both compile-time linking and `PyConfig`. Once `Python::initialize` is configured with `PyConfig`/`PYTHONHOME` from `PythonRuntimeConfig` *and* `cargo build` receives `PYO3_PYTHON` matching the probe, the milestone DoD is satisfied.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py2-review-2.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py2-review-2.md
@@ -1,0 +1,31 @@
+I've reviewed the diff against main, focusing on the milestone_py_2 surface and the two blockers from review-1.
+
+## Blockers
+
+**None.** Both blockers from review-1 are fully resolved.
+
+1. **CPython init honors the selected venv.** `initialize_cpython_with_config` (`crates/sifr_runtime/src/python.rs:235-266`) now drives `Py_InitializeFromConfig` via `pyo3-ffi`. `configure_raw_python_config` (`python.rs:268-320`) sets `executable`, `base_executable`, `program_name`, `prefix`, `exec_prefix`, `base_prefix`, `base_exec_prefix`, `argv`, and the exact `module_search_paths` from the probe; flips `module_search_paths_set = 1`, `use_environment = 0`, `user_site_directory = 0`, `install_signal_handlers = 0`, `parse_argv = 0`; and `PyEval_SaveThread` runs once after init. `verify_interpreter_config` (`python.rs:437-467`) then asserts `sys.executable`, `sys.prefix`, and `sys.base_prefix` match the probe values, so any post-link drift surfaces as `InterpreterConfigMismatch` instead of silent host-global use. This satisfies the "No host-global Python fallback" clause and the milestone_py_2 scope sentence.
+
+2. **Generated cargo build is parametrized by the interpreter.** `materialize_binary_project_at_path` (`crates/sifr_driver/src/build/materialize.rs:81-90`) pulls `interpreter` out of `generated_project.python_runtime`; `run_cargo_build` (`materialize.rs:170-194`) sets `PYO3_PYTHON=<interpreter>` when present. Combined with `apply_package_runtime_metadata` (`project_codegen.rs:99-117`) writing the probe digest into `cache_key_fragment`, the cache invalidates and the build links against the same interpreter the runtime will validate against.
+
+## Non-blocking concerns
+
+1. **Bootstrap text injection is still fragile.** `inject_python_runtime_bootstrap` (`python_runtime.rs:105-126`) continues to anchor on `main_rs.find("fn main")` + `find('{')`. Today's `assemble_project_main_rs` emits a single `fn main` with no preceding comments or `fn main_*` neighbors, so it works — but it remains an unchecked invariant. Moving the bootstrap into codegen (e.g., adding a `pre_main_statements` slot on the project assembler) would remove the textual coupling.
+
+2. **Bootstrap failure still bypasses Sifr diagnostics.** `python_runtime.rs:119-123` emits `eprintln!` + `std::process::exit(1)` on init failure. Acceptable for "no panic" but still unstructured. milestone_py_0 reserved `SIFR-PYENV` through `SIFR-PYTRUST`; a `SIFR-PYRUNTIME-*` family (or reuse of `SIFR-PYENV-*` at runtime) would fit better. Worth slotting into milestone_py_12 if not addressed sooner.
+
+3. **No coverage for `InterpreterVersionMismatch` or `InterpreterConfigMismatch`.** `test_config` derives everything from the live `python3`, so both verifiers always pass. The new `InterpreterConfigMismatch` arm (`python.rs:50-54`, `437-467`) and the existing version mismatch arm have no unit test. A test that constructs a config with deliberately wrong `executable`/`sys_prefix`/`cpython_version_tuple` against the actually-linked Python would exercise both paths without needing alternate interpreters.
+
+4. **`RUNTIME_STATE` mutex is still held across init.** `initialize_runtime` (`python.rs:157-178`) keeps the lock for the duration of `initialize_cpython_with_config` and `configure_interpreter`. Site init or a future callback that reaches `runtime_state()` would deadlock. Not exercised in milestone_py_2 but flagged for milestone_py_10 (callbacks).
+
+5. **`verify_sys_attr` silently no-ops on empty expected values.** `python.rs:452-454` returns `Ok` when `expected.is_empty()`. The probe should always populate these, but a hardening pass could enforce non-empty in `PythonRuntimeConfig` construction rather than relying on caller discipline.
+
+6. **`sys.path` ends up with duplicated entries.** `configure_interpreter` (`python.rs:216-233`) inserts `site_packages` *and* `sys_path` at position 0 of `sys.path` post-init, even though `module_search_paths` already contains `sys_path`. Functionally fine — duplicate entries are harmless — but cosmetically messy and slightly slows the first import scan. Either drop the post-init `sys_path` insert or skip the in-PyConfig pass.
+
+7. **`PyConfig.home` is not set.** With `module_search_paths_set = 1` this doesn't affect path resolution, but `home` also influences a handful of cpython internals (e.g., `sysconfig`'s view of install layout). Worth setting to the venv root for completeness; not required for the milestone DoD.
+
+8. **`append_module_search_path` accepts empty strings.** `python.rs:316-318` does not filter empties; if the probe's `sys.path` ever contained `""` (which CPython itself sometimes emits to mean CWD) it would be propagated. Today the probe filter likely strips these, but adding a guard is cheap.
+
+## Verdict
+
+**Approved for PR after authoritative create-pr validation.** The lifecycle state machine, GIL discipline, GIL-bound `Object` drop, conflict rejection, probe-digest cache plumbing, and now the `PyConfig`-driven init and `PYO3_PYTHON` build wiring all match the milestone_py_2 scope and the phase contract. Run `scripts/run_all_tests.sh --profile create-pr` before opening the PR; the non-blocking items can be addressed in follow-up work or rolled into milestone_py_12.

--- a/verification/areas/coverage_matrix/data/cargo_metadata_classification.json
+++ b/verification/areas/coverage_matrix/data/cargo_metadata_classification.json
@@ -98,6 +98,7 @@
         {"name": "http", "profile_assignment": "merge", "classification": "first_party_runtime"},
         {"name": "i18n", "profile_assignment": "nightly", "classification": "first_party_runtime"},
         {"name": "net", "profile_assignment": "nightly", "classification": "first_party_runtime"},
+        {"name": "python", "profile_assignment": "merge", "classification": "first_party_runtime"},
         {"name": "tls", "profile_assignment": "nightly", "classification": "first_party_runtime"},
         {"name": "unicode", "profile_assignment": "nightly", "classification": "first_party_runtime"}
       ]


### PR DESCRIPTION
## Summary

Implements `milestone_py_2: Embedded Runtime Lifecycle` for the embedded Python interop phase.

- adds optional `sifr_runtime/python` support using PyO3 plus CPython `PyConfig` initialization
- carries validated package Python probe metadata into generated binaries
- initializes the Python runtime before generated user `main` for Python-enabled package projects
- passes `PYO3_PYTHON` to generated Cargo builds so PyO3 build config uses the selected interpreter
- adds runtime state, same-config reinit, conflicting-config rejection, GIL attach/detach helpers, owned Python object tracking, and shutdown diagnostics
- records Opus review passes under `plans/reviews/active/`

## Review

Opus review pass 1 found blockers around selected-venv initialization and generated Cargo build interpreter selection. Both were fixed.

Opus review pass 2 approved the milestone for PR after create-pr validation.

## Validation

- `cargo test -p sifr_runtime --features python python -- --nocapture`
- `cargo test -p sifr_driver python_runtime -- --nocapture`
- `cargo test -p sifr_stdlib python_runtime_feature -- --nocapture`
- `cargo test -p sifr_driver package_project_build_check -- --nocapture`
- `cargo test -p sifr_package python -- --nocapture`
- `cargo test -p sifr mode_resolution_tests::test_package_cli_check_explicit_file_uses_package_imports -- --nocapture`
- `cargo clippy -p sifr_runtime --features python -- -D warnings`
- `cargo clippy -p sifr_stdlib -p sifr_driver -p sifr -- -D warnings`
- `scripts/run_all_tests.sh --profile create-pr`

`create-pr` passed with advisory only: warm wall-time budget exceeded.
