### PR TITLE
Implement Python resource cleanup diagnostics

### DIFF
--- a/crates/sifr_codegen/src/intrinsics/registry/python.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/python.rs
@@ -10,6 +10,8 @@ pub(crate) fn lower_python_intrinsic(name: &str, args: &[RustExpr]) -> Option<Ru
         "py_close" => lower_py_close(args),
         "py_enter_context" => lower_py_enter_context(args),
         "py_exit_context" => lower_py_exit_context(args),
+        "py_exit_context_with_error" => lower_py_exit_context_with_error(args),
+        "py_resource_diagnostics" => lower_py_resource_diagnostics(args),
         "py_run_coroutine_blocking" => lower_py_run_coroutine_blocking(args),
         "py_from_none" => lower_py_from_none(args),
         "py_from_bool" => lower_py_from_bool(args),
@@ -249,6 +251,45 @@ pub(crate) fn lower_py_exit_context(args: &[RustExpr]) -> Option<RustExpr> {
     Some(map_python_error(format!(
         "sifr_runtime::python::exit_context(({handle}, {token}))"
     )))
+}
+
+pub(crate) fn lower_py_exit_context_with_error(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 7 {
+        return None;
+    }
+    let handle = render_expr(&args[0]);
+    let token = render_expr(&args[1]);
+    let kind = render_expr(&args[2]);
+    let exception_type = render_expr(&args[3]);
+    let message = render_expr(&args[4]);
+    let traceback = render_expr(&args[5]);
+    let context = render_expr(&args[6]);
+    Some(map_python_error(format!(
+        r#"sifr_runtime::python::exit_context_with_error(
+            ({handle}, {token}),
+            ({kind}).as_str(),
+            ({exception_type}).as_str(),
+            ({message}).as_str(),
+            ({traceback}).as_str(),
+            ({context}).as_str(),
+        )"#
+    )))
+}
+
+pub(crate) fn lower_py_resource_diagnostics(args: &[RustExpr]) -> Option<RustExpr> {
+    if !args.is_empty() {
+        return None;
+    }
+    Some(map_python_error(
+        r#"sifr_runtime::python::resource_diagnostics().map(|__sifr_python_diagnostics| {
+            (
+                __sifr_python_diagnostics.initialized,
+                __sifr_python_diagnostics.live_objects,
+                __sifr_python_diagnostics.leaked_objects,
+            )
+        })"#
+        .to_string(),
+    ))
 }
 
 pub(crate) fn lower_py_run_coroutine_blocking(args: &[RustExpr]) -> Option<RustExpr> {

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -102,6 +102,27 @@ pub(crate) fn lowers_python_intrinsics_with_runtime_feature_metadata() {
     let coroutine_rendered = render_expr(&coroutine.expr);
     assert!(coroutine_rendered.contains("sifr_runtime::python::run_coroutine_blocking"));
     assert!(coroutine_rendered.contains("(object_handle, object_token)"));
+
+    let diagnostics = lower_intrinsic("py_resource_diagnostics", &[])
+        .expect("py_resource_diagnostics should lower");
+    assert!(render_expr(&diagnostics.expr).contains("sifr_runtime::python::resource_diagnostics"));
+
+    let exit_with_error = lower_intrinsic(
+        "py_exit_context_with_error",
+        &[
+            "object_handle".to_string(),
+            "object_token".to_string(),
+            "kind".to_string(),
+            "exception_type".to_string(),
+            "message".to_string(),
+            "traceback".to_string(),
+            "context".to_string(),
+        ],
+    )
+    .expect("py_exit_context_with_error should lower");
+    let exit_with_error_rendered = render_expr(&exit_with_error.expr);
+    assert!(exit_with_error_rendered.contains("sifr_runtime::python::exit_context_with_error"));
+    assert!(exit_with_error_rendered.contains("(object_handle, object_token)"));
 }
 
 #[test]

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -8,6 +8,7 @@ use std::sync::{Mutex, MutexGuard};
 
 mod coroutine_ops;
 mod object_ops;
+mod resource_ops;
 pub use coroutine_ops::run_coroutine_blocking;
 pub use object_ops::{
     call_attr, call_object, close_object, copy_dict_str_bool, copy_dict_str_bytes,
@@ -20,6 +21,7 @@ pub use object_ops::{
     to_i16, to_i32, to_i64, to_i8, to_int, to_isize, to_none, to_str, to_u16, to_u32, to_u64,
     to_u8, to_usize, ObjectHandle, PythonError,
 };
+pub use resource_ops::{exit_context_with_error, resource_diagnostics, PythonResourceDiagnostics};
 
 static RUNTIME_STATE: Mutex<RuntimeState> = Mutex::new(RuntimeState::new());
 

--- a/crates/sifr_runtime/src/python/resource_ops.rs
+++ b/crates/sifr_runtime/src/python/resource_ops.rs
@@ -1,0 +1,159 @@
+use super::object_ops::clone_handle;
+#[cfg(test)]
+use super::object_ops::store_object;
+use super::{ObjectHandle, PythonError};
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::types::{PyAnyMethods, PyModule};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PythonResourceDiagnostics {
+    pub initialized: bool,
+    pub live_objects: i64,
+    pub leaked_objects: i64,
+}
+
+pub fn resource_diagnostics() -> Result<PythonResourceDiagnostics, PythonError> {
+    let diagnostics = super::shutdown_diagnostics().map_err(PythonError::runtime)?;
+    Ok(PythonResourceDiagnostics {
+        initialized: diagnostics.initialized,
+        live_objects: i64::try_from(diagnostics.live_objects).map_err(|_| {
+            PythonError::runtime(super::PythonRuntimeError::PythonOperationFailed(
+                "Python live object count exceeds Sifr int range".to_string(),
+            ))
+        })?,
+        leaked_objects: i64::try_from(diagnostics.leaked_objects).map_err(|_| {
+            PythonError::runtime(super::PythonRuntimeError::PythonOperationFailed(
+                "Python leaked object count exceeds Sifr int range".to_string(),
+            ))
+        })?,
+    })
+}
+
+pub fn exit_context_with_error(
+    object: ObjectHandle,
+    kind: &str,
+    exception_type: &str,
+    message: &str,
+    traceback: &str,
+    context: &str,
+) -> Result<(), PythonError> {
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let failure = PyRuntimeError::new_err(format!(
+            "Sifr PythonError(kind={kind}, exception_type={exception_type}, context={context}): {message}\n{traceback}"
+        ));
+        object
+            .bind(py)
+            .call_method1(
+                "__exit__",
+                (failure.get_type(py), failure.value(py), py.None()),
+            )
+            .map(|_| ())
+            .map_err(|error| PythonError::from_pyerr(py, error, "call", "__exit__ failure"))
+    })
+    .map_err(PythonError::runtime)?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::python::{
+        close_object, enter_context, from_int, get_attr, initialize_runtime,
+        reset_runtime_state_for_tests, test_config, test_guard, to_bool,
+    };
+
+    #[test]
+    fn resource_diagnostics_reports_live_and_closed_objects() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("resource-diagnostics")).expect("init should succeed");
+
+        let value = from_int(1).expect("object should be stored");
+        assert_eq!(
+            resource_diagnostics().expect("diagnostics should be available"),
+            PythonResourceDiagnostics {
+                initialized: true,
+                live_objects: 1,
+                leaked_objects: 0,
+            }
+        );
+        close_object(value).expect("object should close");
+        assert_eq!(
+            resource_diagnostics().expect("diagnostics should be available"),
+            PythonResourceDiagnostics {
+                initialized: true,
+                live_objects: 0,
+                leaked_objects: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn double_close_reports_deterministic_resource_error() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("double-close")).expect("init should succeed");
+
+        let value = from_int(1).expect("object should be stored");
+        close_object(value).expect("first close should succeed");
+        let error = close_object(value).expect_err("second close should fail");
+
+        assert_eq!(error.kind, "resource");
+        assert_eq!(error.exception_type, "SifrPythonClosedObject");
+        assert!(error.message.contains("closed"));
+    }
+
+    #[test]
+    fn exit_context_with_error_passes_sifr_error_context_to_python_exit() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("context-exit-with-error")).expect("init should succeed");
+
+        let manager = super::super::attach(|py| {
+            let module = PyModule::from_code(
+                py,
+                c"class RecordingContext:\n    def __enter__(self):\n        return self\n    def __exit__(self, exc_type, exc_value, tb):\n        self.saw_error = exc_type is not None and exc_value is not None\n        self.saw_traceback = tb is not None\n        return False\n",
+                c"recording_context.py",
+                c"recording_context",
+            )
+            .map_err(|error| PythonError::from_pyerr(py, error, "call", "recording context"))?;
+            let manager = module
+                .getattr("RecordingContext")
+                .and_then(|class| class.call0())
+                .map_err(|error| PythonError::from_pyerr(py, error, "call", "RecordingContext"))?;
+            store_object(manager.unbind())
+        })
+        .map_err(PythonError::runtime)
+        .expect("recording context should build")
+        .expect("recording context should be stored");
+        let entered = enter_context(manager).expect("context should enter");
+
+        exit_context_with_error(
+            manager,
+            "call",
+            "SifrBodyError",
+            "body failed",
+            "traceback",
+            "with_context body",
+        )
+        .expect("__exit__ should receive Sifr error context");
+
+        let saw_error_attr = get_attr(manager, "saw_error").expect("saw_error should be stored");
+        assert!(to_bool(saw_error_attr).expect("saw_error should be true"));
+        let saw_traceback_attr =
+            get_attr(manager, "saw_traceback").expect("saw_traceback should be stored");
+        assert!(!to_bool(saw_traceback_attr).expect("traceback should be None"));
+
+        for handle in [entered, saw_error_attr, saw_traceback_attr, manager] {
+            close_object(handle).expect("object should close");
+        }
+        assert_eq!(
+            resource_diagnostics().expect("diagnostics should be available"),
+            PythonResourceDiagnostics {
+                initialized: true,
+                live_objects: 0,
+                leaked_objects: 0,
+            }
+        );
+    }
+}

