### PR TITLE
[codex] Add Rust interop verification scaffold

### DIFF
--- a/docs/diagnostics/error-codes.mdx
+++ b/docs/diagnostics/error-codes.mdx
@@ -135,6 +135,25 @@ The `PYIMP`, `PYCALL`, `PYCONV`, `PYRES`, `PYZC`, and `PYCB` families are reserv
 
 </Accordion>
 
+<Accordion title="RUST — Rust interop">
+
+The `SIFR-RUST-*` families are reserved for declaration-level Rust interop through Cargo. These placeholders lock the Rust interop diagnostic namespaces before compiler emission lands.
+
+| Code | Severity | Description |
+|------|----------|-------------|
+| `SIFR-RUST-CONFIG-0001` | Error | Malformed Rust interop decorator. |
+| `SIFR-RUST-RESOLVE-0001` | Error | Unresolved Rust target path. |
+| `SIFR-RUST-TRUST-0001` | Error | Missing Rust interop trust declaration. |
+| `SIFR-RUST-TYPE-0001` | Error | Unsupported Rust bridge type. |
+| `SIFR-RUST-HANDLE-0001` | Error | Invalid opaque handle contract. |
+| `SIFR-RUST-ASYNC-0001` | Error | Invalid Rust async or thread-affinity contract. |
+| `SIFR-RUST-ZC-0001` | Error | Invalid zero-copy or view lifetime contract. |
+| `SIFR-RUST-CB-0001` | Error | Invalid callback lifetime or threading contract. |
+| `SIFR-RUST-PANIC-0001` | Error | Incompatible Rust panic strategy or poisoned handle. |
+| `SIFR-RUST-CARGO-0001` | Error | Cargo metadata, lockfile, or profile mismatch. |
+
+</Accordion>
+
 <Accordion title="DECIMAL — Decimal and fixed-point arithmetic">
 
 The `DECIMAL` family covers errors in Sifr's `Decimal` and `BigDecimal` numeric types. Sifr's decimal types are distinct from Python floats and have their own literal syntax, scale rules, and construction constraints.

--- a/internal_docs/integer_model.md
+++ b/internal_docs/integer_model.md
@@ -495,7 +495,7 @@ Rust interop requires exact signatures. If a Rust function takes `u32`, Sifr exp
 
 ```sifr
 @rust(bridge.net.set_flags)
-def set_flags(flags: uint32) -> Result[None, IOError]:
+def set_flags(flags: uint32) -> Result[None, IOError | RustPanicError]:
     pass
 ```
 

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -1,6 +1,6 @@
 # Rust Interop Architecture
 
-Status: design locked for Phase 39 planning.
+Status: design locked for Rust interop implementation planning.
 
 This document defines Sifr Rust interop as declaration-level Cargo integration. It is a self-contained design for Rust interop and does not depend on the Python interop lane, raw C ABI interop, or earlier interoperability drafts.
 
@@ -147,7 +147,7 @@ RustInteropDecoratorValue =
   | RustTargetPath
 ```
 
-`RustTargetPath` is the structured dotted-path form used by `@rust(...)`, `@rust.opaque(type=...)`, and path-valued policy fields such as `panic=map_error(...)`. `PolicyCall` is allowed only where a decorator explicitly permits it; Phase 39 permits `bounded(N)` for callback backpressure and `custom(path)` for opaque clone policy. Other call-shaped decorator values are rejected with `SIFR-RUST-CONFIG-*` diagnostics instead of being interpreted dynamically.
+`RustTargetPath` is the structured dotted-path form used by `@rust(...)`, `@rust.opaque(type=...)`, and path-valued policy fields such as `panic=map_error(...)`. `PolicyCall` is allowed only where a decorator explicitly permits it; the initial Rust interop contract permits `bounded(N)` for callback backpressure and `custom(path)` for opaque clone policy. Other call-shaped decorator values are rejected with `SIFR-RUST-CONFIG-*` diagnostics instead of being interpreted dynamically.
 
 Opaque decorator keys are fixed:
 
@@ -401,7 +401,7 @@ Exact `int` is not a native ABI integer. `SifrIntBridge` lives in `sifr_runtime:
 
 Nested borrowed forms are generated from the outer ownership mode. For example, borrowed `list[str]` is not `&[&str]`; it is a generated list view whose elements are borrowed string views with the same lifetime as the list view. `Option[str]` and `Option[bytes]` use generated optional borrowed views for borrowed parameters and owned `Option<String>` / `Option<Vec<u8>>` for owned parameters and returns.
 
-Sifr container types not listed above, including `set[T]`, `tuple[...]`, and arbitrary iterator/generator types, are not bridge-compatible in Phase 39 and produce `SIFR-RUST-TYPE-*` diagnostics. No implicit conversion is allowed.
+Sifr container types not listed above, including `set[T]`, `tuple[...]`, and arbitrary iterator/generator types, are not bridge-compatible in the initial Rust interop contract and produce `SIFR-RUST-TYPE-*` diagnostics. No implicit conversion is allowed.
 
 Rejected public bridge surfaces include:
 
