### PR TITLE
Implement Python DLPack tensor interop

### DIFF
--- a/crates/sifr_codegen/src/intrinsics/registry/python.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/python.rs
@@ -15,6 +15,8 @@ pub(crate) fn lower_python_intrinsic(name: &str, args: &[RustExpr]) -> Option<Ru
         "py_arrow_stream" => lower_py_arrow_stream(args),
         "py_arrow_schema" => lower_py_arrow_schema(args),
         "py_release_arrow" => lower_py_release_arrow(args),
+        "py_dlpack_tensor" => lower_py_dlpack_tensor(args),
+        "py_release_dlpack" => lower_py_release_dlpack(args),
         "py_enter_context" => lower_py_enter_context(args),
         "py_exit_context" => lower_py_exit_context(args),
         "py_exit_context_with_error" => lower_py_exit_context_with_error(args),
@@ -322,6 +324,49 @@ fn lower_arrow_export(args: &[RustExpr], function: &str) -> Option<RustExpr> {
 }
 
 fn lower_arrow_conversion(args: &[RustExpr], function: &str) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    let handle = render_expr(&args[0]);
+    let token = render_expr(&args[1]);
+    Some(map_python_error(format!(
+        "sifr_runtime::python::{function}(({handle}, {token}))"
+    )))
+}
+
+pub(crate) fn lower_py_dlpack_tensor(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    let handle = render_expr(&args[0]);
+    let token = render_expr(&args[1]);
+    Some(map_python_error(format!(
+        r#"sifr_runtime::python::dlpack_tensor(({handle}, {token})).map(|__sifr_python_dlpack| {{
+            (
+                __sifr_python_dlpack.handle,
+                __sifr_python_dlpack.token,
+                __sifr_python_dlpack.dtype_code,
+                __sifr_python_dlpack.dtype_bits,
+                __sifr_python_dlpack.dtype_lanes,
+                __sifr_python_dlpack.dtype,
+                __sifr_python_dlpack.device_type,
+                __sifr_python_dlpack.device_id,
+                __sifr_python_dlpack.dimensions,
+                __sifr_python_dlpack.shape,
+                __sifr_python_dlpack.strides,
+                __sifr_python_dlpack.byte_offset,
+                __sifr_python_dlpack.has_deleter,
+                __sifr_python_dlpack.stream_sync_required,
+            )
+        }})"#
+    )))
+}
+
+pub(crate) fn lower_py_release_dlpack(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_dlpack_conversion(args, "release_dlpack")
+}
+
+fn lower_dlpack_conversion(args: &[RustExpr], function: &str) -> Option<RustExpr> {
     if args.len() != 2 {
         return None;
     }

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -159,6 +159,22 @@ pub(crate) fn lowers_python_intrinsics_with_runtime_feature_metadata() {
     )
     .expect("py_release_arrow should lower");
     assert!(render_expr(&release_arrow.expr).contains("sifr_runtime::python::release_arrow"));
+
+    let dlpack = lower_intrinsic(
+        "py_dlpack_tensor",
+        &["object_handle".to_string(), "object_token".to_string()],
+    )
+    .expect("py_dlpack_tensor should lower");
+    let dlpack_rendered = render_expr(&dlpack.expr);
+    assert!(dlpack_rendered.contains("sifr_runtime::python::dlpack_tensor"));
+    assert!(dlpack_rendered.contains("__sifr_python_dlpack.dtype"));
+
+    let release_dlpack = lower_intrinsic(
+        "py_release_dlpack",
+        &["dlpack_handle".to_string(), "dlpack_token".to_string()],
+    )
+    .expect("py_release_dlpack should lower");
+    assert!(render_expr(&release_dlpack.expr).contains("sifr_runtime::python::release_dlpack"));
 }
 
 #[test]

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -9,6 +9,7 @@ use std::sync::{Mutex, MutexGuard};
 mod arrow_ops;
 mod buffer_ops;
 mod coroutine_ops;