--- a/crates/sifr_stdlib/src/python.rs
+++ b/crates/sifr_stdlib/src/python.rs
@@ -104,6 +104,28 @@ pub(super) fn intrinsic_python() -> IntrinsicModule {
         ),
     );
     functions.insert(
+        "py_exit_context_with_error".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+                ("kind".to_string(), Type::Str),
+                ("exception_type".to_string(), Type::Str),
+                ("message".to_string(), Type::Str),
+                ("traceback".to_string(), Type::Str),
+                ("context".to_string(), Type::Str),
+            ],
+            python_error_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "py_resource_diagnostics".to_string(),
+        FunctionType::all_borrow(
+            vec![],
+            python_error_result(Type::Tuple(vec![Type::Bool, Type::Int, Type::Int])),
+        ),
+    );
+    functions.insert(
         "py_run_coroutine_blocking".to_string(),
         FunctionType::all_borrow(
             vec![

--- a/lib/sifr/python.sifr
+++ b/lib/sifr/python.sifr
@@ -1,4 +1,6 @@
 # sifr.python - Explicit embedded CPython interop
+from typing import Callable
+
 from _sifr.python import (
     py_call,
     py_call_attr,
@@ -27,6 +29,7 @@ from _sifr.python import (
     py_copy_tuple_u8,
     py_enter_context,
     py_exit_context,
+    py_exit_context_with_error,
     py_from_bool,
     py_from_bytes,
     py_from_dict_str,
@@ -40,6 +43,7 @@ from _sifr.python import (
     py_get_attr,
     py_get_item_str,
     py_import_module,
+    py_resource_diagnostics,
     py_run_coroutine_blocking,
     py_to_bool,
     py_to_bytes,
@@ -91,11 +95,26 @@ class Object(NonSend):
         self._token = 0
 
 
+class ResourceDiagnostics:
+    initialized: bool
+    live_objects: int
+    leaked_objects: int
+
+    def __init__(self, initialized: bool, live_objects: int, leaked_objects: int):
+        self.initialized = initialized
+        self.live_objects = live_objects
+        self.leaked_objects = leaked_objects
+
+
 def _object_from_handle(raw: tuple[int, int]) -> Object:
     obj: Object = Object()
     obj._handle = raw[0]
     obj._token = raw[1]
     return obj
+
+
+def _object_ref(obj: Object) -> Object:
+    return _object_from_handle((obj._handle, obj._token))
 
 
 def _objects_from_handles(raw_values: list[tuple[int, int]]) -> list[Object]:
@@ -201,6 +220,86 @@ def enter_context(obj: Object) -> Result[Object, PythonError]:
 @blocking_io
 def exit_context(obj: Object) -> Result[None, PythonError]:
     return py_exit_context(obj._handle, obj._token)
+
+
+def _exit_context_with_error(obj: Object, error: PythonError) -> Result[None, PythonError]:
+    return py_exit_context_with_error(
+        obj._handle,
+        obj._token,
+        error.kind,
+        error.exception_type,
+        error.message,
+        error.traceback,
+        error.context,
+    )
+
+
+@blocking_io
+def with_context(
+    obj: Object,
+    body: Callable[[Object], None],
+) -> Result[None, PythonError]:
+    try:
+        entered: Object = enter_context(obj)
+        result: None = _with_entered_context(obj, entered, body)
+        return None
+    except PythonError as e:
+        raise e
+
+
+def _with_entered_context(
+    obj: Object,
+    entered: Object,
+    body: Callable[[Object], None],
+) -> Result[None, PythonError]:
+    body_completed: bool = False
+    body_failed: bool = False
+    error_kind: str = ""
+    error_exception_type: str = ""
+    error_message: str = ""
+    error_traceback: str = ""
+    error_context: str = ""
+    try:
+        body_entered: Object = _object_ref(entered)
+        body_result: None = body(body_entered)
+        body_completed = True
+        exited: None = exit_context(obj)
+        return None
+    except PythonError as e:
+        if not body_completed:
+            body_failed = True
+            error_kind = e.kind
+            error_exception_type = e.exception_type
+            error_message = e.message
+            error_traceback = e.traceback
+            error_context = e.context
+        raise e
+    finally:
+        if body_failed:
+            body_error: PythonError = PythonError(
+                error_message,
+                error_kind,
+                error_exception_type,
+                error_traceback,
+                error_context,
+            )
+            try:
+                exit_result: None = _exit_context_with_error(obj, body_error)
+            except PythonError as e:
+                cleanup_context: str = e.context
+        try:
+            closed: None = close(entered)
+        except PythonError as e:
+            cleanup_context: str = e.context
+
+
+@blocking_io
+def resource_diagnostics() -> Result[ResourceDiagnostics, PythonError]:
+    try:
+        raw: tuple[bool, int, int] = py_resource_diagnostics()
+        return ResourceDiagnostics(raw[0], raw[1], raw[2])
+    except PythonError as e:
+        raise e
 
 
 @blocking_io

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -34,7 +34,7 @@
   - Added lowering-time `SIFR-PYTRUST` diagnostics for static literal imports outside package allow/trust policy and dynamic imports without `@trust_python_dynamic`; single-file mode has no package trust policy, so static `sifr.python.import_module("...")` is rejected instead of falling through to runtime.
   - Added generated runtime config allow/trust/native root metadata and runtime root checks, with native roots detected from probe extension-module origins independently of trusted native roots.
   - Added py3 verification fixture manifests for positive, negative, cleanup, and trust cases.
-  - Deferred `__exit__` failure-triple plumbing to `milestone_py_6` `py.with` lowering, where Sifr/Python failure context will be available.
+  - Deferred `__exit__` failure-triple plumbing to `milestone_py_6` context-helper lowering, where Sifr/Python failure context will be available.
   - Deferred bootstrap reporter/`eprintln!` cleanup to `milestone_py_5` package-runtime startup work; py3 keeps init failure as pre-main process exit.
   - Focused validation passing: runtime Python tests, package Python tests, lowering trust tests, stdlib/codegen feature tests, `verification/python_interop/run.sh --group scaffold`, diagnostics coverage checks, and `scripts/run_all_tests.sh --profile create-pr`.
   - Merged via PR [#2668](https://github.com/sifr-lang/sifr/pull/2668).
@@ -48,7 +48,14 @@
   - Added py4 JSON/source fixtures and required them from the Python interop scaffold runner.
   - Opus review round 2 reported no remaining blockers; local `create-pr` validation passed with only a warm wall-time advisory.
   - Merged via PR [#2669](https://github.com/sifr-lang/sifr/pull/2669).
-- [ ] `milestone_py_5`: Async/blocking integration.
+- [x] `milestone_py_5`: Async/blocking integration.
+  - Classified every public `sifr.python` boundary operation as `@blocking_io`, including explicit constructors, extractors, copy APIs, context operations, calls, and `run_coroutine_blocking`.
+  - Added `py.run_coroutine_blocking` through `_sifr.python` intrinsic metadata, codegen lowering, and runtime `asyncio.run` integration for Python-owned event loops returning explicit `Object` handles to Sifr.
+  - Made `py.Object` inherit `NonSend` and fixed stdlib bootstrap export metadata so imported stdlib parent markers survive real single-file and project checks.
+  - Added async/offload lowering tests for direct Python call rejection, explicit coroutine blocking rejection, offloaded sendable Python work, non-Send object return rejection, and unclassified offload target rejection.
+  - Added async-blocking verification fixtures and required them from the Python interop scaffold runner.
+  - Opus review round 1 reported no blockers; local `create-pr` validation passed with only a warm wall-time advisory.
+  - Merged via PR [#2670](https://github.com/sifr-lang/sifr/pull/2670).
 - [ ] `milestone_py_6`: Resource cleanup and leak diagnostics.
 - [ ] `milestone_py_7`: `Py_buffer` zero-copy core.
 - [ ] `milestone_py_8`: Arrow PyCapsule interop.
@@ -321,7 +328,7 @@ try py.to_str(obj)
 try py.to_bytes(obj)
 try py.scope(lambda gil: ...)
 try py.close(obj)
-try py.with(obj, lambda entered: ...)
+try py.with_context(obj, lambda entered: ...)
 try py.run_coroutine_blocking(coro)
 ```
 
@@ -341,7 +348,7 @@ This phase does not introduce `import python <name>` syntax sugar; explicit `py.
 | `py.copy_as[T](obj)` | `Result[T, py.TypeConversionError]`; explicit copy |
 | `py.scope(fn)` | `Result[T, py.PythonError]`; holds the GIL for batched operations |
 | `py.close(obj)` | `Result[None, py.PythonError]` |
-| `py.with(obj, fn)` | `Result[T, py.PythonError]` |
+| `py.with_context(obj, fn)` | `Result[T, py.PythonError]` |
 | `py.run_coroutine_blocking(coro)` | `Result[py.Object, py.PythonError]`, classified `@blocking_io` |
 
 Outside a `try`/`Result` handling context, fallible Python operations are compile-time errors.
@@ -415,7 +422,7 @@ Supported cleanup APIs:
 ```sifr
 try py.close(obj)
 try py.call_attr(obj, "close", [], [])
-try py.with(obj, lambda entered: ...)
+try py.with_context(obj, lambda entered: ...)
 coro = try py.call_attr(obj, "aclose", [], [])
 try py.run_coroutine_blocking(coro)
 try callback.close()
@@ -426,7 +433,8 @@ Rules:
 
 - Do not rely on Python `__del__` for correctness.
 - Context-manager helpers must call `__enter__` and `__exit__` and preserve Python traceback on failure.
-- `py.with(obj, fn)` is scoped: `entered` cannot escape the lambda, the lambda returns generic `T`, and Python `__exit__(exc_type, exc, tb)` receives Sifr/Python failure context before the final `Result` is produced.
+- `py.with_context(obj, fn)` is scoped: `entered` cannot escape the lambda, the lambda returns generic `T`, and Python `__exit__(exc_type, exc, tb)` receives Sifr/Python failure context before the final `Result` is produced. The exact `py.with(...)` spelling is reserved until the parser supports hard-keyword member calls.
+- The `entered` object passed to a `py.with_context` body is helper-owned. The body may inspect or call through it, but must not call `py.close(entered)`; the helper closes it after `__exit__` on both success and failure paths.
 - Async context managers require a Python wrapper or explicit `py.run_coroutine_blocking`.
 - Callback handles, buffer views, Arrow capsules, and DLPack capsules are resource handles with deterministic close/release semantics.
 - Double close/release is either idempotent by design or reports a deterministic resource-state error; the decision must be documented per resource type.
@@ -812,7 +820,7 @@ Definition of done:
 ### milestone_py_6: Resource Cleanup and Leak Diagnostics
 
 Scope:
-- Implement `py.close`, `py.with`, callback close, buffer release, Arrow/DLPack release tracking, and leak diagnostics.
+- Implement `py.close`, `py.with_context`, callback close, buffer release, Arrow/DLPack release tracking, and leak diagnostics.
 - Define idempotence/error behavior for double close/release per resource.
 
 Definition of done:

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py6-review-1.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py6-review-1.md
@@ -1,0 +1,90 @@
+I've reviewed the milestone py6 implementation. Here are my findings, ordered by severity.
+
+---
+
+## Blocker
+
+### 1. `with_context` never invokes `__exit__` with failure context when the body fails — entered handle is leaked
+
+**File:** `lib/sifr/python.sifr:233-257`
+
+The phase contract (plans/issues/active/ad-hoc-embedded-python-interop.md:436) requires:
+
+> Python `__exit__(exc_type, exc, tb)` receives Sifr/Python failure context before the final `Result` is produced
+
+and (line 434):
+
+> Do not rely on Python `__del__` for correctness-critical resource cleanup.
+
+The supporting infrastructure is fully plumbed: `exit_context_with_error` in `crates/sifr_runtime/src/python/resource_ops.rs:30-53`, the `py_exit_context_with_error` intrinsic in `crates/sifr_codegen/src/intrinsics/registry/python.rs:106-120`, the lowering in `.../python.rs:256-277`, and the private Sifr helper `_exit_context_with_error` at `lib/sifr/python.sifr:221-230`. None of that is ever called.
+
+`_with_entered_context` (lib/sifr/python.sifr:246-257) places `body_result: None = body(entered)` *outside* the try/except:
+
+```python
+def _with_entered_context(obj, entered, body) -> Result[None, PythonError]:
+    body_result: None = body(entered)        # outside try
+    try:
+        exited: None = exit_context(obj)
+        closed: None = close(entered)
+        return None
+    except PythonError as e:
+        raise e
+```
+
+When `body(entered)` raises a `PythonError`:
+- `exit_context(obj)` is never called
+- `close(entered)` is never called
+- `_exit_context_with_error(obj, e)` is never called
+- the error propagates with `entered` leaked
+
+The existing `context_manager_failure.sifr` fixture only exercises `enter_context` failing on a non-context-manager (an `int`). It does not cover the body-failure path that the contract is specifically about. So the milestone DoD ("Fixtures cover ... context manager success/failure") is not met for the failure half.
+
+This is a milestone-blocking gap: an entire branch of plumbing was implemented (intrinsic + codegen + runtime + stdlib helper) but the user-facing `with_context` never reaches it.
+
+---
+
+## Non-blocking findings
+
+### 2. `exit_context_with_error` runtime test does not actually verify the args reached `__exit__`
+
+**File:** `crates/sifr_runtime/src/python/resource_ops.rs:104-137`
+
+The test uses `contextlib.nullcontext`, whose `__exit__` accepts and ignores all args. So the test confirms that the call returns `Ok(())`, not that `exc_type`/`exc_value`/`context` were actually propagated to Python. Use a custom Python class that records the `__exit__` args and assert they are non-None — otherwise a regression that, e.g., always passes `(None, None, None)` would still go green.
+
+### 3. `exit_context_with_error` always passes `py.None()` for the traceback
+
+**File:** `crates/sifr_runtime/src/python/resource_ops.rs:46`
+
+The Sifr-side traceback string is folded into the PyRuntimeError message, which is reasonable as an adaptation, but Python `__exit__` receives `tb=None` even when Sifr has a non-empty traceback. Worth documenting this adaptation in the JSON fixture (alongside the existing `helper` note) or in an internal doc so consumers know not to expect a real Python `TracebackType`.
+
+### 4. Parser limitation around `py.with(...)` — acceptable milestone adaptation, but the phase plan still uses the old surface
+
+The `with_context` rename and fixture JSON note are reasonable adaptations for the current parser. However, the phase plan at `plans/issues/active/ad-hoc-embedded-python-interop.md:331,351` still lists `try py.with(obj, lambda entered: ...)` as the canonical API. Either update the plan to mirror the implemented `with_context` name, or open a follow-up to add soft-keyword support for `with` after `.` before py12 docs ship. Not blocking py6 since the JSON contract is explicit, but consumers reading the plan will be misled.
+
+### 5. Unused `result` binding in `with_context`
+
+**File:** `lib/sifr/python.sifr:240`
+
+`result: None = _with_entered_context(obj, entered, body)` binds a value that is never used. Harmless; minor cleanup.
+
+### 6. `context_manager_failure.sifr` itself leaks `value` on the early-return path
+
+**File:** `verification/python_interop/fixtures/resource_cleanup/context_manager_failure.sifr:1-16`
+
+Because `with_context(value, observe)` will raise (int has no `__enter__`), the trailing `close(value)` never runs and `value` is leaked. This is consistent with the documented contract that callers own cleanup on error paths, but pairing it with a fixture that demonstrates the *body-throws → __exit__-with-error → entered released* path (once finding 1 is fixed) would close the verification story.
+
+---
+
+## Recommendation
+
+Fix the with_context body-failure path before merging. The shape needed:
+
+- Move `body(entered)` inside a try/except in `_with_entered_context`.
+- On body PythonError: call `_exit_context_with_error(obj, e)` (best-effort, may itself error), then close `entered`, then re-raise the original.
+- Add a fixture/test that exercises body failure and asserts `live_objects == 0` and `leaked_objects == 0` after the failure unwinds.
+
+Then strengthen the runtime test in finding 2 with a recording context manager so the wiring stays honest under refactoring.
+
+Everything else (the future-resource-types JSON contract, double-close determinism, diagnostics counters for the existing `py.Object` type, the trust/parser adaptations) looks consistent with the milestone scope.
+
+Blockers: 1.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py6-review-2.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py6-review-2.md
@@ -1,0 +1,40 @@
+# Review Round 2 — milestone_py_6 embedded Python interop
+
+## Blocker status: resolved
+
+The round 1 blocker (body-failure path never invoking `__exit__` with failure context and leaking the entered handle) is fixed in `lib/sifr/python.sifr:250-293`:
+
+- `_object_ref` (line 116) gives the body an aliased wrapper, keeping the original `entered` available in the helper after the body returns or raises.
+- The body call is now inside the `try`, with `body_completed` set only on the success line *after* the call. The `except` distinguishes body failure from `exit_context(obj)` failure by checking `body_completed`, captures `PythonError` fields into locals (since `e` cannot survive the `except` scope), and re-raises the original error.
+- `finally` runs unconditionally: if `body_failed`, it reconstructs the body error and calls `_exit_context_with_error(obj, body_error)`; then it `close(entered)` regardless of which branch ran. Both cleanup calls are wrapped in `try/except` so a secondary error during cleanup cannot mask the original failure.
+
+Walk through:
+- **Body succeeds, exit_context succeeds**: returns None; finally closes `entered`. ✔
+- **Body raises**: except sets `body_failed=True`, re-raises body's PythonError; finally invokes `__exit__` with the captured (kind/exception_type/message/traceback/context) and then closes `entered`; body error propagates. ✔
+- **Body succeeds, `exit_context` raises**: `body_completed=True` so `body_failed` stays False; except re-raises the exit error; finally just closes `entered` (no second `__exit__` attempt — correct, since `__exit__` was already attempted and failed). ✔
+
+The runtime test `exit_context_with_error_passes_sifr_error_context_to_python_exit` (`crates/sifr_runtime/src/python/resource_ops.rs:107-158`) now uses `RecordingContext` and asserts `exc_type` + `exc_value` are non-None and `tb` is None — this would catch a regression that always passed `(None, None, None)`, addressing round 1 finding 2.
+
+The JSON fixture `context_manager_cleanup.json:53-62` adds the body-failure negative case with `expected_exit_args.exc_type: "non_null"`, `exc_value: "Sifr PythonError wrapper"`, `traceback: "none_sifr_traceback_embedded_in_exception_message"`, and `expected_entered_handle_release: "closed_after_exit_with_error"`. The `tb=None` adaptation is now explicit in the contract, addressing round 1 finding 3.
+
+`context_manager_body_failure.sifr` exercises the new path through the lowering surface; runner registration in `verification/python_interop/runner/run.py:62-72` enforces its presence.
+
+Phase plan updates in `plans/issues/active/ad-hoc-embedded-python-interop.md:331,351,425,436` switch to `py.with_context` consistently and document that exact `py.with(...)` is parser-blocked, addressing round 1 finding 4.
+
+The stdlib type registration (`crates/sifr_stdlib/src/python.rs:106-120`), intrinsic lowering test (`crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs:110-125`), and codegen lowering (`crates/sifr_codegen/src/intrinsics/registry/python.rs:256-277`) all line up on the same 7-argument shape (handle, token, kind, exception_type, message, traceback, context).
+
+## Non-blocking observations
+
+These are not milestone blockers; carrying them forward is fine.
+
+1. **Cleanup errors are silently swallowed** in `_with_entered_context`'s `finally` (`lib/sifr/python.sifr:288-293`) — both the `_exit_context_with_error` failure and the `close(entered)` failure bind `cleanup_context` and never read it. That's intentional (preserve the original body error), but it means a programmer-visible double-close or runtime-state error during cleanup goes unobserved. Worth a diagnostic-counter increment in a follow-up so the existing `SIFR-PYRES` counters can surface it.
+
+2. **`body_entered` aliases `entered` via the same `(handle, token)` tuple**. If a body ever calls `close(body_entered)`, the subsequent `close(entered)` in the helper's `finally` would trigger the deterministic double-close error and mask the body's own outcome. The contract "body must not close its parameter" is not documented in the JSON fixture or the phase plan. Worth an explicit rule under "Resource Cleanup" in the issue plan before py12 docs ship.
+
+3. **Unused `result` binding** in `with_context` (`lib/sifr/python.sifr:244`) — round 1 finding 5, still present. Cosmetic.
+
+4. **`context_manager_failure.sifr` and `context_manager_body_failure.sifr` both leak handles** (`contextlib`, `value`, `manager`) on the early-return-via-raise path. Consistent with the "callers own cleanup on error paths" contract, but together they leave the verification story without an end-to-end example of the *full* clean unwind where every handle is closed under failure. Once the runner can execute fixtures, a third fixture that catches the propagated error in `main` and explicitly closes the source/manager handles would complete the picture.
+
+## Conclusion
+
+reviewer satisfied: no blockers

--- a/verification/python_interop/fixtures/resource_cleanup/context_manager_body_failure.sifr
+++ b/verification/python_interop/fixtures/resource_cleanup/context_manager_body_failure.sifr
@@ -1,0 +1,31 @@
+from sifr.python import (
+    Object,
+    PythonError,
+    call_attr,
+    from_int,
+    get_attr,
+    import_module,
+    with_context,
+)
+
+
+def fail_body(entered: Object) -> None:
+    try:
+        missing: Object = get_attr(entered, "sifr_missing_attr")
+        return None
+    except PythonError as e:
+        raise e
+
+
+@trust_python_dynamic
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        module_name: str = "contextlib"
+        contextlib: Object = import_module(module_name)
+        value: Object = from_int(7)
+        manager: Object = call_attr(contextlib, "nullcontext", [value], [])
+        used: None = with_context(manager, fail_body)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/fixtures/resource_cleanup/context_manager_cleanup.json
+++ b/verification/python_interop/fixtures/resource_cleanup/context_manager_cleanup.json
@@ -6,6 +6,11 @@
     {
       "name": "explicit_close_releases_object_handle",
       "operations": ["import_module", "get_attr", "close"],
+      "double_close_behavior": {
+        "object": "deterministic_resource_error",
+        "expected_error_kind": "resource",
+        "expected_exception_type": "SifrPythonClosedObject"
+      },
       "expected_runtime_diagnostics": {
         "live_objects": 0,
         "leaked_objects": 0
@@ -14,11 +19,22 @@
     {
       "name": "context_manager_enter_exit",
       "imports": ["contextlib"],
-      "operations": ["import_module", "get_attr", "call", "enter_context", "exit_context", "close"],
+      "operations": ["import_module", "call_attr", "with_context", "enter_context", "exit_context", "close"],
+      "helper": {
+        "public_name": "with_context",
+        "reason": "the parser currently treats with as a hard keyword after dot syntax, so exact py.with is not parseable",
+        "body_parameter_ownership": "helper_owned_body_must_not_close_entered"
+      },
       "expected_runtime_diagnostics": {
         "live_objects": 0,
         "leaked_objects": 0
       }
+    },
+    {
+      "name": "future_resource_tracking_contract",
+      "resource_classes": ["callback", "buffer", "arrow_capsule", "dlpack_capsule"],
+      "double_release_behavior": "deterministic_resource_error",
+      "tracking": "all future Python resource handles must participate in the same outstanding-resource diagnostics counters before their public release APIs ship"
     }
   ],
   "negative_cases": [
@@ -33,6 +49,25 @@
       "operation": "enter_context",
       "expected_error_kind": "call",
       "expected_exception_type": "AttributeError"
+    },
+    {
+      "name": "body_failure_exits_with_error_context",
+      "operation": "with_context",
+      "expected_error_kind": "attribute",
+      "expected_exit_args": {
+        "exc_type": "non_null",
+        "exc_value": "Sifr PythonError wrapper",
+        "traceback": "none_sifr_traceback_embedded_in_exception_message"
+      },
+      "expected_entered_handle_release": "closed_after_exit_with_error"
+    },
+    {
+      "name": "outstanding_object_diagnostics",
+      "operation": "resource_diagnostics",
+      "expected_runtime_diagnostics": {
+        "live_objects_greater_than": 0,
+        "leaked_objects": 0
+      }
     }
   ]
 }

--- a/verification/python_interop/fixtures/resource_cleanup/context_manager_failure.sifr
+++ b/verification/python_interop/fixtures/resource_cleanup/context_manager_failure.sifr
@@ -1,0 +1,16 @@
+from sifr.python import Object, PythonError, close, from_int, with_context
+
+
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        value: Object = from_int(1)
+
+        def observe(entered: Object) -> None:
+            return None
+
+        used: None = with_context(value, observe)
+        closed: None = close(value)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/fixtures/resource_cleanup/context_manager_success.sifr
+++ b/verification/python_interop/fixtures/resource_cleanup/context_manager_success.sifr
@@ -1,0 +1,33 @@
+from sifr.python import (
+    Object,
+    PythonError,
+    ResourceDiagnostics,
+    call_attr,
+    close,
+    from_int,
+    import_module,
+    resource_diagnostics,
+    with_context,
+)
+
+
+@trust_python_dynamic
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        module_name: str = "contextlib"
+        contextlib: Object = import_module(module_name)
+        value: Object = from_int(7)
+        manager: Object = call_attr(contextlib, "nullcontext", [value], [])
+
+        def observe(entered: Object) -> None:
+            return None
+
+        used: None = with_context(manager, observe)
+        diagnostics: ResourceDiagnostics = resource_diagnostics()
+        manager_closed: None = close(manager)
+        value_closed: None = close(value)
+        contextlib_closed: None = close(contextlib)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/fixtures/resource_cleanup/resource_diagnostics.sifr
+++ b/verification/python_interop/fixtures/resource_cleanup/resource_diagnostics.sifr
@@ -1,0 +1,14 @@
+from sifr.python import Object, PythonError, ResourceDiagnostics, close, from_int, resource_diagnostics
+
+
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        before: ResourceDiagnostics = resource_diagnostics()
+        value: Object = from_int(1)
+        during: ResourceDiagnostics = resource_diagnostics()
+        closed: None = close(value)
+        after: ResourceDiagnostics = resource_diagnostics()
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/runner/run.py
+++ b/verification/python_interop/runner/run.py
@@ -65,6 +65,10 @@ REQUIRED_SOURCE_FIXTURES = (
     "async_blocking/offloaded_python_calls.sifr",
     "async_blocking/unclassified_offload_rejected.sifr",
     "primitive_conversion/primitive_roundtrip.sifr",
+    "resource_cleanup/context_manager_body_failure.sifr",
+    "resource_cleanup/context_manager_failure.sifr",
+    "resource_cleanup/context_manager_success.sifr",
+    "resource_cleanup/resource_diagnostics.sifr",
 )
 
 


### PR DESCRIPTION
## Summary
- add Python resource diagnostics and deterministic double-close coverage for py.Object handles
- add with_context context-manager helper with failure-context __exit__ plumbing and entered-handle cleanup
- add resource-cleanup source fixtures and runner registration, plus py6 Opus review artifacts

## Validation
- scripts/run_all_tests.sh --profile create-pr (passed; advisory: warm wall-time budget exceeded)
- reviewer satisfied: no blockers (plans/reviews/active/ad-hoc-embedded-python-interop-py6-review-2.md)

## Notes
- exact py.with(...) remains parser-blocked because with is a hard keyword after dot syntax; this milestone uses py.with_context(...) and documents that reservation in the phase plan.
