### PR TITLE
Repair installer env script on self-update

### DIFF
--- a/plans/reviews/active/installer-env-repair-review-2.md
+++ b/plans/reviews/active/installer-env-repair-review-2.md
@@ -1,0 +1,38 @@
+I've reviewed the patch deltas against the prior review findings and looked for new portability/correctness regressions. Below are findings, ordered by severity.
+
+## Findings
+
+### No blocking findings
+
+The patch correctly addresses prior-review findings 1, 2, 3, and 5. The fish repair extension and shell-portability changes do not introduce regressions I can spot.
+
+### Low — observations and minor portability nuances
+
+1. **Stray `~/.sifr/env` for custom `SIFR_INSTALL_DIR` on PATH (still present).**
+   `scripts/distribution/generate_version_installer.sh:466-467` unconditionally creates `${HOME}/.sifr/` and writes `${HOME}/.sifr/env` before the `install_dir_on_path` early-return. For a user who sets `SIFR_INSTALL_DIR=/usr/local/bin` (already on PATH), they will now get a `~/.sifr/env` they didn't have before. This is the same finding 4 from review 1; not a regression introduced by *this* delta, but the fish-symmetry change reuses the same ordering, so it's worth a conscious decision rather than carrying it forward by accident.
+
+2. **`SHELL` may be unset in pristine `sh` environments.**
+   `scripts/distribution/generate_version_installer.sh:463` is `shell_name="${SHELL##*/}"`. With `set -u` this errors when `SHELL` is unset. Pre-existing behavior — the tests always pass `SHELL=/bin/zsh`. The repair branch (line 470) also reads `shell_name`, so if a future call site invokes the installer without `SHELL`, the new branch fails identically to the old one. No regression introduced, but the test never exercises the unset-`SHELL` path.
+
+3. **Fish-repair coverage depends on the test pre-creating `~/.config/fish`.**
+   `verification/areas/distribution_release/cases/artifact_configures_path.sh:69` does `mkdir -p "${home_dir}/.config/fish"` before the repair run, which makes the `[ -d "${HOME}/.config/fish" ]` arm in `generate_version_installer.sh:470` true. If a future refactor accidentally swapped the directory check for `[ -f "${HOME}/.config/fish/config.fish" ]` (or similar), this test would still pass because it doesn't pin the trigger condition. Cheap hardening, not a blocker.
+
+4. **`artifact_no_modify_path_respected.sh:55-76` does not pre-create `~/.config/fish`.**
+   So the NO_MODIFY_PATH-on-PATH rerun doesn't exercise the fish branch at all — it relies on the broader "no files created" assertion. That's defensible (NO_MODIFY_PATH returns at line 445, never reaching the fish branch), so the test correctly verifies the documented invariant via the strong negative assertion at line 72. Mentioning for completeness only.
+
+5. **Sourcing `.zshrc` through `sh` is correct, but brittle to future content drift.**
+   `verification/areas/distribution_release/cases/artifact_configures_path.sh:105` uses `sh -c '. "${HOME}/.zshrc"; command -v sifr'`. Today `.zshrc` is exactly one POSIX `. "${HOME}/.sifr/env"` line (written by `append_source_line`), and the env script is POSIX-compatible (`write_env_script_sh`). So this is portable. If a future change writes anything zsh-specific to `.zshrc`, this assertion will start failing through `sh`. Acceptable trade-off for not requiring zsh on the verification host.
+
+6. **`grep -F -c` is portable but counts matching *lines*, not occurrences.**
+   `verification/areas/distribution_release/cases/artifact_configures_path.sh:50,98`. Since `append_source_line` always writes the source command on its own line, this is fine — a duplicate would show up as `2`. Just noting the semantic so a future refactor of `append_source_line` doesn't quietly invalidate the assertion.
+
+## Confirmations
+
+- **POSIX shell portability of the new branch** (`generate_version_installer.sh:469-475`): `[`, `case`, simple assignments only — no Bashisms. `set -eu` semantics preserved.
+- **Symmetry with non-on-PATH fish branch** (`generate_version_installer.sh:495-499` vs `469-475`): same predicate (`[ -d ... ] || [ shell = fish ]`), same `mkdir -p` + `write_env_script_fish` calls. The repair branch correctly omits `changed=1` because it explicitly suppresses the "configured" message — consistent with the silent-repair invariant.
+- **Silent-repair invariant**: `generate_version_installer.sh:469-475` returns before the `if [ "${changed}" = "1" ]` block at `501-507`, so no `"configured Sifr PATH via"` or `"fish users can also run"` output. Test pins this at `artifact_configures_path.sh:79-84`.
+- **No POSIX profile hooks appended on repair**: `append_source_line` is never called on the on-PATH path. Test pins the no-duplicate assertion at `artifact_configures_path.sh:98-102` and the resolution-still-works assertion at `104-109`.
+- **NO_MODIFY_PATH precedence**: `generate_version_installer.sh:445` short-circuits before the new `install_dir_on_path` logic, so the new branch can never run under the opt-out. Test pins this at `artifact_no_modify_path_respected.sh:55-76`.
+
+## Verdict
+No blocking findings on the fish repair extension or the shell-portability changes. Ship.

