### PR TITLE
Add Python async blocking integration

### DIFF
--- a/crates/sifr_codegen/src/intrinsics/registry/python.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/python.rs
@@ -10,6 +10,7 @@ pub(crate) fn lower_python_intrinsic(name: &str, args: &[RustExpr]) -> Option<Ru
         "py_close" => lower_py_close(args),
         "py_enter_context" => lower_py_enter_context(args),
         "py_exit_context" => lower_py_exit_context(args),
+        "py_run_coroutine_blocking" => lower_py_run_coroutine_blocking(args),
         "py_from_none" => lower_py_from_none(args),
         "py_from_bool" => lower_py_from_bool(args),
         "py_from_int" => lower_py_from_int(args),
@@ -248,6 +249,10 @@ pub(crate) fn lower_py_exit_context(args: &[RustExpr]) -> Option<RustExpr> {
     Some(map_python_error(format!(
         "sifr_runtime::python::exit_context(({handle}, {token}))"
     )))
+}
+
+pub(crate) fn lower_py_run_coroutine_blocking(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_handle_conversion(args, "run_coroutine_blocking")
 }
 
 pub(crate) fn lower_py_from_none(args: &[RustExpr]) -> Option<RustExpr> {

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -93,6 +93,15 @@ pub(crate) fn lowers_python_intrinsics_with_runtime_feature_metadata() {
     let record_fields_rendered = render_expr(&record_fields.expr);
     assert!(record_fields_rendered.contains("sifr_runtime::python::copy_record_fields"));
     assert!(record_fields_rendered.contains("__sifr_python_fields"));
+
+    let coroutine = lower_intrinsic(
+        "py_run_coroutine_blocking",
+        &["object_handle".to_string(), "object_token".to_string()],
+    )
+    .expect("py_run_coroutine_blocking should lower");
+    let coroutine_rendered = render_expr(&coroutine.expr);
+    assert!(coroutine_rendered.contains("sifr_runtime::python::run_coroutine_blocking"));
+    assert!(coroutine_rendered.contains("(object_handle, object_token)"));
 }
 
 #[test]

--- a/crates/sifr_driver/src/stdlib/bootstrap.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap.rs
@@ -189,7 +189,7 @@ fn compile_stdlib_uncached_impl() -> Result<StdlibCompiled, Vec<RenderedDiagnost
                     name: class.name.clone(),
                     fields: class.fields.clone(),
                     methods,
-                    parent_class: None,
+                    parent_class: class.parent_class.clone(),
                 };
                 class_exports.insert(class.name.clone(), class_ty);
                 if !class.type_params.is_empty() {
@@ -788,5 +788,24 @@ mod tests {
         assert_eq!(exports.get("ANSWER"), Some(&42));
         assert!(!exports.contains_key("_PRIVATE"));
         assert!(!exports.contains_key("STALE"));
+    }
+
+    #[test]
+    fn stdlib_class_exports_preserve_parent_markers() {
+        let compiled = compile_stdlib_uncached().expect("stdlib should compile");
+        let object_ty = compiled
+            .defs
+            .classes
+            .get("sifr.python")
+            .and_then(|classes| classes.get("Object"))
+            .expect("sifr.python.Object should be exported");
+
+        assert!(matches!(
+            object_ty,
+            Type::Class {
+                parent_class: Some(parent),
+                ..
+            } if parent.split('|').any(|name| name == "NonSend")
+        ));
     }
 }

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -98,6 +98,8 @@ mod ownership_diagnostics;
 mod parallel_calls;
 mod protocol_diagnostics;
 #[cfg(test)]
+mod python_async_tests;
+#[cfg(test)]
 mod python_trust_tests;
 mod result_diagnostics;
 #[cfg(test)]

