### PR TITLE
Implement Python Py_buffer core

### DIFF
--- a/crates/sifr_codegen/src/intrinsics/registry/python.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/python.rs
@@ -8,6 +8,9 @@ pub(crate) fn lower_python_intrinsic(name: &str, args: &[RustExpr]) -> Option<Ru
         "py_call" => lower_py_call(args),
         "py_call_attr" => lower_py_call_attr(args),
         "py_close" => lower_py_close(args),
+        "py_buffer_u8" => lower_py_buffer_u8(args),
+        "py_copy_buffer_u8" => lower_py_copy_buffer_u8(args),
+        "py_release_buffer" => lower_py_release_buffer(args),
         "py_enter_context" => lower_py_enter_context(args),
         "py_exit_context" => lower_py_exit_context(args),
         "py_exit_context_with_error" => lower_py_exit_context_with_error(args),
@@ -228,6 +231,52 @@ pub(crate) fn lower_py_close(args: &[RustExpr]) -> Option<RustExpr> {
     let token = render_expr(&args[1]);
     Some(map_python_error(format!(
         "sifr_runtime::python::close_object(({handle}, {token}))"
+    )))
+}
+
+pub(crate) fn lower_py_buffer_u8(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 3 {
+        return None;
+    }
+    let handle = render_expr(&args[0]);
+    let token = render_expr(&args[1]);
+    let require_writable = render_expr(&args[2]);
+    Some(map_python_error(format!(
+        r#"sifr_runtime::python::buffer_u8(({handle}, {token}), {require_writable}).map(|__sifr_python_buffer| {{
+            (
+                __sifr_python_buffer.handle,
+                __sifr_python_buffer.token,
+                __sifr_python_buffer.len_bytes,
+                __sifr_python_buffer.item_size,
+                __sifr_python_buffer.readonly,
+                __sifr_python_buffer.dimensions,
+                __sifr_python_buffer.shape,
+                __sifr_python_buffer.strides,
+                __sifr_python_buffer.suboffsets,
+                __sifr_python_buffer.c_contiguous,
+                __sifr_python_buffer.f_contiguous,
+                __sifr_python_buffer.format,
+            )
+        }})"#
+    )))
+}
+
+pub(crate) fn lower_py_copy_buffer_u8(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_buffer_conversion(args, "copy_buffer_u8")
+}
+
+pub(crate) fn lower_py_release_buffer(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_buffer_conversion(args, "release_buffer")
+}
+
+fn lower_buffer_conversion(args: &[RustExpr], function: &str) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    let handle = render_expr(&args[0]);
+    let token = render_expr(&args[1]);
+    Some(map_python_error(format!(
+        "sifr_runtime::python::{function}(({handle}, {token}))"
     )))
 }
 

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -123,6 +123,26 @@ pub(crate) fn lowers_python_intrinsics_with_runtime_feature_metadata() {
     let exit_with_error_rendered = render_expr(&exit_with_error.expr);
     assert!(exit_with_error_rendered.contains("sifr_runtime::python::exit_context_with_error"));
     assert!(exit_with_error_rendered.contains("(object_handle, object_token)"));
+
+    let buffer = lower_intrinsic(
+        "py_buffer_u8",
+        &[
+            "object_handle".to_string(),
+            "object_token".to_string(),
+            "false".to_string(),
+        ],
+    )
+    .expect("py_buffer_u8 should lower");
+    let buffer_rendered = render_expr(&buffer.expr);
+    assert!(buffer_rendered.contains("sifr_runtime::python::buffer_u8"));
+    assert!(buffer_rendered.contains("__sifr_python_buffer.shape"));
+
+    let release = lower_intrinsic(
+        "py_release_buffer",
+        &["buffer_handle".to_string(), "buffer_token".to_string()],
+    )
+    .expect("py_release_buffer should lower");
+    assert!(render_expr(&release.expr).contains("sifr_runtime::python::release_buffer"));
 }
 
 #[test]

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -6,9 +6,13 @@ use std::fmt;
 use std::mem::MaybeUninit;
 use std::sync::{Mutex, MutexGuard};
 
+mod buffer_ops;
 mod coroutine_ops;
 mod object_ops;
 mod resource_ops;
