### PR TITLE
Stabilize representative performance p95 checks

### DIFF
--- a/plans/reviews/active/stabilize-representative-perf-budget-review-pass-1.md
+++ b/plans/reviews/active/stabilize-representative-perf-budget-review-pass-1.md
@@ -1,0 +1,31 @@
+## Review
+
+### 1. Blockers
+None — implementation is correct.
+
+- `should_enforce_p95` is referenced at `check_budgets.py:276` and defined later at `check_budgets.py:305`. Fine — Python resolves at call time.
+- Bool-vs-int check in `validate_results_shape` (line 239) correctly excludes `True`/`False` from passing as positive integers.
+- Self-test coverage proves both directions: 5-sample p95 spike does **not** fail (`check_budgets.py:353–354`), 20-sample p95 spike does (`check_budgets.py:343`). The chosen seed benchmarks back this up — `check-project-004-project-graph` has `sample_count: 5` and `interactive-tooling-foundation-002-warm-diagnostics-query` has `sample_count: 20` in baselines, so the seeds aren't accidentally testing the wrong branch.
+- Old `budget_p95_regression_result.json` seed is no longer referenced and not used elsewhere — harmless dead file, not a blocker.
+
+### 2. Gate-policy risk (real, worth raising)
+
+This is the part to weigh before merging — not a bug, but a soft policy shift:
+
+- **Silent scope.** 39 of 65 baselines (`check_budgets.py` data) have `sample_count: 5`, so this patch quietly drops p95 enforcement for ~60% of the budgeted suite. The CLI still prints `performance budget check passed` with no indication that p95 was skipped for any benchmark.
+- **No per-benchmark opt-in.** The decision is a single global constant `MIN_P95_SAMPLE_COUNT = 20` (line 25) with no comment explaining why 20, and no per-budget switch (e.g. `enforce_p95: false` in `budgets.json`). When someone later adds a benchmark with `measured: 10`, p95 silently won't gate it.
+- **Root-cause alternative not addressed.** The manifest hard-codes `measured: 5` for the noisy cases. A more durable fix would be: bump those cases to `measured: 20` in the representative suite, or switch the noisy ones to a robust statistic (trimmed mean / MAD-bounded). This patch lowers the gate sensitivity instead of fixing the sample size. Median is still enforced, so this is defensible — but it is a policy decision worth being explicit about.
+- **Missing visibility hook.** A one-line `print` or stderr note listing benchmarks whose p95 was skipped would turn a silent waiver into an auditable one without changing behaviour.
+
+### 3. Non-blocking suggestions
+
+- Log the list of skipped-p95 benchmarks in `check_budgets`/`compare_result` so operators see what was waived this run.
+- Add a boundary self-test for `sample_count == 19` (skipped) vs `sample_count == 20` (enforced) to lock the threshold.
+- Add a self-test that median regression on a 5-sample seed still fails — proves median enforcement isn't accidentally tied to the same gate.
+- `spike_five_sample_p95` and `spike_twenty_sample_p95` (`check_budgets.py:443–456`) are near-duplicates — could be one helper parameterised by id.
+- Consider validating `len(samples_ms) == sample_count` here (mirrors `check_trend_policy.py:266–267`) since the new policy depends on `sample_count` being truthful. Trend policy catches it elsewhere, so this is defence-in-depth, not required.
+- A comment near `MIN_P95_SAMPLE_COUNT` explaining "below 20 samples, nearest-rank p95 collapses to max and becomes scheduler-noise-bound" would document the why for the next person.
+
+### 4. Merge recommendation
+
+**Merge — conditional on filing the visibility follow-up.** The patch is correct, validation passes, and it unblocks the gate without weakening median/RSS/timeout/cache enforcement. But the silent waiver of p95 for 60% of benchmarks is a real footgun; I'd want either a one-line skip log in this PR or a tracked follow-up to (a) surface skipped p95s and (b) revisit whether to raise the noisy benchmarks to `measured: 20` rather than relax the gate. Without that, the next "p95 looks fine" claim will be hard to trust.

