### PR TITLE
Implement M39.12 Rust interop tooling and docs

### DIFF
--- a/crates/sifr/src/bridge_cli.rs
+++ b/crates/sifr/src/bridge_cli.rs
@@ -1,0 +1,26 @@
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub(crate) enum BridgeCommands {
+    /// Check Rust bridge projections and interop probe diagnostics
+    Check {
+        /// Check all Sifr-capable workspace members through Cargo-compatible selection
+        #[arg(long)]
+        workspace: bool,
+        /// Select one package by Cargo package spec or unambiguous package name
+        #[arg(short = 'p', long = "package")]
+        packages: Vec<String>,
+        /// Exclude one package from workspace selection
+        #[arg(long)]
+        exclude: Vec<String>,
+        /// Require Cargo.lock to be unchanged
+        #[arg(long)]
+        locked: bool,
+        /// Disable network access
+        #[arg(long)]
+        offline: bool,
+        /// Combine --locked and --offline
+        #[arg(long)]
+        frozen: bool,
+    },
+}

--- a/crates/sifr/src/bridge_cli_tests.rs
+++ b/crates/sifr/src/bridge_cli_tests.rs
@@ -1,0 +1,37 @@
+use crate::cli_model_and_entrypoint::{BridgeCommands, Cli, Commands};
+use clap::Parser;
+
+#[test]
+fn bridge_check_cli_parses_workspace_selection_and_lock_flags() {
+    let cli = Cli::try_parse_from([
+        "sifr",
+        "bridge",
+        "check",
+        "--workspace",
+        "-p",
+        "demo-app",
+        "--exclude",
+        "demo-tools",
+        "--frozen",
+    ])
+    .expect("bridge check cli parses");
+
+    let Some(Commands::Bridge {
+        command:
+            BridgeCommands::Check {
+                workspace,
+                packages,
+                exclude,
+                frozen,
+                ..
+            },
+    }) = cli.command
+    else {
+        panic!("expected bridge check command");
+    };
+
+    assert!(workspace);
+    assert_eq!(packages, ["demo-app"]);
+    assert_eq!(exclude, ["demo-tools"]);
+    assert!(frozen);
+}

--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -1,3 +1,4 @@
+pub(crate) use super::bridge_cli::BridgeCommands;
 use super::check_and_package_commands::{cmd_check, cmd_emit, cmd_fmt, cmd_test};
 use super::diagnostic_rendering_and_run::{
     cmd_build, cmd_fetch, cmd_package, cmd_publish, cmd_run_with_options, cmd_tree, cmd_vendor,
@@ -127,6 +128,11 @@ pub(crate) enum Commands {
         /// Check projection drift without writing
         #[arg(long)]
         check: bool,
+    },
+    /// Validate Rust bridge projections and interop probes for a package
+    Bridge {
+        #[command(subcommand)]
+        command: BridgeCommands,
     },
     /// Type-check a .sifr file without compiling
     Check {
@@ -412,6 +418,29 @@ fn run_cli(cli: Cli) -> i32 {
             force,
         } => cmd_init(&path, lib, bin, name.as_deref(), force, diagnostic_format),
         Commands::Repair { check } => cmd_repair(check, diagnostic_format),
+        Commands::Bridge { command } => match command {
+            BridgeCommands::Check {
+                workspace,
+                packages,
+                exclude,
+                locked,
+                offline,
+                frozen,
+            } => {
+                let selection = sifr_package::CargoPackageSelection {
+                    workspace,
+                    packages,
+                    excludes: exclude,
+                };
+                cmd_check(
+                    None,
+                    None,
+                    &selection,
+                    lock_mode_from_flags(locked, offline, frozen),
+                    diagnostic_format,
+                )
+            }
+        },
         Commands::Check {
             path,
             workspace,

--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -12,6 +12,7 @@
 //!   sifr lsp --stdio          Run the native Language Server Protocol server
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used, dead_code))]
 
+mod bridge_cli;
 mod cli_model_and_entrypoint;
 pub(crate) use cli_model_and_entrypoint::main;
 mod build_output;
@@ -26,6 +27,8 @@ mod self_update_runner;
 mod trace_cli;
 mod workspace_run_selection;
 
+#[cfg(test)]
+mod bridge_cli_tests;
 #[cfg(test)]
 mod diagnostics_and_packages_tests;
 #[cfg(test)]

--- a/crates/sifr_analysis/src/completion.rs
+++ b/crates/sifr_analysis/src/completion.rs
@@ -18,6 +18,32 @@ pub struct CompletionEvaluation {
     pub passed: bool,
 }
 