+mod dlpack_ops;
 mod object_ops;
 mod resource_ops;
 pub use arrow_ops::{
@@ -18,6 +19,7 @@ pub use buffer_ops::{
     buffer_u8, copy_buffer_u8, release_buffer, BufferHandle, PythonBufferMetadata,
 };
 pub use coroutine_ops::run_coroutine_blocking;
+pub use dlpack_ops::{dlpack_tensor, release_dlpack, DlpackHandle, PythonDlpackTensorMetadata};
 pub use object_ops::{
     call_attr, call_object, close_object, copy_dict_str_bool, copy_dict_str_bytes,
     copy_dict_str_float, copy_dict_str_i32, copy_dict_str_int, copy_dict_str_str, copy_dict_str_u8,

--- a/crates/sifr_runtime/src/python/dlpack_ops.rs
+++ b/crates/sifr_runtime/src/python/dlpack_ops.rs
@@ -1,0 +1,711 @@
+use super::object_ops::clone_handle;
+use super::{ObjectHandle, PythonError, PythonRuntimeError};
+use pyo3::ffi;
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyTuple};
+use std::collections::HashMap;
+use std::ffi::{c_void, CStr};
+use std::hash::BuildHasher;
+use std::sync::{LazyLock, Mutex, MutexGuard};
+
+const DLTENSOR_NAME: &CStr = c"dltensor";
+const USED_DLTENSOR_NAME: &CStr = c"used_dltensor";
+const DEVICE_CPU: i32 = 1;
+
+static DLPACK_STORE: LazyLock<Mutex<DlpackStore>> =
+    LazyLock::new(|| Mutex::new(DlpackStore::default()));
+static TOKEN_HASHER: LazyLock<std::collections::hash_map::RandomState> =
+    LazyLock::new(std::collections::hash_map::RandomState::new);
+
+pub type DlpackHandle = (i64, i64);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PythonDlpackTensorMetadata {
+    pub handle: i64,
+    pub token: i64,
+    pub dtype_code: i64,
+    pub dtype_bits: i64,
+    pub dtype_lanes: i64,
+    pub dtype: String,
+    pub device_type: i64,
+    pub device_id: i64,
+    pub dimensions: i64,
+    pub shape: Vec<i64>,
+    pub strides: Vec<i64>,
+    pub byte_offset: i64,
+    pub has_deleter: bool,
+    pub stream_sync_required: bool,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct DLDevice {
+    device_type: i32,
+    device_id: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct DLDataType {
+    code: u8,
+    bits: u8,
+    lanes: u16,
+}
+
+#[repr(C)]
+struct DLTensor {
+    data: *mut c_void,
+    device: DLDevice,
+    ndim: i32,
+    dtype: DLDataType,
+    shape: *mut i64,
+    strides: *mut i64,
+    byte_offset: u64,
+}
+
+#[repr(C)]
+struct DLManagedTensor {
+    dl_tensor: DLTensor,
+    manager_ctx: *mut c_void,
+    deleter: Option<unsafe extern "C" fn(*mut DLManagedTensor)>,
+}
+
+#[derive(Default)]
+struct DlpackStore {
+    next_handle: i64,
+    next_nonce: u64,
+    tensors: HashMap<i64, DlpackEntry>,
+}
+
+struct DlpackEntry {
+    token: i64,
+    _tensor: TrackedDlpackTensor,
+}
+
+struct TrackedDlpackTensor {
+    tensor_ptr: usize,
+    deleter: Option<unsafe extern "C" fn(*mut DLManagedTensor)>,
+    released: bool,
+    _owner: Py<PyAny>,
+    _capsule: Py<PyAny>,
+}
+
+impl Drop for TrackedDlpackTensor {
+    fn drop(&mut self) {
+        if !self.released {
+            if let Some(deleter) = self.deleter.take() {
+                let tensor = self.tensor_ptr as *mut DLManagedTensor;
+                unsafe { deleter(tensor) };
+            }
+            self.released = true;
+        }
+        let _ignored = super::update_object_count(-1);
+    }
+}
+
+pub fn dlpack_tensor(object: ObjectHandle) -> Result<PythonDlpackTensorMetadata, PythonError> {
+    super::attach(|py| {
+        let owner = clone_handle(py, object)?;
+        let device = dlpack_device(py, owner.bind(py))?;
+        if device.device_type != DEVICE_CPU {
+            return Err(unsupported_device_error(device));
+        }
+        let capsule = owner
+            .bind(py)
+            .call_method0("__dlpack__")
+            .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "__dlpack__"))?;
+        consume_capsule(py, owner, &capsule)
+    })
+    .map_err(PythonError::runtime)?
+}
+
+pub fn release_dlpack((handle, token): DlpackHandle) -> Result<(), PythonError> {
+    super::attach(|_py| {
+        let mut store = dlpack_store()?;
+        if store
+            .tensors
+            .get(&handle)
+            .is_some_and(|entry| entry.token == token)
+        {
+            let entry = store.tensors.remove(&handle);
+            drop(entry);
+            Ok(())
+        } else {
+            Err(closed_error(handle))
+        }
+    })
+    .map_err(PythonError::runtime)?
+}
+
+fn consume_capsule(
+    py: Python<'_>,
+    owner: Py<PyAny>,
+    capsule: &Bound<'_, PyAny>,
+) -> Result<PythonDlpackTensorMetadata, PythonError> {
+    let capsule = capsule.cast::<PyCapsule>().map_err(|_| {
+        dlpack_error("DLPack exporter returned a non-PyCapsule value; expected dltensor")
+    })?;
+    validate_capsule_name(capsule, DLTENSOR_NAME, "__dlpack__")?;
+    let pointer = capsule
+        .pointer_checked(Some(DLTENSOR_NAME))
+        .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "__dlpack__"))?;
+    let tensor = pointer.as_ptr().cast::<DLManagedTensor>();
+    let metadata = metadata_for_tensor(tensor)?;
+    let rename_result =
+        unsafe { ffi::PyCapsule_SetName(capsule.as_ptr(), USED_DLTENSOR_NAME.as_ptr()) };
+    if rename_result != 0 {
+        return Err(PythonError::from_pyerr(
+            py,
+            PyErr::fetch(py),
+            "zero-copy",
+            "mark DLPack capsule consumed",
+        ));
+    }
+    store_tensor(
+        TrackedDlpackTensor {
+            tensor_ptr: tensor as usize,
+            deleter: unsafe { (*tensor).deleter },
+            released: false,
+            _owner: owner,
+            _capsule: capsule.clone().into_any().unbind(),
+        },
+        metadata,
+    )
+}
+
+fn dlpack_device(py: Python<'_>, object: &Bound<'_, PyAny>) -> Result<DLDevice, PythonError> {
+    let raw = object
+        .call_method0("__dlpack_device__")
+        .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "__dlpack_device__"))?;
+    let tuple = raw
+        .cast::<PyTuple>()
+        .map_err(|_| dlpack_error("__dlpack_device__ must return (device_type, device_id)"))?;
+    if tuple.len() != 2 {
+        return Err(dlpack_error(
+            "__dlpack_device__ must return exactly two values",
+        ));
+    }
+    let device_type = tuple
+        .get_item(0)
+        .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "device type"))?
+        .extract::<i32>()
+        .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "device type"))?;
+    let device_id = tuple
+        .get_item(1)
+        .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "device id"))?
+        .extract::<i32>()
+        .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "device id"))?;
+    Ok(DLDevice {
+        device_type,
+        device_id,
+    })
+}
+
+fn metadata_for_tensor(
+    tensor: *mut DLManagedTensor,
+) -> Result<PythonDlpackTensorMetadata, PythonError> {
+    if tensor.is_null() {
+        return Err(dlpack_error("DLPack capsule pointer is null"));
+    }
+    let tensor_ref = unsafe { &*tensor };
+    let dl_tensor = &tensor_ref.dl_tensor;
+    let dimensions = checked_i64_i32(dl_tensor.ndim, "DLPack dimensions")?;
+    let len = usize::try_from(dl_tensor.ndim)
+        .map_err(|_| dlpack_error("DLPack dimensions exceed Sifr list range"))?;
+    if dl_tensor.shape.is_null() && len > 0 {
+        return Err(dlpack_error("DLPack tensor shape pointer is null"));
+    }
+    let shape = if dl_tensor.shape.is_null() {
+        Vec::new()
+    } else {
+        unsafe { slice_to_vec(dl_tensor.shape, len) }
+    };
+    let strides = if dl_tensor.strides.is_null() {
+        Vec::new()
+    } else {
+        unsafe { slice_to_vec(dl_tensor.strides, len) }
+    };
+    let dtype = dtype_name(dl_tensor.dtype)?;
+    let byte_offset = i64::try_from(dl_tensor.byte_offset)
+        .map_err(|_| dlpack_error("DLPack byte offset exceeds Sifr int range"))?;
+    Ok(PythonDlpackTensorMetadata {
+        handle: -1,
+        token: 0,
+        dtype_code: i64::from(dl_tensor.dtype.code),
+        dtype_bits: i64::from(dl_tensor.dtype.bits),
+        dtype_lanes: i64::from(dl_tensor.dtype.lanes),
+        dtype,
+        device_type: i64::from(dl_tensor.device.device_type),
+        device_id: i64::from(dl_tensor.device.device_id),
+        dimensions,
+        shape,
+        strides,
+        byte_offset,
+        has_deleter: tensor_ref.deleter.is_some(),
+        stream_sync_required: dl_tensor.device.device_type != DEVICE_CPU,
+    })
+}
+
+unsafe fn slice_to_vec(pointer: *mut i64, len: usize) -> Vec<i64> {
+    unsafe { std::slice::from_raw_parts(pointer.cast_const(), len) }.to_vec()
+}
+
+fn dtype_name(dtype: DLDataType) -> Result<String, PythonError> {
+    let lanes = dtype.lanes;
+    if lanes != 1 {
+        return Err(unsupported_dtype_error(dtype));
+    }
+    let name = match (dtype.code, dtype.bits) {
+        (0, 8) => "int8",
+        (0, 16) => "int16",
+        (0, 32) => "int32",
+        (0, 64) => "int64",
+        (1, 8) => "uint8",
+        (1, 16) => "uint16",
+        (1, 32) => "uint32",
+        (1, 64) => "uint64",
+        (2, 16) => "float16",
+        (2, 32) => "float32",
+        (2, 64) => "float64",
+        (4, 16) => "bfloat16",
+        (6, 1) | (6, 8) => "bool",
+        _ => return Err(unsupported_dtype_error(dtype)),
+    };
+    Ok(name.to_string())
+}
+
+fn store_tensor(
+    tensor: TrackedDlpackTensor,
+    mut metadata: PythonDlpackTensorMetadata,
+) -> Result<PythonDlpackTensorMetadata, PythonError> {
+    let mut store = dlpack_store()?;
+    let (handle, token) = reserve_handle(&mut store)?;
+    super::update_object_count(1).map_err(PythonError::runtime)?;
+    metadata.handle = handle;
+    metadata.token = token;
+    store.tensors.insert(
+        handle,
+        DlpackEntry {
+            token,
+            _tensor: tensor,
+        },
+    );
+    Ok(metadata)
+}
+
+fn validate_capsule_name(
+    capsule: &Bound<'_, PyCapsule>,
+    expected_name: &'static CStr,
+    context: &'static str,
+) -> Result<(), PythonError> {
+    let actual_name = unsafe { ffi::PyCapsule_GetName(capsule.as_ptr()) };
+    if actual_name.is_null() {
+        return Err(dlpack_error(format!(
+            "{context} capsule has no name; expected {}",
+            expected_name.to_string_lossy()
+        )));
+    }
+    let actual_name = unsafe { CStr::from_ptr(actual_name) };
+    if actual_name != expected_name {
+        return Err(dlpack_error(format!(
+            "{context} capsule has name '{}'; expected '{}'",
+            actual_name.to_string_lossy(),
+            expected_name.to_string_lossy()
+        )));
+    }
+    Ok(())
+}
+
+fn reserve_handle(store: &mut DlpackStore) -> Result<DlpackHandle, PythonError> {
+    store.next_handle = store.next_handle.checked_add(1).ok_or_else(|| {
+        PythonError::runtime(PythonRuntimeError::PythonOperationFailed(
+            "Python DLPack handle space exhausted".to_string(),
+        ))
+    })?;
+    store.next_nonce = store.next_nonce.checked_add(1).ok_or_else(|| {
+        PythonError::runtime(PythonRuntimeError::PythonOperationFailed(
+            "Python DLPack token space exhausted".to_string(),
+        ))
+    })?;
+    Ok((
+        store.next_handle,
+        token_for(store.next_handle, store.next_nonce),
+    ))
+}
+
+fn checked_i64_i32(value: i32, context: &'static str) -> Result<i64, PythonError> {
+    if value < 0 {
+        return Err(dlpack_error(format!("{context} must be non-negative")));
+    }
+    Ok(i64::from(value))
+}
+
+fn token_for(handle: i64, nonce: u64) -> i64 {
+    let hash = TOKEN_HASHER.hash_one((handle, nonce));
+    i64::from_ne_bytes(hash.to_ne_bytes())
+}
+
+fn unsupported_device_error(device: DLDevice) -> PythonError {
+    PythonError {
+        kind: "zero-copy".to_string(),
+        exception_type: "SifrPythonDlpackUnsupportedDevice".to_string(),
+        message: format!(
+            "DLPack device type {} id {} requires explicit stream/device support",
+            device.device_type, device.device_id
+        ),
+        traceback: String::new(),
+        context: "DLPack device validation".to_string(),
+    }
+}
+
+fn unsupported_dtype_error(dtype: DLDataType) -> PythonError {
+    PythonError {
+        kind: "zero-copy".to_string(),
+        exception_type: "SifrPythonDlpackUnsupportedDtype".to_string(),
+        message: format!(
+            "unsupported DLPack dtype code={} bits={} lanes={}",
+            dtype.code, dtype.bits, dtype.lanes
+        ),
+        traceback: String::new(),
+        context: "DLPack dtype validation".to_string(),
+    }
+}
+
+fn closed_error(handle: i64) -> PythonError {
+    PythonError {
+        kind: "resource".to_string(),
+        exception_type: "SifrPythonClosedDlpackTensor".to_string(),
+        message: format!("Python DLPack tensor handle {handle} is closed"),
+        traceback: String::new(),
+        context: "DLPack tensor handle lookup".to_string(),
+    }
+}
+
+fn dlpack_error(message: impl Into<String>) -> PythonError {
+    PythonError {
+        kind: "zero-copy".to_string(),
+        exception_type: "SifrPythonDlpackError".to_string(),
+        message: message.into(),
+        traceback: String::new(),
+        context: "DLPack validation".to_string(),
+    }
+}
+
+fn dlpack_store() -> Result<MutexGuard<'static, DlpackStore>, PythonError> {
+    DLPACK_STORE.lock().map_err(|_| PythonError {
+        kind: "runtime".to_string(),
+        exception_type: "SifrPythonRuntimeError".to_string(),
+        message: "Python DLPack tensor store is unavailable".to_string(),
+        traceback: String::new(),
+        context: "DLPack tensor store".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::python::{
+        close_object, initialize_runtime, reset_runtime_state_for_tests, resource_diagnostics,
+        test_config, test_guard, PythonResourceDiagnostics,
+    };
+    use pyo3::types::PyDict;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static TEST_DELETER_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    #[repr(C)]
+    struct TestManagedTensor {
+        managed: DLManagedTensor,
+        shape: Vec<i64>,
+        strides: Vec<i64>,
+        data: Vec<u8>,
+    }
+
+    #[test]
+    fn dlpack_cpu_tensor_tracks_metadata_and_release() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        TEST_DELETER_CALLS.store(0, Ordering::SeqCst);
+        initialize_runtime(test_config("dlpack-cpu")).expect("init should succeed");
+
+        let object = exporter(DEVICE_CPU, 0, dtype(2, 32, 1), DLTENSOR_NAME)
+            .expect("exporter should be stored");
+        let tensor = dlpack_tensor(object).expect("DLPack tensor should export");
+
+        assert_eq!(tensor.dtype, "float32");
+        assert_eq!(tensor.shape, [2, 3]);
+        assert_eq!(tensor.strides, [3, 1]);
+        assert_eq!(tensor.byte_offset, 0);
+        assert!(tensor.has_deleter);
+        assert!(!tensor.stream_sync_required);
+        assert_eq!(
+            resource_diagnostics().expect("diagnostics should be available"),
+            PythonResourceDiagnostics {
+                initialized: true,
+                live_objects: 2,
+                leaked_objects: 0,
+            }
+        );
+
+        release_dlpack((tensor.handle, tensor.token)).expect("DLPack tensor should release");
+        assert_eq!(TEST_DELETER_CALLS.load(Ordering::SeqCst), 1);
+        close_object(object).expect("object should close");
+    }
+
+    #[test]
+    fn dlpack_scalar_tensor_allows_null_shape_pointer() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        TEST_DELETER_CALLS.store(0, Ordering::SeqCst);
+        initialize_runtime(test_config("dlpack-scalar")).expect("init should succeed");
+
+        let object = scalar_exporter().expect("scalar exporter should be stored");
+        let tensor = dlpack_tensor(object).expect("scalar tensor should export");
+
+        assert_eq!(tensor.dimensions, 0);
+        assert!(tensor.shape.is_empty());
+        assert!(tensor.strides.is_empty());
+        release_dlpack((tensor.handle, tensor.token)).expect("scalar should release");
+        assert_eq!(TEST_DELETER_CALLS.load(Ordering::SeqCst), 1);
+        close_object(object).expect("object should close");
+    }
+
+    #[test]
+    fn dlpack_rejects_double_consumption_and_double_release() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        TEST_DELETER_CALLS.store(0, Ordering::SeqCst);
+        initialize_runtime(test_config("dlpack-double")).expect("init should succeed");
+
+        let object = exporter(DEVICE_CPU, 0, dtype(1, 8, 1), DLTENSOR_NAME)
+            .expect("exporter should be stored");
+        let tensor = dlpack_tensor(object).expect("first consume should succeed");
+        let consumed = dlpack_tensor(object).expect_err("second consume should fail");
+        assert_eq!(consumed.kind, "zero-copy");
+        assert!(consumed.message.contains("used_dltensor"));
+
+        release_dlpack((tensor.handle, tensor.token)).expect("DLPack tensor should release");
+        let closed =
+            release_dlpack((tensor.handle, tensor.token)).expect_err("second release should fail");
+        assert_eq!(closed.kind, "resource");
+        assert_eq!(closed.exception_type, "SifrPythonClosedDlpackTensor");
+        close_object(object).expect("object should close");
+    }
+
+    #[test]
+    fn dlpack_rejects_invalid_capsule_name_dtype_and_device() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("dlpack-rejects")).expect("init should succeed");
+
+        let invalid_name = exporter(DEVICE_CPU, 0, dtype(2, 32, 1), USED_DLTENSOR_NAME)
+            .expect("invalid-name exporter should be stored");
+        let invalid_name_error =
+            dlpack_tensor(invalid_name).expect_err("used capsule should be rejected");
+        assert_eq!(invalid_name_error.exception_type, "SifrPythonDlpackError");
+
+        let unsupported_dtype = exporter(DEVICE_CPU, 0, dtype(99, 32, 1), DLTENSOR_NAME)
+            .expect("unsupported-dtype exporter should be stored");
+        let dtype_error =
+            dlpack_tensor(unsupported_dtype).expect_err("unsupported dtype should fail");
+        assert_eq!(
+            dtype_error.exception_type,
+            "SifrPythonDlpackUnsupportedDtype"
+        );
+
+        let unsupported_device = exporter(2, 0, dtype(2, 32, 1), DLTENSOR_NAME)
+            .expect("unsupported-device exporter should be stored");
+        let device_error =
+            dlpack_tensor(unsupported_device).expect_err("unsupported device should fail");
+        assert_eq!(
+            device_error.exception_type,
+            "SifrPythonDlpackUnsupportedDevice"
+        );
+
+        close_object(invalid_name).expect("object should close");
+        close_object(unsupported_dtype).expect("object should close");
+        close_object(unsupported_device).expect("object should close");
+    }
+
+    fn exporter(
+        device_type: i32,
+        device_id: i32,
+        dtype: DLDataType,
+        capsule_name: &'static CStr,
+    ) -> Result<ObjectHandle, PythonError> {
+        super::super::attach(|py| {
+            let globals = PyDict::new(py);
+            globals
+                .set_item(
+                    "CAPSULE",
+                    capsule(py, device_type, device_id, dtype, capsule_name)?.bind(py),
+                )
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test capsule"))?;
+            globals
+                .set_item("DEVICE_TYPE", device_type)
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "device type"))?;
+            globals
+                .set_item("DEVICE_ID", device_id)
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "device id"))?;
+            py.run(
+                cr#"
+class DlpackExporter:
+    def __dlpack_device__(self):
+        return (DEVICE_TYPE, DEVICE_ID)
+
+    def __dlpack__(self):
+        return CAPSULE
+
+obj = DlpackExporter()
+"#,
+                Some(&globals),
+                None,
+            )
+            .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test exporter"))?;
+            let object = globals
+                .get_item("obj")
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test exporter"))?
+                .ok_or_else(|| dlpack_error("test exporter did not create obj"))?;
+            super::super::object_ops::store_object(object.unbind())
+        })
+        .map_err(PythonError::runtime)?
+    }
+
+    fn scalar_exporter() -> Result<ObjectHandle, PythonError> {
+        super::super::attach(|py| {
+            let globals = PyDict::new(py);
+            globals
+                .set_item("CAPSULE", scalar_capsule(py)?.bind(py))
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test capsule"))?;
+            py.run(
+                cr#"
+class DlpackExporter:
+    def __dlpack_device__(self):
+        return (1, 0)
+
+    def __dlpack__(self):
+        return CAPSULE
+
+obj = DlpackExporter()
+"#,
+                Some(&globals),
+                None,
+            )
+            .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test exporter"))?;
+            let object = globals
+                .get_item("obj")
+                .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test exporter"))?
+                .ok_or_else(|| dlpack_error("test exporter did not create obj"))?;
+            super::super::object_ops::store_object(object.unbind())
+        })
+        .map_err(PythonError::runtime)?
+    }
+
+    fn capsule(
+        py: Python<'_>,
+        device_type: i32,
+        device_id: i32,
+        dtype: DLDataType,
+        capsule_name: &'static CStr,
+    ) -> Result<Py<PyAny>, PythonError> {
+        let mut owned = Box::new(TestManagedTensor {
+            managed: DLManagedTensor {
+                dl_tensor: DLTensor {
+                    data: std::ptr::null_mut(),
+                    device: DLDevice {
+                        device_type,
+                        device_id,
+                    },
+                    ndim: 2,
+                    dtype,
+                    shape: std::ptr::null_mut(),
+                    strides: std::ptr::null_mut(),
+                    byte_offset: 0,
+                },
+                manager_ctx: std::ptr::null_mut(),
+                deleter: Some(test_deleter),
+            },
+            shape: vec![2, 3],
+            strides: vec![3, 1],
+            data: vec![0; 6],
+        });
+        owned.managed.dl_tensor.data = owned.data.as_mut_ptr().cast::<c_void>();
+        owned.managed.dl_tensor.shape = owned.shape.as_mut_ptr();
+        owned.managed.dl_tensor.strides = owned.strides.as_mut_ptr();
+        let pointer = std::ptr::NonNull::new(Box::into_raw(owned).cast::<c_void>())
+            .ok_or_else(|| dlpack_error("test tensor pointer was null"))?;
+        let capsule = unsafe {
+            PyCapsule::new_with_pointer_and_destructor(
+                py,
+                pointer,
+                capsule_name,
+                Some(test_capsule_destructor),
+            )
+        }
+        .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test capsule"))?;
+        Ok(capsule.into_any().unbind())
+    }
+
+    fn scalar_capsule(py: Python<'_>) -> Result<Py<PyAny>, PythonError> {
+        let mut owned = Box::new(TestManagedTensor {
+            managed: DLManagedTensor {
+                dl_tensor: DLTensor {
+                    data: std::ptr::null_mut(),
+                    device: DLDevice {
+                        device_type: DEVICE_CPU,
+                        device_id: 0,
+                    },
+                    ndim: 0,
+                    dtype: dtype(2, 32, 1),
+                    shape: std::ptr::null_mut(),
+                    strides: std::ptr::null_mut(),
+                    byte_offset: 0,
+                },
+                manager_ctx: std::ptr::null_mut(),
+                deleter: Some(test_deleter),
+            },
+            shape: Vec::new(),
+            strides: Vec::new(),
+            data: vec![0; 1],
+        });
+        owned.managed.dl_tensor.data = owned.data.as_mut_ptr().cast::<c_void>();
+        let pointer = std::ptr::NonNull::new(Box::into_raw(owned).cast::<c_void>())
+            .ok_or_else(|| dlpack_error("test tensor pointer was null"))?;
+        let capsule = unsafe {
+            PyCapsule::new_with_pointer_and_destructor(
+                py,
+                pointer,
+                DLTENSOR_NAME,
+                Some(test_capsule_destructor),
+            )
+        }
+        .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "test capsule"))?;
+        Ok(capsule.into_any().unbind())
+    }
+
+    const fn dtype(code: u8, bits: u8, lanes: u16) -> DLDataType {
+        DLDataType { code, bits, lanes }
+    }
+
+    unsafe extern "C" fn test_capsule_destructor(capsule: *mut ffi::PyObject) {
+        let name = unsafe { ffi::PyCapsule_GetName(capsule) };
+        if name.is_null() {
+            return;
+        }
+        let name = unsafe { CStr::from_ptr(name) };
+        if name != DLTENSOR_NAME {
+            return;
+        }
+        let pointer = unsafe { ffi::PyCapsule_GetPointer(capsule, DLTENSOR_NAME.as_ptr()) };
+        if !pointer.is_null() {
+            unsafe { test_deleter(pointer.cast::<DLManagedTensor>()) };
+        }
+    }
+
+    unsafe extern "C" fn test_deleter(tensor: *mut DLManagedTensor) {
+        TEST_DELETER_CALLS.fetch_add(1, Ordering::SeqCst);
+        if !tensor.is_null() {
+            let _owned = unsafe { Box::from_raw(tensor.cast::<TestManagedTensor>()) };
+        }
+    }
+}

