### PR TITLE
Implement Python Arrow PyCapsule interop

### DIFF
--- a/crates/sifr_codegen/src/intrinsics/registry/python.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/python.rs
@@ -11,6 +11,10 @@ pub(crate) fn lower_python_intrinsic(name: &str, args: &[RustExpr]) -> Option<Ru
         "py_buffer_u8" => lower_py_buffer_u8(args),
         "py_copy_buffer_u8" => lower_py_copy_buffer_u8(args),
         "py_release_buffer" => lower_py_release_buffer(args),
+        "py_arrow_array" => lower_py_arrow_array(args),
+        "py_arrow_stream" => lower_py_arrow_stream(args),
+        "py_arrow_schema" => lower_py_arrow_schema(args),
+        "py_release_arrow" => lower_py_release_arrow(args),
         "py_enter_context" => lower_py_enter_context(args),
         "py_exit_context" => lower_py_exit_context(args),
         "py_exit_context_with_error" => lower_py_exit_context_with_error(args),
@@ -270,6 +274,54 @@ pub(crate) fn lower_py_release_buffer(args: &[RustExpr]) -> Option<RustExpr> {
 }
 
 fn lower_buffer_conversion(args: &[RustExpr], function: &str) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    let handle = render_expr(&args[0]);
+    let token = render_expr(&args[1]);
+    Some(map_python_error(format!(
+        "sifr_runtime::python::{function}(({handle}, {token}))"
+    )))
+}
+
+pub(crate) fn lower_py_arrow_array(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_arrow_export(args, "arrow_array")
+}
+
+pub(crate) fn lower_py_arrow_stream(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_arrow_export(args, "arrow_stream")
+}
+
+pub(crate) fn lower_py_arrow_schema(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_arrow_export(args, "arrow_schema")
+}
+
+pub(crate) fn lower_py_release_arrow(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_arrow_conversion(args, "release_arrow")
+}
+
+fn lower_arrow_export(args: &[RustExpr], function: &str) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    let handle = render_expr(&args[0]);
+    let token = render_expr(&args[1]);
+    Some(map_python_error(format!(
+        r#"sifr_runtime::python::{function}(({handle}, {token})).map(|__sifr_python_arrow| {{
+            (
+                __sifr_python_arrow.handle,
+                __sifr_python_arrow.token,
+                __sifr_python_arrow.kind,
+                __sifr_python_arrow.capsule_names,
+                __sifr_python_arrow.producer_module,
+                __sifr_python_arrow.producer_type,
+                __sifr_python_arrow.copy_possible,
+            )
+        }})"#
+    )))
+}
+
+fn lower_arrow_conversion(args: &[RustExpr], function: &str) -> Option<RustExpr> {
     if args.len() != 2 {
         return None;
     }

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -143,6 +143,22 @@ pub(crate) fn lowers_python_intrinsics_with_runtime_feature_metadata() {
     )
     .expect("py_release_buffer should lower");
     assert!(render_expr(&release.expr).contains("sifr_runtime::python::release_buffer"));
+
+    let arrow = lower_intrinsic(
+        "py_arrow_stream",
+        &["object_handle".to_string(), "object_token".to_string()],
+    )
+    .expect("py_arrow_stream should lower");
+    let arrow_rendered = render_expr(&arrow.expr);
+    assert!(arrow_rendered.contains("sifr_runtime::python::arrow_stream"));
+    assert!(arrow_rendered.contains("__sifr_python_arrow.copy_possible"));
+
+    let release_arrow = lower_intrinsic(
+        "py_release_arrow",
+        &["arrow_handle".to_string(), "arrow_token".to_string()],
+    )
+    .expect("py_release_arrow should lower");
+    assert!(render_expr(&release_arrow.expr).contains("sifr_runtime::python::release_arrow"));
 }
 
 #[test]

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -6,10 +6,14 @@ use std::fmt;
 use std::mem::MaybeUninit;
 use std::sync::{Mutex, MutexGuard};
 
+mod arrow_ops;
 mod buffer_ops;
 mod coroutine_ops;
 mod object_ops;
 mod resource_ops;
+pub use arrow_ops::{
+    arrow_array, arrow_schema, arrow_stream, release_arrow, ArrowHandle, PythonArrowCapsuleMetadata,
+};
 pub use buffer_ops::{
     buffer_u8, copy_buffer_u8, release_buffer, BufferHandle, PythonBufferMetadata,
 };

