### PR TITLE
[codex] Document M39.4 PR link

### DIFF
--- a/plans/phases/39_rust_interop.md
+++ b/plans/phases/39_rust_interop.md
@@ -119,7 +119,7 @@ Status: implemented in [PR #2704](https://github.com/sifr-lang/sifr/pull/2704); 
 
 ### milestone_39_4: Bridge Type Contract and Conversion Runtime
 
-Status: implemented locally on branch `phase39-rust-interop-m39-4`; focused validation passed and reviewer sign-off is recorded in `plans/reviews/active/rust-interop-milestone39-4-review-round2.md`.
+Status: implemented in [PR #2705](https://github.com/sifr-lang/sifr/pull/2705); local `create-pr` validation passed and reviewer sign-off is recorded in `plans/reviews/active/rust-interop-milestone39-4-review-round2.md`.
 
 - Scope:
   - Implement checked bridge mappings for booleans, fixed-width integers, exact integers through `sifr_runtime::interop::SifrIntBridge`, floats, strings, bytes, lists, order-preserving dicts, `Option`, `Result`, closed enums, records, opaque handles through `sifr_runtime::interop::Handle<T>`, callbacks, and errors.


### PR DESCRIPTION
## Summary

Updates the Phase 39 tracker to record that M39.4 landed in PR #2705.

## Validation

Documentation-only status update. M39.4 implementation validation is recorded in PR #2705:

- `scripts/run_all_tests.sh --profile create-pr`
- reviewer sign-off in `plans/reviews/active/rust-interop-milestone39-4-review-round2.md`