### PR TITLE
Document Python interop closeout

### DIFF
--- a/docs/diagnostics/error-codes.mdx
+++ b/docs/diagnostics/error-codes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sifr Diagnostic Code Reference for All Error Families"
 sidebarTitle: "Error Codes"
-description: "A complete reference for Sifr's 23 active diagnostic code families plus the reserved CODEGEN family."
+description: "A complete reference for Sifr's active diagnostic code families and reserved diagnostic namespaces."
 ---
 
 Sifr organizes every diagnostic into a named family. Each code follows the format `SIFR-<FAMILY>-dddd`, where the four-digit number is scoped within its family. This page lists every active diagnostic family and links each code to a dedicated reference page. Use `sifr --explain <CODE>` in your terminal to get the exact renderer template and suggestions for your installed compiler version.
@@ -95,6 +95,43 @@ The `ASYNC` family covers violations of Sifr's async effect system. Sifr tracks 
 | [`SIFR-ASYNC-0005`](/errors/SIFR-ASYNC-0005) | Error | Blocking offload target is not classified as blocking I/O or CPU-heavy work. |
 | [`SIFR-ASYNC-0006`](/errors/SIFR-ASYNC-0006) | Error | Synchronous workload annotation applied to async function. |
 | [`SIFR-ASYNC-0007`](/errors/SIFR-ASYNC-0007) | Error | Shell execution function called directly from async context. |
+
+</Accordion>
+
+<Accordion title="PYENV — Embedded CPython environment">
+
+The `PYENV` family covers root Python environment selection and live interpreter probe failures for embedded CPython interop.
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| [`SIFR-PYENV-0001`](/errors/SIFR-PYENV-0001) | Error | Python environment configuration is malformed. |
+| [`SIFR-PYENV-0002`](/errors/SIFR-PYENV-0002) | Error | Package graph selects more than one Python virtual environment. |
+| [`SIFR-PYENV-0003`](/errors/SIFR-PYENV-0003) | Error | A package graph requires Python but no root environment is selected. |
+| [`SIFR-PYENV-0004`](/errors/SIFR-PYENV-0004) | Error | Selected Python interpreter probe failed or returned invalid JSON. |
+| [`SIFR-PYENV-0005`](/errors/SIFR-PYENV-0005) | Error | Selected Python interpreter is not supported CPython. |
+| [`SIFR-PYENV-0006`](/errors/SIFR-PYENV-0006) | Error | Selected interpreter does not belong to the configured virtual environment. |
+| [`SIFR-PYENV-0007`](/errors/SIFR-PYENV-0007) | Error | Selected Python environment has no site-packages path. |
+| [`SIFR-PYENV-0008`](/errors/SIFR-PYENV-0008) | Error | Declared Python import root is missing from the selected environment. |
+| [`SIFR-PYENV-0009`](/errors/SIFR-PYENV-0009) | Error | Trusted native Python import root failed to load. |
+| [`SIFR-PYENV-0010`](/errors/SIFR-PYENV-0010) | Error | Free-threaded CPython is not supported for embedded interop. |
+| [`SIFR-PYENV-0011`](/errors/SIFR-PYENV-0011) | Error | Configured Python project or lockfile is missing or stale. |
+
+</Accordion>
+
+<Accordion title="PYTRUST — Embedded Python trust policy">
+
+The `PYTRUST` family covers import-root and native-extension trust policy for embedded Python interop.
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| [`SIFR-PYTRUST-0001`](/errors/SIFR-PYTRUST-0001) | Error | Dependency package declares a wildcard Python trust root. |
+| [`SIFR-PYTRUST-0002`](/errors/SIFR-PYTRUST-0002) | Error | Python import root is not trusted by package policy. |
+| [`SIFR-PYTRUST-0003`](/errors/SIFR-PYTRUST-0003) | Error | Native Python import root is trusted without an allow-imports entry. |
+| [`SIFR-PYTRUST-0004`](/errors/SIFR-PYTRUST-0004) | Error | Dynamic Python import requires an explicit trust annotation. |
+
+<Note>
+The `PYIMP`, `PYCALL`, `PYCONV`, `PYRES`, `PYZC`, and `PYCB` families are reserved for future compiler-emitted Python interop diagnostics. Current runtime failures in those areas are returned as structured `PythonError` values.
+</Note>
 
 </Accordion>
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,7 +70,8 @@
               "introduction",
               "installation",
               "quickstart",