--- a/crates/sifr_runtime/src/python/arrow_ops.rs
+++ b/crates/sifr_runtime/src/python/arrow_ops.rs
@@ -1,0 +1,564 @@
+use super::object_ops::clone_handle;
+use super::{ObjectHandle, PythonError, PythonRuntimeError};
+use pyo3::ffi;
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyTuple};
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::hash::BuildHasher;
+use std::sync::{LazyLock, Mutex, MutexGuard};
+
+const ARROW_SCHEMA_NAME: &CStr = c"arrow_schema";
+const ARROW_ARRAY_NAME: &CStr = c"arrow_array";
+const ARROW_STREAM_NAME: &CStr = c"arrow_array_stream";
+
+static ARROW_STORE: LazyLock<Mutex<ArrowStore>> =
+    LazyLock::new(|| Mutex::new(ArrowStore::default()));
+static TOKEN_HASHER: LazyLock<std::collections::hash_map::RandomState> =
+    LazyLock::new(std::collections::hash_map::RandomState::new);
+
+pub type ArrowHandle = (i64, i64);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PythonArrowCapsuleMetadata {
+    pub handle: i64,
+    pub token: i64,
+    pub kind: String,
+    pub capsule_names: Vec<String>,
+    pub producer_module: String,
+    pub producer_type: String,
+    pub copy_possible: bool,
+}
+
+#[derive(Default)]
+struct ArrowStore {
+    next_handle: i64,
+    next_nonce: u64,
+    capsules: HashMap<i64, ArrowEntry>,
+}
+
+struct ArrowEntry {
+    token: i64,
+    _capsules: TrackedArrowCapsules,
+}
+
+struct TrackedArrowCapsules {
+    capsules: Vec<Py<PyAny>>,
+}
+
+impl Drop for TrackedArrowCapsules {
+    fn drop(&mut self) {
+        self.capsules.clear();
+        let _ignored = super::update_object_count(-1);
+    }
+}
+
+pub fn arrow_array(object: ObjectHandle) -> Result<PythonArrowCapsuleMetadata, PythonError> {
+    acquire_arrow_capsules(object, ArrowKind::Array)
+}
+
+pub fn arrow_stream(object: ObjectHandle) -> Result<PythonArrowCapsuleMetadata, PythonError> {
+    acquire_arrow_capsules(object, ArrowKind::Stream)
+}
+
+pub fn arrow_schema(object: ObjectHandle) -> Result<PythonArrowCapsuleMetadata, PythonError> {
+    acquire_arrow_capsules(object, ArrowKind::Schema)
+}
+
+pub fn release_arrow((handle, token): ArrowHandle) -> Result<(), PythonError> {
+    let entry = {
+        let mut store = arrow_store()?;
+        if store
+            .capsules
+            .get(&handle)
+            .is_some_and(|entry| entry.token == token)
+        {
+            store.capsules.remove(&handle)
+        } else {
+            return Err(closed_error(handle));
+        }
+    };
+    super::attach(|_py| drop(entry)).map_err(PythonError::runtime)?;
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum ArrowKind {
+    Array,
+    Stream,
+    Schema,
+}
+
+impl ArrowKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Array => "array",
+            Self::Stream => "stream",
+            Self::Schema => "schema",
+        }
+    }
+
+    const fn method(self) -> &'static str {
+        match self {
+            Self::Array => "__arrow_c_array__",
+            Self::Stream => "__arrow_c_stream__",
+            Self::Schema => "__arrow_c_schema__",
+        }
+    }
+}
+
+fn acquire_arrow_capsules(
+    object: ObjectHandle,
+    kind: ArrowKind,
+) -> Result<PythonArrowCapsuleMetadata, PythonError> {
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let producer = producer_info(object.bind(py));
+        let exported = call_export_method(py, object.bind(py), kind)
+            .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", kind.method()))?;
+        let capsules = extract_capsules(py, &exported, kind)?;
+        let capsule_names = capsule_names(kind);
+        store_arrow_capsules(capsules, kind, capsule_names, producer)
+    })
+    .map_err(PythonError::runtime)?
+}
+
+fn call_export_method<'py>(
+    py: Python<'py>,
+    object: &Bound<'py, PyAny>,
+    kind: ArrowKind,
+) -> PyResult<Bound<'py, PyAny>> {
+    match kind {
+        ArrowKind::Array | ArrowKind::Stream => object.call_method1(kind.method(), (py.None(),)),
+        ArrowKind::Schema => object.call_method0(kind.method()),
+    }
+}
+
+fn extract_capsules(
+    py: Python<'_>,
+    exported: &Bound<'_, PyAny>,
+    kind: ArrowKind,
+) -> Result<Vec<Py<PyAny>>, PythonError> {
+    match kind {
+        ArrowKind::Array => {
+            let tuple = exported.cast::<PyTuple>().map_err(|_| {
+                arrow_error("__arrow_c_array__ must return (arrow_schema, arrow_array)")
+            })?;
+            if tuple.len() != 2 {
+                return Err(arrow_error(
+                    "__arrow_c_array__ must return exactly two capsules",
+                ));
+            }
+            let schema = tuple.get_item(0).map_err(|error| {
+                PythonError::from_pyerr(py, error, "zero-copy", "__arrow_c_array__ schema")
+            })?;
+            let array = tuple.get_item(1).map_err(|error| {
+                PythonError::from_pyerr(py, error, "zero-copy", "__arrow_c_array__ array")
+            })?;
+            validate_capsule(py, &schema, ARROW_SCHEMA_NAME, "__arrow_c_array__ schema")?;
+            validate_capsule(py, &array, ARROW_ARRAY_NAME, "__arrow_c_array__ array")?;
+            Ok(vec![schema.unbind(), array.unbind()])
+        }
+        ArrowKind::Stream => {
+            validate_capsule(py, exported, ARROW_STREAM_NAME, "__arrow_c_stream__")?;
+            Ok(vec![exported.clone().unbind()])
+        }
+        ArrowKind::Schema => {
+            validate_capsule(py, exported, ARROW_SCHEMA_NAME, "__arrow_c_schema__")?;
+            Ok(vec![exported.clone().unbind()])
+        }
+    }
+}
+
+fn validate_capsule(
+    py: Python<'_>,
+    object: &Bound<'_, PyAny>,
+    expected_name: &'static CStr,
+    context: &'static str,
+) -> Result<(), PythonError> {
+    let capsule = object.cast::<PyCapsule>().map_err(|_| {
+        arrow_error(format!(
+            "{context} returned a non-PyCapsule value; expected {}",
+            expected_name.to_string_lossy()
+        ))
+    })?;
+    let actual_name = unsafe { ffi::PyCapsule_GetName(capsule.as_ptr()) };
+    if actual_name.is_null() {
+        return Err(arrow_error(format!(
+            "{context} capsule has no name; expected {}",
+            expected_name.to_string_lossy()
+        )));
+    }
+    let actual_name = unsafe { CStr::from_ptr(actual_name) };
+    if actual_name != expected_name {
+        return Err(arrow_error(format!(
+            "{context} capsule has name '{}'; expected '{}'",
+            actual_name.to_string_lossy(),
+            expected_name.to_string_lossy()
+        )));
+    }
+    capsule
+        .pointer_checked(Some(expected_name))
+        .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", context))?;
+    let destructor = unsafe { ffi::PyCapsule_GetDestructor(capsule.as_ptr()) };
+    if destructor.is_none() {
+        let _stale_error = PyErr::take(py);
+        return Err(arrow_error(format!(
+            "{context} capsule '{}' has no destructor",
+            expected_name.to_string_lossy()
+        )));
+    }
+    Ok(())
+}
+
+fn store_arrow_capsules(
+    capsules: Vec<Py<PyAny>>,
+    kind: ArrowKind,
+    capsule_names: Vec<String>,
+    producer: ProducerInfo,
+) -> Result<PythonArrowCapsuleMetadata, PythonError> {
+    let mut store = arrow_store()?;
+    let (handle, token) = reserve_handle(&mut store)?;
+    super::update_object_count(1).map_err(PythonError::runtime)?;
+    store.capsules.insert(
+        handle,
+        ArrowEntry {
+            token,
+            _capsules: TrackedArrowCapsules { capsules },
+        },
+    );
+    Ok(PythonArrowCapsuleMetadata {
+        handle,
+        token,
+        kind: kind.label().to_string(),
+        capsule_names,
+        producer_module: producer.module,
+        producer_type: producer.name,
+        copy_possible: producer.copy_possible,
+    })
+}
+
+struct ProducerInfo {
+    module: String,
+    name: String,
+    copy_possible: bool,
+}
+
+fn producer_info(object: &Bound<'_, PyAny>) -> ProducerInfo {
+    let type_object = object.get_type();
+    let module = type_object
+        .getattr("__module__")
+        .and_then(|value| value.extract::<String>())
+        .unwrap_or_default();
+    let name = type_object
+        .name()
+        .map_or_else(|_| "object".to_string(), |name| name.to_string());
+    let copy_possible = !is_proven_zero_copy_module(&module);
+    ProducerInfo {
+        module,
+        name,
+        copy_possible,
+    }
+}
+
+fn is_proven_zero_copy_module(module: &str) -> bool {
+    // Only audited zero-copy producers belong here.
+    module == "pyarrow"
+        || module.starts_with("pyarrow.")
+        || module == "polars"
+        || module.starts_with("polars.")
+}
+
+fn capsule_names(kind: ArrowKind) -> Vec<String> {
+    match kind {
+        ArrowKind::Array => vec!["arrow_schema".to_string(), "arrow_array".to_string()],
+        ArrowKind::Stream => vec!["arrow_array_stream".to_string()],
+        ArrowKind::Schema => vec!["arrow_schema".to_string()],
+    }
+}
+
+fn reserve_handle(store: &mut ArrowStore) -> Result<ArrowHandle, PythonError> {
+    store.next_handle = store.next_handle.checked_add(1).ok_or_else(|| {
+        PythonError::runtime(PythonRuntimeError::PythonOperationFailed(
+            "Python Arrow handle space exhausted".to_string(),
+        ))
+    })?;
+    store.next_nonce = store.next_nonce.checked_add(1).ok_or_else(|| {
+        PythonError::runtime(PythonRuntimeError::PythonOperationFailed(
+            "Python Arrow token space exhausted".to_string(),
+        ))
+    })?;
+    Ok((
+        store.next_handle,
+        token_for(store.next_handle, store.next_nonce),
+    ))
+}
+
+fn token_for(handle: i64, nonce: u64) -> i64 {
+    let hash = TOKEN_HASHER.hash_one((handle, nonce));
+    i64::from_ne_bytes(hash.to_ne_bytes())
+}
+
+fn closed_error(handle: i64) -> PythonError {
+    PythonError {
+        kind: "resource".to_string(),
+        exception_type: "SifrPythonClosedArrowCapsule".to_string(),
+        message: format!("Python Arrow capsule handle {handle} is closed"),
+        traceback: String::new(),
+        context: "Arrow capsule handle lookup".to_string(),
+    }
+}
+
+fn arrow_error(message: impl Into<String>) -> PythonError {
+    PythonError {
+        kind: "zero-copy".to_string(),
+        exception_type: "SifrPythonArrowCapsuleError".to_string(),
+        message: message.into(),
+        traceback: String::new(),
+        context: "Arrow PyCapsule validation".to_string(),
+    }
+}
+
+fn arrow_store() -> Result<MutexGuard<'static, ArrowStore>, PythonError> {
+    ARROW_STORE.lock().map_err(|_| PythonError {
+        kind: "runtime".to_string(),
+        exception_type: "SifrPythonRuntimeError".to_string(),
+        message: "Python Arrow capsule store is unavailable".to_string(),
+        traceback: String::new(),
+        context: "Arrow capsule store".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::python::{
+        close_object, initialize_runtime, reset_runtime_state_for_tests, resource_diagnostics,
+        test_config, test_guard, PythonResourceDiagnostics,
+    };
+    use pyo3::types::{PyCapsule, PyDict};
+
+    #[test]
+    fn arrow_array_stream_schema_track_metadata_and_release() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("arrow-capsules")).expect("init should succeed");
+
+        let object = exporter().expect("exporter should be stored");
+        let array = arrow_array(object).expect("array capsules should export");
+        let stream = arrow_stream(object).expect("stream capsule should export");
+        let schema = arrow_schema(object).expect("schema capsule should export");
+
+        assert_eq!(array.kind, "array");
+        assert_eq!(array.capsule_names, ["arrow_schema", "arrow_array"]);
+        assert!(!array.copy_possible);
+        assert_eq!(stream.capsule_names, ["arrow_array_stream"]);
+        assert_eq!(schema.capsule_names, ["arrow_schema"]);
+        assert_eq!(
+            resource_diagnostics().expect("diagnostics should be available"),
+            PythonResourceDiagnostics {
+                initialized: true,
+                live_objects: 4,
+                leaked_objects: 0,
+            }
+        );
+
+        release_arrow((array.handle, array.token)).expect("array should release");
+        release_arrow((stream.handle, stream.token)).expect("stream should release");
+        release_arrow((schema.handle, schema.token)).expect("schema should release");
+        close_object(object).expect("object should close");
+    }
+
+    #[test]
+    fn arrow_marks_pandas_like_producers_copy_possible() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("arrow-copy-possible")).expect("init should succeed");
+
+        let object = pandas_exporter().expect("exporter should be stored");
+        let stream = arrow_stream(object).expect("stream capsule should export");
+
+        assert!(stream.copy_possible);
+        release_arrow((stream.handle, stream.token)).expect("stream should release");
+        close_object(object).expect("object should close");
+    }
+
+    #[test]
+    fn arrow_rejects_malformed_capsule_and_double_release() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("arrow-errors")).expect("init should succeed");
+
+        let malformed = malformed_exporter().expect("malformed exporter should be stored");
+        let error = arrow_array(malformed).expect_err("wrong capsule names must fail");
+        assert_eq!(error.kind, "zero-copy");
+        assert_eq!(error.exception_type, "SifrPythonArrowCapsuleError");
+
+        let object = exporter().expect("exporter should be stored");
+        let stream = arrow_stream(object).expect("stream capsule should export");
+        release_arrow((stream.handle, stream.token)).expect("stream should release");
+        let closed =
+            release_arrow((stream.handle, stream.token)).expect_err("second release should fail");
+        assert_eq!(closed.kind, "resource");
+        assert_eq!(closed.exception_type, "SifrPythonClosedArrowCapsule");
+
+        close_object(malformed).expect("malformed object should close");
+        close_object(object).expect("object should close");
+    }
+
+    #[test]
+    fn arrow_rejects_capsules_without_destructors() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("arrow-no-destructor")).expect("init should succeed");
+
+        let malformed = exporter_without_destructor().expect("exporter should be stored");
+        let error = arrow_schema(malformed).expect_err("missing destructor must fail");
+
+        assert_eq!(error.kind, "zero-copy");
+        assert_eq!(error.exception_type, "SifrPythonArrowCapsuleError");
+        assert!(error.message.contains("has no destructor"));
+        close_object(malformed).expect("malformed object should close");
+    }
+
+    fn exporter() -> Result<ObjectHandle, PythonError> {
+        exporter_with_schema("pyarrow.lib", ARROW_SCHEMA_NAME)
+    }
+
+    fn pandas_exporter() -> Result<ObjectHandle, PythonError> {
+        super::super::attach(|py| {
+            let globals = PyDict::new(py);
+            globals
+                .set_item("STREAM", capsule_any(py, ARROW_STREAM_NAME)?.bind(py))
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test stream"))?;
+            py.run(
+                cr#"
+class PandasExporter:
+    __module__ = "pandas.core.frame"
+
+    def __arrow_c_stream__(self, requested_schema=None):
+        return STREAM
+
+obj = PandasExporter()
+"#,
+                Some(&globals),
+                None,
+            )
+            .map_err(|error| {
+                PythonError::from_pyerr(py, error, "zero-copy", "test pandas exporter")
+            })?;
+            let object = globals
+                .get_item("obj")
+                .map_err(|error| {
+                    PythonError::from_pyerr(py, error, "zero-copy", "test pandas exporter")
+                })?
+                .ok_or_else(|| arrow_error("test pandas exporter did not create obj"))?;
+            super::super::object_ops::store_object(object.unbind())
+        })
+        .map_err(PythonError::runtime)?
+    }
+
+    fn malformed_exporter() -> Result<ObjectHandle, PythonError> {
+        exporter_with_schema("pyarrow.lib", ARROW_STREAM_NAME)
+    }
+
+    fn exporter_without_destructor() -> Result<ObjectHandle, PythonError> {
+        super::super::attach(|py| {
+            let globals = PyDict::new(py);
+            globals
+                .set_item("SCHEMA", capsule_without_destructor(py)?.bind(py))
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test schema"))?;
+            py.run(
+                cr#"
+class ArrowExporter:
+    __module__ = "pyarrow.lib"
+
+    def __arrow_c_schema__(self):
+        return SCHEMA
+
+obj = ArrowExporter()
+"#,
+                Some(&globals),
+                None,
+            )
+            .map_err(|error| {
+                PythonError::from_pyerr(py, error, "zero-copy", "test destructorless exporter")
+            })?;
+            let object = globals
+                .get_item("obj")
+                .map_err(|error| {
+                    PythonError::from_pyerr(py, error, "zero-copy", "test destructorless exporter")
+                })?
+                .ok_or_else(|| arrow_error("test destructorless exporter did not create obj"))?;
+            super::super::object_ops::store_object(object.unbind())
+        })
+        .map_err(PythonError::runtime)?
+    }
+
+    fn exporter_with_schema(
+        module_name: &str,
+        schema_name: &'static CStr,
+    ) -> Result<ObjectHandle, PythonError> {
+        super::super::attach(|py| {
+            let globals = PyDict::new(py);
+            globals
+                .set_item("MODULE_NAME", module_name)
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test module"))?;
+            globals
+                .set_item("SCHEMA", capsule_any(py, schema_name)?.bind(py))
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test schema"))?;
+            globals
+                .set_item("ARRAY", capsule_any(py, ARROW_ARRAY_NAME)?.bind(py))
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test array"))?;
+            globals
+                .set_item("STREAM", capsule_any(py, ARROW_STREAM_NAME)?.bind(py))
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test stream"))?;
+            py.run(
+                cr#"
+class ArrowExporter:
+    __module__ = MODULE_NAME
+
+    def __arrow_c_array__(self, requested_schema=None):
+        return (SCHEMA, ARRAY)
+
+    def __arrow_c_stream__(self, requested_schema=None):
+        return STREAM
+
+    def __arrow_c_schema__(self):
+        return SCHEMA
+
+obj = ArrowExporter()
+"#,
+                Some(&globals),
+                None,
+            )
+            .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test exporter"))?;
+            let object = globals
+                .get_item("obj")
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test exporter"))?
+                .ok_or_else(|| arrow_error("test exporter did not create obj"))?;
+            super::super::object_ops::store_object(object.unbind())
+        })
+        .map_err(PythonError::runtime)?
+    }
+
+    fn capsule<'py>(py: Python<'py>, name: &'static CStr) -> PyResult<Bound<'py, PyCapsule>> {
+        PyCapsule::new_with_value(py, 1_u8, name)
+    }
+
+    fn capsule_any(py: Python<'_>, name: &'static CStr) -> Result<Py<PyAny>, PythonError> {
+        capsule(py, name)
+            .map(|capsule| capsule.into_any().unbind())
+            .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test capsule"))
+    }
+
+    fn capsule_without_destructor(py: Python<'_>) -> Result<Py<PyAny>, PythonError> {
+        let leaked = Box::leak(Box::new(1_u8));
+        let pointer = std::ptr::NonNull::from(leaked).cast();
+        let capsule = unsafe { PyCapsule::new_with_pointer(py, pointer, ARROW_SCHEMA_NAME) }
+            .map_err(|error| {
+                PythonError::from_pyerr(py, error, "zero-copy", "test destructorless capsule")
+            })?;
+        Ok(capsule.into_any().unbind())
+    }
+}