--- a/crates/sifr_lowering/src/lower/python_async_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_async_tests.rs
@@ -1,0 +1,141 @@
+use crate::{ExternalDefs, HirDiagnostic};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_parser::parse_module;
+use sifr_type_system::{FunctionType, Type};
+use std::collections::HashMap;
+
+fn object_ty() -> Type {
+    Type::Class {
+        name: "Object".to_string(),
+        fields: Vec::new(),
+        methods: Vec::new(),
+        parent_class: Some("NonSend".to_string()),
+    }
+}
+
+fn error_ty() -> Type {
+    Type::Class {
+        name: "PythonError".to_string(),
+        fields: Vec::new(),
+        methods: Vec::new(),
+        parent_class: Some("Error".to_string()),
+    }
+}
+
+fn python_externals() -> ExternalDefs {
+    let object_ty = object_ty();
+    let error_ty = error_ty();
+    let mut functions = HashMap::new();
+    functions.insert(
+        "from_int".to_string(),
+        FunctionType::all_borrow(
+            vec![("value".to_string(), Type::Int)],
+            Type::Result(Box::new(object_ty.clone()), Box::new(error_ty.clone())),
+        ),
+    );
+    functions.insert(
+        "run_coroutine_blocking".to_string(),
+        FunctionType::all_borrow(
+            vec![("coro".to_string(), object_ty.clone())],
+            Type::Result(Box::new(object_ty.clone()), Box::new(error_ty.clone())),
+        ),
+    );
+    functions.insert(
+        "to_int".to_string(),
+        FunctionType::all_borrow(
+            vec![("obj".to_string(), object_ty.clone())],
+            Type::Result(Box::new(Type::Int), Box::new(error_ty.clone())),
+        ),
+    );
+    functions.insert(
+        "close".to_string(),
+        FunctionType::new(
+            vec![("obj".to_string(), object_ty.clone())],
+            Type::Result(Box::new(Type::None), Box::new(error_ty.clone())),
+        ),
+    );
+
+    let mut classes = HashMap::new();
+    classes.insert("Object".to_string(), object_ty);
+    classes.insert("PythonError".to_string(), error_ty);
+
+    let mut workloads = HashMap::new();
+    for name in ["from_int", "run_coroutine_blocking", "to_int", "close"] {
+        workloads.insert(name.to_string(), "blocking_io".to_string());
+    }
+
+    let mut externals = ExternalDefs::default();
+    externals
+        .functions
+        .insert("sifr.python".to_string(), functions);
+    externals.classes.insert("sifr.python".to_string(), classes);
+    externals
+        .function_workloads
+        .insert("sifr.python".to_string(), workloads);
+    externals.error_types.insert("PythonError".to_string());
+    externals
+}
+
+fn lower(source: &str) -> Result<(), Vec<HirDiagnostic>> {
+    let parsed = parse_module(source).expect("source should parse");
+    crate::lower_module_with_externals(parsed.suite(), &python_externals()).map(|_| ())
+}
+
+#[test]
+fn async_python_call_is_rejected_without_offload() {
+    let source = "from sifr.python import Object, PythonError, from_int\n\nasync def main() -> Result[None, PythonError]:\n    obj: Object = from_int(1)\n    return None\n";
+    let errors = lower(source).expect_err("direct Python call should fail in async code");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::ASYNC_DIRECT_BLOCKING_IO_CALL)
+            && error.message.contains("blocking_io function 'from_int'")
+    }));
+}
+
+#[test]
+fn run_coroutine_blocking_is_rejected_without_offload() {
+    let source = "from sifr.python import Object, PythonError, run_coroutine_blocking\n\nasync def main(coro: Object) -> Result[None, PythonError]:\n    result: Object = run_coroutine_blocking(coro)\n    return None\n";
+    let errors = lower(source).expect_err("run_coroutine_blocking should fail in async code");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::ASYNC_DIRECT_BLOCKING_IO_CALL)
+            && error
+                .message
+                .contains("blocking_io function 'run_coroutine_blocking'")
+    }));
+}
+
+#[test]
+fn offloaded_python_worker_is_allowed_when_returning_send_value() {
+    let source = "from sifr.python import Object, PythonError, from_int, to_int\n\n@blocking_io\ndef build_value() -> Result[int, PythonError]:\n    try:\n        obj: Object = from_int(41)\n        value: int = to_int(obj)\n        return value\n    except PythonError as e:\n        raise e\n\nasync def main() -> Result[None, ScopeFailure]:\n    handle = task.spawn_blocking(build_value)\n    result = await handle\n    return None\n";
+
+    lower(source).expect("annotated Python worker returning sendable data should lower");
+}
+
+#[test]
+fn offloaded_python_worker_cannot_return_object_handle() {
+    let source = "from sifr.python import Object, PythonError, from_int\n\n@blocking_io\ndef build_object() -> Result[Object, PythonError]:\n    try:\n        obj: Object = from_int(41)\n        return obj\n    except PythonError as e:\n        raise e\n\nasync def main() -> Result[None, ScopeFailure]:\n    handle = task.spawn_blocking(build_object)\n    result = await handle\n    return None\n";
+    let errors = lower(source).expect_err("py.Object should not cross worker boundary");
+
+    assert!(errors.iter().any(|error| {
+        error
+            .message
+            .contains("task.spawn_blocking() cannot return non-send value type 'Object'")
+            && error
+                .message
+                .contains("`Object` inherits the `NonSend` marker")
+    }));
+}
+
+#[test]
+fn offloaded_python_worker_must_be_classified() {
+    let source = "from sifr.python import Object, PythonError, from_int, to_int\n\ndef build_value() -> Result[int, PythonError]:\n    try:\n        obj: Object = from_int(41)\n        value: int = to_int(obj)\n        return value\n    except PythonError as e:\n        raise e\n\nasync def main() -> Result[None, ScopeFailure]:\n    handle = task.spawn_blocking(build_value)\n    result = await handle\n    return None\n";
+    let errors = lower(source).expect_err("unclassified Python worker should fail offload");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::ASYNC_UNCLASSIFIED_BLOCKING_OFFLOAD_TARGET)
+            && error
+                .message
+                .contains("target 'build_value' is not classified")
+    }));
+}

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -6,7 +6,9 @@ use std::fmt;
 use std::mem::MaybeUninit;
 use std::sync::{Mutex, MutexGuard};
 
