### PR TITLE
Add Python package certification matrix

### DIFF
--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -87,7 +87,12 @@
   - Split shared Python wrapper types into `sifr.python_core` with targeted `sifr.python` re-export metadata preservation for blocking workloads and constructor defaults.
   - Added callback contract/source fixtures and native build coverage for real Sifr handler invocation through Python callables.
   - Opus review round 4 reported no blockers; local `create-pr` validation passed with only a warm wall-time advisory.
-- [ ] `milestone_py_11`: Package certification matrix.
+  - Merged via PR [#2675](https://github.com/sifr-lang/sifr/pull/2675).
+- [x] `milestone_py_11`: Package certification matrix.
+  - Expanded Tier 1 certification matrices, Tier 2/Tier 3 deterministic smoke matrices, and Tier 4 host-dependent skip evidence.
+  - Added deterministic package certification reports with `matrix-passed` status for matrix-only evidence and explicit host-dependent skip counts.
+  - Added representative package-family contract fixtures for web, data, DB, broker, cloud/AI, TLS/native, callbacks, and tensor surfaces.
+  - Opus review round 1 reported no blockers; local focused validation passed.
 - [ ] `milestone_py_12`: Documentation, diagnostics, and closeout.
 
 ## Objective
@@ -648,7 +653,7 @@ Packages already covered by Tier 1a may reappear here when they anchor a Tier 1b
 - HTTP/async/networking: `requests`, `urllib3`, `httpx`, `httpcore`, `aiohttp`, `anyio`, `async-timeout`, `sniffio`, `h11`, `httptools`, `websockets`, `uvicorn`, `uvloop`, `grpcio`.
 - Web frameworks: `fastapi`, `starlette`, `starlette-context`, `django`, `sanic`, `sanic-routing`, `sanic-testing`, `webargs`, `webargs-sanic`, `jinja2`, `markupsafe`, `python-multipart`.
 - Databases/queues/brokers: `sqlalchemy`, `sqlalchemy-utils`, `alembic`, `psycopg`, `psycopg2`, `psycopg2-binary`, `asyncpg`, `pymongo`, `motor`, `mongoengine`, `redis`, `fakeredis`, `hiredis`, `valkey`, `aiokafka`, `confluent-kafka`, `kafka-python`, `python-schema-registry-client`, `pika`, `moto`.
-- Cloud/AI clients: `boto3`, `botocore`, `openai`, `google-genai`, `google-api-core`, `google-api-python-client`, `google-auth`, `google-auth-httplib2`, `google-auth-oauthlib`, `google-cloud-core`, `google-cloud-storage`, `google-cloud-firestore`, `google-cloud-aiplatform`, `firebase-admin`, `kubernetes`, `pinecone-client`, `gspread`, `gspread-asyncio`.
+- Cloud/AI clients: `boto3`, `botocore`, `openai`, `google-genai`, `google-api-core`, `google-api-python-client`, `google-auth`, `google-auth-httplib2`, `google-auth-oauthlib`, `google-cloud-core`, `google-cloud-storage`, `google-cloud-firestore`, `google-cloud-aiplatform`, `google-cloud-pubsub`, `firebase-admin`, `kubernetes`, `pinecone-client`, `gspread`, `gspread-asyncio`.
 - Security/crypto/native loading: `cryptography`, `cffi`, `pycparser`, `certifi`, `idna`, `charset-normalizer`, `chardet`, `oauthlib`, `requests-oauthlib`, `python-jose`, `rsa`, `pyasn1`, `pyasn1-modules`.
 - Data/binary/parser: `pandas`, `pyarrow`, `openpyxl`, `lxml`, `bleach`, `defusedxml`, `nh3`, `regex`, `ujson`, `fastavro`, `avro`, `avro-python3`, `google-crc32c`, `tiktoken`, `Pillow`, `tensorflow`, `scikit-learn`.
 - Observability/production infra: `opentelemetry-api`, `opentelemetry-semantic-conventions`, `opentracing`, `sentry-sdk`, `sentry-asgi`, `datadog`, `structlog`, `logstash-formatter`.
@@ -909,6 +914,7 @@ Definition of done:
 - Tier 1 package certification is green in the full Python interop gate.
 - Tier 2/Tier 3 smoke gates are deterministic.
 - Host-dependent skips are explicit and reported.
+- Tier 1 packages that are host-dependent because of wheel or CPU feature availability must report explicit skip evidence in matrix-only gates and require live evidence in the full external gate.
 
 ### milestone_py_12: Documentation, Diagnostics, and Closeout
 

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py11-review-1.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py11-review-1.md
@@ -1,0 +1,37 @@
+I've reviewed the milestone_py_11 implementation against the phase contract. Below are findings ordered by severity.
+
+## Findings
+
+### Blockers
+None.
+
+### Non-blocking — worth flagging
+
+1. **`tensorflow` host-dependent skip lives in Tier 1b**
+   `verification/python_interop/packages/data.toml:16-23` marks `tensorflow` as Tier 1 + `host-dependent = true`, which is allowed by the validator (`runner/certification_matrix.py:51-52` only forbids Tier 2/3 host-dependence). It produces the single Tier 1 skip in the observed report. The phase contract DoD reads "Tier 1 package certification is green in the full Python interop gate", and the contract Tier 1b "Data/binary/parser" list includes tensorflow without a host-dependent caveat. Status today is technically "passed with explicit skip", which is defensible (wheel/AVX availability varies) but the contract should be updated to allow Tier 1 host-dependents explicitly, otherwise milestone_py_12 will reopen the policy question.
+
+2. **`status = "passed"` is identical for "matrix evidence assembled" vs. "packages actually loaded"**
+   `runner/run.py:144-150` and `report_status` return `"passed"` whenever a tier/gate/group/package selector is present, even though no import or smoke test runs. `summary.total_failures` and `package_certification.status` disambiguate per record, but the top-level field will read the same once live package gates exist. Consider a `"matrix-only"` / `"deterministic"` status now, or note explicitly in the report payload that this is matrix evidence, so milestone_py_12's live gate has a discriminator to flip.
+
+3. **`google-cloud-pubsub` is in cloud.toml but not in the phase contract Tier 1b list**
+   `verification/python_interop/packages/cloud.toml:64-69`. The fixture (`fixtures/pubsub/pubsub_contract.json`) and the phase's Pub/Sub-callback pattern motivate adding it, but it is a contract drift. Either add it to the phase contract's Tier 1b "Cloud/AI clients" enumeration or note the deliberate addition in the README/phase tracker.
+
+4. **`avro` and `avro-python3` collide on the `avro` import root**
+   `data.toml:79-90`. Deterministic matrix tracks both; the real environment can only install one. This is a phase-contract policy artefact (both names are in the phase list), not a runner bug, but the live gate will eventually need to choose one. Worth surfacing as a known eventual conflict.
+
+### Nits
+
+- `runner/certification_matrix.py:53-54` checks `entry.import_roots` is non-empty, but `runner/import_matrix.py:46-47` always backfills via `default_import_root`, so the assertion is dead under the parser. Either drop the check or comment it as defense-in-depth.
+- `verification/python_interop/packages/async.toml:2-6` contains `urllib3` (sync HTTP) — pure file-organization choice; doesn't affect behavior, but worth moving to a non-async file if you ever sort matrix files by category.
+- Phase contract notes "packages already covered by Tier 1a may reappear in Tier 1b when they anchor a category". The implementation enforces one canonical gate per package via `(name, tier)` dedup and validates the Tier 1a set exactly — fine in practice but does mean the contract's "may reappear" wording is now structurally impossible; consider tightening the contract.
+
+### Verified
+
+- Tier 1a set in `CORE_TIER1A_PACKAGES` (`certification_matrix.py:8-30`) matches the phase contract's 21-package list exactly.
+- Tier 1 variant count (149), Tier 2 (46), Tier 3 (39), Tier 4 (30) all align with the phase contract enumeration after cross-checking every package across the 9 matrix files.
+- Every host-dependent entry has a `skip_reason` and every Tier 4 entry is host-dependent (policy validator at `certification_matrix.py:44-54` and matrix data agree).
+- No implicit uv sync: `runner/run.py:138` runs `run_env_probe` only when `--group env` is selected; tier/gate/package selectors emit purely from disk data. Fixture JSON validation (`run.py:225-229`) is `json.loads`-only.
+- All 22 fixture JSON contracts are valid, reference packages present in the matrix, and declare `host_policy` (`fixtures/*/contract.json` reads match the `REQUIRED_FIXTURE_FILES` list and the matrix).
+- Negative self-tests (`run.py:280-327`) cover unknown filters, missing tier1 gate, gate on non-tier1, missing tier4 skip, and certified/skip-count drift.
+
+reviewer satisfied: no blockers

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py11-review-4.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py11-review-4.md
@@ -1,0 +1,21 @@
+I reviewed the milestone_py_11 diff against the six blocker axes you listed.
+
+## Blocker checks
+
+**Package certification matrix semantics** — `runner/certification_matrix.py:32-54` enforces all stated invariants: Tier 1a anchor set fixed at 21 (`CORE_TIER1A_PACKAGES` matches phase contract anchor list exactly), `native=true` requires the `native` group, `host_dependent` requires `skip_reason`, Tier 4 must be host-dependent, Tier 2/3 must not be, every entry must expose ≥1 import root. Negative self-tests in `run.py:280-326` exercise each. ✓
+
+**Report status/schema** — `report_status` (`run.py:260-272`) returns `matrix-passed` for tier/gate/group/package selectors without env probe, `passed` only with env evidence, `scaffold` otherwise — confirmed live: tier1/2/3/4 all read `matrix-passed`. `package_certification` block exposes `selected_packages`, `certified_packages`, `host_dependent_skips`, plus `tier_counts`/`gate_counts`/`group_counts` and a sorted `packages` array; `summary.skipped` now tracks host-dependent skips. ✓
+
+**Host-dependent skip policy** — Validator forbids Tier 2/3 host-dependence, requires it for Tier 4, and demands `skip_reason` whenever host-dependent. All 30 Tier 4 entries in `tier4.toml` declare skip-reason; `tensorflow` (`data.toml:16-22`) is the lone Tier 1 host-dependent and ships its skip-reason. ✓
+
+**Fixture coverage** — 15 new contract JSON fixtures land alongside existing ones; all 22 are wired into `REQUIRED_FIXTURE_FILES` (`run.py:43-77`) and json-parsed at every run. Every new fixture declares `schema_version`, `groups`, `packages`, `default_gate`, `host_policy`, and `cases`; package references all resolve in the matrix. ✓
+
+**Package/import-root metadata** — `PackageEntry` gains `import_roots` and `skip_reason` (`import_matrix.py:8-17`); `parse_entry` backfills via `default_import_root` (dashes→underscores). All explicit `import-roots` entries map correctly to actual dotted module paths (`google.cloud.pubsub`, `pydantic_core`, `Cython`, `PIL`, etc.). ✓
+
+**README / phase-contract drift** — README updated to document `matrix-passed`, the certification-record fields, and the tier4 filter. Plan adds `google-cloud-pubsub` to the Tier 1b cloud/AI list, adds the explicit "Tier 1 host-dependent → matrix-only skip + external live evidence" DoD line, and marks `milestone_py_11` complete. ✓
+
+## Validation
+
+`run.sh --self-test` ok. Tier reports match the cited numbers exactly: tier1 149/148/1, tier2 46/46/0, tier3 39/39/0, tier4 30/0/30.
+
+reviewer satisfied: no blockers

--- a/verification/python_interop/README.md
+++ b/verification/python_interop/README.md
@@ -11,14 +11,17 @@ The canonical entrypoint is:
 verification/python_interop/run.sh --group scaffold
 verification/python_interop/run.sh --group env
 verification/python_interop/run.sh --tier tier1
+verification/python_interop/run.sh --tier tier4
 verification/python_interop/run.sh --package pandas
 verification/python_interop/run.sh --self-test
 ```
 
-The scaffold group validates the checked-in matrix and fixture surface. The env
-group records live interpreter ABI evidence and validates checked-in positive
-probe fixtures plus concrete negative probe/selection cases. The runner must
-never invoke `uv sync` or install packages implicitly.
+The scaffold group validates the checked-in matrix and fixture surface. Tier,
+gate, and package filters emit deterministic package-certification evidence from
+the checked-in matrix and contracts. The env group records live interpreter ABI
+evidence and validates checked-in positive probe fixtures plus concrete negative
+probe/selection cases. The runner must never invoke `uv sync` or install
+packages implicitly.
 
 ## Groups
 
@@ -44,5 +47,14 @@ never invoke `uv sync` or install packages implicitly.
 
 Runner output is written to `reports/latest.json` by default. Reports use
 deterministic JSON with selected filters, matrix counts, fixture coverage, and
-scaffold status so interop evidence can be reviewed before implementation gates
-exist.
+package-certification status so interop evidence can be reviewed before live
+package execution gates exist.
+
+Package certification records include:
+
+- per-package tier, gate, group, native-extension, and host-dependency metadata;
+- deterministic pass records for Tier 1, Tier 2, and Tier 3 matrix contracts;
+- top-level `matrix-passed` status for matrix-only evidence, distinct from live
+  environment/package execution status;
+- explicit Tier 4 skip records with `skip_reason` for host-dependent packages;
+- aggregate tier, gate, pass, and skip counts.

--- a/verification/python_interop/fixtures/async_http/async_http_contract.json
+++ b/verification/python_interop/fixtures/async_http/async_http_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "async_http",
+  "groups": ["async", "web", "imports"],
+  "packages": ["httpx", "httpcore", "aiohttp", "anyio", "h11", "sniffio"],
+  "default_gate": "import_and_inprocess_smoke",
+  "host_policy": "no external network; loopback-only clients in live gates",
+  "cases": [
+    "httpx_client_imports_without_event_loop_takeover",
+    "aiohttp_client_session_imports_under_blocking_boundary",
+    "asyncio_coroutine_results_are_explicitly_blocked_or_offloaded"
+  ]
+}

--- a/verification/python_interop/fixtures/aws_sns/aws_sns_contract.json
+++ b/verification/python_interop/fixtures/aws_sns/aws_sns_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "aws_sns",
+  "groups": ["cloud", "brokers", "imports"],
+  "packages": ["boto3", "botocore", "moto"],
+  "default_gate": "stubbed_client_smoke",
+  "host_policy": "no live AWS credentials in default gate",
+  "cases": [
+    "sns_client_imports",
+    "botocore_stubber_publish_request",
+    "python_error_mapping_for_stubbed_failure"
+  ]
+}

--- a/verification/python_interop/fixtures/aws_sns_sqs_subscription/aws_sns_sqs_subscription_contract.json
+++ b/verification/python_interop/fixtures/aws_sns_sqs_subscription/aws_sns_sqs_subscription_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "aws_sns_sqs_subscription",
+  "groups": ["cloud", "brokers", "callbacks"],
+  "packages": ["boto3", "botocore", "moto"],
+  "default_gate": "stubbed_subscription_smoke",
+  "host_policy": "no live AWS credentials in default gate",
+  "cases": [
+    "sns_to_sqs_subscription_shape",
+    "sqs_receive_message_polling_shape",
+    "callback_progress_hook_scaffolded"
+  ]
+}

--- a/verification/python_interop/fixtures/aws_sqs/aws_sqs_contract.json
+++ b/verification/python_interop/fixtures/aws_sqs/aws_sqs_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "aws_sqs",
+  "groups": ["cloud", "brokers", "imports"],
+  "packages": ["boto3", "botocore", "moto"],
+  "default_gate": "stubbed_client_smoke",
+  "host_policy": "no live AWS credentials in default gate",
+  "cases": [
+    "sqs_client_imports",
+    "botocore_stubber_send_receive_delete",
+    "long_polling_timeout_is_blocking_io"
+  ]
+}

--- a/verification/python_interop/fixtures/cryptography_tls/cryptography_tls_contract.json
+++ b/verification/python_interop/fixtures/cryptography_tls/cryptography_tls_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "cryptography_tls",
+  "groups": ["native", "imports"],
+  "packages": ["cryptography", "cffi", "certifi"],
+  "default_gate": "native_import_and_object_smoke",
+  "host_policy": "no external certificate fetches in default gate",
+  "cases": [
+    "cryptography_native_extension_imports",
+    "cffi_backend_imports",
+    "certificate_object_creation_maps_errors"
+  ]
+}

--- a/verification/python_interop/fixtures/fastapi_app/fastapi_app_contract.json
+++ b/verification/python_interop/fixtures/fastapi_app/fastapi_app_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "fastapi_app",
+  "groups": ["web", "async", "imports"],
+  "packages": ["fastapi", "starlette", "pydantic", "uvicorn"],
+  "default_gate": "inprocess_app_smoke",
+  "host_policy": "no bound public sockets in default gate",
+  "cases": [
+    "fastapi_app_constructs",
+    "pydantic_request_model_constructs",
+    "asgi_call_shape_is_blocking_or_offloaded"
+  ]
+}

--- a/verification/python_interop/fixtures/kafka/kafka_contract.json
+++ b/verification/python_interop/fixtures/kafka/kafka_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "kafka",
+  "groups": ["brokers", "callbacks", "native"],
+  "packages": ["confluent-kafka", "aiokafka", "kafka-python"],
+  "default_gate": "import_and_callback_shape",
+  "host_policy": "broker-backed tests require external integration gate",
+  "cases": [
+    "confluent_kafka_native_imports",
+    "poll_callback_shape_uses_threadsafe_callback",
+    "aiokafka_imports_without_running_event_loop"
+  ]
+}

--- a/verification/python_interop/fixtures/pandas_arrow/pandas_arrow_contract.json
+++ b/verification/python_interop/fixtures/pandas_arrow/pandas_arrow_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "pandas_arrow",
+  "groups": ["dataframes", "arrow", "native"],
+  "packages": ["pandas", "pyarrow", "numpy"],
+  "default_gate": "dataframe_arrow_smoke",
+  "host_policy": "CPU-only local dataframes in default gate",
+  "cases": [
+    "pandas_dataframe_imports",
+    "arrow_table_export_shape",
+    "copy_possible_paths_are_reported"
+  ]
+}

--- a/verification/python_interop/fixtures/polars_arrow/polars_arrow_contract.json
+++ b/verification/python_interop/fixtures/polars_arrow/polars_arrow_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "polars_arrow",
+  "groups": ["dataframes", "arrow", "native"],
+  "packages": ["polars", "pyarrow"],
+  "default_gate": "dataframe_arrow_smoke",
+  "host_policy": "CPU-only local dataframes in default gate",
+  "cases": [
+    "polars_dataframe_imports",
+    "arrow_capsule_export_shape",
+    "zero_copy_claim_requires_capsule_metadata"
+  ]
+}

--- a/verification/python_interop/fixtures/pubsub/pubsub_contract.json
+++ b/verification/python_interop/fixtures/pubsub/pubsub_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "pubsub",
+  "groups": ["cloud", "brokers", "callbacks"],
+  "packages": ["google-api-core", "google-cloud-pubsub", "google-auth"],
+  "default_gate": "import_and_callback_shape",
+  "host_policy": "live Pub/Sub requires external integration gate",
+  "cases": [
+    "google_client_imports",
+    "subscriber_callback_shape_uses_threadsafe_callback",
+    "credential_failure_maps_to_python_error"
+  ]
+}

--- a/verification/python_interop/fixtures/pydantic_models/pydantic_models_contract.json
+++ b/verification/python_interop/fixtures/pydantic_models/pydantic_models_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "pydantic_models",
+  "groups": ["imports"],
+  "packages": ["pydantic", "pydantic-core", "annotated-types"],
+  "default_gate": "model_validation_smoke",
+  "host_policy": "pure in-process validation only",
+  "cases": [
+    "model_constructs",
+    "validation_error_maps_to_python_error",
+    "pydantic_core_native_extension_imports"
+  ]
+}

--- a/verification/python_interop/fixtures/redis/redis_contract.json
+++ b/verification/python_interop/fixtures/redis/redis_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "redis",
+  "groups": ["databases", "imports"],
+  "packages": ["redis", "fakeredis", "hiredis"],
+  "default_gate": "inprocess_fake_service_smoke",
+  "host_policy": "live Redis requires external integration gate",
+  "cases": [
+    "redis_client_imports",
+    "fakeredis_roundtrip_shape",
+    "hiredis_native_import_is_trusted"
+  ]
+}

--- a/verification/python_interop/fixtures/sqlalchemy_psycopg/sqlalchemy_psycopg_contract.json
+++ b/verification/python_interop/fixtures/sqlalchemy_psycopg/sqlalchemy_psycopg_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "sqlalchemy_psycopg",
+  "groups": ["databases", "imports"],
+  "packages": ["sqlalchemy", "psycopg", "alembic"],
+  "default_gate": "dialect_import_smoke",
+  "host_policy": "live Postgres requires external integration gate",
+  "cases": [
+    "sqlalchemy_engine_imports",
+    "psycopg_driver_imports",
+    "connection_failure_maps_to_python_error"
+  ]
+}

--- a/verification/python_interop/fixtures/tensorflow_dlpack/tensorflow_dlpack_contract.json
+++ b/verification/python_interop/fixtures/tensorflow_dlpack/tensorflow_dlpack_contract.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "fixture": "tensorflow_dlpack",
+  "groups": ["tensors", "dlpack", "native"],
+  "packages": ["tensorflow", "numpy"],
+  "default_gate": "host_dependent_tensor_smoke",
+  "host_policy": "TensorFlow wheel availability is host dependent; CPU-only evidence accepted",
+  "cases": [
+    "tensorflow_import_is_host_dependent",
+    "cpu_tensor_dlpack_shape",
+    "unsupported_device_is_reported"
+  ]
+}

--- a/verification/python_interop/packages/async.toml
+++ b/verification/python_interop/packages/async.toml
@@ -1,14 +1,64 @@
 [[packages]]
+name = "urllib3"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
 name = "aiohttp"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "async", "web"]
 
 [[packages]]
+name = "httpcore"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async"]
+
+[[packages]]
 name = "anyio"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "async"]
+
+[[packages]]
+name = "async-timeout"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async"]
+import-roots = ["async_timeout"]
+
+[[packages]]
+name = "sniffio"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async"]
+
+[[packages]]
+name = "h11"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async"]
+
+[[packages]]
+name = "httptools"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native", "async", "web"]
+native = true
+
+[[packages]]
+name = "websockets"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async", "web"]
+
+[[packages]]
+name = "uvicorn"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async", "web"]
 
 [[packages]]
 name = "uvloop"
@@ -28,3 +78,69 @@ name = "starlette"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "async", "web"]
+
+[[packages]]
+name = "starlette-context"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async", "web"]
+import-roots = ["starlette_context"]
+
+[[packages]]
+name = "django"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "web"]
+
+[[packages]]
+name = "sanic"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async", "web"]
+
+[[packages]]
+name = "sanic-routing"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async", "web"]
+import-roots = ["sanic_routing"]
+
+[[packages]]
+name = "sanic-testing"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async", "web"]
+import-roots = ["sanic_testing"]
+
+[[packages]]
+name = "webargs"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "web"]
+
+[[packages]]
+name = "webargs-sanic"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async", "web"]
+import-roots = ["webargs_sanic"]
+
+[[packages]]
+name = "jinja2"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "web"]
+
+[[packages]]
+name = "markupsafe"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native", "web"]
+native = true
+
+[[packages]]
+name = "python-multipart"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "web"]
+import-roots = ["multipart"]

--- a/verification/python_interop/packages/brokers.toml
+++ b/verification/python_interop/packages/brokers.toml
@@ -1,4 +1,77 @@
 [[packages]]
+name = "sqlalchemy-utils"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "databases"]
+import-roots = ["sqlalchemy_utils"]
+
+[[packages]]
+name = "alembic"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "databases"]
+
+[[packages]]
+name = "psycopg2"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native", "databases"]
+native = true
+
+[[packages]]
+name = "psycopg2-binary"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native", "databases"]
+native = true
+import-roots = ["psycopg2"]
+
+[[packages]]
+name = "asyncpg"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native", "async", "databases"]
+native = true
+
+[[packages]]
+name = "pymongo"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native", "databases"]
+native = true
+
+[[packages]]
+name = "motor"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async", "databases"]
+
+[[packages]]
+name = "mongoengine"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "databases"]
+
+[[packages]]
+name = "fakeredis"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "databases"]
+
+[[packages]]
+name = "hiredis"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native", "databases"]
+native = true
+
+[[packages]]
+name = "valkey"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "databases"]
+
+[[packages]]
 name = "aiokafka"
 tier = "tier1"
 gate = "tier1b"
@@ -9,12 +82,14 @@ name = "kafka-python"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "brokers"]
+import-roots = ["kafka"]
 
 [[packages]]
 name = "python-schema-registry-client"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "brokers"]
+import-roots = ["schema_registry"]
 
 [[packages]]
 name = "pika"

--- a/verification/python_interop/packages/cloud.toml
+++ b/verification/python_interop/packages/cloud.toml
@@ -3,33 +3,153 @@ name = "google-api-core"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "cloud"]
+import-roots = ["google.api_core"]
 
 [[packages]]
 name = "google-api-python-client"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "cloud"]
+import-roots = ["googleapiclient"]
 
 [[packages]]
 name = "google-auth"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "cloud"]
+import-roots = ["google.auth"]
+
+[[packages]]
+name = "google-auth-httplib2"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "cloud"]
+import-roots = ["google_auth_httplib2"]
+
+[[packages]]
+name = "google-auth-oauthlib"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "cloud"]
+import-roots = ["google_auth_oauthlib"]
+
+[[packages]]
+name = "google-cloud-core"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "cloud"]
+import-roots = ["google.cloud"]
 
 [[packages]]
 name = "google-cloud-storage"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "cloud"]
+import-roots = ["google.cloud.storage"]
 
 [[packages]]
 name = "google-cloud-firestore"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "cloud"]
+import-roots = ["google.cloud.firestore"]
+
+[[packages]]
+name = "google-cloud-aiplatform"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "cloud"]
+import-roots = ["google.cloud.aiplatform"]
+
+[[packages]]
+name = "google-cloud-pubsub"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "cloud", "brokers", "callbacks"]
+import-roots = ["google.cloud.pubsub"]
+
+[[packages]]
+name = "firebase-admin"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "cloud"]
+import-roots = ["firebase_admin"]
 
 [[packages]]
 name = "kubernetes"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "cloud"]
+
+[[packages]]
+name = "pinecone-client"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "cloud"]
+import-roots = ["pinecone"]
+
+[[packages]]
+name = "gspread"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "cloud"]
+
+[[packages]]
+name = "gspread-asyncio"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "async", "cloud"]
+import-roots = ["gspread_asyncio"]
+
+[[packages]]
+name = "opentelemetry-api"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["opentelemetry"]
+
+[[packages]]
+name = "opentelemetry-semantic-conventions"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["opentelemetry.semconv"]
+
+[[packages]]
+name = "opentracing"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "sentry-sdk"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["sentry_sdk"]
+
+[[packages]]
+name = "sentry-asgi"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "web"]
+import-roots = ["sentry_asgi"]
+
+[[packages]]
+name = "datadog"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "structlog"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "logstash-formatter"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["logstash_formatter"]

--- a/verification/python_interop/packages/data.toml
+++ b/verification/python_interop/packages/data.toml
@@ -10,6 +10,7 @@ tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "native", "buffers", "arrow"]
 native = true
+import-roots = ["PIL"]
 
 [[packages]]
 name = "tensorflow"
@@ -18,6 +19,7 @@ gate = "tier1b"
 groups = ["imports", "native", "dlpack", "tensors"]
 native = true
 host-dependent = true
+skip-reason = "TensorFlow wheel availability and CPU feature requirements vary by host"
 
 [[packages]]
 name = "scikit-learn"
@@ -25,9 +27,78 @@ tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "native"]
 native = true
+import-roots = ["sklearn"]
+
+[[packages]]
+name = "lxml"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native"]
+native = true
+
+[[packages]]
+name = "bleach"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "defusedxml"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "nh3"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native"]
+native = true
+
+[[packages]]
+name = "regex"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native"]
+native = true
+
+[[packages]]
+name = "ujson"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native"]
+native = true
 
 [[packages]]
 name = "fastavro"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native"]
+native = true
+
+[[packages]]
+name = "avro"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "avro-python3"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["avro"]
+
+[[packages]]
+name = "google-crc32c"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports", "native", "cloud"]
+native = true
+import-roots = ["google_crc32c"]
+
+[[packages]]
+name = "tiktoken"
 tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "native"]

--- a/verification/python_interop/packages/native.toml
+++ b/verification/python_interop/packages/native.toml
@@ -4,24 +4,74 @@ tier = "tier1"
 gate = "tier1b"
 groups = ["imports", "native", "cloud"]
 native = true
+import-roots = ["grpc"]
 
 [[packages]]
-name = "lxml"
+name = "pycparser"
 tier = "tier1"
 gate = "tier1b"
-groups = ["imports", "native"]
-native = true
+groups = ["imports"]
 
 [[packages]]
-name = "tiktoken"
+name = "certifi"
 tier = "tier1"
 gate = "tier1b"
-groups = ["imports", "native"]
-native = true
+groups = ["imports"]
 
 [[packages]]
-name = "google-crc32c"
+name = "idna"
 tier = "tier1"
 gate = "tier1b"
-groups = ["imports", "native", "cloud"]
-native = true
+groups = ["imports"]
+
+[[packages]]
+name = "charset-normalizer"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["charset_normalizer"]
+
+[[packages]]
+name = "chardet"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "oauthlib"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "requests-oauthlib"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["requests_oauthlib"]
+
+[[packages]]
+name = "python-jose"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["jose"]
+
+[[packages]]
+name = "rsa"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "pyasn1"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "pyasn1-modules"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["pyasn1_modules"]

--- a/verification/python_interop/packages/tier1.toml
+++ b/verification/python_interop/packages/tier1.toml
@@ -10,6 +10,7 @@ tier = "tier1"
 gate = "tier1a"
 groups = ["imports", "native"]
 native = true
+import-roots = ["pydantic_core"]
 
 [[packages]]
 name = "httpx"
@@ -96,6 +97,7 @@ tier = "tier1"
 gate = "tier1a"
 groups = ["imports", "native", "brokers", "callbacks"]
 native = true
+import-roots = ["confluent_kafka"]
 
 [[packages]]
 name = "boto3"
@@ -120,6 +122,7 @@ name = "google-genai"
 tier = "tier1"
 gate = "tier1a"
 groups = ["imports", "cloud"]
+import-roots = ["google.genai"]
 
 [[packages]]
 name = "biip"
@@ -132,3 +135,251 @@ name = "schwifty"
 tier = "tier1"
 gate = "tier1a"
 groups = ["imports"]
+
+[[packages]]
+name = "pip"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "setuptools"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "wheel"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "build"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "hatchling"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "poetry-core"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["poetry.core"]
+
+[[packages]]
+name = "uv-build"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["uv_build"]
+
+[[packages]]
+name = "pyproject-hooks"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["pyproject_hooks"]
+
+[[packages]]
+name = "packaging"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "pkginfo"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "importlib-metadata"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["importlib_metadata"]
+
+[[packages]]
+name = "zipp"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "platformdirs"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "appdirs"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "typing-extensions"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["typing_extensions"]
+
+[[packages]]
+name = "exceptiongroup"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "pydantic-extra-types"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["pydantic_extra_types"]
+
+[[packages]]
+name = "annotated-types"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["annotated_types"]
+
+[[packages]]
+name = "attrs"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "marshmallow"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "cerberus"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "jsonpickle"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "deepdiff"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "protobuf"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["google.protobuf"]
+
+[[packages]]
+name = "proto-plus"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["proto"]
+
+[[packages]]
+name = "pyyaml"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["yaml"]
+
+[[packages]]
+name = "toml"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "tomli"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "python-dotenv"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["dotenv"]
+
+[[packages]]
+name = "pycountry"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "babel"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "holidays"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "dateparser"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "pendulum"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "python-dateutil"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["dateutil"]
+
+[[packages]]
+name = "pytz"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "tzdata"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+
+[[packages]]
+name = "uuid-utils"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["uuid_utils"]
+
+[[packages]]
+name = "rank-bm25"
+tier = "tier1"
+gate = "tier1b"
+groups = ["imports"]
+import-roots = ["rank_bm25"]

--- a/verification/python_interop/packages/tier2.toml
+++ b/verification/python_interop/packages/tier2.toml
@@ -24,7 +24,90 @@ tier = "tier2"
 groups = ["imports"]
 
 [[packages]]
+name = "colorama"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "decorator"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "deprecated"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "backoff"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "backoff-utils"
+tier = "tier2"
+groups = ["imports"]
+import-roots = ["backoff_utils"]
+
+[[packages]]
 name = "tenacity"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "ratelimit"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "cachetools"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "cachecontrol"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "aiocache"
+tier = "tier2"
+groups = ["imports", "async"]
+
+[[packages]]
+name = "aiofiles"
+tier = "tier2"
+groups = ["imports", "async"]
+
+[[packages]]
+name = "asgi-lifespan"
+tier = "tier2"
+groups = ["imports", "async", "web"]
+import-roots = ["asgi_lifespan"]
+
+[[packages]]
+name = "basicauth"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "faker"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "freezegun"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "time-machine"
+tier = "tier2"
+groups = ["imports"]
+import-roots = ["time_machine"]
+
+[[packages]]
+name = "testfixtures"
 tier = "tier2"
 groups = ["imports"]
 
@@ -37,6 +120,66 @@ groups = ["imports"]
 name = "requests-mock"
 tier = "tier2"
 groups = ["imports"]
+import-roots = ["requests_mock"]
+
+[[packages]]
+name = "pytest-httpx"
+tier = "tier2"
+groups = ["imports"]
+import-roots = ["pytest_httpx"]
+
+[[packages]]
+name = "sortedcontainers"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "more-itertools"
+tier = "tier2"
+groups = ["imports"]
+import-roots = ["more_itertools"]
+
+[[packages]]
+name = "inflect"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "text-unidecode"
+tier = "tier2"
+groups = ["imports"]
+import-roots = ["text_unidecode"]
+
+[[packages]]
+name = "python-slugify"
+tier = "tier2"
+groups = ["imports"]
+import-roots = ["slugify"]
+
+[[packages]]
+name = "pyhumps"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "parse"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "docopt"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "argh"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "commonmark"
+tier = "tier2"
+groups = ["imports"]
 
 [[packages]]
 name = "markdown"
@@ -44,6 +187,54 @@ tier = "tier2"
 groups = ["imports"]
 
 [[packages]]
+name = "markdown-it-py"
+tier = "tier2"
+groups = ["imports"]
+import-roots = ["markdown_it"]
+
+[[packages]]
+name = "mdurl"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "pymdown-extensions"
+tier = "tier2"
+groups = ["imports"]
+import-roots = ["pymdownx"]
+
+[[packages]]
 name = "docutils"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "readme-renderer"
+tier = "tier2"
+groups = ["imports"]
+import-roots = ["readme_renderer"]
+
+[[packages]]
+name = "rfc3986"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "uritemplate"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "webencodings"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "wrapt"
+tier = "tier2"
+groups = ["imports"]
+
+[[packages]]
+name = "wcwidth"
 tier = "tier2"
 groups = ["imports"]

--- a/verification/python_interop/packages/tier3.toml
+++ b/verification/python_interop/packages/tier3.toml
@@ -7,6 +7,61 @@ groups = ["imports"]
 name = "pytest-asyncio"
 tier = "tier3"
 groups = ["imports", "async"]
+import-roots = ["pytest_asyncio"]
+
+[[packages]]
+name = "pytest-bdd"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["pytest_bdd"]
+
+[[packages]]
+name = "pytest-cov"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["pytest_cov"]
+
+[[packages]]
+name = "pytest-mock"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["pytest_mock"]
+
+[[packages]]
+name = "pytest-env"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["pytest_env"]
+
+[[packages]]
+name = "pytest-freezegun"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["pytest_freezegun"]
+
+[[packages]]
+name = "pytest-redis"
+tier = "tier3"
+groups = ["imports", "databases"]
+import-roots = ["pytest_redis"]
+
+[[packages]]
+name = "pytest-postgresql"
+tier = "tier3"
+groups = ["imports", "databases"]
+import-roots = ["pytest_postgresql"]
+
+[[packages]]
+name = "pytest-pgsql"
+tier = "tier3"
+groups = ["imports", "databases"]
+import-roots = ["pytest_pgsql"]
+
+[[packages]]
+name = "pytest-sugar"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["pytest_sugar"]
 
 [[packages]]
 name = "coverage"
@@ -22,6 +77,7 @@ groups = ["imports"]
 name = "pre-commit"
 tier = "tier3"
 groups = ["imports"]
+import-roots = ["pre_commit"]
 
 [[packages]]
 name = "black"
@@ -29,7 +85,82 @@ tier = "tier3"
 groups = ["imports"]
 
 [[packages]]
+name = "flake8"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
+name = "flake8-black"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["flake8_black"]
+
+[[packages]]
+name = "flake8-isort"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["flake8_isort"]
+
+[[packages]]
+name = "flake8-eradicate"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["flake8_eradicate"]
+
+[[packages]]
+name = "flake8-pyprojecttoml"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["flake8_pyprojecttoml"]
+
+[[packages]]
+name = "isort"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
 name = "mypy"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
+name = "mypy-extensions"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["mypy_extensions"]
+
+[[packages]]
+name = "pycodestyle"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
+name = "pyflakes"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
+name = "mccabe"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
+name = "bandit"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
+name = "eradicate"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
+name = "yapf"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
+name = "reno"
 tier = "tier3"
 groups = ["imports"]
 
@@ -44,7 +175,42 @@ tier = "tier3"
 groups = ["imports"]
 
 [[packages]]
+name = "mkdocs-material"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["mkdocs_material"]
+
+[[packages]]
+name = "mkdocs-material-extensions"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["mkdocs_material_extensions"]
+
+[[packages]]
+name = "ghp-import"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["ghp_import"]
+
+[[packages]]
+name = "twine"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
+name = "pep517"
+tier = "tier3"
+groups = ["imports"]
+
+[[packages]]
+name = "setuptools-scm"
+tier = "tier3"
+groups = ["imports"]
+import-roots = ["setuptools_scm"]
+
+[[packages]]
 name = "cython"
 tier = "tier3"
 groups = ["imports", "native"]
 native = true
+import-roots = ["Cython"]

--- a/verification/python_interop/packages/tier4.toml
+++ b/verification/python_interop/packages/tier4.toml
@@ -3,12 +3,36 @@ name = "gunicorn"
 tier = "tier4"
 groups = ["imports", "web"]
 host-dependent = true
+skip-reason = "requires process-manager behavior that varies by host platform"
+
+[[packages]]
+name = "uvicorn-worker"
+tier = "tier4"
+groups = ["imports", "web"]
+host-dependent = true
+import-roots = ["uvicorn_worker"]
+skip-reason = "requires process-manager behavior that varies by host platform"
 
 [[packages]]
 name = "testcontainers"
 tier = "tier4"
 groups = ["imports", "databases", "brokers"]
 host-dependent = true
+skip-reason = "requires a usable local container runtime or external service endpoints"
+
+[[packages]]
+name = "pyngrok"
+tier = "tier4"
+groups = ["imports", "web"]
+host-dependent = true
+skip-reason = "requires host tunnel binary and external network access"
+
+[[packages]]
+name = "wmctrl"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "requires a Linux window manager control backend"
 
 [[packages]]
 name = "watchdog"
@@ -16,6 +40,7 @@ tier = "tier4"
 groups = ["imports", "native"]
 native = true
 host-dependent = true
+skip-reason = "requires host filesystem event backend support"
 
 [[packages]]
 name = "psutil"
@@ -23,21 +48,169 @@ tier = "tier4"
 groups = ["imports", "native"]
 native = true
 host-dependent = true
+skip-reason = "reports host process and kernel capabilities"
 
 [[packages]]
 name = "pexpect"
 tier = "tier4"
 groups = ["imports"]
 host-dependent = true
+skip-reason = "requires pseudo-terminal support from the host"
+
+[[packages]]
+name = "ptyprocess"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "requires pseudo-terminal support from the host"
+
+[[packages]]
+name = "sh"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "executes host shell commands"
+
+[[packages]]
+name = "keyring"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "requires host credential-store backend"
+
+[[packages]]
+name = "secretstorage"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "requires Linux Secret Service backend"
+
+[[packages]]
+name = "jeepney"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "requires host DBus behavior for live coverage"
+
+[[packages]]
+name = "keyrings-google-artifactregistry-auth"
+tier = "tier4"
+groups = ["imports", "cloud"]
+host-dependent = true
+import-roots = ["keyrings.google_artifactregistry_auth"]
+skip-reason = "requires host keyring and Google credential configuration"
 
 [[packages]]
 name = "ipython"
 tier = "tier4"
 groups = ["imports"]
 host-dependent = true
+skip-reason = "interactive shell behavior is host dependent"
 
 [[packages]]
 name = "ipykernel"
 tier = "tier4"
 groups = ["imports"]
 host-dependent = true
+skip-reason = "kernel startup and transport behavior are host dependent"
+
+[[packages]]
+name = "ipdb"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "interactive debugger behavior is host dependent"
+
+[[packages]]
+name = "pdbpp"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "interactive debugger behavior is host dependent"
+
+[[packages]]
+name = "pdbp"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "interactive debugger behavior is host dependent"
+
+[[packages]]
+name = "pdbr"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "interactive debugger behavior is host dependent"
+
+[[packages]]
+name = "fancycompleter"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "interactive completion depends on host terminal capabilities"
+
+[[packages]]
+name = "jedi"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "interactive analysis behavior depends on host files and environment"
+
+[[packages]]
+name = "parso"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "interactive analysis behavior depends on host files and environment"
+
+[[packages]]
+name = "prompt-toolkit"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+import-roots = ["prompt_toolkit"]
+skip-reason = "terminal UI behavior depends on host terminal capabilities"
+
+[[packages]]
+name = "pyrepl"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "REPL behavior depends on host terminal capabilities"
+
+[[packages]]
+name = "asttokens"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "interactive traceback behavior depends on host source context"
+
+[[packages]]
+name = "executing"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "interactive traceback behavior depends on host source context"
+
+[[packages]]
+name = "pure-eval"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+import-roots = ["pure_eval"]
+skip-reason = "interactive traceback behavior depends on host source context"
+
+[[packages]]
+name = "stack-data"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+import-roots = ["stack_data"]
+skip-reason = "interactive traceback behavior depends on host source context"
+
+[[packages]]
+name = "traitlets"
+tier = "tier4"
+groups = ["imports"]
+host-dependent = true
+skip-reason = "kernel and interactive configuration depend on host runtime context"

--- a/verification/python_interop/runner/certification_matrix.py
+++ b/verification/python_interop/runner/certification_matrix.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from import_matrix import PackageEntry
+
+CORE_TIER1A_PACKAGES = {
+    "biip",
+    "boto3",
+    "botocore",
+    "cffi",
+    "confluent-kafka",
+    "cryptography",
+    "google-genai",
+    "httpx",
+    "numpy",
+    "openai",
+    "pandas",
+    "polars",
+    "psycopg",
+    "pyarrow",
+    "pydantic",
+    "pydantic-core",
+    "redis",
+    "requests",
+    "schwifty",
+    "sqlalchemy",
+    "torch",
+}
+
+def validate_certification_policy(entries: list[PackageEntry]) -> None:
+    tier1a = {entry.name for entry in entries if entry.tier == "tier1" and entry.gate == "tier1a"}
+    missing = sorted(CORE_TIER1A_PACKAGES.difference(tier1a))
+    extra = sorted(tier1a.difference(CORE_TIER1A_PACKAGES))
+    if missing or extra:
+        parts = []
+        if missing:
+            parts.append(f"missing tier1a package(s): {', '.join(missing)}")
+        if extra:
+            parts.append(f"unexpected tier1a package(s): {', '.join(extra)}")
+        raise SystemExit("; ".join(parts))
+
+    for entry in entries:
+        if entry.native and "native" not in entry.groups:
+            raise SystemExit(f"native package {entry.name} must include the native group")
+        if entry.host_dependent and not entry.skip_reason:
+            raise SystemExit(f"host-dependent package {entry.name} must declare skip-reason")
+        if entry.tier == "tier4" and not entry.host_dependent:
+            raise SystemExit(f"tier4 package {entry.name} must be host-dependent")
+        if entry.tier in {"tier2", "tier3"} and entry.host_dependent:
+            raise SystemExit(f"{entry.tier} package {entry.name} must be deterministic")
+        if not entry.import_roots:
+            raise SystemExit(f"package {entry.name} must expose at least one import root")
+
+
+def build_certification_report(entries: list[PackageEntry]) -> dict[str, Any]:
+    certified = [entry for entry in entries if not entry.host_dependent]
+    skipped = [entry for entry in entries if entry.host_dependent]
+    tier_counts = Counter(entry.tier for entry in entries)
+    gate_counts = Counter(entry.gate for entry in entries if entry.gate is not None)
+    group_counts = Counter(group for entry in entries for group in entry.groups)
+
+    return {
+        "selected_packages": len(entries),
+        "certified_packages": len(certified),
+        "host_dependent_skips": len(skipped),
+        "tier_counts": dict(sorted(tier_counts.items())),
+        "gate_counts": dict(sorted(gate_counts.items())),
+        "group_counts": dict(sorted(group_counts.items())),
+        "packages": [package_payload(entry) for entry in sorted(entries, key=entry_sort_key)],
+    }
+
+
+def package_payload(entry: PackageEntry) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "name": entry.name,
+        "tier": entry.tier,
+        "groups": list(entry.groups),
+        "import_roots": list(entry.import_roots),
+        "status": "host-dependent-skip" if entry.host_dependent else "certified",
+    }
+    if entry.gate is not None:
+        payload["gate"] = entry.gate
+    if entry.native:
+        payload["native"] = True
+    if entry.host_dependent:
+        payload["skip_reason"] = entry.skip_reason
+    return payload
+
+
+def entry_sort_key(entry: PackageEntry) -> tuple[str, str, str]:
+    return (entry.tier, entry.gate or "", entry.name)

--- a/verification/python_interop/runner/import_matrix.py
+++ b/verification/python_interop/runner/import_matrix.py
@@ -13,6 +13,8 @@ class PackageEntry:
     gate: str | None = None
     native: bool = False
     host_dependent: bool = False
+    import_roots: tuple[str, ...] = ()
+    skip_reason: str | None = None
 
 
 def load_matrix(path: Path) -> list[PackageEntry]:
@@ -32,7 +34,18 @@ def parse_entry(path: Path, index: int, entry: object) -> PackageEntry:
     gate = optional_string(path, index, entry, "gate")
     native = optional_bool(path, index, entry, "native")
     host_dependent = optional_bool(path, index, entry, "host-dependent")
-    return PackageEntry(name, tier, tuple(groups), gate, native, host_dependent)
+    import_roots = optional_string_list(path, index, entry, "import-roots")
+    skip_reason = optional_string(path, index, entry, "skip-reason")
+    return PackageEntry(
+        name,
+        tier,
+        tuple(groups),
+        gate,
+        native,
+        host_dependent,
+        tuple(import_roots or [default_import_root(name)]),
+        skip_reason,
+    )
 
 
 def required_string(path: Path, index: int, entry: dict[str, object], key: str) -> str:
@@ -65,3 +78,20 @@ def optional_string(path: Path, index: int, entry: dict[str, object], key: str) 
     if not isinstance(value, str) or not value:
         raise ValueError(f"{path} package entry {index} field {key} must be a non-empty string")
     return value
+
+
+def optional_string_list(
+    path: Path, index: int, entry: dict[str, object], key: str
+) -> list[str] | None:
+    value = entry.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{path} package entry {index} field {key} must be a non-empty list")
+    if not all(isinstance(item, str) and item for item in value):
+        raise ValueError(f"{path} package entry {index} field {key} must contain strings")
+    return value
+
+
+def default_import_root(package_name: str) -> str:
+    return package_name.replace("-", "_")

--- a/verification/python_interop/runner/run.py
+++ b/verification/python_interop/runner/run.py
@@ -8,6 +8,7 @@ from pathlib import Path
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from certification_matrix import build_certification_report, validate_certification_policy
 from env import discover_paths
 from env_probe import run_env_probe
 from import_matrix import PackageEntry, load_matrix
@@ -56,10 +57,24 @@ REQUIRED_FIXTURE_FILES = (
     "simple_import/opaque_object_operations.json",
     "primitive_conversion/primitive_roundtrip.json",
     "async_blocking/async_blocking_contract.json",
+    "async_http/async_http_contract.json",
+    "aws_sns/aws_sns_contract.json",
+    "aws_sns_sqs_subscription/aws_sns_sqs_subscription_contract.json",
+    "aws_sqs/aws_sqs_contract.json",
+    "cryptography_tls/cryptography_tls_contract.json",
+    "fastapi_app/fastapi_app_contract.json",
+    "kafka/kafka_contract.json",
     "numpy_buffer/py_buffer_contract.json",
+    "pandas_arrow/pandas_arrow_contract.json",
+    "polars_arrow/polars_arrow_contract.json",
+    "pubsub/pubsub_contract.json",
     "pyarrow_capsule/arrow_capsule_contract.json",
+    "pydantic_models/pydantic_models_contract.json",
+    "redis/redis_contract.json",
     "torch_dlpack/dlpack_tensor_contract.json",
     "cffi_callback/callback_contract.json",
+    "sqlalchemy_psycopg/sqlalchemy_psycopg_contract.json",
+    "tensorflow_dlpack/tensorflow_dlpack_contract.json",
     "resource_cleanup/context_manager_cleanup.json",
 )
 
@@ -109,6 +124,7 @@ def main(argv: list[str] | None = None) -> int:
     selected_gates = validate_filters("gate", args.gate, KNOWN_GATES)
     matrices = load_matrices(paths.packages_root)
     validate_matrix_entries(matrices)
+    validate_certification_policy(matrices)
     validate_fixtures(paths.fixtures_root)
     validate_fixture_files(paths.fixtures_root)
 
@@ -120,10 +136,18 @@ def main(argv: list[str] | None = None) -> int:
         set(args.package),
     )
     env_result = run_env_probe(paths.area_root) if "env" in selected_groups else None
+    certification = build_certification_report(selected)
+    skipped = certification["host_dependent_skips"]
     payload = {
         "schema_version": 1,
         "area": "python_interop",
-        "status": "passed" if env_result else "scaffold",
+        "status": report_status(
+            env_result,
+            selected_groups,
+            selected_tiers,
+            selected_gates,
+            bool(args.package),
+        ),
         "groups": selected_groups or ["scaffold"],
         "tiers": selected_tiers,
         "gates": selected_gates or sorted({entry.gate for entry in selected if entry.gate is not None}),
@@ -138,7 +162,9 @@ def main(argv: list[str] | None = None) -> int:
             "total_failures": 0,
             "blocking_failures": 0,
             "non_blocking_failures": 0,
+            "skipped": skipped,
         },
+        "package_certification": certification,
     }
     if env_result is not None:
         payload["env_probe"] = env_result
@@ -231,9 +257,24 @@ def select_entries(
     return selected
 
 
+def report_status(
+    env_result: dict[str, object] | None,
+    groups: list[str],
+    tiers: list[str],
+    gates: list[str],
+    has_package_filter: bool,
+) -> str:
+    if env_result is not None:
+        return "passed"
+    if tiers or gates or has_package_filter or (groups and groups != ["scaffold"]):
+        return "matrix-passed"
+    return "scaffold"
+
+
 def run_self_tests(area_root: Path) -> None:
     entries = load_matrices(area_root / "packages")
     validate_matrix_entries(entries)
+    validate_certification_policy(entries)
     validate_fixture_files(area_root / "fixtures")
     run_env_probe(area_root)
     try:
@@ -266,6 +307,24 @@ def run_self_tests(area_root: Path) -> None:
         pass
     else:
         raise SystemExit("negative self-test failed: non-tier1 package with gate was accepted")
+    try:
+        validate_certification_policy([PackageEntry("bad-tier4", "tier4", ("imports",))])
+    except SystemExit:
+        pass
+    else:
+        raise SystemExit("negative self-test failed: tier4 package without skip was accepted")
+    payload = build_certification_report([
+        PackageEntry(name="requests", tier="tier1", groups=("imports",), gate="tier1a"),
+        PackageEntry(
+            name="watchdog",
+            tier="tier4",
+            groups=("imports",),
+            host_dependent=True,
+            skip_reason="requires host filesystem event backend",
+        ),
+    ])
+    if payload["certified_packages"] != 1 or payload["host_dependent_skips"] != 1:
+        raise SystemExit("negative self-test failed: package status counts drifted")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add deterministic Python package certification matrix validation and report payloads
- expand Tier 1 through Tier 4 package metadata, import roots, host-dependent skips, and matrix-only report status
- add representative contract fixtures across async/web, data, brokers, cloud/AI, native/TLS, callbacks, and tensor surfaces
- update py11 phase status and README documentation

## Validation
- python3 -m py_compile verification/python_interop/runner/*.py
- verification/python_interop/run.sh --self-test
- verification/python_interop/run.sh --group scaffold
- verification/python_interop/run.sh --tier tier1 --report reports/tier1.latest.json
- verification/python_interop/run.sh --tier tier2 --report reports/tier2.latest.json
- verification/python_interop/run.sh --tier tier3 --report reports/tier3.latest.json
- verification/python_interop/run.sh --tier tier4 --report reports/tier4.latest.json
- verification/python_interop/run.sh --group cloud --package boto3 --report reports/package.latest.json
- git diff --check
- python3 scripts/check_file_size_guardrails.py
- python3 verification/areas/coverage_matrix/checks/verification_taxonomy.py
- scripts/run_all_tests.sh --profile create-pr

## Review
- plans/reviews/active/ad-hoc-embedded-python-interop-py11-review-1.md
- plans/reviews/active/ad-hoc-embedded-python-interop-py11-review-4.md
- reviewer satisfied: no blockers

## Notes
- Initial create-pr run hit transient 10s audit fixture timeouts; targeted audit fixture rerun passed, and a full create-pr rerun passed.