### PR TITLE
Document beta 9 preview release

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -51,7 +51,7 @@ Sifr provides prebuilt preview binaries for the following targets:
     sifr --version
     ```
 
-    You should see a version string such as `0.1.0-beta.7`. If the command is not found, check that `~/.sifr/bin` is in your `PATH`.
+    You should see a version string such as `0.1.0-beta.9`. If the command is not found, check that `~/.sifr/bin` is in your `PATH`.
   </Step>
 </Steps>
 
@@ -62,7 +62,7 @@ Sifr provides prebuilt preview binaries for the following targets:
 If you need a specific preview release — for reproducible CI environments or to test a particular build — pass `--version` to the installer:
 
 ```bash
-curl -fsSL https://sifr.sh/install | sh -s -- --version 0.1.0-beta.7
+curl -fsSL https://sifr.sh/install | sh -s -- --version 0.1.0-beta.9
 ```
 
 ### Install to a custom directory
@@ -115,7 +115,7 @@ sifr self update --channel beta
 You can update to a specific preview version rather than the latest on your channel:
 
 ```bash
-sifr self update --version 0.1.0-beta.7
+sifr self update --version 0.1.0-beta.9
 ```
 
 ### Reinstalls, downgrades, and channel switches
@@ -123,7 +123,7 @@ sifr self update --version 0.1.0-beta.7
 Same-version reinstalls, downgrades, and channel switches all require `--force`:
 
 ```bash
-sifr self update --version 0.1.0-beta.7 --force
+sifr self update --version 0.1.0-beta.9 --force
 sifr self update --channel alpha --force
 ```
 

--- a/docs/self_update.md
+++ b/docs/self_update.md
@@ -41,7 +41,7 @@ in text mode.
 
 `sifr self update` defaults to the channel recorded in the install receipt.
 Use `--channel alpha|beta` to switch preview channels or `--version` to pin an
-exact preview version such as `0.1.0-beta.2`.
+exact preview version such as `0.1.0-beta.9`.
 
 Use `--dry-run` to print the resolved plan without downloading an installer or
 acquiring the install lock. `--format json` is available only with `--dry-run`.
@@ -56,7 +56,7 @@ also rejected before the stable release channel is enabled.
 Same-version reinstalls, downgrades, and channel switches require `--force`:
 
 ```bash
-sifr self update --version 0.1.0-beta.2 --force
+sifr self update --version 0.1.0-beta.9 --force
 sifr self update --channel alpha --force
 ```
 


### PR DESCRIPTION
## Summary
- update public install docs to show the newly published `0.1.0-beta.9` preview
- update self-update reference examples to use the current beta pin

## Release evidence
- published release: https://github.com/sifr-lang/sifr/releases/tag/0.1.0-beta.9
- preview-release workflow: https://github.com/sifr-lang/sifr/actions/runs/27901221688
- channel metadata now resolves beta to `0.1.0-beta.9`

## Validation
- `git diff --check`
- `rg -n "0\\.1\\.0-beta\\.[0-8]" docs/installation.mdx docs/self_update.md` (no matches)
- `uv run --project verification --locked python -m sifr_verify areas run --area core_language --suite audit-fixtures` (rerun after a transient timeout in first gate attempt)
- `scripts/run_all_tests.sh --profile create-pr` (pass; advisory: warm wall-time budget exceeded)