+mod coroutine_ops;
 mod object_ops;
+pub use coroutine_ops::run_coroutine_blocking;
 pub use object_ops::{
     call_attr, call_object, close_object, copy_dict_str_bool, copy_dict_str_bytes,
     copy_dict_str_float, copy_dict_str_i32, copy_dict_str_int, copy_dict_str_str, copy_dict_str_u8,
@@ -623,12 +625,14 @@ print(os.pathsep.join(sys.path))
         sys_path,
         site_packages: Vec::new(),
         allowed_import_roots: vec![
+            "asyncio".to_string(),
             "builtins".to_string(),
             "contextlib".to_string(),
             "math".to_string(),
             "sys".to_string(),
         ],
         trusted_import_roots: vec![
+            "asyncio".to_string(),
             "builtins".to_string(),
             "contextlib".to_string(),
             "math".to_string(),

--- a/crates/sifr_runtime/src/python/coroutine_ops.rs
+++ b/crates/sifr_runtime/src/python/coroutine_ops.rs
@@ -1,0 +1,58 @@
+use super::object_ops::{clone_handle, store_object};
+use super::{ObjectHandle, PythonError};
+use pyo3::types::PyAnyMethods;
+
+pub fn run_coroutine_blocking(coroutine: ObjectHandle) -> Result<ObjectHandle, PythonError> {
+    super::attach(|py| {
+        let coroutine = clone_handle(py, coroutine)?;
+        let asyncio = py
+            .import("asyncio")
+            .map_err(|error| PythonError::from_pyerr(py, error, "import", "asyncio"))?;
+        let value = asyncio
+            .call_method1("run", (coroutine.bind(py),))
+            .map_err(|error| PythonError::from_pyerr(py, error, "call", "asyncio.run coroutine"))?;
+        store_object(value.unbind())
+    })
+    .map_err(PythonError::runtime)?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::python::{
+        call_object, close_object, from_float, from_int, get_attr, import_module,
+        initialize_runtime, reset_runtime_state_for_tests, shutdown_diagnostics, test_config,
+        test_guard, to_int, PythonRuntimeDiagnostics,
+    };
+
+    #[test]
+    fn run_coroutine_blocking_runs_python_owned_event_loop() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("run-coroutine")).expect("init should succeed");
+
+        let asyncio = import_module("asyncio").expect("asyncio module should import");
+        let sleep = get_attr(asyncio, "sleep").expect("sleep should resolve");
+        let delay = from_float(0.0).expect("delay should store");
+        let expected = from_int(41).expect("result should store");
+        let coroutine = call_object(sleep, &[delay], &[("result", expected)])
+            .expect("sleep coroutine should be created");
+        close_object(delay).expect("delay should close after coroutine creation");
+        close_object(expected).expect("expected value should close after coroutine creation");
+        let value = run_coroutine_blocking(coroutine).expect("coroutine should complete");
+
+        assert_eq!(to_int(value).expect("coroutine result should convert"), 41);
+
+        for handle in [asyncio, sleep, coroutine, value] {
+            close_object(handle).expect("object should close");
+        }
+        assert_eq!(
+            shutdown_diagnostics().expect("diagnostics should be available"),
+            PythonRuntimeDiagnostics {
+                initialized: true,
+                live_objects: 0,
+                leaked_objects: 0,
+            }
+        );
+    }
+}