--- a/plans/reviews/active/stabilize-representative-perf-budget-review-pass-2.md
+++ b/plans/reviews/active/stabilize-representative-perf-budget-review-pass-2.md
@@ -1,0 +1,25 @@
+## Review (Pass 2)
+
+### 1. Blockers
+
+None. All Pass 1 follow-ups landed correctly:
+
+- **p95 skip rationale comment** at `check_budgets.py:25-27`. Reads cleanly.
+- **CLI audit note** at `check_budgets.py:319-330`. Threaded via `report_skipped_p95=True` only from `main()` (line 58), so direct CLI runs *and* `sifr_verify areas run` (which shells out to `check_budgets.py` via `runner.py:173,199`) both surface it; in-process self-tests stay quiet — correct separation.
+- **Sample-count / samples_ms validation** at `check_budgets.py:243-250`. The bool exclusion is right (`isinstance(True, int)` is True in Python), positive-integer guard, list-shape, length match, and numeric-non-bool sample contents all covered. I verified `baselines.json` (65 entries) and every result-bearing negative seed already satisfy the new shape — no false positives.
+- **Boundary coverage** at `check_budgets.py:378-379`. `spike_p95_below_threshold` forces 19 samples and passes; `spike_p95_at_threshold` forces 20 and fails. Both branches of `should_enforce_p95` are now locked in.
+- **Median-still-enforced on 5-sample case** at `check_budgets.py:377` — uses `check-project-004-project-graph` (confirmed `sample_count: 5` in baselines), so it proves median is independent of the new gate.
+- **Ordering of new validation vs malformed seed:** `budget_malformed_result.json` is missing `p95_ms` but has valid `sample_count: 5` / matching `samples_ms`, so it still fails on the existing `missing metric` diagnostic — refactor didn't regress that path.
+
+### 2. Non-blocking suggestions
+
+- **Redundant p95 spike test.** `spike_twenty_sample_p95` (line 367) and `spike_p95_at_threshold` (line 379) produce the same effective result — the baseline already has `sample_count: 20` for `interactive-tooling-foundation-002-warm-diagnostics-query`, so `force_sample_count(...,20)` is a no-op. Either drop line 367 (the boundary test subsumes it) or fold the boundary tests next to it for grouping.
+- **Orphan seed file.** `verification/areas/performance/negative_seeds/budget_p95_regression_result.json` is no longer referenced from anywhere. Pass 1 flagged this as harmless; still worth deleting in this PR to avoid the next reader wondering whether it should be wired in.
+- **`int(result["sample_count"])` cast** at `check_budgets.py:316` is defensive — validation already guarantees a positive int. Minor; harmless either way.
+- **Audit note legibility.** `id:count` is parser-friendly but a bit terse for a human glancing at CI logs. `id (sample_count=N)` would scan slightly better; not worth blocking on.
+- **Comment wording.** The "scheduler-bound" framing at line 25-27 is technically right but might be opaque to a future reader; "with <20 samples the nearest-rank p95 collapses to the max sample, so it tracks scheduler noise rather than the workload" is the longer-form version.
+- **`spike_metric` / `force_sample_count` raise `BudgetError`** for "case not found" — these are programmer-invariant violations, not budget failures. Using `AssertionError` (or just `assert`) would be more idiomatic, but `BudgetError` propagates through the self-test harness the same way, so functionally fine.
+
+### 3. Merge recommendation
+
+**Approve / ready to merge.** The Pass 1 visibility ask is addressed (skipped-p95 audit note surfaces in both CLI and area-runner paths), boundary and median-still-enforced regressions are locked in, and the new shape validation defends the precondition that `should_enforce_p95` depends on. The only cleanup I'd consider doing in this same PR is deleting the orphaned `budget_p95_regression_result.json` and dropping the duplicate `spike_twenty_sample_p95` self-test line — both are trivial and avoid leaving the next reviewer with the same "is this still wired in?" question.

--- a/verification/areas/performance/check_budgets.py
+++ b/verification/areas/performance/check_budgets.py
@@ -22,6 +22,9 @@ DEFAULT_WAIVERS = PERF_DATA / "waivers.json"
 NEGATIVE_ROOT = PERF_ROOT / "negative_seeds"
 RUNNER_VERSION = 1
 ALLOWED_WAIVER_OVERRIDE_KEYS = {"median_ms", "p95_ms", "peak_rss_bytes", "cache_hits"}