--- a/plans/reviews/active/installer-env-repair-review.md
+++ b/plans/reviews/active/installer-env-repair-review.md
@@ -1,0 +1,29 @@
+I've reviewed the diff against the surrounding installer logic. The fix is correctly scoped to the root cause. No blocking findings.
+
+## Verdict
+No blocking correctness regressions. The change preserves the documented invariants (`NO_MODIFY_PATH=1`/`--no-modify-path` → no writes; install_dir-on-PATH → no profile edits or "configured" message), and the new test correctly exercises the "already installed → repair" path that self-update hits.
+
+## Findings (ordered by severity)
+
+### Medium — Test gaps versus the stated invariants
+
+1. **No assertion that the repair path is silent.** The prompt says: "If install_dir is already on PATH, it should still avoid appending profile hooks or printing a fresh PATH configuration message." `artifact_configures_path.sh:68-75` captures `output` but never asserts the absence of `"configured Sifr PATH via"`. A future regression that re-emits the message (or, worse, re-touches profiles) would slip past CI.
+   - Suggested guard: assert `output` does NOT contain `"configured Sifr PATH via"`; assert `.zshrc` line count / mtime is unchanged across the repair run (or that it still has exactly one `. "${HOME}/.sifr/env"` line).
+
+2. **No regression coverage for `SIFR_NO_MODIFY_PATH=1` on the repair path.** The fix moves writes ahead of the early return for `install_dir_on_path`, but the `NO_MODIFY_PATH=1` short-circuit at `generate_version_installer.sh:445` remains the only thing preventing writes when the user opted out. There's no test combining `SIFR_NO_MODIFY_PATH=1` with an `install_dir`-on-PATH re-run that asserts `~/.sifr/env` is *not* created. Given how easy that invariant is to break inside `configure_path` if someone later reorders, an explicit negative test would be cheap insurance.
+
+### Low — Parallel hole / behavior nuances (not regressions)
+
+3. **Fish env script is not repaired symmetrically.** The new early-return at `generate_version_installer.sh:469-471` sits *before* the fish block (`491-495`). So if a fish user loses `~/.config/fish/conf.d/sifr.env.fish` (the analogue of the bug being fixed) and runs self-update with install_dir on PATH, the fish file is not recreated. Same root cause, just on a less common shell. Not a regression — the old code didn't handle it either — but worth deciding whether to extend the fix or document the asymmetry.
+
+4. **Stray `~/.sifr/env` for custom install dirs on PATH.** When a user sets `SIFR_INSTALL_DIR` to something outside `$HOME/.sifr/bin` *and* that dir is already on PATH, the new code unconditionally creates `~/.sifr/` and writes `~/.sifr/env` pointing at the custom dir. Previously the home tree was left untouched in this scenario. The env content is harmless (it adds the custom dir to PATH if missing), but it's a new side effect on custom installs.
+
+5. **Test now requires `zsh` on the verification host.** Line 85 actually invokes `zsh -c '…'` (the first test used `SHELL=/bin/zsh` but never executed zsh). If any verification environment runs without zsh, this case will newly fail. The macOS/Linux CI runners likely already have it, but worth confirming so this doesn't surprise an offline contributor.
+
+### Nit
+- `install_dir_on_path=0` + `case` + later `[ "${install_dir_on_path}" = "1" ]` reads fine but is one extra global. Equivalent without the flag: re-`case` against `:${PATH}:` at the second decision point. Style preference only.
+
+## Confirmations
+- POSIX shell portability: `[`, `case`, simple assignments only — fine. `set -eu` semantics preserved (no unset reads added).
+- Idempotent env rewrite: `write_env_script_sh` truncates, so successive repair runs converge.
+- Self-update path: the "already installed" branch at `generate_version_installer.sh:541-546` calls `configure_path` then exits — this is precisely what the new test exercises, so the targeted bug class is covered.

