### PR TITLE
Add explicit Python conversion APIs

### DIFF
--- a/crates/sifr_codegen/src/intrinsics/registry.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry.rs
@@ -786,17 +786,7 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         ),
         "runtime_emit_diagnostic" => (runtime::lower_runtime_emit_diagnostic(args), None),
         name if name.starts_with("py_") => (
-            match name {
-                "py_import_module" => python::lower_py_import_module(args),
-                "py_get_attr" => python::lower_py_get_attr(args),
-                "py_get_item_str" => python::lower_py_get_item_str(args),
-                "py_call" => python::lower_py_call(args),
-                "py_call_attr" => python::lower_py_call_attr(args),
-                "py_close" => python::lower_py_close(args),
-                "py_enter_context" => python::lower_py_enter_context(args),
-                "py_exit_context" => python::lower_py_exit_context(args),
-                _ => None,
-            },
+            python::lower_python_intrinsic(name, args),
             Some(StdlibFeature::PythonRuntime),
         ),
         "task_current_context" => (

--- a/crates/sifr_codegen/src/intrinsics/registry/python.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/python.rs
@@ -1,5 +1,67 @@
 use crate::{render_expr, RustExpr};
 
+pub(crate) fn lower_python_intrinsic(name: &str, args: &[RustExpr]) -> Option<RustExpr> {
+    match name {
+        "py_import_module" => lower_py_import_module(args),
+        "py_get_attr" => lower_py_get_attr(args),
+        "py_get_item_str" => lower_py_get_item_str(args),
+        "py_call" => lower_py_call(args),
+        "py_call_attr" => lower_py_call_attr(args),
+        "py_close" => lower_py_close(args),
+        "py_enter_context" => lower_py_enter_context(args),
+        "py_exit_context" => lower_py_exit_context(args),
+        "py_from_none" => lower_py_from_none(args),
+        "py_from_bool" => lower_py_from_bool(args),
+        "py_from_int" => lower_py_from_int(args),
+        "py_from_float" => lower_py_from_float(args),
+        "py_from_str" => lower_py_from_str(args),
+        "py_from_bytes" => lower_py_from_bytes(args),
+        "py_from_list" => lower_py_from_list(args),
+        "py_from_tuple" => lower_py_from_tuple(args),
+        "py_from_dict_str" => lower_py_from_dict_str(args),
+        "py_from_record" => lower_py_from_record(args),
+        "py_to_none" => lower_py_to_none(args),
+        "py_to_bool" => lower_py_to_bool(args),
+        "py_to_int" => lower_py_to_int(args),
+        "py_to_i8" => lower_py_to_i8(args),
+        "py_to_i16" => lower_py_to_i16(args),
+        "py_to_i32" => lower_py_to_i32(args),
+        "py_to_i64" => lower_py_to_i64(args),
+        "py_to_u8" => lower_py_to_u8(args),
+        "py_to_u16" => lower_py_to_u16(args),
+        "py_to_u32" => lower_py_to_u32(args),
+        "py_to_u64" => lower_py_to_u64(args),
+        "py_to_isize" => lower_py_to_isize(args),
+        "py_to_usize" => lower_py_to_usize(args),
+        "py_to_float" => lower_py_to_float(args),
+        "py_to_str" => lower_py_to_str(args),
+        "py_to_bytes" => lower_py_to_bytes(args),
+        "py_copy_list_bool" => lower_handle_conversion(args, "copy_list_bool"),
+        "py_copy_list_int" => lower_handle_conversion(args, "copy_list_int"),
+        "py_copy_list_i32" => lower_handle_conversion(args, "copy_list_i32"),
+        "py_copy_list_u8" => lower_handle_conversion(args, "copy_list_u8"),
+        "py_copy_list_float" => lower_handle_conversion(args, "copy_list_float"),
+        "py_copy_list_str" => lower_handle_conversion(args, "copy_list_str"),
+        "py_copy_list_bytes" => lower_handle_conversion(args, "copy_list_bytes"),
+        "py_copy_tuple_bool" => lower_handle_conversion(args, "copy_tuple_bool"),
+        "py_copy_tuple_int" => lower_handle_conversion(args, "copy_tuple_int"),
+        "py_copy_tuple_i32" => lower_handle_conversion(args, "copy_tuple_i32"),
+        "py_copy_tuple_u8" => lower_handle_conversion(args, "copy_tuple_u8"),
+        "py_copy_tuple_float" => lower_handle_conversion(args, "copy_tuple_float"),
+        "py_copy_tuple_str" => lower_handle_conversion(args, "copy_tuple_str"),
+        "py_copy_tuple_bytes" => lower_handle_conversion(args, "copy_tuple_bytes"),
+        "py_copy_dict_str_bool" => lower_handle_conversion(args, "copy_dict_str_bool"),
+        "py_copy_dict_str_int" => lower_handle_conversion(args, "copy_dict_str_int"),
+        "py_copy_dict_str_i32" => lower_handle_conversion(args, "copy_dict_str_i32"),
+        "py_copy_dict_str_u8" => lower_handle_conversion(args, "copy_dict_str_u8"),
+        "py_copy_dict_str_float" => lower_handle_conversion(args, "copy_dict_str_float"),
+        "py_copy_dict_str_str" => lower_handle_conversion(args, "copy_dict_str_str"),
+        "py_copy_dict_str_bytes" => lower_handle_conversion(args, "copy_dict_str_bytes"),
+        "py_copy_record_fields" => lower_py_copy_record_fields(args),
+        _ => None,
+    }
+}
+
 fn map_python_error(expr: String) -> RustExpr {
     RustExpr::Ident(format!(
         r#"({expr}).map_err(|__sifr_python_error| PythonError {{
@@ -10,6 +72,68 @@ fn map_python_error(expr: String) -> RustExpr {
             context: __sifr_python_error.context,
         }})"#
     ))
+}
+
+fn object_expr(handle: String, token: String) -> String {
+    format!("({handle}, {token})")
+}
+
+fn lower_handle_conversion(args: &[RustExpr], function: &str) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    let handle = render_expr(&args[0]);
+    let token = render_expr(&args[1]);
+    Some(map_python_error(format!(
+        "sifr_runtime::python::{function}({})",
+        object_expr(handle, token)
+    )))
+}
+
+fn object_handles_expr(values: String) -> String {
+    format!(
+        r#"({values})
+                .iter()
+                .map(|__sifr_python_value| (__sifr_python_value.0, __sifr_python_value.1))
+                .collect::<Vec<(i64, i64)>>()"#
+    )
+}
+
+fn keyed_object_handles_expr(values: String) -> String {
+    format!(
+        r#"({values})
+                .iter()
+                .map(|__sifr_python_value| (__sifr_python_value.0.as_str(), (__sifr_python_value.1.0, __sifr_python_value.1.1)))
+                .collect::<Vec<(&str, (i64, i64))>>()"#
+    )
+}
+
+fn lower_object_list_constructor(args: &[RustExpr], function: &str) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let values = render_expr(&args[0]);
+    Some(map_python_error(format!(
+        r#"{{
+            let __sifr_python_values = {};
+            sifr_runtime::python::{function}(&__sifr_python_values)
+        }}"#,
+        object_handles_expr(values)
+    )))
+}
+
+fn lower_keyed_object_constructor(args: &[RustExpr], function: &str) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let values = render_expr(&args[0]);
+    Some(map_python_error(format!(
+        r#"{{
+            let __sifr_python_values = {};
+            sifr_runtime::python::{function}(&__sifr_python_values)
+        }}"#,
+        keyed_object_handles_expr(values)
+    )))
 }
 
 pub(crate) fn lower_py_import_module(args: &[RustExpr]) -> Option<RustExpr> {
@@ -58,11 +182,11 @@ pub(crate) fn lower_py_call(args: &[RustExpr]) -> Option<RustExpr> {
         r#"{{
             let __sifr_python_args = ({positional})
                 .iter()
-                .map(|__sifr_python_arg| (__sifr_python_arg._handle, __sifr_python_arg._token))
+                .map(|__sifr_python_arg| (__sifr_python_arg.0, __sifr_python_arg.1))
                 .collect::<Vec<(i64, i64)>>();
             let __sifr_python_kwargs = ({keyword})
                 .iter()
-                .map(|__sifr_python_kwarg| (__sifr_python_kwarg.0.as_str(), (__sifr_python_kwarg.1._handle, __sifr_python_kwarg.1._token)))
+                .map(|__sifr_python_kwarg| (__sifr_python_kwarg.0.as_str(), (__sifr_python_kwarg.1.0, __sifr_python_kwarg.1.1)))
                 .collect::<Vec<(&str, (i64, i64))>>();
             sifr_runtime::python::call_object(({handle}, {token}), &__sifr_python_args, &__sifr_python_kwargs)
         }}"#
@@ -82,11 +206,11 @@ pub(crate) fn lower_py_call_attr(args: &[RustExpr]) -> Option<RustExpr> {
         r#"{{
             let __sifr_python_args = ({positional})
                 .iter()
-                .map(|__sifr_python_arg| (__sifr_python_arg._handle, __sifr_python_arg._token))
+                .map(|__sifr_python_arg| (__sifr_python_arg.0, __sifr_python_arg.1))
                 .collect::<Vec<(i64, i64)>>();
             let __sifr_python_kwargs = ({keyword})
                 .iter()
-                .map(|__sifr_python_kwarg| (__sifr_python_kwarg.0.as_str(), (__sifr_python_kwarg.1._handle, __sifr_python_kwarg.1._token)))
+                .map(|__sifr_python_kwarg| (__sifr_python_kwarg.0.as_str(), (__sifr_python_kwarg.1.0, __sifr_python_kwarg.1.1)))
                 .collect::<Vec<(&str, (i64, i64))>>();
             sifr_runtime::python::call_attr(({handle}, {token}), ({name}).as_str(), &__sifr_python_args, &__sifr_python_kwargs)
         }}"#
