### PR TITLE
Fix LSP workspace command contract

### DIFF
--- a/crates/sifr_lsp/src/capabilities.rs
+++ b/crates/sifr_lsp/src/capabilities.rs
@@ -105,12 +105,8 @@ pub(crate) fn server_capabilities(
         },
         "executeCommandProvider": {
             "commands": [
-                "sifr.restartServer",
-                "sifr.showServerLogs",
-                "sifr.explainDiagnostic",
-                "sifr.showGeneratedRust",
-                "sifr.checkWorkspace",
-                "sifr.runTests"
+                "sifr.server.explainDiagnostic",
+                "sifr.server.showGeneratedRust"
             ]
         },
         "workspace": {
@@ -127,7 +123,7 @@ pub(crate) fn server_capabilities(
 
 #[cfg(test)]
 mod tests {
-    use super::negotiated_position_encoding;
+    use super::{negotiated_position_encoding, server_capabilities};
     use serde_json::json;
     use sifr_source::PositionEncoding;
 
@@ -136,6 +132,18 @@ mod tests {
         assert_eq!(
             negotiated_position_encoding(&json!({ "capabilities": {} })),
             PositionEncoding::Utf16
+        );
+    }
+
+    #[test]
+    fn execute_command_provider_only_advertises_server_workspace_commands() {
+        let capabilities = server_capabilities(false, PositionEncoding::Utf16);
+        assert_eq!(
+            capabilities.pointer("/executeCommandProvider/commands"),
+            Some(&json!([
+                "sifr.server.explainDiagnostic",
+                "sifr.server.showGeneratedRust"
+            ]))
         );
     }
 

--- a/crates/sifr_lsp/src/commands.rs
+++ b/crates/sifr_lsp/src/commands.rs
@@ -3,7 +3,10 @@ use crate::errors::{LspError, LspResult};
 use crate::session::Session;
 use serde_json::{json, Value};
 use sifr_analysis::AnalysisQueryResult;
-use sifr_analysis::{DiagnosticId, TestItemId};
+use sifr_analysis::DiagnosticId;
+
+const EXPLAIN_DIAGNOSTIC_COMMAND: &str = "sifr.server.explainDiagnostic";
+const SHOW_GENERATED_RUST_COMMAND: &str = "sifr.server.showGeneratedRust";
 
 pub(crate) struct CommandRegistry;
 
@@ -14,14 +17,8 @@ impl CommandRegistry {
         arguments: &[Value],
     ) -> LspResult<Value> {
         match command {
-            "sifr.restartServer" => Ok(json!({"status": "restart-requested"})),
-            "sifr.showServerLogs" => Ok(json!({"status": "stdio-server", "logs": []})),
-            "sifr.explainDiagnostic" => explain_diagnostic(session, arguments),
-            "sifr.showGeneratedRust" => generated_rust_preview(session, arguments),
-            "sifr.checkWorkspace" => {
-                Ok(json!({"command": "sifr", "args": ["check"], "status": "metadata-only"}))
-            }
-            "sifr.runTests" => run_tests(session, arguments),
+            EXPLAIN_DIAGNOSTIC_COMMAND => explain_diagnostic(session, arguments),
+            SHOW_GENERATED_RUST_COMMAND => generated_rust_preview(session, arguments),
             _ => Err(LspError::method_not_found(format!(
                 "unknown Sifr command: {command}"
             ))),
@@ -35,7 +32,9 @@ fn explain_diagnostic(session: &mut Session, arguments: &[Value]) -> LspResult<V
         .and_then(Value::as_str)
         .map(DiagnosticId::hard)
         .ok_or_else(|| {
-            LspError::invalid_params("sifr.explainDiagnostic requires a diagnostic code argument")
+            LspError::invalid_params(
+                "sifr.server.explainDiagnostic requires a diagnostic code argument",
+            )
         })?;
     for uri in session.document_uris() {
         let explanation =
@@ -60,7 +59,7 @@ fn explain_diagnostic(session: &mut Session, arguments: &[Value]) -> LspResult<V
 
 fn generated_rust_preview(session: &mut Session, arguments: &[Value]) -> LspResult<Value> {
     let uri = arguments.first().and_then(Value::as_str).ok_or_else(|| {
-        LspError::invalid_params("sifr.showGeneratedRust requires a document URI argument")
+        LspError::invalid_params("sifr.server.showGeneratedRust requires a document URI argument")
     })?;
     session.with_document_analysis(uri, |snapshot, host, file, _source| {
         snapshot
@@ -68,33 +67,4 @@ fn generated_rust_preview(session: &mut Session, arguments: &[Value]) -> LspResu
             .map_err(|error| LspError::internal(error.message))
             .map(|result| conversion::generated_rust_preview(result.into_value()))
     })
-}
-
-fn run_tests(session: &mut Session, arguments: &[Value]) -> LspResult<Value> {
-    if let Some(test_id) = arguments.first().and_then(Value::as_str) {
-        if let Some(uri) = session.document_uris().first().cloned() {
-            let command =
-                session.with_document_analysis(&uri, |snapshot, host, _file, _source| {
-                    snapshot
-                        .test_command(host, TestItemId(test_id.to_string()))
-                        .map_err(|error| LspError::internal(error.message))
-                        .map(AnalysisQueryResult::into_value)
-                })?;
-            return Ok(conversion::test_command(command));
-        }
-    }
-    let mut tests = Vec::new();
-    for uri in session.document_uris() {
-        let mut document_tests =
-            session.with_document_analysis(&uri, |snapshot, host, _file, _source| {
-                snapshot
-                    .discover_tests(host)
-                    .map_err(|error| LspError::internal(error.message))
-                    .map(AnalysisQueryResult::into_value)
-            })?;
-        tests.append(&mut document_tests);
-    }
-    Ok(Value::Array(
-        tests.into_iter().map(conversion::test_item).collect(),
-    ))
 }

--- a/crates/sifr_lsp/src/conversion.rs
+++ b/crates/sifr_lsp/src/conversion.rs
@@ -5,8 +5,8 @@ use serde_json::{json, Value};
 use sifr_analysis::{
     CodeAction, CompletionItem, DeferredCodeAction, DiagnosticClass, DiagnosticId,
     DocumentHighlight, DocumentSymbol, FileId, FileTextEdits, FoldingRange, GeneratedRustPreview,
-    HoverInfo, InlayHint, Location, SemanticToken, SignatureHelp, TestCommand, TestCommandKind,
-    TestItem, TextEdit, TypeHierarchyItem, WorkspaceEdit, WorkspaceSymbol,
+    HoverInfo, InlayHint, Location, SemanticToken, SignatureHelp, TextEdit, TypeHierarchyItem,
+    WorkspaceEdit, WorkspaceSymbol,
 };
 use sifr_diagnostics::{DiagnosticArg, DiagnosticSpan, RenderedDiagnostic, Severity};
 use sifr_source::{PositionEncoding, SourceText as SourceTextMap, TextPosition};
@@ -466,22 +466,6 @@ pub(crate) fn generated_rust_preview(preview: GeneratedRustPreview) -> Value {
         "rust": preview.rust,
         "unavailableReason": preview.unavailable_reason
     })
-}
-
-pub(crate) fn test_item(item: TestItem) -> Value {
-    json!({
-        "id": item.id.0,
-        "label": item.label,
-        "file": item.file.map(FileId::as_u32)
-    })
-}
-
-pub(crate) fn test_command(command: TestCommand) -> Value {
-    let kind = match command.kind {
-        TestCommandKind::Check => "check",
-        TestCommandKind::Run => "run",
-    };
-    json!({ "kind": kind, "args": command.args })
 }
 
 fn diagnostic_span_range(

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -51,7 +51,7 @@ Sifr provides prebuilt preview binaries for the following targets:
     sifr --version
     ```
 
-    You should see a version string such as `0.1.0-beta.10`. If the command is not found, check that `~/.sifr/bin` is in your `PATH`.
+    You should see a version string such as `0.1.0-beta.11`. If the command is not found, check that `~/.sifr/bin` is in your `PATH`.
   </Step>
 </Steps>
 
@@ -62,7 +62,7 @@ Sifr provides prebuilt preview binaries for the following targets:
 If you need a specific preview release — for reproducible CI environments or to test a particular build — pass `--version` to the installer:
 
 ```bash
-curl -fsSL https://sifr.sh/install | sh -s -- --version 0.1.0-beta.10
+curl -fsSL https://sifr.sh/install | sh -s -- --version 0.1.0-beta.11
 ```
 
 ### Install to a custom directory
@@ -115,7 +115,7 @@ sifr self update --channel beta
 You can update to a specific preview version rather than the latest on your channel:
 
 ```bash
-sifr self update --version 0.1.0-beta.10
+sifr self update --version 0.1.0-beta.11
 ```
 
 ### Reinstalls, downgrades, and channel switches
@@ -123,7 +123,7 @@ sifr self update --version 0.1.0-beta.10
 Same-version reinstalls, downgrades, and channel switches all require `--force`:
 
 ```bash
-sifr self update --version 0.1.0-beta.10 --force
+sifr self update --version 0.1.0-beta.11 --force
 sifr self update --channel alpha --force
 ```
 

--- a/docs/self_update.md
+++ b/docs/self_update.md
@@ -41,7 +41,7 @@ in text mode.
 
 `sifr self update` defaults to the channel recorded in the install receipt.
 Use `--channel alpha|beta` to switch preview channels or `--version` to pin an
-exact preview version such as `0.1.0-beta.10`.
+exact preview version such as `0.1.0-beta.11`.
 
 Use `--dry-run` to print the resolved plan without downloading an installer or
 acquiring the install lock. `--format json` is available only with `--dry-run`.
@@ -56,7 +56,7 @@ also rejected before the stable release channel is enabled.
 Same-version reinstalls, downgrades, and channel switches require `--force`:
 
 ```bash
-sifr self update --version 0.1.0-beta.10 --force
+sifr self update --version 0.1.0-beta.11 --force
 sifr self update --channel alpha --force
 ```
 

--- a/internal_docs/lsp_server.md
+++ b/internal_docs/lsp_server.md
@@ -155,16 +155,23 @@ through `sifr_analysis`, and fail closed if the document version changed.
 
 ## Commands
 
-Required command identifiers:
+Required server workspace command identifiers:
 
-- `sifr.restartServer`
-- `sifr.showServerLogs`
-- `sifr.explainDiagnostic`
-- `sifr.showGeneratedRust`
-- `sifr.checkWorkspace`
-- `sifr.runTests`
+- `sifr.server.explainDiagnostic`
+- `sifr.server.showGeneratedRust`
 
-Command payloads are Sifr-owned and versioned through this document and the protocol matrix.
+Only server-executable workspace commands may be advertised through
+`executeCommandProvider`. Editor lifecycle and UI commands such as restart,
+show logs, task execution, and command-palette actions are owned by editor
+integrations and must not be advertised by the LSP server. This avoids global
+command registration collisions in clients such as VS Code and keeps the LSP
+surface portable across editors.
+
+Command payloads are Sifr-owned and versioned through this document and the
+protocol matrix.
+
+- `sifr.server.explainDiagnostic` arguments: `[diagnosticCode: string]`.
+- `sifr.server.showGeneratedRust` arguments: `[uri: string]`.
 
 Lint-related code actions use standard LSP code-action kinds:
 

--- a/internal_docs/vscode_extension.md
+++ b/internal_docs/vscode_extension.md
@@ -96,6 +96,11 @@ The extension must not implement:
 
 All commands delegate to Sifr LSP or CLI surfaces.
 
+The command-palette identifiers above are editor-owned UI commands. When they
+need server analysis, they call internal LSP workspace commands such as
+`sifr.server.showGeneratedRust` and `sifr.server.explainDiagnostic`; they must
+not share identifiers with commands advertised by the LSP server.
+
 ## Versioning Covenant
 
 Before VS Code extension layer closes, the extension must document whether its version is coupled to the Sifr compiler version or declares an explicit supported Sifr version range. Extension releases are gated on the main-repo rules check, `sifr lsp --stdio` smoke tests, extension tests, and `.vsix` packaging.

--- a/plans/reviews/active/lsp-command-contract-claude-review-1.md
+++ b/plans/reviews/active/lsp-command-contract-claude-review-1.md
@@ -1,0 +1,58 @@
+Here are the findings.
+
+## Blocking
+
+### 1. `String(diagnostic.code)` is `"[object Object]"` for every Sifr diagnostic — explainDiagnostic silently always misses
+`editor_integrations/vscode/src/commands.ts:107-110`
+
+```ts
+arguments: [String(diagnostic.code)],
+```
+
+Sifr's diagnostic renderer always emits `codeDescription.href` (`crates/sifr_diagnostics/src/codes/registry.rs:314` — `docs_url()` returns `format!("https://docs.sifr.sh/errors/{}", self.code())`, never empty). When `codeDescription` is present, `vscode-languageclient` rewrites `Diagnostic.code` into the object form `{ value, target: Uri }` (`node_modules/vscode-languageclient/lib/common/protocolConverter.js:73-78`). `String({value, target})` is `"[object Object]"`, so the server-side lookup at `crates/sifr_analysis/src/host/implementation.rs:591` (`rendered.code == diagnostic.code`) never matches and `crates/sifr_lsp/src/commands.rs:54-57` returns `"diagnostic code [object Object] is not present in the current workspace snapshot"`. The whole point of this PR is to make the round-trip work; today every real invocation breaks. The static `npm run test:extension` smoke didn't catch it because it only checks command registration.
+
+Fix shape:
+
+```ts
+const rawCode = diagnostic.code;
+const code =
+  typeof rawCode === "object" && rawCode !== null
+    ? String((rawCode as { value: string | number }).value)
+    : String(rawCode);
+```
+
+### 2. No runtime coverage for `sifr.server.explainDiagnostic`
+`verification/areas/developer_tooling/lsp_protocol_smoke.py:161-167`
+
+The smoke removed the `sifr.runTests` call but only added `sifr.server.showGeneratedRust`. There is no `executeCommand` call that exercises explainDiagnostic against a real published diagnostic with `codeDescription` set. Adding one would have surfaced finding #1, and would lock the argument schema for future drift.
+
+## Should fix
+
+### 3. Doc/version bump beta.10 → beta.11 is out of scope for this PR
+`docs/installation.mdx:54,65,118,126`, `docs/self_update.md:44,59`, `editor_integrations/vscode/README.md:33`.
+
+The task is the LSP command contract fix; these bumps claim a `0.1.0-beta.11` release that does not exist yet (latest tag is beta.10 — commit `5cf47f086`). If beta.11 is being staged in this PR intentionally, fine, but the title and CHANGELOG don't say so. If not, separate the doc bumps so the command-contract fix can ship without coupling to an unreleased CLI version. The vscode `0.1.4` README also pre-binds itself to a CLI version that isn't yet shipped — fragile.
+
+## Non-blocking observations / nits
+
+### 4. The transcript-replay tightening is the right call
+`verification/areas/developer_tooling/check_lsp_transcript_replay.py:128`. Flipping `expected.difference(commands)` to `set(commands) != expected_commands` catches drift in both directions — extras now fail too, which is exactly what we want now that the advertised set is supposed to be minimal. Worth keeping.
+
+### 5. `executeCommand` `_ =>` arm vs. the contract
+`crates/sifr_lsp/src/commands.rs:22-24`. Returning `method_not_found` for any unadvertised command is correct LSP behavior. Worth a one-line unit test that calling a no-longer-advertised name like `"sifr.runTests"` errors — cheap insurance against accidental re-introduction.
+
+### 6. capabilities test pins one encoding only
+`crates/sifr_lsp/src/capabilities.rs:138-148`. Since the command list doesn't vary by encoding, a single case is fine. Optional: parametrise over `(client_supports_pull_diagnostics, encoding)` so a future regression that adds an encoding-conditional command would be caught.
+
+### 7. Argument schema dropped `range` for `showGeneratedRust`
+The old call passed `{uri, range}`; the new call passes `[uri.toString()]`. `snapshot.generated_rust_preview(host, file, None)` already ignored the range (third arg hard-coded `None`), so no behavior loss — but worth a note in `internal_docs/lsp_server.md` that the argument schema is `[uri: string]` so future contributors don't reintroduce range plumbing.
+
+### 8. Dead types in `sifr_analysis`
+`TestItem`, `TestCommand`, `TestItemId`, and `TestCommandKind` are still exported from `crates/sifr_analysis` but no longer reached via LSP. If nothing else surfaces them, a follow-up can prune them. Out of scope for this PR — flagging only.
+
+### 9. Namespacing choice is good
+`sifr.server.*` keeps the LSP surface portable across editors and the invariant ("editor UI commands must not share IDs with advertised LSP commands") is documented in both `internal_docs/lsp_server.md:163-168` and `internal_docs/vscode_extension.md:99-102`. No collision risk for the current command set.
+
+## Summary
+
+The contract design (server owns `sifr.server.*`, editor owns `sifr.*`), the fixture/protocol-matrix sync, and the inventory/rules lock updates are all consistent and correct. The blocking issue is the VS Code-side argument conversion in finding #1, plus the missing runtime smoke that would have caught it. Recommend fixing #1, adding a real explainDiagnostic round-trip to `lsp_protocol_smoke.py`, and deciding whether the beta.11 doc bump belongs in this PR before landing.

--- a/verification/areas/developer_tooling/check_lsp_transcript_replay.py
+++ b/verification/areas/developer_tooling/check_lsp_transcript_replay.py
@@ -120,14 +120,10 @@ def replay_initialize_capability_snapshot(_: dict[str, Any]) -> None:
                 raise LspProtocolError("workspace folders are not advertised as supported")
             commands = require_dict(capabilities.get("executeCommandProvider"), "executeCommandProvider").get("commands")
             expected_commands = {
-                "sifr.restartServer",
-                "sifr.showServerLogs",
-                "sifr.explainDiagnostic",
-                "sifr.showGeneratedRust",
-                "sifr.checkWorkspace",
-                "sifr.runTests",
+                "sifr.server.explainDiagnostic",
+                "sifr.server.showGeneratedRust",
             }
-            if not isinstance(commands, list) or expected_commands.difference(commands):
+            if not isinstance(commands, list) or set(commands) != expected_commands:
                 raise LspProtocolError(f"initialize command advertisement drifted: {commands}")
             legend = require_dict(
                 require_dict(capabilities.get("semanticTokensProvider"), "semanticTokensProvider").get("legend"),

--- a/verification/areas/developer_tooling/check_tooling_rules_lock.py
+++ b/verification/areas/developer_tooling/check_tooling_rules_lock.py
@@ -72,12 +72,8 @@ REQUIRED_METHODS = {
 }
 
 REQUIRED_COMMANDS = {
-    "sifr.restartServer",
-    "sifr.showServerLogs",
-    "sifr.explainDiagnostic",
-    "sifr.showGeneratedRust",
-    "sifr.checkWorkspace",
-    "sifr.runTests",
+    "sifr.server.explainDiagnostic",
+    "sifr.server.showGeneratedRust",
 }
 
 REQUIRED_SETTINGS = {

--- a/verification/areas/developer_tooling/data/lsp_capability_inventory.json
+++ b/verification/areas/developer_tooling/data/lsp_capability_inventory.json
@@ -65,12 +65,8 @@
       "source_token": "executeCommandProvider",
       "methods": ["workspace/executeCommand"],
       "commands": [
-        "sifr.restartServer",
-        "sifr.showServerLogs",
-        "sifr.explainDiagnostic",
-        "sifr.showGeneratedRust",
-        "sifr.checkWorkspace",
-        "sifr.runTests"
+        "sifr.server.explainDiagnostic",
+        "sifr.server.showGeneratedRust"
       ],
       "marker_required": true,
       "category": "commands"

--- a/verification/areas/developer_tooling/lsp_protocol_matrix.json
+++ b/verification/areas/developer_tooling/lsp_protocol_matrix.json
@@ -87,12 +87,8 @@
     {"method": "textDocument/rangeFormatting", "owner": "sifr_lsp::requests::range_formatting", "analysis_owner": "AnalysisHost::format_range", "positive": "range edits match formatter rules using discovered formatter config and LSP options", "negative": "invalid range and disabled formatter setting are rejected", "budget_id": "lsp-formatting"}
   ],
   "required_commands": [
-    {"command": "sifr.restartServer", "owner": "CommandRegistry", "positive": "server restart request is logged", "negative": "restart during shutdown is rejected"},
-    {"command": "sifr.showServerLogs", "owner": "CommandRegistry", "positive": "server log location or content returned", "negative": "missing log file reports actionable error"},
-    {"command": "sifr.explainDiagnostic", "owner": "AnalysisHost::explain_diagnostic", "positive": "diagnostic explanation preserves canonical schema", "negative": "unknown diagnostic id rejected"},
-    {"command": "sifr.showGeneratedRust", "owner": "AnalysisHost::generated_rust_preview", "positive": "preview uses compiler codegen/source maps", "negative": "content-modified cancellation rejects partial output"},
-    {"command": "sifr.checkWorkspace", "owner": "sifr CLI check", "positive": "workspace check command metadata invokes Sifr", "negative": "workspace load failure reports diagnostics"},
-    {"command": "sifr.runTests", "owner": "sifr CLI test metadata", "positive": "test command metadata invokes Sifr test runner", "negative": "project without tests returns empty tree"}
+    {"command": "sifr.server.explainDiagnostic", "owner": "AnalysisHost::explain_diagnostic", "positive": "diagnostic explanation preserves canonical schema", "negative": "unknown diagnostic id rejected"},
+    {"command": "sifr.server.showGeneratedRust", "owner": "AnalysisHost::generated_rust_preview", "positive": "preview uses compiler codegen/source maps", "negative": "content-modified cancellation rejects partial output"}
   ],
   "unsupported_surfaces": [
     {"surface": "notebookDocumentSync", "policy": "do not advertise; reject notebook URIs deterministically"},

--- a/verification/areas/developer_tooling/lsp_protocol_smoke.py
+++ b/verification/areas/developer_tooling/lsp_protocol_smoke.py
@@ -43,6 +43,12 @@ def main() -> int:
     return 0
 """
 
+EXPLAIN_DIAGNOSTIC_SAMPLE = """\
+def main() -> int:
+    value: int = missing_name
+    return value
+"""
+
 def initialize(
     client: LspClient,
     root: Path,
@@ -94,7 +100,7 @@ def initialize(
     return capabilities
 
 
-def open_document(client: LspClient, path: Path, text: str, version: int = 1) -> None:
+def open_document(client: LspClient, path: Path, text: str, version: int = 1) -> list[dict[str, Any]]:
     client.notify(
         "textDocument/didOpen",
         {
@@ -112,8 +118,10 @@ def open_document(client: LspClient, path: Path, text: str, version: int = 1) ->
         raise LspProtocolError("publishDiagnostics used the wrong document URI")
     if params.get("version") != version:
         raise LspProtocolError("publishDiagnostics did not preserve document version")
-    if not isinstance(params.get("diagnostics"), list):
+    diagnostics = params.get("diagnostics")
+    if not isinstance(diagnostics, list):
         raise LspProtocolError("publishDiagnostics missing diagnostics list")
+    return [item for item in diagnostics if isinstance(item, dict)]
 
 
 def run_queries(client: LspClient, uri: str) -> None:
@@ -161,12 +169,23 @@ def run_queries(client: LspClient, uri: str) -> None:
 
     preview = client.request(
         "workspace/executeCommand",
-        {"command": "sifr.showGeneratedRust", "arguments": [uri]},
+        {"command": "sifr.server.showGeneratedRust", "arguments": [uri]},
     )
     if not isinstance(preview, dict) or "rust" not in preview:
         raise LspProtocolError("generated Rust command did not return preview payload")
 
-    client.request("workspace/executeCommand", {"command": "sifr.runTests", "arguments": []})
+
+def run_explain_diagnostic_check(client: LspClient, path: Path) -> None:
+    diagnostics = open_document(client, path, EXPLAIN_DIAGNOSTIC_SAMPLE)
+    diagnostic_code = next((item.get("code") for item in diagnostics if item.get("code")), None)
+    if diagnostic_code is None:
+        raise LspProtocolError(f"explainDiagnostic sample did not publish a coded diagnostic: {diagnostics}")
+    explanation = client.request(
+        "workspace/executeCommand",
+        {"command": "sifr.server.explainDiagnostic", "arguments": [str(diagnostic_code)]},
+    )
+    if not isinstance(explanation, dict) or not explanation.get("diagnostic"):
+        raise LspProtocolError(f"explainDiagnostic did not return an explanation payload: {explanation}")
 
 
 def run_formatting_checks(client: LspClient, path: Path) -> None:
@@ -313,13 +332,16 @@ def run_smoke() -> None:
         root = Path(raw)
         source = root / "main.sifr"
         formatting_source = root / "formatting.sifr"
+        explain_source = root / "explain.sifr"
         source.write_text(SAMPLE, encoding="utf-8")
         formatting_source.write_text(UNFORMATTED_SAMPLE, encoding="utf-8")
+        explain_source.write_text(EXPLAIN_DIAGNOSTIC_SAMPLE, encoding="utf-8")
         client = LspClient()
         try:
             initialize(client, root)
             open_document(client, source, SAMPLE)
             run_queries(client, file_uri(source))
+            run_explain_diagnostic_check(client, explain_source)
             run_formatting_checks(client, formatting_source)
             client.request("shutdown", {})
             client.notify("exit", {})

--- a/verification/areas/developer_tooling/vscode_extension_rules.json
+++ b/verification/areas/developer_tooling/vscode_extension_rules.json
@@ -45,8 +45,8 @@
     {"command": "sifr.runLint", "title": "Sifr: Run Lint", "backend": "cli:sifr lint"},
     {"command": "sifr.checkFormat", "title": "Sifr: Check Format", "backend": "cli:sifr fmt --check"},
     {"command": "sifr.formatDocument", "title": "Sifr: Format Document", "backend": "lsp-or-cli:sifr fmt"},
-    {"command": "sifr.showGeneratedRust", "title": "Sifr: Show Generated Rust", "backend": "lsp:sifr.showGeneratedRust"},
-    {"command": "sifr.explainDiagnostic", "title": "Sifr: Explain Diagnostic", "backend": "lsp:sifr.explainDiagnostic"}
+    {"command": "sifr.showGeneratedRust", "title": "Sifr: Show Generated Rust", "backend": "lsp:sifr.server.showGeneratedRust"},
+    {"command": "sifr.explainDiagnostic", "title": "Sifr: Explain Diagnostic", "backend": "lsp:sifr.server.explainDiagnostic"}
   ],
   "package_scripts": ["lint", "typecheck", "test", "test:extension", "package"],
   "forbidden_extension_behavior": [

--- a/verification/areas/performance/lsp_query_bench.py
+++ b/verification/areas/performance/lsp_query_bench.py
@@ -68,7 +68,7 @@ def run_family(client: LspClient, uri: str) -> None:
     )
     client.request("textDocument/diagnostic", {"textDocument": document})
     client.request("workspace/diagnostic", {})
-    client.request("workspace/executeCommand", {"command": "sifr.showGeneratedRust", "arguments": [uri]})
+    client.request("workspace/executeCommand", {"command": "sifr.server.showGeneratedRust", "arguments": [uri]})
 
 
 def run_completion(client: LspClient, uri: str) -> None:
@@ -157,7 +157,7 @@ def run_workspace_diagnostics(client: LspClient, _uri: str) -> None:
 
 
 def run_generated_rust_preview(client: LspClient, uri: str) -> None:
-    client.request("workspace/executeCommand", {"command": "sifr.showGeneratedRust", "arguments": [uri]})
+    client.request("workspace/executeCommand", {"command": "sifr.server.showGeneratedRust", "arguments": [uri]})
 
 
 WARM_SCENARIOS: dict[str, Callable[[LspClient, str], None]] = {


### PR DESCRIPTION
## Summary
- split LSP workspace commands into internal sifr.server.* IDs and stop advertising editor UI commands
- align VS Code generated-Rust and diagnostic-explanation calls with the server command schemas
- update LSP protocol inventories, smoke tests, transcript replay, docs, and release docs for 0.1.0-beta.11
- update editor_integrations pointer to the merged VS Code extension 0.1.4 fix

## Claude review
- Review artifact: plans/reviews/active/lsp-command-contract-claude-review-1.md
- Addressed blocking findings: VS Code diagnostic code object handling and runtime smoke coverage for sifr.server.explainDiagnostic

## Validation
- cargo fmt --check
- cargo test -p sifr_lsp
- VS Code extension: npm run lint, npm run typecheck, npm test, npm run test:extension, npm run package
- Direct LSP initialize probe confirmed executeCommandProvider only advertises sifr.server.explainDiagnostic and sifr.server.showGeneratedRust
- python3 verification/areas/developer_tooling/runner.py --suite static --suite lsp-smoke
- scripts/run_all_tests.sh --profile create-pr: LSP/developer-tooling checks passed; later failed in unrelated rust_interop_async_contract_tests
- Clean origin/main worktree reproduced a rust_interop_async_contract_tests failure, confirming the remaining full-gate failure is pre-existing and unrelated to this PR