--- a/crates/sifr_runtime/src/python/object_ops.rs
+++ b/crates/sifr_runtime/src/python/object_ops.rs
@@ -42,7 +42,7 @@ pub struct PythonError {
 }
 
 impl PythonError {
-    fn runtime(error: PythonRuntimeError) -> Self {
+    pub(super) fn runtime(error: PythonRuntimeError) -> Self {
         Self {
             kind: "runtime".to_string(),
             exception_type: "SifrPythonRuntimeError".to_string(),
@@ -72,7 +72,7 @@ impl PythonError {
         }
     }
 
-    fn from_pyerr(
+    pub(super) fn from_pyerr(
         py: Python<'_>,
         error: PyErr,
         kind: &'static str,
@@ -452,7 +452,7 @@ fn contains_root(roots: &[String], root: &str) -> bool {
         .any(|candidate| candidate == root || candidate == "*")
 }
 
-fn store_object(object: Py<PyAny>) -> Result<ObjectHandle, PythonError> {
+pub(super) fn store_object(object: Py<PyAny>) -> Result<ObjectHandle, PythonError> {
     let object = Object::new(object).map_err(PythonError::runtime)?;
     let mut store = object_store()?;
     let (handle, token) = reserve_handle(&mut store)?;
@@ -729,7 +729,10 @@ fn clone_handles(py: Python<'_>, values: &[ObjectHandle]) -> Result<Vec<Py<PyAny
         .collect::<Result<Vec<_>, _>>()
 }
 
-fn clone_handle(py: Python<'_>, (handle, token): ObjectHandle) -> Result<Py<PyAny>, PythonError> {
+pub(super) fn clone_handle(
+    py: Python<'_>,
+    (handle, token): ObjectHandle,
+) -> Result<Py<PyAny>, PythonError> {
     object_store()?
         .objects
         .get(&handle)

--- a/crates/sifr_stdlib/src/python.rs
+++ b/crates/sifr_stdlib/src/python.rs
@@ -104,6 +104,16 @@ pub(super) fn intrinsic_python() -> IntrinsicModule {
         ),
     );
     functions.insert(
+        "py_run_coroutine_blocking".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(object_handle()),
+        ),
+    );
+    functions.insert(
         "py_from_none".to_string(),
         FunctionType::all_borrow(vec![], python_error_result(object_handle())),
     );

--- a/lib/sifr/python.sifr
+++ b/lib/sifr/python.sifr
@@ -40,6 +40,7 @@ from _sifr.python import (
     py_get_attr,
     py_get_item_str,
     py_import_module,
+    py_run_coroutine_blocking,
     py_to_bool,
     py_to_bytes,
     py_to_float,
@@ -81,7 +82,7 @@ class PythonError(Error):
         self.context = context
 
 
-class Object:
+class Object(NonSend):
     _handle: int
     _token: int
 
@@ -125,6 +126,7 @@ def _keyed_handles_from_objects(values: list[tuple[str, Object]]) -> list[tuple[
     return raw_values
 
 
+@blocking_io
 def import_module(name: str) -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_import_module(name)
@@ -133,6 +135,7 @@ def import_module(name: str) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def get_attr(obj: Object, name: str) -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_get_attr(obj._handle, obj._token, name)
@@ -141,6 +144,7 @@ def get_attr(obj: Object, name: str) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def get_item(obj: Object, key: str) -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_get_item_str(obj._handle, obj._token, key)
@@ -149,6 +153,7 @@ def get_item(obj: Object, key: str) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def call(
     callable_obj: Object,
     args: list[Object],
@@ -163,6 +168,7 @@ def call(
         raise e
 
 
+@blocking_io
 def call_attr(
     obj: Object,
     name: str,
@@ -178,10 +184,12 @@ def call_attr(
         raise e
 
 
+@blocking_io
 def close(own obj: Object) -> Result[None, PythonError]:
     return py_close(obj._handle, obj._token)
 
 
+@blocking_io
 def enter_context(obj: Object) -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_enter_context(obj._handle, obj._token)
@@ -190,10 +198,12 @@ def enter_context(obj: Object) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def exit_context(obj: Object) -> Result[None, PythonError]:
     return py_exit_context(obj._handle, obj._token)
 
 
+@blocking_io
 def from_none() -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_from_none()
@@ -202,6 +212,7 @@ def from_none() -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def from_bool(value: bool) -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_from_bool(value)
@@ -210,6 +221,7 @@ def from_bool(value: bool) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def from_int(value: int) -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_from_int(value)
@@ -218,6 +230,7 @@ def from_int(value: int) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def from_float(value: float) -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_from_float(value)
@@ -226,6 +239,7 @@ def from_float(value: float) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def from_str(value: str) -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_from_str(value)
@@ -234,6 +248,7 @@ def from_str(value: str) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def from_bytes(value: bytes) -> Result[Object, PythonError]:
     try:
         raw: tuple[int, int] = py_from_bytes(value)
@@ -242,6 +257,7 @@ def from_bytes(value: bytes) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def from_list(own values: list[Object]) -> Result[Object, PythonError]:
     try:
         raw_values: list[tuple[int, int]] = _handles_from_objects(values)
@@ -251,6 +267,7 @@ def from_list(own values: list[Object]) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def from_tuple(own values: list[Object]) -> Result[Object, PythonError]:
     try:
         raw_values: list[tuple[int, int]] = _handles_from_objects(values)
@@ -260,6 +277,7 @@ def from_tuple(own values: list[Object]) -> Result[Object, PythonError]:
         raise e
 
 
+@blocking_io
 def from_dict_str(own values: list[tuple[str, Object]]) -> Result[Object, PythonError]:
     try:
         raw_values: list[tuple[str, tuple[int, int]]] = _keyed_handles_from_objects(values)
@@ -269,6 +287,7 @@ def from_dict_str(own values: list[tuple[str, Object]]) -> Result[Object, Python
         raise e
 
 
+@blocking_io
 def from_record(own values: list[tuple[str, Object]]) -> Result[Object, PythonError]:
     try:
         raw_values: list[tuple[str, tuple[int, int]]] = _keyed_handles_from_objects(values)
@@ -278,157 +297,204 @@ def from_record(own values: list[tuple[str, Object]]) -> Result[Object, PythonEr
         raise e
 
 
+@blocking_io
 def to_none(obj: Object) -> Result[None, PythonError]:
     return py_to_none(obj._handle, obj._token)
 
 
+@blocking_io
 def to_bool(obj: Object) -> Result[bool, PythonError]:
     return py_to_bool(obj._handle, obj._token)
 
 
+@blocking_io
 def to_int(obj: Object) -> Result[int, PythonError]:
     return py_to_int(obj._handle, obj._token)
 
 
+@blocking_io
 def to_i8(obj: Object) -> Result[int8, PythonError]:
     return py_to_i8(obj._handle, obj._token)
 
 
+@blocking_io
 def to_i16(obj: Object) -> Result[int16, PythonError]:
     return py_to_i16(obj._handle, obj._token)
 
 
+@blocking_io
 def to_i32(obj: Object) -> Result[int32, PythonError]:
     return py_to_i32(obj._handle, obj._token)
 
 
+@blocking_io
 def to_i64(obj: Object) -> Result[int64, PythonError]:
     return py_to_i64(obj._handle, obj._token)
 
 
+@blocking_io
 def to_u8(obj: Object) -> Result[uint8, PythonError]:
     return py_to_u8(obj._handle, obj._token)
 
 
+@blocking_io
 def to_u16(obj: Object) -> Result[uint16, PythonError]:
     return py_to_u16(obj._handle, obj._token)
 
 
+@blocking_io
 def to_u32(obj: Object) -> Result[uint32, PythonError]:
     return py_to_u32(obj._handle, obj._token)
 
 
+@blocking_io
 def to_u64(obj: Object) -> Result[uint64, PythonError]:
     return py_to_u64(obj._handle, obj._token)
 
 
+@blocking_io
 def to_isize(obj: Object) -> Result[isize, PythonError]:
     return py_to_isize(obj._handle, obj._token)
 
 
+@blocking_io
 def to_usize(obj: Object) -> Result[usize, PythonError]:
     return py_to_usize(obj._handle, obj._token)
 
 
+@blocking_io
 def to_float(obj: Object) -> Result[float, PythonError]:
     return py_to_float(obj._handle, obj._token)
 
 
+@blocking_io
 def to_str(obj: Object) -> Result[str, PythonError]:
     return py_to_str(obj._handle, obj._token)
 
 
+@blocking_io
 def to_bytes(obj: Object) -> Result[bytes, PythonError]:
     return py_to_bytes(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_list_bool(obj: Object) -> Result[list[bool], PythonError]:
     return py_copy_list_bool(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_list_int(obj: Object) -> Result[list[int], PythonError]:
     return py_copy_list_int(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_list_i32(obj: Object) -> Result[list[int32], PythonError]:
     return py_copy_list_i32(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_list_u8(obj: Object) -> Result[list[uint8], PythonError]:
     return py_copy_list_u8(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_list_float(obj: Object) -> Result[list[float], PythonError]:
     return py_copy_list_float(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_list_str(obj: Object) -> Result[list[str], PythonError]:
     return py_copy_list_str(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_list_bytes(obj: Object) -> Result[list[bytes], PythonError]:
     return py_copy_list_bytes(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_tuple_bool(obj: Object) -> Result[list[bool], PythonError]:
     return py_copy_tuple_bool(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_tuple_int(obj: Object) -> Result[list[int], PythonError]:
     return py_copy_tuple_int(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_tuple_i32(obj: Object) -> Result[list[int32], PythonError]:
     return py_copy_tuple_i32(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_tuple_u8(obj: Object) -> Result[list[uint8], PythonError]:
     return py_copy_tuple_u8(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_tuple_float(obj: Object) -> Result[list[float], PythonError]:
     return py_copy_tuple_float(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_tuple_str(obj: Object) -> Result[list[str], PythonError]:
     return py_copy_tuple_str(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_tuple_bytes(obj: Object) -> Result[list[bytes], PythonError]:
     return py_copy_tuple_bytes(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_dict_str_bool(obj: Object) -> Result[dict[str, bool], PythonError]:
     return py_copy_dict_str_bool(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_dict_str_int(obj: Object) -> Result[dict[str, int], PythonError]:
     return py_copy_dict_str_int(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_dict_str_i32(obj: Object) -> Result[dict[str, int32], PythonError]:
     return py_copy_dict_str_i32(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_dict_str_u8(obj: Object) -> Result[dict[str, uint8], PythonError]:
     return py_copy_dict_str_u8(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_dict_str_float(obj: Object) -> Result[dict[str, float], PythonError]:
     return py_copy_dict_str_float(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_dict_str_str(obj: Object) -> Result[dict[str, str], PythonError]:
     return py_copy_dict_str_str(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_dict_str_bytes(obj: Object) -> Result[dict[str, bytes], PythonError]:
     return py_copy_dict_str_bytes(obj._handle, obj._token)
 
 
+@blocking_io
 def copy_record_fields(obj: Object, fields: list[str]) -> Result[list[tuple[str, Object]], PythonError]:
     try:
         raw: list[tuple[str, tuple[int, int]]] = py_copy_record_fields(obj._handle, obj._token, fields)
         return _record_fields_from_handles(raw)
+    except PythonError as e:
+        raise e
+
+
+@blocking_io
+def run_coroutine_blocking(coro: Object) -> Result[Object, PythonError]:
+    try:
+        raw: tuple[int, int] = py_run_coroutine_blocking(coro._handle, coro._token)
+        return _object_from_handle(raw)
     except PythonError as e:
         raise e

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py5-review-1.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py5-review-1.md
@@ -1,0 +1,44 @@
+I have enough context to deliver the review.
+
+## Milestone py_5 Review — Async/Blocking Integration
+
+### Scope verification
+
+**1. Python calls classified as `@blocking_io`** ✓
+Every public function in `lib/sifr/python.sifr` (import_module, get_attr, get_item, call, call_attr, close, enter_context, exit_context, all `from_*`/`to_*`/`copy_*`, and `run_coroutine_blocking`) carries `@blocking_io`. Imported workloads are propagated to local callsites via `imported_defaults.rs:32-45`.
+
+**2. Direct Python calls in async Sifr code are rejected unless offloaded** ✓
+- `workload_annotations.rs:96-117 reject_async_direct_call` flags any `@blocking_io` function called directly from an async function with `SIFR-ASYNC-0003`.
+- `python_async_tests.rs:84-93` proves it fires for `from_int`.
+- `python_async_tests.rs:95-106` proves it fires for `run_coroutine_blocking`.
+- Negative fixture `direct_python_call_rejected.sifr` documents the same expectation.
+
+**3. No `py.blocking` alias added** ✓
+`lib/sifr/python.sifr` exports the existing primitives only; the offloaded fixture goes through `task.spawn_blocking` directly. No new offload alias is introduced.
+
+**4. `py.run_coroutine_blocking` is an explicitly blocking operation** ✓
+- Annotated `@blocking_io` (`python.sifr:494`).
+- Intrinsic lowered through the same handle-conversion path as other blocking ops (`registry/python.rs:254`).
+- Runtime entry (`coroutine_ops.rs:5-17`) acquires the GIL, clones the coroutine handle, drives `asyncio.run`, and stores the result.
+- Loop policy: `asyncio.run` uses the installed event-loop policy, so uvloop is respected per the contract.
+- Reentry rejection: implicit via `asyncio.run`’s `RuntimeError` when a loop is already running on the thread.
+
+**5. `py.Object` is `NonSend` by default and cannot cross worker boundaries** ✓
+- `lib/sifr/python.sifr:85 class Object(NonSend)`.
+- `stdlib_class_exports_preserve_parent_markers` verifies the parent marker survives stdlib bootstrap export.
+- `task_calls.rs:302-324` (`spawn_blocking`) and `task_calls.rs:174-200` (`spawn_cpu`) reject non-send Ok/Err return types; `offload_worker_captures.rs:23-34` rejects captured non-send values.
+- `python_async_tests.rs:115-128 offloaded_python_worker_cannot_return_object_handle` proves NonSend propagation from `Object` to the `spawn_blocking` Result.
+- Negative fixture `object_crossing_rejected.sifr` documents the same.
+
+**6. Verification fixtures under `verification/python_interop/fixtures/async_blocking/`** ✓
+Contract manifest, 1 positive, 3 negatives matching the DoD; `runner/run.py` requires all four `.sifr` files plus the JSON manifest.
+
+### Non-blocking observations (not gating py_5)
+
+- **No live runtime test for the “reentry rejection” claim**: `asyncio.run` provides it implicitly, but only the positive event-loop drive is covered by `run_coroutine_blocking_runs_python_owned_event_loop`. The DoD doesn’t require a reentry test for this milestone, so this is a follow-up note for py_6/12, not a blocker.
+- **`asyncio` import in `coroutine_ops.rs:9` bypasses `validate_import_policy`**: This is correct (it’s runtime infrastructure, not user code), but worth keeping in mind when py_6 documents the trust-boundary surface.
+- **Negative `.sifr` fixtures are required-to-exist by `run.py`, but never run through the compiler in this milestone’s validation list**: equivalent semantics are covered by `python_async_tests.rs`, so coverage is sound. py_11/12 verification gates can wire them through `sifr check` when fixture execution is in scope.
+
+### Verdict
+
+reviewer satisfied: no blockers

--- a/verification/python_interop/fixtures/async_blocking/async_blocking_contract.json
+++ b/verification/python_interop/fixtures/async_blocking/async_blocking_contract.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "contract": "py5_async_blocking",
+  "name": "async_blocking_contract",
+  "positive": [
+    {
+      "fixture": "offloaded_python_calls.sifr",
+      "covers": [
+        "annotated Python work is offloaded through task.spawn_blocking",
+        "run_coroutine_blocking is an explicit blocking operation",
+        "Python-owned event loop results are copied back to sendable Sifr values"
+      ]
+    }
+  ],
+  "negative": [
+    {
+      "fixture": "direct_python_call_rejected.sifr",
+      "diagnostic": "SIFR-ASYNC-0003",
+      "covers": "direct Python calls in async code are rejected"
+    },
+    {
+      "fixture": "object_crossing_rejected.sifr",
+      "diagnostic": "SIFR-TYPE-0002",
+      "covers": "py.Object is non-Send and cannot cross worker boundaries"
+    },
+    {
+      "fixture": "unclassified_offload_rejected.sifr",
+      "diagnostic": "SIFR-ASYNC-0005",
+      "covers": "blocking offload targets must be classified"
+    }
+  ]
+}

--- a/verification/python_interop/fixtures/async_blocking/direct_python_call_rejected.sifr
+++ b/verification/python_interop/fixtures/async_blocking/direct_python_call_rejected.sifr
@@ -1,0 +1,11 @@
+# expect-error: SIFR-ASYNC-0003
+from sifr.python import Object, PythonError, from_int
+
+
+async def main() -> Result[None, PythonError]:
+    try:
+        value: Object = from_int(41)
+        await task.sleep(0.0)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/fixtures/async_blocking/object_crossing_rejected.sifr
+++ b/verification/python_interop/fixtures/async_blocking/object_crossing_rejected.sifr
@@ -1,0 +1,17 @@
+# expect-error: SIFR-TYPE-0002
+from sifr.python import Object, PythonError, from_int
+
+
+@blocking_io
+def build_object() -> Result[Object, PythonError]:
+    try:
+        value: Object = from_int(41)
+        return value
+    except PythonError as e:
+        raise e
+
+
+async def main() -> Result[None, ScopeFailure]:
+    handle = task.spawn_blocking(build_object)
+    await task.sleep(0.0)
+    return None

--- a/verification/python_interop/fixtures/async_blocking/offloaded_python_calls.sifr
+++ b/verification/python_interop/fixtures/async_blocking/offloaded_python_calls.sifr
@@ -1,0 +1,51 @@
+from sifr.python import (
+    Object,
+    PythonError,
+    call_attr,
+    close,
+    from_float,
+    from_int,
+    import_module,
+    run_coroutine_blocking,
+    to_int,
+)
+
+
+@blocking_io
+def build_value() -> Result[int, PythonError]:
+    try:
+        obj: Object = from_int(41)
+        value: int = to_int(obj)
+        closed: None = close(obj)
+        return value
+    except PythonError as e:
+        raise e
+
+
+@trust_python_dynamic
+@blocking_io
+def run_python_owned_loop() -> Result[int, PythonError]:
+    try:
+        module_name: str = "asyncio"
+        asyncio: Object = import_module(module_name)
+        delay: Object = from_float(0.0)
+        expected: Object = from_int(42)
+        coro: Object = call_attr(asyncio, "sleep", [delay], [("result", expected)])
+        result_obj: Object = run_coroutine_blocking(coro)
+        result: int = to_int(result_obj)
+        result_closed: None = close(result_obj)
+        coro_closed: None = close(coro)
+        expected_closed: None = close(expected)
+        delay_closed: None = close(delay)
+        asyncio_closed: None = close(asyncio)
+        return result
+    except PythonError as e:
+        raise e
+
+
+async def main() -> Result[None, ScopeFailure]:
+    value_handle = task.spawn_blocking(build_value)
+    loop_handle = task.spawn_blocking(run_python_owned_loop)
+    value = await value_handle
+    loop_value = await loop_handle
+    return None

--- a/verification/python_interop/fixtures/async_blocking/unclassified_offload_rejected.sifr
+++ b/verification/python_interop/fixtures/async_blocking/unclassified_offload_rejected.sifr
@@ -1,0 +1,17 @@
+# expect-error: SIFR-ASYNC-0005
+from sifr.python import Object, PythonError, from_int, to_int
+
+
+def build_value() -> Result[int, PythonError]:
+    try:
+        obj: Object = from_int(41)
+        value: int = to_int(obj)
+        return value
+    except PythonError as e:
+        raise e
+
+
+async def main() -> Result[None, ScopeFailure]:
+    handle = task.spawn_blocking(build_value)
+    await task.sleep(0.0)
+    return None

--- a/verification/python_interop/runner/run.py
+++ b/verification/python_interop/runner/run.py
@@ -30,6 +30,7 @@ REQUIRED_FIXTURES = (
     "simple_import",
     "primitive_conversion",
     "pydantic_models",
+    "async_blocking",
     "async_http",
     "fastapi_app",
     "sqlalchemy_psycopg",
@@ -54,10 +55,15 @@ REQUIRED_FIXTURES = (
 REQUIRED_FIXTURE_FILES = (
     "simple_import/opaque_object_operations.json",
     "primitive_conversion/primitive_roundtrip.json",
+    "async_blocking/async_blocking_contract.json",
     "resource_cleanup/context_manager_cleanup.json",
 )
 
 REQUIRED_SOURCE_FIXTURES = (
+    "async_blocking/direct_python_call_rejected.sifr",
+    "async_blocking/object_crossing_rejected.sifr",
+    "async_blocking/offloaded_python_calls.sifr",
+    "async_blocking/unclassified_offload_rejected.sifr",
     "primitive_conversion/primitive_roundtrip.sifr",
 )
 


### PR DESCRIPTION
## Summary

Implements `milestone_py_5` for the embedded Python interop phase:

- Marks the public `sifr.python` boundary surface as `@blocking_io` and makes `py.Object` inherit `NonSend`.
- Adds `py.run_coroutine_blocking` through the public stdlib wrapper, intrinsic metadata/codegen, and runtime `asyncio.run` integration.
- Preserves stdlib parent markers during bootstrap so imported `sifr.python.Object` remains non-Send in real project/single-file checks.
- Adds focused async/offload lowering tests and Python interop async-blocking verification fixtures.

## Validation

- `scripts/run_all_tests.sh --profile create-pr` passed with only `advisories=warm wall-time budget exceeded`.
- Opus review artifact: `plans/reviews/active/ad-hoc-embedded-python-interop-py5-review-1.md` (`reviewer satisfied: no blockers`).

Focused checks also run before the full gate:

- `cargo test -p sifr_runtime --features python python -- --nocapture`
- `cargo test -p sifr_lowering python_async -- --nocapture`
- `cargo test -p sifr_codegen lowers_python_intrinsics_with_runtime_feature_metadata -- --nocapture`
- `cargo test -p sifr_driver stdlib_class_exports_preserve_parent_markers -- --nocapture`
- `cargo test -p sifr_stdlib python_runtime_feature -- --nocapture`
- `cargo run -q -p sifr -- check verification/python_interop/fixtures/primitive_conversion/primitive_roundtrip.sifr`
- `cargo run -q -p sifr -- check verification/python_interop/fixtures/async_blocking/offloaded_python_calls.sifr`
- `verification/python_interop/run.sh --group scaffold`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo fmt --check`