--- a/scripts/distribution/generate_version_installer.sh
+++ b/scripts/distribution/generate_version_installer.sh
@@ -445,9 +445,10 @@ configure_path() {
   [ "\${NO_MODIFY_PATH}" = "1" ] && return 0
   [ -n "\${HOME:-}" ] || return 0
 
+  install_dir_on_path=0
   case ":\${PATH}:" in
     *:"\${install_dir}":*)
-      return 0
+      install_dir_on_path=1
       ;;
   esac
 
@@ -464,6 +465,14 @@ configure_path() {
 
   mkdir -p "\${sifr_home}"
   write_env_script_sh "\${install_dir_expr}" "\${env_script_path}"
+
+  if [ "\${install_dir_on_path}" = "1" ]; then
+    if [ -d "\${HOME}/.config/fish" ] || [ "\${shell_name}" = "fish" ]; then
+      mkdir -p "\${fish_config_dir}"
+      write_env_script_fish "\${install_dir_expr}" "\${fish_env_script_path}"
+    fi
+    return 0
+  fi
 
   if append_source_line "\${HOME}/.profile" "\${source_line}"; then
     :

--- a/verification/areas/distribution_release/cases/artifact_configures_path.sh
+++ b/verification/areas/distribution_release/cases/artifact_configures_path.sh
@@ -47,6 +47,7 @@ fi
 
 grep -F '. "${HOME}/.sifr/env"' "${home_dir}/.profile" >/dev/null
 grep -F '. "${HOME}/.sifr/env"' "${home_dir}/.zshrc" >/dev/null
+zshrc_source_count_before="$(grep -F -c '. "${HOME}/.sifr/env"' "${home_dir}/.zshrc")"
 
 resolved="$(
   HOME="${home_dir}" PATH="/usr/bin:/bin" sh -c '. "${HOME}/.sifr/env"; command -v sifr'
@@ -61,5 +62,49 @@ output="$(
 )"
 if [[ "${output}" != "path fixture" ]]; then
   echo "installed sifr was not runnable through configured PATH: ${output}" >&2
