### PR TITLE
Show CLI help for bare sifr invocation

### DIFF
--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -7,7 +7,7 @@ use super::formatter_cli::FmtArgs;
 use super::lint_cli::{cmd_lint, LintArgs};
 use super::self_update_cli::{cmd_self, SelfArgs};
 use super::trace_cli::cmd_trace;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, RenderedDiagnostic, Severity};
 #[cfg(test)]
 use sifr_driver::diagnostic_label_for_code_str;
@@ -360,16 +360,13 @@ fn run_cli(cli: Cli) -> i32 {
     if let Some(code) = cli.explain {
         return cmd_explain(&code, diagnostic_format);
     }
-    let config = cli.config;
-    let isolated = cli.isolated;
     let Some(command) = cli.command else {
-        let diagnostic = diagnostic_with_code(
-            "no command provided",
-            DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
-        );
-        render_diagnostics(&[diagnostic], diagnostic_format);
+        let mut cli_command = Cli::command();
+        let _ = cli_command.write_help(&mut io::stderr());
         return EXIT_USAGE_OR_CONFIG;
     };
+    let config = cli.config;
+    let isolated = cli.isolated;
     match command {
         Commands::Build {
             file,

--- a/crates/sifr/tests/build_output_behavior.rs
+++ b/crates/sifr/tests/build_output_behavior.rs
@@ -65,6 +65,38 @@ fn run_sifr_with_env(args: &[&str], cwd: &Path, envs: &[(&str, &str)]) -> Comman
 }
 
 #[test]
+fn bare_invocation_shows_available_commands() {
+    let project = TestProject::new("bare_invocation", "def main():\n    pass\n");
+
+    let capture = run_sifr(&[], &project.root);
+
+    assert_eq!(capture.status_code, 2);
+    assert!(capture.stdout.is_empty());
+    assert!(capture.stderr.contains("Usage:"));
+    assert!(capture.stderr.contains("--diagnostic-format"));
+    assert!(capture.stderr.contains("--explain"));
+    assert!(capture.stderr.contains("Commands:"));
+    for command in [
+        "build", "run", "check", "emit", "fmt", "lint", "lsp", "test",
+    ] {
+        assert!(capture.stderr.contains(command), "missing {command}");
+    }
+    assert!(!capture.stderr.contains("SIFR-WORKSPACE-0004"));
+    assert!(!capture.stderr.contains("no command provided"));
+}
+
+#[test]
+fn explain_without_subcommand_still_prints_explanation() {
+    let project = TestProject::new("explain_without_subcommand", "def main():\n    pass\n");
+
+    let capture = run_sifr(&["--explain", "SIFR-PACKAGE-0105"], &project.root);
+
+    assert_eq!(capture.status_code, 0);
+    assert!(capture.stdout.contains("SIFR-PACKAGE-0105 is retired"));
+    assert!(capture.stderr.is_empty());
+}
+
+#[test]
 fn build_output_default_is_phase_aware_and_stderr_only() {
     let project = TestProject::new("default", "def main():\n    print(\"ok\")\n");
     let output_dir = project.output_dir("out");


### PR DESCRIPTION
## Summary
- Render clap-generated top-level help for bare `sifr` instead of emitting `SIFR-WORKSPACE-0004`
- Preserve usage/config exit code 2 and keep `--explain` working without a subcommand
- Add black-box CLI coverage for the bare invocation and explain path

## Validation
- `cargo fmt --check`
- `cargo test -p sifr --test build_output_behavior`
- `scripts/check_hir_maintainability_guardrails.py`
- `scripts/run_all_tests.sh --profile create-pr` passed with advisory: warm wall-time budget exceeded; zero blocking failures

## Review
- Reviewed twice with Claude Opus via `.cursor/skills/talk-to-claude-opus/`; first-pass actionables were applied, second pass found no actionable findings.