+pub(crate) fn rust_interop_completion_candidates(
+    source: &str,
+    position: &sifr_syntax::TextPosition,
+) -> Vec<CompletionCandidate> {
+    let source_text = sifr_syntax::SourceText::new(source.to_string());
+    let Some(offset) = source_text.byte_offset(position) else {
+        return Vec::new();
+    };
+    let Ok(offset) = usize::try_from(offset.to_u32()) else {
+        return Vec::new();
+    };
+    let line_start = source[..offset].rfind('\n').map_or(0, |index| index + 1);
+    let prefix = source[line_start..offset].trim_start();
+    if !prefix.contains('(') && is_rust_interop_decorator_prefix(prefix) {
+        return rust_interop_decorator_candidates();
+    }
+
+    let Some(context) = rust_interop_completion_context(source, offset) else {
+        return Vec::new();
+    };
+    if !context.policy_keys_available {
+        return Vec::new();
+    }
+    rust_interop_policy_key_candidates(context.decorator)
+}
+
 pub fn rank_completion_candidates(
     query: &str,
     mut candidates: Vec<CompletionCandidate>,
@@ -66,9 +92,203 @@ fn completion_score(query: &str, candidate: &CompletionCandidate) -> u8 {
     0
 }
 
+fn rust_interop_decorator_candidates() -> Vec<CompletionCandidate> {
+    [
+        ("rust", "Rust interop decorator root"),
+        ("rust.async", "Rust async bridge contract decorator"),
+        ("rust.opaque", "Rust opaque handle contract decorator"),
+        ("rust.zero_copy", "Rust zero-copy contract decorator"),
+        ("rust.view", "Rust borrowed view contract decorator"),
+        ("rust.callback", "Rust callback contract decorator"),
+    ]
+    .into_iter()
+    .map(|(label, detail)| CompletionCandidate {
+        label: label.to_string(),
+        kind: "decorator".to_string(),
+        detail: Some(detail.to_string()),
+    })
+    .collect()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RustInteropCompletionDecorator {
+    Function,
+    Async,
+    Opaque,
+    ZeroCopy,
+    View,
+    Callback,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RustInteropCompletionContext {
+    decorator: RustInteropCompletionDecorator,
+    policy_keys_available: bool,
+}
+
+fn is_rust_interop_decorator_prefix(prefix: &str) -> bool {
+    let Some(name) = prefix.strip_prefix('@') else {
+        return false;
+    };
+    [
+        "rust",
+        "rust.async",
+        "rust.opaque",
+        "rust.zero_copy",
+        "rust.view",
+        "rust.callback",
+    ]
+    .into_iter()
+    .any(|candidate| candidate.starts_with(name))
+}
+
+fn rust_interop_completion_context(
+    source: &str,
+    offset: usize,
+) -> Option<RustInteropCompletionContext> {
+    let before_cursor = &source[..offset];
+    let mut search_end = before_cursor.len();
+    while let Some(index) = before_cursor[..search_end].rfind("@rust") {
+        if !is_decorator_start_boundary(source, index) {
+            search_end = index;
+            continue;
+        }
+        let after_rust = &before_cursor[index + "@rust".len()..];
+        let Some((decorator, after_decorator)) = parse_decorator_suffix(after_rust) else {
+            search_end = index;
+            continue;
+        };
+        let after_decorator = after_decorator.trim_start();
+        let Some(arguments) = after_decorator.strip_prefix('(') else {
+            search_end = index;
+            continue;
+        };
+        let Some(policy_keys_available) = policy_keys_available_before_cursor(decorator, arguments)
+        else {
+            search_end = index;
+            continue;
+        };
+        return Some(RustInteropCompletionContext {
+            decorator,
+            policy_keys_available,
+        });
+    }
+    None
+}
+
+fn is_decorator_start_boundary(source: &str, index: usize) -> bool {
+    if index == 0 {
+        return true;
+    }
+    source[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|character| character.is_whitespace())
+}
+
+fn parse_decorator_suffix(after_rust: &str) -> Option<(RustInteropCompletionDecorator, &str)> {
+    [
+        (".zero_copy", RustInteropCompletionDecorator::ZeroCopy),
+        (".callback", RustInteropCompletionDecorator::Callback),
+        (".opaque", RustInteropCompletionDecorator::Opaque),
+        (".async", RustInteropCompletionDecorator::Async),
+        (".view", RustInteropCompletionDecorator::View),
+    ]
+    .into_iter()
+    .find_map(|(suffix, decorator)| {
+        after_rust
+            .strip_prefix(suffix)
+            .map(|remaining| (decorator, remaining))
+    })
+    .or(Some((RustInteropCompletionDecorator::Function, after_rust)))
+}
+
+fn policy_keys_available_before_cursor(
+    decorator: RustInteropCompletionDecorator,
+    arguments: &str,
+) -> Option<bool> {
+    let mut depth = 1_i32;
+    let mut saw_function_target_separator = false;
+    for character in arguments.chars() {
+        match character {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth <= 0 {
+                    return None;
+                }
+            }
+            ',' if depth == 1 => saw_function_target_separator = true,
+            _ => {}
+        }
+    }
+    Some(decorator != RustInteropCompletionDecorator::Function || saw_function_target_separator)
+}
+
+fn rust_interop_policy_key_candidates(
+    decorator: RustInteropCompletionDecorator,
+) -> Vec<CompletionCandidate> {
+    match decorator {
+        RustInteropCompletionDecorator::Function => &[("panic", "Rust panic boundary policy")][..],
+        RustInteropCompletionDecorator::Async => &[(
+            "thread_affinity",
+            "Rust runtime or OS-thread affinity policy",
+        )],
+        RustInteropCompletionDecorator::Opaque => &[
+            ("type", "Rust opaque handle target type"),
+            ("send", "Rust Send bridge policy"),
+            ("sync", "Rust Sync bridge policy"),
+            ("clone", "Rust opaque handle clone policy"),
+            ("close", "Rust opaque handle close policy"),
+            ("borrow", "Rust opaque method receiver policy"),
+            (
+                "thread_affinity",
+                "Rust runtime or OS-thread affinity policy",
+            ),
+        ],
+        RustInteropCompletionDecorator::ZeroCopy => &[
+            ("owner", "Rust zero-copy owner binding"),
+            ("view", "Rust zero-copy view target type"),
+        ],
+        RustInteropCompletionDecorator::View => &[
+            ("owner", "Rust borrowed view owner binding"),
+            ("lifetime", "Rust borrowed view lifetime policy"),
+            ("mutability", "Rust borrowed view mutability policy"),
+            ("send", "Rust Send bridge policy"),
+            ("sync", "Rust Sync bridge policy"),
+            ("data", "Rust advanced data view kind"),
+            ("schema", "Rust Arrow schema path"),
+            ("dtype", "Rust tensor dtype"),
+            ("rank", "Rust tensor rank"),
+            ("shape", "Rust tensor shape"),
+            ("layout", "Rust tensor layout"),
+            ("strides", "Rust tensor strides"),
+            ("device", "Rust tensor device"),
+            ("ownership", "Rust advanced data ownership policy"),
+            ("protocol", "Rust DLPack protocol path"),
+        ],
+        RustInteropCompletionDecorator::Callback => &[
+            ("backpressure", "Rust callback backpressure policy"),
+            ("overflow", "Rust callback overflow policy"),
+            ("shutdown", "Rust callback shutdown policy"),
+        ],
+    }
+    .into_iter()
+    .map(|(label, detail)| CompletionCandidate {
+        label: label.to_string(),
+        kind: "property".to_string(),
+        detail: Some(detail.to_string()),
+    })
+    .collect()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{evaluate_completion_ranking, rank_completion_candidates, CompletionCandidate};
+    use super::{
+        evaluate_completion_ranking, rank_completion_candidates,
+        rust_interop_completion_candidates, CompletionCandidate,
+    };
+    use sifr_syntax::TextPosition;
 
     fn candidate(label: &str) -> CompletionCandidate {
         CompletionCandidate {
@@ -109,5 +329,148 @@ mod tests {
 
         assert!(evaluation.passed);
         assert_eq!(evaluation.actual_top_label.as_deref(), Some("helper"));
+    }
+
+    #[test]
+    fn rust_interop_completion_suggests_decorator_paths_on_rust_decorator_line() {
+        let source = "@rust.\ndef main():\n    return 1\n";
+        let candidates = rust_interop_completion_candidates(
+            source,
+            &TextPosition {
+                line: 0,
+                character: 6,
+            },
+        );
+        let labels = candidates
+            .iter()
+            .map(|candidate| candidate.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(labels.contains(&"rust.async"));
+        assert!(labels.contains(&"rust.opaque"));
+        assert!(labels.contains(&"rust.zero_copy"));
+        assert!(labels.contains(&"rust.view"));
+        assert!(labels.contains(&"rust.callback"));
+    }
+
+    #[test]
+    fn rust_interop_completion_suggests_policy_keys_inside_decorator_call() {
+        let source = "@rust(callback_target, )\ndef main():\n    return 1\n";
+        let candidates = rust_interop_completion_candidates(
+            source,
+            &TextPosition {
+                line: 0,
+                character: 22,
+            },
+        );
+        let labels = candidates
+            .iter()
+            .map(|candidate| candidate.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(labels, vec!["panic"]);
+    }
+
+    #[test]
+    fn rust_interop_completion_uses_callback_policy_keys_only() {
+        let source = "@rust.callback(back)\ndef main():\n    return 1\n";
+        let candidates = rust_interop_completion_candidates(
+            source,
+            &TextPosition {
+                line: 0,
+                character: 19,
+            },
+        );
+        let labels = candidates
+            .iter()
+            .map(|candidate| candidate.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(labels, vec!["backpressure", "overflow", "shutdown"]);
+        assert!(!labels.contains(&"lifetime"));
+        assert!(!labels.contains(&"panic"));
+    }
+
+    #[test]
+    fn rust_interop_completion_uses_opaque_policy_keys_only() {
+        let source = "@rust.opaque(type=bridge.Token, )\nclass Token:\n    pass\n";
+        let candidates = rust_interop_completion_candidates(
+            source,
+            &TextPosition {
+                line: 0,
+                character: 32,
+            },
+        );
+        let labels = candidates
+            .iter()
+            .map(|candidate| candidate.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(labels.contains(&"type"));
+        assert!(labels.contains(&"thread_affinity"));
+        assert!(!labels.contains(&"backpressure"));
+        assert!(!labels.contains(&"owner"));
+    }
+
+    #[test]
+    fn rust_interop_completion_supports_multiline_view_policy_keys() {
+        let source = "@rust.view(\n    owner=input,\n    schema=\n)\ndef main():\n    return 1\n";
+        let candidates = rust_interop_completion_candidates(
+            source,
+            &TextPosition {
+                line: 2,
+                character: 11,
+            },
+        );
+        let labels = candidates
+            .iter()
+            .map(|candidate| candidate.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(labels.contains(&"lifetime"));
+        assert!(labels.contains(&"schema"));
+        assert!(labels.contains(&"protocol"));
+        assert!(!labels.contains(&"backpressure"));
+    }
+
+    #[test]
+    fn rust_interop_completion_waits_for_function_target_separator() {
+        let before_target_separator = "@rust()";
+        assert!(rust_interop_completion_candidates(
+            before_target_separator,
+            &TextPosition {
+                line: 0,
+                character: 6,
+            },
+        )
+        .is_empty());
+
+        let after_target_separator = "@rust(bridge.hash, )";
+        let labels = rust_interop_completion_candidates(
+            after_target_separator,
+            &TextPosition {
+                line: 0,
+                character: 19,
+            },
+        )
+        .into_iter()
+        .map(|candidate| candidate.label)
+        .collect::<Vec<_>>();
+
+        assert_eq!(labels, vec!["panic"]);
+    }
+
+    #[test]
+    fn rust_interop_completion_ignores_non_decorator_lines() {
+        let source = "value = rust\n";
+        let candidates = rust_interop_completion_candidates(
+            source,
+            &TextPosition {
+                line: 0,
+                character: 10,
+            },
+        );
+
+        assert!(candidates.is_empty());
     }
 }

--- a/crates/sifr_analysis/src/host/implementation.rs
+++ b/crates/sifr_analysis/src/host/implementation.rs
@@ -1,5 +1,7 @@
 use super::text_edits::{fixed_source_edits, full_range, ranges_overlap, source_edit_to_text_edit};
-use crate::completion::{rank_completion_candidates, CompletionCandidate};
+use crate::completion::{
+    rank_completion_candidates, rust_interop_completion_candidates, CompletionCandidate,
+};
 use crate::editor::{line_end_insert_range, EditorFacts, EditorToken};
 use crate::queries::{
     CodeAction, CodeActionContext, CodeActionData, CompletionItem, CompletionItems,
@@ -166,12 +168,12 @@ impl AnalysisHost {
         file: FileId,
         position: &TextPosition,
     ) -> QueryResult<CompletionItems> {
-        let query = self
-            .editor_facts(file)?
+        let facts = self.editor_facts(file)?;
+        let query = facts
             .identifier_at_position(position)
             .map(|token| token.text.clone())
             .unwrap_or_default();
-        let candidates = self
+        let mut candidates: Vec<CompletionCandidate> = self
             .symbol_index()?
             .completion_symbols("")
             .into_iter()
@@ -181,6 +183,7 @@ impl AnalysisHost {
                 detail: symbol.container_name,
             })
             .collect();
+        candidates.extend(rust_interop_completion_candidates(&facts.source, position));
         let ranked = rank_completion_candidates(&query, candidates);
         let items = ranked
             .candidates

--- a/crates/sifr_analysis/src/host/tests.rs
+++ b/crates/sifr_analysis/src/host/tests.rs
@@ -229,6 +229,34 @@ fn analysis_snapshot_carries_workspace_state_and_query_metadata() {
 }
 
 #[test]
+fn completion_query_includes_rust_interop_policy_candidates() {
+    let source = "@rust.callback(\n    \n)\ndef main():\n    return 1\n";
+    let mut host =
+        AnalysisHost::open_single_file(single_file_input(source)).expect("host should load");
+    let file = host.files()[0];
+    let completions = host
+        .completion(
+            file,
+            &TextPosition {
+                line: 1,
+                character: 4,
+            },
+        )
+        .expect("completion should query")
+        .into_value();
+    let labels = completions
+        .items
+        .into_iter()
+        .map(|item| item.label)
+        .collect::<Vec<_>>();
+
+    assert!(labels.contains(&"backpressure".to_string()));
+    assert!(labels.contains(&"overflow".to_string()));
+    assert!(labels.contains(&"shutdown".to_string()));
+    assert!(!labels.contains(&"lifetime".to_string()));
+}
+
+#[test]
 fn project_symbol_index_is_stable_for_workspace_queries() {
     let dir = std::env::temp_dir().join(format!(
         "sifr_analysis_project_{}_{}",

--- a/crates/sifr_lsp/src/conversion.rs
+++ b/crates/sifr_lsp/src/conversion.rs
@@ -513,7 +513,9 @@ fn completion_kind(kind: &str) -> u32 {
         "function" => 3,
         "type" | "class" => 7,
         "module" => 9,
+        "property" => 10,
         "keyword" => 14,
+        "decorator" => 15,
         _ => 6,
     }
 }
@@ -543,9 +545,10 @@ fn token_modifier_bits(modifiers: &[String]) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{lsp_range_with_encoding, text_range_with_encoding};
+    use super::{completion_item, lsp_range_with_encoding, text_range_with_encoding};
     use ruff_text_size::{TextRange, TextSize};
     use serde_json::json;
+    use sifr_analysis::CompletionItem;
     use sifr_source::PositionEncoding;
 
     #[test]
@@ -571,5 +574,22 @@ mod tests {
             "end": { "line": 0, "character": 3 }
         });
         assert!(lsp_range_with_encoding(&range_json, source, PositionEncoding::Utf16).is_err());
+    }
+
+    #[test]
+    fn completion_conversion_maps_rust_interop_kinds_to_lsp_kinds() {
+        let decorator = completion_item(CompletionItem {
+            label: "rust.callback".to_string(),
+            kind: "decorator".to_string(),
+            detail: Some("Rust interop decorator".to_string()),
+        });
+        assert_eq!(decorator["kind"], json!(15));
+
+        let property = completion_item(CompletionItem {
+            label: "panic".to_string(),
+            kind: "property".to_string(),
+            detail: Some("Rust interop policy key".to_string()),
+        });
+        assert_eq!(property["kind"], json!(10));
     }
 }

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -40,6 +40,7 @@ These flags apply across all subcommands.
 | `sifr lsp --stdio` | Start the Language Server Protocol server over stdio. |
 | `sifr init [PATH]` | Create a new Sifr package in the given directory. |
 | `sifr fetch` | Fetch package dependencies. |
+| `sifr bridge check` | Validate Rust bridge projections and interop probes. |
 | `sifr tree` | Show the package dependency tree. |
 | `sifr package` | Assemble and verify a Cargo package archive. |
 | `sifr publish` | Publish a Sifr package through Cargo. |

--- a/docs/cli/packages-workspaces.mdx
+++ b/docs/cli/packages-workspaces.mdx
@@ -12,6 +12,7 @@ Sifr's package commands are Cargo-compatible where that matters, but they preser
 | --- | --- |
 | `sifr init [PATH]` | Create a new Sifr package in `PATH` or the current directory. |
 | `sifr fetch` | Fetch package dependencies without building. |
+| `sifr bridge check` | Validate Rust bridge projections and interop probes. |
 | `sifr repair` | Repair Sifr-managed Cargo projection drift. |
 | `sifr tree` | Print the package dependency tree with Cargo-compatible tree options. |
 | `sifr package` | Assemble and verify a package archive. |
@@ -34,11 +35,14 @@ sifr init math-lib --lib --name math-lib
 ## Check or Repair Projection Drift
 
 ```bash
+sifr bridge check
 sifr repair --check
 sifr repair
 ```
 
-`--check` reports drift without writing. Without `--check`, Sifr repairs the Sifr-managed Cargo projection files.
+`sifr bridge check` runs the same package check path as `sifr check`, including Rust decorator parsing, target resolution, bridge type contracts, trust policy, and probe diagnostics. Use it while authoring `@rust(...)` declarations or `src/bridges/*.rs` files.
+
+`sifr repair --check` reports drift without writing. `sifr repair` repairs Sifr-managed Cargo projection files and leaves user-owned local bridge files untouched.
 
 ## Select Workspace Packages
 

--- a/docs/diagnostics/error-codes.mdx
+++ b/docs/diagnostics/error-codes.mdx
@@ -137,20 +137,20 @@ The `PYIMP`, `PYCALL`, `PYCONV`, `PYRES`, `PYZC`, and `PYCB` families are reserv
 
 <Accordion title="RUST — Rust interop">
 
-The `SIFR-RUST-*` families are reserved for declaration-level Rust interop through Cargo. These placeholders lock the Rust interop diagnostic namespaces before compiler emission lands.
+The `SIFR-RUST-*` families cover declaration-level Rust interop through Cargo. These diagnostics are emitted by the same compiler path used by `sifr check`, `sifr bridge check`, package build, and package publish validation.
 
 | Code | Severity | Description |
 |------|----------|-------------|
-| `SIFR-RUST-CONFIG-0001` | Error | Malformed Rust interop decorator. |
-| `SIFR-RUST-RESOLVE-0001` | Error | Unresolved Rust target path. |
-| `SIFR-RUST-TRUST-0001` | Error | Missing Rust interop trust declaration. |
-| `SIFR-RUST-TYPE-0001` | Error | Unsupported Rust bridge type. |
-| `SIFR-RUST-HANDLE-0001` | Error | Invalid opaque handle contract. |
-| `SIFR-RUST-ASYNC-0001` | Error | Invalid Rust async or thread-affinity contract. |
-| `SIFR-RUST-ZC-0001` | Error | Invalid zero-copy or view lifetime contract. |
-| `SIFR-RUST-CB-0001` | Error | Invalid callback lifetime or threading contract. |
-| `SIFR-RUST-PANIC-0001` | Error | Incompatible Rust panic strategy or poisoned handle. |
-| `SIFR-RUST-CARGO-0001` | Error | Cargo metadata, lockfile, or profile mismatch. |
+| [`SIFR-RUST-CONFIG-0001`](/errors/SIFR-RUST-CONFIG-0001) | Error | Malformed Rust interop decorator. |
+| [`SIFR-RUST-RESOLVE-0001`](/errors/SIFR-RUST-RESOLVE-0001) | Error | Unresolved Rust target path. |
+| [`SIFR-RUST-TRUST-0001`](/errors/SIFR-RUST-TRUST-0001) | Error | Missing Rust interop trust declaration. |
+| [`SIFR-RUST-TYPE-0001`](/errors/SIFR-RUST-TYPE-0001) | Error | Unsupported Rust bridge type. |
+| [`SIFR-RUST-HANDLE-0001`](/errors/SIFR-RUST-HANDLE-0001) | Error | Invalid opaque handle contract. |
+| [`SIFR-RUST-ASYNC-0001`](/errors/SIFR-RUST-ASYNC-0001) | Error | Invalid Rust async or thread-affinity contract. |
+| [`SIFR-RUST-ZC-0001`](/errors/SIFR-RUST-ZC-0001) | Error | Invalid zero-copy or view lifetime contract. |
+| [`SIFR-RUST-CB-0001`](/errors/SIFR-RUST-CB-0001) | Error | Invalid callback lifetime or threading contract. |
+| [`SIFR-RUST-PANIC-0001`](/errors/SIFR-RUST-PANIC-0001) | Error | Incompatible Rust panic strategy or poisoned handle. |
+| [`SIFR-RUST-CARGO-0001`](/errors/SIFR-RUST-CARGO-0001) | Error | Cargo metadata, lockfile, or profile mismatch. |
 
 </Accordion>
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -71,7 +71,8 @@
               "installation",
               "quickstart",
               "from-python",
-              "python-interop"
+              "python-interop",
+              "rust-interop"
             ]
           },
           {

--- a/docs/guides/rust-developers/index.mdx
+++ b/docs/guides/rust-developers/index.mdx
@@ -19,6 +19,9 @@ If you know Rust, Sifr's safety model will feel familiar, but the source languag
   <Card title="Check and Emit" icon="file-code" href="/cli/check-emit">
     Inspect generated Rust with `sifr emit`.
   </Card>
+  <Card title="Rust Interop" icon="plug-zap" href="/rust-interop">
+    Expose Rust crates and bridge modules through checked Sifr declarations.
+  </Card>
   <Card title="Build and Run" icon="terminal" href="/cli/build-run">
     Compile Sifr into native binaries.
   </Card>
@@ -31,7 +34,8 @@ If you know Rust, Sifr's safety model will feel familiar, but the source languag
 3. Learn source-level ownership: [Ownership and Mutability](/language/ownership).
 4. Review typed failures: [Error Handling](/language/error-handling).
 5. Understand structured async: [Concurrency Overview](/language/concurrency).
-6. Ship a binary: [Build and Run](/cli/build-run).
+6. Expose Rust-backed APIs: [Rust Interop](/rust-interop).
+7. Ship a binary: [Build and Run](/cli/build-run).
 
 <Note>
 Sifr is not a Rust macro language. The generated Rust is an implementation target you can inspect, while the Sifr source model remains the language contract.

--- a/docs/packages/dependencies.mdx
+++ b/docs/packages/dependencies.mdx
@@ -87,11 +87,13 @@ A pure Sifr package contains no non-trivial Rust code — all behavior is expres
 
 Sifr validates this marker and rejects any package that contains non-trivial Rust in `src/lib.rs` but does not declare Rust-backed behavior. Do not add Rust logic to `lib.rs` in a pure Sifr package.
 
-## Trust policy for backend Rust crates
+## Trust policy for Rust interop
 
-Some Sifr packages interoperate with Rust crates at the backend level. Sifr enforces a trust policy that controls which Rust crates a package is permitted to call. This policy is configured in `sifr.toml` and validated during `sifr package` and `sifr publish`.
+Some Sifr packages expose Rust crates or local bridge modules through `@rust(...)` declarations. Sifr enforces trust policy for build scripts, proc macros, native links, unsafe local bridge files, no-panic assertions, and panic-abort opt-ins. This policy is configured in `sifr.toml` and validated by `sifr bridge check`, `sifr check`, `sifr package`, and `sifr publish`.
 
-Packages that exceed their declared trust boundary are rejected at publish time with a backend trust violation error.
+Packages that exceed their declared trust boundary are rejected with `SIFR-RUST-TRUST-*` diagnostics before the final Rust-backed package build is accepted.
+
+See [Rust Interop](/rust-interop) for direct bindings, local bridges, shared bridge crates, opaque handles, async, zero-copy, callbacks, and trust examples.
 
 <Warning>
 Sifr wraps Cargo process failures in diagnostic code `SIFR-PACKAGE-0101`. If a dependency fetch, tree command, or other Cargo-delegated operation fails, run `sifr --explain SIFR-PACKAGE-0101` for structured diagnostic help. The explainer does not perform any package operations — it is safe to run at any time.

--- a/docs/packages/manifest.mdx
+++ b/docs/packages/manifest.mdx
@@ -128,7 +128,7 @@ Knowing where to put configuration prevents confusion and keeps Sifr's tooling w
 - Source root (`[source].roots`)
 - Formatter and lint configuration
 - Named scripts
-- Native trust policy for backend Rust crates
+- Rust interop bridge metadata and native trust policy
 - Root application Python environment selection and Python trust policy
 
 **Put in `Cargo.toml`:**
@@ -148,6 +148,28 @@ The Cargo metadata hook is the bridge between the two files. Sifr reads `cargo m
 manifest = "sifr.toml"
 # end sifr-managed
 ```
+
+## `[rust]` and Rust interop trust policy
+
+Rust-backed packages declare Sifr-owned bridge projection metadata in `[rust]` and execution trust evidence in `[trust]`.
+
+```toml
+[rust]
+bridge-version = 1
+bridges = ["src/bridges"]
+
+[trust]
+rust-build-scripts = []
+rust-proc-macros = []
+native-links = []
+unsafe-rust-bridges = []
+rust-no-panic = ["crc32fast.hash"]
+rust-panic-abort = []
+```
+
+`bridge-version` pins the generated bridge module contract. `bridges` lists package-local Rust bridge roots that Sifr may reference through the `bridge` decorator root. Files such as `src/bridges/tokenizer.rs` are user-owned; Sifr-managed projection files are checked with `sifr repair --check` and regenerated with `sifr repair`.
+
+See [Rust Interop](/rust-interop) for direct bindings, local bridges, shared bridge crates, opaque handles, async, zero-copy, callbacks, and the `sifr bridge check` workflow.
 
 ## `[python]` and Python trust policy
 

--- a/docs/rust-interop.mdx
+++ b/docs/rust-interop.mdx
@@ -1,0 +1,207 @@
+---
+title: "Rust Interop"
+sidebarTitle: "Rust Interop"
+description: "Expose Rust crates and bridge modules as checked Sifr declarations through Cargo-backed Rust interop."
+---
+
+Rust interop lets a Sifr package expose Rust-backed declarations while keeping the same compile-time contracts as ordinary Sifr code. Sifr resolves targets through Cargo metadata, validates bridge-compatible signatures before final build, and reports Rust interop failures as `SIFR-RUST-*` diagnostics.
+
+Rust interop is source-level Cargo integration. It is not Rust ABI loading, `dlopen`, or a C FFI layer.
+
+## Package Setup
+
+Declare Rust dependencies in `Cargo.toml` and Sifr interop policy in `sifr.toml`:
+
+```toml Cargo.toml
+[dependencies]
+crc32fast = "1"
+blake3 = "1"
+reqwest = { version = "0.12", default-features = false }
+```
+
+```toml sifr.toml
+[rust]
+bridge-version = 1
+bridges = ["src/bridges"]
+
+[trust]
+rust-build-scripts = []
+rust-proc-macros = []
+native-links = []
+unsafe-rust-bridges = []
+rust-no-panic = ["crc32fast.hash"]
+rust-panic-abort = []
+```
+
+Use `sifr bridge check` for Rust interop feedback. It uses the same package check path as `sifr check`, so decorator parsing, target resolution, bridge contracts, trust policy, and probe diagnostics match the compiler.
+
+```bash
+sifr bridge check
+sifr bridge check --workspace --locked
+sifr repair --check
+sifr repair
+```
+
+`sifr repair --check` reports drift in Sifr-managed Cargo projection files. `sifr repair` regenerates only Sifr-owned projection metadata and does not overwrite user-authored bridge files under `src/bridges`.
+
+## Direct Bindings
+
+Use `@rust(...)` when a public Rust function has a bridge-compatible signature. The target is a dotted path, not a string.
+
+```sifr
+@rust(crc32fast.hash, panic=trusted_no_panic)
+def crc32(data: bytes) -> uint32: ...
+```
+
+```sifr
+class HashError(Error):
+    message: str
+
+@rust(blake3.hash, panic=map_error(bridge.hash.map_panic))
+def blake3_hash(data: bytes) -> Result[bytes, HashError | RustPanicError]: ...
+```
+
+Direct binding is for compatible Rust signatures. If a crate exposes lifetimes, generics, borrowed returns, trait objects, raw pointers, closures, `unsafe fn`, or another unsupported shape, write a bridge.
+
+## Local Bridges
+
+Local bridges adapt Rust APIs that are not directly bridge-compatible. The Sifr target root `bridge` resolves to user-authored Rust modules under `src/bridges`.
+
+```sifr
+@rust.opaque(type=bridge.tokenizer.Tokenizer, close=close, send=True, sync=False)
+class Tokenizer:
+    @rust(Self.encode, panic=map_error(bridge.tokenizer.map_panic))
+    def encode(self, text: str) -> Result[list[uint32], TokenizerError | RustPanicError]: ...
+
+    @rust(bridge.tokenizer.close, panic=map_error(bridge.tokenizer.map_panic))
+    def close(own self) -> Result[None, TokenizerError | RustPanicError]: ...
+```
+
+```rust src/bridges/tokenizer.rs
+pub struct Tokenizer {
+    inner: tokenizer_backend::Tokenizer,
+}
+
+pub fn close(_tokenizer: Tokenizer) -> Result<(), TokenizerErrorBridge> {
+    Ok(())
+}
+```
+
+Package-local bridges may import generated bridge types from `crate::__sifr_bridge::<module>`. Shared bridge crates must not import those package-specific generated modules; they expose stable Rust types or `sifr_runtime::interop` helper types instead.
+
+## Async HTTP
+
+Async Rust interop must be declared on an `async def`. By default, returned futures must be `Send`; add `@rust.async(thread_affinity=tokio_current_thread)` only for explicitly current-runtime futures.
+
+```sifr
+class HttpError(Error):
+    message: str
+
+@rust(bridge.http.fetch_text, panic=map_error(bridge.http.map_panic))
+async def fetch_text(url: str) -> Result[str, HttpError | RustPanicError]: ...
+```
+
+Blocking or CPU-heavy Rust calls are never hidden inside async scheduler paths. Declare them explicitly with the existing Sifr blocking or CPU-heavy annotations and call them through the appropriate offload workflow.
+
+## Zero-Copy And Views
+
+Zero-copy declarations must make owner, lifetime, mutability, and view metadata explicit. Sifr rejects silent copy fallback.
+
+```sifr
+@rust.zero_copy(owner=input, view=sifr_arrow_bridge.record_batch.RecordBatchView)
+@rust.view(
+    owner=input,
+    lifetime=owner,
+    mutability=immutable,
+    send=True,
+    sync=True,
+    data=arrow_record_batch,
+    schema=sifr_arrow_bridge.schema.RecordBatch,
+    ownership=borrowed,
+)
+@rust(sifr_arrow_bridge.record_batch_from_bytes, panic=map_error(sifr_arrow_bridge.panic.map))
+def arrow_batch(input: bytes) -> Result[ArrowRecordBatch, ArrowError | RustPanicError]: ...
+```
+
+```sifr
+@rust.zero_copy(owner=input, view=sifr_tensor_bridge.dlpack.DlpackView)
+@rust.view(
+    owner=input,
+    lifetime=owner,
+    mutability=immutable,
+    send=True,
+    sync=True,
+    data=dlpack,
+    dtype=f32,
+    rank=2,
+    shape=[2, 3],
+    layout=strided,
+    strides=[3, 1],
+    device=cpu,
+    ownership=transfer,
+    protocol=sifr_tensor_bridge.dlpack.Capsule,
+)
+@rust(sifr_tensor_bridge.dlpack_from_bytes, panic=map_error(sifr_tensor_bridge.panic.map))
+def dlpack_tensor(own input: bytes) -> Result[Tensor, TensorError | RustPanicError]: ...
+```
+
+Returned borrowed views cannot outlive their owner, mutable views require exclusive ownership, and async functions cannot suspend while holding a borrowed Rust view.
+
+## Callbacks
+
+Backpressure, overflow, and shutdown behavior must be visible in callback registration declarations. Thread-safety is part of the callback type and the explicit `@rust.callback(...)` contract.
+
+```sifr
+@rust.callback(
+    backpressure=bounded(1024),
+    overflow=error,
+    shutdown=drain,
+)
+@rust(bridge.events.subscribe, panic=map_error(bridge.events.map_panic))
+def subscribe(handler: ThreadsafeCallback[[Event], Result[None, EventError]]) -> Result[Subscription, EventError | RustPanicError]: ...
+```
+
+Sifr rejects callback contracts that permit hidden storage, unmanaged thread entry, missing shutdown behavior, or captures that cannot cross the declared thread boundary.
+
+## Diagnostics
+
+Rust interop diagnostics are grouped by contract family:
+
+| Family | Covers |
+| --- | --- |
+| [`SIFR-RUST-CONFIG-*`](/diagnostics/error-codes) | Malformed decorators, invalid policy values, and unsupported decorator shapes. |
+| [`SIFR-RUST-RESOLVE-*`](/diagnostics/error-codes) | Unresolved dependency roots, bridge modules, Rust items, or `Self` targets. |
+| [`SIFR-RUST-TRUST-*`](/diagnostics/error-codes) | Missing build-script, proc-macro, native-link, unsafe bridge, no-panic, or panic-abort trust evidence. |
+| [`SIFR-RUST-TYPE-*`](/diagnostics/error-codes) | Bridge signature mismatches and unsupported Rust/Sifr type mappings. |
+| [`SIFR-RUST-HANDLE-*`](/diagnostics/error-codes) | Opaque handle ownership, close, clone, thread, and poisoning contracts. |
+| [`SIFR-RUST-ASYNC-*`](/diagnostics/error-codes) | Async function, future `Send`, thread-affinity, blocking, and CPU-heavy violations. |
+| [`SIFR-RUST-ZC-*`](/diagnostics/error-codes) | Zero-copy owner, lifetime, mutability, view, and copy-fallback violations. |
+| [`SIFR-RUST-CB-*`](/diagnostics/error-codes) | Callback lifetime, threading, backpressure, overflow, and shutdown violations. |
+| [`SIFR-RUST-PANIC-*`](/diagnostics/error-codes) | Panic policy, panic strategy, and poisoned handle contract violations. |
+| [`SIFR-RUST-CARGO-*`](/diagnostics/error-codes) | Missing Cargo context, metadata, lock, profile, and feature consistency failures. |
+
+Run `sifr --explain SIFR-RUST-CB-0001` for a stable explanation of any active code.
+
+## Rejected Designs
+
+These forms are invalid and produce diagnostics:
+
+```sifr
+@rust("crc32fast::hash")
+def bad_string_target(data: bytes) -> uint32: ...
+```
+
+```sifr
+extern rust crc32fast.hash
+```
+
+```sifr
+from rust import crc32fast
+```
+
+```sifr
+@rust(crate="crc32fast", path="hash")
+def bad_legacy_shape(data: bytes) -> uint32: ...
+```
+
+Rust interop never falls back from zero-copy to copying, never creates a hidden Tokio runtime, and never lets a Rust panic unwind through Sifr user code in recoverable builds.

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -848,17 +848,18 @@ The initial verification scaffold reserves the first code in every family:
 
 ## Tooling
 
-LSP support is staged:
+LSP support is staged and must use the same analysis/compiler facts that back `sifr check`:
 
-1. Resolve decorator roots from Sifr package metadata and Cargo metadata.
-2. Parse package-local bridge module names and exported functions for completions.
-3. Integrate rust-analyzer metadata for richer signatures and go-to-definition.
+1. Complete canonical Rust interop decorator dotted paths and policy keys (`@rust`, `@rust.async`, `@rust.opaque`, `@rust.zero_copy`, `@rust.view`, `@rust.callback`, and their policy arguments).
+2. Resolve decorator roots from Sifr package metadata and Cargo metadata.
+3. Parse package-local bridge module names and exported functions for completions.
+4. Integrate rust-analyzer metadata for richer signatures and go-to-definition.
 
 Completion must prefer valid dotted paths. Invalid string-style Rust targets are rejected instead of tolerated.
 
 `sifr check` is the source of truth for Rust-backed packages. Plain `cargo check` on a source package may require prior Sifr projection generation because local bridge files can import generated `crate::__sifr_bridge` modules. Tooling must provide:
 
-- `sifr bridge check` for bridge projection and probe validation,
+- `sifr bridge check` for bridge projection and probe validation through the same package check path,
 - `sifr repair --check` for detecting missing or stale managed projection files,
 - `sifr repair` for regenerating Sifr-managed projection files without touching user-owned bridge files.
 

--- a/plans/reviews/active/rust-interop-milestone39-12-review-round1.md
+++ b/plans/reviews/active/rust-interop-milestone39-12-review-round1.md
@@ -1,0 +1,109 @@
+# M39.12 Rust Interop Tooling, Diagnostics, Docs — Review Round 1
+
+Branch: `phase39-rust-interop-m39-12`
+Scope: items listed under `milestone_39_12` in `plans/phases/39_rust_interop.md`.
+Result: **Not satisfied.** Two critical, one high, two medium, two low findings.
+
+## Critical
+
+### C1. `docs/rust-interop.mdx:100` — `@rust.async(thread_affinity=send)` is rejected by the compiler.
+
+The async HTTP example writes:
+
+```sifr
+@rust.async(thread_affinity=send)
+@rust(bridge.http.fetch_text, panic=map_error(bridge.http.map_panic))
+async def fetch_text(url: str) -> Result[str, HttpError | RustPanicError]: ...
+```
+
+`crates/sifr_driver/src/build/rust_interop/async_validation.rs:56-65` only accepts `thread_affinity=none` or `thread_affinity=tokio_current_thread`; everything else emits `SIFR-RUST-ASYNC-*` with message ``thread_affinity=` must be none or tokio_current_thread`` (see test `package_rust_interop_async_rejects_unsupported_thread_affinity` in `rust_interop_async_contract_tests.rs:126`). A user copy-pasting the doc example fails the very contract this milestone documents.
+
+Per DoD: "Public and internal docs are aligned with the architecture document." `internal_docs/rust_interop_architecture.md` does not list `send` anywhere as a `thread_affinity` symbol.
+
+Remediation: drop the decorator entirely (Send is the default for async returns) or replace with `@rust.async(thread_affinity=tokio_current_thread)` and add a short sentence saying the default contract already requires `Send`, so the decorator is needed only for current-thread futures. Mirror the wording in `internal_docs/rust_interop_architecture.md` (Async section) so internal + public examples stay in lockstep.
+
+### C2. `docs/rust-interop.mdx:156-164` — `@rust.callback(lifetime=threadsafe, …)` fails callback validation.
+
+The callback registration example writes:
+
+```sifr
+@rust.callback(
+    lifetime=threadsafe,
+    backpressure=bounded(1024),
+    overflow=error,
+    shutdown=drain,
+)
+```
+
+`crates/sifr_driver/src/build/rust_interop/callback_validation.rs:132-156` accepts only `backpressure`, `overflow`, `shutdown` and returns ``unsupported `@rust.callback(...)` key `<other>` `` for anything else. `internal_docs/rust_interop_architecture.md:698-723` shows the same example *without* a `lifetime=` key and explicitly enumerates the three legal keys; M39.11's contract grammar never accepted `lifetime` for callbacks. The public example will produce `SIFR-RUST-CB-0001`.
+
+This is the user-facing example called out by the DoD ("user-facing examples for … callback registration") and is the only callback walkthrough in public docs.
+
+Remediation: delete the `lifetime=threadsafe,` line so the example matches the architecture doc verbatim. Replace the surrounding prose ("Thread-safe callback registration requires an explicit callback contract.") with: "Backpressure, overflow, and shutdown behavior must be visible in the declaration; thread-safety is part of the callback type (`ThreadsafeCallback[...]` or `Callable[...]` with an explicit `@rust.callback(...)` contract)." Optional: switch the parameter type to `ThreadsafeCallback[[Event], Result[None, EventError]]` so the example mirrors the canonical architecture form rather than the more general `Callable` (see `internal_docs/rust_interop_architecture.md:704-707`).
+
+## High
+
+### H1. `crates/sifr_analysis/src/completion.rs:113-141` — policy-key completion fires uniformly regardless of decorator kind.
+
+`rust_interop_policy_key_candidates()` returns the union of every policy key across `@rust`, `@rust.async`, `@rust.opaque`, `@rust.zero_copy`, `@rust.view`, and `@rust.callback`. `host/implementation.rs:186` appends that union whenever `prefix.contains('(')` (completion.rs:41-44), so:
+
+- Inside `@rust.callback(...)`, the LSP offers `panic`, `type`, `send`, `sync`, `clone`, `close`, `borrow`, `owner`, `view`, `lifetime`, `mutability` — twelve keys that the validator (`callback_validation.rs`) will reject as ``unsupported `@rust.callback(...)` key``.
+- Inside `@rust.opaque(...)`, the LSP offers `panic`, `owner`, `view`, `lifetime`, `mutability`, `backpressure`, `overflow`, `shutdown`. `opaque_contract.rs:84-143` rejects all eight.
+- Symmetrically for `@rust.zero_copy`, `@rust.view`, `@rust.async`, and `@rust`.
+
+This directly contradicts the architecture's tooling contract: ``Complete canonical Rust interop decorator dotted paths and policy keys (`@rust`, `@rust.async`, `@rust.opaque`, `@rust.zero_copy`, `@rust.view`, `@rust.callback`, and their policy arguments)`` — "their policy arguments" reads naturally as "the policy arguments of that decorator," not "the union of all decorator policy arguments." It also confused C2 above: the docs author appears to have copied a key that the LSP would have happily suggested.
+
+Remediation: extract the decorator kind from the prefix (parse what follows `@rust` up to `(`) and switch the per-decorator key set inside `rust_interop_completion_candidates`. The valid sets are already encoded as match arms in the corresponding validators (`callback_validation.rs:136-156`, `opaque_contract.rs:84-143`, `zero_copy_validation.rs:230-244`, `async_validation.rs:56-65`); centralise them so completion and validation share one table. Add a completion test per decorator that asserts the *negative* set as well (e.g. `@rust.callback(...)` must not surface `lifetime`).
+
+## Medium
+
+### M1. `crates/sifr_analysis/src/completion.rs:32-38` — decorator completion does not trigger on continuation lines.
+
+`prefix` is built from the start of the current line up to the cursor. Multi-line decorator calls (which the milestone's own docs use heavily — see `docs/rust-interop.mdx:113-125` and `:128-147`) put each named argument on its own line, and those lines do not start with `@ru`. The completion shortcuts return `Vec::new()`, so:
+
+- Typing the second argument of `@rust.view(\n    owner=input,\n    lifetime=|` gets zero policy-key suggestions.
+- Every Arrow, DLPack, and view example shipped in `docs/rust-interop.mdx` is multi-line; the LSP cannot help with any of them past the first line.
+
+The DoD says "LSP completion and validation for Rust decorator dotted paths." Completion that disappears for the canonical decorator shape advertised in the same PR's docs is a real gap, not a future enhancement.
+
+Remediation: when the current line's trimmed prefix does not start with `@ru`, scan backwards through preceding lines (or use the parsed module tokens already available via `editor_facts.tokens`) to determine whether the cursor is inside an unclosed `@rust*(...)` decorator call, and offer the policy keys for that decorator. The tokens stream already exposes parenthesis depth; reusing it avoids a brittle line-by-line scanner.
+
+### M2. `crates/sifr_analysis/src/completion.rs:41-44` — policy keys offered immediately after `@rust(`, where the next token is the positional target path.
+
+For `@rust(`, the first argument is always a `TargetPath` (e.g. `crc32fast.hash`), never a policy key. The current logic suggests `panic`, `thread_affinity`, etc. as soon as `(` appears, which steers users toward typing `panic=…` in the slot reserved for the target path. The validator then emits `SIFR-RUST-CONFIG-*` ("decorator requires a Rust target path"), making completion a foot-gun.
+
+Remediation: only enable policy-key completion once we are past the first comma at depth 1 inside the decorator argument list. The token-aware traversal proposed in M1 gives this for free.
+
+## Low
+
+### L1. `crates/sifr_lsp/src/conversion.rs:191-198` — `completionItem` has no `insertText`/`textEdit`, so dotted labels can splice incorrectly.
+
+Selecting `rust.callback` while the cursor sits mid-token at `@rust.cal|` lets the LSP client decide what range to replace. Most clients default to "current word", producing `@rust.rust.callback`. This is pre-existing infrastructure, but it becomes user-visible the moment dotted labels (`rust.async`, `rust.opaque`, `rust.zero_copy`, `rust.view`, `rust.callback`) ship as completion items.
+
+Remediation: emit `filterText: "callback"` (or the last dotted segment) and `insertText: "rust.callback"` for dotted decorator labels, or supply a `textEdit` whose range is the decorator identifier including the `rust.` prefix. The conversion test added at `conversion.rs:580-595` should grow an assertion for the inserted-range behavior so the contract is locked.
+
+### L2. No end-to-end test asserts that `sifr bridge check` and `sifr check` produce identical diagnostics on the same input.
+
+`crates/sifr/src/bridge_cli_tests.rs` covers argument parsing only. Routing is structurally a thin wrapper around `cmd_check` (`cli_model_and_entrypoint.rs:421-443`), so equivalence holds by construction today, but the DoD ("Tooling surfaces the same target resolution and diagnostics as the compiler") is a behavioral promise. A regression that diverges the two paths in a later milestone would slip past the existing argument-parsing tests.
+
+Remediation: add one integration test that drives both commands against a fixture with a known `SIFR-RUST-RESOLVE-*` or `SIFR-RUST-CONFIG-*` violation and asserts the rendered diagnostic codes/messages are identical. Reuse the temp-package scaffolding in `mode_resolution_tests.rs`.
+
+## Observations (non-blocking)
+
+- `docs/rust-interop.mdx:60` references `bridge.hash.map_panic` but the doc never shows a `src/bridges/hash.rs` companion. The crc32fast example two lines above is self-contained; the blake3 example would benefit from a sibling Rust snippet or a forward reference to the tokenizer section so users know where `map_panic` lives.
+- `docs/rust-interop.mdx:163`: the canonical thread-safe-callback example in `internal_docs/rust_interop_architecture.md:704-707` uses `ThreadsafeCallback[[Message], Result[None, KafkaError]]`. The public docs use `Callable[[Event], Result[None, EventError]]`. Both are accepted today; preferring the explicit `ThreadsafeCallback` form mirrors the architecture and makes the threading contract visible at the type site.
+- `crates/sifr_analysis/src/host/tests.rs:397-403` only asserts that `host.completion` returns a result with `AnalysisQueryKind::Completion`. There is no host-level test that the Rust interop candidates appear through the full pipeline (symbol index + interop candidates + ranker). The unit tests in `completion.rs:192-246` exercise the helper in isolation; adding one host-level test would prevent a silent regression if the `host/implementation.rs:186` `candidates.extend(...)` line is ever dropped.
+- `crates/sifr_analysis/Cargo.toml` and `crates/sifr_lint/Cargo.toml` carry `[lib] doctest = false` in this branch. The review brief flagged these as unrelated worktree noise; calling out here only so the PR author confirms they were intentional before merge (they unrelated to milestone scope and should either land in their own PR or be reverted).
+
+## What is good
+
+- `sifr bridge check` routes through the same `cmd_check` → `package_session_for_cwd` → `session.plan_check` → `execute_cargo_plan` / `cmd_check_package_file` pipeline that backs `sifr check` (`cli_model_and_entrypoint.rs:421-443`). There is no parallel diagnostic stack.
+- Rejected designs (`docs/rust-interop.mdx:187-209`) are framed as forbidden forms, not "alternate styles": `@rust("…")` string targets, `extern rust`, `from rust import`, and the `crate=`/`path=` shape are listed without remediation prose that would imply they are configurable.
+- `docs/docs.json:71-75` adds `rust-interop` to the get-started group and the Rust developers landing page (`docs/guides/rust-developers/index.mdx:22-24`) cross-links into it; users with Rust backgrounds land on the right doc.
+- Diagnostic family table in `docs/diagnostics/error-codes.mdx:140-156` now links each code to `/errors/SIFR-RUST-*-0001`, and every linked page exists under `docs/errors/`.
+- Trust-policy keys quoted in the docs (`rust-build-scripts`, `rust-proc-macros`, `native-links`, `unsafe-rust-bridges`, `rust-no-panic`, `rust-panic-abort`) match the schema in `crates/sifr_package/src/manifest/sifr_fields.rs:73-109`. `[rust].bridge-version` and `[rust].bridges` likewise match `sifr_fields.rs:148-172`.
+- LSP completion kind mapping (`crates/sifr_lsp/src/conversion.rs:511-521`) and its test (`:580-595`) cover the two new kinds (`decorator` → 15, `property` → 10) introduced for Rust interop.
+
+## Required for Round 2
+
+C1, C2, and H1 must be resolved before the milestone can be closed. M1 and M2 should be addressed in the same PR if H1 is fixed by sharing a decorator-kind dispatcher (they collapse into one change). L1, L2, and the observations may be deferred to follow-ups but should be tracked.

--- a/plans/reviews/active/rust-interop-milestone39-12-review-round2.md
+++ b/plans/reviews/active/rust-interop-milestone39-12-review-round2.md
@@ -1,0 +1,87 @@
+# M39.12 Rust Interop Tooling, Diagnostics, Docs — Review Round 2
+
+Branch: `phase39-rust-interop-m39-12`
+Scope: items listed under `milestone_39_12` in `plans/phases/39_rust_interop.md`.
+Result: **Reviewer is satisfied.** All four round 1 blocking findings (C1, C2, H1, M1, M2) are resolved. Two non-blocking carry-overs (L1, L2) plus the doctest worktree noise remain as previously documented.
+
+## Verification of round 1 blockers
+
+### C1 — async example no longer asserts a rejected `thread_affinity` symbol — resolved.
+
+`docs/rust-interop.mdx:92-104` now reads:
+
+> Async Rust interop must be declared on an `async def`. By default, returned futures must be `Send`; add `@rust.async(thread_affinity=tokio_current_thread)` only for explicitly current-runtime futures.
+>
+> ```sifr
+> @rust(bridge.http.fetch_text, panic=map_error(bridge.http.map_panic))
+> async def fetch_text(url: str) -> Result[str, HttpError | RustPanicError]: ...
+> ```
+
+This matches `crates/sifr_driver/src/build/rust_interop/async_validation.rs:55-67` (only `none` and `tokio_current_thread` are accepted) and `internal_docs/rust_interop_architecture.md:597-615` (`Send` is the default async contract; current-thread is the only opt-out).
+
+### C2 — callback example no longer uses a rejected `lifetime=` key — resolved.
+
+`docs/rust-interop.mdx:151-164` now reads:
+
+> Backpressure, overflow, and shutdown behavior must be visible in callback registration declarations. Thread-safety is part of the callback type and the explicit `@rust.callback(...)` contract.
+>
+> ```sifr
+> @rust.callback(
+>     backpressure=bounded(1024),
+>     overflow=error,
+>     shutdown=drain,
+> )
+> @rust(bridge.events.subscribe, panic=map_error(bridge.events.map_panic))
+> def subscribe(handler: ThreadsafeCallback[[Event], Result[None, EventError]]) -> Result[Subscription, EventError | RustPanicError]: ...
+> ```
+
+The keys match `crates/sifr_driver/src/build/rust_interop/callback_validation.rs:136-156` exactly. The recommended remediation from round 1 (switch the parameter type to `ThreadsafeCallback[...]` to mirror `internal_docs/rust_interop_architecture.md:704-707`) was also adopted.
+
+### H1 — policy-key completion is now per-decorator — resolved.
+
+`crates/sifr_analysis/src/completion.rs:228-275` dispatches on `RustInteropCompletionDecorator`, and each arm matches its validator:
+
+- `Function → ["panic"]`, matching `panic_validation.rs:125-149` (only `panic` is consumed; nothing else is suggested).
+- `Async → ["thread_affinity"]`, matching `async_validation.rs:55-77`.
+- `Opaque → ["type","send","sync","clone","close","borrow","thread_affinity"]`, matching `opaque_contract.rs:84-143` and `internal_docs/rust_interop_architecture.md:152-170`.
+- `ZeroCopy → ["owner","view"]`, matching `zero_copy_validation.rs:225-251`.
+- `View → ["owner","lifetime","mutability","send","sync"] + advanced data keys`, matching `zero_copy_validation.rs:254-291` plus `advanced_data_validation.rs:162-175`.
+- `Callback → ["backpressure","overflow","shutdown"]`, matching `callback_validation.rs:136-156`.
+
+Three negative-set tests guard the regression that round 1 flagged (`completion.rs:374-413`): callback excludes `lifetime`/`panic`, opaque excludes `backpressure`/`owner`, view excludes `backpressure`. The host pipeline is now covered too at `crates/sifr_analysis/src/host/tests.rs:231-257` — observation 3 from round 1 is also resolved.
+
+### M1 — multi-line decorator completion works — resolved.
+
+`crates/sifr_analysis/src/completion.rs:145-176` walks backward from the cursor for `@rust`, then parses the suffix (`parse_decorator_suffix` at `:189-204`) and the argument depth (`policy_keys_available_before_cursor` at `:206-226`). The canonical multi-line shape used in `docs/rust-interop.mdx:110-146` is locked by `completion.rs:415-434` (`@rust.view(\n    owner=input,\n    schema=\n)` returns `lifetime`, `schema`, `protocol`).
+
+### M2 — `@rust(` no longer suggests policy keys before the target separator — resolved.
+
+`completion.rs:206-226` only returns `policy_keys_available = true` when `decorator != Function` OR a `,` was observed at depth 1. `completion.rs:436-461` locks this directly: `@rust()` returns empty, `@rust(bridge.hash, )` returns `panic`.
+
+## Other DoD checks
+
+- **Tooling parity** — `cli_model_and_entrypoint.rs:421-443` routes `sifr bridge check` through `cmd_check` with the same selection/lock-mode shape used by `Commands::Check` (`:444-466`). There is no second diagnostic stack, no second metadata path, and no command-specific filter. Argument-parsing coverage is at `bridge_cli_tests.rs:4-37`.
+- **Docs alignment** — diagnostic family table at `docs/diagnostics/error-codes.mdx:138-155` links each `SIFR-RUST-*` family to its `/errors/SIFR-RUST-*-0001` page; all ten target pages exist under `docs/errors/`. Trust policy keys in `docs/packages/manifest.mdx:161-168` and `docs/rust-interop.mdx:22-34` match `crates/sifr_package/src/manifest/sifr_fields.rs` (no schema drift).
+- **LSP completion kinds** — `crates/sifr_lsp/src/conversion.rs:511-521` maps `decorator → 15` and `property → 10`, locked by `:579-594`.
+- **Rejected designs** — `docs/rust-interop.mdx:185-207` lists `@rust("crc32fast::hash")`, `extern rust`, `from rust import`, and `@rust(crate=..., path=...)` as invalid forms without remediation prose. The closing sentence at `:207` explicitly forbids the three banned silent fallbacks (zero-copy → copy, hidden Tokio runtime, unwinding panic in recoverable builds).
+- **User-facing examples** — `docs/rust-interop.mdx` ships the six required walkthroughs (crc32fast direct, blake3 with `map_error`, tokenizer opaque handle, async HTTP, Arrow + DLPack zero-copy/view stacks, and threadsafe callback registration).
+
+## Non-blocking carry-overs
+
+### L1 (deferred from round 1) — `completion_item` still emits no `insertText`/`textEdit`.
+
+`crates/sifr_lsp/src/conversion.rs:191-198` returns only `label`, `kind`, `detail`, and `data`. Dotted labels (`rust.callback`, etc.) can still be spliced by the client into `@rust.rust.callback` when the cursor sits mid-token. Round 1 categorised this as Low and deferrable; flagging again so it stays on the M39.13 / follow-up list. Remediation unchanged: emit `filterText` + `insertText` for dotted decorator labels, then extend the existing kind-mapping test at `conversion.rs:579-594` with an inserted-text assertion.
+
+### L2 (deferred from round 1) — no end-to-end test asserts `sifr bridge check` and `sifr check` produce identical diagnostics.
+
+`crates/sifr/src/bridge_cli_tests.rs` still covers argument parsing only. `mode_resolution_tests.rs` adds no bridge fixture (grep for `bridge` finds only an unrelated `rust_member` Cargo manifest at `:517-528`). Equivalence holds by construction today, but the DoD wording — "Tooling surfaces the same target resolution and diagnostics as the compiler" — is a behavioural promise that should be locked with one regression test. Remediation unchanged: drive both commands against a shared fixture and assert identical `RenderedDiagnostic` output.
+
+## Observations (non-blocking)
+
+- `crates/sifr_analysis/Cargo.toml` and `crates/sifr_lint/Cargo.toml` add `[lib] doctest = false` (validation support). These changes are unrelated to M39.12 scope. Per the reviewer brief, they should land in a separate PR or be reverted before merge of this milestone, but they do not block the technical correctness of the M39.12 work.
+- `crates/sifr_analysis/src/completion.rs:189-204`: the decorator suffix parser uses raw `strip_prefix`, so `.viewer` would briefly match `.view` (next char check then fails on `(`). The current flow rejects the false hit safely. Worth tightening if any new decorator name shares a prefix with an existing one; not a real bug today.
+- `docs/rust-interop.mdx:60` references `bridge.hash.map_panic` but the doc never shows a `src/bridges/hash.rs` companion (the crc32fast example two lines above is self-contained). Round 1 observation; still present and still non-blocking.
+
+## Sign-off
+
+C1, C2, H1, M1, and M2 are resolved with corresponding negative-set tests. The M39.12 implementation is technically complete. Recommend addressing L1/L2 and clearing the unrelated `doctest = false` worktree noise as their own follow-up changes; this milestone PR is otherwise mergeable.


### PR DESCRIPTION
## Summary

Implements Phase 39 milestone 39.12 tooling, diagnostics, and documentation for Rust interop.

- Add `sifr bridge check` as a package-check routed command for Rust bridge projection/probe validation.
- Add Rust interop LSP completion candidates for canonical decorator paths and decorator-specific policy keys, including multi-line decorator calls and `@rust(...)` target-position handling.
- Map Rust interop completion kinds to LSP decorator/property kinds.
- Publish Rust interop docs covering direct bindings, local/shared bridges, opaque handles, async, zero-copy, callbacks, trust policy, diagnostics families, repair workflows, examples, and rejected designs.
- Align internal architecture tooling notes and package/CLI/diagnostic docs.
- Record reviewer rounds in `plans/reviews/active/rust-interop-milestone39-12-review-round{1,2}.md`; round 2 is satisfied.

## Validation

Passed:

- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `git diff --cached --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `python3 scripts/check_file_size_guardrails.py`
- `CARGO_TARGET_DIR=target/m39_12_test cargo test -p sifr_analysis rust_interop_completion -- --nocapture`
- `CARGO_TARGET_DIR=target/m39_12_test cargo test -p sifr_analysis completion_query_includes_rust_interop_policy_candidates -- --nocapture`
- `CARGO_TARGET_DIR=target/m39_12_test cargo test -p sifr_lsp completion_conversion_maps_rust_interop_kinds_to_lsp_kinds -- --nocapture`
- `CARGO_TARGET_DIR=target/m39_12_test cargo test -p sifr bridge_check_cli_parses_workspace_selection_and_lock_flags -- --nocapture`
- `CARGO_TARGET_DIR=target/m39_12_test cargo test -p sifr_analysis -- --nocapture`
- `CARGO_TARGET_DIR=target/m39_12_test cargo test -p sifr_lsp -- --nocapture`
- `cargo test -p sifr --bin sifr -- --nocapture --test-threads=1`
- `uv run --project verification python -m sifr_verify areas run --area core_language --suite audit-fixtures --result-json target/verification/areas/core-language-rerun-results.json`
- `uv run --project verification python -m sifr_verify areas run --area performance --suite frontend-syntax-guardrails --result-json target/verification/areas/performance-frontend-syntax-rerun-results.json`
- `uv run --project verification python -m sifr_verify areas run --area performance --suite smoke --result-json target/verification/areas/performance-smoke-rerun-results.json`
- `uv run --project verification python -m sifr_verify areas run --area developer_tooling --suite static --suite lsp-smoke --result-json target/verification/areas/developer-tooling-m39-12-rerun-results.json`
- `uv run --project verification python -m sifr_verify areas run --area generated_code_quality --suite smoke --result-json target/verification/areas/generated-code-quality-m39-12-rerun-results.json`
- `uv run --project verification python -m sifr_verify areas run --area algorithmic_compatibility --suite profile-manifest --result-json target/verification/areas/algorithmic-compatibility-m39-12-rerun-results.json`
- `uv run --project verification python -m sifr_verify areas run --area runtime_platform --suite platform-golden --suite platform-support-matrix --suite platform-evidence --result-json target/verification/areas/runtime-platform-m39-12-rerun-results.json`

Facade notes:

- `scripts/run_all_tests.sh --profile create-pr` was run three times.
- The first two runs failed in `core_language` audit fixtures due hard 10s per-fixture timeouts (`exit=124`); direct fixture checks and a direct `core_language --suite audit-fixtures` rerun passed with all smoke fixtures around 2.2s.
- The third run progressed past coverage matrix, core guardrails/audits, diagnostics, Python interop, and frontend/syntax guardrails, then the exec session terminated with exit 143 during later crate compilation before writing a final lane report. The affected/relevant remaining selected areas listed above were rerun directly and passed.

## Reviewer

- Round 1 found invalid docs examples and completion-policy gaps.
- Round 2 verified C1/C2/H1/M1/M2 were resolved and says: reviewer is satisfied.