+pub use buffer_ops::{
+    buffer_u8, copy_buffer_u8, release_buffer, BufferHandle, PythonBufferMetadata,
+};
 pub use coroutine_ops::run_coroutine_blocking;
 pub use object_ops::{
     call_attr, call_object, close_object, copy_dict_str_bool, copy_dict_str_bytes,
@@ -525,7 +529,7 @@ fn runtime_config() -> Result<PythonRuntimeConfig, PythonRuntimeError> {
         .ok_or(PythonRuntimeError::NotInitialized)
 }
 
-fn update_object_count(delta: isize) -> Result<(), PythonRuntimeError> {
+pub(super) fn update_object_count(delta: isize) -> Result<(), PythonRuntimeError> {
     let mut state = runtime_state()?;
     if delta.is_positive() {
         state.live_objects = state.live_objects.saturating_add(delta.cast_unsigned());
@@ -535,7 +539,7 @@ fn update_object_count(delta: isize) -> Result<(), PythonRuntimeError> {
     Ok(())
 }
 
-fn record_leaked_object() -> Result<(), PythonRuntimeError> {
+pub(super) fn record_leaked_object() -> Result<(), PythonRuntimeError> {
     let mut state = runtime_state()?;
     state.live_objects = state.live_objects.saturating_sub(1);
     state.leaked_objects = state.leaked_objects.saturating_add(1);

--- a/crates/sifr_runtime/src/python/buffer_ops.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops.rs
@@ -1,0 +1,310 @@
+use super::object_ops::clone_handle;
+use super::{ObjectHandle, PythonError, PythonRuntimeError};
+use pyo3::buffer::PyBuffer;
+use pyo3::exceptions::PyBufferError;
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+use std::sync::{LazyLock, Mutex, MutexGuard};
+
+static BUFFER_STORE: LazyLock<Mutex<BufferStore>> =
+    LazyLock::new(|| Mutex::new(BufferStore::default()));
+static TOKEN_HASHER: LazyLock<std::collections::hash_map::RandomState> =
+    LazyLock::new(std::collections::hash_map::RandomState::new);
+
+pub type BufferHandle = (i64, i64);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PythonBufferMetadata {
+    pub handle: i64,
+    pub token: i64,
+    pub len_bytes: i64,
+    pub item_size: i64,
+    pub readonly: bool,
+    pub dimensions: i64,
+    pub shape: Vec<i64>,
+    pub strides: Vec<i64>,
+    pub suboffsets: Vec<i64>,
+    pub c_contiguous: bool,
+    pub f_contiguous: bool,
+    pub format: String,
+}
+
+#[derive(Default)]
+struct BufferStore {
+    next_handle: i64,
+    next_nonce: u64,
+    buffers: HashMap<i64, BufferEntry>,
+}
+
+struct BufferEntry {
+    token: i64,
+    buffer: TrackedBuffer,
+}
+
+struct TrackedBuffer {
+    buffer: Option<PyBuffer<u8>>,
+}
+
+impl Drop for TrackedBuffer {
+    fn drop(&mut self) {
+        let Some(buffer) = self.buffer.take() else {
+            return;
+        };
+        drop(buffer);
+        let _ignored = super::update_object_count(-1);
+    }
+}
+
+pub fn buffer_u8(
+    object: ObjectHandle,
+    require_writable: bool,
+) -> Result<PythonBufferMetadata, PythonError> {
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let buffer = PyBuffer::<u8>::get(object.bind(py))
+            .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "Py_buffer<u8>"))?;
+        if require_writable && buffer.readonly() {
+            return Err(PythonError::from_pyerr(
+                py,
+                PyBufferError::new_err("requested writable buffer from readonly exporter"),
+                "zero-copy",
+                "writable Py_buffer<u8>",
+            ));
+        }
+        let metadata = metadata_for_buffer(&buffer)?;
+        store_buffer(buffer, metadata)
+    })
+    .map_err(PythonError::runtime)?
+}
+
+pub fn copy_buffer_u8(buffer: BufferHandle) -> Result<Vec<u8>, PythonError> {
+    super::attach(|py| {
+        let store = buffer_store()?;
+        let entry = lookup_buffer(&store, buffer)?;
+        entry
+            .buffer
+            .buffer
+            .as_ref()
+            .ok_or_else(|| closed_error(buffer.0))?
+            .to_vec(py)
+            .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "copy Py_buffer<u8>"))
+    })
+    .map_err(PythonError::runtime)?
+}
+
+pub fn release_buffer((handle, token): BufferHandle) -> Result<(), PythonError> {
+    let entry = {
+        let mut store = buffer_store()?;
+        if store
+            .buffers
+            .get(&handle)
+            .is_some_and(|entry| entry.token == token)
+        {
+            store.buffers.remove(&handle)
+        } else {
+            return Err(closed_error(handle));
+        }
+    };
+    drop(entry);
+    Ok(())
+}
+
+fn metadata_for_buffer(buffer: &PyBuffer<u8>) -> Result<PythonBufferMetadata, PythonError> {
+    Ok(PythonBufferMetadata {
+        handle: -1,
+        token: 0,
+        len_bytes: checked_i64(buffer.len_bytes(), "buffer length")?,
+        item_size: checked_i64(buffer.item_size(), "buffer item size")?,
+        readonly: buffer.readonly(),
+        dimensions: checked_i64(buffer.dimensions(), "buffer dimensions")?,
+        shape: checked_i64_vec(buffer.shape(), "buffer shape")?,
+        strides: checked_i64_vec(buffer.strides(), "buffer strides")?,
+        suboffsets: checked_i64_vec(buffer.suboffsets().unwrap_or(&[]), "buffer suboffsets")?,
+        c_contiguous: buffer.is_c_contiguous(),
+        f_contiguous: buffer.is_fortran_contiguous(),
+        format: buffer.format().to_string_lossy().into_owned(),
+    })
+}
+
+fn store_buffer(
+    buffer: PyBuffer<u8>,
+    mut metadata: PythonBufferMetadata,
+) -> Result<PythonBufferMetadata, PythonError> {
+    let mut store = buffer_store()?;
+    let (handle, token) = reserve_handle(&mut store)?;
+    super::update_object_count(1).map_err(PythonError::runtime)?;
+    metadata.handle = handle;
+    metadata.token = token;
+    store.buffers.insert(
+        handle,
+        BufferEntry {
+            token,
+            buffer: TrackedBuffer {
+                buffer: Some(buffer),
+            },
+        },
+    );
+    Ok(metadata)
+}
+
+fn lookup_buffer(
+    store: &BufferStore,
+    (handle, token): BufferHandle,
+) -> Result<&BufferEntry, PythonError> {
+    store
+        .buffers
+        .get(&handle)
+        .filter(|entry| entry.token == token)
+        .ok_or_else(|| closed_error(handle))
+}
+
+fn reserve_handle(store: &mut BufferStore) -> Result<BufferHandle, PythonError> {
+    store.next_handle = store.next_handle.checked_add(1).ok_or_else(|| {
+        PythonError::runtime(PythonRuntimeError::PythonOperationFailed(
+            "Python buffer handle space exhausted".to_string(),
+        ))
+    })?;
+    store.next_nonce = store.next_nonce.checked_add(1).ok_or_else(|| {
+        PythonError::runtime(PythonRuntimeError::PythonOperationFailed(
+            "Python buffer token space exhausted".to_string(),
+        ))
+    })?;
+    Ok((
+        store.next_handle,
+        token_for(store.next_handle, store.next_nonce),
+    ))
+}
+
+fn checked_i64(value: usize, context: &'static str) -> Result<i64, PythonError> {
+    i64::try_from(value).map_err(|_| {
+        PythonError::runtime(PythonRuntimeError::PythonOperationFailed(format!(
+            "{context} exceeds Sifr int range"
+        )))
+    })
+}
+
+fn checked_i64_vec<T>(values: &[T], context: &'static str) -> Result<Vec<i64>, PythonError>
+where
+    T: Copy + TryInto<i64>,
+{
+    values
+        .iter()
+        .copied()
+        .map(|value| {
+            value.try_into().map_err(|_| {
+                PythonError::runtime(PythonRuntimeError::PythonOperationFailed(format!(
+                    "{context} entry exceeds Sifr int range"
+                )))
+            })
+        })
+        .collect()
+}
+
+fn closed_error(handle: i64) -> PythonError {
+    PythonError {
+        kind: "resource".to_string(),
+        exception_type: "SifrPythonClosedBuffer".to_string(),
+        message: format!("Python buffer handle {handle} is closed"),
+        traceback: String::new(),
+        context: "buffer handle lookup".to_string(),
+    }
+}
+
+fn token_for(handle: i64, nonce: u64) -> i64 {
+    let hash = TOKEN_HASHER.hash_one((handle, nonce));
+    i64::from_ne_bytes(hash.to_ne_bytes())
+}
+
+fn buffer_store() -> Result<MutexGuard<'static, BufferStore>, PythonError> {
+    BUFFER_STORE.lock().map_err(|_| PythonError {
+        kind: "runtime".to_string(),
+        exception_type: "SifrPythonRuntimeError".to_string(),
+        message: "Python buffer store is unavailable".to_string(),
+        traceback: String::new(),
+        context: "buffer store".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::python::{
+        close_object, from_bytes, from_int, initialize_runtime, reset_runtime_state_for_tests,
+        resource_diagnostics, test_config, test_guard, PythonResourceDiagnostics,
+    };
+
+    #[test]
+    fn buffer_view_tracks_metadata_copy_and_release() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("buffer-view")).expect("init should succeed");
+
+        let object = from_bytes(&[1, 2, 3]).expect("bytes should be stored");
+        let view = buffer_u8(object, false).expect("bytes should expose u8 buffer");
+
+        assert_eq!(view.len_bytes, 3);
+        assert_eq!(view.item_size, 1);
+        assert!(view.readonly);
+        assert!(view.c_contiguous);
+        assert_eq!(
+            copy_buffer_u8((view.handle, view.token)).expect("buffer should copy"),
+            vec![1, 2, 3]
+        );
+        assert_eq!(
+            resource_diagnostics().expect("diagnostics should be available"),
+            PythonResourceDiagnostics {
+                initialized: true,
+                live_objects: 2,
+                leaked_objects: 0,
+            }
+        );
+        release_buffer((view.handle, view.token)).expect("buffer should release");
+        close_object(object).expect("object should close");
+        assert_eq!(
+            resource_diagnostics().expect("diagnostics should be available"),
+            PythonResourceDiagnostics {
+                initialized: true,
+                live_objects: 0,
+                leaked_objects: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn buffer_double_release_is_deterministic_resource_error() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("buffer-double-release")).expect("init should succeed");
+
+        let object = from_bytes(&[1]).expect("bytes should be stored");
+        let view = buffer_u8(object, false).expect("bytes should expose u8 buffer");
+        release_buffer((view.handle, view.token)).expect("buffer should release");
+        let error = release_buffer((view.handle, view.token)).expect_err("second release fails");
+        let copy_error =
+            copy_buffer_u8((view.handle, view.token)).expect_err("copy after release fails");
+
+        assert_eq!(error.kind, "resource");
+        assert_eq!(error.exception_type, "SifrPythonClosedBuffer");
+        assert_eq!(copy_error.kind, "resource");
+        assert_eq!(copy_error.exception_type, "SifrPythonClosedBuffer");
+        close_object(object).expect("object should close");
+    }
+
+    #[test]
+    fn buffer_rejects_wrong_dtype_and_readonly_writable_request() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("buffer-rejects")).expect("init should succeed");
+
+        let object = from_bytes(&[1]).expect("bytes should be stored");
+        let writable = buffer_u8(object, true).expect_err("bytes are readonly");
+        assert_eq!(writable.kind, "zero-copy");
+
+        let integer = from_int(1).expect("int should be stored");
+        let unsupported = buffer_u8(integer, false).expect_err("int has no u8 buffer");
+        assert_eq!(unsupported.kind, "zero-copy");
+
+        close_object(object).expect("object should close");
+        close_object(integer).expect("integer should close");
+    }
+}