+# The nearest-rank p95 used by the benchmark runner collapses to the maximum
+# sample below 20 samples, making quick representative runs scheduler-bound.
+MIN_P95_SAMPLE_COUNT = 20
 EMPTY_WAIVERS = {
     "version": 1,
     "waivers": [],
@@ -52,7 +55,7 @@ def main() -> int:
         budgets = load_json(Path(args.budgets))
         waivers = load_json(Path(args.waivers))
         results = load_json(Path(args.results))
-        check_budgets(manifest, budgets, waivers, results, allow_subset=args.allow_subset)
+        check_budgets(manifest, budgets, waivers, results, allow_subset=args.allow_subset, report_skipped_p95=True)
         print("performance budget check passed")
         return 0
     except BudgetError as error:
@@ -67,6 +70,7 @@ def check_budgets(
     results: dict[str, Any],
     *,
     allow_subset: bool = False,
+    report_skipped_p95: bool = False,
 ) -> None:
     cases = validate_manifest(manifest)
     budget_entries = validate_budgets(budgets, cases)
@@ -85,6 +89,8 @@ def check_budgets(
 
     if failures:
         raise BudgetError("budget check failed:\n" + "\n".join(failures))
+    if report_skipped_p95:
+        report_p95_skips(results_by_id, budget_entries)
 
 
 def validate_manifest(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -234,6 +240,14 @@ def validate_results_shape(
             raise BudgetError(f"duplicate benchmark result id {result_id}")
         seen.add(result_id)
         require_string(raw, "budget_id", f"benchmark result {result_id}")
+        sample_count = raw.get("sample_count")
+        if not isinstance(sample_count, int) or isinstance(sample_count, bool) or sample_count <= 0:
+            raise BudgetError(f"benchmark result {result_id} field sample_count must be a positive integer")
+        samples = raw.get("samples_ms")
+        if not isinstance(samples, list) or len(samples) != sample_count:
+            raise BudgetError(f"benchmark result {result_id} samples_ms length must match sample_count")
+        if not all(isinstance(sample, int | float) and not isinstance(sample, bool) for sample in samples):
+            raise BudgetError(f"benchmark result {result_id} samples_ms entries must be numeric")
         metrics = raw.get("metrics")
         if not isinstance(metrics, dict):
             raise BudgetError(f"benchmark result {result_id} is missing metrics")
@@ -268,8 +282,9 @@ def compare_result(
     thresholds = budget["thresholds"]
     checks = [
         ("median_ms", metrics["median_ms"], thresholds["median_ms"]),
-        ("p95_ms", metrics["p95_ms"], thresholds["p95_ms"]),
     ]
+    if should_enforce_p95(result):
+        checks.append(("p95_ms", metrics["p95_ms"], thresholds["p95_ms"]))
     if thresholds.get("peak_rss_bytes") is not None and metrics.get("peak_rss_bytes") is not None:
         checks.append(("peak_rss_bytes", metrics["peak_rss_bytes"], thresholds["peak_rss_bytes"]))
     for metric, measured, threshold in checks:
@@ -295,6 +310,24 @@ def compare_result(
             )
         )
     return failures
+
+
+def should_enforce_p95(result: dict[str, Any]) -> bool:
+    return int(result["sample_count"]) >= MIN_P95_SAMPLE_COUNT
+
+
+def report_p95_skips(results_by_id: dict[str, dict[str, Any]], budget_entries: dict[str, dict[str, Any]]) -> None:
+    skipped = [
+        f"{case_id}:{results_by_id[case_id]['sample_count']}"
+        for case_id in sorted(budget_entries)
+        if case_id in results_by_id and not should_enforce_p95(results_by_id[case_id])
+    ]
+    if skipped:
+        print(
+            f"performance budget note: skipped p95_ms for {len(skipped)} benchmark(s) "
+            f"with sample_count < {MIN_P95_SAMPLE_COUNT}: {', '.join(skipped)}",
+            file=sys.stderr,
+        )
 
 
 def has_waiver(case_id: str, budget_id: str, metric: str, waivers: list[dict[str, Any]]) -> bool:
@@ -331,7 +364,7 @@ def run_self_test() -> None:
     check_budgets(manifest, budgets, waivers, baselines)
 
     assert_budget_fails("budget_median_regression_result.json", "median_ms regression", allow_subset=True)
-    assert_budget_fails("budget_p95_regression_result.json", "p95_ms regression", allow_subset=True)
+    assert_result_fails(make_result_seed(spike_twenty_sample_p95), "p95_ms regression", allow_subset=True)
     assert_budget_fails("budget_rss_regression_result.json", "peak_rss_bytes regression", allow_subset=True)
     assert_budget_fails("budget_timeout_result.json", "timeout regression", allow_subset=True)
     assert_budget_fails("budget_missing_result.json", "missing benchmark ids")
@@ -341,18 +374,33 @@ def run_self_test() -> None:
     assert_waiver_fails("malformed_waiver.json", "owner")
     assert_waiver_fails("correctness_waiver.json", "non-performance")
 
+    assert_result_fails(make_result_seed(spike_five_sample_median), "median_ms regression", allow_subset=True)
+    check_budgets(manifest, budgets, EMPTY_WAIVERS, make_result_seed(spike_p95_below_threshold))
+    assert_result_fails(make_result_seed(spike_p95_at_threshold), "p95_ms regression", allow_subset=True)
+
     active_waiver = load_json(NEGATIVE_ROOT / "active_median_waiver.json")
     median_regression = load_json(NEGATIVE_ROOT / "budget_median_regression_result.json")
     check_budgets(manifest, budgets, active_waiver, median_regression, allow_subset=True)
 
 
 def assert_budget_fails(seed: str, expected: str, *, allow_subset: bool = False) -> None:
+    result = load_json(NEGATIVE_ROOT / seed)
+    assert_result_fails(result, expected, allow_subset=allow_subset, seed=seed)
+
+
+def assert_result_fails(
+    result: dict[str, Any],
+    expected: str,
+    *,
+    allow_subset: bool = False,
+    seed: str = "generated result",
+) -> None:
     try:
         check_budgets(
             load_json(DEFAULT_MANIFEST),
             load_json(DEFAULT_BUDGETS),
             EMPTY_WAIVERS,
-            load_json(NEGATIVE_ROOT / seed),
+            result,
             allow_subset=allow_subset,
         )
     except BudgetError as error:
@@ -415,6 +463,41 @@ def parse_date(value: str, waiver_id: str, field: str) -> date:
         return date.fromisoformat(value)
     except ValueError as error:
         raise BudgetError(f"waiver {waiver_id} field {field} must be ISO date YYYY-MM-DD") from error
+
+
+def spike_five_sample_median(result: dict[str, Any]) -> None:
+    spike_metric(result, "check-project-004-project-graph", "median_ms")
+
+
+def spike_twenty_sample_p95(result: dict[str, Any]) -> None:
+    spike_metric(result, "interactive-tooling-foundation-002-warm-diagnostics-query", "p95_ms")
+
+
+def spike_p95_below_threshold(result: dict[str, Any]) -> None:
+    force_sample_count(result, "interactive-tooling-foundation-002-warm-diagnostics-query", MIN_P95_SAMPLE_COUNT - 1)
+    spike_twenty_sample_p95(result)
+
+
+def spike_p95_at_threshold(result: dict[str, Any]) -> None:
+    force_sample_count(result, "interactive-tooling-foundation-002-warm-diagnostics-query", MIN_P95_SAMPLE_COUNT)
+    spike_twenty_sample_p95(result)
+
+
+def spike_metric(result: dict[str, Any], case_id: str, metric: str) -> None:
+    for entry in result["results"]:
+        if entry["id"] == case_id:
+            entry["metrics"][metric] = 999_999
+            return
+    raise BudgetError(f"self-test seed did not find {case_id}")
+
+
+def force_sample_count(result: dict[str, Any], case_id: str, sample_count: int) -> None:
+    for entry in result["results"]:
+        if entry["id"] == case_id:
+            entry["sample_count"] = sample_count
+            entry["samples_ms"] = entry["samples_ms"][:sample_count]
+            return
+    raise BudgetError(f"self-test seed did not find {case_id}")
 
 
 def make_result_seed(mutator: Any) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- enforce p95 budgets only when benchmark results contain enough samples for nearest-rank p95 to be meaningful
- keep median/RSS/timeout/cache enforcement active for all benchmark result sizes
- validate sample_count/samples_ms consistency and emit an audit note when p95 is skipped
- add Claude Opus review pass artifacts under plans/reviews/active

## Validation
- python3 verification/areas/performance/check_budgets.py --self-test
- python3 verification/areas/performance/check_budgets.py --results target/performance/representative.budget.latest.json --allow-subset
- python3 -m py_compile verification/areas/performance/check_budgets.py
- uv run --project verification --locked python -m sifr_verify areas run --area performance --suite representative
- scripts/run_all_tests.sh --profile create-pr (passes; warm wall-time advisory reported)

## Review
- talk-to-claude-opus pass 1: no blockers; requested p95 skip visibility and boundary coverage
- talk-to-claude-opus pass 2: approved / ready to merge