--- a/crates/sifr_stdlib/src/python.rs
+++ b/crates/sifr_stdlib/src/python.rs
@@ -127,6 +127,36 @@ pub(super) fn intrinsic_python() -> IntrinsicModule {
             python_error_result(Type::None),
         ),
     );
+    for name in ["py_arrow_array", "py_arrow_stream", "py_arrow_schema"] {
+        functions.insert(
+            name.to_string(),
+            FunctionType::all_borrow(
+                vec![
+                    ("handle".to_string(), Type::Int),
+                    ("token".to_string(), Type::Int),
+                ],
+                python_error_result(Type::Tuple(vec![
+                    Type::Int,
+                    Type::Int,
+                    Type::Str,
+                    Type::List(Box::new(Type::Str)),
+                    Type::Str,
+                    Type::Str,
+                    Type::Bool,
+                ])),
+            ),
+        );
+    }
+    functions.insert(
+        "py_release_arrow".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::None),
+        ),
+    );
     functions.insert(
         "py_enter_context".to_string(),
         FunctionType::all_borrow(

--- a/lib/sifr/python.sifr
+++ b/lib/sifr/python.sifr
@@ -2,6 +2,9 @@
 from typing import Callable
 
 from _sifr.python import (
+    py_arrow_array,
+    py_arrow_schema,
+    py_arrow_stream,
     py_call,
     py_call_attr,
     py_buffer_u8,
@@ -46,6 +49,7 @@ from _sifr.python import (
     py_get_item_str,
     py_import_module,
     py_resource_diagnostics,
+    py_release_arrow,
     py_release_buffer,
     py_run_coroutine_blocking,
     py_to_bool,
@@ -138,6 +142,25 @@ class BufferView(NonSend):
         self.format = ""
 
 
+class ArrowCapsule(NonSend):
+    _handle: int
+    _token: int
+    kind: str
+    capsule_names: list[str]
+    producer_module: str
+    producer_type: str
+    copy_possible: bool
+
+    def __init__(self):
+        self._handle = -1
+        self._token = 0
+        self.kind = ""
+        self.capsule_names = []
+        self.producer_module = ""
+        self.producer_type = ""
+        self.copy_possible = True
+
+
 def _object_from_handle(raw: tuple[int, int]) -> Object:
     obj: Object = Object()
     obj._handle = raw[0]
@@ -171,6 +194,18 @@ def _buffer_from_raw(raw: tuple[int, int, int, int, bool, int, list[int], list[i
     view.f_contiguous = raw[10]
     view.format = raw[11]
     return view
+
+
+def _arrow_from_raw(raw: tuple[int, int, str, list[str], str, str, bool]) -> ArrowCapsule:
+    capsule: ArrowCapsule = ArrowCapsule()
+    capsule._handle = raw[0]
+    capsule._token = raw[1]
+    capsule.kind = raw[2]
+    capsule.capsule_names = raw[3]
+    capsule.producer_module = raw[4]
+    capsule.producer_type = raw[5]
+    capsule.copy_possible = raw[6]
+    return capsule
 
 
 def _record_fields_from_handles(raw_values: list[tuple[str, tuple[int, int]]]) -> list[tuple[str, Object]]:
@@ -291,6 +326,92 @@ def copy_buffer_bytes(view: BufferView) -> Result[bytes, PythonError]:
 @blocking_io
 def release_buffer(own view: BufferView) -> Result[None, PythonError]:
     return py_release_buffer(view._handle, view._token)
+
+
+@blocking_io
+def export_arrow_array(obj: Object) -> Result[ArrowCapsule, PythonError]:
+    try:
+        raw: tuple[int, int, str, list[str], str, str, bool] = py_arrow_array(obj._handle, obj._token)
+        return _arrow_from_raw(raw)
+    except PythonError as e:
+        raise e
+
+
+@blocking_io
+def export_arrow_stream(obj: Object) -> Result[ArrowCapsule, PythonError]:
+    try:
+        raw: tuple[int, int, str, list[str], str, str, bool] = py_arrow_stream(obj._handle, obj._token)
+        return _arrow_from_raw(raw)
+    except PythonError as e:
+        raise e
+
+
+@blocking_io
+def export_arrow_schema(obj: Object) -> Result[ArrowCapsule, PythonError]:
+    try:
+        raw: tuple[int, int, str, list[str], str, str, bool] = py_arrow_schema(obj._handle, obj._token)
+        return _arrow_from_raw(raw)
+    except PythonError as e:
+        raise e
+
+
+@blocking_io
+def release_arrow(own capsule: ArrowCapsule) -> Result[None, PythonError]:
+    return py_release_arrow(capsule._handle, capsule._token)
+
+
+@blocking_io
+def zero_copy_arrow_array(obj: Object) -> Result[ArrowCapsule, PythonError]:
+    try:
+        raw: tuple[int, int, str, list[str], str, str, bool] = py_arrow_array(obj._handle, obj._token)
+        if raw[6]:
+            released: None = py_release_arrow(raw[0], raw[1])
+            raise PythonError(
+                "Arrow array exporter may copy; zero-copy was not proven",
+                "zero-copy",
+                "SifrPythonArrowCopyPossible",
+                "",
+                "Arrow PyCapsule export",
+            )
+        return _arrow_from_raw(raw)
+    except PythonError as e:
+        raise e
+
+
+@blocking_io
+def zero_copy_arrow_stream(obj: Object) -> Result[ArrowCapsule, PythonError]:
+    try:
+        raw: tuple[int, int, str, list[str], str, str, bool] = py_arrow_stream(obj._handle, obj._token)
+        if raw[6]:
+            released: None = py_release_arrow(raw[0], raw[1])
+            raise PythonError(
+                "Arrow stream exporter may copy; zero-copy was not proven",
+                "zero-copy",
+                "SifrPythonArrowCopyPossible",
+                "",
+                "Arrow PyCapsule export",
+            )
+        return _arrow_from_raw(raw)
+    except PythonError as e:
+        raise e
+
+
+@blocking_io
+def zero_copy_arrow_schema(obj: Object) -> Result[ArrowCapsule, PythonError]:
+    try:
+        raw: tuple[int, int, str, list[str], str, str, bool] = py_arrow_schema(obj._handle, obj._token)
+        if raw[6]:
+            released: None = py_release_arrow(raw[0], raw[1])
+            raise PythonError(
+                "Arrow schema exporter may copy; zero-copy was not proven",
+                "zero-copy",
+                "SifrPythonArrowCopyPossible",
+                "",
+                "Arrow PyCapsule export",
+            )
+        return _arrow_from_raw(raw)
+    except PythonError as e:
+        raise e
 
 
 @blocking_io

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -63,7 +63,12 @@
   - Documented the parser reservation for exact `py.with(...)` and the helper-owned entered-object rule.
   - Opus review round 2 reported no blockers; local `create-pr` validation passed with only a warm wall-time advisory.
   - Merged via PR [#2671](https://github.com/sifr-lang/sifr/pull/2671).
-- [ ] `milestone_py_7`: `Py_buffer` zero-copy core.
+- [x] `milestone_py_7`: `Py_buffer` zero-copy core.
+  - Added `py.BufferView` and explicit u8 buffer helpers for zero-copy acquisition, checked writable requests, explicit copy, and deterministic release.
+  - Added runtime `PyBuffer<u8>` ownership tracking with shape, stride, contiguity, format, readonly, and double-release diagnostics.
+  - Added numpy-buffer contract/source fixtures covering readonly bytes, memoryview, explicit copy, wrong dtype, writable-on-readonly, and use-after-release behavior.
+  - Opus review round 2 reported no blockers; local `create-pr` validation passed with only a warm wall-time advisory.
+  - Merged via PR [#2672](https://github.com/sifr-lang/sifr/pull/2672).
 - [ ] `milestone_py_8`: Arrow PyCapsule interop.
 - [ ] `milestone_py_9`: DLPack tensor interop.
 - [ ] `milestone_py_10`: Python-to-Sifr callbacks.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py8-review-1.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py8-review-1.md
@@ -1,0 +1,23 @@
+I've reviewed the milestone_py_8 changes against the phase contract and the listed validation. Findings below, ordered by severity.
+
+## Blockers
+
+None.
+
+## Non-blocking observations
+
+1. **Contract case `capsule_without_destructor_rejected` is unverified.** `verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_contract.json:49-53` lists this negative case, but neither the Rust unit tests (`crates/sifr_runtime/src/python/arrow_ops.rs:330-503`) nor the source fixtures exercise it. `PyCapsule::new_with_value` always installs a destructor, so the rejection branch at `crates/sifr_runtime/src/python/arrow_ops.rs:203-209` is implemented but untested. Either add a fixture/test that creates a destructor-less capsule via `pyo3::ffi::PyCapsule_New(ptr, name, None)`, or trim the contract claim.
+
+2. **Sifr-level type collapse vs. spec.** The phase contract (`plans/issues/active/ad-hoc-embedded-python-interop.md:286-291`) defines `py.ArrowArray`, `py.ArrowStream`, `py.ArrowSchema` as separate types. `lib/sifr/python.sifr:145-161` unifies them into one `ArrowCapsule` with a `kind: str` discriminator. Runtime kind is preserved, so safety holds, but a Sifr caller cannot statically distinguish a stream handle from a schema handle — type system can't catch passing the wrong one to `release_arrow`. Worth noting for py_9/py_11 follow-up; not blocking here because the milestone's exit criteria don't enumerate per-kind Sifr types.
+
+3. **Zero-copy producer allowlist is undocumented.** `crates/sifr_runtime/src/python/arrow_ops.rs:263-268` hardcodes `pyarrow` and `polars` as proven-zero-copy. The choice matches the spec ("Polars Arrow stream export is the preferred dataframe zero-copy target"), but the function lacks a comment naming the criterion future maintainers should apply when adding a new producer (e.g. duckdb, vaex). A one-line `// Why:` comment would prevent drift.
+
+4. **`release_arrow` runs without GIL attach.** `crates/sifr_runtime/src/python/arrow_ops.rs:68-83` removes the entry under the store lock, then drops `TrackedArrowCapsules` outside any `super::attach(...)`. This relies on PyO3's deferred-decref to eventually run the PyCapsule destructor (which invokes the Arrow C release callback) on the next GIL acquisition. This is the same pattern py_7 chose for `release_buffer` (`crates/sifr_runtime/src/python/buffer_ops.rs:95-110`), so it's an intentional inheritance, but the spec wording (`plans/issues/active/ad-hoc-embedded-python-interop.md:450-451` "deterministic close/release semantics") permits but doesn't promise synchronous in-thread destructor execution. Worth a project-wide note before py_9 (DLPack one-shot semantics may need stronger guarantees).
+
+5. **`PyCapsule_GetDestructor` error path not cleared.** `crates/sifr_runtime/src/python/arrow_ops.rs:203` treats a `None` return as "no destructor". The CPython contract is that `None` may also mean an exception was set. After a successful `cast::<PyCapsule>`, that error path is effectively unreachable, but a defensive `PyErr::take(py)` would prevent a stale exception from leaking into the next Python operation if invariants ever shift.
+
+6. **.sifr fixtures only exercise type-checking.** `arrow_capsule_roundtrip.sifr`, `arrow_capsule_zero_copy.sifr`, and `arrow_capsule_copy_possible.sifr` use `from_none()` as the producer, which has no `__arrow_c_array__`. They're validated only via `cargo run -- check`. Real pyarrow/polars/pandas runtime behavior is covered exclusively by the Rust unit tests with synthetic exporter classes (`pyarrow.lib`, `pandas.core.frame`). That matches the validation list provided, but the milestone-exit claim "Polars and pyarrow zero-copy paths are verified" rests on `producer_info`'s `__module__` heuristic, not on a real polars/pyarrow capsule. Acceptable as a scaffold ahead of py_11 certification — flagging so the gap is explicit.
+
+7. **Pillow Arrow path neither tested nor whitelisted.** Spec lists Pillow Arrow images in scope (`plans/issues/active/ad-hoc-embedded-python-interop.md:508-511`). The implementation correctly defaults Pillow to `copy_possible = true`, which is safe, but neither the contract JSON nor any test asserts this. Add a `pillow_image_is_marked_copy_possible` case to the contract for completeness when py_11 wires real Pillow into the matrix.
+
+reviewer satisfied: no blockers

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py8-review-2.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py8-review-2.md
@@ -1,0 +1,24 @@
+I've inspected the diff, all listed files, and re-run the validation set. One blocker surfaces from the cleanup that addressed round 1's observation #3.
+
+## Blockers
+
+1. **`crates/sifr_runtime/src/python/arrow_ops.rs:265` introduces a delivery-plan-taxonomy violation.** The newly added comment `// Only producers with a phase-owned zero-copy contract belong here.` contains `phase-owned`, which matches the `\b(?:phase|milestone|wave)[_-][a-z0-9][a-z0-9_-]*\b` rule in `verification/areas/coverage_matrix/checks/verification_taxonomy.py:107`. Re-running that check (it was in the "earlier validation before cleanup also passed" list) now fails:
+   ```
+   verification-taxonomy error: crates/sifr_runtime/src/python/arrow_ops.rs:265:
+   line contains delivery-plan taxonomy: // Only producers with a phase-owned zero-copy contract belong here.
+   ```
+   This was introduced by the round-2 fix for round-1 observation #3. Rewording to e.g., `// Only vetted/audited zero-copy producers belong here` resolves it. The post-cleanup validation set the user ran did not include the taxonomy script, so the regression slipped through.
+
+## Non-blocking observations
+
+1. **Round 1 items resolved correctly.** The destructor-less unit test (`arrow_ops.rs:409-422`, using `PyCapsule::new_with_pointer`) closes the gap from observation #1; `release_arrow` now drops capsules under `super::attach(|_py| drop(entry))` at `arrow_ops.rs:81` (#4); `PyErr::take(py)` at `arrow_ops.rs:205` clears any stale exception state (#5); the Pillow copy-possible contract case is present at `arrow_capsule_contract.json:40-45` (#7). All four are clean.
+
+2. **`pillow_image_arrow_export_is_marked_copy_possible` is structurally identical to `unknown_arrow_producer_is_marked_copy_possible`.** Both list `operations: ["export_arrow_array"]`, `expected_copy_possible: true`, `zero_copy_helper_behavior: "rejects_without_silent_copy"`, with no `producer_module` discriminator. The case relies on the runtime's default-non-allowlisted behavior. Acceptable scaffold ahead of py_11 wiring real Pillow producers into the matrix, but worth noting the two cases aren't behaviourally distinct yet.
+
+3. **Sifr-level type collapse (round 1 #2) still open.** `ArrowCapsule` continues to unify `ArrowArray`/`ArrowStream`/`ArrowSchema` via a runtime `kind: str` discriminator. Intentional deferral for py_9/py_11; flagging only so the spec-vs-impl gap isn't lost.
+
+4. **Source-fixture coverage (round 1 #6) unchanged.** `arrow_capsule_*.sifr` still use `from_none()` as the producer and are exercised only by `cargo run -- check`. Real pyarrow/polars/pandas/Pillow runtime paths are covered exclusively by the Rust unit tests with synthetic exporters (`pyarrow.lib`, `pandas.core.frame`, etc.). Same posture as py_7's numpy fixtures.
+
+5. **Pre-existing clippy warnings on the python feature remain (`resource_ops.rs:6` unused import, `object_ops.rs` `needless_pass_by_value`).** Confirmed pre-existing by reverting the diff and re-running clippy — not introduced here, just inherited. Worth scheduling cleanup before py_9 if the workspace enables `-D warnings` for `--features python`.
+
+Once the comment in `arrow_ops.rs:265` is reworded so `verification_taxonomy.py` passes, I expect to be satisfied.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py8-review-3.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py8-review-3.md
@@ -1,0 +1,30 @@
+I've re-inspected the diff, confirmed the round-2 blocker is resolved, and re-run the listed validation.
+
+## Round 2 blocker resolution
+
+- `crates/sifr_runtime/src/python/arrow_ops.rs:265` now reads `// Only audited zero-copy producers belong here.`. The disallowed `phase-owned` token is gone, and a fresh run of `python3 verification/areas/coverage_matrix/checks/verification_taxonomy.py` prints `verification taxonomy ok`. A grep of the touched files against the `(phase|milestone|wave|roadmap|closeout|backlog|epic|ticket)[_-]...` family returns no matches.
+
+## Post-fix validation re-run locally
+
+- `cargo fmt --check` — clean.
+- `cargo test -p sifr_runtime --features python python::arrow_ops -- --nocapture` — 4 passed, 0 failed (`arrow_array_stream_schema_track_metadata_and_release`, `arrow_marks_pandas_like_producers_copy_possible`, `arrow_rejects_malformed_capsule_and_double_release`, `arrow_rejects_capsules_without_destructors`).
+- `python3 verification/areas/coverage_matrix/checks/verification_taxonomy.py` — ok.
+- `scripts/check_hir_maintainability_guardrails.py` — PASS.
+- `scripts/run_all_tests.sh --profile create-pr` — pass with only the inherited warm wall-time advisory; no blocking failures.
+- File-size guardrail: arrow_ops.rs 564 lines, python.sifr 816, registry/python.rs 555, stdlib python.rs 413 — all under the 900-line cap.
+
+## Blockers
+
+None.
+
+## Non-blocking observations
+
+1. **Round-1 #2 / Round-2 #3 still open: Sifr-level type collapse.** `lib/sifr/python.sifr:145-161` continues to unify `ArrowArray`/`ArrowStream`/`ArrowSchema` into a single `ArrowCapsule` with a runtime `kind: str` discriminator. Intentional deferral for `milestone_py_9`/`milestone_py_11`; runtime safety holds, but the Sifr type system cannot statically prevent passing a stream handle to a schema-consumer. Re-flagging only so the spec-vs-impl gap remains visible.
+
+2. **Round-1 #6 / Round-2 #4 still open: `.sifr` fixtures exercise type-checking only.** `arrow_capsule_roundtrip.sifr`, `arrow_capsule_zero_copy.sifr`, and `arrow_capsule_copy_possible.sifr` still use `from_none()` as the producer (no `__arrow_c_array__`); real pyarrow/polars/pandas/Pillow runtime paths are covered exclusively by the Rust unit tests with synthetic exporters. Matches the validation list provided and the posture of py_7's numpy fixtures.
+
+3. **Round-2 #2 still open: `pillow_image_arrow_export_is_marked_copy_possible` is structurally identical to `unknown_arrow_producer_is_marked_copy_possible`.** Both rely on the default-non-allowlisted branch with no `producer_module` discriminator. Acceptable scaffold ahead of `milestone_py_11` wiring real Pillow producers into the matrix.
+
+4. **Round-2 #5 still open: Pre-existing clippy warnings on the python feature.** Inherited from py_7, not introduced here. Worth scheduling cleanup before py_9 if the workspace enables `-D warnings` for `--features python`.
+
+reviewer satisfied: no blockers

--- a/verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_contract.json
+++ b/verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_contract.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "case_group": "python_arrow_pycapsule_interop",
+  "surface": "sifr.python",
+  "positive_cases": [
+    {
+      "name": "pyarrow_array_capsules_are_zero_copy_proven",
+      "operations": ["export_arrow_array", "zero_copy_arrow_array", "release_arrow"],
+      "expected_capsule_names": ["arrow_schema", "arrow_array"],
+      "expected_copy_possible": false,
+      "producer_roots": ["pyarrow"]
+    },
+    {
+      "name": "polars_stream_capsule_is_zero_copy_proven",
+      "operations": ["export_arrow_stream", "zero_copy_arrow_stream", "release_arrow"],
+      "expected_capsule_names": ["arrow_array_stream"],
+      "expected_copy_possible": false,
+      "producer_roots": ["polars"]
+    },
+    {
+      "name": "schema_capsule_preserves_release_ownership",
+      "operations": ["export_arrow_schema", "release_arrow"],
+      "expected_capsule_names": ["arrow_schema"],
+      "release_behavior": "deterministic_resource_release"
+    }
+  ],
+  "copy_possible_cases": [
+    {
+      "name": "pandas_stream_is_marked_copy_possible",
+      "operations": ["export_arrow_stream"],
+      "expected_copy_possible": true,
+      "zero_copy_helper_behavior": "rejects_without_silent_copy"
+    },
+    {
+      "name": "unknown_arrow_producer_is_marked_copy_possible",
+      "operations": ["export_arrow_array"],
+      "expected_copy_possible": true,
+      "zero_copy_helper_behavior": "rejects_without_silent_copy"
+    },
+    {
+      "name": "pillow_image_arrow_export_is_marked_copy_possible",
+      "operations": ["export_arrow_array"],
+      "expected_copy_possible": true,
+      "zero_copy_helper_behavior": "rejects_without_silent_copy"
+    }
+  ],
+  "negative_cases": [
+    {
+      "name": "malformed_capsule_name_rejected",
+      "operation": "export_arrow_array",
+      "expected_error_kind": "zero-copy",
+      "expected_exception_type": "SifrPythonArrowCapsuleError"
+    },
+    {
+      "name": "capsule_without_destructor_rejected",
+      "operation": "export_arrow_schema",
+      "expected_error_kind": "zero-copy",
+      "expected_exception_type": "SifrPythonArrowCapsuleError"
+    },
+    {
+      "name": "double_release_rejected",
+      "operation": "release_arrow",
+      "expected_error_kind": "resource",
+      "expected_exception_type": "SifrPythonClosedArrowCapsule"
+    }
+  ]
+}

--- a/verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_copy_possible.sifr
+++ b/verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_copy_possible.sifr
@@ -1,0 +1,22 @@
+from sifr.python import (
+    ArrowCapsule,
+    Object,
+    PythonError,
+    close,
+    export_arrow_stream,
+    from_none,
+    release_arrow,
+)
+
+
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        obj: Object = from_none()
+        stream: ArrowCapsule = export_arrow_stream(obj)
+        may_copy: bool = stream.copy_possible
+        released: None = release_arrow(stream)
+        closed: None = close(obj)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_roundtrip.sifr
+++ b/verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_roundtrip.sifr
@@ -1,0 +1,27 @@
+from sifr.python import (
+    ArrowCapsule,
+    Object,
+    PythonError,
+    close,
+    export_arrow_array,
+    export_arrow_schema,
+    export_arrow_stream,
+    from_none,
+    release_arrow,
+)
+
+
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        obj: Object = from_none()
+        array: ArrowCapsule = export_arrow_array(obj)
+        stream: ArrowCapsule = export_arrow_stream(obj)
+        schema: ArrowCapsule = export_arrow_schema(obj)
+        array_released: None = release_arrow(array)
+        stream_released: None = release_arrow(stream)
+        schema_released: None = release_arrow(schema)
+        closed: None = close(obj)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_zero_copy.sifr
+++ b/verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_zero_copy.sifr
@@ -1,0 +1,27 @@
+from sifr.python import (
+    ArrowCapsule,
+    Object,
+    PythonError,
+    close,
+    from_none,
+    release_arrow,
+    zero_copy_arrow_array,
+    zero_copy_arrow_schema,
+    zero_copy_arrow_stream,
+)
+
+
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        obj: Object = from_none()
+        array: ArrowCapsule = zero_copy_arrow_array(obj)
+        stream: ArrowCapsule = zero_copy_arrow_stream(obj)
+        schema: ArrowCapsule = zero_copy_arrow_schema(obj)
+        array_released: None = release_arrow(array)
+        stream_released: None = release_arrow(stream)
+        schema_released: None = release_arrow(schema)
+        closed: None = close(obj)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/runner/run.py
+++ b/verification/python_interop/runner/run.py
@@ -57,6 +57,7 @@ REQUIRED_FIXTURE_FILES = (
     "primitive_conversion/primitive_roundtrip.json",
     "async_blocking/async_blocking_contract.json",
     "numpy_buffer/py_buffer_contract.json",
+    "pyarrow_capsule/arrow_capsule_contract.json",
     "resource_cleanup/context_manager_cleanup.json",
 )
 
@@ -69,6 +70,9 @@ REQUIRED_SOURCE_FIXTURES = (
     "numpy_buffer/py_buffer_readonly_failure.sifr",
     "numpy_buffer/py_buffer_memoryview.sifr",
     "numpy_buffer/py_buffer_roundtrip.sifr",
+    "pyarrow_capsule/arrow_capsule_copy_possible.sifr",
+    "pyarrow_capsule/arrow_capsule_roundtrip.sifr",
+    "pyarrow_capsule/arrow_capsule_zero_copy.sifr",
     "resource_cleanup/context_manager_body_failure.sifr",
     "resource_cleanup/context_manager_failure.sifr",
     "resource_cleanup/context_manager_success.sifr",


### PR DESCRIPTION
## Summary
- add runtime Arrow PyCapsule acquisition/release for __arrow_c_array__, __arrow_c_stream__, and __arrow_c_schema__ with exact capsule-name and destructor validation
- expose Arrow capsule intrinsics through stdlib/codegen and add sifr.python ArrowCapsule export, zero-copy-proof, and release helpers
- mark pandas/unknown/Pillow-style producers copy-possible while allowing audited pyarrow/polars producer roots as zero-copy-proven
- add pyarrow_capsule contract/source fixtures and record three Opus review rounds with reviewer satisfied: no blockers

## Validation
- cargo fmt --check
- cargo test -p sifr_runtime --features python python::arrow_ops -- --nocapture
- cargo test -p sifr_runtime --features python python -- --nocapture
- cargo test -p sifr_codegen lowers_python_intrinsics_with_runtime_feature_metadata -- --nocapture
- verification/python_interop/run.sh --group scaffold
- cargo run -q -p sifr -- check verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_roundtrip.sifr
- cargo run -q -p sifr -- check verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_zero_copy.sifr
- cargo run -q -p sifr -- check verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_copy_possible.sifr
- git diff --check
- python3 scripts/check_file_size_guardrails.py
- python3 verification/areas/coverage_matrix/checks/verification_taxonomy.py
- scripts/run_all_tests.sh --profile create-pr (passed; advisory: warm wall-time budget exceeded)

## Review
- plans/reviews/active/ad-hoc-embedded-python-interop-py8-review-1.md
- plans/reviews/active/ad-hoc-embedded-python-interop-py8-review-2.md
- plans/reviews/active/ad-hoc-embedded-python-interop-py8-review-3.md