@@ -589,7 +589,7 @@ def resize(input: bytes, width: uint32, height: uint32) -> Result[bytes, ImageEr
 
 Direct calls to classified blocking or CPU-heavy Rust functions from async Sifr code are compile-time errors unless explicitly offloaded through the Sifr task/offload APIs.
 
-`@blocking_io` and `@cpu_heavy` classify synchronous Rust-backed declarations. They are rejected on `async def` Rust interop declarations unless a later design adds an explicit async-blocking adapter surface. Phase 39 does not generate hidden blocking adapters, hidden `block_on`, or implicit offload for async Rust declarations.
+`@blocking_io` and `@cpu_heavy` classify synchronous Rust-backed declarations. They are rejected on `async def` Rust interop declarations unless a future design adds an explicit async-blocking adapter surface. The initial Rust interop contract does not generate hidden blocking adapters, hidden `block_on`, or implicit offload for async Rust declarations.
 
 Default async bridge requirements:
 
@@ -798,7 +798,7 @@ Rust interop diagnostics use stable diagnostic families:
 
 Every diagnostic must include source span, resolved target when available, required fix, and documentation URL.
 
-Milestone 39.0 reserves the first code in every family:
+The initial verification scaffold reserves the first code in every family:
 
 | Code | Reserved meaning |
 | --- | --- |
@@ -831,7 +831,7 @@ Completion must prefer valid dotted paths. Invalid string-style Rust targets are
 
 ## Verification Area
 
-Phase 39 creates a first-class verification area:
+Rust interop creates a first-class verification area:
 
 ```text
 verification/areas/rust_interop/
@@ -916,7 +916,7 @@ Ecosystem certification fixtures:
 | Backend/service certification | `axum`, `tower-http`, `sqlx` |
 | CLI/tooling certification | `clap`, `tracing`, `tracing-subscriber`, `anyhow` |
 
-Ecosystem certification for `axum`, `tower-http`, and `sqlx` is limited to canonical-package compilation and probe coverage; product-level web framework workflows remain out of Phase 39.
+Ecosystem certification for `axum`, `tower-http`, and `sqlx` is limited to canonical-package compilation and probe coverage; product-level web framework workflows remain out of the Rust interop scope.
 
 `tokio` runtime behavior is exercised through `async_runtime_reqwest`, `async_ecosystem_matrix`, `opaque_resource_matrix`, and `callback_subscription_matrix`; do not add a redundant standalone Tokio fixture unless a future runtime contract requires it.
 
@@ -924,18 +924,18 @@ Feature-sensitive fixtures must pin Cargo features in `rust_interop_fixture_matr
 
 - `reqwest`: `default-features = false`, `features = ["rustls-tls", "json"]`; do not enable `blocking` in async fixtures.
 - `tokio-postgres`: `default-features = false`, `features = ["runtime"]`; TLS is not part of the primary opaque-resource fixture.
-- `rusqlite`: `features = ["bundled"]`; the unbundled system-sqlite variant is intentionally not certified in Phase 39.
+- `rusqlite`: `features = ["bundled"]`; the unbundled system-sqlite variant is intentionally not certified in the Rust interop scope.
 - `redis`: `default-features = false`, `features = ["tokio-comp"]`; pub/sub fixtures use loopback service infrastructure.
 - `tokio-tungstenite`: `default-features = false`; add `features = ["rustls-tls-webpki-roots"]` only for explicit network/TLS coverage.
 - `sqlx`: `default-features = false`, `features = ["runtime-tokio-rustls", "postgres", "macros"]`; query-macro fixtures must use checked-in `.sqlx/` offline artifacts instead of requiring `DATABASE_URL` during Cargo execution.
 - `axum` and `tower-http`: use default feature sets unless a fixture documents a narrower feature requirement.
 - `tracing-subscriber`: include `env-filter`.
 - `flate2`: `default-features = false`, `features = ["rust_backend"]`.
-- `candle`: CPU-only default backend; GPU and accelerator backend features are out of scope for Phase 39.
+- `candle`: CPU-only default backend; GPU and accelerator backend features are out of scope for Rust interop.
 - `prost-build`: use default features over a checked-in `.proto` input; generated output must be deterministic.
 
 Runtime-service fixtures must declare whether they are compile/probe-only, loopback-service backed, or in-process stub backed. `reqwest`, `tokio-tungstenite`, and `notify` fixtures should prefer loopback or local filesystem inputs. `tokio-postgres` and `redis` fixtures require explicit local service configuration and must be skippable only by fixture-tier policy, not by silently degrading the interop behavior under test.
 
-The matrix proves the Rust interop contract and package model. It does not create first-party Sifr wrappers for every listed crate and it does not move game, GUI, embedded, or product-level web framework work into Phase 39.
+The matrix proves the Rust interop contract and package model. It does not create first-party Sifr wrappers for every listed crate and it does not move game, GUI, embedded, or product-level web framework work into Rust interop.
 
 The area must record positive and negative fixtures for every declared capability. A feature is not complete until its failure mode is as deliberate as its success path.

--- a/plans/phases/37_package_management.md
+++ b/plans/phases/37_package_management.md
@@ -78,9 +78,13 @@ tls = { cargo-package = "reqwest", cargo-feature = "rustls-tls" }
 json = { cargo-package = "reqwest", cargo-feature = "json" }
 
 [trust]
-native = ["reqwest"]
-build-scripts = []
-proc-macros = []
+rust-build-scripts = []
+rust-proc-macros = []
+native-links = []
+unsafe-rust-bridges = []
+build-env = []
+rust-no-panic = []
+rust-panic-abort = []
 ```
 
 Pure Sifr packages still include a minimal Rust target because Cargo requires at least one target. The generated `src/lib.rs` marker should contain no semantic implementation and must not become a second source of truth for Sifr behavior.
@@ -713,9 +717,13 @@ roots = ["sifr"]
 modules = ["demo_http"]
 
 [trust]
-native = ["reqwest"]
-build-scripts = []
-proc-macros = []
+rust-build-scripts = []
+rust-proc-macros = []
+native-links = []
+unsafe-rust-bridges = []
+build-env = []
+rust-no-panic = []
+rust-panic-abort = []
 ```
 
 Consumer demo:

--- a/plans/phases/39_rust_interop.md
+++ b/plans/phases/39_rust_interop.md
@@ -32,8 +32,8 @@ Phase 39 owns the full Rust interop implementation:
 - Python interop.
 - Raw C ABI interop.
 - Rust dynamic ABI loading.
-- `extern rust` syntax.
-- Runtime `dlopen` of Rust functions.
+- Rejected `extern rust` syntax.
+- Rejected runtime `dlopen` of Rust functions.
 - Compatibility shims for earlier draft interop syntax.
 - Silent copy fallback for zero-copy APIs.
 - Hidden Tokio runtimes, generated `block_on`, or implicit offload.

--- a/plans/reviews/active/rust-interop-milestone39-0-review-round1.md
+++ b/plans/reviews/active/rust-interop-milestone39-0-review-round1.md
@@ -1,0 +1,35 @@
+Review complete. The scaffold passes its own checks and satisfies the milestone DoD (area exists, every architecture-required fixture is named, architecture and phase file agree, no stale `extern rust`/`dlopen`/`@rust(crate=,path=)`/`native = [` in active docs). Below are review-improvement gaps, ordered by severity. None are blocking.
+
+## Medium — would let drift through later milestones
+
+1. **`opaque_resource_matrix` is missing every pinned feature it covers.** The architecture says feature-sensitive fixtures *must* pin Cargo features in `rust_interop_fixture_matrix.json` (architecture doc lines 923–937). That fixture covers `reqwest`, `tokio-postgres`, `rusqlite`, `redis` — all four have architecture-mandated pins (`reqwest` rustls-tls+json, `tokio-postgres` runtime, `rusqlite` bundled, `redis` tokio-comp) — and the entry has no `features` block. A later milestone could land the fixture with defaults (e.g. accidentally pulling in `reqwest` `blocking`, native `rusqlite`) and no check would flag it.
+
+2. **`check_fixture_matrix.py` does not validate the `features` block.** The script enforces fixture IDs, crate coverage, diagnostic families, evidence shape, and execution kind, but ignores `features` entirely. The pinned policy in the architecture is therefore unguarded — finding #1 is symptomatic of this. Recommend adding a per-crate expected-features table keyed off the architecture (or at minimum, asserting that the listed feature-sensitive crates appear in any fixture that requires them with a non-empty `features` entry).
+
+3. **`check_stale_drafts.py` misses two patterns the milestone explicitly enumerates.** The milestone scope (phase 39 line 61) calls out:
+   - **"panic examples without `RustPanicError` or explicit panic policy"** — no detector. A new `@rust(...)` example added without `Result[..., ... | RustPanicError]` or a `panic=trusted_no_panic|map_error(...)|abort` argument would not be flagged.
+   - **"Python code fences for Sifr interop examples"** — no detector. A `` ```python `` fence containing `@rust(...)`/`@rust.opaque(...)`/`@rust.async(...)`/`@rust.view(...)` slips through.
+
+4. **`REJECTION_CONTEXT` in `check_stale_drafts.py` is too permissive.** The regex matches bare `\b(no|not|...)\b`. Any line containing the word "no" or "not" anywhere bypasses the stale-pattern check on that line. A safer form requires the rejection token immediately adjacent to the stale pattern, or restricts to specific markers (`Rejected`, `out of scope`, `removed`, …).
+
+## Low — small drift / discoverability
+
+5. **No `SIFR-RUST-*` placeholders in `docs/diagnostics/error-codes.mdx` or `docs/errors/`.** The architecture doc lists the 10 reserved codes and the matrix JSON dictionary records them, which arguably satisfies "diagnostic family inventory." But the milestone explicitly says "documentation placeholders for `SIFR-RUST-*`," and the public diagnostics index/per-code stubs do not yet contain a single `SIFR-RUST-*` entry. Borderline — full docs are milestone 39.12 — but a one-line table entry per family in `docs/diagnostics/error-codes.mdx` would actually meet the "placeholder" bar.
+
+6. **`prost-build` lives in `native_build_script`, not `proc_macro_trust`.** The architecture's required-crate tables put `serde_derive, prost-build` under "Build and proc-macro trust" and `cc, bindgen, cxx, zstd` under "Native/build links." The matrix moves `prost-build` into `native_build_script` with the cc/bindgen/cxx/zstd group. Crate coverage is still complete, but a reader cross-walking the architecture table will not find `prost-build` where it expects.
+
+7. **Runner skeleton names diverge from architecture terminology.** Architecture uses `RustBridgeProbePlan`, `PoisonOnPanic`, `GeneratedGlueToken`, `HandleStateError`. The skeleton defines `CargoProbePlan`, `BridgeProjectionCheck`, `TrustEvidence`, `NativeLinkEvidence`. Acceptable for placeholders, but renaming `CargoProbePlan → RustBridgeProbePlan` would lock the canonical identifier from the start.
+
+8. **Manifest declares `network_mode: "offline"` while tier-2 fixtures are `runtime-observed` against `tokio-postgres`/`redis`.** This is fine today because no Cargo work runs, but milestone 39.2+ needs to reconcile the area-level offline policy with the architecture's "explicit local service configuration" requirement. Worth a tracking note.
+
+## Not findings (verified)
+
+- All 30 fixture directories listed in the architecture exist with the architecture-mandated names and tags (`contract-only`, etc.). ✓
+- All 10 `SIFR-RUST-*-0001` codes are reserved in the matrix with descriptions matching the architecture. ✓
+- All 44 architecture-required crates appear in some fixture's `required_crates`. ✓
+- Tier descriptions in `rust_interop_tiers.toml` match the phase and architecture tier definitions; every matrix fixture is tier-assigned exactly once. ✓
+- The only remaining `@rust(...)` examples in active docs all carry either `RustPanicError`, `panic=trusted_no_panic`, or `panic=map_error(...)` (including the one updated in `integer_model.md:497`). ✓
+- The `[trust]` schema in `37_package_management.md` now matches the architecture's seven keys verbatim. ✓
+- `python-native = [...]` in `docs/python-interop.mdx` etc. is correctly excluded by the `(?<!python-)` lookbehind. ✓
+
+**Bottom line:** scaffold is review-satisfied for the milestone_39_0 definition of done. The five medium/low items above are real review-improvement opportunities — especially #1, #2, and #3 — and worth addressing before declaring the scaffold immutable, but none block the milestone.

--- a/plans/reviews/active/rust-interop-milestone39-0-review-round2.md
+++ b/plans/reviews/active/rust-interop-milestone39-0-review-round2.md
@@ -1,0 +1,32 @@
+I've verified each round-1 finding and run the full validation suite. All scaffold checks pass (`fixtures=30 diagnostics=10 crates=44`; `tiers=5 fixtures=30`; stale-draft scan clean; `sifr_verify areas run --area rust_interop` reports 0 failures; `areas check` clean).
+
+## Round 1 closure status
+
+All eight round-1 findings are closed:
+
+1. **opaque_resource_matrix feature pins** — `data/rust_interop_fixture_matrix.json:105-110` now pins reqwest/rusqlite/tokio-postgres/redis exactly per architecture lines 925-928.
+2. **`check_fixture_matrix.py` feature validation** — `EXPECTED_FEATURE_POLICIES` (lines 110-124) covers the 10 feature-sensitive crates; `_validate_feature_policies` (lines 210-231) asserts exact match and flags missing `features` blocks.
+3. **Stale checks for RustPanicError and python fences** — `RUST_TARGET_DECORATOR` + `_scan_panic_surface` (lines 21, 90-105) flag `@rust(...)` defs that return `Result[...]` without `RustPanicError`, while `SIFR_INTEROP_DECORATOR` (line 22, 51-53) flags Sifr interop decorators inside python fences. Architecture/phase 39 corpus passes (every existing `@rust(...)` example either carries `panic=...` or `RustPanicError`).
+4. **`REJECTION_CONTEXT` tightening** — `_is_rejection_context` now checks only `line[:match_start]` and is anchored to a fixed marker list (lines 69-87). The five active occurrences in `architecture.md`, `python-interop.mdx`, and `39_rust_interop.md` all sit behind one of the markers (`no `, `not `, `stale`, `rejected`).
+5. **`SIFR-RUST-*` placeholders** — `docs/diagnostics/error-codes.mdx:138-155` contains a RUST accordion with all ten codes.
+6. **`prost-build` placement** — moved to `proc_macro_trust` (matrix lines 284-292), matching architecture line 897.
+7. **`RustBridgeProbePlan` rename** — `runner/cargo_probe.py:10` adopts the canonical identifier; `BridgeProjectionCheck`/`TrustEvidence`/`NativeLinkEvidence` remain as skeleton names (round 1 marked these "acceptable for placeholders").
+8. **Offline-policy documentation** — `verification/areas/rust_interop/README.md:14-17` documents that runtime-observed Redis/Postgres fixtures must use explicit local service config, not silently degrade.
+
+## Remaining gaps against milestone_39_0 DoD
+
+No blocking findings. The three DoD items hold:
+
+- All 30 architecture-required fixture directories and matrix entries are present and tier-assigned exactly once.
+- `plans/phases/39_rust_interop.md` and `internal_docs/rust_interop_architecture.md` agree on capabilities, rejected designs, trust schema keys, feature pins, and the 10 diagnostic families.
+- No accepted `extern rust`/`dlopen`/legacy `@rust(crate=…)`/`native = [` syntax remains in active docs.
+
+## Non-blocking observations (scaffold quality, deferrable)
+
+- **`runner/report.py:to_jsonable`** is shallow: `asdict()` recurses into the dataclass but does not stringify nested `Path` fields, so `json.dumps(to_jsonable(RustBridgeProbePlan(...)))` would raise. No current caller exercises it (skeleton-only).
+- **`_validate_feature_policies`** uses exact equality. Future fixtures that augment a pinned crate (e.g. `tokio-tungstenite` + `rustls-tls-webpki-roots` for TLS coverage, allowed by architecture line 929) will require widening the check; today no such fixture exists.
+- **`_is_rejection_context`** still keeps bare `no ` / `not ` markers in the prefix-only check. Lines like `Sifr is not Python; we use extern rust here for X` would still be exempted. Not present in current corpus; not blocking.
+- **`_next_fence_language`** returns the full post-``` token (e.g. ` ```python title="…" ` becomes `"python title=\"…\""`), so the `fence_language == "python"` test misses titled fences. Current docs have no `@rust(...)` examples in titled python fences.
+- **`_scan_panic_surface`** only flags a defect when `Result[` is in the def. A `def f() -> None` with `@rust(...)` and no `panic=` would not be flagged. Doesn't occur today.
+
+**Bottom line:** Round-1 findings are all closed, scaffold validation is green, and the milestone_39_0 definition of done is satisfied. The five items above are minor scaffold-quality nits that do not block the milestone and have no failing case in the current corpus.

--- a/verification/areas/rust_interop/README.md
+++ b/verification/areas/rust_interop/README.md
@@ -1,0 +1,36 @@
+# Rust Interop Verification Area
+
+This area tracks Rust interop verification.
+
+The canonical design is `internal_docs/rust_interop_architecture.md`. This
+area intentionally starts as an architecture scaffold: it names every fixture
+required by the architecture, records the tier assignment, reserves the
+diagnostic families, and provides runner skeletons for subsequent implementation.
+
+The matrix is contract-first. A fixture can be marked `planned`, `probe-only`,
+or `runtime-observed`, but it must always declare both positive and negative
+evidence before a subsequent implementation step can call the capability complete.
+
+The area-level `network_mode` is `offline` for scaffold and compile/probe
+checks. Later runtime-observed fixtures that need services such as Redis or
+PostgreSQL must use explicit local service configuration recorded in the
+fixture evidence; they must not silently degrade to compile-only coverage.
+
+## Suites
+
+- `matrix`: verifies the fixture matrix, required fixture directories, crate
+  coverage, evidence placeholders, and diagnostic family inventory.
+- `tiers`: verifies tier definitions and fixture tier assignments.
+- `stale-drafts`: scans active planning and documentation paths for accepted
+  examples of abandoned Rust interop syntax.
+
+## Runner Skeletons
+
+The `runner/` modules are intentionally thin until subsequent implementation
+wires them to compiler, Cargo, probe, and native-link execution:
+
+- `cargo_probe.py`: Cargo metadata and signature probe orchestration.
+- `bridge_check.py`: package-local/shared bridge projection checks.
+- `trust_check.py`: pre-execution and post-execution trust evidence checks.
+- `native_probe.py`: native-link and build-script evidence checks.
+- `report.py`: fixture evidence reporting helpers.

--- a/verification/areas/rust_interop/checks/check_fixture_matrix.py
+++ b/verification/areas/rust_interop/checks/check_fixture_matrix.py
@@ -1,0 +1,235 @@
+"""Validate the Rust interop fixture matrix scaffold."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+AREA_ROOT = REPO_ROOT / "verification" / "areas" / "rust_interop"
+MATRIX_PATH = AREA_ROOT / "data" / "rust_interop_fixture_matrix.json"
+FIXTURES_ROOT = AREA_ROOT / "fixtures"
+
+REQUIRED_FIXTURES = {
+    "advanced_data_matrix",
+    "arrow_record_batch",
+    "async_ecosystem_matrix",
+    "async_runtime_reqwest",
+    "blocking_diagnostics",
+    "bridge_type_matrix",
+    "bridge_version_mismatch",
+    "callback_subscription_matrix",
+    "callbacks_call_scoped",
+    "callbacks_threadsafe",
+    "cargo_locked_offline",
+    "close_after_use",
+    "direct_crate_crc32",
+    "direct_crate_matrix",
+    "direct_crate_negative_type",
+    "dotted_path_resolution",
+    "ecosystem_backend_certification",
+    "ecosystem_cli_certification",
+    "local_bridge_blake3",
+    "native_build_script",
+    "opaque_handle_tokenizer",
+    "opaque_resource_matrix",
+    "panic_abort_profile",
+    "panic_boundary",
+    "proc_macro_trust",
+    "same_workspace_crate",
+    "shared_bridge_crate",
+    "tensor_dlpack_bridge",
+    "zero_copy_bytes",
+    "zero_copy_view_matrix",
+}
+
+REQUIRED_DIAGNOSTICS = {
+    "SIFR-RUST-ASYNC-0001",
+    "SIFR-RUST-CARGO-0001",
+    "SIFR-RUST-CB-0001",
+    "SIFR-RUST-CONFIG-0001",
+    "SIFR-RUST-HANDLE-0001",
+    "SIFR-RUST-PANIC-0001",
+    "SIFR-RUST-RESOLVE-0001",
+    "SIFR-RUST-TRUST-0001",
+    "SIFR-RUST-TYPE-0001",
+    "SIFR-RUST-ZC-0001",
+}
+
+REQUIRED_CRATES = {
+    "anyhow",
+    "arrow",
+    "axum",
+    "bindgen",
+    "blake3",
+    "bytemuck",
+    "bytes",
+    "candle",
+    "cc",
+    "clap",
+    "crc32fast",
+    "cxx",
+    "datafusion",
+    "flate2",
+    "futures",
+    "http",
+    "http-body",
+    "indexmap",
+    "memmap2",
+    "ndarray",
+    "notify",
+    "polars",
+    "prost-build",
+    "rayon",
+    "redis",
+    "regex",
+    "reqwest",
+    "rusqlite",
+    "serde",
+    "serde_derive",
+    "serde_json",
+    "sha2",
+    "sqlx",
+    "thiserror",
+    "tokio",
+    "tokio-postgres",
+    "tokio-tungstenite",
+    "tower",
+    "tower-http",
+    "tracing",
+    "tracing-subscriber",
+    "uuid",
+    "zerocopy",
+    "zstd",
+}
+
+VALID_EVIDENCE_STATUS = {"planned", "probe-only", "runtime-observed", "passing", "failing"}
+
+EXPECTED_FEATURE_POLICIES = {
+    "candle": {"backend": "cpu-only"},
+    "flate2": {"default_features": False, "features": ["rust_backend"]},
+    "prost-build": {"generated_output": "deterministic"},
+    "redis": {"default_features": False, "features": ["tokio-comp"]},
+    "reqwest": {"default_features": False, "features": ["rustls-tls", "json"]},
+    "rusqlite": {"features": ["bundled"]},
+    "sqlx": {
+        "default_features": False,
+        "features": ["runtime-tokio-rustls", "postgres", "macros"],
+    },
+    "tokio-postgres": {"default_features": False, "features": ["runtime"]},
+    "tokio-tungstenite": {"default_features": False},
+    "tracing-subscriber": {"features": ["env-filter"]},
+}
+
+
+def main() -> int:
+    matrix = json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+    failures: list[str] = []
+
+    if matrix.get("schema_version") != 1:
+        failures.append("matrix schema_version must be 1")
+    if matrix.get("phase") != "39_rust_interop":
+        failures.append("matrix phase must be 39_rust_interop")
+    if matrix.get("bridge_version") != 1:
+        failures.append("matrix bridge_version must be 1")
+
+    diagnostics = set(matrix.get("diagnostic_families", {}))
+    failures.extend(
+        f"missing diagnostic family reservation: {code}"
+        for code in sorted(REQUIRED_DIAGNOSTICS.difference(diagnostics))
+    )
+    unexpected_diagnostics = diagnostics.difference(REQUIRED_DIAGNOSTICS)
+    failures.extend(
+        f"unexpected diagnostic family reservation: {code}"
+        for code in sorted(unexpected_diagnostics)
+    )
+
+    fixtures = matrix.get("fixtures", [])
+    if not isinstance(fixtures, list):
+        failures.append("fixtures must be a list")
+        fixtures = []
+    fixture_ids = [str(fixture.get("id")) for fixture in fixtures if isinstance(fixture, dict)]
+    fixture_id_set = set(fixture_ids)
+    if len(fixture_ids) != len(fixture_id_set):
+        failures.append("fixture ids must be unique")
+    failures.extend(f"missing fixture matrix entry: {item}" for item in sorted(REQUIRED_FIXTURES - fixture_id_set))
+    failures.extend(f"unexpected fixture matrix entry: {item}" for item in sorted(fixture_id_set - REQUIRED_FIXTURES))
+
+    discovered_dirs = {path.name for path in FIXTURES_ROOT.iterdir() if path.is_dir()}
+    failures.extend(f"missing fixture directory: {item}" for item in sorted(REQUIRED_FIXTURES - discovered_dirs))
+    failures.extend(f"unexpected fixture directory: {item}" for item in sorted(discovered_dirs - REQUIRED_FIXTURES))
+
+    covered_crates: set[str] = set()
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append("fixture entries must be objects")
+            continue
+        fixture_id = str(fixture.get("id"))
+        tier = fixture.get("tier")
+        if tier not in {0, 1, 2, 3, 4}:
+            failures.append(f"{fixture_id}: tier must be 0..4")
+        if not fixture.get("capability"):
+            failures.append(f"{fixture_id}: capability is required")
+        if fixture.get("execution_kind") not in {"compiler-diagnostic", "contract-only", "cargo-probe", "runtime-observed"}:
+            failures.append(f"{fixture_id}: invalid execution_kind")
+        crates = fixture.get("required_crates", [])
+        if not isinstance(crates, list):
+            failures.append(f"{fixture_id}: required_crates must be a list")
+            crates = []
+        covered_crates.update(str(crate) for crate in crates)
+        _validate_feature_policies(failures, fixture_id, fixture.get("features"), crates)
+        _validate_evidence(failures, fixture_id, fixture.get("positive_evidence"), "positive_evidence")
+        _validate_evidence(failures, fixture_id, fixture.get("negative_evidence"), "negative_evidence")
+
+    failures.extend(f"required crate lacks fixture coverage: {crate}" for crate in sorted(REQUIRED_CRATES - covered_crates))
+
+    if failures:
+        for failure in failures:
+            print(f"rust interop fixture matrix error: {failure}", file=sys.stderr)
+        return 1
+    print(
+        "rust interop fixture matrix ok: "
+        f"fixtures={len(fixture_id_set)} diagnostics={len(diagnostics)} crates={len(covered_crates)}"
+    )
+    return 0
+
+
+def _validate_evidence(failures: list[str], fixture_id: str, value: Any, field: str) -> None:
+    if not isinstance(value, dict):
+        failures.append(f"{fixture_id}: {field} must be an object")
+        return
+    if not value.get("id"):
+        failures.append(f"{fixture_id}: {field}.id is required")
+    status = value.get("status")
+    if status not in VALID_EVIDENCE_STATUS:
+        failures.append(f"{fixture_id}: {field}.status is invalid")
+
+
+def _validate_feature_policies(
+    failures: list[str],
+    fixture_id: str,
+    raw_features: Any,
+    crates: list[Any],
+) -> None:
+    required_pins = {
+        str(crate): EXPECTED_FEATURE_POLICIES[str(crate)]
+        for crate in crates
+        if str(crate) in EXPECTED_FEATURE_POLICIES
+    }
+    if not required_pins:
+        return
+    if not isinstance(raw_features, dict):
+        failures.append(f"{fixture_id}: missing features block for feature-sensitive crates")
+        return
+    for crate, expected in sorted(required_pins.items()):
+        actual = raw_features.get(crate)
+        if actual != expected:
+            failures.append(
+                f"{fixture_id}: feature policy for {crate} must be {expected!r}, got {actual!r}"
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/rust_interop/checks/check_stale_drafts.py
+++ b/verification/areas/rust_interop/checks/check_stale_drafts.py
@@ -1,0 +1,109 @@
+"""Reject accepted examples of abandoned Rust interop draft syntax."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCAN_ROOTS = ("docs", "internal_docs", "plans")
+SKIP_PARTS = {"archive", "reviews"}
+
+STALE_PATTERNS = {
+    "extern rust": re.compile(r"\bextern\s+rust\b"),
+    "from rust import": re.compile(r"\bfrom\s+rust\s+import\b"),
+    "rust dynamic loading": re.compile(r"\bdlopen\b"),
+    "legacy rust decorator keywords": re.compile(r"@rust\s*\([^)]*\b(crate|path)\s*="),
+    "legacy native trust key": re.compile(r"(?<!python-)native\s*=\s*\["),
+}
+
+RUST_TARGET_DECORATOR = re.compile(r"^\s*@rust\s*\(")
+SIFR_INTEROP_DECORATOR = re.compile(r"@rust(?:\.|\s*\()")
+
+
+def main() -> int:
+    failures: list[str] = []
+    for root in SCAN_ROOTS:
+        for path in sorted((REPO_ROOT / root).rglob("*")):
+            if path.suffix not in {".md", ".mdx"}:
+                continue
+            if any(part in SKIP_PARTS for part in path.relative_to(REPO_ROOT).parts):
+                continue
+            _scan_path(path, failures)
+
+    if failures:
+        for failure in failures:
+            print(f"rust interop stale draft error: {failure}", file=sys.stderr)
+        return 1
+    print("rust interop stale draft scan ok")
+    return 0
+
+
+def _scan_path(path: Path, failures: list[str]) -> None:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    fence_language: str | None = None
+    for line_number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            fence_language = _next_fence_language(stripped, fence_language)
+            continue
+        if fence_language == "python" and SIFR_INTEROP_DECORATOR.search(line):
+            display = path.relative_to(REPO_ROOT)
+            failures.append(f"{display}:{line_number}: Sifr Rust interop example uses python fence")
+        for label, pattern in STALE_PATTERNS.items():
+            match = pattern.search(line)
+            if match and not _is_rejection_context(line, match.start()):
+                display = path.relative_to(REPO_ROOT)
+                failures.append(f"{display}:{line_number}: accepted {label} syntax")
+        if RUST_TARGET_DECORATOR.search(line) and "panic=" not in line:
+            _scan_panic_surface(path, lines, line_number, failures)
+
+
+def _next_fence_language(stripped: str, current: str | None) -> str | None:
+    if current is not None:
+        return None
+    return stripped.removeprefix("```").strip().lower() or ""
+
+
+def _is_rejection_context(line: str, match_start: int) -> bool:
+    prefix = line[:match_start].lower()
+    return any(
+        marker in prefix
+        for marker in (
+            "rejected",
+            "reject ",
+            "rejects ",
+            "no ",
+            "not ",
+            "does not use",
+            "out of scope",
+            "out-of-scope",
+            "non-goal",
+            "stale",
+            "abandoned",
+            "remove",
+        )
+    )
+
+
+def _scan_panic_surface(
+    path: Path,
+    lines: list[str],
+    decorator_line_number: int,
+    failures: list[str],
+) -> None:
+    lookahead = lines[decorator_line_number : decorator_line_number + 6]
+    definition = next((line.strip() for line in lookahead if line.strip().startswith(("def ", "async def "))), None)
+    if definition is None:
+        return
+    if "RustPanicError" in definition or "Result[" not in definition:
+        return
+    display = path.relative_to(REPO_ROOT)
+    failures.append(
+        f"{display}:{decorator_line_number}: Rust interop example lacks RustPanicError or panic policy"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/rust_interop/checks/check_tiers.py
+++ b/verification/areas/rust_interop/checks/check_tiers.py
@@ -1,0 +1,74 @@
+"""Validate Rust interop tier metadata."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+AREA_ROOT = REPO_ROOT / "verification" / "areas" / "rust_interop"
+MATRIX_PATH = AREA_ROOT / "data" / "rust_interop_fixture_matrix.json"
+TIERS_PATH = AREA_ROOT / "data" / "rust_interop_tiers.toml"
+
+
+def main() -> int:
+    matrix = json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+    tiers = tomllib.loads(TIERS_PATH.read_text(encoding="utf-8"))
+    failures: list[str] = []
+
+    expected_tiers = {f"tier{index}" for index in range(5)}
+    actual_tiers = set(tiers)
+    failures.extend(f"missing tier definition: {tier}" for tier in sorted(expected_tiers - actual_tiers))
+    failures.extend(f"unexpected tier definition: {tier}" for tier in sorted(actual_tiers - expected_tiers))
+
+    matrix_tiers = {
+        str(fixture["id"]): int(fixture["tier"])
+        for fixture in matrix.get("fixtures", [])
+        if isinstance(fixture, dict) and "id" in fixture and "tier" in fixture
+    }
+    tier_assignments: dict[str, int] = {}
+    for tier_name, tier_data in tiers.items():
+        if not isinstance(tier_data, dict):
+            failures.append(f"{tier_name}: tier data must be a table")
+            continue
+        if not tier_data.get("name"):
+            failures.append(f"{tier_name}: name is required")
+        if not tier_data.get("description"):
+            failures.append(f"{tier_name}: description is required")
+        try:
+            tier_number = int(tier_name.removeprefix("tier"))
+        except ValueError:
+            continue
+        fixtures = tier_data.get("fixtures", [])
+        if not isinstance(fixtures, list) or not fixtures:
+            failures.append(f"{tier_name}: fixtures must be a non-empty list")
+            continue
+        for fixture_id in fixtures:
+            key = str(fixture_id)
+            if key in tier_assignments:
+                failures.append(f"{key}: assigned to multiple tiers")
+            tier_assignments[key] = tier_number
+
+    for fixture_id, matrix_tier in sorted(matrix_tiers.items()):
+        assigned_tier = tier_assignments.get(fixture_id)
+        if assigned_tier is None:
+            failures.append(f"{fixture_id}: missing tier assignment")
+        elif assigned_tier != matrix_tier:
+            failures.append(
+                f"{fixture_id}: tier matrix mismatch, matrix={matrix_tier} tiers={assigned_tier}"
+            )
+    for fixture_id in sorted(set(tier_assignments) - set(matrix_tiers)):
+        failures.append(f"{fixture_id}: tier assignment has no matrix fixture")
+
+    if failures:
+        for failure in failures:
+            print(f"rust interop tier error: {failure}", file=sys.stderr)
+        return 1
+    print(f"rust interop tiers ok: tiers={len(actual_tiers)} fixtures={len(tier_assignments)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/rust_interop/data/rust_interop_fixture_matrix.json
+++ b/verification/areas/rust_interop/data/rust_interop_fixture_matrix.json
@@ -1,0 +1,303 @@
+{
+  "schema_version": 1,
+  "phase": "39_rust_interop",
+  "architecture": "internal_docs/rust_interop_architecture.md",
+  "bridge_version": 1,
+  "diagnostic_families": {
+    "SIFR-RUST-ASYNC-0001": "invalid Rust async/thread-affinity contract",
+    "SIFR-RUST-CARGO-0001": "Cargo metadata or lock/profile mismatch",
+    "SIFR-RUST-CB-0001": "invalid callback lifetime or threading contract",
+    "SIFR-RUST-CONFIG-0001": "malformed Rust interop decorator",
+    "SIFR-RUST-HANDLE-0001": "invalid opaque handle contract",
+    "SIFR-RUST-PANIC-0001": "incompatible Rust panic strategy or poisoned handle",
+    "SIFR-RUST-RESOLVE-0001": "unresolved Rust target path",
+    "SIFR-RUST-TRUST-0001": "missing Rust interop trust declaration",
+    "SIFR-RUST-TYPE-0001": "unsupported Rust bridge type",
+    "SIFR-RUST-ZC-0001": "invalid zero-copy/view lifetime contract"
+  },
+  "fixtures": [
+    {
+      "id": "direct_crate_crc32",
+      "tier": 1,
+      "capability": "direct compatible function binding",
+      "required_crates": ["crc32fast"],
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "crc32fast_hash_uint32", "status": "planned"},
+      "negative_evidence": {"id": "crc32fast_missing_panic_policy", "status": "planned"}
+    },
+    {
+      "id": "direct_crate_matrix",
+      "tier": 1,
+      "capability": "direct crate matrix",
+      "required_crates": ["blake3", "sha2", "uuid", "regex"],
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "compatible_direct_signatures", "status": "planned"},
+      "negative_evidence": {"id": "incompatible_direct_signatures", "status": "planned"}
+    },
+    {
+      "id": "direct_crate_negative_type",
+      "tier": 0,
+      "capability": "invalid direct bridge type diagnostics",
+      "required_crates": ["regex"],
+      "execution_kind": "compiler-diagnostic",
+      "positive_evidence": {"id": "unsupported_type_rejected", "status": "planned"},
+      "negative_evidence": {"id": "unsupported_type_cannot_compile_silently", "status": "planned"}
+    },
+    {
+      "id": "dotted_path_resolution",
+      "tier": 0,
+      "capability": "structured Rust decorator paths",
+      "required_crates": [],
+      "execution_kind": "compiler-diagnostic",
+      "positive_evidence": {"id": "valid_structured_paths", "status": "planned"},
+      "negative_evidence": {"id": "string_and_reserved_root_rejection", "status": "planned"}
+    },
+    {
+      "id": "bridge_type_matrix",
+      "tier": 1,
+      "capability": "bridge type generation and conversion",
+      "required_crates": ["serde", "serde_json", "thiserror", "bytes", "indexmap"],
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "supported_type_roundtrips", "status": "planned"},
+      "negative_evidence": {"id": "unsupported_container_rejections", "status": "planned"}
+    },
+    {
+      "id": "local_bridge_blake3",
+      "tier": 1,
+      "capability": "package-local bridge binding",
+      "required_crates": ["blake3"],
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "local_bridge_hash_bytes", "status": "planned"},
+      "negative_evidence": {"id": "missing_local_bridge_export", "status": "planned"}
+    },
+    {
+      "id": "same_workspace_crate",
+      "tier": 1,
+      "capability": "same-workspace crate as ordinary Cargo dependency",
+      "required_crates": [],
+      "execution_kind": "contract-only",
+      "positive_evidence": {"id": "declared_path_dependency_resolves", "status": "planned"},
+      "negative_evidence": {"id": "undeclared_workspace_crate_rejected", "status": "planned"}
+    },
+    {
+      "id": "shared_bridge_crate",
+      "tier": 1,
+      "capability": "shared bridge crate boundary",
+      "required_crates": [],
+      "execution_kind": "contract-only",
+      "positive_evidence": {"id": "stable_runtime_types_only", "status": "planned"},
+      "negative_evidence": {"id": "package_generated_type_import_rejected", "status": "planned"}
+    },
+    {
+      "id": "opaque_handle_tokenizer",
+      "tier": 2,
+      "capability": "opaque Rust handle basics",
+      "required_crates": [],
+      "execution_kind": "runtime-observed",
+      "positive_evidence": {"id": "owned_handle_method_and_close", "status": "planned"},
+      "negative_evidence": {"id": "use_after_close_rejected", "status": "planned"}
+    },
+    {
+      "id": "opaque_resource_matrix",
+      "tier": 2,
+      "capability": "resource-shaped opaque handles",
+      "required_crates": ["reqwest", "rusqlite", "tokio-postgres", "redis"],
+      "features": {
+        "redis": {"default_features": false, "features": ["tokio-comp"]},
+        "reqwest": {"default_features": false, "features": ["rustls-tls", "json"]},
+        "rusqlite": {"features": ["bundled"]},
+        "tokio-postgres": {"default_features": false, "features": ["runtime"]}
+      },
+      "execution_kind": "runtime-observed",
+      "positive_evidence": {"id": "resource_close_aclose_matrix", "status": "planned"},
+      "negative_evidence": {"id": "invalid_resource_aliasing", "status": "planned"}
+    },
+    {
+      "id": "close_after_use",
+      "tier": 2,
+      "capability": "closed and poisoned handle state transitions",
+      "required_crates": [],
+      "execution_kind": "runtime-observed",
+      "positive_evidence": {"id": "closed_handle_error_surface", "status": "planned"},
+      "negative_evidence": {"id": "double_close_and_poisoned_access", "status": "planned"}
+    },
+    {
+      "id": "bridge_version_mismatch",
+      "tier": 0,
+      "capability": "bridge-version validation",
+      "required_crates": [],
+      "execution_kind": "compiler-diagnostic",
+      "positive_evidence": {"id": "bridge_version_1_accepted", "status": "planned"},
+      "negative_evidence": {"id": "unsupported_bridge_version_rejected", "status": "planned"}
+    },
+    {
+      "id": "panic_boundary",
+      "tier": 2,
+      "capability": "panic-to-error behavior",
+      "required_crates": [],
+      "execution_kind": "contract-only",
+      "positive_evidence": {"id": "panic_maps_to_rust_panic_error", "status": "planned"},
+      "negative_evidence": {"id": "panic_payload_not_exposed", "status": "planned"}
+    },
+    {
+      "id": "panic_abort_profile",
+      "tier": 2,
+      "capability": "abort-profile rejection and trust",
+      "required_crates": [],
+      "execution_kind": "contract-only",
+      "positive_evidence": {"id": "explicit_abort_trust_declared", "status": "planned"},
+      "negative_evidence": {"id": "recoverable_abort_profile_rejected", "status": "planned"}
+    },
+    {
+      "id": "async_runtime_reqwest",
+      "tier": 2,
+      "capability": "async Rust bridge on Sifr Tokio runtime",
+      "required_crates": ["tokio", "reqwest"],
+      "features": {"reqwest": {"default_features": false, "features": ["rustls-tls", "json"]}},
+      "execution_kind": "runtime-observed",
+      "positive_evidence": {"id": "async_reqwest_loopback", "status": "planned"},
+      "negative_evidence": {"id": "hidden_block_on_rejected", "status": "planned"}
+    },
+    {
+      "id": "async_ecosystem_matrix",
+      "tier": 2,
+      "capability": "async ecosystem signature probing",
+      "required_crates": ["futures", "tower", "http", "http-body"],
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "future_output_shapes", "status": "planned"},
+      "negative_evidence": {"id": "non_send_future_without_affinity", "status": "planned"}
+    },
+    {
+      "id": "blocking_diagnostics",
+      "tier": 0,
+      "capability": "blocking I/O and CPU-heavy classification",
+      "required_crates": ["rusqlite", "rayon", "flate2"],
+      "features": {"rusqlite": {"features": ["bundled"]}, "flate2": {"default_features": false, "features": ["rust_backend"]}},
+      "execution_kind": "compiler-diagnostic",
+      "positive_evidence": {"id": "classified_sync_calls", "status": "planned"},
+      "negative_evidence": {"id": "classified_async_declarations_rejected", "status": "planned"}
+    },
+    {
+      "id": "callbacks_call_scoped",
+      "tier": 2,
+      "capability": "call-scoped callback lifetime",
+      "required_crates": [],
+      "execution_kind": "runtime-observed",
+      "positive_evidence": {"id": "callback_valid_during_call", "status": "planned"},
+      "negative_evidence": {"id": "callback_storage_rejected", "status": "planned"}
+    },
+    {
+      "id": "callbacks_threadsafe",
+      "tier": 2,
+      "capability": "thread-safe callback policy",
+      "required_crates": [],
+      "execution_kind": "runtime-observed",
+      "positive_evidence": {"id": "bounded_callback_policy", "status": "planned"},
+      "negative_evidence": {"id": "missing_backpressure_rejected", "status": "planned"}
+    },
+    {
+      "id": "callback_subscription_matrix",
+      "tier": 2,
+      "capability": "callback subscriptions and shutdown",
+      "required_crates": ["tokio-tungstenite", "redis", "notify"],
+      "features": {"redis": {"default_features": false, "features": ["tokio-comp"]}, "tokio-tungstenite": {"default_features": false}},
+      "execution_kind": "runtime-observed",
+      "positive_evidence": {"id": "subscription_cancel_shutdown", "status": "planned"},
+      "negative_evidence": {"id": "invalid_thread_capture_rejected", "status": "planned"}
+    },
+    {
+      "id": "zero_copy_bytes",
+      "tier": 2,
+      "capability": "zero-copy bytes view",
+      "required_crates": ["bytes"],
+      "execution_kind": "runtime-observed",
+      "positive_evidence": {"id": "borrowed_bytes_view", "status": "planned"},
+      "negative_evidence": {"id": "copy_fallback_rejected", "status": "planned"}
+    },
+    {
+      "id": "zero_copy_view_matrix",
+      "tier": 2,
+      "capability": "core zero-copy views",
+      "required_crates": ["memmap2", "bytemuck", "zerocopy"],
+      "execution_kind": "runtime-observed",
+      "positive_evidence": {"id": "owner_lifetime_views", "status": "planned"},
+      "negative_evidence": {"id": "mutable_alias_rejected", "status": "planned"}
+    },
+    {
+      "id": "arrow_record_batch",
+      "tier": 4,
+      "capability": "Arrow record batch exchange",
+      "required_crates": ["arrow"],
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "arrow_schema_identity", "status": "planned"},
+      "negative_evidence": {"id": "invalid_arrow_metadata", "status": "planned"}
+    },
+    {
+      "id": "tensor_dlpack_bridge",
+      "tier": 4,
+      "capability": "tensor and DLPack handoff",
+      "required_crates": ["ndarray"],
+      "execution_kind": "contract-only",
+      "positive_evidence": {"id": "explicit_tensor_ownership", "status": "planned"},
+      "negative_evidence": {"id": "implicit_dlpack_ownership_rejected", "status": "planned"}
+    },
+    {
+      "id": "advanced_data_matrix",
+      "tier": 4,
+      "capability": "advanced data and tensor ecosystems",
+      "required_crates": ["datafusion", "polars", "ndarray", "candle"],
+      "features": {"candle": {"backend": "cpu-only"}},
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "advanced_data_metadata", "status": "planned"},
+      "negative_evidence": {"id": "dtype_shape_mismatch", "status": "planned"}
+    },
+    {
+      "id": "ecosystem_backend_certification",
+      "tier": 4,
+      "capability": "backend/service ecosystem certification",
+      "required_crates": ["axum", "tower-http", "sqlx"],
+      "features": {"sqlx": {"default_features": false, "features": ["runtime-tokio-rustls", "postgres", "macros"]}},
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "backend_probe_coverage", "status": "planned"},
+      "negative_evidence": {"id": "sqlx_without_offline_artifacts", "status": "planned"}
+    },
+    {
+      "id": "ecosystem_cli_certification",
+      "tier": 4,
+      "capability": "CLI/tooling ecosystem certification",
+      "required_crates": ["clap", "tracing", "tracing-subscriber", "anyhow"],
+      "features": {"tracing-subscriber": {"features": ["env-filter"]}},
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "cli_tooling_probe_coverage", "status": "planned"},
+      "negative_evidence": {"id": "unsupported_anyhow_surface", "status": "planned"}
+    },
+    {
+      "id": "native_build_script",
+      "tier": 3,
+      "capability": "build-script and native-link trust",
+      "required_crates": ["cc", "bindgen", "cxx", "zstd"],
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "trusted_build_script_native_evidence", "status": "planned"},
+      "negative_evidence": {"id": "untrusted_native_link_rejected", "status": "planned"}
+    },
+    {
+      "id": "proc_macro_trust",
+      "tier": 3,
+      "capability": "build-script and proc-macro trust",
+      "required_crates": ["serde_derive", "prost-build"],
+      "features": {"prost-build": {"generated_output": "deterministic"}},
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "trusted_proc_macro", "status": "planned"},
+      "negative_evidence": {"id": "untrusted_proc_macro_rejected_pre_execution", "status": "planned"}
+    },
+    {
+      "id": "cargo_locked_offline",
+      "tier": 3,
+      "capability": "locked/offline/frozen Cargo behavior",
+      "required_crates": [],
+      "execution_kind": "cargo-probe",
+      "positive_evidence": {"id": "locked_offline_cache_hit", "status": "planned"},
+      "negative_evidence": {"id": "lockfile_feature_drift_rejected", "status": "planned"}
+    }
+  ]
+}

--- a/verification/areas/rust_interop/data/rust_interop_tiers.toml
+++ b/verification/areas/rust_interop/data/rust_interop_tiers.toml
@@ -1,0 +1,59 @@
+[tier0]
+name = "parser-lowering-metadata-diagnostics"
+description = "Parser, lowering, metadata, and diagnostics without Cargo build."
+fixtures = [
+  "dotted_path_resolution",
+  "direct_crate_negative_type",
+  "bridge_version_mismatch",
+  "blocking_diagnostics",
+]
+
+[tier1]
+name = "direct-and-local-bridge-build"
+description = "Direct crate and local bridge build fixtures."
+fixtures = [
+  "direct_crate_crc32",
+  "direct_crate_matrix",
+  "bridge_type_matrix",
+  "local_bridge_blake3",
+  "same_workspace_crate",
+  "shared_bridge_crate",
+]
+
+[tier2]
+name = "runtime-safety-and-core-views"
+description = "Opaque handles, panic boundary, async/blocking, callbacks, and zero-copy."
+fixtures = [
+  "opaque_handle_tokenizer",
+  "opaque_resource_matrix",
+  "close_after_use",
+  "panic_boundary",
+  "panic_abort_profile",
+  "async_runtime_reqwest",
+  "async_ecosystem_matrix",
+  "callbacks_call_scoped",
+  "callbacks_threadsafe",
+  "callback_subscription_matrix",
+  "zero_copy_bytes",
+  "zero_copy_view_matrix",
+]
+
+[tier3]
+name = "cargo-trust-native-locked"
+description = "Build scripts, proc macros, native linking, and offline/locked Cargo behavior."
+fixtures = [
+  "native_build_script",
+  "proc_macro_trust",
+  "cargo_locked_offline",
+]
+
+[tier4]
+name = "production-ecosystem-certification"
+description = "Production examples and compatibility matrix for selected Rust ecosystems."
+fixtures = [
+  "arrow_record_batch",
+  "tensor_dlpack_bridge",
+  "advanced_data_matrix",
+  "ecosystem_backend_certification",
+  "ecosystem_cli_certification",
+]

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/arrow_record_batch/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/arrow_record_batch/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/bridge_version_mismatch/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/bridge_version_mismatch/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/callbacks_call_scoped/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/callbacks_call_scoped/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/callbacks_threadsafe/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/callbacks_threadsafe/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/cargo_locked_offline/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/cargo_locked_offline/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/close_after_use/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/close_after_use/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/direct_crate_crc32/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/direct_crate_crc32/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/direct_crate_negative_type/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/direct_crate_negative_type/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/dotted_path_resolution/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/dotted_path_resolution/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/local_bridge_blake3/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/local_bridge_blake3/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/native_build_script/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/native_build_script/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/panic_abort_profile/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/panic_abort_profile/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/panic_boundary/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/panic_boundary/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/same_workspace_crate/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/same_workspace_crate/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/shared_bridge_crate/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/shared_bridge_crate/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/zero_copy_bytes/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/zero_copy_bytes/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/.gitkeep
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/.gitkeep
@@ -1,0 +1,1 @@
+tracked fixture directory

--- a/verification/areas/rust_interop/manifest.json
+++ b/verification/areas/rust_interop/manifest.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 2,
+  "name": "rust_interop",
+  "owner": "compiler/package-management",
+  "description": "Rust interop declaration, Cargo, trust, probe, bridge, runtime, and ecosystem verification.",
+  "parallel_safe": false,
+  "resource_classes": [
+    "default-local",
+    "external-corpus",
+    "platform-specific",
+    "long-running"
+  ],
+  "timeout_seconds": 1800,
+  "suites": [
+    {
+      "name": "matrix",
+      "kind": "adapter",
+      "cases": [
+        {
+          "id": "rust-interop-matrix",
+          "entry": "verification/areas/rust_interop/checks/check_fixture_matrix.py",
+          "command": "area-check",
+          "expect_exit_code": 0,
+          "diagnostic_formats": []
+        }
+      ]
+    },
+    {
+      "name": "tiers",
+      "kind": "adapter",
+      "cases": [
+        {
+          "id": "rust-interop-tiers",
+          "entry": "verification/areas/rust_interop/checks/check_tiers.py",
+          "command": "area-check",
+          "expect_exit_code": 0,
+          "diagnostic_formats": []
+        }
+      ]
+    },
+    {
+      "name": "stale-drafts",
+      "kind": "adapter",
+      "cases": [
+        {
+          "id": "rust-interop-stale-drafts",
+          "entry": "verification/areas/rust_interop/checks/check_stale_drafts.py",
+          "command": "area-check",
+          "expect_exit_code": 0,
+          "diagnostic_formats": []
+        }
+      ]
+    }
+  ],
+  "network_mode": "offline",
+  "pinned_corpus": {
+    "required": false,
+    "revision": "not-applicable",
+    "checksum": "not-applicable"
+  },
+  "skip_policy": {
+    "allowed": false,
+    "requires_reason": true
+  },
+  "baseline_metadata_rules": {
+    "required": false,
+    "source": "not-applicable"
+  }
+}

--- a/verification/areas/rust_interop/runner.py
+++ b/verification/areas/rust_interop/runner.py
@@ -1,0 +1,55 @@
+"""Rust interop verification area adapter."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from sifr_verify.area_adapter import AreaAdapterConfig, AreaRunOptions, run_area
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MANIFEST_PATH = Path(__file__).resolve().with_name("manifest.json")
+ACTUAL_ROOT = REPO_ROOT / "target" / "verification" / "actual" / "rust_interop"
+RESULT_JSON = REPO_ROOT / "target" / "verification" / "areas" / "rust-interop-results.json"
+CONFIG = AreaAdapterConfig(
+    area="rust_interop",
+    owner="compiler/package-management",
+    runner_name="rust-interop-area",
+    manifest_path=MANIFEST_PATH,
+    actual_root=ACTUAL_ROOT,
+    status_label="rust interop",
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", action="append", default=[], help="Suite filter; can repeat.")
+    parser.add_argument("--bless", action="store_true", help="Update checked-in baselines.")
+    parser.add_argument(
+        "--result-json",
+        default=str(RESULT_JSON.relative_to(REPO_ROOT)),
+        help="Path for machine-readable rust interop area result summary.",
+    )
+    parser.add_argument(
+        "--hardening-summary",
+        action="store_true",
+        help="Emit the legacy hardening summary line consumed by validation reports.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return run_area(
+        CONFIG,
+        AreaRunOptions(
+            suite_filters=set(args.suite),
+            bless=args.bless,
+            result_json=Path(args.result_json),
+            hardening_summary=args.hardening_summary,
+        ),
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/rust_interop/runner/bridge_check.py
+++ b/verification/areas/rust_interop/runner/bridge_check.py
@@ -1,0 +1,24 @@
+"""Bridge projection check skeletons for Rust interop fixtures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BridgeProjectionCheck:
+    fixture_id: str
+    managed_files: tuple[Path, ...]
+    user_owned_files: tuple[Path, ...]
+    bridge_version: int
+
+
+def load_projection_check(fixture_root: Path) -> BridgeProjectionCheck:
+    """Return the future projection ownership check for a fixture root."""
+    return BridgeProjectionCheck(
+        fixture_id=fixture_root.name,
+        managed_files=(),
+        user_owned_files=(),
+        bridge_version=1,
+    )

--- a/verification/areas/rust_interop/runner/cargo_probe.py
+++ b/verification/areas/rust_interop/runner/cargo_probe.py
@@ -1,0 +1,28 @@
+"""Cargo metadata and Rust signature probe skeletons for Rust interop fixtures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RustBridgeProbePlan:
+    fixture_id: str
+    package_root: Path
+    target_paths: tuple[str, ...]
+    locked: bool
+    offline: bool
+    frozen: bool
+
+
+def load_probe_plan(fixture_root: Path) -> RustBridgeProbePlan:
+    """Return the future probe plan hook for a fixture root."""
+    return RustBridgeProbePlan(
+        fixture_id=fixture_root.name,
+        package_root=fixture_root,
+        target_paths=(),
+        locked=True,
+        offline=True,
+        frozen=False,
+    )

--- a/verification/areas/rust_interop/runner/native_probe.py
+++ b/verification/areas/rust_interop/runner/native_probe.py
@@ -1,0 +1,21 @@
+"""Native-link evidence probe skeletons for Rust interop fixtures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NativeLinkEvidence:
+    fixture_id: str
+    native_links: tuple[str, ...]
+    build_script_outputs: tuple[str, ...]
+
+
+def empty_native_evidence(fixture_id: str) -> NativeLinkEvidence:
+    """Return an empty native evidence record until tier 3 fixtures are implemented."""
+    return NativeLinkEvidence(
+        fixture_id=fixture_id,
+        native_links=(),
+        build_script_outputs=(),
+    )

--- a/verification/areas/rust_interop/runner/report.py
+++ b/verification/areas/rust_interop/runner/report.py
@@ -1,0 +1,23 @@
+"""Reporting helpers for Rust interop verification fixtures."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+
+def write_report(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return asdict(value)
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, tuple):
+        return [to_jsonable(item) for item in value]
+    return value

--- a/verification/areas/rust_interop/runner/trust_check.py
+++ b/verification/areas/rust_interop/runner/trust_check.py
@@ -1,0 +1,21 @@
+"""Trust evidence check skeletons for Rust interop fixtures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TrustEvidence:
+    fixture_id: str
+    pre_execution_checks: tuple[str, ...]
+    post_execution_checks: tuple[str, ...]
+
+
+def empty_trust_evidence(fixture_id: str) -> TrustEvidence:
+    """Return an empty evidence record until Cargo metadata integration lands."""
+    return TrustEvidence(
+        fixture_id=fixture_id,
+        pre_execution_checks=(),
+        post_execution_checks=(),
+    )


### PR DESCRIPTION
## What changed

- Adds the first-class `verification/areas/rust_interop` scaffold with the architecture-required fixture tree, fixture matrix, tier metadata, runner skeletons, and area checks.
- Reserves the `SIFR-RUST-*` diagnostic families in the public diagnostics index and the Rust interop matrix.
- Cleans active Rust interop docs away from abandoned syntax/trust examples and aligns architecture wording with verification taxonomy guardrails.
- Records two Claude Opus review rounds for the scaffold; round two marks the scaffold review-satisfied.

## Why

Rust interop needs a concrete verification area before parser/lowering/Cargo implementation starts. The scaffold locks fixture names, tier ownership, crate coverage, feature pins, diagnostic families, and stale-draft cleanup so later work has executable guardrails instead of relying on prose only.

## Validation

- `python3 verification/areas/rust_interop/checks/check_fixture_matrix.py`
- `python3 verification/areas/rust_interop/checks/check_tiers.py`
- `python3 verification/areas/rust_interop/checks/check_stale_drafts.py`
- `PYTHONPATH=verification/runner python3 -m sifr_verify areas run --area rust_interop`
- `PYTHONPATH=verification/runner python3 -m sifr_verify areas check`
- `PYTHONPATH=verification/runner python3 -m sifr_verify areas run --area coverage_matrix --suite readiness`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `scripts/run_all_tests.sh --profile create-pr` passed; advisory only: warm wall-time budget exceeded because e2e rebuilt all groups with 0/44 cache hits.

## Review

- `plans/reviews/active/rust-interop-milestone39-0-review-round1.md`
- `plans/reviews/active/rust-interop-milestone39-0-review-round2.md`
