### PR TITLE
Negotiate LSP position encoding

### DIFF
--- a/crates/sifr_lsp/src/capabilities.rs
+++ b/crates/sifr_lsp/src/capabilities.rs
@@ -1,5 +1,6 @@
 use lsp_types::PositionEncodingKind;
 use serde_json::{json, Value};
+use sifr_source::PositionEncoding;
 
 pub(crate) const LANGUAGE_ID: &str = "sifr";
 
@@ -23,9 +24,37 @@ pub(crate) const SEMANTIC_TOKEN_TYPES: &[&str] = &[
 
 pub(crate) const SEMANTIC_TOKEN_MODIFIERS: &[&str] = &["declaration", "readonly"];
 
-pub(crate) fn server_capabilities(format_enable: bool) -> Value {
+pub(crate) fn negotiated_position_encoding(initialize_params: &Value) -> PositionEncoding {
+    let Some(encodings) = initialize_params
+        .pointer("/capabilities/general/positionEncodings")
+        .and_then(Value::as_array)
+    else {
+        return PositionEncoding::Utf16;
+    };
+    for encoding in encodings {
+        match encoding.as_str() {
+            Some("utf-8") => return PositionEncoding::Utf8,
+            Some("utf-32") => return PositionEncoding::Utf32,
+            _ => {}
+        }
+    }
+    PositionEncoding::Utf16
+}
+
+pub(crate) fn position_encoding_kind(encoding: PositionEncoding) -> PositionEncodingKind {
+    match encoding {
+        PositionEncoding::Utf8 => PositionEncodingKind::UTF8,
+        PositionEncoding::Utf16 => PositionEncodingKind::UTF16,
+        PositionEncoding::Utf32 => PositionEncodingKind::UTF32,
+    }
+}
+
+pub(crate) fn server_capabilities(
+    format_enable: bool,
+    position_encoding: PositionEncoding,
+) -> Value {
     let mut capabilities = json!({
-        "positionEncoding": PositionEncodingKind::UTF8,
+        "positionEncoding": position_encoding_kind(position_encoding),
         "textDocumentSync": {
             "openClose": true,
             "change": 2,
@@ -94,4 +123,43 @@ pub(crate) fn server_capabilities(format_enable: bool) -> Value {
         capabilities["documentRangeFormattingProvider"] = json!(true);
     }
     capabilities
+}
+
+#[cfg(test)]
+mod tests {
+    use super::negotiated_position_encoding;
+    use serde_json::json;
+    use sifr_source::PositionEncoding;
+
+    #[test]
+    fn negotiation_defaults_to_utf16_for_legacy_clients() {
+        assert_eq!(
+            negotiated_position_encoding(&json!({ "capabilities": {} })),
+            PositionEncoding::Utf16
+        );
+    }
+
+    #[test]
+    fn negotiation_prefers_utf8_when_client_offers_it() {
+        assert_eq!(
+            negotiated_position_encoding(&json!({
+                "capabilities": {
+                    "general": { "positionEncodings": ["utf-16", "utf-8"] }
+                }
+            })),
+            PositionEncoding::Utf8
+        );
+    }
+
+    #[test]
+    fn negotiation_uses_utf16_for_vscode_style_clients() {
+        assert_eq!(
+            negotiated_position_encoding(&json!({
+                "capabilities": {
+                    "general": { "positionEncodings": ["utf-16"] }
+                }
+            })),
+            PositionEncoding::Utf16
+        );
+    }
 }

--- a/crates/sifr_lsp/src/conversion.rs
+++ b/crates/sifr_lsp/src/conversion.rs
@@ -1,6 +1,6 @@
 use crate::capabilities::{SEMANTIC_TOKEN_MODIFIERS, SEMANTIC_TOKEN_TYPES};
 use crate::errors::{LspError, LspResult};
-use ruff_text_size::TextRange;
+use ruff_text_size::{TextRange, TextSize};
 use serde_json::{json, Value};
 use sifr_analysis::{
     CodeAction, CompletionItem, DeferredCodeAction, DiagnosticClass, DiagnosticId,
@@ -42,8 +42,48 @@ pub(crate) fn lsp_position(value: &Value) -> LspResult<TextPosition> {
     Ok(TextPosition { line, character })
 }
 
-pub(crate) fn lsp_range(value: &Value, source: &str) -> LspResult<TextRange> {
-    lsp_range_with_encoding(value, source, PositionEncoding::Utf8)
+pub(crate) fn lsp_position_to_utf8(
+    value: &Value,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<TextPosition> {
+    let position = lsp_position(value)?;
+    if encoding == PositionEncoding::Utf8 {
+        return Ok(position);
+    }
+    let source = SourceTextMap::new(source);
+    let offset = source
+        .byte_offset_with_encoding(&position, encoding)
+        .ok_or_else(|| LspError::invalid_params("position is outside the document"))?;
+    source
+        .position_at(offset, PositionEncoding::Utf8)
+        .ok_or_else(|| LspError::invalid_params("position is outside the document"))
+}
+
+pub(crate) fn text_position(
+    position: &TextPosition,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
+    if encoding == PositionEncoding::Utf8 {
+        return Ok(json!({ "line": position.line, "character": position.character }));
+    }
+    let source = SourceTextMap::new(source);
+    let offset = source
+        .byte_offset_with_encoding(position, PositionEncoding::Utf8)
+        .ok_or_else(|| LspError::internal("analysis returned a position outside the document"))?;
+    let encoded = source
+        .position_at(offset, encoding)
+        .ok_or_else(|| LspError::internal("analysis returned a position outside the document"))?;
+    Ok(json!({ "line": encoded.line, "character": encoded.character }))
+}
+
+pub(crate) fn lsp_range(
+    value: &Value,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<TextRange> {
+    lsp_range_with_encoding(value, source, encoding)
 }
 
 fn lsp_range_with_encoding(
@@ -74,8 +114,12 @@ fn lsp_range_with_encoding(
     Ok(TextRange::new(start, end))
 }
 
-pub(crate) fn text_range(range: TextRange, source: &str) -> LspResult<Value> {
-    text_range_with_encoding(range, source, PositionEncoding::Utf8)
+pub(crate) fn text_range(
+    range: TextRange,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
+    text_range_with_encoding(range, source, encoding)
 }
 
 fn text_range_with_encoding(
@@ -105,11 +149,12 @@ pub(crate) fn location(
     location: &Location,
     uri_for_file: impl Fn(FileId) -> LspResult<String>,
     source: &str,
+    encoding: PositionEncoding,
 ) -> LspResult<Value> {
     let uri = uri_for_file(location.file)?;
     let range = location.range.map_or_else(
         || Ok(json!({"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}})),
-        |range| text_range(range, source),
+        |range| text_range(range, source, encoding),
     )?;
     Ok(json!({ "uri": uri, "range": range }))
 }
@@ -126,10 +171,14 @@ pub(crate) fn workspace_symbol(symbol: WorkspaceSymbol, uri: String) -> Value {
     })
 }
 
-pub(crate) fn document_symbol(symbol: DocumentSymbol, source: &str) -> LspResult<Value> {
+pub(crate) fn document_symbol(
+    symbol: DocumentSymbol,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
     let range = symbol.range.map_or_else(
         || Ok(json!({"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}})),
-        |range| text_range(range, source),
+        |range| text_range(range, source, encoding),
     )?;
     Ok(json!({
         "name": symbol.name,
@@ -165,18 +214,22 @@ pub(crate) fn signature_help(help: SignatureHelp) -> Value {
     })
 }
 
-pub(crate) fn semantic_tokens(tokens: Vec<SemanticToken>, source: &str) -> LspResult<Value> {
+pub(crate) fn semantic_tokens(
+    tokens: Vec<SemanticToken>,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
     let source_map = SourceTextMap::new(source);
     let mut encoded = Vec::new();
     let mut previous_line = 0;
     let mut previous_start = 0;
     for token in tokens {
-        let Some(start) = source_map.text_position(token.range.start()) else {
+        let Some(start) = source_map.position_at(token.range.start(), encoding) else {
             return Err(LspError::internal(
                 "semantic token start is outside the document",
             ));
         };
-        let Some(end) = source_map.text_position(token.range.end()) else {
+        let Some(end) = source_map.position_at(token.range.end(), encoding) else {
             return Err(LspError::internal(
                 "semantic token end is outside the document",
             ));
@@ -198,20 +251,32 @@ pub(crate) fn semantic_tokens(tokens: Vec<SemanticToken>, source: &str) -> LspRe
     Ok(json!({ "data": encoded }))
 }
 
-pub(crate) fn inlay_hint(hint: InlayHint) -> Value {
-    json!({
-        "position": { "line": hint.position.line, "character": hint.position.character },
+pub(crate) fn inlay_hint(
+    hint: InlayHint,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
+    Ok(json!({
+        "position": text_position(&hint.position, source, encoding)?,
         "label": hint.label,
         "kind": 1
-    })
+    }))
 }
 
-pub(crate) fn document_highlight(highlight: DocumentHighlight, source: &str) -> LspResult<Value> {
-    Ok(json!({ "range": text_range(highlight.range, source)?, "kind": 1 }))
+pub(crate) fn document_highlight(
+    highlight: DocumentHighlight,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
+    Ok(json!({ "range": text_range(highlight.range, source, encoding)?, "kind": 1 }))
 }
 
-pub(crate) fn folding_range(range: FoldingRange, source: &str) -> LspResult<Value> {
-    let value = text_range(range.range, source)?;
+pub(crate) fn folding_range(
+    range: FoldingRange,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
+    let value = text_range(range.range, source, encoding)?;
     Ok(json!({
         "startLine": value["start"]["line"],
         "startCharacter": value["start"]["character"],
@@ -223,13 +288,14 @@ pub(crate) fn folding_range(range: FoldingRange, source: &str) -> LspResult<Valu
 pub(crate) fn selection_range(
     range: sifr_analysis::SelectionRange,
     source: &str,
+    encoding: PositionEncoding,
 ) -> LspResult<Value> {
     let parent = range
         .parent
-        .map(|parent| selection_range(*parent, source))
+        .map(|parent| selection_range(*parent, source, encoding))
         .transpose()?;
     Ok(json!({
-        "range": text_range(range.range, source)?,
+        "range": text_range(range.range, source, encoding)?,
         "parent": parent
     }))
 }
@@ -238,10 +304,11 @@ pub(crate) fn type_hierarchy_item(
     item: TypeHierarchyItem,
     uri: String,
     source: &str,
+    encoding: PositionEncoding,
 ) -> LspResult<Value> {
     let range = item.location.range.map_or_else(
         || Ok(json!({"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 0}})),
-        |range| text_range(range, source),
+        |range| text_range(range, source, encoding),
     )?;
     Ok(json!({
         "name": item.name,
@@ -258,10 +325,11 @@ pub(crate) fn code_action(
     request_uri: &str,
     uri_for_file: impl Fn(FileId) -> LspResult<String>,
     source_for_file: impl Fn(FileId) -> LspResult<String>,
+    encoding: PositionEncoding,
 ) -> LspResult<Value> {
     let edit = action
         .edit
-        .map(|edit| workspace_edit(edit, uri_for_file, source_for_file))
+        .map(|edit| workspace_edit(edit, uri_for_file, source_for_file, encoding))
         .transpose()?;
     Ok(json!({
         "title": action.title,
@@ -290,11 +358,12 @@ pub(crate) fn workspace_edit(
     edit: WorkspaceEdit,
     uri_for_file: impl Fn(FileId) -> LspResult<String>,
     source_for_file: impl Fn(FileId) -> LspResult<String>,
+    encoding: PositionEncoding,
 ) -> LspResult<Value> {
     let mut changes = serde_json::Map::new();
     for file_edit in edit.edits {
         let uri = uri_for_file(file_edit.file)?;
-        changes.insert(uri, file_text_edits(file_edit, &source_for_file)?);
+        changes.insert(uri, file_text_edits(file_edit, &source_for_file, encoding)?);
     }
     Ok(json!({ "changes": changes }))
 }
@@ -302,17 +371,22 @@ pub(crate) fn workspace_edit(
 pub(crate) fn file_text_edits(
     file_edit: FileTextEdits,
     source_for_file: &impl Fn(FileId) -> LspResult<String>,
+    encoding: PositionEncoding,
 ) -> LspResult<Value> {
     let source = source_for_file(file_edit.file)?;
-    text_edits(file_edit.edits, &source)
+    text_edits(file_edit.edits, &source, encoding)
 }
 
-pub(crate) fn text_edits(edits: Vec<TextEdit>, source: &str) -> LspResult<Value> {
+pub(crate) fn text_edits(
+    edits: Vec<TextEdit>,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
     edits
         .into_iter()
         .map(|edit| {
             Ok(json!({
-                "range": text_range(edit.range, source)?,
+                "range": text_range(edit.range, source, encoding)?,
                 "newText": edit.replacement
             }))
         })
@@ -320,7 +394,11 @@ pub(crate) fn text_edits(edits: Vec<TextEdit>, source: &str) -> LspResult<Value>
         .map(Value::Array)
 }
 
-pub(crate) fn diagnostic(diagnostic: RenderedDiagnostic) -> Value {
+pub(crate) fn diagnostic(
+    diagnostic: RenderedDiagnostic,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
     let primary = diagnostic
         .spans
         .iter()
@@ -328,8 +406,8 @@ pub(crate) fn diagnostic(diagnostic: RenderedDiagnostic) -> Value {
         .or_else(|| diagnostic.spans.first());
     let class = diagnostic_class(&diagnostic);
     let rule_id = diagnostic_rule_id(&diagnostic);
-    json!({
-        "range": primary.map_or_else(default_range, diagnostic_span_range),
+    Ok(json!({
+        "range": primary.map_or_else(|| Ok(default_range()), |span| diagnostic_span_range(span, source, encoding))?,
         "severity": diagnostic_severity(diagnostic.severity),
         "code": diagnostic.code,
         "codeDescription": { "href": diagnostic.url },
@@ -343,7 +421,7 @@ pub(crate) fn diagnostic(diagnostic: RenderedDiagnostic) -> Value {
             "children": diagnostic.children,
             "suggestions": diagnostic.suggestions
         }
-    })
+    }))
 }
 
 pub(crate) fn diagnostic_id(value: &Value) -> Option<DiagnosticId> {
@@ -406,17 +484,19 @@ pub(crate) fn test_command(command: TestCommand) -> Value {
     json!({ "kind": kind, "args": command.args })
 }
 
-fn diagnostic_span_range(span: &DiagnosticSpan) -> Value {
-    json!({
-        "start": {
-            "line": span.line.unwrap_or(1).saturating_sub(1),
-            "character": span.column.unwrap_or(1).saturating_sub(1)
-        },
-        "end": {
-            "line": span.end_line.unwrap_or_else(|| span.line.unwrap_or(1)).saturating_sub(1),
-            "character": span.end_column.unwrap_or_else(|| span.column.unwrap_or(1)).saturating_sub(1)
-        }
-    })
+fn diagnostic_span_range(
+    span: &DiagnosticSpan,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
+    if span.byte_start > span.byte_end {
+        return Err(LspError::internal("diagnostic span start is after end"));
+    }
+    text_range(
+        TextRange::new(TextSize::new(span.byte_start), TextSize::new(span.byte_end)),
+        source,
+        encoding,
+    )
 }
 
 fn default_range() -> Value {

--- a/crates/sifr_lsp/src/diagnostic_jobs.rs
+++ b/crates/sifr_lsp/src/diagnostic_jobs.rs
@@ -1,0 +1,50 @@
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ScheduledDiagnosticJob {
+    pub(crate) uri: String,
+    pub(crate) version: Option<i32>,
+    sequence: u64,
+}
+
+#[derive(Default)]
+pub(crate) struct DiagnosticJobs {
+    jobs: BTreeMap<String, ScheduledDiagnosticJob>,
+    next_sequence: u64,
+}
+
+impl DiagnosticJobs {
+    pub(crate) fn clear(&mut self) {
+        self.jobs.clear();
+    }
+
+    pub(crate) fn remove(&mut self, uri: &str) {
+        self.jobs.remove(uri);
+    }
+
+    pub(crate) fn schedule(&mut self, uri: &str, version: Option<i32>) -> ScheduledDiagnosticJob {
+        let sequence = if let Some(existing) = self.jobs.get(uri) {
+            existing.sequence
+        } else {
+            let sequence = self.next_sequence;
+            self.next_sequence = self.next_sequence.saturating_add(1);
+            sequence
+        };
+        let job = ScheduledDiagnosticJob {
+            uri: uri.to_string(),
+            version,
+            sequence,
+        };
+        self.jobs.insert(uri.to_string(), job.clone());
+        job
+    }
+
+    pub(crate) fn take_next(&mut self) -> Option<ScheduledDiagnosticJob> {
+        let uri = self
+            .jobs
+            .iter()
+            .min_by_key(|(_, job)| job.sequence)
+            .map(|(uri, _)| uri.clone())?;
+        self.jobs.remove(&uri)
+    }
+}

--- a/crates/sifr_lsp/src/diagnostics.rs
+++ b/crates/sifr_lsp/src/diagnostics.rs
@@ -120,25 +120,27 @@ fn publish_progress(connection: &Connection, params: Value) -> LspResult<()> {
 }
 
 pub(crate) fn document_diagnostics(session: &mut Session, uri: &str) -> LspResult<Vec<Value>> {
+    let position_encoding = session.position_encoding();
+    let source = session.store().document(uri)?.text().to_string();
     // Load-time diagnostics are replaced whenever the document analysis owner is
     // opened or updated. Publication still captures and checks the document
     // version in `DiagnosticsController` before this shortcut can be observed.
     if !session.load_diagnostics(uri).is_empty() {
-        return Ok(session
+        return session
             .load_diagnostics(uri)
             .iter()
             .cloned()
-            .map(conversion::diagnostic)
-            .collect());
+            .map(|diagnostic| conversion::diagnostic(diagnostic, &source, position_encoding))
+            .collect::<LspResult<Vec<_>>>();
     }
-    session.with_document_analysis(uri, |snapshot, host, file, _source| {
+    session.with_document_analysis(uri, |snapshot, host, file, source| {
         let diagnostics = snapshot
             .diagnostics(host, file)
             .map_err(|error| crate::errors::LspError::internal(error.message))?
             .into_value();
-        Ok(diagnostics
+        diagnostics
             .into_iter()
-            .map(conversion::diagnostic)
-            .collect())
+            .map(|diagnostic| conversion::diagnostic(diagnostic, source, position_encoding))
+            .collect::<LspResult<Vec<_>>>()
     })
 }

--- a/crates/sifr_lsp/src/document_store.rs
+++ b/crates/sifr_lsp/src/document_store.rs
@@ -1,6 +1,7 @@
 use crate::conversion::uri_to_path;
 use crate::document_events::{CompactedDocumentChange, DocumentContentChange};
 use crate::errors::{LspError, LspResult};
+use sifr_source::PositionEncoding;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
@@ -84,6 +85,7 @@ impl DocumentStore {
         uri: &str,
         version: Option<i32>,
         change: &CompactedDocumentChange,
+        position_encoding: PositionEncoding,
     ) -> LspResult<bool> {
         let state = self.document_mut(uri)?;
         state.reject_stale(version)?;
@@ -94,7 +96,7 @@ impl DocumentStore {
                     state.text.clone_from(text);
                 }
                 DocumentContentChange::Incremental { range, text } => {
-                    state.apply_incremental_change(range, text)?;
+                    state.apply_incremental_change(range, text, position_encoding)?;
                 }
             }
         }
@@ -174,8 +176,13 @@ impl DocumentState {
         Ok(())
     }
 
-    fn apply_incremental_change(&mut self, range: &serde_json::Value, text: &str) -> LspResult<()> {
-        let range = crate::conversion::lsp_range(range, &self.text)?;
+    fn apply_incremental_change(
+        &mut self,
+        range: &serde_json::Value,
+        text: &str,
+        position_encoding: PositionEncoding,
+    ) -> LspResult<()> {
+        let range = crate::conversion::lsp_range(range, &self.text, position_encoding)?;
         let start = usize::try_from(range.start().to_u32())
             .map_err(|_| LspError::invalid_params("incremental edit start is out of range"))?;
         let end = usize::try_from(range.end().to_u32())

--- a/crates/sifr_lsp/src/lib.rs
+++ b/crates/sifr_lsp/src/lib.rs
@@ -11,6 +11,7 @@ mod cancellation;
 mod capabilities;
 mod commands;
 mod conversion;
+mod diagnostic_jobs;
 mod diagnostics;
 mod document_events;
 mod document_store;

--- a/crates/sifr_lsp/src/requests/code_action.rs
+++ b/crates/sifr_lsp/src/requests/code_action.rs
@@ -8,10 +8,11 @@ use sifr_analysis::CodeActionContext;
 pub(crate) fn code_action(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
     let source = session.store().document(&uri)?.text().to_string();
+    let position_encoding = session.position_encoding();
     let range = params
         .get("range")
         .ok_or_else(|| LspError::invalid_params("codeAction requires range"))
-        .and_then(|range| conversion::lsp_range(range, &source))?;
+        .and_then(|range| conversion::lsp_range(range, &source, position_encoding))?;
     let context = CodeActionContext {
         diagnostics: code_action_context_diagnostics(&params),
     };
@@ -29,6 +30,7 @@ pub(crate) fn code_action(session: &mut Session, params: Value) -> LspResult<Val
                     &uri,
                     |file| file_maps.uri_for(file),
                     |file| file_maps.source_for(file),
+                    position_encoding,
                 )
             })
             .collect::<LspResult<Vec<_>>>()
@@ -70,6 +72,7 @@ pub(crate) fn resolve(session: &mut Session, mut params: Value) -> LspResult<Val
         .to_string();
     let expected_version = data.get("expectedVersion").and_then(Value::as_i64);
     let file_maps = session.file_maps_for_uri(&uri)?;
+    let position_encoding = session.position_encoding();
     if let (Some(expected), Some(current)) =
         (expected_version, session.store().document(&uri)?.version())
     {
@@ -94,6 +97,7 @@ pub(crate) fn resolve(session: &mut Session, mut params: Value) -> LspResult<Val
             edit,
             |file| file_maps.uri_for(file),
             |file| file_maps.source_for(file),
+            position_encoding,
         )
     })?;
     params["edit"] = edit;

--- a/crates/sifr_lsp/src/requests/completion.rs
+++ b/crates/sifr_lsp/src/requests/completion.rs
@@ -1,12 +1,12 @@
 use crate::conversion;
 use crate::errors::{LspError, LspResult};
-use crate::requests::{position, text_document_uri};
+use crate::requests::{document_position, text_document_uri};
 use crate::session::Session;
 use serde_json::{json, Value};
 
 pub(crate) fn completion(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
-    let position = position(&params)?;
+    let position = document_position(session, &uri, &params)?;
     session.with_document_analysis(&uri, |snapshot, host, file, _source| {
         let result = snapshot
             .completion(host, file, &position)

--- a/crates/sifr_lsp/src/requests/folding_range.rs
+++ b/crates/sifr_lsp/src/requests/folding_range.rs
@@ -6,13 +6,14 @@ use serde_json::Value;
 
 pub(crate) fn folding_range(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
+    let position_encoding = session.position_encoding();
     session.with_document_analysis(&uri, |snapshot, host, file, source| {
         snapshot
             .folding_ranges(host, file)
             .map_err(|error| LspError::internal(error.message))?
             .into_value()
             .into_iter()
-            .map(|range| conversion::folding_range(range, source))
+            .map(|range| conversion::folding_range(range, source, position_encoding))
             .collect::<LspResult<Vec<_>>>()
             .map(Value::Array)
     })

--- a/crates/sifr_lsp/src/requests/formatting.rs
+++ b/crates/sifr_lsp/src/requests/formatting.rs
@@ -11,12 +11,13 @@ pub(crate) fn formatting(session: &mut Session, params: Value) -> LspResult<Valu
     let uri = text_document_uri(&params)?;
     let path = session.store().document(&uri)?.path().to_path_buf();
     let options = format_options(&params, &path)?;
+    let position_encoding = session.position_encoding();
     session.with_document_analysis(&uri, |snapshot, host, file, source| {
         let edits = snapshot
             .format_document(host, file, options)
             .map_err(|error| LspError::internal(error.message))?
             .into_value();
-        conversion::text_edits(edits, source)
+        conversion::text_edits(edits, source, position_encoding)
     })
 }
 
@@ -26,17 +27,18 @@ pub(crate) fn range_formatting(session: &mut Session, params: Value) -> LspResul
     let document = session.store().document(&uri)?;
     let source = document.text().to_string();
     let path = document.path().to_path_buf();
+    let position_encoding = session.position_encoding();
     let range = params
         .get("range")
         .ok_or_else(|| LspError::invalid_params("rangeFormatting requires range"))
-        .and_then(|range| conversion::lsp_range(range, &source))?;
+        .and_then(|range| conversion::lsp_range(range, &source, position_encoding))?;
     let options = format_options(&params, &path)?;
     session.with_document_analysis(&uri, |snapshot, host, file, source| {
         let edits = snapshot
             .format_range(host, file, range, options)
             .map_err(|error| LspError::internal(error.message))?
             .into_value();
-        conversion::text_edits(edits, source)
+        conversion::text_edits(edits, source, position_encoding)
     })
 }
 

--- a/crates/sifr_lsp/src/requests/hover.rs
+++ b/crates/sifr_lsp/src/requests/hover.rs
@@ -1,12 +1,12 @@
 use crate::conversion;
 use crate::errors::{LspError, LspResult};
-use crate::requests::{position, text_document_uri};
+use crate::requests::{document_position, text_document_uri};
 use crate::session::Session;
 use serde_json::Value;
 
 pub(crate) fn hover(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
-    let position = position(&params)?;
+    let position = document_position(session, &uri, &params)?;
     session.with_document_analysis(&uri, |snapshot, host, file, _source| {
         let hover = snapshot
             .hover(host, file, &position)
@@ -18,7 +18,7 @@ pub(crate) fn hover(session: &mut Session, params: Value) -> LspResult<Value> {
 
 pub(crate) fn signature_help(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
-    let position = position(&params)?;
+    let position = document_position(session, &uri, &params)?;
     session.with_document_analysis(&uri, |snapshot, host, file, _source| {
         let help = snapshot
             .signature_help(host, file, &position)

--- a/crates/sifr_lsp/src/requests/inlay_hint.rs
+++ b/crates/sifr_lsp/src/requests/inlay_hint.rs
@@ -8,17 +8,20 @@ pub(crate) fn inlay_hint(session: &mut Session, params: Value) -> LspResult<Valu
     let uri = text_document_uri(&params)?;
     let range = params.get("range").cloned();
     let source = session.store().document(&uri)?.text().to_string();
+    let position_encoding = session.position_encoding();
     let range = range
         .as_ref()
-        .map(|range| conversion::lsp_range(range, &source))
+        .map(|range| conversion::lsp_range(range, &source, position_encoding))
         .transpose()?;
-    session.with_document_analysis(&uri, |snapshot, host, file, _source| {
+    session.with_document_analysis(&uri, |snapshot, host, file, source| {
         let hints = snapshot
             .inlay_hints(host, file, range)
             .map_err(|error| LspError::internal(error.message))?
             .into_value();
-        Ok(Value::Array(
-            hints.into_iter().map(conversion::inlay_hint).collect(),
-        ))
+        hints
+            .into_iter()
+            .map(|hint| conversion::inlay_hint(hint, source, position_encoding))
+            .collect::<LspResult<Vec<_>>>()
+            .map(Value::Array)
     })
 }

--- a/crates/sifr_lsp/src/requests/mod.rs
+++ b/crates/sifr_lsp/src/requests/mod.rs
@@ -69,11 +69,18 @@ fn text_document_uri(params: &Value) -> LspResult<String> {
     crate::errors::required_string(params, "/textDocument/uri")
 }
 
-fn position(params: &Value) -> LspResult<sifr_analysis::TextPosition> {
+fn document_position(
+    session: &Session,
+    uri: &str,
+    params: &Value,
+) -> LspResult<sifr_analysis::TextPosition> {
+    let source = session.store().document(uri)?.text();
     params
         .get("position")
         .ok_or_else(|| LspError::invalid_params("request requires position"))
-        .and_then(crate::conversion::lsp_position)
+        .and_then(|position| {
+            crate::conversion::lsp_position_to_utf8(position, source, session.position_encoding())
+        })
 }
 
 fn code_action_context_diagnostics(params: &Value) -> Vec<sifr_analysis::DiagnosticId> {

--- a/crates/sifr_lsp/src/requests/navigation.rs
+++ b/crates/sifr_lsp/src/requests/navigation.rs
@@ -1,6 +1,6 @@
 use crate::conversion;
 use crate::errors::{LspError, LspResult};
-use crate::requests::{position, text_document_uri};
+use crate::requests::{document_position, text_document_uri};
 use crate::session::Session;
 use serde_json::{json, Value};
 use sifr_analysis::SymbolName;
@@ -31,7 +31,8 @@ pub(crate) fn references(session: &mut Session, params: Value) -> LspResult<Valu
 
 pub(crate) fn document_highlight(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
-    let position = position(&params)?;
+    let position = document_position(session, &uri, &params)?;
+    let position_encoding = session.position_encoding();
     session.with_document_analysis(&uri, |snapshot, host, file, source| {
         let highlights = snapshot
             .document_highlights(host, file, &position)
@@ -39,7 +40,7 @@ pub(crate) fn document_highlight(session: &mut Session, params: Value) -> LspRes
             .into_value();
         highlights
             .into_iter()
-            .map(|highlight| conversion::document_highlight(highlight, source))
+            .map(|highlight| conversion::document_highlight(highlight, source, position_encoding))
             .collect::<LspResult<Vec<_>>>()
             .map(Value::Array)
     })
@@ -47,7 +48,9 @@ pub(crate) fn document_highlight(session: &mut Session, params: Value) -> LspRes
 
 pub(crate) fn prepare_rename(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
-    let position = position(&params)?;
+    let position = document_position(session, &uri, &params)?;
+    let source = session.store().document(&uri)?.text().to_string();
+    let position_encoding = session.position_encoding();
     session.with_document_analysis(&uri, |snapshot, host, file, _source| {
         let target = snapshot
             .prepare_rename(host, file, &position)
@@ -56,15 +59,16 @@ pub(crate) fn prepare_rename(session: &mut Session, params: Value) -> LspResult<
         let Some(target) = target else {
             return Ok(Value::Null);
         };
+        let end = sifr_analysis::TextPosition {
+            line: position.line,
+            character: position
+                .character
+                .saturating_add(u32::try_from(target.symbol.name.len()).unwrap_or(0)),
+        };
         Ok(json!({
             "range": {
-                "start": { "line": position.line, "character": position.character },
-                "end": {
-                    "line": position.line,
-                    "character": position
-                        .character
-                        .saturating_add(u32::try_from(target.symbol.name.len()).unwrap_or(0))
-                }
+                "start": conversion::text_position(&position, &source, position_encoding)?,
+                "end": conversion::text_position(&end, &source, position_encoding)?
             },
             "placeholder": target.symbol.name
         }))
@@ -73,12 +77,13 @@ pub(crate) fn prepare_rename(session: &mut Session, params: Value) -> LspResult<
 
 pub(crate) fn rename(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
-    let position = position(&params)?;
+    let position = document_position(session, &uri, &params)?;
     let new_name = params
         .get("newName")
         .and_then(Value::as_str)
         .ok_or_else(|| LspError::invalid_params("textDocument/rename requires newName"))?;
     let file_maps = session.file_maps_for_uri(&uri)?;
+    let position_encoding = session.position_encoding();
     session.with_document_analysis(&uri, |snapshot, host, file, _source| {
         let edit = snapshot
             .rename(host, file, &position, &SymbolName(new_name.to_string()))
@@ -88,6 +93,7 @@ pub(crate) fn rename(session: &mut Session, params: Value) -> LspResult<Value> {
             edit,
             |file| file_maps.uri_for(file),
             |file| file_maps.source_for(file),
+            position_encoding,
         )
     })
 }
@@ -106,8 +112,9 @@ fn locations(
     >,
 ) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
-    let position = position(&params)?;
+    let position = document_position(session, &uri, &params)?;
     let file_maps = session.file_maps_for_uri(&uri)?;
+    let position_encoding = session.position_encoding();
     session.with_document_analysis(&uri, |snapshot, host, file, source| {
         operation(snapshot, host, file, &position)
             .map_err(|error| LspError::internal(error.message))?
@@ -117,7 +124,12 @@ fn locations(
                 let location_source = file_maps
                     .source_for(location.file)
                     .unwrap_or_else(|_| source.to_string());
-                conversion::location(&location, |file| file_maps.uri_for(file), &location_source)
+                conversion::location(
+                    &location,
+                    |file| file_maps.uri_for(file),
+                    &location_source,
+                    position_encoding,
+                )
             })
             .collect::<LspResult<Vec<_>>>()
             .map(Value::Array)

--- a/crates/sifr_lsp/src/requests/selection_range.rs
+++ b/crates/sifr_lsp/src/requests/selection_range.rs
@@ -6,12 +6,14 @@ use serde_json::Value;
 
 pub(crate) fn selection_range(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
+    let source = session.store().document(&uri)?.text().to_string();
+    let position_encoding = session.position_encoding();
     let positions = params
         .get("positions")
         .and_then(Value::as_array)
         .ok_or_else(|| LspError::invalid_params("selectionRange requires positions"))?
         .iter()
-        .map(conversion::lsp_position)
+        .map(|position| conversion::lsp_position_to_utf8(position, &source, position_encoding))
         .collect::<LspResult<Vec<_>>>()?;
     session.with_document_analysis(&uri, |snapshot, host, file, source| {
         snapshot
@@ -19,7 +21,7 @@ pub(crate) fn selection_range(session: &mut Session, params: Value) -> LspResult
             .map_err(|error| LspError::internal(error.message))?
             .into_value()
             .into_iter()
-            .map(|range| conversion::selection_range(range, source))
+            .map(|range| conversion::selection_range(range, source, position_encoding))
             .collect::<LspResult<Vec<_>>>()
             .map(Value::Array)
     })

--- a/crates/sifr_lsp/src/requests/semantic_tokens.rs
+++ b/crates/sifr_lsp/src/requests/semantic_tokens.rs
@@ -11,10 +11,11 @@ pub(crate) fn full(session: &mut Session, params: Value) -> LspResult<Value> {
 pub(crate) fn range(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
     let source = session.store().document(&uri)?.text().to_string();
+    let position_encoding = session.position_encoding();
     let range = params
         .get("range")
         .ok_or_else(|| LspError::invalid_params("semanticTokens/range requires range"))
-        .and_then(|range| conversion::lsp_range(range, &source))?;
+        .and_then(|range| conversion::lsp_range(range, &source, position_encoding))?;
     tokens(session, params, Some(range))
 }
 
@@ -24,11 +25,12 @@ fn tokens(
     range: Option<ruff_text_size::TextRange>,
 ) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
+    let position_encoding = session.position_encoding();
     session.with_document_analysis(&uri, |snapshot, host, file, source| {
         let tokens = snapshot
             .semantic_tokens(host, file, range)
             .map_err(|error| LspError::internal(error.message))?
             .into_value();
-        conversion::semantic_tokens(tokens, source)
+        conversion::semantic_tokens(tokens, source, position_encoding)
     })
 }

--- a/crates/sifr_lsp/src/requests/symbols.rs
+++ b/crates/sifr_lsp/src/requests/symbols.rs
@@ -8,13 +8,14 @@ use std::collections::BTreeSet;
 
 pub(crate) fn document_symbol(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
+    let position_encoding = session.position_encoding();
     session.with_document_analysis(&uri, |snapshot, host, file, source| {
         snapshot
             .document_symbols(host, file)
             .map_err(|error| LspError::internal(error.message))?
             .into_value()
             .into_iter()
-            .map(|symbol| conversion::document_symbol(symbol, source))
+            .map(|symbol| conversion::document_symbol(symbol, source, position_encoding))
             .collect::<LspResult<Vec<_>>>()
             .map(Value::Array)
     })

--- a/crates/sifr_lsp/src/requests/type_hierarchy.rs
+++ b/crates/sifr_lsp/src/requests/type_hierarchy.rs
@@ -1,14 +1,15 @@
 use crate::conversion;
 use crate::errors::{LspError, LspResult};
-use crate::requests::{position, text_document_uri};
+use crate::requests::{document_position, text_document_uri};
 use crate::session::Session;
 use serde_json::Value;
 use sifr_analysis::{AnalysisQueryResult, TypeHierarchyItemId};
 
 pub(crate) fn prepare(session: &mut Session, params: Value) -> LspResult<Value> {
     let uri = text_document_uri(&params)?;
-    let position = position(&params)?;
+    let position = document_position(session, &uri, &params)?;
     let file_maps = session.file_maps_for_uri(&uri)?;
+    let position_encoding = session.position_encoding();
     session.with_document_analysis(&uri, |snapshot, host, file, source| {
         let item = snapshot
             .prepare_type_hierarchy(host, file, &position)
@@ -18,7 +19,7 @@ pub(crate) fn prepare(session: &mut Session, params: Value) -> LspResult<Value> 
             return Ok(Value::Null);
         };
         let uri = file_maps.uri_for(item.location.file)?;
-        conversion::type_hierarchy_item(item, uri, source)
+        conversion::type_hierarchy_item(item, uri, source, position_encoding)
     })
 }
 

--- a/crates/sifr_lsp/src/server.rs
+++ b/crates/sifr_lsp/src/server.rs
@@ -50,9 +50,14 @@ impl LspServer {
         self.session.set_work_done_progress_enabled(
             crate::settings::work_done_progress_from_initialize_params(&initialize_params),
         );
+        let position_encoding = capabilities::negotiated_position_encoding(&initialize_params);
+        self.session.set_position_encoding(position_encoding);
         self.session.store_mut().apply_settings(settings.clone());
         let initialize_data = serde_json::json!({
-            "capabilities": capabilities::server_capabilities(settings.format_enable),
+            "capabilities": capabilities::server_capabilities(
+                settings.format_enable,
+                position_encoding
+            ),
             "serverInfo": {
                 "name": "sifr-lsp",
                 "version": env!("CARGO_PKG_VERSION")

--- a/crates/sifr_lsp/src/session.rs
+++ b/crates/sifr_lsp/src/session.rs
@@ -1,5 +1,6 @@
 use crate::analysis_workspace::{LspAnalysisWorkspace, LspFileMaps, LspWorkspaceSymbol};
 use crate::cancellation::CancellationToken;
+use crate::diagnostic_jobs::{DiagnosticJobs, ScheduledDiagnosticJob};
 use crate::document_events::{compact_content_changes, CompactedDocumentChange};
 use crate::document_store::DocumentStore;
 use crate::errors::{LspError, LspResult};
@@ -13,7 +14,7 @@ use sifr_analysis::{
     WorkspaceTracePhase,
 };
 use sifr_diagnostics::RenderedDiagnostic;
-use std::collections::BTreeMap;
+use sifr_source::PositionEncoding;
 
 const MAX_LSP_TRACE_EVENTS: usize = 256;
 
@@ -24,25 +25,18 @@ pub(crate) struct Session {
     progress: ProgressState,
     active_request: Option<CancellationToken>,
     initialized: bool,
+    position_encoding: PositionEncoding,
     shutdown_requested: bool,
     exit_requested: bool,
     traces: Vec<WorkspaceTraceEvent>,
     next_trace_sequence: u64,
-    diagnostic_jobs: BTreeMap<String, ScheduledDiagnosticJob>,
-    next_diagnostic_sequence: u64,
+    diagnostic_jobs: DiagnosticJobs,
 }
 
 pub(crate) struct DocumentChangeSummary {
     pub(crate) raw_change_count: usize,
     pub(crate) compacted_change_count: usize,
     pub(crate) text_changed: bool,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ScheduledDiagnosticJob {
-    pub(crate) uri: String,
-    pub(crate) version: Option<i32>,
-    sequence: u64,
 }
 
 impl Session {
@@ -54,12 +48,12 @@ impl Session {
             progress: ProgressState::default(),
             active_request: None,
             initialized: false,
+            position_encoding: PositionEncoding::Utf16,
             shutdown_requested: false,
             exit_requested: false,
             traces: Vec::new(),
             next_trace_sequence: 0,
-            diagnostic_jobs: BTreeMap::new(),
-            next_diagnostic_sequence: 0,
+            diagnostic_jobs: DiagnosticJobs::default(),
         }
     }
 
@@ -69,6 +63,14 @@ impl Session {
 
     pub(crate) fn store_mut(&mut self) -> &mut DocumentStore {
         &mut self.store
+    }
+
+    pub(crate) fn position_encoding(&self) -> PositionEncoding {
+        self.position_encoding
+    }
+
+    pub(crate) fn set_position_encoding(&mut self, encoding: PositionEncoding) {
+        self.position_encoding = encoding;
     }
 
     pub(crate) fn open_document(
@@ -102,9 +104,9 @@ impl Session {
         version: Option<i32>,
         compacted: CompactedDocumentChange,
     ) -> LspResult<DocumentChangeSummary> {
-        let text_changed = self
-            .store
-            .apply_compacted_change(uri, version, &compacted)?;
+        let text_changed =
+            self.store
+                .apply_compacted_change(uri, version, &compacted, self.position_encoding)?;
         let document = self.store.document(uri)?;
         if self.analysis.update_document(document) {
             self.analysis.refresh_projects(&self.store);
@@ -354,19 +356,7 @@ impl Session {
         uri: &str,
     ) -> LspResult<ScheduledDiagnosticJob> {
         let version = self.store.document(uri)?.version();
-        let sequence = if let Some(existing) = self.diagnostic_jobs.get(uri) {
-            existing.sequence
-        } else {
-            let sequence = self.next_diagnostic_sequence;
-            self.next_diagnostic_sequence = self.next_diagnostic_sequence.saturating_add(1);
-            sequence
-        };
-        let job = ScheduledDiagnosticJob {
-            uri: uri.to_string(),
-            version,
-            sequence,
-        };
-        self.diagnostic_jobs.insert(uri.to_string(), job.clone());
+        let job = self.diagnostic_jobs.schedule(uri, version);
         self.trace(
             WorkspaceTracePhase::Scheduler,
             format!("scheduled_diagnostics uri={uri} version={:?}", job.version),
@@ -375,12 +365,7 @@ impl Session {
     }
 
     pub(crate) fn take_next_diagnostic_job(&mut self) -> Option<ScheduledDiagnosticJob> {
-        let uri = self
-            .diagnostic_jobs
-            .iter()
-            .min_by_key(|(_, job)| job.sequence)
-            .map(|(uri, _)| uri.clone())?;
-        self.diagnostic_jobs.remove(&uri)
+        self.diagnostic_jobs.take_next()
     }
 
     pub(crate) fn document_version_matches(

--- a/plans/reviews/active/lsp-position-encoding-opus-review.md
+++ b/plans/reviews/active/lsp-position-encoding-opus-review.md
@@ -1,0 +1,38 @@
+Confirmed: diagnostic columns are `prefix.chars().count()` — UTF-32 codepoint count — emitted unconditionally by `conversion::diagnostic`, bypassing encoding negotiation.
+
+## Review
+
+The encoding negotiation, the conversion-layer threading, the UTF-16-by-default policy, and the new diagnostic-jobs split are well-executed. Validation passed end-to-end. One blocking gap remains and a few minor cleanups.
+
+### Blocking
+
+**`conversion::diagnostic` is the missed encoding boundary** — `crates/sifr_lsp/src/conversion.rs:397-421` and the helpers at `:483-494`.
+
+`DiagnosticSpan.column`/`end_column` are populated by `sifr_diagnostics::render::line_column` (`crates/sifr_diagnostics/src/render/mod.rs:284`) as `prefix.chars().count() + 1` — i.e. a **UTF-32 codepoint count**, used for terminal rendering. `conversion::diagnostic` emits that value directly as the LSP `character` field with no encoding translation and no source-text input. After this PR the server may negotiate UTF-16 (default) or UTF-8, and in both cases the diagnostic range is wrong:
+
+- UTF-8 clients: off by `(utf8_bytes − codepoints)` for any non-ASCII byte on the line (every multi-byte character on the prefix).
+- UTF-16 clients: correct for BMP, but off by `−1` per non-BMP character (emoji, mathematical symbols, etc.) — exactly the category of input that motivated negotiating an encoding in the first place.
+
+Effect: misplaced squigglies, quick-fix targeting the wrong span, and (because `code_action` reads the client-supplied `range` through the encoded boundary) potential downstream encoding mismatches when the client echoes a diagnostic range back. The PR description lists "ranges" and "code actions" as in-scope boundaries, and `crates/sifr_lsp/src/diagnostics.rs:131,141` is the only converter that still ignores `session.position_encoding()`.
+
+Fix sketch: thread `(source, encoding)` into `conversion::diagnostic`, build a `TextRange` from `span.byte_start`/`byte_end`, and route through the existing `text_range_with_encoding`. The byte offsets are already on the struct — no rendering changes needed.
+
+### Non-blocking
+
+1. **`lsp_position_to_utf8` skips validation when the negotiated encoding is UTF-8** (`crates/sifr_lsp/src/conversion.rs:50-53`). UTF-16/UTF-32 paths validate the position via `byte_offset_with_encoding`; UTF-8 returns the raw client position. Pre-existing asymmetry, but now reachable by any UTF-8-capable client.
+
+2. **`prepare_rename` end-position math** (`crates/sifr_lsp/src/requests/navigation.rs:62-67`) still assumes the symbol begins at the cursor and uses `target.symbol.name.len()` (UTF-8 byte length). The encoding round-trip now goes through `text_position`, which is internally consistent (UTF-8 in, UTF-8 column + UTF-8 byte length → re-encode). But clicking mid-identifier produces a wrong range — pre-existing, just inherited unchanged by this PR.
+
+3. **`lsp_range` and `text_range` are now trivial pass-throughs** to their `_with_encoding` siblings (`crates/sifr_lsp/src/conversion.rs:81-87,117-123`). Two of the four can be folded together.
+
+4. **The UTF-16 smoke check is too lax to detect the regression it's meant to catch** (`verification/areas/developer_tooling/lsp_protocol_smoke.py:259-282`). Line `    δ: int = helper(41)` with position `(line=4, character=14)` lands inside `helper` for both UTF-16 (col 14 → `e`) and UTF-8 (byte 14 → `h`). The assertion only checks `"helper" in contents` — it passes regardless of which encoding the server used to decode the position. Add a non-BMP character (e.g. emoji) and pick a column where UTF-16 vs UTF-8 disagree by more than the symbol's length, then assert exact placement.
+
+5. **`Session::position_encoding` defaults to `Utf16` before `initialize`** (`crates/sifr_lsp/src/session.rs:51`). Safe in practice (the server cannot serve requests before initialize), but folding the negotiated encoding into a constructor argument once initialize is observed would remove the implicit-default window.
+
+### Other notes
+
+- `diagnostic_jobs.rs` extraction is a clean split — keeps `session.rs` at 882 lines (under the 900 cap) and the new module has no encoding involvement.
+- All other touched request handlers (`semantic_tokens`, `inlay_hint`, `folding_range`, `selection_range`, `formatting`, `code_action`, `navigation`, `symbols`, `type_hierarchy`) correctly read `session.position_encoding()` and propagate it to the conversion layer. The new `document_position` helper centralizes inbound position decode cleanly.
+- `negotiated_position_encoding` priority list (UTF-8 > UTF-32 > UTF-16 default) ignores client preference order. Spec says "any of the encodings is supported by the client" with no ordering contract on the server side, so this is a defensible choice; just worth being aware of if a client offers `["utf-32", "utf-8"]` expecting UTF-32.
+
+Address finding 1 before merging.

--- a/verification/areas/developer_tooling/lsp_protocol_smoke.py
+++ b/verification/areas/developer_tooling/lsp_protocol_smoke.py
@@ -28,6 +28,21 @@ def main()->int:
     return value
 """
 
+UNICODE_POSITION_SAMPLE = """\
+def helper(value: int) -> int:
+    return value + 1
+
+def main() -> int:
+    result: int = 0 if "🦀" else helper(41)
+    return result
+"""
+
+UNICODE_DIAGNOSTIC_SAMPLE = """\
+def main() -> int:
+    value: int = "🦀" @
+    return 0
+"""
+
 def initialize(
     client: LspClient,
     root: Path,
@@ -40,6 +55,7 @@ def initialize(
             "publishDiagnostics": {"relatedInformation": True},
             "semanticTokens": {"requests": {"full": True, "range": True}},
         },
+        "general": {"positionEncodings": ["utf-16"]},
         "workspace": {"configuration": True, "workspaceFolders": True},
     }
     if work_done_progress:
@@ -59,6 +75,10 @@ def initialize(
     capabilities = result.get("capabilities")
     if not isinstance(capabilities, dict):
         raise LspProtocolError("initialize response missing capabilities")
+    if capabilities.get("positionEncoding") != "utf-16":
+        raise LspProtocolError(
+            f"initialize negotiated unexpected position encoding: {capabilities.get('positionEncoding')!r}"
+        )
     required_capabilities = {
         "textDocumentSync",
         "diagnosticProvider",
@@ -199,6 +219,95 @@ def run_disabled_formatting_check(root: Path) -> None:
         client.close()
 
 
+def run_utf8_negotiation_check(root: Path) -> None:
+    client = LspClient()
+    try:
+        capabilities = initialize(
+            client,
+            root,
+            work_done_progress=False,
+        )
+        if capabilities.get("positionEncoding") != "utf-16":
+            raise LspProtocolError("default smoke initialization should negotiate utf-16")
+        client.request("shutdown", {})
+        client.notify("exit", {})
+    finally:
+        client.close()
+
+    client = LspClient()
+    try:
+        result = client.request(
+            "initialize",
+            {
+                "processId": None,
+                "rootUri": file_uri(root),
+                "capabilities": {
+                    "general": {"positionEncodings": ["utf-16", "utf-8"]},
+                    "workspace": {"configuration": True, "workspaceFolders": True},
+                },
+                "workspaceFolders": [{"uri": file_uri(root), "name": "sifr-lsp-smoke"}],
+                "initializationOptions": {},
+            },
+        )
+        capabilities = result.get("capabilities") if isinstance(result, dict) else None
+        if not isinstance(capabilities, dict):
+            raise LspProtocolError("utf-8 negotiation initialize missing capabilities")
+        if capabilities.get("positionEncoding") != "utf-8":
+            raise LspProtocolError(
+                f"utf-8 capable client negotiated {capabilities.get('positionEncoding')!r}"
+            )
+        client.notify("initialized", {})
+        client.request("shutdown", {})
+        client.notify("exit", {})
+    finally:
+        client.close()
+
+
+def run_utf16_position_behavior_check(root: Path) -> None:
+    source = root / "unicode-position.sifr"
+    source.write_text(UNICODE_POSITION_SAMPLE, encoding="utf-8")
+    client = LspClient()
+    try:
+        initialize(client, root)
+        open_document(client, source, UNICODE_POSITION_SAMPLE)
+        hover = client.request(
+            "textDocument/hover",
+            {
+                "textDocument": {"uri": file_uri(source)},
+                "position": {"line": 4, "character": 33},
+            },
+        )
+        contents = hover.get("contents", {}) if isinstance(hover, dict) else {}
+        if "helper" not in contents.get("value", ""):
+            raise LspProtocolError(f"utf-16 hover position did not resolve helper: {hover}")
+        client.request("shutdown", {})
+        client.notify("exit", {})
+    finally:
+        client.close()
+
+
+def run_utf16_diagnostic_range_check(root: Path) -> None:
+    source = root / "unicode-diagnostic.sifr"
+    source.write_text(UNICODE_DIAGNOSTIC_SAMPLE, encoding="utf-8")
+    client = LspClient()
+    try:
+        initialize(client, root)
+        open_document(client, source, UNICODE_DIAGNOSTIC_SAMPLE)
+        report = client.request("textDocument/diagnostic", {"textDocument": {"uri": file_uri(source)}})
+        items = report.get("items", []) if isinstance(report, dict) else []
+        starts = [
+            item.get("range", {}).get("start")
+            for item in items
+            if isinstance(item, dict) and item.get("range", {}).get("start", {}).get("line") == 1
+        ]
+        if {"line": 1, "character": 23} not in starts:
+            raise LspProtocolError(f"utf-16 diagnostic range did not land on invalid token: {items}")
+        client.request("shutdown", {})
+        client.notify("exit", {})
+    finally:
+        client.close()
+
+
 def run_smoke() -> None:
     with tempfile.TemporaryDirectory(prefix="sifr-lsp-smoke-") as raw:
         root = Path(raw)
@@ -217,6 +326,9 @@ def run_smoke() -> None:
         finally:
             client.close()
         run_disabled_formatting_check(root)
+        run_utf8_negotiation_check(root)
+        run_utf16_position_behavior_check(root)
+        run_utf16_diagnostic_range_check(root)
 
 
 def run_self_test() -> None:


### PR DESCRIPTION
## Summary
- negotiate LSP position encoding during initialize, defaulting legacy and VS Code-style clients to UTF-16
- thread the negotiated encoding through inbound request positions, ranges, diagnostics, edits, semantic tokens, hints, navigation, formatting, and workspace edits
- add protocol smoke coverage for UTF-16 behavior with non-BMP text and UTF-8 negotiation

## Review
- Opus review artifact: plans/reviews/active/lsp-position-encoding-opus-review.md
- Addressed blocking review finding: diagnostic ranges now convert from diagnostic byte offsets using the negotiated LSP position encoding

## Validation
- cargo fmt --check
- cargo test -p sifr_lsp
- cargo clippy -p sifr_lsp --no-deps -- -D warnings
- python3 verification/areas/developer_tooling/lsp_protocol_smoke.py
- python3 verification/areas/developer_tooling/runner.py --suite lsp-smoke
- python3 scripts/check_file_size_guardrails.py
- scripts/run_all_tests.sh --profile create-pr