@@ -123,5 +247,162 @@ pub(crate) fn lower_py_exit_context(args: &[RustExpr]) -> Option<RustExpr> {
     let token = render_expr(&args[1]);
     Some(map_python_error(format!(
         "sifr_runtime::python::exit_context(({handle}, {token}))"
+    )))
+}
+
+pub(crate) fn lower_py_from_none(args: &[RustExpr]) -> Option<RustExpr> {
+    if !args.is_empty() {
+        return None;
+    }
+    Some(map_python_error(
+        "sifr_runtime::python::from_none()".to_string(),
+    ))
+}
+
+pub(crate) fn lower_py_from_bool(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let value = render_expr(&args[0]);
+    Some(map_python_error(format!(
+        "sifr_runtime::python::from_bool({value})"
+    )))
+}
+
+pub(crate) fn lower_py_from_int(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let value = render_expr(&args[0]);
+    Some(map_python_error(format!(
+        "sifr_runtime::python::from_int({value})"
+    )))
+}
+
+pub(crate) fn lower_py_from_float(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let value = render_expr(&args[0]);
+    Some(map_python_error(format!(
+        "sifr_runtime::python::from_float({value})"
+    )))
+}
+
+pub(crate) fn lower_py_from_str(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let value = render_expr(&args[0]);
+    Some(map_python_error(format!(
+        "sifr_runtime::python::from_str(({value}).as_str())"
+    )))
+}
+
+pub(crate) fn lower_py_from_bytes(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let value = render_expr(&args[0]);
+    Some(map_python_error(format!(
+        "sifr_runtime::python::from_bytes(({value}).as_slice())"
+    )))
+}
+
+pub(crate) fn lower_py_from_list(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_object_list_constructor(args, "from_list")
+}
+
+pub(crate) fn lower_py_from_tuple(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_object_list_constructor(args, "from_tuple")
+}
+
+pub(crate) fn lower_py_from_dict_str(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_keyed_object_constructor(args, "from_dict_str")
+}
+
+pub(crate) fn lower_py_from_record(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_keyed_object_constructor(args, "from_record")
+}
+
+pub(crate) fn lower_py_to_none(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_none")
+}
+
+pub(crate) fn lower_py_to_bool(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_bool")
+}
+
+pub(crate) fn lower_py_to_int(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_int")
+}
+
+pub(crate) fn lower_py_to_i8(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_i8")
+}
+
+pub(crate) fn lower_py_to_i16(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_i16")
+}
+
+pub(crate) fn lower_py_to_i32(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_i32")
+}
+
+pub(crate) fn lower_py_to_i64(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_i64")
+}
+
+pub(crate) fn lower_py_to_u8(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_u8")
+}
+
+pub(crate) fn lower_py_to_u16(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_u16")
+}
+
+pub(crate) fn lower_py_to_u32(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_u32")
+}
+
+pub(crate) fn lower_py_to_u64(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_u64")
+}
+
+pub(crate) fn lower_py_to_isize(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_isize")
+}
+
+pub(crate) fn lower_py_to_usize(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_usize")
+}
+
+pub(crate) fn lower_py_to_float(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_float")
+}
+
+pub(crate) fn lower_py_to_str(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_str")
+}
+
+pub(crate) fn lower_py_to_bytes(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "to_bytes")
+}
+
+pub(crate) fn lower_py_copy_record_fields(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 3 {
+        return None;
+    }
+    let handle = render_expr(&args[0]);
+    let token = render_expr(&args[1]);
+    let fields = render_expr(&args[2]);
+    Some(map_python_error(format!(
+        r#"{{
+            let __sifr_python_fields = ({fields})
+                .iter()
+                .map(|__sifr_python_field| __sifr_python_field.as_str())
+                .collect::<Vec<&str>>();
+            sifr_runtime::python::copy_record_fields(({handle}, {token}), &__sifr_python_fields)
+        }}"#
     )))
 }

--- a/crates/sifr_codegen/src/intrinsics/registry_core_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_core_tests.rs
@@ -141,39 +141,6 @@ pub(crate) fn runtime_diagnostic_intrinsic_rejects_wrong_arity() {
 }
 
 #[test]
-pub(crate) fn lowers_python_intrinsics_with_runtime_feature_metadata() {
-    let imported = lower_intrinsic("py_import_module", &["module".to_string()])
-        .expect("py_import_module should lower");
-    assert_eq!(
-        imported.required_feature,
-        Some(sifr_stdlib::StdlibFeature::PythonRuntime)
-    );
-    let rendered = render_expr(&imported.expr);
-    assert!(rendered.contains("sifr_runtime::python::import_module"));
-    assert!(rendered.contains("PythonError"));
-
-    let call = lower_intrinsic(
-        "py_call",
-        &[
-            "callable_handle".to_string(),
-            "callable_token".to_string(),
-            "args".to_string(),
-            "kwargs".to_string(),
-        ],
-    )
-    .expect("py_call should lower");
-    assert_eq!(
-        call.required_feature,
-        Some(sifr_stdlib::StdlibFeature::PythonRuntime)
-    );
-    let call_rendered = render_expr(&call.expr);
-    assert!(call_rendered.contains("sifr_runtime::python::call_object"));
-    assert!(call_rendered.contains("(callable_handle, callable_token)"));
-    assert!(call_rendered.contains("__sifr_python_args"));
-    assert!(call_rendered.contains("__sifr_python_kwargs"));
-}
-
-#[test]
 pub(crate) fn runtime_module_dependency_metadata_includes_observability_facades() {
     let deps = sifr_stdlib::generated_cargo_dependencies(
         &std::collections::HashSet::from(["sifr.runtime".to_string()]),

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -16,6 +16,86 @@ pub(crate) fn legacy_subprocess_intrinsics_are_not_lowered() {
 }
 
 #[test]
+pub(crate) fn lowers_python_intrinsics_with_runtime_feature_metadata() {
+    let imported = lower_intrinsic("py_import_module", &["module".to_string()])
+        .expect("py_import_module should lower");
+    assert_eq!(
+        imported.required_feature,
+        Some(sifr_stdlib::StdlibFeature::PythonRuntime)
+    );
+    let rendered = render_expr(&imported.expr);
+    assert!(rendered.contains("sifr_runtime::python::import_module"));
+    assert!(rendered.contains("PythonError"));
+
+    let call = lower_intrinsic(
+        "py_call",
+        &[
+            "callable_handle".to_string(),
+            "callable_token".to_string(),
+            "args".to_string(),
+            "kwargs".to_string(),
+        ],
+    )
+    .expect("py_call should lower");
+    assert_eq!(
+        call.required_feature,
+        Some(sifr_stdlib::StdlibFeature::PythonRuntime)
+    );
+    let call_rendered = render_expr(&call.expr);
+    assert!(call_rendered.contains("sifr_runtime::python::call_object"));
+    assert!(call_rendered.contains("(callable_handle, callable_token)"));
+    assert!(call_rendered.contains("__sifr_python_args"));
+    assert!(call_rendered.contains("__sifr_python_kwargs"));
+
+    let from_str =
+        lower_intrinsic("py_from_str", &["value".to_string()]).expect("py_from_str should lower");
+    assert_eq!(
+        from_str.required_feature,
+        Some(sifr_stdlib::StdlibFeature::PythonRuntime)
+    );
+    assert!(render_expr(&from_str.expr).contains("sifr_runtime::python::from_str"));
+
+    let to_i32 = lower_intrinsic(
+        "py_to_i32",
+        &["object_handle".to_string(), "object_token".to_string()],
+    )
+    .expect("py_to_i32 should lower");
+    assert_eq!(
+        to_i32.required_feature,
+        Some(sifr_stdlib::StdlibFeature::PythonRuntime)
+    );
+    let to_i32_rendered = render_expr(&to_i32.expr);
+    assert!(to_i32_rendered.contains("sifr_runtime::python::to_i32"));
+    assert!(to_i32_rendered.contains("(object_handle, object_token)"));
+
+    let from_list = lower_intrinsic("py_from_list", &["values".to_string()])
+        .expect("py_from_list should lower");
+    let from_list_rendered = render_expr(&from_list.expr);
+    assert!(from_list_rendered.contains("sifr_runtime::python::from_list"));
+    assert!(from_list_rendered.contains("__sifr_python_value.0"));
+
+    let copy_list_u8 = lower_intrinsic(
+        "py_copy_list_u8",
+        &["object_handle".to_string(), "object_token".to_string()],
+    )
+    .expect("py_copy_list_u8 should lower");
+    assert!(render_expr(&copy_list_u8.expr).contains("sifr_runtime::python::copy_list_u8"));
+
+    let record_fields = lower_intrinsic(
+        "py_copy_record_fields",
+        &[
+            "object_handle".to_string(),
+            "object_token".to_string(),
+            "fields".to_string(),
+        ],
+    )
+    .expect("py_copy_record_fields should lower");
+    let record_fields_rendered = render_expr(&record_fields.expr);
+    assert!(record_fields_rendered.contains("sifr_runtime::python::copy_record_fields"));
+    assert!(record_fields_rendered.contains("__sifr_python_fields"));
+}
+
+#[test]
 pub(crate) fn lowers_uuid_intrinsic_via_registry() {
     let uuid = lower_intrinsic("uuid4", &[]).expect("uuid4");
     assert_eq!(

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -8,8 +8,15 @@ use std::sync::{Mutex, MutexGuard};
 
 mod object_ops;
 pub use object_ops::{
-    call_attr, call_object, close_object, enter_context, exit_context, get_attr, get_item_str,
-    import_module, ObjectHandle, PythonError,
+    call_attr, call_object, close_object, copy_dict_str_bool, copy_dict_str_bytes,
+    copy_dict_str_float, copy_dict_str_i32, copy_dict_str_int, copy_dict_str_str, copy_dict_str_u8,
+    copy_list_bool, copy_list_bytes, copy_list_float, copy_list_i32, copy_list_int, copy_list_str,
+    copy_list_u8, copy_record_fields, copy_tuple_bool, copy_tuple_bytes, copy_tuple_float,
+    copy_tuple_i32, copy_tuple_int, copy_tuple_str, copy_tuple_u8, enter_context, exit_context,
+    from_bool, from_bytes, from_dict_str, from_float, from_int, from_list, from_none, from_record,
+    from_str, from_tuple, get_attr, get_item_str, import_module, to_bool, to_bytes, to_float,
+    to_i16, to_i32, to_i64, to_i8, to_int, to_isize, to_none, to_str, to_u16, to_u32, to_u64,
+    to_u8, to_usize, ObjectHandle, PythonError,
 };
 
 static RUNTIME_STATE: Mutex<RuntimeState> = Mutex::new(RuntimeState::new());
@@ -543,6 +550,14 @@ fn reset_runtime_state_for_tests() {
 }
 
 #[cfg(test)]
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(test)]
+fn test_guard() -> MutexGuard<'static, ()> {
+    TEST_LOCK.lock().expect("test lock should be available")
+}
+
+#[cfg(test)]
 fn test_config(label: &str) -> PythonRuntimeConfig {
     let mut config = local_python_config();
     config.probe_digest = format!("digest-{label}");
@@ -627,13 +642,6 @@ print(os.pathsep.join(sys.path))
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard};
-
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
-
-    fn test_guard() -> MutexGuard<'static, ()> {
-        TEST_LOCK.lock().expect("test lock should be available")
-    }
 
     #[test]
     fn initializes_and_accepts_repeated_same_config() {
@@ -821,6 +829,27 @@ mod tests {
 
         assert_eq!(error.kind, "resource");
         assert!(error.message.contains("closed"));
+    }
+
+    #[test]
+    fn failed_record_field_copy_does_not_leak_partial_handles() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("record-field-leak")).expect("init should succeed");
+        let value = from_int(42).expect("field value should be stored");
+        let record = from_record(&[("value", value)]).expect("record should be stored");
+        let before = shutdown_diagnostics().expect("diagnostics should be available");
+
+        let error = copy_record_fields(record, &["value", "missing"])
+            .expect_err("missing field should fail");
+
+        assert_eq!(error.kind, "conversion");
+        assert_eq!(
+            shutdown_diagnostics().expect("diagnostics should be available"),
+            before
+        );
+        close_object(record).expect("record should close");
+        close_object(value).expect("field value should close");
     }
 
     #[test]