--- a/crates/sifr_stdlib/src/python.rs
+++ b/crates/sifr_stdlib/src/python.rs
@@ -84,6 +84,50 @@ pub(super) fn intrinsic_python() -> IntrinsicModule {
         ),
     );
     functions.insert(
+        "py_buffer_u8".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+                ("require_writable".to_string(), Type::Bool),
+            ],
+            python_error_result(Type::Tuple(vec![
+                Type::Int,
+                Type::Int,
+                Type::Int,
+                Type::Int,
+                Type::Bool,
+                Type::Int,
+                Type::List(Box::new(Type::Int)),
+                Type::List(Box::new(Type::Int)),
+                Type::List(Box::new(Type::Int)),
+                Type::Bool,
+                Type::Bool,
+                Type::Str,
+            ])),
+        ),
+    );
+    functions.insert(
+        "py_copy_buffer_u8".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::Bytes),
+        ),
+    );
+    functions.insert(
+        "py_release_buffer".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::None),
+        ),
+    );
+    functions.insert(
         "py_enter_context".to_string(),
         FunctionType::all_borrow(
             vec![

--- a/lib/sifr/python.sifr
+++ b/lib/sifr/python.sifr
@@ -4,7 +4,9 @@ from typing import Callable
 from _sifr.python import (
     py_call,
     py_call_attr,
+    py_buffer_u8,
     py_close,
+    py_copy_buffer_u8,
     py_copy_dict_str_bool,
     py_copy_dict_str_bytes,
     py_copy_dict_str_float,
@@ -44,6 +46,7 @@ from _sifr.python import (
     py_get_item_str,
     py_import_module,
     py_resource_diagnostics,
+    py_release_buffer,
     py_run_coroutine_blocking,
     py_to_bool,
     py_to_bytes,
@@ -106,6 +109,35 @@ class ResourceDiagnostics:
         self.leaked_objects = leaked_objects
 
 
+class BufferView(NonSend):
+    _handle: int
+    _token: int
+    length: int
+    item_size: int
+    readonly: bool
+    dimensions: int
+    shape: list[int]
+    strides: list[int]
+    suboffsets: list[int]
+    c_contiguous: bool
+    f_contiguous: bool
+    format: str
+
+    def __init__(self):
+        self._handle = -1
+        self._token = 0
+        self.length = 0
+        self.item_size = 0
+        self.readonly = True
+        self.dimensions = 0
+        self.shape = []
+        self.strides = []
+        self.suboffsets = []
+        self.c_contiguous = False
+        self.f_contiguous = False
+        self.format = ""
+
+
 def _object_from_handle(raw: tuple[int, int]) -> Object:
     obj: Object = Object()
     obj._handle = raw[0]
@@ -122,6 +154,23 @@ def _objects_from_handles(raw_values: list[tuple[int, int]]) -> list[Object]:
     for raw in raw_values:
         values.append(_object_from_handle(raw))
     return values
+
+
+def _buffer_from_raw(raw: tuple[int, int, int, int, bool, int, list[int], list[int], list[int], bool, bool, str]) -> BufferView:
+    view: BufferView = BufferView()
+    view._handle = raw[0]
+    view._token = raw[1]
+    view.length = raw[2]
+    view.item_size = raw[3]
+    view.readonly = raw[4]
+    view.dimensions = raw[5]
+    view.shape = raw[6]
+    view.strides = raw[7]
+    view.suboffsets = raw[8]
+    view.c_contiguous = raw[9]
+    view.f_contiguous = raw[10]
+    view.format = raw[11]
+    return view
 
 
 def _record_fields_from_handles(raw_values: list[tuple[str, tuple[int, int]]]) -> list[tuple[str, Object]]:
@@ -206,6 +255,53 @@ def call_attr(
 @blocking_io
 def close(own obj: Object) -> Result[None, PythonError]:
     return py_close(obj._handle, obj._token)
+
+
+@blocking_io
+def zero_copy_as_u8(obj: Object) -> Result[BufferView, PythonError]:
+    try:
+        raw: tuple[int, int, int, int, bool, int, list[int], list[int], list[int], bool, bool, str] = py_buffer_u8(
+            obj._handle,
+            obj._token,
+            False,
+        )
+        return _buffer_from_raw(raw)
+    except PythonError as e:
+        raise e
+
+
+@blocking_io
+def zero_copy_as_writable_u8(obj: Object) -> Result[BufferView, PythonError]:
+    try:
+        raw: tuple[int, int, int, int, bool, int, list[int], list[int], list[int], bool, bool, str] = py_buffer_u8(
+            obj._handle,
+            obj._token,
+            True,
+        )
+        return _buffer_from_raw(raw)
+    except PythonError as e:
+        raise e
+
+
+@blocking_io
+def copy_buffer_bytes(view: BufferView) -> Result[bytes, PythonError]:
+    return py_copy_buffer_u8(view._handle, view._token)
+
+
+@blocking_io
+def release_buffer(own view: BufferView) -> Result[None, PythonError]:
+    return py_release_buffer(view._handle, view._token)
+
+
+@blocking_io
+def copy_as_bytes(obj: Object) -> Result[bytes, PythonError]:
+    try:
+        view: BufferView = zero_copy_as_u8(obj)
+        data: bytes = copy_buffer_bytes(view)
+        released: None = release_buffer(view)
+        return data
+    except PythonError as e:
+        raise e
 
 
 @blocking_io

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -56,7 +56,13 @@
   - Added async-blocking verification fixtures and required them from the Python interop scaffold runner.
   - Opus review round 1 reported no blockers; local `create-pr` validation passed with only a warm wall-time advisory.
   - Merged via PR [#2670](https://github.com/sifr-lang/sifr/pull/2670).
-- [ ] `milestone_py_6`: Resource cleanup and leak diagnostics.
+- [x] `milestone_py_6`: Resource cleanup and leak diagnostics.
+  - Added `py.with_context` with failure-aware `__exit__` plumbing and deterministic entered-handle cleanup on success, body failure, and normal `__exit__` failure paths.
+  - Added runtime `resource_diagnostics` and `exit_context_with_error` operations with object double-close resource errors and recording context-manager coverage.
+  - Added resource cleanup source fixtures for context-manager success, missing-enter failure, body failure, and outstanding diagnostics.
+  - Documented the parser reservation for exact `py.with(...)` and the helper-owned entered-object rule.
+  - Opus review round 2 reported no blockers; local `create-pr` validation passed with only a warm wall-time advisory.
+  - Merged via PR [#2671](https://github.com/sifr-lang/sifr/pull/2671).
 - [ ] `milestone_py_7`: `Py_buffer` zero-copy core.
 - [ ] `milestone_py_8`: Arrow PyCapsule interop.
 - [ ] `milestone_py_9`: DLPack tensor interop.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py7-review-1.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py7-review-1.md
@@ -1,0 +1,32 @@
+I have enough to provide a complete review. The implementation is straightforward and consistent with prior milestones (py3/py4/py5/py6) patterns, with proper integration of buffer handles into the existing `live_objects` resource diagnostics surface.
+
+# Review findings — milestone_py_7 `Py_buffer` zero-copy core
+
+## Contract coverage (verified)
+
+- `PyObject_GetBuffer`/`PyBuffer_Release` via PyO3's `PyBuffer<u8>` — `crates/sifr_runtime/src/python/buffer_ops.rs:64-78`, `48-56`. PyO3's `PyBuffer::drop` re-acquires the GIL internally for `PyBuffer_Release`, satisfying the GIL discipline rule in the phase contract.
+- Tracks owner / pointer-metadata / length / readonly / itemsize / format / ndim / shape / strides / suboffsets / contiguity — `buffer_ops.rs:112-127`. All required fields are present.
+- Handle/token store with deterministic double-release / use-after-release reporting `SifrPythonClosedBuffer` — `buffer_ops.rs:150-159`, `203-211`. Tokens use a process-random `RandomState` seed via `hash_one`, mirroring the object store's pattern, so use-after-release across reused handle ids is statistically detectable. Handles are monotonic and never reused (`buffer_ops.rs:161-176`), so detection is in fact exact.
+- Participation in the shared `live_objects` count for `resource_diagnostics`/`validate_shutdown` — `buffer_ops.rs:133` (`update_object_count(1)`) and `buffer_ops.rs:48-56` (`-1` on `TrackedBuffer::drop`). The runtime test at `buffer_ops.rs:255-260` asserts `live_objects: 2` for one bytes object + one buffer view, then `0` after release+close. Matches the phase note.
+- Zero-copy vs copy split exposed at the Sifr surface (`zero_copy_as_u8`, `zero_copy_as_writable_u8`, `copy_buffer_bytes`, `copy_as_bytes`, `release_buffer`) — `lib/sifr/python.sifr:261-305`. Fixtures `py_buffer_roundtrip.sifr`, `py_buffer_memoryview.sifr`, and `py_buffer_readonly_failure.sifr` exercise the positive and the readonly-rejection negative paths; runner additions in `verification/python_interop/runner/run.py:55-76` enforce all four artifacts.
+- Negative-path coverage of "non-buffer exporter", "double release", and "wrong dtype / writable on readonly" via the JSON contract and the three Rust unit tests `buffer_view_tracks_metadata_copy_and_release`, `buffer_double_release_is_deterministic_resource_error`, `buffer_rejects_wrong_dtype_and_readonly_writable_request`.
+- Codegen lowering of all three new intrinsics + shared metadata feature gate — `crates/sifr_codegen/src/intrinsics/registry/python.rs:237-281` and assertions in `registry_extended_tests.rs:127-145`.
+
+## Non-blocking observations
+
+1. **Counter accounting on improbable failure paths** — `crates/sifr_runtime/src/python/buffer_ops.rs:129-148`. `update_object_count(+1)` runs *before* `buffer_store()` and `reserve_handle`. If either fails after the increment (mutex poison or `i64` overflow on `next_handle`/`next_nonce`), the raw `PyBuffer<u8>` is dropped without going through `TrackedBuffer::drop`, so `live_objects` is leaked by 1 and shutdown is blocked forever. Both failure modes are essentially unreachable in practice (≈2^63 buffer allocations or a poisoned mutex), so this is informational; if you want belt-and-braces, swap the order so `update_object_count(+1)` happens only after `reserve_handle` succeeds.
+
+2. **`require_writable` is checked post-acquisition, not via `PyBUF_WRITABLE`** — `buffer_ops.rs:64-73`. PyO3's `PyBuffer::<u8>::get` doesn't request `PyBUF_WRITABLE`, so we always acquire whatever view the exporter offers and then reject if `buffer.readonly()`. That correctly rejects bytes-style readonly producers (covered by `py_buffer_readonly_failure.sifr` and the unit test), and it correctly accepts producers that natively return a writable view (e.g., `bytearray`). It is *not* equivalent to requesting `PyBUF_WRITABLE` from CPython, but since no actual mutation API is exposed in py7 (only `copy_buffer_u8`/`release_buffer`), the difference isn't observable yet. Worth a note for whichever future milestone adds a writable byte-poke API.
+
+3. **No standalone Rust unit test for use-after-release via `copy_buffer_u8`** — the JSON contract `numpy_buffer/py_buffer_contract.json:43-49` names this case but only the double-release Rust test exercises the closed-handle path. Both paths flow through the same `lookup_buffer` filter (`buffer_ops.rs:150-159`), so behavior is covered transitively; a one-line `copy_buffer_u8` call after release would make coverage explicit, but isn't required.
+
+4. **Phase doc** — `plans/issues/active/ad-hoc-embedded-python-interop.md` is touched only to mark py6 as merged (`#2671`); the py7 entry stays `[ ]`, matching the project convention of ticking the box at merge time, not pre-PR.
+
+## Severity summary
+
+| Severity | Count |
+| --- | --- |
+| Blocker | 0 |
+| Non-blocking observations | 4 |
+
+reviewer satisfied: no blockers

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py7-review-2.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py7-review-2.md
@@ -1,0 +1,19 @@
+Round 2 review
+
+Verified both follow-up changes against `crates/sifr_runtime/src/python/buffer_ops.rs`:
+
+**1. Reserve-before-increment ordering** — `store_buffer` (buffer_ops.rs:129-148) now does:
+- L133: acquire mutex (`buffer_store()?`) — failure path: no increment.
+- L134: `reserve_handle(&mut store)?` — failure path (overflow): no increment.
+- L135: `update_object_count(1)?` — only runs after lock + handle reserved.
+- L138: `store.buffers.insert(...)` — infallible HashMap insert.
+
+The invariant holds: if `update_object_count(+1)` returns Ok, the `TrackedBuffer` is unconditionally stored (insert can't fail). If `update_object_count` itself errors, the parameter `buffer: PyBuffer<u8>` drops as a raw PyO3 buffer (no `TrackedBuffer::drop` decrement), so net `live_objects` delta is 0 — no leak. Address of round-1 observation #1.
+
+**2. `copy_buffer_u8`-after-release assertion** — `buffer_double_release_is_deterministic_resource_error` (buffer_ops.rs:273-291) now calls `copy_buffer_u8((view.handle, view.token))` after `release_buffer` and asserts both `error.kind == "resource"` / `error.exception_type == "SifrPythonClosedBuffer"` *and* the same on `copy_error`. Addresses round-1 observation #3 — the closed-handle path is now exercised explicitly through both `release_buffer` and `copy_buffer_u8`.
+
+**Adjacent diff sanity** — `crates/sifr_runtime/src/python.rs` only adds the `buffer_ops` mod/re-exports and widens `update_object_count`/`record_leaked_object` to `pub(super)`, which is the minimum visibility needed for the submodule. Nothing else was touched.
+
+No regressions, no new blockers.
+
+reviewer satisfied: no blockers

--- a/verification/python_interop/fixtures/numpy_buffer/py_buffer_contract.json
+++ b/verification/python_interop/fixtures/numpy_buffer/py_buffer_contract.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "case_group": "python_py_buffer_zero_copy_core",
+  "surface": "sifr.python",
+  "positive_cases": [
+    {
+      "name": "bytes_exporter_u8_readonly_view",
+      "operations": ["from_bytes", "zero_copy_as_u8", "copy_buffer_bytes", "release_buffer"],
+      "expected_metadata": {
+        "item_size": 1,
+        "readonly": true,
+        "c_contiguous": true,
+        "format": "B"
+      },
+      "release_behavior": "deterministic_resource_release"
+    },
+    {
+      "name": "copy_as_bytes_explicit_copy",
+      "operations": ["from_bytes", "copy_as_bytes"],
+      "copy_semantics": "explicit_copy_from_buffer_view"
+    },
+    {
+      "name": "memoryview_exporter_u8_view",
+      "operations": ["builtins.memoryview", "zero_copy_as_u8", "release_buffer"],
+      "expected_metadata": {
+        "item_size": 1,
+        "c_contiguous": true
+      }
+    }
+  ],
+  "negative_cases": [
+    {
+      "name": "readonly_exporter_rejects_writable_request",
+      "operation": "zero_copy_as_writable_u8",
+      "expected_error_kind": "zero-copy",
+      "expected_exception_type": "BufferError"
+    },
+    {
+      "name": "double_release",
+      "operation": "release_buffer",
+      "expected_error_kind": "resource",
+      "expected_exception_type": "SifrPythonClosedBuffer"
+    },
+    {
+      "name": "use_after_release",
+      "operation": "copy_buffer_bytes",
+      "expected_error_kind": "resource",
+      "expected_exception_type": "SifrPythonClosedBuffer"
+    },
+    {
+      "name": "non_buffer_exporter_rejected",
+      "operation": "zero_copy_as_u8",
+      "expected_error_kind": "zero-copy"
+    }
+  ]
+}

--- a/verification/python_interop/fixtures/numpy_buffer/py_buffer_memoryview.sifr
+++ b/verification/python_interop/fixtures/numpy_buffer/py_buffer_memoryview.sifr
@@ -1,0 +1,29 @@
+from sifr.python import (
+    BufferView,
+    Object,
+    PythonError,
+    call_attr,
+    close,
+    from_bytes,
+    import_module,
+    release_buffer,
+    zero_copy_as_u8,
+)
+
+
+@trust_python_dynamic
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        module_name: str = "builtins"
+        builtins: Object = import_module(module_name)
+        payload: Object = from_bytes(b"memory")
+        view_obj: Object = call_attr(builtins, "memoryview", [payload], [])
+        view: BufferView = zero_copy_as_u8(view_obj)
+        released: None = release_buffer(view)
+        view_obj_closed: None = close(view_obj)
+        payload_closed: None = close(payload)
+        builtins_closed: None = close(builtins)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/fixtures/numpy_buffer/py_buffer_readonly_failure.sifr
+++ b/verification/python_interop/fixtures/numpy_buffer/py_buffer_readonly_failure.sifr
@@ -1,0 +1,12 @@
+from sifr.python import BufferView, Object, PythonError, close, from_bytes, zero_copy_as_writable_u8
+
+
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        obj: Object = from_bytes(b"readonly")
+        view: BufferView = zero_copy_as_writable_u8(obj)
+        closed: None = close(obj)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/fixtures/numpy_buffer/py_buffer_roundtrip.sifr
+++ b/verification/python_interop/fixtures/numpy_buffer/py_buffer_roundtrip.sifr
@@ -1,0 +1,25 @@
+from sifr.python import (
+    BufferView,
+    Object,
+    PythonError,
+    close,
+    copy_as_bytes,
+    copy_buffer_bytes,
+    from_bytes,
+    release_buffer,
+    zero_copy_as_u8,
+)
+
+
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        obj: Object = from_bytes(b"sifr")
+        view: BufferView = zero_copy_as_u8(obj)
+        copied: bytes = copy_buffer_bytes(view)
+        direct_copy: bytes = copy_as_bytes(obj)
+        released: None = release_buffer(view)
+        closed: None = close(obj)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/runner/run.py
+++ b/verification/python_interop/runner/run.py
@@ -56,6 +56,7 @@ REQUIRED_FIXTURE_FILES = (
     "simple_import/opaque_object_operations.json",
     "primitive_conversion/primitive_roundtrip.json",
     "async_blocking/async_blocking_contract.json",
+    "numpy_buffer/py_buffer_contract.json",
     "resource_cleanup/context_manager_cleanup.json",
 )
 
@@ -65,6 +66,9 @@ REQUIRED_SOURCE_FIXTURES = (
     "async_blocking/offloaded_python_calls.sifr",
     "async_blocking/unclassified_offload_rejected.sifr",
     "primitive_conversion/primitive_roundtrip.sifr",
+    "numpy_buffer/py_buffer_readonly_failure.sifr",
+    "numpy_buffer/py_buffer_memoryview.sifr",
+    "numpy_buffer/py_buffer_roundtrip.sifr",
     "resource_cleanup/context_manager_body_failure.sifr",
     "resource_cleanup/context_manager_failure.sifr",
     "resource_cleanup/context_manager_success.sifr",


### PR DESCRIPTION
## Summary
- add runtime Py_buffer acquisition/copy/release support for u8-compatible exporters with deterministic closed-buffer errors
- expose py_buffer_u8, py_copy_buffer_u8, and py_release_buffer intrinsics through stdlib/codegen and lib/sifr/python.sifr BufferView helpers
- add numpy_buffer scaffold contract fixtures and runner required-fixture coverage
- record Opus review rounds for py7 with reviewer satisfied: no blockers

## Validation
- cargo fmt --check
- cargo test -p sifr_runtime --features python python -- --nocapture
- cargo test -p sifr_runtime --features python python::buffer_ops -- --nocapture
- cargo test -p sifr_codegen lowers_python_intrinsics_with_runtime_feature_metadata -- --nocapture
- verification/python_interop/run.sh --group scaffold
- cargo run -q -p sifr -- check verification/python_interop/fixtures/numpy_buffer/py_buffer_roundtrip.sifr
- cargo run -q -p sifr -- check verification/python_interop/fixtures/numpy_buffer/py_buffer_memoryview.sifr
- cargo run -q -p sifr -- check verification/python_interop/fixtures/numpy_buffer/py_buffer_readonly_failure.sifr
- git diff --check
- python3 scripts/check_file_size_guardrails.py
- python3 verification/areas/coverage_matrix/checks/verification_taxonomy.py
- scripts/run_all_tests.sh --profile create-pr (passed; advisory: warm wall-time budget exceeded)

## Review
- plans/reviews/active/ad-hoc-embedded-python-interop-py7-review-1.md
- plans/reviews/active/ad-hoc-embedded-python-interop-py7-review-2.md
