### PR TITLE
Prepare Python interop verification closeout

### DIFF
--- a/plans/issues/active/python-interop-verification-production.md
+++ b/plans/issues/active/python-interop-verification-production.md
@@ -40,7 +40,7 @@ Make embedded Python interop verification authoritative enough to prove real exa
 - `verification_py_area_1`: implemented in PR [#2680](https://github.com/sifr-lang/sifr/pull/2680).
 - `verification_py_area_2`: implemented in PR [#2681](https://github.com/sifr-lang/sifr/pull/2681) (`python-interop-container-policy`).
 - `verification_py_area_3`: implemented in PR [#2682](https://github.com/sifr-lang/sifr/pull/2682) (`python-interop-testcontainers-live-examples`).
-- `verification_py_area_4`: final closeout implemented on branch `python-interop-verification-closeout`; PR pending.
+- `verification_py_area_4`: final closeout implemented in PR #2683 (`python-interop-verification-closeout`); pending merge.
 
 ## Final Evidence
 

--- a/plans/issues/active/python-interop-verification-production.md
+++ b/plans/issues/active/python-interop-verification-production.md
@@ -1,6 +1,6 @@
 # Python Interop Verification Productionization
 
-> Status: in progress. This follow-up converts Python interop verification from a standalone matrix/probe runner into a first-class verification area and adds production-grade live dependency examples backed by testcontainers.
+> Status: closeout in progress. The implementation PRs have converted Python interop verification from a standalone matrix/probe runner into a first-class verification area and added production-grade live dependency examples backed by testcontainers. The final closeout PR is pending.
 
 ## Objective
 
@@ -38,5 +38,16 @@ Make embedded Python interop verification authoritative enough to prove real exa
 ## Milestone Evidence
 
 - `verification_py_area_1`: implemented in PR [#2680](https://github.com/sifr-lang/sifr/pull/2680).
-- `verification_py_area_2`: implemented in PR #2681 (`python-interop-container-policy`).
-- `verification_py_area_3`: implemented in PR #2682 (`python-interop-testcontainers-live-examples`).
+- `verification_py_area_2`: implemented in PR [#2681](https://github.com/sifr-lang/sifr/pull/2681) (`python-interop-container-policy`).
+- `verification_py_area_3`: implemented in PR [#2682](https://github.com/sifr-lang/sifr/pull/2682) (`python-interop-testcontainers-live-examples`).
+- `verification_py_area_4`: final closeout implemented on branch `python-interop-verification-closeout`; PR pending.
+
+## Final Evidence
+
+- First-class area migration merged in PR #2680.
+- Container-runtime/live-profile policy merged in PR #2681.
+- Testcontainers-backed live examples merged in PR #2682.
+- PR3 Opus reviews reported no blockers through `plans/reviews/active/python-interop-live-examples-review-4.md`.
+- Closeout Opus reviews are tracked in `plans/reviews/active/python-interop-verification-closeout-review-1.md` and `plans/reviews/active/python-interop-verification-closeout-review-2.md`.
+- Latest local PR gate for the live examples passed on 2026-06-19: `scripts/run_all_tests.sh --profile create-pr` completed with zero failures and advisory `warm wall-time budget exceeded`.
+- Latest live profile evidence on 2026-06-19: `scripts/run_all_tests.sh --profile python-interop-live` passed; Sifr source checks passed, and service cases reported `structured-skip` because the local Docker daemon was unavailable.

--- a/plans/phases/index.md
+++ b/plans/phases/index.md
@@ -51,4 +51,4 @@ Phase status remains authoritative in each phase file header and is mirrored her
 | 42 | Phase 42: Data Science and ML | unspecified | [42_data_science_ml.md](./42_data_science_ml.md) |
 | 43 | Phase 43: Interoperability | unspecified | [43_interoperability.md](./43_interoperability.md) |
 | PY-1 | Ad Hoc Embedded Python Interop | complete (py0-py12 merged through PR #2677; py12 docs, diagnostics, reviews, and local validation complete) | [../issues/active/ad-hoc-embedded-python-interop.md](../issues/active/ad-hoc-embedded-python-interop.md) |
-| PY-1V | Python Interop Verification Productionization | in progress | [../issues/active/python-interop-verification-production.md](../issues/active/python-interop-verification-production.md) |
+| PY-1V | Python Interop Verification Productionization | closeout in progress (area migration PR #2680, live policy PR #2681, testcontainers examples PR #2682 merged; final closeout PR pending) | [../issues/active/python-interop-verification-production.md](../issues/active/python-interop-verification-production.md) |

--- a/plans/reviews/active/python-interop-verification-closeout-review-1.md
+++ b/plans/reviews/active/python-interop-verification-closeout-review-1.md
@@ -1,0 +1,37 @@
+Closeout review for the Python Interop Verification Productionization phase. Findings below are severity-ordered (blockers first), with file and line refs. No files modified.
+
+## Blockers
+
+### B1 — Closeout review artifact is empty (missing required closure doc)
+- File: `plans/reviews/active/python-interop-verification-closeout-review-1.md` (0 bytes; 1 line)
+- Milestone `verification_py_area_4` (`plans/issues/active/python-interop-verification-production.md:26-29`) requires "Run Opus review rounds until no blockers remain" for the closeout itself. The cited review-4 (`plans/reviews/active/python-interop-live-examples-review-4.md:1-11`) is scoped to PR3 (the testcontainers live examples), not to the closeout branch's documentation/status edits.
+- Prior phase closeouts followed the pattern of a dedicated final review with content (e.g., `ad-hoc-embedded-python-interop-final-review-4.md`, 2380 bytes). Here the equivalent file exists but is empty.
+- Result: the closeout has no recorded review verdict; "complete" cannot be substantiated against the workflow's review gate.
+
+### B2 — Closeout PR not opened/merged, but the phase is already marked complete
+- `plans/issues/active/python-interop-verification-production.md:43`: "final closeout implemented on branch `python-interop-verification-closeout`; PR pending."
+- vs. `plans/issues/active/python-interop-verification-production.md:3`: "Status: complete."
+- vs. `plans/phases/index.md:54`: "complete (… final closeout complete)".
+- vs. `plans/roadmap.md:125`: "(complete follow-up: …)".
+- `git log` confirms PRs #2680/#2681/#2682 merged into `main`, but no merge commit exists for the closeout branch. AGENTS.md "Required workflow" (steps 3-4: open PR → review and merge) is not satisfied for milestone 4. Marking the phase complete before its own closeout PR exists is inaccurate status.
+
+### B3 — Milestone 4 checkbox premature relative to its own acceptance criteria
+- `plans/issues/active/python-interop-verification-production.md:26-29`: milestone 4 explicitly requires "Record merged PR links and final evidence."
+- Same file line 43 states the closeout PR is pending, so no merged PR link can yet be recorded for milestone 4. The `[x]` on line 26 is set before its third bullet is satisfiable.
+
+## Non-blocker consistency findings (worth fixing alongside the closeout PR)
+
+### N1 — Asymmetric PR hyperlinks in Milestone Evidence
+- `plans/issues/active/python-interop-verification-production.md:40` links #2680 to GitHub; lines 41-42 reference #2681/#2682 as bare numbers. Cosmetic, but undermines auditability since the merge commits exist.
+
+### N2 — "Final Evidence" cites review-4 as the closeout sign-off
+- `plans/issues/active/python-interop-verification-production.md:50` reads as if `python-interop-live-examples-review-4.md` is the phase's final review. That file's verdict (`...:1-11`) explicitly covers PR3's delta only ("Reviewed the delta only — no other files in the working tree were modified for this round"). It is not a closeout-scope review and should not be presented as one.
+
+### N3 — Live execution evidence is structured-skip only on this host
+- `plans/issues/active/python-interop-verification-production.md:52` and `verification/areas/python_interop/reports/python_interop_exit_evidence.md:102` accurately record that `python-interop-live` reported `structured-skip` because Docker is unavailable. Per design this is acceptable (live profile is opt-in, testcontainers gated on Docker). However, the phase has **no recorded end-to-end pass against real Redis/Postgres/Kafka-compatible/LocalStack endpoints anywhere in the closure evidence** — only "Sifr source checks passed, services structured-skip." If the objective "prove real examples with real dependencies" (issue line 7) is to be defensible, at least one host-Docker-available pass should be captured (locally or in a review) before declaring the phase complete. Not a strict blocker against the recorded design, but a credibility gap given the stated objective.
+
+## Final verdict
+
+**Not satisfied.**
+
+The closure documentation contradicts itself on whether the closeout is complete (B2), the milestone-4 checkbox is set before its "record merged PR links" criterion is satisfiable (B3), and the closeout-scope review artifact is empty (B1). Address by: (a) writing the closeout review content, (b) opening and merging the closeout PR, (c) updating `Milestone Evidence` line 42-43 + `Final Evidence` with the merged closeout PR link, and (d) keeping `phases/index.md:54` aligned with the issue's milestone state until the PR merges. N1/N2/N3 should be fixed in the same closeout PR.

--- a/plans/reviews/active/python-interop-verification-closeout-review-2.md
+++ b/plans/reviews/active/python-interop-verification-closeout-review-2.md
@@ -1,0 +1,35 @@
+I've reviewed the four edited files, the round 1 review, the two review files in `plans/reviews/active/`, and the git log. Here's round 2 of the closeout review.
+
+## Status of round 1 blockers
+
+**B1 (empty closeout review artifact): FIXED.** `plans/reviews/active/python-interop-verification-closeout-review-1.md` now contains 37 lines / 4657 bytes with severity-ordered findings — no longer 0 bytes.
+
+**B2 (phase marked complete before its own PR exists/merges): FIXED.**
+- `plans/issues/active/python-interop-verification-production.md:3` — "Status: closeout in progress. … The final closeout PR is pending."
+- `plans/phases/index.md:54` — "closeout in progress (area migration PR #2680, live policy PR #2681, testcontainers examples PR #2682 merged; final closeout PR pending)".
+- `plans/roadmap.md:125` — "closeout in progress; implementation complete through PR #2682 …".
+- `verification/areas/python_interop/reports/python_interop_exit_evidence.md:5-10` — "Additional verification productionization implementation is complete through PR #2682 … Final status is tracked in `plans/issues/active/python-interop-verification-production.md`." Phrasing scopes the "complete" claim to implementation only, not to closeout. The four files are mutually consistent.
+
+**B3 (milestone 4 checkbox premature): FIXED.** `plans/issues/active/python-interop-verification-production.md:26` now shows `[ ]` for `verification_py_area_4`. Line 43 records "PR pending" rather than a merged link, so the third milestone-4 bullet ("Record merged PR links and final evidence") remains correctly unsatisfied until the closeout PR merges.
+
+## Status of round 1 non-blockers
+
+**N1 (asymmetric PR hyperlinks): FIXED.** Issue lines 41-42 now hyperlink #2681 and #2682.
+
+**N2 (review-4 cited as closeout sign-off): FIXED.** Issue line 50 ("PR3 Opus reviews reported no blockers through `…live-examples-review-4.md`") and line 51 ("Closeout Opus review is tracked in `…closeout-review-1.md`") correctly partition PR3-scope from closeout-scope, matching review-4's self-described "delta only" scope.
+
+**N3 (no real-services pass evidence): NOT addressed in this branch.** The issue and exit evidence still record `structured-skip` only, because the local Docker daemon was unavailable. Round 1 explicitly classified this as "not a strict blocker against the recorded design" since the live profile is opt-in and Docker-gated. Carrying the same classification into round 2: not a blocker for opening this PR as a closeout-progress PR; remains a credibility note against the issue's "real examples with real dependencies" objective and should be closed by at least one Docker-available pass before the phase is flipped to `complete`.
+
+## New observations
+
+- `Final Evidence` references `closeout-review-1.md` only. Once this round 2 review is recorded, the same section should list both rounds for symmetry — natural to fold into this same closeout PR.
+- The exit evidence's added commands block correctly puts `scripts/run_all_tests.sh --profile python-interop-live` under "Verification Commands" without claiming a real-services pass — consistent with N3 being design-acknowledged.
+- Validation re-runs you reported (`git diff --check`; coverage_matrix readiness suite) are appropriate signals for a docs-only diff; no additional gate is needed for this branch's scope.
+
+## Final verdict
+
+**Satisfied** — closeout PR is ready to open/merge as a *closeout-progress* PR.
+
+Sequence the merge-time follow-up explicitly:
+1. Open the closeout PR with the current diff.
+2. After it merges, update in a final tiny PR (or amend before merging if your workflow allows): issue line 26 → `[x]`; line 43 → merged closeout PR link; line 3 → "complete"; `phases/index.md:54` → "complete"; `roadmap.md:125` → "complete". Do not pre-flip any of these in the current closeout PR — keeping them as "closeout in progress" is what makes this branch internally consistent.

--- a/plans/roadmap.md
+++ b/plans/roadmap.md
@@ -122,4 +122,4 @@ flowchart LR
 - [42_data_science_ml.md](./phases/42_data_science_ml.md) (needs more planning)
 - [43_interoperability.md](./phases/43_interoperability.md) (needs more planning)
 - [ad-hoc-embedded-python-interop.md](./issues/active/ad-hoc-embedded-python-interop.md) (complete for the sequence-independent embedded CPython/uv interop lane; py0-py12 are merged through PR #2677 with public/internal docs, diagnostic evidence, py12 and phase-level Opus reviews, and local validation)
-- [python-interop-verification-production.md](./issues/active/python-interop-verification-production.md) (active follow-up to make embedded Python interop verification first-class under `verification/areas` and add testcontainers-backed live dependency examples)
+- [python-interop-verification-production.md](./issues/active/python-interop-verification-production.md) (closeout in progress; implementation complete through PR #2682 with first-class area wiring, explicit live/container policy, and testcontainers-backed Redis/Postgres/Kafka-compatible/LocalStack SNS-SQS examples)

--- a/verification/areas/python_interop/reports/python_interop_exit_evidence.md
+++ b/verification/areas/python_interop/reports/python_interop_exit_evidence.md
@@ -2,6 +2,13 @@
 
 Status: documentation, evidence, Opus sign-offs, and local validation are complete. PR #2677 merged on 2026-06-19.
 
+Additional verification productionization implementation is complete through
+PR #2682: PR #2680 moved the runner into `verification/areas/python_interop`,
+PR #2681 added explicit container-runtime/live-profile policy, and PR #2682
+added the opt-in testcontainers-backed live examples for Redis, Postgres,
+Kafka-compatible Redpanda, and LocalStack SNS/SQS. Final status is tracked in
+`plans/issues/active/python-interop-verification-production.md`.
+
 ## Scope Covered
 
 - Root-owned uv CPython environment selection, probing, and cache metadata.
@@ -51,6 +58,7 @@ verification/areas/python_interop/run.sh --tier tier4 --report ../../../target/v
 verification/areas/python_interop/run.sh --group callbacks --report ../../../target/verification/areas/python_interop/callbacks.latest.json
 verification/areas/python_interop/run.sh --group dataframes --report ../../../target/verification/areas/python_interop/dataframes.latest.json
 verification/areas/python_interop/run.sh --group cloud --package boto3 --report ../../../target/verification/areas/python_interop/package.latest.json
+scripts/run_all_tests.sh --profile python-interop-live
 ```
 
 Repository gates:
@@ -90,6 +98,10 @@ Latest local validation evidence:
   - project-workspace hardening baselines passed after the manifest-level quiet-run support was added for run baselines with deterministic stdout and intentionally empty stderr.
   - note: earlier local attempts were invalidated by stale overlapping validation work; the recorded gates above are the clean authoritative passes.
 - Opus sign-offs are recorded in the issue tracker review artifacts with no remaining blockers after documented fixes.
+- Additional verification productionization validation on 2026-06-19:
+  - `scripts/run_all_tests.sh --profile create-pr`: passed with zero failures and advisory `warm wall-time budget exceeded`.
+  - `scripts/run_all_tests.sh --profile python-interop-live`: passed; live Sifr source checks passed and service cases reported `structured-skip` because the local Docker daemon was unavailable.
+  - Final Opus review through `plans/reviews/active/python-interop-live-examples-review-4.md`: no blockers.
 
 ## PR Record
 
@@ -106,3 +118,6 @@ Latest local validation evidence:
 - py10: [#2675](https://github.com/sifr-lang/sifr/pull/2675)
 - py11: [#2676](https://github.com/sifr-lang/sifr/pull/2676)
 - py12: [#2677](https://github.com/sifr-lang/sifr/pull/2677)
+- verification area migration: [#2680](https://github.com/sifr-lang/sifr/pull/2680)
+- verification live policy: [#2681](https://github.com/sifr-lang/sifr/pull/2681)
+- verification live examples: [#2682](https://github.com/sifr-lang/sifr/pull/2682)


### PR DESCRIPTION
## Summary
- record Python interop verification productionization implementation evidence through PRs #2680, #2681, and #2682
- keep closeout state honest as in-progress until this closeout PR is merged
- update roadmap, phase index, and Python interop exit evidence with the live profile/testcontainers evidence

## Validation
- git diff --check
- uv run --project verification --locked python -m sifr_verify areas run --area coverage_matrix --suite readiness

## Reviews
- plans/reviews/active/python-interop-verification-closeout-review-1.md: Opus found premature completion blockers, fixed in this branch
- plans/reviews/active/python-interop-verification-closeout-review-2.md: Opus satisfied, no blockers; ready to open/merge as closeout-progress PR

## Follow-up after merge
- Final tiny PR should flip the phase to complete and record this closeout PR as merged.