-              "from-python"
+              "from-python",
+              "python-interop"
             ]
           },
           {

--- a/docs/from-python.mdx
+++ b/docs/from-python.mdx
@@ -72,6 +72,9 @@ else:
   <Accordion title="Imports use the Sifr namespace">
     Use `from sifr.collections import Counter`, not `import collections`. Supported stdlib-style modules live under `sifr.*`; see the [collections import example](/stdlib/collections#importing).
   </Accordion>
+  <Accordion title="Calling installed Python packages is explicit">
+    Use `sifr.python` when you intentionally embed CPython and call packages from a uv-created environment. Configure the root package's `[python]` and `[trust]` tables first; see [Embedded Python Interop](/python-interop).
+  </Accordion>
   <Accordion title="Mutation is explicit">
     Use `mut` when a function should mutate a borrowed parameter, and `own mut` when it should take ownership and mutate the value.
   </Accordion>
@@ -88,5 +91,8 @@ else:
   </Card>
   <Card title="Error Handling" icon="triangle-alert" href="/language/error-handling">
     See how `Result` and `try`/`except` replace recoverable exceptions.
+  </Card>
+  <Card title="Embedded Python Interop" icon="package-open" href="/python-interop">
+    Call installed Python packages through explicit environment and trust boundaries.
   </Card>
 </CardGroup>

--- a/docs/packages/dependencies.mdx
+++ b/docs/packages/dependencies.mdx
@@ -97,6 +97,17 @@ Packages that exceed their declared trust boundary are rejected at publish time 
 Sifr wraps Cargo process failures in diagnostic code `SIFR-PACKAGE-0101`. If a dependency fetch, tree command, or other Cargo-delegated operation fails, run `sifr --explain SIFR-PACKAGE-0101` for structured diagnostic help. The explainer does not perform any package operations — it is safe to run at any time.
 </Warning>
 
+## Python package requirements
+
+Sifr does not resolve Python dependencies. Python packages are installed by the root application's uv environment, and Sifr verifies the final interpreter/probe before compile or run. Dependency packages may declare:
+
+```toml
+[python]
+requires-imports = ["pydantic", "httpx"]
+```
+
+The root application must select one `[python].venv`, allow the required import roots, and trust the Python and native-extension roots it is willing to execute in process. See [Embedded Python Interop](/python-interop).
+
 ## Cross-package imports and public APIs
 
 Only names that a dependency exposes through its public namespace are importable from outside that package. A package's public API is defined by `src/__init__.sifr` and any child namespaces that have their own `__init__.sifr`. Implementation files such as `src/client.sifr` are private to the package unless explicitly re-exported.

--- a/docs/packages/manifest.mdx
+++ b/docs/packages/manifest.mdx
@@ -129,6 +129,7 @@ Knowing where to put configuration prevents confusion and keeps Sifr's tooling w
 - Formatter and lint configuration
 - Named scripts
 - Native trust policy for backend Rust crates
+- Root application Python environment selection and Python trust policy
 
 **Put in `Cargo.toml`:**
 - Distribution metadata (description, authors, license, repository URL)
@@ -147,6 +148,36 @@ The Cargo metadata hook is the bridge between the two files. Sifr reads `cargo m
 manifest = "sifr.toml"
 # end sifr-managed
 ```
+
+## `[python]` and Python trust policy
+
+Embedded Python interop is configured in `sifr.toml`. The root application selects exactly one uv-created virtual environment; libraries may only declare import roots that the final application must provide.
+
+Root application example:
+
+```toml
+[python]
+venv = ".venv"
+pyproject = "pyproject.toml"
+lock = "uv.lock"
+interpreter = ".venv/bin/python"
+allow-imports = ["pandas", "pyarrow", "torch"]
+
+[trust]
+python = ["pandas", "pyarrow", "torch"]
+python-native = ["numpy", "pyarrow", "torch"]
+```
+
+Library package example:
+
+```toml
+[python]
+requires-imports = ["polars"]
+```
+
+Sifr verifies the selected interpreter before generated Python-enabled binaries run. It rejects missing root selection, multiple selected virtual environments, non-CPython interpreters, free-threaded CPython, missing declared imports, failed trusted native imports, and stale configured project metadata. Sifr never runs `uv sync` automatically.
+
+See [Embedded Python Interop](/python-interop) for runtime, blocking, callback, resource, and zero-copy semantics.
 
 ## Keeping Cargo.toml in sync with `sifr repair`
 

--- a/docs/python-interop.mdx
+++ b/docs/python-interop.mdx
@@ -1,0 +1,328 @@
+---
+title: "Embedded Python Interop"
+sidebarTitle: "Python Interop"
+description: "Configure and use embedded CPython from Sifr with explicit environment ownership, trust, blocking, resource, and zero-copy semantics."
+---
+
+Sifr can embed one uv-created CPython environment in a compiled Sifr application. This is for calling Python ecosystem packages from Sifr while preserving Sifr's normal contracts: fallible operations return `Result`, Python objects are opaque and non-send by default, native Python extensions are explicitly trusted, and zero-copy APIs never silently copy.
+
+This is not Python source compatibility and it is not a generic `dlopen` layer. Use Sifr's native `sifr.*` standard library for Sifr code, and use `sifr.python` only when you intentionally cross into installed Python packages.
+
+## Package Configuration
+
+The root application owns the Python environment. Sifr verifies and consumes that environment; it does not run `uv sync`, install packages, or fall back to host-global Python.
+
+```toml
+[python]
+venv = ".venv"
+pyproject = "pyproject.toml"
+lock = "uv.lock"
+interpreter = ".venv/bin/python"
+allow-imports = ["pandas", "pyarrow", "torch", "httpx"]
+
+[trust]
+python = ["pandas", "pyarrow", "torch", "httpx"]
+python-native = ["numpy", "pyarrow", "torch"]
+```
+
+`interpreter` is optional when the platform-standard interpreter path under `venv` is correct. `pyproject` and `lock` are cache and diagnostic inputs; the live interpreter probe remains the source of truth.
+
+Library packages may declare the import roots they require, but they do not choose the interpreter or virtual environment:
+
+```toml
+[python]
+requires-imports = ["polars"]
+```
+
+Sifr rejects package graphs that need Python but have no root-selected environment, graphs that select multiple virtual environments, non-CPython interpreters, free-threaded CPython, stale or missing project metadata, missing declared imports, and trusted native roots that fail to load.
+
+## Trust Boundary
+
+Python import roots and native extension roots are separate trust decisions.
+
+| Key | Meaning |
+| --- | --- |
+| `[python].allow-imports` | Roots Sifr source may import or call dynamically after trust checks. |
+| `[python].requires-imports` | Roots a library requires the final app to provide. |
+| `[trust].python` | Roots allowed to execute Python code in process. |
+| `[trust].python-native` | Roots allowed to load native Python extension modules in process. |
+
+Native Python extensions can abort the process, create threads, release the GIL, or call back into Python/Sifr. That is the explicit trust boundary exception to Sifr-attributable no-panic guarantees.
+
+Root applications may use wildcard Python trust during local control. Published dependency packages cannot rely on wildcard Python trust roots.
+
+## Runtime Semantics
+
+The generated binary initializes CPython once before user `main` when Python interop is used. Initialization uses the validated probe metadata: executable, venv prefix, site-packages, `sys.path`, CPython version, SOABI, extension suffixes, platform, pointer width, and `libpython` when discoverable.
+
+Rules:
+
+- CPython main interpreter only; no subinterpreters.
+- No normal shutdown finalization with `Py_FinalizeEx`.
+- Reinitialization with the same config is allowed; conflicting config is rejected.
+- Every CPython API operation that needs the GIL acquires it.
+- Decref and resource release happen while holding the GIL.
+- `py.Object`, buffers, Arrow capsules, DLPack tensors, and callbacks are tracked for deterministic close/release diagnostics.
+
+## Calling Python
+
+The public surface is explicit:
+
+```python
+from sifr.python import Object, PythonError, call_attr, from_str, import_module, to_str
+
+def main() -> Result[None, PythonError]:
+    try:
+        biip: Object = import_module("biip")
+        gs1: Object = from_str("01070327700360141524010110ABC123")
+        parsed: Object = call_attr(biip, "parse", [gs1], [])
+        print(to_str(parsed))
+
+        schwifty: Object = import_module("schwifty")
+        bic_code: Object = from_str("DEUTDEFF")
+        bic: Object = call_attr(schwifty, "BIC", [bic_code], [])
+        print(to_str(bic))
+        return None
+    except PythonError as e:
+        raise e
+```
+
+Every Python boundary operation returns `Result`. Python exceptions are captured as structured `py.PythonError` values with exception type, message, traceback, operation context, and conversion/resource/zero-copy metadata where relevant. Python exceptions do not unwind through Sifr user code.
+
+## Blocking And Async
+
+Every public `sifr.python` operation is classified as `@blocking_io`. Direct Python calls in async Sifr code are rejected unless the work is explicitly offloaded through Sifr's blocking offload primitive.
+
+```python
+from sifr.python import Object, PythonError, call_attr, from_str, get_attr, import_module, to_str
+
+async def fetch_status() -> Result[str, PythonError]:
+    handle = task.spawn_blocking(fetch_status_sync)
+    return await handle.join()
+
+@blocking_io
+def fetch_status_sync() -> Result[str, PythonError]:
+    try:
+        httpx: Object = import_module("httpx")
+        url_obj: Object = from_str("https://example.com")
+        response: Object = call_attr(httpx, "get", [url_obj], [])
+        status: Object = get_attr(response, "status_code")
+        return to_str(status)
+    except PythonError as e:
+        raise e
+```
+
+`py.run_coroutine_blocking` is also `@blocking_io`. It is for Python-owned coroutine objects and returns only after Python finishes.
+
+## Resources
+
+Python resources must be closed or released explicitly when correctness depends on cleanup:
+
+```python
+from sifr.python import Object, PythonError, call_attr, from_str, import_module, to_str, with_context
+
+def consume_file(entered: Object) -> Result[None, PythonError]:
+    try:
+        text: Object = call_attr(entered, "read", [], [])
+        print(to_str(text))
+        return None
+    except PythonError as e:
+        raise e
+
+def read_with_context(path: str) -> Result[None, PythonError]:
+    try:
+        builtins: Object = import_module("builtins")
+        path_obj: Object = from_str(path)
+        mode: Object = from_str("r")
+        handle: Object = call_attr(builtins, "open", [path_obj, mode], [])
+        return with_context(handle, consume_file)
+    except PythonError as e:
+        raise e
+```
+
+Use `py.close`, `py.with_context`, callback `close`, buffer `release`, Arrow release helpers, and DLPack release helpers. Double close/release returns deterministic resource-state errors for resource types that are not intentionally idempotent.
+
+## Callbacks
+
+Sifr supports two callback lifetimes:
+
+- `py.local_callback`: valid only during the active Sifr-to-Python call. It is non-send and cannot be stored by Python beyond the active call.
+- `py.threadsafe_callback`: may be called later from Python-created threads, native extension callback threads, thread pools, or event-loop schedulers. Captured state must satisfy send-like constraints.
+
+Callback dispatch converts Sifr errors into Python exceptions and maps Python callback-dispatch failures back into `Result` when control returns to Sifr.
+
+Kafka-style and Pub/Sub-style callbacks are represented by contract fixtures in the Python interop verification area. Cloud SDK callback examples use deterministic stubs or structured matrix evidence unless an external integration gate is explicitly selected.
+
+## Zero-Copy Interop
+
+Sifr exposes zero-copy APIs only when view semantics can be proven:
+
+```python
+from sifr.python import ArrowCapsule, DlpackTensor, Object, PythonError, zero_copy_arrow_stream, zero_copy_dlpack_tensor
+
+def dataframe_to_arrow_stream(df: Object) -> Result[ArrowCapsule, PythonError]:
+    try:
+        return zero_copy_arrow_stream(df)
+    except PythonError as e:
+        raise e
+
+def torch_tensor_to_dlpack(tensor: Object) -> Result[DlpackTensor, PythonError]:
+    try:
+        return zero_copy_dlpack_tensor(tensor)
+    except PythonError as e:
+        raise e
+```
+
+Supported surfaces:
+
+- `Py_buffer` for bytes-like objects, memoryview, NumPy, and other buffer protocol producers.
+- Arrow PyCapsules for `__arrow_c_array__`, `__arrow_c_stream__`, and `__arrow_c_schema__`.
+- DLPack capsules for NumPy, torch, and TensorFlow CPU tensor paths.
+- Array-interface protocols with owner retention and metadata validation.
+
+Zero-copy APIs reject unsupported dtype, shape, stride, device, mutability, malformed capsule, double-consumption, and copy-required paths. Explicit copy APIs are separate and never claim view semantics.
+
+## Package Examples
+
+These are representative patterns covered by verification fixtures or matrix contracts:
+
+```python biip / schwifty validation
+from sifr.python import Object, PythonError, call_attr, from_str, import_module, to_str
+
+def validate_identifiers(gtin: str, bic_text: str) -> Result[str, PythonError]:
+    try:
+        biip: Object = import_module("biip")
+        gtin_obj: Object = from_str(gtin)
+        parsed: Object = call_attr(biip, "parse", [gtin_obj], [])
+
+        schwifty: Object = import_module("schwifty")
+        bic_obj: Object = from_str(bic_text)
+        bic: Object = call_attr(schwifty, "BIC", [bic_obj], [])
+        parsed_text: str = to_str(parsed)
+        bic_text_value: str = to_str(bic)
+        return f"{parsed_text} / {bic_text_value}"
+    except PythonError as e:
+        raise e
+```
+
+```python FastAPI in-process import
+from sifr.python import Object, PythonError, call_attr, import_module
+
+def build_app() -> Result[Object, PythonError]:
+    try:
+        fastapi: Object = import_module("fastapi")
+        return call_attr(fastapi, "FastAPI", [], [])
+    except PythonError as e:
+        raise e
+```
+
+```python pandas / pyarrow / polars Arrow bridge
+from sifr.python import (
+    ArrowCapsule,
+    Object,
+    PythonError,
+    call_attr,
+    export_arrow_stream,
+    from_dict_str,
+    from_int,
+    from_list,
+    get_attr,
+    import_module,
+    zero_copy_arrow_stream,
+)
+
+def arrow_contract() -> Result[ArrowCapsule, PythonError]:
+    try:
+        one: Object = from_int(1)
+        two: Object = from_int(2)
+        three: Object = from_int(3)
+        column: Object = from_list([one, two, three])
+        data: Object = from_dict_str([("x", column)])
+
+        pandas: Object = import_module("pandas")
+        pdf: Object = call_attr(pandas, "DataFrame", [data], [])
+
+        polars: Object = import_module("polars")
+        df: Object = call_attr(polars, "from_pandas", [pdf], [])
+
+        pyarrow: Object = import_module("pyarrow")
+        table_class: Object = get_attr(pyarrow, "Table")
+        table: Object = call_attr(table_class, "from_pandas", [pdf], [])
+        exported: ArrowCapsule = export_arrow_stream(table)
+        return zero_copy_arrow_stream(df)
+    except PythonError as e:
+        raise e
+```
+
+```python torch / tensorflow DLPack
+from sifr.python import DlpackTensor, Object, PythonError, call_attr, from_float, from_list, import_module, zero_copy_dlpack_tensor
+
+def tensor_contract() -> Result[DlpackTensor, PythonError]:
+    try:
+        torch: Object = import_module("torch")
+        one: Object = from_float(1.0)
+        two: Object = from_float(2.0)
+        three: Object = from_float(3.0)
+        values: Object = from_list([one, two, three])
+        tensor: Object = call_attr(torch, "tensor", [values], [])
+        torch_view: DlpackTensor = zero_copy_dlpack_tensor(tensor)
+
+        tensorflow: Object = import_module("tensorflow")
+        tf_tensor: Object = call_attr(tensorflow, "constant", [values], [])
+        return zero_copy_dlpack_tensor(tf_tensor)
+    except PythonError as e:
+        raise e
+```
+
+```python Kafka callback shape
+from sifr.python import Object, PythonError, call_attr, from_list, from_str, threadsafe_callback
+
+def handle_message(msg: Object) -> Result[Object, PythonError]:
+    return msg
+
+def register_callback(consumer: Object) -> Result[None, PythonError]:
+    try:
+        callback = threadsafe_callback(handle_message)
+        topic: Object = from_str("events")
+        topics: Object = from_list([topic])
+        result: Object = call_attr(consumer, "subscribe", [topics], [("on_assign", callback.callable)])
+        return None
+    except PythonError as e:
+        raise e
+```
+
+```python Cloud and AI clients
+from sifr.python import Object, PythonError, call_attr, import_module
+
+def import_cloud_clients() -> Result[tuple[Object, Object, Object], PythonError]:
+    try:
+        openai: Object = import_module("openai")
+        boto3: Object = import_module("boto3")
+        pubsub: Object = import_module("google.cloud.pubsub")
+        client: Object = call_attr(openai, "OpenAI", [], [])
+        return (client, boto3, pubsub)
+    except PythonError as e:
+        raise e
+```
+
+Credentialed or service-backed behavior belongs in the external Python interop gate. The default local gate uses import, stub, contract, and matrix evidence.
+
+## Diagnostics And Reports
+
+Compiler diagnostics use stable URLs and structured JSON fields:
+
+- `SIFR-PYENV-0001..0011`: environment selection, probing, interpreter, ABI, import, native-load, and metadata diagnostics.
+- `SIFR-PYTRUST-0001..0004`: Python trust policy and dynamic import diagnostics.
+- `SIFR-PYIMP`, `SIFR-PYCALL`, `SIFR-PYCONV`, `SIFR-PYRES`, `SIFR-PYZC`, and `SIFR-PYCB`: reserved families for future compiler-emitted diagnostics; current runtime failures in these areas are returned as structured `py.PythonError` values.
+
+Verification lives under `verification/python_interop/`:
+
+```bash
+verification/python_interop/run.sh --group env
+verification/python_interop/run.sh --tier tier1
+verification/python_interop/run.sh --group callbacks
+verification/python_interop/run.sh --group dataframes
+verification/python_interop/run.sh --self-test
+```
+
+Matrix-only package evidence reports `matrix-passed`; live environment execution reports `passed`. Host-dependent packages include explicit skip reasons.

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -51,7 +51,7 @@
 - Historical references in this architecture document may mention legacy sequencing from earlier planning versions.
 - When numbered-record conflicts exist, follow the project planning index and the matching staged planning files.
 - Network/TLS/URL/HTTP substrate architecture is tracked in [`network_http_architecture.md`](./network_http_architecture.md). The public boundary is `sifr.net`, `sifr.tls`, `sifr.url`, and `sifr.http`; CPython-shaped networking modules remain unsupported diagnostics or rejected surfaces.
-- Embedded CPython interop has a separate design contract in the planning tree. Package metadata now records Python environment selection, declared import roots, and Python trust roots; the package layer resolves a single selected environment and validates canonical CPython probe JSON before runtime embedding work consumes it. The verification scaffold lives under [`verification/python_interop/`](../verification/python_interop/); this lane is separate from Rust-backed packages, raw C ABI interop, and CPython source-parity adaptation.
+- Embedded CPython interop is production-grade complete as a separate lane from Rust-backed packages, raw C ABI interop, and CPython source-parity adaptation. Package metadata records Python environment selection, declared import roots, and Python trust roots; the package layer resolves a single selected environment and validates canonical CPython probe JSON before runtime embedding consumes it. Runtime lifecycle, GIL/refcount ownership, blocking/offload, callbacks, resources, and zero-copy rules are documented in [`python_interop_architecture.md`](./python_interop_architecture.md), with verification under [`verification/python_interop/`](../verification/python_interop/).
 
 ## Vision
 

--- a/internal_docs/python_interop_architecture.md
+++ b/internal_docs/python_interop_architecture.md
@@ -1,0 +1,102 @@
+# Embedded Python Interop Architecture
+
+This note records the production contract implemented by the embedded CPython interop phase. It complements the public guide in `docs/python-interop.mdx` and the verification surface in `verification/python_interop/`.
+
+## Ownership Boundary
+
+Python interop is a separate lane from Sifr's Rust-backed packages and raw C ABI interop. The final root application owns one uv-created CPython virtual environment. Sifr verifies and consumes that environment; it never installs packages, runs `uv sync`, or searches host-global Python as a fallback.
+
+Library packages may declare `[python].requires-imports`, but only the root application may select `[python].venv`, `[python].interpreter`, `[python].pyproject`, or `[python].lock`.
+
+## Environment Probe
+
+The package layer resolves the package graph, validates Python trust policy, and builds a `PythonEnvironmentRequest` containing:
+
+- root-selected venv and interpreter;
+- declared Python imports from root allow-list and dependency requirements;
+- trusted native Python imports;
+- configured `pyproject.toml` and `uv.lock` paths.
+
+The selected interpreter is probed before codegen/build. Probe validation rejects non-CPython, free-threaded CPython, prefixes outside the selected venv, missing site-packages, missing declared imports, failed trusted native imports, and missing/stale configured metadata.
+
+Probe metadata participates in generated artifact cache keys: interpreter path, CPython version tuple, SOABI, extension suffixes, pointer width, platform, `libpython` when available, project/lock digests, declared imports, and trust config.
+
+## Runtime Lifecycle
+
+The optional `sifr_runtime/python` feature owns embedded CPython lifecycle through PyO3 embedding APIs plus narrow CPython FFI where PyO3 does not expose the required primitive.
+
+Rules:
+
+- initialize CPython once per process from generated runtime metadata;
+- use the main interpreter only;
+- reject conflicting reinitialization;
+- do not call `Py_FinalizeEx` during normal shutdown;
+- acquire the GIL for every CPython API operation that requires it;
+- decref owned object handles while holding the GIL;
+- track owned Python object, buffer, Arrow, DLPack, and callback resources for deterministic diagnostics.
+
+Generated package binaries initialize Python before user `main` when Python metadata is present. Generated Cargo metadata threads `PYO3_PYTHON` so PyO3 links/configures against the selected interpreter.
+
+## Object And Error Model
+
+`py.Object` is opaque foreign state, not `Any`, and is non-send by default. Public operations are explicit `sifr.python` helpers for import, attribute/item access, calls, kwargs, conversion, context management, coroutine blocking, callbacks, and zero-copy handles.
+
+Every Python boundary operation is fallible. Python exceptions are captured as `py.PythonError` values with operation context and traceback instead of crossing into Sifr as unwinds or panics. Compiler-emitted setup/trust failures use `SIFR-PYENV-*` and `SIFR-PYTRUST-*`; runtime Python object/call/conversion/resource/zero-copy/callback failures are typed `Result` payloads.
+
+## Blocking And Sendability
+
+Every public Python boundary operation is classified as `@blocking_io`. Async Sifr code must offload Python work through the existing blocking offload primitive. `py.Object`, `py.BufferView`, Arrow handles, DLPack handles, and local callbacks cannot cross task/thread boundaries unless an explicit audited bridge such as `py.threadsafe_callback` owns the transfer constraints.
+
+## Data Interchange
+
+Zero-copy support is explicit:
+
+- `Py_buffer` tracks owner, pointer, length, readonly flag, format, item size, shape, strides, suboffsets, requested flags, and release state.
+- Arrow validates exact PyCapsule names and release callbacks for array, stream, and schema surfaces.
+- DLPack enforces one-shot capsule consumption, `"used_dltensor"` marking, dtype/device validation, and exact-once deleter release.
+- Array-interface protocols retain owners and validate pointer/dtype/shape/stride/device metadata.
+
+Zero-copy APIs never fall back to copying. Copy-capable paths are represented by explicit copy APIs or `copy_possible` contract evidence.
+
+## Verification Gates
+
+The canonical local entrypoint is `verification/python_interop/run.sh`.
+
+Important selectors:
+
+- `--group scaffold`: matrix, fixture, and runner contract shape.
+- `--group env`: live interpreter probe plus checked-in positive/negative probe fixtures.
+- `--tier tier1`, `--tier tier2`, `--tier tier3`, `--tier tier4`: deterministic package certification evidence.
+- `--group callbacks`, `--group dataframes`, `--group cloud`, `--group brokers`, and similar group filters: representative contract coverage.
+- `--self-test`: runner positive/negative tests, certification-policy invariants, fixture JSON validation, and env-probe smoke.
+
+Report status values are intentional:
+
+- `passed`: live environment execution ran.
+- `matrix-passed`: deterministic matrix or contract evidence ran without live package execution.
+- `scaffold`: repository-shape scaffold validation only.
+
+Tier 4 and other host-dependent entries must include explicit `skip_reason` evidence. The full external gate is responsible for live service/host evidence.
+
+## Example Evidence Map
+
+The public examples in `docs/python-interop.mdx` are intentionally backed by checked-in verification evidence:
+
+| Example family | Evidence |
+| --- | --- |
+| biip / schwifty package calls | Tier 1a package matrix entries and `simple_import` opaque-object contract coverage. |
+| FastAPI app construction | `verification/python_interop/fixtures/fastapi_app/fastapi_app_contract.json`. |
+| pandas / pyarrow / polars Arrow bridge | `pandas_arrow`, `polars_arrow`, and `pyarrow_capsule` fixture contracts. |
+| torch / TensorFlow DLPack | `torch_dlpack` source fixtures and `tensorflow_dlpack` package contract. |
+| Kafka callbacks | `kafka` and `cffi_callback` contracts plus callback source fixtures. |
+| cloud / AI clients | `aws_sqs`, `aws_sns`, `aws_sns_sqs_subscription`, `pubsub`, and Tier 1 cloud package matrices. |
+| observability / production clients | Tier 1 cloud/observability package matrix entries and deterministic matrix reports. |
+
+## Diagnostic Evidence
+
+Active compiler diagnostics:
+
+- `SIFR-PYENV-0001..0011`: malformed config, multiple venvs, missing root env, probe failure, unsupported implementation, prefix mismatch, missing site-packages, missing declared import, native-load failure, free-threaded CPython, and stale project metadata.
+- `SIFR-PYTRUST-0001..0004`: dependency wildcard rejection, allowed-but-untrusted imports, native trust without allow-list, and dynamic import without explicit trust annotation.
+
+Reserved families `SIFR-PYIMP`, `SIFR-PYCALL`, `SIFR-PYCONV`, `SIFR-PYRES`, `SIFR-PYZC`, and `SIFR-PYCB` remain allocated for future compiler-emitted diagnostics if runtime Python error values later need promotion to compiler diagnostics.

--- a/plans/issues/active/ad-hoc-embedded-python-interop.md
+++ b/plans/issues/active/ad-hoc-embedded-python-interop.md
@@ -1,6 +1,6 @@
 # Ad Hoc Phase: Embedded Python Interop
 
-> Status: in progress. Planning lock is active; `milestone_py_0` established scaffold and diagnostic reservations, and `milestone_py_1` owns Python environment discovery/probing. This phase is intentionally scoped as a complete design contract, not an MVP. Implementation may be delivered in milestones, but the design decisions below are binding for the whole Python interop surface.
+> Status: complete pending py12 PR #2677 merge. `milestone_py_0` through `milestone_py_11` are merged; `milestone_py_12` completed public/internal docs, diagnostic evidence, py12 Opus review, phase-level final implementation review, and local validation. This phase is intentionally scoped as a complete design contract, not an MVP. Implementation may be delivered in milestones, but the design decisions below are binding for the whole Python interop surface.
 
 ## Execution Status
 
@@ -92,8 +92,16 @@
   - Expanded Tier 1 certification matrices, Tier 2/Tier 3 deterministic smoke matrices, and Tier 4 host-dependent skip evidence.
   - Added deterministic package certification reports with `matrix-passed` status for matrix-only evidence and explicit host-dependent skip counts.
   - Added representative package-family contract fixtures for web, data, DB, broker, cloud/AI, TLS/native, callbacks, and tensor surfaces.
-  - Opus review round 1 reported no blockers; local focused validation passed.
-- [ ] `milestone_py_12`: Documentation, diagnostics, and closeout.
+  - Opus review round 4 reported no blockers; local `create-pr` validation passed with only a warm wall-time advisory.
+  - Merged via PR [#2676](https://github.com/sifr-lang/sifr/pull/2676).
+- [x] `milestone_py_12`: Documentation, diagnostics, and closeout.
+  - Published public Python interop examples covering biip/schwifty, FastAPI, Kafka callbacks, pandas/pyarrow/polars Arrow, torch/tensorflow DLPack, and cloud/AI clients.
+  - Recorded internal architecture evidence for runtime lifecycle, GIL/refcount ownership, environment probes, verification gates, and example-to-fixture mapping.
+  - Confirmed active Python environment/trust diagnostics have stable codes, generated docs, structured JSON arguments, and positive/negative test references.
+  - Recorded exit evidence in `verification/python_interop/reports/python_interop_exit_evidence.md`.
+  - Opus py12 review round 4 and final implementation review round 3 reported no blockers.
+  - Local py12 validation passed on 2026-06-19: `scripts/run_all_tests.sh --profile create-pr` completed 132 e2e pass tests with 0 failures and one warm wall-time advisory; default `scripts/run_all_tests.sh` completed 651 e2e pass tests and 260 hardening variants with 0 failures, plus warm wall-time and group-skew advisories.
+  - PR [#2677](https://github.com/sifr-lang/sifr/pull/2677) opened for final documentation PR merge.
 
 ## Objective
 
@@ -336,31 +344,35 @@ The canonical surface is explicit:
 from sifr import python as py
 
 def main() -> Result[None, py.PythonError]:
-    torch = try py.import_module("torch")
-    x = try py.call_attr(torch, "tensor", [[1.0, 2.0], [3.0, 4.0]], [])
-    y = try py.call_attr(torch, "matmul", [x, x], [])
-    text = try py.to_str(y)
-    print(text)
-    return None
+    try:
+        torch = py.import_module("torch")
+        x = py.call_attr(torch, "tensor", [[1.0, 2.0], [3.0, 4.0]], [])
+        y = py.call_attr(torch, "matmul", [x, x], [])
+        text = py.to_str(y)
+        print(text)
+        return None
+    except py.PythonError as e:
+        raise e
 ```
 
 Core operations:
 
 ```sifr
-try py.import_module("module.name")
-try py.get_attr(obj, "name")
-try py.set_attr(obj, "name", value)
-try py.get_item(obj, key)
-try py.set_item(obj, key, value)
-try py.call(callable, args, kwargs)
-try py.call_attr(obj, "method", args, kwargs)
-try py.to[T](obj)
-try py.to_str(obj)
-try py.to_bytes(obj)
-try py.scope(lambda gil: ...)
-try py.close(obj)
-try py.with_context(obj, lambda entered: ...)
-try py.run_coroutine_blocking(coro)
+try:
+    module = py.import_module("module.name")
+    attr = py.get_attr(obj, "name")
+    updated_attr = py.set_attr(obj, "name", value)
+    item = py.get_item(obj, key)
+    updated_item = py.set_item(obj, key, value)
+    result = py.call(callable, args, kwargs)
+    method_result = py.call_attr(obj, "method", args, kwargs)
+    text = py.to_str(result)
+    raw = py.to_bytes(result)
+    closed = py.close(result)
+    context_result = py.with_context(obj, lambda entered: ...)
+    coroutine_result = py.run_coroutine_blocking(coro)
+except py.PythonError as e:
+    raise e
 ```
 
 This phase does not introduce `import python <name>` syntax sugar; explicit `py.*` operations are the only user-facing surface.
@@ -451,13 +463,16 @@ Python resource cleanup must be explicit and ergonomic.
 Supported cleanup APIs:
 
 ```sifr
-try py.close(obj)
-try py.call_attr(obj, "close", [], [])
-try py.with_context(obj, lambda entered: ...)
-coro = try py.call_attr(obj, "aclose", [], [])
-try py.run_coroutine_blocking(coro)
-try callback.close()
-try buffer.release()
+try:
+    closed = py.close(obj)
+    close_result = py.call_attr(obj, "close", [], [])
+    context_result = py.with_context(obj, lambda entered: ...)
+    coro = py.call_attr(obj, "aclose", [], [])
+    coroutine_result = py.run_coroutine_blocking(coro)
+    callback_closed = py.close_callback(callback)
+    buffer_released = py.release_buffer(buffer)
+except py.PythonError as e:
+    raise e
 ```
 
 Rules:
@@ -756,7 +771,7 @@ Runner shape: `run.sh` is canonical; it validates environment prerequisites and 
 verification/python_interop/run.sh --group env
 verification/python_interop/run.sh --tier tier1
 verification/python_interop/run.sh --group native
-verification/python_interop/run.sh --group data
+verification/python_interop/run.sh --group dataframes
 verification/python_interop/run.sh --package pandas
 ```
 
@@ -971,7 +986,7 @@ Python interop gates, once implemented:
 verification/python_interop/run.sh --group env
 verification/python_interop/run.sh --tier tier1
 verification/python_interop/run.sh --group native
-verification/python_interop/run.sh --group data
+verification/python_interop/run.sh --group dataframes
 verification/python_interop/run.sh --group callbacks
 ```
 

--- a/plans/phases/index.md
+++ b/plans/phases/index.md
@@ -50,4 +50,4 @@ Phase status remains authoritative in each phase file header and is mirrored her
 | 41 | Phase 41: Web Framework and Platform Expansion | unspecified | [41_web_framework_and_platform_expansion.md](./41_web_framework_and_platform_expansion.md) |
 | 42 | Phase 42: Data Science and ML | unspecified | [42_data_science_ml.md](./42_data_science_ml.md) |
 | 43 | Phase 43: Interoperability | unspecified | [43_interoperability.md](./43_interoperability.md) |
-| PY-1 | Ad Hoc Embedded Python Interop | in progress (`milestone_py_1` environment probe ready) | [../issues/active/ad-hoc-embedded-python-interop.md](../issues/active/ad-hoc-embedded-python-interop.md) |
+| PY-1 | Ad Hoc Embedded Python Interop | complete pending py12 PR #2677 merge (py0-py11 merged through PR #2676; py12 docs, diagnostics, reviews, and local validation complete) | [../issues/active/ad-hoc-embedded-python-interop.md](../issues/active/ad-hoc-embedded-python-interop.md) |

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-final-review-2.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-final-review-2.md
@@ -1,0 +1,38 @@
+## Review
+
+**B1 — `docs/python-interop.mdx:103` blocking/async example: offload target `fetch_status_sync` is missing the required `@blocking_io` classification, which contradicts the implemented offload contract.**
+
+The docs section "Blocking And Async" (`docs/python-interop.mdx:99-112`) shows:
+
+```python
+async def fetch_status() -> Result[str, PythonError]:
+    handle = task.spawn_blocking(fetch_status_sync)
+    return await handle.join()
+
+def fetch_status_sync() -> Result[str, PythonError]:
+    try:
+        httpx: Object = import_module("httpx")
+        ...
+```
+
+`fetch_status_sync` is a sync function with no `@blocking_io` classification, and is used as the target of `task.spawn_blocking`. Per the implemented async/offload contract, this emits `SIFR-ASYNC-0005` ("Blocking offload target is not classified as blocking I/O or CPU-heavy work"). Evidence:
+
+- `verification/python_interop/fixtures/async_blocking/unclassified_offload_rejected.sifr:1` — same shape (sync fn calling `from_int`/`to_int`, no `@blocking_io`, used in `task.spawn_blocking`) is explicitly an `expect-error: SIFR-ASYNC-0005` negative fixture.
+- `crates/sifr/tests/e2e/fail/spawn_blocking_unannotated_rejected.sifr:1-9` — generalized e2e fail confirms unannotated `spawn_blocking` target is rejected.
+- The positive fixture `verification/python_interop/fixtures/async_blocking/offloaded_python_calls.sifr:14,26` requires `@blocking_io` on both `build_value` and `run_python_owned_loop`.
+
+The docs text at `docs/python-interop.mdx:94` says "Every public `sifr.python` operation is classified as `@blocking_io`" and the architecture (`internal_docs/python_interop_architecture.md:47`) says "Async Sifr code must offload Python work through the existing blocking offload primitive" — but the example illustrating that exact offload pattern omits the user-side classification that the diagnostic enforces. The docs example as written will not compile.
+
+Required fix: add `@blocking_io` decorator on `fetch_status_sync` (and import/note as appropriate), matching the offloaded_python_calls fixture pattern.
+
+---
+
+Other items checked and clean:
+- Phase tracker / roadmap / phase index / exit evidence: status strings ("complete pending py12 PR merge", `milestone_py_12` checked with sub-bullet "PR link pending final documentation PR creation") are internally consistent. PR record py0–py11 listed; py12 marked pending.
+- Diagnostic families `SIFR-PYENV-0001..0011` and `SIFR-PYTRUST-0001..0004` are stable, documented in `docs/diagnostics/error-codes.mdx:107-130`, registered in the exit-evidence file, and reserved families `PYIMP/PYCALL/PYCONV/PYRES/PYZC/PYCB` are noted consistently in all three docs.
+- Verification group/tier selectors and report statuses (`passed`/`matrix-passed`/`scaffold`) are consistent across `docs/python-interop.mdx:319-327`, `internal_docs/python_interop_architecture.md:65-79`, `verification/python_interop/README.md:26-60`, and the exit evidence.
+- Adapter/schema "quiet" support (`verification/runner/sifr_verify/area_adapter.py:397-411`, `verification/schemas/area.schema.json:162-164`, `verification/areas/project_workspace/manifest.json:47,67`) is appropriately scoped: schema adds optional boolean, adapter rejects `quiet: true` for any command other than `build`/`run`, manifest opts in only for the two run baselines whose stdout would otherwise vary by build progress. This matches the exit-evidence note about manifest-level quiet support for run baselines. Acceptable.
+- Public example imports (`Object`, `PythonError`, `call_attr`, `from_str`, `from_int`, `from_float`, `from_list`, `from_dict_str`, `import_module`, `to_str`, `with_context`, `threadsafe_callback`, `zero_copy_arrow_stream`, `export_arrow_stream`, `zero_copy_dlpack_tensor`, etc.) match symbols present in `crates/sifr_stdlib/src/python.rs` and the canonical fixtures.
+- Local validation evidence (132 pass / 0 fail create-pr; 651 pass / 0 fail merge gate; only advisory warm wall-time and group-skew) is recorded in the exit-evidence file and the issue tracker bullet.
+
+Not satisfied — fix B1 before phase closure.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-final-review-3.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-final-review-3.md
@@ -1,0 +1,13 @@
+The two targeted patches are confirmed in place:
+
+- `docs/python-interop.mdx:103` now has `@blocking_io` on `fetch_status_sync`, matching the contract enforced by `SIFR-ASYNC-0005` and the positive fixture `verification/python_interop/fixtures/async_blocking/offloaded_python_calls.sifr:14,26` (no import needed; `@blocking_io` is a built-in, same as in the fixture). The surrounding async offload shape (`task.spawn_blocking`, `await handle.join()`) also matches the canonical fixture and `crates/sifr/tests/e2e/fail/spawn_blocking_unannotated_rejected.sifr`.
+- `internal_docs/python_interop_architecture.md:70` now reads `--group dataframes`, consistent with `verification/python_interop/README.md:38`, `docs/python-interop.mdx:324`, `verification/python_interop/reports/python_interop_exit_evidence.md:52,78`, and the canonical group list in the phase tracker.
+
+Focused checks all clean:
+- `rg` for `--group data\b`, raw `try` expressions, and `phase_closeout` returns no matches in scope.
+- `git diff --check` clean.
+- `docs.json` parses.
+
+Items previously verified clean in final-review-2 (phase tracker / roadmap / exit-evidence status strings; `SIFR-PYENV-0001..0011` and `SIFR-PYTRUST-0001..0004` diagnostic registration; reserved family list `PYIMP/PYCALL/PYCONV/PYRES/PYZC/PYCB`; quiet support scoped to `build`/`run` in `area_adapter.py:397-411`, schema `area.schema.json:162-164`, and manifest `project_workspace/manifest.json:48,67`; public-example symbol coverage in `sifr_stdlib`; local validation evidence 132/0 create-pr, 651/0 merge gate with only advisory wall-time/group-skew) remain valid — no scope was touched outside the two B1/group-rename patches, so those judgments still apply.
+
+reviewer satisfied: no blockers

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py12-review-3.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py12-review-3.md
@@ -1,0 +1,63 @@
+Blockers found. Not satisfied.
+
+## Blockers
+
+**B1 — `docs/python-interop.mdx`: all code examples use a `try`-as-expression-prefix form that Sifr does not support.**
+
+Sifr's `try` is the Python-statement form: a `try:`/`except` block where assignments inside the block are auto-unwrapped, per `docs/language/error-handling.mdx:48-60`. The parser inherits Ruff's grammar, which models only `StmtTry` (no `try` expression). Every verified Python-interop fixture uses the statement form — e.g., `verification/python_interop/fixtures/resource_cleanup/context_manager_success.sifr:16-33` and `verification/python_interop/fixtures/pyarrow_capsule/arrow_capsule_zero_copy.sifr:14-27`:
+
+```python
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        obj: Object = from_none()
+        array: ArrowCapsule = zero_copy_arrow_array(obj)
+        ...
+    except PythonError as e:
+        raise e
+```
+
+But the new `docs/python-interop.mdx` uses `try` as an expression prefix throughout — ~50+ occurrences spanning lines 75-83, 102-106, 119-128, 175-182, 188-190, 208-225, 231-242, 248-256, 263-269, plus inside f-strings (line 182). Examples:
+
+- `biip: Object = try import_module("biip")` (line 75)
+- `print(try to_str(parsed))` (line 78)
+- `return try call_attr(fastapi, "FastAPI", [], [])` (line 190)
+- `return f"{try to_str(parsed)} / {try to_str(bic)}"` (line 182)
+
+None would parse with Sifr's compiler. The docs contradict the language's actual error-handling shape and the implemented Python-interop syntax.
+
+**B2 — `docs/python-interop.mdx:97-99` task-handle usage diverges from the verified offload contract.**
+
+Docs show:
+```python
+handle = task.spawn_blocking(fetch_status_sync)
+return await handle
+```
+
+The merged demo (`demos/blocking_offload_demo/main.sifr:21-22`) and stdlib-parity inventory require `await handle.join()`:
+```python
+score_handle = task.spawn_blocking(compute_score)
+score_result = await score_handle.join()
+```
+
+No demo or fixture awaits a `TaskHandle` directly, and none uses `from sifr import task` (also new in the docs at line 95). This is the second class of "examples imply unsupported source syntax/API."
+
+**B3 — `plans/issues/active/ad-hoc-embedded-python-interop.md:101` points to a non-existent closeout artifact.**
+
+The new bullet says:
+> Phase exit evidence recorded in `verification/python_interop/reports/phase_closeout.md`…
+
+The file checked in is `verification/python_interop/reports/python_interop_exit_evidence.md` (correctly referenced by `verification/python_interop/README.md:62`). The closeout link in the phase plan is dead.
+
+**B4 — `plans/issues/active/ad-hoc-embedded-python-interop.md` milestone_py_12 status is internally inconsistent.**
+
+`milestone_py_12` is marked `- [x]` (complete), but its own sub-bullets state:
+- "final review and merge-gate validation pending before PR merge"
+- "Final validation and review evidence pending on the py12 closeout PR"
+
+The exit-evidence report agrees with "pending," not "done": "py12 full local validation must rerun `create-pr` and the default merge gate before the phase is marked closed" (`verification/python_interop/reports/python_interop_exit_evidence.md:80`). `plans/phases/index.md:53` and `plans/roadmap.md:124` both correctly read "closeout in progress" — only the issue file's checkbox is wrong. Phase tracking is inaccurate.
+
+## Out of scope / not flagged
+- `SIFR-PYENV-0001..0011` and `SIFR-PYTRUST-0001..0004` have stable codes, doc pages under `docs/errors/`, registry entries with structured JSON args, and test-reference pointers — diagnostic evidence coverage is fine.
+- Report status semantics (`passed` vs `matrix-passed` vs `scaffold`, host-dependent skip evidence) are documented consistently in `docs/python-interop.mdx:293`, `internal_docs/python_interop_architecture.md:73-79`, and the exit-evidence file.
+- `internal_docs/architecture.md` "production-grade complete" wording is defensible as a design-contract statement and is paired with the in-tree `python_interop_architecture.md` link.

--- a/plans/reviews/active/ad-hoc-embedded-python-interop-py12-review-4.md
+++ b/plans/reviews/active/ad-hoc-embedded-python-interop-py12-review-4.md
@@ -1,0 +1,19 @@
+I reviewed the closeout diff against the prior review's blockers and the user's gate criteria.
+
+**Prior B1 — try-as-expression syntax**: Fixed. All examples in `docs/python-interop.mdx` now use the statement form `try:` … `except PythonError as e: raise e` (lines 73-88, 99-112, 121-140, 161-173, 186-205, 207-216, 218-254, 257-274, 276-291, 293-305). `raise e` matches `demos/network_tcp_echo/main.sifr:17,41`.
+
+**Prior B2 — task handle / `from sifr import task` import**: Fixed. `docs/python-interop.mdx:96-112` uses `handle = task.spawn_blocking(fetch_status_sync); return await handle.join()` — matches `demos/blocking_offload_demo/main.sifr:21-22`. No `from sifr import task` is imported (consistent with the demo's bare-`task` reference).
+
+**Prior B3 — stale closeout artifact path**: Fixed. `plans/issues/active/ad-hoc-embedded-python-interop.md:101` points to `verification/python_interop/reports/python_interop_exit_evidence.md`, the file that actually exists and is referenced by `verification/python_interop/README.md:62`.
+
+**Prior B4 — milestone_py_12 status consistency**: Fixed. `plans/issues/active/ad-hoc-embedded-python-interop.md:97` is `- [ ]` pending with sub-bullet `Final validation and review evidence pending on the py12 PR.` (line 102). `plans/phases/index.md:53` and `plans/roadmap.md:124` both read "closeout in progress (py0-py11 merged through PR #2676; py12 owns docs, diagnostics, and final validation)" — consistent across the three trackers and the exit-evidence file's `pending full gates` line.
+
+**Diagnostic families**: `SIFR-PYENV-0001..0011` and `SIFR-PYTRUST-0001..0004` are the active families across `docs/diagnostics/error-codes.mdx:107-130`, `docs/python-interop.mdx:313-315`, `internal_docs/python_interop_architecture.md:97-102`, and the exit-evidence file (lines 20-34). `SIFR-PYIMP`, `PYCALL`, `PYCONV`, `PYRES`, `PYZC`, `PYCB` are marked reserved in every place. Doc URL format `/errors/<CODE>` is consistent.
+
+**Verification taxonomy**: Group/tier selectors in `docs/python-interop.mdx:319-325`, the exit-evidence file (lines 42-54), and `internal_docs/python_interop_architecture.md:65-71` match the canonical set in `verification/python_interop/README.md:26-44` (no `--group data`; only `--group dataframes`).
+
+**Report status semantics**: `passed` (live) / `matrix-passed` (matrix-only) / `scaffold` (shape only) are documented identically in `docs/python-interop.mdx:327`, `internal_docs/python_interop_architecture.md:73-79`, `verification/python_interop/README.md:53-60`, and the exit-evidence file.
+
+**py12 DoD evidence**: Exit evidence captures focused validation passes for py_compile, self-test, scaffold/env/tier1-4/callbacks/dataframes/cloud-boto3 selectors, and explicitly notes pending `create-pr` and default `run_all_tests`. Plan tracking aligns with that pending state.
+
+reviewer satisfied: no blockers

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -121,4 +121,4 @@ flowchart LR
 - Phase 42 and Phase 43 are intentionally excluded from the main execution table until post-Phase-41 planning lock.
 - [42_data_science_ml.md](./phases/42_data_science_ml.md) (needs more planning)
 - [43_interoperability.md](./phases/43_interoperability.md) (needs more planning)
-- [ad-hoc-embedded-python-interop.md](./issues/active/ad-hoc-embedded-python-interop.md) (active sequence-independent embedded CPython/uv interop lane; `milestone_py_1` adds package config parsing, environment selection, canonical probe validation, and `verification/python_interop --group env` evidence)
+- [ad-hoc-embedded-python-interop.md](./issues/active/ad-hoc-embedded-python-interop.md) (complete pending py12 PR #2677 merge for the sequence-independent embedded CPython/uv interop lane; py0-py11 are merged through PR #2676, and py12 completed public/internal docs, diagnostic evidence, py12 and phase-level Opus reviews, and local validation)

--- a/verification/areas/project_workspace/manifest.json
+++ b/verification/areas/project_workspace/manifest.json
@@ -44,7 +44,8 @@
           "entry": "verification/areas/project_workspace/fixtures/project/multi_module_run/main.sifr",
           "command": "run",
           "expect_exit_code": 0,
-          "diagnostic_formats": []
+          "diagnostic_formats": [],
+          "quiet": true
         },
         {
           "id": "missing_import_reports_error",
@@ -62,7 +63,8 @@
           "entry": "verification/areas/project_workspace/fixtures/project/workspace_dotted_helper_run/app.sifr",
           "command": "run",
           "expect_exit_code": 0,
-          "diagnostic_formats": []
+          "diagnostic_formats": [],
+          "quiet": true
         },
         {
           "id": "workspace_ambiguous_import",

--- a/verification/python_interop/README.md
+++ b/verification/python_interop/README.md
@@ -58,3 +58,8 @@ Package certification records include:
   environment/package execution status;
 - explicit Tier 4 skip records with `skip_reason` for host-dependent packages;
 - aggregate tier, gate, pass, and skip counts.
+
+The exit evidence is recorded in
+`reports/python_interop_exit_evidence.md`, including diagnostic families,
+validation commands, PR links, and the distinction between live and matrix-only
+gates.

--- a/verification/python_interop/reports/python_interop_exit_evidence.md
+++ b/verification/python_interop/reports/python_interop_exit_evidence.md
@@ -1,0 +1,108 @@
+# Embedded Python Interop Exit Evidence
+
+Status: documentation, evidence, Opus sign-offs, and local validation are complete. PR #2677 is pending merge.
+
+## Scope Covered
+
+- Root-owned uv CPython environment selection, probing, and cache metadata.
+- Embedded CPython runtime lifecycle, GIL/refcount discipline, object handles, and startup wiring.
+- Opaque object import/attribute/item/call helpers, kwargs, Python traceback capture, and typed `Result` errors.
+- Primitive, list/tuple/dict, record, bytes, and fixed-width conversion contracts.
+- Async blocking classification, offload constraints, and Python coroutine blocking.
+- Context-manager cleanup, explicit close/release, resource diagnostics, and double-release coverage.
+- `Py_buffer`, Arrow PyCapsule, DLPack, and array-interface zero-copy contracts with explicit copy-vs-view evidence.
+- Local and threadsafe Python-to-Sifr callbacks.
+- Tier 1 through Tier 4 package certification matrices with deterministic matrix reports and explicit host-dependent skips.
+- Public docs, internal architecture docs, diagnostics documentation, and issue tracking updates.
+
+## Diagnostics
+
+Active compiler diagnostic families:
+
+| Family | Codes | Evidence |
+| --- | --- | --- |
+| `SIFR-PYENV` | `0001..0011` | `crates/sifr_package/src/python/tests.rs`; generated docs under `docs/errors/`; registry rows in `internal_docs/diagnostic_codes.md`. |
+| `SIFR-PYTRUST` | `0001..0004` | `crates/sifr_package/src/python/trust_policy_tests.rs`, `crates/sifr_lowering/src/lower/python_trust_tests.rs`; generated docs under `docs/errors/`; registry rows in `internal_docs/diagnostic_codes.md`. |
+
+Reserved runtime-adjacent families:
+
+- `SIFR-PYIMP`
+- `SIFR-PYCALL`
+- `SIFR-PYCONV`
+- `SIFR-PYRES`
+- `SIFR-PYZC`
+- `SIFR-PYCB`
+
+Runtime failures in those areas currently return structured `py.PythonError` family values. They are not compiler diagnostics unless a future compiler-emitted failure mode requires a stable diagnostic code.
+
+## Verification Commands
+
+Focused Python interop commands:
+
+```bash
+python3 -m py_compile verification/python_interop/runner/*.py
+verification/python_interop/run.sh --self-test
+verification/python_interop/run.sh --group scaffold
+verification/python_interop/run.sh --group env
+verification/python_interop/run.sh --tier tier1 --report reports/tier1.latest.json
+verification/python_interop/run.sh --tier tier2 --report reports/tier2.latest.json
+verification/python_interop/run.sh --tier tier3 --report reports/tier3.latest.json
+verification/python_interop/run.sh --tier tier4 --report reports/tier4.latest.json
+verification/python_interop/run.sh --group callbacks --report reports/callbacks.latest.json
+verification/python_interop/run.sh --group dataframes --report reports/dataframes.latest.json
+verification/python_interop/run.sh --group cloud --package boto3 --report reports/package.latest.json
+```
+
+Repository gates:
+
+```bash
+git diff --check
+python3 scripts/check_file_size_guardrails.py
+python3 scripts/check_hir_maintainability_guardrails.py
+python3 verification/areas/coverage_matrix/checks/verification_taxonomy.py
+scripts/run_all_tests.sh --profile create-pr
+scripts/run_all_tests.sh
+```
+
+Latest local validation evidence:
+
+- py11 `create-pr` validation passed on 2026-06-19 with zero failures and advisory `warm wall-time budget exceeded`; this included Python interop package certification code as merged in PR #2676.
+- py12 focused validation on 2026-06-19:
+  - `python3 -m py_compile verification/python_interop/runner/*.py`
+  - `verification/python_interop/run.sh --self-test`
+  - `verification/python_interop/run.sh --group scaffold`: `scaffold`
+  - `verification/python_interop/run.sh --group env`: `passed`
+  - `verification/python_interop/run.sh --tier tier1`: `matrix-passed`, 149 selected, 148 certified, 1 host-dependent skip.
+  - `verification/python_interop/run.sh --tier tier4`: `matrix-passed`, 30 selected, 0 certified, 30 host-dependent skips.
+  - `verification/python_interop/run.sh --group callbacks`: `matrix-passed`, 5 certified packages.
+  - `verification/python_interop/run.sh --group dataframes`: `matrix-passed`, 4 certified packages.
+  - `verification/python_interop/run.sh --group cloud --package boto3`: `matrix-passed`, 1 certified package.
+- py12 `scripts/run_all_tests.sh --profile create-pr` passed on 2026-06-19:
+  - `wall_time=713.46s`, `cpu=719.98s`, `max_rss=518.8MiB`, `swaps=0`.
+  - e2e: 132 passed, 0 failed; cache hits `0/44`.
+  - hardening summary: 6 variants, 0 failures, 0 blocking failures.
+  - advisory: `warm wall-time budget exceeded` from cold e2e cache rebuilds.
+- py12 `scripts/run_all_tests.sh` default merge gate passed on 2026-06-19:
+  - `wall_time=1360.56s`, `cpu=1268.50s`, `max_rss=542.7MiB`, `swaps=0`.
+  - e2e: 651 passed, 0 failed; cache hits `182/182`.
+  - hardening summary: 260 variants, 0 failures, 0 blocking failures.
+  - advisories: `warm wall-time budget exceeded`; `group skew is high; investigate batching balance or fixture clustering`.
+  - project-workspace hardening baselines passed after the manifest-level quiet-run support was added for run baselines with deterministic stdout and intentionally empty stderr.
+  - note: earlier local attempts were invalidated by stale overlapping validation work; the recorded gates above are the clean authoritative passes.
+- Opus sign-offs are recorded in the issue tracker review artifacts with no remaining blockers.
+
+## PR Record
+
+- py0: [#2665](https://github.com/sifr-lang/sifr/pull/2665)
+- py1: [#2666](https://github.com/sifr-lang/sifr/pull/2666)
+- py2: [#2667](https://github.com/sifr-lang/sifr/pull/2667)
+- py3: [#2668](https://github.com/sifr-lang/sifr/pull/2668)
+- py4: [#2669](https://github.com/sifr-lang/sifr/pull/2669)
+- py5: [#2670](https://github.com/sifr-lang/sifr/pull/2670)
+- py6: [#2671](https://github.com/sifr-lang/sifr/pull/2671)
+- py7: [#2672](https://github.com/sifr-lang/sifr/pull/2672)
+- py8: [#2673](https://github.com/sifr-lang/sifr/pull/2673)
+- py9: [#2674](https://github.com/sifr-lang/sifr/pull/2674)
+- py10: [#2675](https://github.com/sifr-lang/sifr/pull/2675)
+- py11: [#2676](https://github.com/sifr-lang/sifr/pull/2676)
+- py12: [#2677](https://github.com/sifr-lang/sifr/pull/2677)

--- a/verification/runner/sifr_verify/area_adapter.py
+++ b/verification/runner/sifr_verify/area_adapter.py
@@ -313,6 +313,7 @@ def run_baseline_case(
 ) -> tuple[dict[str, Any], bool, int]:
     case_id, entry, command_name, formats = baseline_case_metadata(config, suite_name, case)
     expected_exit = int(case["expect_exit_code"])
+    quiet = baseline_case_quiet(config, suite_name, case_id, command_name, case)
 
     case_failed = False
     failed_variants = 0
@@ -328,6 +329,7 @@ def run_baseline_case(
             command_name=command_name,
             entry=entry,
             diagnostic_format=diagnostic_format,
+            quiet=quiet,
         )
         stdout_norm = canonicalize_output(stdout, diagnostic_format, "stdout")
         stderr_norm = canonicalize_output(stderr, diagnostic_format, "stderr")
@@ -390,6 +392,23 @@ def baseline_case_metadata(
         raise SystemExit(f"{config.area} suite '{suite_name}' case '{case_id}' has invalid diagnostic_formats")
     validate_unique_diagnostic_formats(suite_name, case_id, formats)
     return case_id, entry, command_name, formats
+
+
+def baseline_case_quiet(
+    config: AreaAdapterConfig,
+    suite_name: str,
+    case_id: str,
+    command_name: str,
+    case: dict[str, Any],
+) -> bool:
+    raw_quiet = case.get("quiet", False)
+    if not isinstance(raw_quiet, bool):
+        raise SystemExit(f"{config.area} suite '{suite_name}' case '{case_id}' quiet must be a boolean")
+    if raw_quiet and command_name not in {"build", "run"}:
+        raise SystemExit(
+            f"{config.area} suite '{suite_name}' case '{case_id}' quiet is only supported for build/run"
+        )
+    return raw_quiet
 
 
 def case_entry_path(
@@ -464,6 +483,7 @@ def run_sifr_variant(
     command_name: str,
     entry: Path,
     diagnostic_format: str | None,
+    quiet: bool,
 ) -> tuple[int, str, str, float, list[str]]:
     cwd = REPO_ROOT
     argv = ["cargo", "run", "--locked", "-q", "-p", "sifr", "--"]
@@ -518,7 +538,10 @@ def run_sifr_variant(
     elif command_name == "self-version":
         argv.extend(["self", "version"])
     else:
-        argv.extend([command_name, str(entry)])
+        argv.append(command_name)
+        if quiet:
+            argv.append("--quiet")
+        argv.append(str(entry))
     env = None
     if command_name == "self-version":
         env = dict(os.environ)

--- a/verification/schemas/area.schema.json
+++ b/verification/schemas/area.schema.json
@@ -158,6 +158,9 @@
                   "items": {
                     "type": "string"
                   }
+                },
+                "quiet": {
+                  "type": "boolean"
                 }
               }
             }


### PR DESCRIPTION
## Summary
- add the public Python interop docs page and package/diagnostic doc links
- add internal Python interop architecture and exit evidence for py0-py12
- record py12 milestone and final Opus review artifacts
- add manifest-level quiet support for deterministic project-workspace run baselines

## Validation
- focused Python interop checks passed: runner py_compile, self-test, scaffold, env, tier1, tier4, callbacks, dataframes, cloud boto3
- focused guardrails after final review fixes: git diff --check, docs/docs.json JSON parse, file-size guardrails, HIR maintainability guardrails, verification taxonomy
- scripts/run_all_tests.sh --profile create-pr: passed, 132 e2e pass tests, 0 failures, hardening 6 variants, advisory warm wall-time budget exceeded
- scripts/run_all_tests.sh: passed, 651 e2e pass tests, 0 failures, hardening 260 variants, advisories warm wall-time budget exceeded and group skew high

## Reviews
- py12 Opus review round 4: reviewer satisfied, no blockers
- final implementation Opus review round 3: reviewer satisfied, no blockers