+  exit 1
+fi
+
+rm -f "${home_dir}/.sifr/env"
+mkdir -p "${home_dir}/.config/fish"
+output="$(
+  HOME="${home_dir}" \
+    SHELL=/bin/zsh \
+    PATH="${home_dir}/.sifr/bin:/usr/bin:/bin" \
+    SIFR_TARGET="${target}" \
+    SIFR_ARTIFACT_BASE_URL="file://${artifact_dir}" \
+    sh "${installer}"
+)"
+
+if [[ "${output}" == *"configured Sifr PATH via"* ]]; then
+  echo "installer reported PATH configuration while repairing an already-on-PATH install" >&2
+  echo "--- output ---" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${home_dir}/.sifr/env" ]]; then
+  echo "installer did not repair missing managed env script when install dir was already on PATH" >&2
+  echo "--- output ---" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${home_dir}/.config/fish/conf.d/sifr.env.fish" ]]; then
+  echo "installer did not repair missing fish env script when install dir was already on PATH" >&2
+  exit 1
+fi
+
+zshrc_source_count_after="$(grep -F -c '. "${HOME}/.sifr/env"' "${home_dir}/.zshrc")"
+if [[ "${zshrc_source_count_after}" != "${zshrc_source_count_before}" ]]; then
+  echo "installer duplicated zsh profile hook while repairing an already-on-PATH install" >&2
+  exit 1
+fi
+
+resolved="$(
+  HOME="${home_dir}" PATH="/usr/bin:/bin" sh -c '. "${HOME}/.zshrc"; command -v sifr'
+)"
+if [[ "${resolved}" != "${home_dir}/.sifr/bin/sifr" ]]; then
+  echo "repaired zsh profile did not resolve installed sifr: ${resolved}" >&2
   exit 1
 fi

--- a/verification/areas/distribution_release/cases/artifact_no_modify_path_respected.sh
+++ b/verification/areas/distribution_release/cases/artifact_no_modify_path_respected.sh
@@ -52,6 +52,29 @@ if [[ -e "${home_dir}/.sifr/env" || -e "${home_dir}/.profile" || -e "${home_dir}
   exit 1
 fi
 
+output="$(
+  HOME="${home_dir}" \
+    SHELL=/bin/zsh \
+    PATH="${home_dir}/.sifr/bin:/usr/bin:/bin" \
+    SIFR_TARGET="${target}" \
+    SIFR_ARTIFACT_BASE_URL="file://${artifact_dir}" \
+    SIFR_NO_MODIFY_PATH=1 \
+    sh "${installer}" --no-modify-path
+)"
+
+if [[ "${output}" == *"configured Sifr PATH"* ]]; then
+  echo "installer configured PATH on already-on-PATH opt-out rerun" >&2
+  echo "--- output ---" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+if [[ -e "${home_dir}/.sifr/env" || -e "${home_dir}/.profile" || -e "${home_dir}/.zshrc" ]]; then
+  echo "installer wrote shell profile files on already-on-PATH opt-out rerun" >&2
+  find "${home_dir}" -maxdepth 2 -type f -print >&2
+  exit 1
+fi
+
 if [[ "$("${home_dir}/.sifr/bin/sifr")" != "no path fixture" ]]; then
   echo "installer did not install binary when PATH modification was disabled" >&2
   exit 1


### PR DESCRIPTION
## Summary
- repair the generated installer so PATH-managed installs always recreate `~/.sifr/env` before silently returning when the install dir is already on `PATH`
- also repair the fish env helper on the same already-on-PATH path without appending POSIX profile hooks or printing a new PATH configuration message
- add distribution regression coverage for stale env repair, silent/idempotent profile behavior, and no-modify-path reruns
- add Claude Opus review artifacts under `plans/reviews/active/`

## Validation
- `sh -n scripts/distribution/generate_version_installer.sh`
- `git diff --check`
- `verification/areas/distribution_release/cases/artifact_configures_path.sh`
- `verification/areas/distribution_release/cases/artifact_no_modify_path_respected.sh`
- `uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite full` — PASS, 38 variants, 0 failures
- `python3 scripts/check_file_size_guardrails.py`
- `cargo fmt --check`
- `scripts/run_all_tests.sh --profile create-pr` — PASS, advisory only: warm wall-time budget exceeded, e2e report_signature `5edef8cd4b961ef8`, 132 pass tests

## Review
- `plans/reviews/active/installer-env-repair-review.md`: no blocking findings; medium test gaps addressed
- `plans/reviews/active/installer-env-repair-review-2.md`: no blocking findings; verdict: ship