--- a/crates/sifr_runtime/src/python/object_ops.rs
+++ b/crates/sifr_runtime/src/python/object_ops.rs
@@ -1,6 +1,7 @@
 use super::{runtime_config, Object, PythonRuntimeError};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyTuple};
+use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
+use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::BuildHasher;
@@ -12,6 +13,24 @@ static TOKEN_HASHER: LazyLock<std::collections::hash_map::RandomState> =
     LazyLock::new(std::collections::hash_map::RandomState::new);
 
 pub type ObjectHandle = (i64, i64);
+
+macro_rules! typed_container_conversions {
+    ($($list:ident, $tuple:ident, $dict:ident => $ty:ty, $expected:literal);+ $(;)?) => {
+        $(
+            pub fn $list(object: ObjectHandle) -> Result<Vec<$ty>, PythonError> {
+                copy_list(object, $expected, stringify!($list))
+            }
+
+            pub fn $tuple(object: ObjectHandle) -> Result<Vec<$ty>, PythonError> {
+                copy_tuple(object, $expected, stringify!($tuple))
+            }
+
+            pub fn $dict(object: ObjectHandle) -> Result<HashMap<String, $ty>, PythonError> {
+                copy_dict_str(object, $expected, stringify!($dict))
+            }
+        )+
+    };
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PythonError {
@@ -218,6 +237,185 @@ pub fn close_object((handle, token): ObjectHandle) -> Result<(), PythonError> {
     }
 }
 
+pub fn from_none() -> Result<ObjectHandle, PythonError> {
+    super::attach(|py| store_object(py.None())).map_err(PythonError::runtime)?
+}
+
+pub fn from_bool(value: bool) -> Result<ObjectHandle, PythonError> {
+    store_primitive(value, "from bool")
+}
+
+pub fn from_int(value: i64) -> Result<ObjectHandle, PythonError> {
+    store_primitive(value, "from int")
+}
+
+pub fn from_float(value: f64) -> Result<ObjectHandle, PythonError> {
+    store_primitive(value, "from float")
+}
+
+pub fn from_str(value: &str) -> Result<ObjectHandle, PythonError> {
+    store_primitive(value, "from str")
+}
+
+pub fn from_bytes(value: &[u8]) -> Result<ObjectHandle, PythonError> {
+    super::attach(|py| store_object(PyBytes::new(py, value).into_any().unbind()))
+        .map_err(PythonError::runtime)?
+}
+
+pub fn from_list(values: &[ObjectHandle]) -> Result<ObjectHandle, PythonError> {
+    super::attach(|py| {
+        let values = clone_handles(py, values)?;
+        PyList::new(py, values.iter())
+            .map_err(|error| PythonError::from_pyerr(py, error, "conversion", "from_list"))
+            .and_then(|list| store_object(list.into_any().unbind()))
+    })
+    .map_err(PythonError::runtime)?
+}
+
+pub fn from_tuple(values: &[ObjectHandle]) -> Result<ObjectHandle, PythonError> {
+    super::attach(|py| {
+        let values = clone_handles(py, values)?;
+        PyTuple::new(py, values.iter())
+            .map_err(|error| PythonError::from_pyerr(py, error, "conversion", "from_tuple"))
+            .and_then(|tuple| store_object(tuple.into_any().unbind()))
+    })
+    .map_err(PythonError::runtime)?
+}
+
+pub fn from_dict_str(values: &[(&str, ObjectHandle)]) -> Result<ObjectHandle, PythonError> {
+    store_dict(values, "from_dict_str")
+}
+
+pub fn from_record(values: &[(&str, ObjectHandle)]) -> Result<ObjectHandle, PythonError> {
+    store_dict(values, "from_record")
+}
+
+pub fn to_none(object: ObjectHandle) -> Result<(), PythonError> {
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        if object.bind(py).is_none() {
+            Ok(())
+        } else {
+            Err(conversion_error("expected Python None", "to_none"))
+        }
+    })
+    .map_err(PythonError::runtime)?
+}
+
+pub fn to_bool(object: ObjectHandle) -> Result<bool, PythonError> {
+    extract_handle(object, "bool", "to_bool")
+}
+
+pub fn to_int(object: ObjectHandle) -> Result<i64, PythonError> {
+    extract_handle(object, "int", "to_int")
+}
+
+pub fn to_i8(object: ObjectHandle) -> Result<i8, PythonError> {
+    extract_handle(object, "int8", "to_i8")
+}
+
+pub fn to_i16(object: ObjectHandle) -> Result<i16, PythonError> {
+    extract_handle(object, "int16", "to_i16")
+}
+
+pub fn to_i32(object: ObjectHandle) -> Result<i32, PythonError> {
+    extract_handle(object, "int32", "to_i32")
+}
+
+pub fn to_i64(object: ObjectHandle) -> Result<i64, PythonError> {
+    extract_handle(object, "int64", "to_i64")
+}
+
+pub fn to_u8(object: ObjectHandle) -> Result<u8, PythonError> {
+    extract_handle(object, "uint8", "to_u8")
+}
+
+pub fn to_u16(object: ObjectHandle) -> Result<u16, PythonError> {
+    extract_handle(object, "uint16", "to_u16")
+}
+
+pub fn to_u32(object: ObjectHandle) -> Result<u32, PythonError> {
+    extract_handle(object, "uint32", "to_u32")
+}
+
+pub fn to_u64(object: ObjectHandle) -> Result<u64, PythonError> {
+    extract_handle(object, "uint64", "to_u64")
+}
+
+pub fn to_isize(object: ObjectHandle) -> Result<isize, PythonError> {
+    extract_handle(object, "isize", "to_isize")
+}
+
+pub fn to_usize(object: ObjectHandle) -> Result<usize, PythonError> {
+    extract_handle(object, "usize", "to_usize")
+}
+
+pub fn to_float(object: ObjectHandle) -> Result<f64, PythonError> {
+    extract_handle(object, "float", "to_float")
+}
+
+pub fn to_str(object: ObjectHandle) -> Result<String, PythonError> {
+    extract_handle(object, "str", "to_str")
+}
+
+pub fn to_bytes(object: ObjectHandle) -> Result<Vec<u8>, PythonError> {
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        object
+            .bind(py)
+            .cast::<PyBytes>()
+            .map(|bytes| bytes.as_bytes().to_vec())
+            .map_err(|_| conversion_error("expected Python bytes", "to_bytes: expected bytes"))
+    })
+    .map_err(PythonError::runtime)?
+}
+
+typed_container_conversions! {
+    copy_list_bool, copy_tuple_bool, copy_dict_str_bool => bool, "bool";
+    copy_list_int, copy_tuple_int, copy_dict_str_int => i64, "int";
+    copy_list_i32, copy_tuple_i32, copy_dict_str_i32 => i32, "int32";
+    copy_list_u8, copy_tuple_u8, copy_dict_str_u8 => u8, "uint8";
+    copy_list_float, copy_tuple_float, copy_dict_str_float => f64, "float";
+    copy_list_str, copy_tuple_str, copy_dict_str_str => String, "str"
+}
+
+pub fn copy_list_bytes(object: ObjectHandle) -> Result<Vec<Vec<u8>>, PythonError> {
+    copy_list_exact_bytes(object, "copy_list_bytes")
+}
+
+pub fn copy_tuple_bytes(object: ObjectHandle) -> Result<Vec<Vec<u8>>, PythonError> {
+    copy_tuple_exact_bytes(object, "copy_tuple_bytes")
+}
+
+pub fn copy_dict_str_bytes(object: ObjectHandle) -> Result<HashMap<String, Vec<u8>>, PythonError> {
+    copy_dict_str_exact_bytes(object, "copy_dict_str_bytes")
+}
+
+pub fn copy_record_fields(
+    object: ObjectHandle,
+    fields: &[&str],
+) -> Result<Vec<(String, ObjectHandle)>, PythonError> {
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let object = object.bind(py);
+        let mut values = Vec::with_capacity(fields.len());
+        for field in fields {
+            let value = object.getattr(*field).or_else(|_| object.get_item(*field));
+            let value = value.map_err(|_| {
+                conversion_error(
+                    format!("expected Python record field '{field}'"),
+                    format!("copy_record_fields.{field}"),
+                )
+            })?;
+            values.push(((*field).to_string(), value.unbind()));
+        }
+        let (names, objects): (Vec<_>, Vec<_>) = values.into_iter().unzip();
+        let handles = store_objects(objects)?;
+        Ok(names.into_iter().zip(handles).collect())
+    })
+    .map_err(PythonError::runtime)?
+}
+
 fn validate_import_policy(name: &str) -> Result<(), PythonError> {
     let root = name
         .split('.')
@@ -257,6 +455,30 @@ fn contains_root(roots: &[String], root: &str) -> bool {
 fn store_object(object: Py<PyAny>) -> Result<ObjectHandle, PythonError> {
     let object = Object::new(object).map_err(PythonError::runtime)?;
     let mut store = object_store()?;
+    let (handle, token) = reserve_handle(&mut store)?;
+    store.objects.insert(handle, ObjectEntry { token, object });
+    Ok((handle, token))
+}
+
+fn store_objects(objects: Vec<Py<PyAny>>) -> Result<Vec<ObjectHandle>, PythonError> {
+    let objects = objects
+        .into_iter()
+        .map(Object::new)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(PythonError::runtime)?;
+    let mut handles = Vec::with_capacity(objects.len());
+    let mut entries = Vec::with_capacity(objects.len());
+    let mut store = object_store()?;
+    for object in objects {
+        let (handle, token) = reserve_handle(&mut store)?;
+        handles.push((handle, token));
+        entries.push((handle, ObjectEntry { token, object }));
+    }
+    store.objects.extend(entries);
+    Ok(handles)
+}
+
+fn reserve_handle(store: &mut ObjectStore) -> Result<ObjectHandle, PythonError> {
     store.next_handle = store.next_handle.checked_add(1).ok_or_else(|| {
         PythonError::runtime(PythonRuntimeError::PythonOperationFailed(
             "Python object handle space exhausted".to_string(),
@@ -267,10 +489,244 @@ fn store_object(object: Py<PyAny>) -> Result<ObjectHandle, PythonError> {
             "Python object token space exhausted".to_string(),
         ))
     })?;
-    let handle = store.next_handle;
-    let token = token_for(handle, store.next_nonce);
-    store.objects.insert(handle, ObjectEntry { token, object });
-    Ok((handle, token))
+    Ok((
+        store.next_handle,
+        token_for(store.next_handle, store.next_nonce),
+    ))
+}
+
+fn store_primitive<T>(value: T, context: &'static str) -> Result<ObjectHandle, PythonError>
+where
+    T: for<'py> IntoPyObjectExt<'py>,
+{
+    super::attach(|py| {
+        value
+            .into_py_any(py)
+            .map_err(|error| PythonError::from_pyerr(py, error, "conversion", context))
+            .and_then(store_object)
+    })
+    .map_err(PythonError::runtime)?
+}
+
+fn store_dict(
+    values: &[(&str, ObjectHandle)],
+    context: &'static str,
+) -> Result<ObjectHandle, PythonError> {
+    super::attach(|py| {
+        let dict = PyDict::new(py);
+        for (key, value_handle) in values {
+            let value = clone_handle(py, *value_handle)?;
+            dict.set_item(*key, value.bind(py))
+                .map_err(|error| PythonError::from_pyerr(py, error, "conversion", *key))?;
+        }
+        store_object(dict.into_any().unbind())
+    })
+    .map_err(PythonError::runtime)?
+    .map_err(|mut error| {
+        if error.context.is_empty() {
+            error.context = context.to_string();
+        }
+        error
+    })
+}
+
+fn extract_handle<T>(
+    object: ObjectHandle,
+    expected: &'static str,
+    context: &'static str,
+) -> Result<T, PythonError>
+where
+    for<'py> T: FromPyObject<'py, 'py>,
+{
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        object.bind(py).extract::<T>().map_err(|error| {
+            let mut converted = PythonError::from_pyerr(py, error.into(), "conversion", context);
+            converted.context = format!("{context}: expected {expected}");
+            converted
+        })
+    })
+    .map_err(PythonError::runtime)?
+}
+
+fn extract_py_value<'a, 'py, T>(
+    py: Python<'py>,
+    value: &'a Bound<'py, PyAny>,
+    expected: &'static str,
+    context: String,
+) -> Result<T, PythonError>
+where
+    T: FromPyObject<'a, 'py>,
+{
+    value.extract::<T>().map_err(|error| {
+        let mut converted = PythonError::from_pyerr(py, error.into(), "conversion", &context);
+        converted.context = format!("{context}: expected {expected}");
+        converted
+    })
+}
+
+fn copy_list<T>(
+    object: ObjectHandle,
+    expected: &'static str,
+    context: &'static str,
+) -> Result<Vec<T>, PythonError>
+where
+    for<'a, 'py> T: FromPyObject<'a, 'py>,
+{
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let list = object
+            .bind(py)
+            .cast::<PyList>()
+            .map_err(|_| conversion_error("expected Python list", context))?;
+        let mut converted = Vec::with_capacity(list.len());
+        for (index, value) in list.iter().enumerate() {
+            converted.push(extract_py_value(
+                py,
+                &value,
+                expected,
+                format!("{context}[{index}]"),
+            )?);
+        }
+        Ok(converted)
+    })
+    .map_err(PythonError::runtime)?
+}
+
+fn copy_tuple<T>(
+    object: ObjectHandle,
+    expected: &'static str,
+    context: &'static str,
+) -> Result<Vec<T>, PythonError>
+where
+    for<'a, 'py> T: FromPyObject<'a, 'py>,
+{
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let tuple = object
+            .bind(py)
+            .cast::<PyTuple>()
+            .map_err(|_| conversion_error("expected Python tuple", context))?;
+        let mut converted = Vec::with_capacity(tuple.len());
+        for (index, value) in tuple.iter().enumerate() {
+            converted.push(extract_py_value(
+                py,
+                &value,
+                expected,
+                format!("{context}[{index}]"),
+            )?);
+        }
+        Ok(converted)
+    })
+    .map_err(PythonError::runtime)?
+}
+
+fn copy_dict_str<T>(
+    object: ObjectHandle,
+    expected: &'static str,
+    context: &'static str,
+) -> Result<HashMap<String, T>, PythonError>
+where
+    for<'a, 'py> T: FromPyObject<'a, 'py>,
+{
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let dict = object
+            .bind(py)
+            .cast::<PyDict>()
+            .map_err(|_| conversion_error("expected Python dict", context))?;
+        let mut converted = HashMap::with_capacity(dict.len());
+        for (key, value) in dict.iter() {
+            let key = extract_py_value::<String>(py, &key, "str", format!("{context}.<key>"))?;
+            let value = extract_py_value(py, &value, expected, format!("{context}[{key:?}]"))?;
+            converted.insert(key, value);
+        }
+        Ok(converted)
+    })
+    .map_err(PythonError::runtime)?
+}
+
+fn copy_list_exact_bytes(
+    object: ObjectHandle,
+    context: &'static str,
+) -> Result<Vec<Vec<u8>>, PythonError> {
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let list = object
+            .bind(py)
+            .cast::<PyList>()
+            .map_err(|_| conversion_error("expected Python list", context))?;
+        let mut converted = Vec::with_capacity(list.len());
+        for (index, value) in list.iter().enumerate() {
+            converted.push(extract_exact_bytes(value, format!("{context}[{index}]"))?);
+        }
+        Ok(converted)
+    })
+    .map_err(PythonError::runtime)?
+}
+
+fn copy_tuple_exact_bytes(
+    object: ObjectHandle,
+    context: &'static str,
+) -> Result<Vec<Vec<u8>>, PythonError> {
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let tuple = object
+            .bind(py)
+            .cast::<PyTuple>()
+            .map_err(|_| conversion_error("expected Python tuple", context))?;
+        let mut converted = Vec::with_capacity(tuple.len());
+        for (index, value) in tuple.iter().enumerate() {
+            converted.push(extract_exact_bytes(value, format!("{context}[{index}]"))?);
+        }
+        Ok(converted)
+    })
+    .map_err(PythonError::runtime)?
+}
+
+fn copy_dict_str_exact_bytes(
+    object: ObjectHandle,
+    context: &'static str,
+) -> Result<HashMap<String, Vec<u8>>, PythonError> {
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let dict = object
+            .bind(py)
+            .cast::<PyDict>()
+            .map_err(|_| conversion_error("expected Python dict", context))?;
+        let mut converted = HashMap::with_capacity(dict.len());
+        for (key, value) in dict.iter() {
+            let key = extract_py_value::<String>(py, &key, "str", format!("{context}.<key>"))?;
+            let value = extract_exact_bytes(value, format!("{context}[{key:?}]"))?;
+            converted.insert(key, value);
+        }
+        Ok(converted)
+    })
+    .map_err(PythonError::runtime)?
+}
+
+fn extract_exact_bytes(value: Bound<'_, PyAny>, context: String) -> Result<Vec<u8>, PythonError> {
+    value
+        .cast::<PyBytes>()
+        .map(|bytes| bytes.as_bytes().to_vec())
+        .map_err(|_| conversion_error("expected Python bytes", context))
+}
+
+fn conversion_error(message: impl Into<String>, context: impl Into<String>) -> PythonError {
+    PythonError {
+        kind: "conversion".to_string(),
+        exception_type: "SifrPythonTypeConversionError".to_string(),
+        message: message.into(),
+        traceback: String::new(),
+        context: context.into(),
+    }
+}
+
+fn clone_handles(py: Python<'_>, values: &[ObjectHandle]) -> Result<Vec<Py<PyAny>>, PythonError> {
+    values
+        .iter()
+        .map(|value| clone_handle(py, *value))
+        .collect::<Result<Vec<_>, _>>()
 }
 
 fn clone_handle(py: Python<'_>, (handle, token): ObjectHandle) -> Result<Py<PyAny>, PythonError> {
@@ -316,4 +772,124 @@ fn format_traceback(py: Python<'_>, error: &PyErr) -> String {
 pub(super) fn reset_object_store_for_tests() {
     let mut store = object_store().expect("object store should be available");
     *store = ObjectStore::default();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::python::{
+        initialize_runtime, reset_runtime_state_for_tests, shutdown_diagnostics, test_config,
+        test_guard, PythonRuntimeDiagnostics,
+    };
+
+    #[test]
+    fn primitive_conversion_round_trips_and_rejects_fixed_width_overflow() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("primitive-conversion")).expect("init should succeed");
+
+        let none = from_none().expect("None object should be stored");
+        to_none(none).expect("None should convert to None");
+        close_object(none).expect("None object should close");
+
+        let flag = from_bool(true).expect("bool object should be stored");
+        assert!(to_bool(flag).expect("bool should convert"));
+        close_object(flag).expect("bool object should close");
+
+        let integer = from_int(127).expect("int object should be stored");
+        assert_eq!(to_int(integer).expect("int should convert"), 127);
+        assert_eq!(to_i8(integer).expect("int8 should convert"), 127);
+        assert_eq!(to_u8(integer).expect("uint8 should convert"), 127);
+        close_object(integer).expect("int object should close");
+
+        let too_wide = from_int(256).expect("wide int object should be stored");
+        let overflow = to_u8(too_wide).expect_err("uint8 overflow should fail");
+        assert_eq!(overflow.kind, "conversion");
+        assert!(overflow.context.contains("uint8"));
+        close_object(too_wide).expect("wide int object should close");
+
+        let float = from_float(1.25).expect("float object should be stored");
+        assert_eq!(to_float(float).expect("float should convert"), 1.25);
+        close_object(float).expect("float object should close");
+
+        let text = from_str("sifr").expect("str object should be stored");
+        assert_eq!(to_str(text).expect("str should convert"), "sifr");
+        close_object(text).expect("str object should close");
+
+        let bytes = from_bytes(&[1, 2, 3]).expect("bytes object should be stored");
+        assert_eq!(
+            to_bytes(bytes).expect("bytes should convert"),
+            vec![1, 2, 3]
+        );
+        close_object(bytes).expect("bytes object should close");
+
+        assert_eq!(
+            shutdown_diagnostics().expect("diagnostics should be available"),
+            PythonRuntimeDiagnostics {
+                initialized: true,
+                live_objects: 0,
+                leaked_objects: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn explicit_container_copy_conversions_preserve_nested_paths() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("container-conversion")).expect("init should succeed");
+
+        let first = from_int(1).expect("int object should be stored");
+        let second = from_int(2).expect("int object should be stored");
+        let list = from_list(&[first, second]).expect("list should be stored");
+        assert_eq!(copy_list_int(list).expect("list should copy"), vec![1, 2]);
+
+        let tuple = from_tuple(&[first, second]).expect("tuple should be stored");
+        assert_eq!(
+            copy_tuple_i32(tuple).expect("tuple should copy"),
+            vec![1, 2]
+        );
+
+        let too_wide = from_int(256).expect("wide int object should be stored");
+        let bad_list = from_list(&[first, too_wide]).expect("bad list should be stored");
+        let overflow = copy_list_u8(bad_list).expect_err("nested overflow should fail");
+        assert_eq!(overflow.kind, "conversion");
+        assert!(overflow.context.contains("copy_list_u8[1]"));
+        assert!(overflow.context.contains("uint8"));
+
+        let dict =
+            from_dict_str(&[("first", first), ("second", second)]).expect("dict should be stored");
+        let copied = copy_dict_str_int(dict).expect("dict should copy");
+        assert_eq!(copied.get("first"), Some(&1));
+        assert_eq!(copied.get("second"), Some(&2));
+
+        let record = from_record(&[("answer", second)]).expect("record should be stored");
+        let fields = copy_record_fields(record, &["answer"]).expect("record should copy fields");
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].0, "answer");
+        assert_eq!(to_int(fields[0].1).expect("field should convert"), 2);
+
+        for handle in [
+            first,
+            second,
+            list,
+            tuple,
+            too_wide,
+            bad_list,
+            dict,
+            record,
+            fields[0].1,
+        ] {
+            close_object(handle).expect("object should close");
+        }
+
+        assert_eq!(
+            shutdown_diagnostics().expect("diagnostics should be available"),
+            PythonRuntimeDiagnostics {
+                initialized: true,
+                live_objects: 0,
+                leaked_objects: 0,
+            }
+        );
+    }
 }