--- a/crates/sifr_stdlib/src/python.rs
+++ b/crates/sifr_stdlib/src/python.rs
@@ -158,6 +158,41 @@ pub(super) fn intrinsic_python() -> IntrinsicModule {
         ),
     );
     functions.insert(
+        "py_dlpack_tensor".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::Tuple(vec![
+                Type::Int,
+                Type::Int,
+                Type::Int,
+                Type::Int,
+                Type::Int,
+                Type::Str,
+                Type::Int,
+                Type::Int,
+                Type::Int,
+                Type::List(Box::new(Type::Int)),
+                Type::List(Box::new(Type::Int)),
+                Type::Int,
+                Type::Bool,
+                Type::Bool,
+            ])),
+        ),
+    );
+    functions.insert(
+        "py_release_dlpack".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("token".to_string(), Type::Int),
+            ],
+            python_error_result(Type::None),
+        ),
+    );
+    functions.insert(
         "py_enter_context".to_string(),
         FunctionType::all_borrow(
             vec![

--- a/lib/sifr/python.sifr
+++ b/lib/sifr/python.sifr
@@ -32,6 +32,7 @@ from _sifr.python import (
     py_copy_tuple_int,
     py_copy_tuple_str,
     py_copy_tuple_u8,
+    py_dlpack_tensor,
     py_enter_context,
     py_exit_context,
     py_exit_context_with_error,
@@ -51,6 +52,7 @@ from _sifr.python import (
     py_resource_diagnostics,
     py_release_arrow,
     py_release_buffer,
+    py_release_dlpack,
     py_run_coroutine_blocking,
     py_to_bool,
     py_to_bytes,
@@ -161,6 +163,39 @@ class ArrowCapsule(NonSend):
         self.copy_possible = True
 
 
+class DlpackTensor(NonSend):
+    _handle: int
+    _token: int
+    dtype_code: int
+    dtype_bits: int
+    dtype_lanes: int
+    dtype: str
+    device_type: int
+    device_id: int
+    dimensions: int
+    shape: list[int]
+    strides: list[int]
+    byte_offset: int
+    has_deleter: bool
+    stream_sync_required: bool
+
+    def __init__(self):
+        self._handle = -1
+        self._token = 0
+        self.dtype_code = 0
+        self.dtype_bits = 0
+        self.dtype_lanes = 0
+        self.dtype = ""
+        self.device_type = 0
+        self.device_id = 0
+        self.dimensions = 0
+        self.shape = []
+        self.strides = []
+        self.byte_offset = 0
+        self.has_deleter = False
+        self.stream_sync_required = True
+
+
 def _object_from_handle(raw: tuple[int, int]) -> Object:
     obj: Object = Object()
     obj._handle = raw[0]
@@ -206,6 +241,25 @@ def _arrow_from_raw(raw: tuple[int, int, str, list[str], str, str, bool]) -> Arr
     capsule.producer_type = raw[5]
     capsule.copy_possible = raw[6]
     return capsule
+
+
+def _dlpack_from_raw(raw: tuple[int, int, int, int, int, str, int, int, int, list[int], list[int], int, bool, bool]) -> DlpackTensor:
+    tensor: DlpackTensor = DlpackTensor()
+    tensor._handle = raw[0]
+    tensor._token = raw[1]
+    tensor.dtype_code = raw[2]
+    tensor.dtype_bits = raw[3]
+    tensor.dtype_lanes = raw[4]
+    tensor.dtype = raw[5]
+    tensor.device_type = raw[6]
+    tensor.device_id = raw[7]
+    tensor.dimensions = raw[8]
+    tensor.shape = raw[9]
+    tensor.strides = raw[10]
+    tensor.byte_offset = raw[11]
+    tensor.has_deleter = raw[12]
+    tensor.stream_sync_required = raw[13]
+    return tensor
 
 
 def _record_fields_from_handles(raw_values: list[tuple[str, tuple[int, int]]]) -> list[tuple[str, Object]]:
@@ -412,6 +466,23 @@ def zero_copy_arrow_schema(obj: Object) -> Result[ArrowCapsule, PythonError]:
         return _arrow_from_raw(raw)
     except PythonError as e:
         raise e
+
+
+@blocking_io
+def zero_copy_dlpack_tensor(obj: Object) -> Result[DlpackTensor, PythonError]:
+    try:
+        raw: tuple[int, int, int, int, int, str, int, int, int, list[int], list[int], int, bool, bool] = py_dlpack_tensor(
+            obj._handle,
+            obj._token,
+        )
+        return _dlpack_from_raw(raw)
+    except PythonError as e:
+        raise e
+
+
+@blocking_io
+def release_dlpack(own tensor: DlpackTensor) -> Result[None, PythonError]:
+    return py_release_dlpack(tensor._handle, tensor._token)
 
 
 @blocking_io

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -69,7 +69,12 @@
   - Added numpy-buffer contract/source fixtures covering readonly bytes, memoryview, explicit copy, wrong dtype, writable-on-readonly, and use-after-release behavior.
   - Opus review round 2 reported no blockers; local `create-pr` validation passed with only a warm wall-time advisory.
   - Merged via PR [#2672](https://github.com/sifr-lang/sifr/pull/2672).
-- [ ] `milestone_py_8`: Arrow PyCapsule interop.
+- [x] `milestone_py_8`: Arrow PyCapsule interop.
+  - Added `py.ArrowCapsule` export, zero-copy-proof, copy-possible, and deterministic release helpers for Arrow array, stream, and schema PyCapsules.
+  - Added runtime validation for exact Arrow capsule names, PyCapsule destructors, malformed capsules, destructor-less capsules, and double release.
+  - Added pyarrow capsule contract/source fixtures covering pyarrow, polars, pandas, Pillow, unknown producer, malformed capsule, and copy-possible behavior.
+  - Opus review round 3 reported no blockers; local `create-pr` validation passed with only a warm wall-time advisory.
+  - Merged via PR [#2673](https://github.com/sifr-lang/sifr/pull/2673).
 - [ ] `milestone_py_9`: DLPack tensor interop.
 - [ ] `milestone_py_10`: Python-to-Sifr callbacks.
 - [ ] `milestone_py_11`: Package certification matrix.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py9-review-1.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py9-review-1.md
@@ -1,0 +1,44 @@
+I've reviewed the changes. Here are my findings.
+
+## Blockers
+
+**B1. Latent UB in `metadata_for_tensor` for 0-dim tensors with `shape == NULL`** — `crates/sifr_runtime/src/python/dlpack_ops.rs:219-222`
+
+```rust
+if dl_tensor.shape.is_null() && len > 0 {
+    return Err(dlpack_error("DLPack tensor shape pointer is null"));
+}
+let shape = unsafe { slice_to_vec(dl_tensor.shape, len) };
+```
+
+When a producer hands us a 0-dim tensor with `ndim == 0` and `shape == NULL`, the guard does not fire (because `len > 0` is false), and we call `slice_to_vec(NULL, 0)` → `slice::from_raw_parts(NULL, 0)`. Per the documented safety contract of `slice::from_raw_parts`, `data must be non-null and aligned even for zero-length slices`. The DLPack spec permits `shape == NULL` for scalar tensors, so a spec-compliant producer can trigger this.
+
+This conflicts with the milestone's "no user-triggerable runtime panics/crashes in Sifr-attributable paths" invariant (UB is strictly worse than a panic). The strides branch already handles `is_null() → Vec::new()` correctly; shape should mirror that — e.g.
+
+```rust
+let shape = if dl_tensor.shape.is_null() {
+    Vec::new()
+} else {
+    unsafe { slice_to_vec(dl_tensor.shape, len) }
+};
+```
+
+Real-world torch/numpy/tensorflow scalars don't currently set `shape == NULL` so this likely won't manifest in the listed positive fixtures, but it's a latent soundness hole on the DLPack import path and the fix is trivial.
+
+## Non-blocking suggestions
+
+**N1. Redundant negative-ndim check** — `dlpack_ops.rs:211-216`. `checked_i64_i32` already returns an error for `value < 0`, so the subsequent `if dl_tensor.ndim < 0 { ... }` is unreachable. Either remove the second check or replace `checked_i64_i32` with `i64::from(dl_tensor.ndim)` and keep the explicit message.
+
+**N2. Empty review placeholder** — `plans/reviews/active/ad-hoc-embedded-python-interop-py9-review-1.md` is 0 bytes. If this is meant to capture this review, it should be populated; if it was created by accident, it should be removed before merge.
+
+**N3. Sifr fixtures are type-check only** — `dlpack_tensor_roundtrip.sifr` and `dlpack_tensor_device_failure.sifr` both invoke `zero_copy_dlpack_tensor(from_none())`. `None` has no `__dlpack__`, so these can't exercise the export path at runtime — the contract's positive cases (`numpy_cpu_tensor_supported_dtype`, `torch_cpu_tensor_supported_dtype`, `tensorflow_cpu_tensor_supported_dtype`) and the `sync_required_device_rejected_in_zero_copy_helper` negative case live only in `dlpack_tensor_contract.json` as scaffolding. Runtime coverage for CPU dtypes, double-consume, invalid capsule name, unsupported dtype, and unsupported device is in `dlpack_ops.rs` Rust tests. This matches the py7/py8 pattern, but the gap between the contract document and what's actually executed is worth flagging — the package-certification gates (milestone_py_11) will need real numpy/torch/tf fixtures to discharge these claims.
+
+**N4. Drop-without-GIL on `attach` failure** — `dlpack_ops.rs:135` (and identically in `arrow_ops.rs`, `buffer_ops.rs`). `release_dlpack` captures `entry` into `super::attach(|_py| drop(entry))`. If `attach` returns `NotInitialized` before invoking the closure, the captured `entry` is dropped here without the GIL, which runs `TrackedDlpackTensor::drop` → calls `deleter(tensor)` and drops `Py<PyAny>` for `_owner` / `_capsule` without the GIL attached. This is the same shape as the accepted py8 pattern, but py9 inherits it. Realistically unreachable (you wouldn't be releasing a tensor with no runtime), but if it ever fires it is unsafe. Acceptable for this milestone if explicitly inherited.
+
+**N5. `stream_sync_required` is dead for accepted tensors** — `dlpack_ops.rs:245`. Since non-CPU devices are rejected upstream at line 110, the value is always `false` in returned metadata. The field is still useful as part of the data contract for when device support arrives, but the negative fixture name `sync_required_device_rejected_in_zero_copy_helper` is currently indistinguishable from `unsupported_device_rejected` — both produce `SifrPythonDlpackUnsupportedDevice`. Worth a comment in the contract JSON or a TODO in the phase doc clarifying that these collapse into the same path until device tensors are wired in.
+
+**N6. Double-consume semantics depend on the producer** — `dlpack_ops.rs:147-162`. The rename to `used_dltensor` enforces one-shot consumption *of a given capsule*, which is exactly what the DLPack spec mandates. Real producers (torch/numpy) mint a fresh capsule per `__dlpack__()` call, so calling `obj.__dlpack__()` twice will succeed twice — and that is correct DLPack behavior. The Rust test asserts the per-capsule property correctly via a producer that returns the same global capsule each call. Not a defect, just worth keeping in mind when authoring the eventual torch/numpy fixtures so they don't accidentally expect double-call-on-the-same-producer to be rejected.
+
+---
+
+reviewer not satisfied: 1 blocker (B1).

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py9-review-2.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py9-review-2.md
@@ -1,0 +1,41 @@
+## Review Summary
+
+**Round 1 blocker (B1) verified resolved.**
+
+The UB at `slice::from_raw_parts(NULL, 0)` for 0-dim DLPack tensors is gone. At `dlpack_ops.rs:215-227`:
+
+```rust
+if dl_tensor.shape.is_null() && len > 0 {
+    return Err(dlpack_error("DLPack tensor shape pointer is null"));
+}
+let shape = if dl_tensor.shape.is_null() {
+    Vec::new()
+} else {
+    unsafe { slice_to_vec(dl_tensor.shape, len) }
+};
+let strides = if dl_tensor.strides.is_null() {
+    Vec::new()
+} else {
+    unsafe { slice_to_vec(dl_tensor.shape, len)... }
+};
+```
+
+The NULL-with-len>0 error path is preserved; NULL-with-len==0 takes the safe `Vec::new()` branch and never dereferences. The new test `dlpack_scalar_tensor_allows_null_shape_pointer` at `dlpack_ops.rs:455-471` exercises exactly this path with `ndim: 0, shape: null_mut(), strides: null_mut()` and asserts `dimensions == 0` and empty shape/strides, then releases successfully (deleter count goes to 1).
+
+**Other listed fixes verified:**
+
+- **N1 (redundant negative-ndim check)** — removed at `dlpack_ops.rs:212-214`. `checked_i64_i32` handles negatives; the follow-up `usize::try_from` is now the only width-narrowing check (defensive but cheap).
+- **N4 (drop-without-GIL on attach failure)** — `release_dlpack` (lines 122-138) now performs the `store.tensors.remove(&handle)` and `drop(entry)` *inside* the `super::attach(|_py| { ... })` closure. If attach fails, the closure never runs, the entry stays in the store, and no `TrackedDlpackTensor::drop` runs without the GIL. The closure has no Python-object captures.
+
+**Lifecycle re-checked:**
+
+- `metadata_for_tensor` validates `tensor.is_null()` (line 207) before any deref. The downstream `unsafe { (*tensor).deleter }` at `consume_capsule:167` is unreachable when `tensor` is null because `metadata_for_tensor` errors out first.
+- Drop order in `TrackedDlpackTensor`: explicit `Drop::drop` calls deleter first (with GIL via attach), then fields drop in declaration order — `_owner: Py<PyAny>`, `_capsule: Py<PyAny>` — also with GIL held. Capsule rename to `used_dltensor` means the producer's destructor won't double-call the deleter when the capsule's refcount eventually hits zero.
+- `store_tensor` increments `update_object_count(1)` exactly once on successful insert; `TrackedDlpackTensor::drop` decrements by 1. Balanced.
+
+**Non-blocking observations (carried forward, not regressions):**
+
+- Sifr fixtures (`dlpack_tensor_roundtrip.sifr`, `dlpack_tensor_device_failure.sifr`) still pass `from_none()` and exercise no real exporter — runtime coverage lives in the Rust tests; the contract's numpy/torch/tf rows are scaffolding for milestone_py_11. Same as round 1 N3.
+- `sync_required_device_rejected_in_zero_copy_helper` and `unsupported_device_rejected` collapse to the same path/exception. Same as round 1 N5.
+
+reviewer satisfied: no blockers

--- a/verification/python_interop/fixtures/torch_dlpack/dlpack_tensor_contract.json
+++ b/verification/python_interop/fixtures/torch_dlpack/dlpack_tensor_contract.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "case_group": "python_dlpack_tensor_interop",
+  "surface": "sifr.python",
+  "positive_cases": [
+    {
+      "name": "numpy_cpu_tensor_supported_dtype",
+      "operations": ["zero_copy_dlpack_tensor", "release_dlpack"],
+      "expected_device_type": 1,
+      "expected_stream_sync_required": false,
+      "expected_metadata": ["dtype", "shape", "strides", "byte_offset", "has_deleter"]
+    },
+    {
+      "name": "torch_cpu_tensor_supported_dtype",
+      "operations": ["zero_copy_dlpack_tensor", "release_dlpack"],
+      "expected_device_type": 1,
+      "expected_stream_sync_required": false
+    },
+    {
+      "name": "tensorflow_cpu_tensor_supported_dtype",
+      "operations": ["zero_copy_dlpack_tensor", "release_dlpack"],
+      "expected_device_type": 1,
+      "expected_stream_sync_required": false
+    }
+  ],
+  "negative_cases": [
+    {
+      "name": "double_consumption_rejected",
+      "operation": "zero_copy_dlpack_tensor",
+      "expected_error_kind": "zero-copy",
+      "expected_exception_type": "SifrPythonDlpackError"
+    },
+    {
+      "name": "double_release_rejected",
+      "operation": "release_dlpack",
+      "expected_error_kind": "resource",
+      "expected_exception_type": "SifrPythonClosedDlpackTensor"
+    },
+    {
+      "name": "unsupported_dtype_rejected",
+      "operation": "zero_copy_dlpack_tensor",
+      "expected_error_kind": "zero-copy",
+      "expected_exception_type": "SifrPythonDlpackUnsupportedDtype"
+    },
+    {
+      "name": "unsupported_device_rejected",
+      "operation": "zero_copy_dlpack_tensor",
+      "expected_error_kind": "zero-copy",
+      "expected_exception_type": "SifrPythonDlpackUnsupportedDevice"
+    },
+    {
+      "name": "invalid_capsule_name_rejected",
+      "operation": "zero_copy_dlpack_tensor",
+      "expected_error_kind": "zero-copy",
+      "expected_exception_type": "SifrPythonDlpackError"
+    },
+    {
+      "name": "sync_required_device_rejected_in_zero_copy_helper",
+      "operation": "zero_copy_dlpack_tensor",
+      "expected_error_kind": "zero-copy",
+      "expected_exception_type": "SifrPythonDlpackUnsupportedDevice"
+    }
+  ]
+}

--- a/verification/python_interop/fixtures/torch_dlpack/dlpack_tensor_device_failure.sifr
+++ b/verification/python_interop/fixtures/torch_dlpack/dlpack_tensor_device_failure.sifr
@@ -1,0 +1,18 @@
+from sifr.python import (
+    DlpackTensor,
+    Object,
+    PythonError,
+    from_none,
+    zero_copy_dlpack_tensor,
+)
+
+
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        obj: Object = from_none()
+        tensor: DlpackTensor = zero_copy_dlpack_tensor(obj)
+        requires_sync: bool = tensor.stream_sync_required
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/fixtures/torch_dlpack/dlpack_tensor_roundtrip.sifr
+++ b/verification/python_interop/fixtures/torch_dlpack/dlpack_tensor_roundtrip.sifr
@@ -1,0 +1,23 @@
+from sifr.python import (
+    DlpackTensor,
+    Object,
+    PythonError,
+    close,
+    from_none,
+    release_dlpack,
+    zero_copy_dlpack_tensor,
+)
+
+
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        obj: Object = from_none()
+        tensor: DlpackTensor = zero_copy_dlpack_tensor(obj)
+        dtype: str = tensor.dtype
+        dims: int = tensor.dimensions
+        released: None = release_dlpack(tensor)
+        closed: None = close(obj)
+        return None
+    except PythonError as e:
+        raise e

--- a/verification/python_interop/runner/run.py
+++ b/verification/python_interop/runner/run.py
@@ -58,6 +58,7 @@ REQUIRED_FIXTURE_FILES = (
     "async_blocking/async_blocking_contract.json",
     "numpy_buffer/py_buffer_contract.json",
     "pyarrow_capsule/arrow_capsule_contract.json",
+    "torch_dlpack/dlpack_tensor_contract.json",
     "resource_cleanup/context_manager_cleanup.json",
 )
 
@@ -73,6 +74,8 @@ REQUIRED_SOURCE_FIXTURES = (
     "pyarrow_capsule/arrow_capsule_copy_possible.sifr",
     "pyarrow_capsule/arrow_capsule_roundtrip.sifr",
     "pyarrow_capsule/arrow_capsule_zero_copy.sifr",
+    "torch_dlpack/dlpack_tensor_device_failure.sifr",
+    "torch_dlpack/dlpack_tensor_roundtrip.sifr",
     "resource_cleanup/context_manager_body_failure.sifr",
     "resource_cleanup/context_manager_failure.sifr",
     "resource_cleanup/context_manager_success.sifr",


### PR DESCRIPTION
## Summary
- add runtime DLPack capsule consumption with dltensor validation, used_dltensor one-shot marking, metadata extraction, and exact-once deleter release
- expose DlpackTensor through stdlib/codegen and sifr.python with dtype/device/shape/stride/offset/deleter/sync metadata
- add DLPack scaffold contract/source fixtures for CPU tensor positives and unsupported dtype/device/invalid capsule/double-consumption negatives
- record Opus py9 review rounds with reviewer satisfied: no blockers

## Validation
- cargo fmt --check
- cargo test -p sifr_runtime --features python python::dlpack_ops -- --nocapture
- cargo test -p sifr_codegen lowers_python_intrinsics_with_runtime_feature_metadata -- --nocapture
- verification/python_interop/run.sh --group scaffold
- cargo run -q -p sifr -- check verification/python_interop/fixtures/torch_dlpack/dlpack_tensor_roundtrip.sifr
- cargo run -q -p sifr -- check verification/python_interop/fixtures/torch_dlpack/dlpack_tensor_device_failure.sifr
- git diff --check
- python3 scripts/check_file_size_guardrails.py
- python3 verification/areas/coverage_matrix/checks/verification_taxonomy.py
- scripts/run_all_tests.sh --profile create-pr (passed; advisory: warm wall-time budget exceeded)

## Review
- plans/reviews/active/ad-hoc-embedded-python-interop-py9-review-1.md
- plans/reviews/active/ad-hoc-embedded-python-interop-py9-review-2.md
