### PR TITLE
Document M39.6 PR link

### DIFF
--- a/plans/phases/39_rust_interop.md
+++ b/plans/phases/39_rust_interop.md
@@ -147,7 +147,7 @@ Status: implemented in [PR #2707](https://github.com/sifr-lang/sifr/pull/2707); 
 
 ### milestone_39_6: Opaque Rust Handles and Resource Cleanup
 
-Status: implemented locally on branch `phase39-rust-interop-m39-6`; focused driver/runtime validation covers opaque contract parsing, Send/Sync/Copy probes, explicit close/aclose contract diagnostics, and runtime closed/poisoned handle transitions. Full ecosystem resource wrappers remain tracked by `opaque_resource_matrix`.
+Status: implemented in [PR #2709](https://github.com/sifr-lang/sifr/pull/2709); focused driver/runtime validation covers opaque contract parsing, Send/Sync/Copy probes, explicit close/aclose contract diagnostics, and runtime closed/poisoned handle transitions. Full ecosystem resource wrappers remain tracked by `opaque_resource_matrix`.
 
 - Scope:
   - Implement `@rust.opaque(...)` classes with ownership, borrowing, clone, close, `Send`, `Sync`, and thread-affinity metadata.


### PR DESCRIPTION
## Summary
- document that M39.6 opaque Rust handle contracts landed in PR #2709

## Validation
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`