--- a/crates/sifr_stdlib/src/python.rs
+++ b/crates/sifr_stdlib/src/python.rs
@@ -1,21 +1,9 @@
 use super::{result_ty, IntrinsicModule};
-use sifr_type_system::{FunctionType, Type};
+use sifr_type_system::{FixedIntType, FunctionType, Type};
 use std::collections::HashMap;
 
 fn python_error_result(ok: Type) -> Type {
     result_ty(ok, "PythonError")
-}
-
-fn object_class() -> Type {
-    Type::Class {
-        name: "Object".to_string(),
-        fields: vec![
-            ("_handle".to_string(), Type::Int),
-            ("_token".to_string(), Type::Int),
-        ],
-        methods: vec![],
-        parent_class: None,
-    }
 }
 
 fn object_handle() -> Type {
@@ -60,10 +48,10 @@ pub(super) fn intrinsic_python() -> IntrinsicModule {
             vec![
                 ("handle".to_string(), Type::Int),
                 ("token".to_string(), Type::Int),
-                ("args".to_string(), Type::List(Box::new(object_class()))),
+                ("args".to_string(), Type::List(Box::new(object_handle()))),
                 (
                     "kwargs".to_string(),
-                    Type::List(Box::new(Type::Tuple(vec![Type::Str, object_class()]))),
+                    Type::List(Box::new(Type::Tuple(vec![Type::Str, object_handle()]))),
                 ),
             ],
             python_error_result(object_handle()),
@@ -76,10 +64,10 @@ pub(super) fn intrinsic_python() -> IntrinsicModule {
                 ("handle".to_string(), Type::Int),
                 ("token".to_string(), Type::Int),
                 ("name".to_string(), Type::Str),
-                ("args".to_string(), Type::List(Box::new(object_class()))),
+                ("args".to_string(), Type::List(Box::new(object_handle()))),
                 (
                     "kwargs".to_string(),
-                    Type::List(Box::new(Type::Tuple(vec![Type::Str, object_class()]))),
+                    Type::List(Box::new(Type::Tuple(vec![Type::Str, object_handle()]))),
                 ),
             ],
             python_error_result(object_handle()),
@@ -113,6 +101,203 @@ pub(super) fn intrinsic_python() -> IntrinsicModule {
                 ("token".to_string(), Type::Int),
             ],
             python_error_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "py_from_none".to_string(),
+        FunctionType::all_borrow(vec![], python_error_result(object_handle())),
+    );
+    functions.insert(
+        "py_from_bool".to_string(),
+        FunctionType::all_borrow(
+            vec![("value".to_string(), Type::Bool)],
+            python_error_result(object_handle()),
+        ),
+    );
+    functions.insert(
+        "py_from_int".to_string(),
+        FunctionType::all_borrow(
+            vec![("value".to_string(), Type::Int)],
+            python_error_result(object_handle()),
+        ),
+    );
+    functions.insert(
+        "py_from_float".to_string(),
+        FunctionType::all_borrow(
+            vec![("value".to_string(), Type::Float)],
+            python_error_result(object_handle()),
+        ),
+    );
+    functions.insert(
+        "py_from_str".to_string(),
+        FunctionType::all_borrow(
+            vec![("value".to_string(), Type::Str)],
+            python_error_result(object_handle()),
+        ),
+    );
+    functions.insert(
+        "py_from_bytes".to_string(),
+        FunctionType::all_borrow(
+            vec![("value".to_string(), Type::Bytes)],
+            python_error_result(object_handle()),
+        ),
+    );
+    functions.insert(
+        "py_from_list".to_string(),
+        FunctionType::all_borrow(
+            vec![("values".to_string(), Type::List(Box::new(object_handle())))],
+            python_error_result(object_handle()),
+        ),
+    );
+    functions.insert(
+        "py_from_tuple".to_string(),
+        FunctionType::all_borrow(
+            vec![("values".to_string(), Type::List(Box::new(object_handle())))],
+            python_error_result(object_handle()),
+        ),
+    );
+    for name in ["py_from_dict_str", "py_from_record"] {
+        functions.insert(
+            name.to_string(),
+            FunctionType::all_borrow(
+                vec![(
+                    "values".to_string(),
+                    Type::List(Box::new(Type::Tuple(vec![Type::Str, object_handle()]))),
+                )],
+                python_error_result(object_handle()),
+            ),
+        );
+    }
+    functions.insert(
+        "py_to_none".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "py_to_bool".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::Bool),
+        ),
+    );
+    functions.insert(
+        "py_to_int".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::Int),
+        ),
+    );
+    for (name, fixed) in [
+        ("py_to_i8", FixedIntType::I8),
+        ("py_to_i16", FixedIntType::I16),
+        ("py_to_i32", FixedIntType::I32),
+        ("py_to_i64", FixedIntType::I64),
+        ("py_to_u8", FixedIntType::U8),
+        ("py_to_u16", FixedIntType::U16),
+        ("py_to_u32", FixedIntType::U32),
+        ("py_to_u64", FixedIntType::U64),
+        ("py_to_isize", FixedIntType::ISize),
+        ("py_to_usize", FixedIntType::USize),
+    ] {
+        functions.insert(
+            name.to_string(),
+            FunctionType::all_borrow(
+                vec![
+                    ("handle".to_string(), Type::Int),
+                    ("token".to_string(), Type::Int),
+                ],
+                python_error_result(Type::FixedInt(fixed)),
+            ),
+        );
+    }
+    functions.insert(
+        "py_to_float".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::Float),
+        ),
+    );
+    functions.insert(
+        "py_to_str".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::Str),
+        ),
+    );
+    functions.insert(
+        "py_to_bytes".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::Bytes),
+        ),
+    );
+    for (suffix, value_ty) in [
+        ("bool", Type::Bool),
+        ("int", Type::Int),
+        ("i32", Type::FixedInt(FixedIntType::I32)),
+        ("u8", Type::FixedInt(FixedIntType::U8)),
+        ("float", Type::Float),
+        ("str", Type::Str),
+        ("bytes", Type::Bytes),
+    ] {
+        let handle_params = vec![
+            ("handle".to_string(), Type::Int),
+            ("token".to_string(), Type::Int),
+        ];
+        functions.insert(
+            format!("py_copy_list_{suffix}"),
+            FunctionType::all_borrow(
+                handle_params.clone(),
+                python_error_result(Type::List(Box::new(value_ty.clone()))),
+            ),
+        );
+        functions.insert(
+            format!("py_copy_tuple_{suffix}"),
+            FunctionType::all_borrow(
+                handle_params.clone(),
+                python_error_result(Type::List(Box::new(value_ty.clone()))),
+            ),
+        );
+        functions.insert(
+            format!("py_copy_dict_str_{suffix}"),
+            FunctionType::all_borrow(
+                handle_params,
+                python_error_result(Type::Dict(Box::new(Type::Str), Box::new(value_ty))),
+            ),
+        );
+    }
+    functions.insert(
+        "py_copy_record_fields".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+                ("fields".to_string(), Type::List(Box::new(Type::Str))),
+            ],
+            python_error_result(Type::List(Box::new(Type::Tuple(vec![
+                Type::Str,
+                object_handle(),
+            ])))),
         ),
     );
     IntrinsicModule {

--- a/crates/sifr_type_system/src/types/display_impl.rs
+++ b/crates/sifr_type_system/src/types/display_impl.rs
@@ -314,6 +314,29 @@ mod tests {
             Box::new(Type::Union(vec![Type::Int, Type::Str])),
         );
         assert!(!dict_int_int.is_assignable_to(&dict_int_union));
+
+        let object_a = Type::Class {
+            name: "Object".to_string(),
+            fields: vec![("_handle".to_string(), Type::Int)],
+            methods: vec![],
+            parent_class: None,
+        };
+        let object_b = Type::Class {
+            name: "Object".to_string(),
+            fields: vec![("_token".to_string(), Type::Int)],
+            methods: vec![],
+            parent_class: None,
+        };
+        assert!(Type::List(Box::new(object_a.clone()))
+            .is_assignable_to(&Type::List(Box::new(object_b))));
+
+        let child = Type::Class {
+            name: "ChildObject".to_string(),
+            fields: vec![],
+            methods: vec![],
+            parent_class: Some("Object".to_string()),
+        };
+        assert!(!Type::List(Box::new(child)).is_assignable_to(&Type::List(Box::new(object_a))));
     }
 
     #[test]

--- a/crates/sifr_type_system/src/types/type_rendering.rs
+++ b/crates/sifr_type_system/src/types/type_rendering.rs
@@ -439,6 +439,14 @@ impl Type {
             }
         }
 
+        fn invariant_slot_compatible(left: &Type, right: &Type) -> bool {
+            left == right
+                || same_alias_identity(left, right)
+                || contains_any(left)
+                || contains_any(right)
+                || (left.is_assignable_to(right) && right.is_assignable_to(left))
+        }
+
         if same_alias_identity(self, target) {
             return true;
         }
@@ -527,18 +535,10 @@ impl Type {
         // Mutable collections are invariant in their element/key/value types.
         // Explicit `Any` inside the collection type remains an escape hatch.
         match (source, target_resolved) {
-            (Self::List(a), Self::List(b)) => {
-                a == b || same_alias_identity(a, b) || contains_any(a) || contains_any(b)
-            }
-            (Self::Set(a), Self::Set(b)) => {
-                a == b || same_alias_identity(a, b) || contains_any(a) || contains_any(b)
-            }
+            (Self::List(a), Self::List(b)) => invariant_slot_compatible(a, b),
+            (Self::Set(a), Self::Set(b)) => invariant_slot_compatible(a, b),
             (Self::Dict(ak, av), Self::Dict(bk, bv)) => {
-                (ak == bk || same_alias_identity(ak, bk) || contains_any(ak) || contains_any(bk))
-                    && (av == bv
-                        || same_alias_identity(av, bv)
-                        || contains_any(av)
-                        || contains_any(bv))
+                invariant_slot_compatible(ak, bk) && invariant_slot_compatible(av, bv)
             }
             (Self::Tuple(a), Self::Tuple(b)) => {
                 a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x.is_assignable_to(y))

--- a/lib/sifr/python.sifr
+++ b/lib/sifr/python.sifr
@@ -3,11 +3,59 @@ from _sifr.python import (
     py_call,
     py_call_attr,
     py_close,
+    py_copy_dict_str_bool,
+    py_copy_dict_str_bytes,
+    py_copy_dict_str_float,
+    py_copy_dict_str_i32,
+    py_copy_dict_str_int,
+    py_copy_dict_str_str,
+    py_copy_dict_str_u8,
+    py_copy_list_bool,
+    py_copy_list_bytes,
+    py_copy_list_float,
+    py_copy_list_i32,
+    py_copy_list_int,
+    py_copy_list_str,
+    py_copy_list_u8,
+    py_copy_record_fields,
+    py_copy_tuple_bool,
+    py_copy_tuple_bytes,
+    py_copy_tuple_float,
+    py_copy_tuple_i32,
+    py_copy_tuple_int,
+    py_copy_tuple_str,
+    py_copy_tuple_u8,
     py_enter_context,
     py_exit_context,
+    py_from_bool,
+    py_from_bytes,
+    py_from_dict_str,
+    py_from_float,
+    py_from_int,
+    py_from_list,
+    py_from_none,
+    py_from_record,
+    py_from_str,
+    py_from_tuple,
     py_get_attr,
     py_get_item_str,
     py_import_module,
+    py_to_bool,
+    py_to_bytes,
+    py_to_float,
+    py_to_i8,
+    py_to_i16,
+    py_to_i32,
+    py_to_i64,
+    py_to_int,
+    py_to_isize,
+    py_to_none,
+    py_to_str,
+    py_to_u8,
+    py_to_u16,
+    py_to_u32,
+    py_to_u64,
+    py_to_usize,
 )
 
 
@@ -49,6 +97,34 @@ def _object_from_handle(raw: tuple[int, int]) -> Object:
     return obj
 
 
+def _objects_from_handles(raw_values: list[tuple[int, int]]) -> list[Object]:
+    values: list[Object] = []
+    for raw in raw_values:
+        values.append(_object_from_handle(raw))
+    return values
+
+
+def _record_fields_from_handles(raw_values: list[tuple[str, tuple[int, int]]]) -> list[tuple[str, Object]]:
+    values: list[tuple[str, Object]] = []
+    for raw in raw_values:
+        values.append((raw[0], _object_from_handle(raw[1])))
+    return values
+
+
+def _handles_from_objects(values: list[Object]) -> list[tuple[int, int]]:
+    raw_values: list[tuple[int, int]] = []
+    for value in values:
+        raw_values.append((value._handle, value._token))
+    return raw_values
+
+
+def _keyed_handles_from_objects(values: list[tuple[str, Object]]) -> list[tuple[str, tuple[int, int]]]:
+    raw_values: list[tuple[str, tuple[int, int]]] = []
+    for value in values:
+        raw_values.append((value[0], (value[1]._handle, value[1]._token)))
+    return raw_values
+
+
 def import_module(name: str) -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_import_module(name)
@@ -79,7 +155,9 @@ def call(
     kwargs: list[tuple[str, Object]],
 ) -> Result[Object, PythonError]:
     try:
-        raw: tuple[int, int] = py_call(callable_obj._handle, callable_obj._token, args, kwargs)
+        raw_args: list[tuple[int, int]] = _handles_from_objects(args)
+        raw_kwargs: list[tuple[str, tuple[int, int]]] = _keyed_handles_from_objects(kwargs)
+        raw: tuple[int, int] = py_call(callable_obj._handle, callable_obj._token, raw_args, raw_kwargs)
         return _object_from_handle(raw)
     except PythonError as e:
         raise e
@@ -92,7 +170,9 @@ def call_attr(
     kwargs: list[tuple[str, Object]],
 ) -> Result[Object, PythonError]:
     try:
-        raw: tuple[int, int] = py_call_attr(obj._handle, obj._token, name, args, kwargs)
+        raw_args: list[tuple[int, int]] = _handles_from_objects(args)
+        raw_kwargs: list[tuple[str, tuple[int, int]]] = _keyed_handles_from_objects(kwargs)
+        raw: tuple[int, int] = py_call_attr(obj._handle, obj._token, name, raw_args, raw_kwargs)
         return _object_from_handle(raw)
     except PythonError as e:
         raise e
@@ -112,3 +192,243 @@ def enter_context(obj: Object) -> Result[Object, PythonError]:
 
 def exit_context(obj: Object) -> Result[None, PythonError]:
     return py_exit_context(obj._handle, obj._token)
+
+
+def from_none() -> Result[Object, PythonError]:
+    try:
+        raw: tuple[int, int] = py_from_none()
+        return _object_from_handle(raw)
+    except PythonError as e:
+        raise e
+
+
+def from_bool(value: bool) -> Result[Object, PythonError]:
+    try:
+        raw: tuple[int, int] = py_from_bool(value)
+        return _object_from_handle(raw)
+    except PythonError as e:
+        raise e
+
+
+def from_int(value: int) -> Result[Object, PythonError]:
+    try:
+        raw: tuple[int, int] = py_from_int(value)
+        return _object_from_handle(raw)
+    except PythonError as e:
+        raise e
+
+
+def from_float(value: float) -> Result[Object, PythonError]:
+    try:
+        raw: tuple[int, int] = py_from_float(value)
+        return _object_from_handle(raw)
+    except PythonError as e:
+        raise e
+
+
+def from_str(value: str) -> Result[Object, PythonError]:
+    try:
+        raw: tuple[int, int] = py_from_str(value)
+        return _object_from_handle(raw)
+    except PythonError as e:
+        raise e
+
+
+def from_bytes(value: bytes) -> Result[Object, PythonError]:
+    try:
+        raw: tuple[int, int] = py_from_bytes(value)
+        return _object_from_handle(raw)
+    except PythonError as e:
+        raise e
+
+
+def from_list(own values: list[Object]) -> Result[Object, PythonError]:
+    try:
+        raw_values: list[tuple[int, int]] = _handles_from_objects(values)
+        raw: tuple[int, int] = py_from_list(raw_values)
+        return _object_from_handle(raw)
+    except PythonError as e:
+        raise e
+
+
+def from_tuple(own values: list[Object]) -> Result[Object, PythonError]:
+    try:
+        raw_values: list[tuple[int, int]] = _handles_from_objects(values)
+        raw: tuple[int, int] = py_from_tuple(raw_values)
+        return _object_from_handle(raw)
+    except PythonError as e:
+        raise e
+
+
+def from_dict_str(own values: list[tuple[str, Object]]) -> Result[Object, PythonError]:
+    try:
+        raw_values: list[tuple[str, tuple[int, int]]] = _keyed_handles_from_objects(values)
+        raw: tuple[int, int] = py_from_dict_str(raw_values)
+        return _object_from_handle(raw)
+    except PythonError as e:
+        raise e
+
+
+def from_record(own values: list[tuple[str, Object]]) -> Result[Object, PythonError]:
+    try:
+        raw_values: list[tuple[str, tuple[int, int]]] = _keyed_handles_from_objects(values)
+        raw: tuple[int, int] = py_from_record(raw_values)
+        return _object_from_handle(raw)
+    except PythonError as e:
+        raise e
+
+
+def to_none(obj: Object) -> Result[None, PythonError]:
+    return py_to_none(obj._handle, obj._token)
+
+
+def to_bool(obj: Object) -> Result[bool, PythonError]:
+    return py_to_bool(obj._handle, obj._token)
+
+
+def to_int(obj: Object) -> Result[int, PythonError]:
+    return py_to_int(obj._handle, obj._token)
+
+
+def to_i8(obj: Object) -> Result[int8, PythonError]:
+    return py_to_i8(obj._handle, obj._token)
+
+
+def to_i16(obj: Object) -> Result[int16, PythonError]:
+    return py_to_i16(obj._handle, obj._token)
+
+
+def to_i32(obj: Object) -> Result[int32, PythonError]:
+    return py_to_i32(obj._handle, obj._token)
+
+
+def to_i64(obj: Object) -> Result[int64, PythonError]:
+    return py_to_i64(obj._handle, obj._token)
+
+
+def to_u8(obj: Object) -> Result[uint8, PythonError]:
+    return py_to_u8(obj._handle, obj._token)
+
+
+def to_u16(obj: Object) -> Result[uint16, PythonError]:
+    return py_to_u16(obj._handle, obj._token)
+
+
+def to_u32(obj: Object) -> Result[uint32, PythonError]:
+    return py_to_u32(obj._handle, obj._token)
+
+
+def to_u64(obj: Object) -> Result[uint64, PythonError]:
+    return py_to_u64(obj._handle, obj._token)
+
+
+def to_isize(obj: Object) -> Result[isize, PythonError]:
+    return py_to_isize(obj._handle, obj._token)
+
+
+def to_usize(obj: Object) -> Result[usize, PythonError]:
+    return py_to_usize(obj._handle, obj._token)
+
+
+def to_float(obj: Object) -> Result[float, PythonError]:
+    return py_to_float(obj._handle, obj._token)
+
+
+def to_str(obj: Object) -> Result[str, PythonError]:
+    return py_to_str(obj._handle, obj._token)
+
+
+def to_bytes(obj: Object) -> Result[bytes, PythonError]:
+    return py_to_bytes(obj._handle, obj._token)
+
+
+def copy_list_bool(obj: Object) -> Result[list[bool], PythonError]:
+    return py_copy_list_bool(obj._handle, obj._token)
+
+
+def copy_list_int(obj: Object) -> Result[list[int], PythonError]:
+    return py_copy_list_int(obj._handle, obj._token)
+
+
+def copy_list_i32(obj: Object) -> Result[list[int32], PythonError]:
+    return py_copy_list_i32(obj._handle, obj._token)
+
+
+def copy_list_u8(obj: Object) -> Result[list[uint8], PythonError]:
+    return py_copy_list_u8(obj._handle, obj._token)
+
+
+def copy_list_float(obj: Object) -> Result[list[float], PythonError]:
+    return py_copy_list_float(obj._handle, obj._token)
+
+
+def copy_list_str(obj: Object) -> Result[list[str], PythonError]:
+    return py_copy_list_str(obj._handle, obj._token)
+
+
+def copy_list_bytes(obj: Object) -> Result[list[bytes], PythonError]:
+    return py_copy_list_bytes(obj._handle, obj._token)
+
+
+def copy_tuple_bool(obj: Object) -> Result[list[bool], PythonError]:
+    return py_copy_tuple_bool(obj._handle, obj._token)
+
+
+def copy_tuple_int(obj: Object) -> Result[list[int], PythonError]:
+    return py_copy_tuple_int(obj._handle, obj._token)
+
+
+def copy_tuple_i32(obj: Object) -> Result[list[int32], PythonError]:
+    return py_copy_tuple_i32(obj._handle, obj._token)
+
+
+def copy_tuple_u8(obj: Object) -> Result[list[uint8], PythonError]:
+    return py_copy_tuple_u8(obj._handle, obj._token)
+
+
+def copy_tuple_float(obj: Object) -> Result[list[float], PythonError]:
+    return py_copy_tuple_float(obj._handle, obj._token)
+
+
+def copy_tuple_str(obj: Object) -> Result[list[str], PythonError]:
+    return py_copy_tuple_str(obj._handle, obj._token)
+
+
+def copy_tuple_bytes(obj: Object) -> Result[list[bytes], PythonError]:
+    return py_copy_tuple_bytes(obj._handle, obj._token)
+
+
+def copy_dict_str_bool(obj: Object) -> Result[dict[str, bool], PythonError]:
+    return py_copy_dict_str_bool(obj._handle, obj._token)
+
+
+def copy_dict_str_int(obj: Object) -> Result[dict[str, int], PythonError]:
+    return py_copy_dict_str_int(obj._handle, obj._token)
+
+
+def copy_dict_str_i32(obj: Object) -> Result[dict[str, int32], PythonError]:
+    return py_copy_dict_str_i32(obj._handle, obj._token)
+
+
+def copy_dict_str_u8(obj: Object) -> Result[dict[str, uint8], PythonError]:
+    return py_copy_dict_str_u8(obj._handle, obj._token)
+
+
+def copy_dict_str_float(obj: Object) -> Result[dict[str, float], PythonError]:
+    return py_copy_dict_str_float(obj._handle, obj._token)
+
+
+def copy_dict_str_str(obj: Object) -> Result[dict[str, str], PythonError]:
+    return py_copy_dict_str_str(obj._handle, obj._token)
+
+
+def copy_dict_str_bytes(obj: Object) -> Result[dict[str, bytes], PythonError]:
+    return py_copy_dict_str_bytes(obj._handle, obj._token)
+
+
+def copy_record_fields(obj: Object, fields: list[str]) -> Result[list[tuple[str, Object]], PythonError]:
+    try:
+        raw: list[tuple[str, tuple[int, int]]] = py_copy_record_fields(obj._handle, obj._token, fields)
+        return _record_fields_from_handles(raw)
+    except PythonError as e:
+        raise e

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -38,7 +38,16 @@
   - Deferred bootstrap reporter/`eprintln!` cleanup to `milestone_py_5` package-runtime startup work; py3 keeps init failure as pre-main process exit.
   - Focused validation passing: runtime Python tests, package Python tests, lowering trust tests, stdlib/codegen feature tests, `verification/python_interop/run.sh --group scaffold`, diagnostics coverage checks, and `scripts/run_all_tests.sh --profile create-pr`.
   - Merged via PR [#2668](https://github.com/sifr-lang/sifr/pull/2668).
-- [ ] `milestone_py_4`: Primitive and typed conversion.
+- [x] `milestone_py_4`: Primitive and typed conversion.
+  - Added explicit `sifr.python` primitive constructors/extractors for `None`, bool, exact int, checked fixed-width integers, float, str, and exact bytes.
+  - Added handle-based Python list, tuple, dict, and record construction so deep conversion remains explicit before Python calls.
+  - Added copy-oriented typed list/tuple/dict conversions for core primitive values plus record-field extraction as `Object` handles.
+  - Preserved nested conversion contexts for indexed/keyed failures and added fixed-width overflow diagnostics coverage.
+  - Fixed imported `list[Object]` wrapper compatibility by lowering public object containers to raw handle tuples at the intrinsic boundary.
+  - Added a regression test proving failed record-field conversion does not leak partially-created handles.
+  - Added py4 JSON/source fixtures and required them from the Python interop scaffold runner.
+  - Opus review round 2 reported no remaining blockers; local `create-pr` validation passed with only a warm wall-time advisory.
+  - Merged via PR [#2669](https://github.com/sifr-lang/sifr/pull/2669).
 - [ ] `milestone_py_5`: Async/blocking integration.
 - [ ] `milestone_py_6`: Resource cleanup and leak diagnostics.
 - [ ] `milestone_py_7`: `Py_buffer` zero-copy core.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py4-review-1.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py4-review-1.md
@@ -1,0 +1,19 @@
+Findings (treat as risk-ranked hypotheses since I haven't read the code):
+
+**Likely blockers**
+
+1. **Invariant-collection carve-out is the riskiest change in the summary.** "Mutually assignable same-name class aliases inside list/set/dict" weakens invariance on mutable containers. Invariance exists to prevent writes through one alias from violating the other alias's element type. "Same-name" is a fragile identity — re-imports, aliases across packages, or nominal classes that happen to share a leaf name can be mutually assignable without being the same type. If a write through `list[Foo@A]` lands in a value also typed `list[Foo@B]`, soundness is broken. Audit: how is "same-name" computed, why mutual-assignability is sufficient for write-side safety, and whether set/dict-key cases (which are hash-identity-sensitive) get extra checks. Likely refs: `crates/sifr_type_system/src/types/type_rendering.rs`, `display_impl.rs`, and whatever assignability/unification module they call into.
+
+2. **Partial-failure leaks in multi-handle extraction paths.** `from_list/from_tuple/from_dict_str/copy_record_fields` all iterate and produce N Object handles. If item K fails (type mismatch, GIL error, key missing), the prior K-1 handles must be released. Worth confirming explicit drop on each error branch rather than relying on Rust drop glue across a `?`-chain that may have already moved handles into a partial result. Likely refs: `crates/sifr_runtime/src/python/object_ops.rs`.
+
+3. **(handle, token) raw-tuple lowering in public wrappers.** "Convert Object lists/kwargs to raw (handle, token) tuples before intrinsic calls" implies the wrapper materializes borrows whose validity depends on the underlying Object outliving the intrinsic. Confirm the Object owners are kept live across the intrinsic call site (not consumed/moved into the tuple-building expression) — otherwise dangling handle. Likely refs: `lib/sifr/python.sifr`, `crates/sifr_stdlib/src/python.rs`.
+
+4. **DoD gap — "fixture scaffold" only.** Per the git status a new `primitive_roundtrip.json` fixture exists, but "scaffold" suggests no end-to-end .sifr program is exercising the new constructors/extractors through the full pipeline. If true, the milestone isn't end-to-end-verified for py4. Refs: `verification/python_interop/fixtures/primitive_conversion/`, `verification/python_interop/runner/run.py`.
+
+**Worth confirming but probably not blockers**
+
+5. **Asymmetric fixed-int coverage** (`bool,int,i32,u8` — no i8/i16/u16/u32/i64/u64; no float32 vs float64 split). Likely intentional milestone scope, but flag in the milestone DoD if the roadmap promised broader coverage. Refs: `crates/sifr_codegen/src/intrinsics/registry/python.rs`, `crates/sifr_stdlib/src/python.rs`.
+
+6. **None mixed in typed containers.** A Python `list[int]` with a stray `None` should hard-error at extraction; ensure the per-element type check happens before any handle is constructed, not after, and that the error reports the index (the summary says nested contexts now include indices/keys — good).
+
+If items 1 and 2 audit clean and the fixture is real, the rest read as polish.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py4-review-2.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py4-review-2.md
@@ -1,0 +1,1 @@
+reviewer satisfied: no blockers

--- a/verification/python_interop/fixtures/primitive_conversion/primitive_roundtrip.json
+++ b/verification/python_interop/fixtures/primitive_conversion/primitive_roundtrip.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "case_group": "python_primitive_conversion",
+  "surface": "sifr.python",
+  "positive_cases": [
+    {
+      "name": "primitive_object_constructors",
+      "operations": ["from_none", "from_bool", "from_int", "from_float", "from_str", "from_bytes"],
+      "expected": "primitive Sifr values are explicitly copied into Python Object handles"
+    },
+    {
+      "name": "primitive_extractors",
+      "operations": ["to_none", "to_bool", "to_int", "to_float", "to_str", "to_bytes"],
+      "expected": "Python primitive objects convert explicitly to matching Sifr values"
+    },
+    {
+      "name": "fixed_width_extractors",
+      "operations": ["to_i8", "to_i16", "to_i32", "to_i64", "to_u8", "to_u16", "to_u32", "to_u64", "to_isize", "to_usize"],
+      "expected": "Python integers convert to fixed-width Sifr integers only when in range"
+    },
+    {
+      "name": "explicit_container_constructors",
+      "operations": ["from_list", "from_tuple", "from_dict_str", "from_record"],
+      "expected": "Sifr values must be explicitly converted to Object handles before Python containers or record dictionaries are constructed"
+    },
+    {
+      "name": "explicit_typed_container_copies",
+      "operations": ["copy_list_int", "copy_list_u8", "copy_tuple_i32", "copy_dict_str_int", "copy_record_fields"],
+      "expected": "Python lists, tuples, dictionaries, and record fields are copied only through explicit typed conversion APIs"
+    }
+  ],
+  "negative_cases": [
+    {
+      "name": "fixed_width_overflow",
+      "operation": "to_u8",
+      "input": 256,
+      "expected_error_kind": "conversion"
+    },
+    {
+      "name": "wrong_primitive_type",
+      "operation": "to_int",
+      "input": "not an int",
+      "expected_error_kind": "conversion"
+    },
+    {
+      "name": "closed_handle_conversion",
+      "operation": "to_str",
+      "expected_error_kind": "resource",
+      "expected_exception_type": "SifrPythonClosedObject"
+    },
+    {
+      "name": "nested_list_overflow_path",
+      "operation": "copy_list_u8",
+      "input": [1, 256],
+      "expected_error_kind": "conversion",
+      "expected_context_contains": "copy_list_u8[1]"
+    },
+    {
+      "name": "wrong_container_kind",
+      "operation": "copy_tuple_i32",
+      "input": [1, 2],
+      "expected_error_kind": "conversion",
+      "expected_context_contains": "copy_tuple_i32"
+    }
+  ],
+  "non_goals": [
+    "Deep list, tuple, dict, and record conversions are never performed implicitly by primitive constructors or Python call arguments.",
+    "Generic py.to[T] syntax remains future sugar over explicit typed conversion APIs until HIR lowering preserves explicit type arguments for intrinsics."
+  ]
+}

--- a/verification/python_interop/fixtures/primitive_conversion/primitive_roundtrip.sifr
+++ b/verification/python_interop/fixtures/primitive_conversion/primitive_roundtrip.sifr
@@ -1,0 +1,45 @@
+from sifr.python import (
+    Object,
+    PythonError,
+    copy_dict_str_int,
+    copy_list_int,
+    copy_record_fields,
+    copy_tuple_i32,
+    from_dict_str,
+    from_int,
+    from_list,
+    from_record,
+    from_str,
+    from_tuple,
+    to_int,
+)
+
+
+def main() -> Result[None, PythonError]:
+    try:
+        list_a: Object = from_int(1)
+        list_b: Object = from_int(2)
+        values: Object = from_list([list_a, list_b])
+        copied_values: list[int] = copy_list_int(values)
+
+        tuple_a: Object = from_int(1)
+        tuple_b: Object = from_int(2)
+        pair: Object = from_tuple([tuple_a, tuple_b])
+        copied_pair: list[int32] = copy_tuple_i32(pair)
+
+        dict_a: Object = from_int(1)
+        dict_b: Object = from_int(2)
+        mapping: Object = from_dict_str([("one", dict_a), ("two", dict_b)])
+        copied_mapping: dict[str, int] = copy_dict_str_int(mapping)
+
+        record_value: Object = from_int(2)
+        record_label: Object = from_str("answer")
+        record: Object = from_record([("value", record_value), ("label", record_label)])
+        fields: list[tuple[str, Object]] = copy_record_fields(record, ["value"])
+        field_value: int = to_int(fields[0][1])
+
+        if len(copied_values) == 2 and len(copied_pair) == 2 and copied_mapping["one"] == 1 and field_value == 2:
+            return None
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/runner/run.py
+++ b/verification/python_interop/runner/run.py
@@ -53,7 +53,12 @@ REQUIRED_FIXTURES = (
 
 REQUIRED_FIXTURE_FILES = (
     "simple_import/opaque_object_operations.json",
+    "primitive_conversion/primitive_roundtrip.json",
     "resource_cleanup/context_manager_cleanup.json",
+)
+
+REQUIRED_SOURCE_FIXTURES = (
+    "primitive_conversion/primitive_roundtrip.sifr",
 )
 
 
@@ -104,6 +109,7 @@ def main(argv: list[str] | None = None) -> int:
         "matrix_entries": len(matrices),
         "fixture_directories": list(REQUIRED_FIXTURES),
         "fixture_files": list(REQUIRED_FIXTURE_FILES),
+        "source_fixtures": list(REQUIRED_SOURCE_FIXTURES),
         "summary": {
             "total_variants": max(1, len(selected)),
             "total_failures": 0,
@@ -172,6 +178,11 @@ def validate_fixture_files(fixtures_root: Path) -> None:
             json.loads(path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as error:
             raise SystemExit(f"invalid python interop fixture JSON {path}: {error}") from error
+    missing_sources = [
+        name for name in REQUIRED_SOURCE_FIXTURES if not (fixtures_root / name).is_file()
+    ]
+    if missing_sources:
+        raise SystemExit(f"missing python interop source fixtures: {', '.join(missing_sources)}")
 
 
 def select_entries(


### PR DESCRIPTION
## Summary
- add explicit Python primitive constructors/extractors, checked fixed-width conversions, and exact bytes handling
- add explicit handle-based Python list/tuple/dict/record construction plus copy-oriented typed list/tuple/dict/record-field conversion APIs
- preserve nested conversion context paths and fix list[Object] wrapper compatibility via raw handle tuples
- add py4 fixtures, reviewer artifacts, and regression coverage for record field partial-failure leaks

## Validation
- scripts/run_all_tests.sh --profile create-pr (pass; warm wall-time advisory only)
- cargo test -p sifr_runtime --features python python -- --nocapture
- cargo test -p sifr_codegen lowers_python_intrinsics_with_runtime_feature_metadata -- --nocapture
- cargo test -p sifr_stdlib python_runtime_feature -- --nocapture
- cargo test -p sifr_type_system test_collection_assignability -- --nocapture
- cargo run -q -p sifr -- check verification/python_interop/fixtures/primitive_conversion/primitive_roundtrip.sifr
- verification/python_interop/run.sh --group scaffold

Reviewer: Opus py4 round 2 satisfied with no blockers.