### PR TITLE
Fix LSP stdlib analysis context

### DIFF
--- a/crates/sifr_analysis/src/host.rs
+++ b/crates/sifr_analysis/src/host.rs
@@ -7,5 +7,7 @@ pub use implementation::*;
 mod overlay_updates;
 mod snapshot_queries;
 #[cfg(test)]
+mod stdlib_tests;
+#[cfg(test)]
 mod tests;
 mod text_edits;

--- a/crates/sifr_analysis/src/host/implementation.rs
+++ b/crates/sifr_analysis/src/host/implementation.rs
@@ -37,12 +37,18 @@ pub struct AnalysisHost {
 
 impl AnalysisHost {
     pub fn open_project(root: &ProjectRoot) -> Result<Self, Vec<RenderedDiagnostic>> {
-        let session = WorkspaceSession::open_project(root.clone())?;
+        let session = WorkspaceSession::open_project_with_external_defs(
+            root.clone(),
+            sifr_driver::stdlib_external_defs()?,
+        )?;
         Self::new(session)
     }
 
     pub fn open_single_file(input: FrontendInput) -> Result<Self, Vec<RenderedDiagnostic>> {
-        let session = WorkspaceSession::open_single_file(input)?;
+        let session = WorkspaceSession::open_single_file_with_external_defs(
+            input,
+            sifr_driver::stdlib_external_defs()?,
+        )?;
         Self::new(session)
     }
 

--- a/crates/sifr_analysis/src/host/overlay_updates.rs
+++ b/crates/sifr_analysis/src/host/overlay_updates.rs
@@ -11,7 +11,10 @@ impl AnalysisHost {
         root: &ProjectRoot,
         overlays: Vec<(SourcePath, Option<String>, DocumentVersion, SourceText)>,
     ) -> Result<Self, Vec<RenderedDiagnostic>> {
-        let mut session = WorkspaceSession::project(root.clone());
+        let mut session = WorkspaceSession::project_with_external_defs(
+            root.clone(),
+            sifr_driver::stdlib_external_defs()?,
+        );
         for (path, uri, version, source) in overlays {
             session.upsert_overlay(path, uri, version, source, None);
         }
@@ -26,7 +29,11 @@ impl AnalysisHost {
         source: SourceText,
         mode: FrontendMode,
     ) -> Result<Self, Vec<RenderedDiagnostic>> {
-        let mut session = WorkspaceSession::single_file(path.clone(), mode);
+        let mut session = WorkspaceSession::single_file_with_external_defs(
+            path.clone(),
+            mode,
+            sifr_driver::stdlib_external_defs()?,
+        );
         session.upsert_overlay(path, uri, version, source, None);
         session.reload()?;
         Self::new(session)

--- a/crates/sifr_analysis/src/host/stdlib_tests.rs
+++ b/crates/sifr_analysis/src/host/stdlib_tests.rs
@@ -1,0 +1,81 @@
+use super::AnalysisHost;
+use crate::{FrontendInput, ProjectRoot};
+use sifr_frontend::{FileId, FrontendMode, SourcePath, SourceText};
+use std::path::PathBuf;
+
+const STDLIB_IMPORT_SAMPLE: &str = "from sifr.random import randint\n\n\
+def main() -> int:\n    value = randint(0, 100)\n    mismatch: int = \"not int\"\n    return mismatch\n";
+
+fn single_file_input(source: &str) -> FrontendInput {
+    FrontendInput {
+        path: SourcePath::new("main.sifr"),
+        source: SourceText::new(source),
+        mode: FrontendMode::SingleFile,
+    }
+}
+
+fn temp_project_dir(name: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("time should move forward")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "sifr_analysis_{name}_{}_{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("temp project should be created");
+    dir
+}
+
+fn assert_stdlib_import_resolves(host: &mut AnalysisHost, file: FileId) {
+    let diagnostics = host
+        .diagnostics(file)
+        .expect("diagnostics should query")
+        .into_value();
+    let codes = diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        !codes.contains(&"SIFR-IMPORT-0002"),
+        "stdlib import should resolve in single-file analysis: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&"SIFR-NAME-0002"),
+        "stdlib import should expose imported names in single-file analysis: {codes:?}"
+    );
+    assert!(
+        codes.contains(&"SIFR-TYPE-0002"),
+        "sample should reach semantic type checking: {codes:?}"
+    );
+}
+
+#[test]
+fn single_file_analysis_resolves_embedded_stdlib_imports() {
+    let mut host = AnalysisHost::open_single_file(single_file_input(STDLIB_IMPORT_SAMPLE))
+        .expect("single-file analysis host should load with stdlib definitions");
+    let file = host.files()[0];
+
+    assert_stdlib_import_resolves(&mut host, file);
+}
+
+#[test]
+fn project_analysis_resolves_embedded_stdlib_imports() {
+    let dir = temp_project_dir("stdlib_project");
+    let entrypoint = dir.join("main.sifr");
+    std::fs::write(&entrypoint, STDLIB_IMPORT_SAMPLE).expect("project source should be written");
+    let root = ProjectRoot {
+        root: SourcePath::new(&dir),
+        entrypoint: SourcePath::new(&entrypoint),
+    };
+
+    let mut host =
+        AnalysisHost::open_project(&root).expect("project analysis host should load stdlib defs");
+    let file = host
+        .document_file_for_path(&entrypoint)
+        .expect("entrypoint should be indexed");
+
+    assert_stdlib_import_resolves(&mut host, file);
+    std::fs::remove_dir_all(dir).expect("temp project should be removed");
+}

--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -31,6 +31,7 @@ pub use frontend::{
     lower_source, parse_source, type_check_source,
 };
 pub use sifr_codegen::LoweringStats;
+pub use stdlib::external_defs as stdlib_external_defs;
 pub use test_runner::run_tests;
 pub use workspace::{find_workspace_root, SifrWorkspaceConfig, WorkspaceRoot};
 

--- a/crates/sifr_driver/src/stdlib/bootstrap.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap.rs
@@ -16,6 +16,10 @@ pub(crate) fn compile_stdlib() -> Result<StdlibCompiled, Vec<RenderedDiagnostic>
     get_or_init_stdlib_cache(&STDLIB_COMPILED_CACHE, compile_stdlib_uncached)
 }
 
+pub fn external_defs() -> Result<ExternalDefs, Vec<RenderedDiagnostic>> {
+    compile_stdlib().map(|compiled| compiled.defs)
+}
+
 pub(crate) fn compile_stdlib_uncached() -> Result<StdlibCompiled, Vec<RenderedDiagnostic>> {
     compile_stdlib_uncached_impl()
 }

--- a/crates/sifr_driver/src/stdlib/mod.rs
+++ b/crates/sifr_driver/src/stdlib/mod.rs
@@ -5,6 +5,7 @@ mod re_exports;
 mod types;
 
 pub(crate) use bootstrap::compile_stdlib;
+pub use bootstrap::external_defs;
 pub(crate) use types::StdlibCompiled;
 
 #[cfg(test)]

--- a/crates/sifr_frontend/src/graph_cache_and_queries.rs
+++ b/crates/sifr_frontend/src/graph_cache_and_queries.rs
@@ -391,6 +391,14 @@ impl FrontendContext {
         root: &ProjectRoot,
         provider: &mut impl SourceProvider,
     ) -> Result<Self, Vec<RenderedDiagnostic>> {
+        Self::load_project_with_provider_and_external_defs(root, provider, ExternalDefs::default())
+    }
+
+    pub fn load_project_with_provider_and_external_defs(
+        root: &ProjectRoot,
+        provider: &mut impl SourceProvider,
+        external_defs: ExternalDefs,
+    ) -> Result<Self, Vec<RenderedDiagnostic>> {
         let entrypoint = root.entrypoint.as_path();
         let project_dir = root.root.as_path();
         let entry_source = provider.read_file(entrypoint).map_err(|error| {
@@ -487,8 +495,8 @@ impl FrontendContext {
             cache_target,
             compiler_options,
             package_config_identity,
-            base_external_defs: ExternalDefs::default(),
-            external_defs: ExternalDefs::default(),
+            base_external_defs: external_defs.clone(),
+            external_defs,
             lowering_modules: BTreeSet::new(),
         };
         context.rebuild_edges();

--- a/crates/sifr_frontend/src/workspace_session.rs
+++ b/crates/sifr_frontend/src/workspace_session.rs
@@ -8,6 +8,7 @@ use super::{
     WorkspaceStatusSnapshot, WorkspaceTracePhase, WorkspaceTraceState,
 };
 use sifr_diagnostics::RenderedDiagnostic;
+use sifr_lowering::ExternalDefs;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -212,6 +213,7 @@ pub struct WorkspaceSession {
     snapshot_source_dependencies: Option<Arc<Vec<SourceDependency>>>,
     snapshot_compiler_options: Arc<WorkspaceCompilerOptions>,
     snapshot_package_config_identity: Arc<WorkspacePackageConfigIdentity>,
+    base_external_defs: ExternalDefs,
     dirty_scope_report: WorkspaceDirtyScopeReport,
     cache_registry: WorkspaceCacheRegistryHandles,
     residency: WorkspaceResidencyState,
@@ -225,8 +227,22 @@ impl WorkspaceSession {
         Ok(session)
     }
 
+    pub fn open_project_with_external_defs(
+        root: ProjectRoot,
+        external_defs: ExternalDefs,
+    ) -> Result<Self, Vec<RenderedDiagnostic>> {
+        let mut session = Self::project_with_external_defs(root, external_defs);
+        session.reload()?;
+        Ok(session)
+    }
+
     #[must_use]
     pub fn project(root: ProjectRoot) -> Self {
+        Self::project_with_external_defs(root, ExternalDefs::default())
+    }
+
+    #[must_use]
+    pub fn project_with_external_defs(root: ProjectRoot, external_defs: ExternalDefs) -> Self {
         let compiler_options = WorkspaceCompilerOptions {
             mode: FrontendMode::ProjectEntrypoint,
         };
@@ -235,13 +251,29 @@ impl WorkspaceSession {
             entrypoint: Some(root.entrypoint.clone()),
         };
         let target = WorkspaceSessionTarget::Project(root);
-        Self::new(target, compiler_options, package_config_identity)
+        Self::new(
+            target,
+            compiler_options,
+            package_config_identity,
+            external_defs,
+        )
     }
 
     pub fn open_single_file(input: FrontendInput) -> Result<Self, Vec<RenderedDiagnostic>> {
-        let mut session = Self::single_file(input.path.clone(), input.mode);
+        Self::open_single_file_with_external_defs(input, ExternalDefs::default())
+    }
+
+    pub fn open_single_file_with_external_defs(
+        input: FrontendInput,
+        external_defs: ExternalDefs,
+    ) -> Result<Self, Vec<RenderedDiagnostic>> {
+        let mut session =
+            Self::single_file_with_external_defs(input.path.clone(), input.mode, external_defs);
         session.single_file_source = Some(input.source.clone());
-        session.context = Some(FrontendContext::load_single_file(input)?);
+        session.context = Some(FrontendContext::load_single_file_with_external_defs(
+            input,
+            session.base_external_defs.clone(),
+        )?);
         session.refresh_residency();
         session.record_compiler_phase_trace();
         Ok(session)
@@ -249,16 +281,31 @@ impl WorkspaceSession {
 
     #[must_use]
     pub fn single_file(path: SourcePath, mode: FrontendMode) -> Self {
+        Self::single_file_with_external_defs(path, mode, ExternalDefs::default())
+    }
+
+    #[must_use]
+    pub fn single_file_with_external_defs(
+        path: SourcePath,
+        mode: FrontendMode,
+        external_defs: ExternalDefs,
+    ) -> Self {
         let compiler_options = WorkspaceCompilerOptions { mode };
         let package_config_identity = WorkspacePackageConfigIdentity::default();
         let target = WorkspaceSessionTarget::SingleFile(WorkspaceSingleFileTarget { path, mode });
-        Self::new(target, compiler_options, package_config_identity)
+        Self::new(
+            target,
+            compiler_options,
+            package_config_identity,
+            external_defs,
+        )
     }
 
     fn new(
         target: WorkspaceSessionTarget,
         compiler_options: WorkspaceCompilerOptions,
         package_config_identity: WorkspacePackageConfigIdentity,
+        base_external_defs: ExternalDefs,
     ) -> Self {
         let residency = WorkspaceResidencyState::for_target(&target);
         let mut trace = WorkspaceTraceState::default();
@@ -276,6 +323,7 @@ impl WorkspaceSession {
             next_snapshot_id: 0,
             snapshot_compiler_options: Arc::new(compiler_options),
             snapshot_package_config_identity: Arc::new(package_config_identity),
+            base_external_defs,
             snapshot_overlays: None,
             snapshot_source_dependencies: None,
             dirty_scope_report: WorkspaceDirtyScopeReport::default(),
@@ -294,7 +342,11 @@ impl WorkspaceSession {
                     overlay_provider.insert_overlay(overlay);
                 }
                 let mut provider = TrackingSourceProvider::new(overlay_provider);
-                let context = FrontendContext::load_project_with_provider(root, &mut provider)?;
+                let context = FrontendContext::load_project_with_provider_and_external_defs(
+                    root,
+                    &mut provider,
+                    self.base_external_defs.clone(),
+                )?;
                 let (_, dependencies) = provider.into_parts();
                 self.context = Some(context);
                 self.source_dependencies = dependencies;
@@ -302,7 +354,10 @@ impl WorkspaceSession {
             }
             WorkspaceSessionTarget::SingleFile(target) => {
                 let input = self.single_file_input(target);
-                self.context = Some(FrontendContext::load_single_file(input)?);
+                self.context = Some(FrontendContext::load_single_file_with_external_defs(
+                    input,
+                    self.base_external_defs.clone(),
+                )?);
                 self.source_dependencies = Vec::new();
                 self.snapshot_source_dependencies = None;
             }

--- a/internal_docs/lsp_server.md
+++ b/internal_docs/lsp_server.md
@@ -71,6 +71,13 @@ session. Current implementation reality:
   files without a workspace manifest keep the single-file fallback. Both paths
   wrap `WorkspaceSession` and update unsaved editor buffers through
   `WorkspaceSession` overlays.
+- All LSP analysis hosts are compiler-backed with embedded Sifr stdlib
+  definitions from `sifr_driver::stdlib_external_defs()`. Standalone files,
+  `sifr.toml` workspaces, and Cargo-backed Sifr package folders therefore
+  resolve `sifr.*` imports the same way the CLI does before editor diagnostics,
+  completion, navigation, or generated-Rust queries run. If stdlib bootstrap
+  fails, host open reports that compiler failure instead of continuing with an
+  empty semantic context.
 - LSP notifications update `DocumentStore` first, then feed the latest document
   text/version into the session-owned analysis workspace before diagnostics or
   semantic requests capture snapshots.
@@ -192,7 +199,9 @@ LSP 3.17 is the developer tooling surface target. Any `lsp-types` version bump r
 `verification/areas/developer_tooling/lsp_protocol_smoke.py` initializes the server, opens a
 `.sifr` buffer, validates versioned push diagnostics, runs the required
 document/workspace query families, exercises generated-Rust and test commands,
-and shuts down through `shutdown` plus `exit`.
+checks embedded stdlib import resolution across standalone, `sifr.toml`
+workspace, and Cargo-backed package layouts, and shuts down through `shutdown`
+plus `exit`.
 
 `verification/areas/developer_tooling/lsp_protocol_stress.py` covers cancellation
 notifications, full sync, stale-version rejection, invalid-range protocol

--- a/internal_docs/typescript_go_architecture_transfer_workspace_session.md
+++ b/internal_docs/typescript_go_architecture_transfer_workspace_session.md
@@ -32,6 +32,14 @@ single-file source captured during `open_single_file`. Single-file reloads do
 not perform provider reads, so their tracked dependency list is intentionally
 empty in workspace-session owner.
 
+`WorkspaceSession` also stores caller-provided base `ExternalDefs`. Callers that
+do not supply definitions keep an empty base, while `sifr_analysis::AnalysisHost`
+passes the compiler's embedded stdlib definitions from
+`sifr_driver::stdlib_external_defs()`. Every project and single-file reload
+clones those base definitions before rebuilding workspace exports, so editor
+analysis cannot lose `sifr.*` imports after opening, changing, or refreshing a
+document.
+
 ## Snapshot Model
 
 `WorkspaceSnapshot` currently freezes:

--- a/plans/reviews/active/lsp-stdlib-analysis-context-claude-review-1.md
+++ b/plans/reviews/active/lsp-stdlib-analysis-context-claude-review-1.md
@@ -1,0 +1,26 @@
+Review complete — analyzed the diff across the 11 changed files plus the new `host/stdlib_tests.rs` and traced the data flow through reload, signature-change invalidation, and overlay paths.
+
+## Findings, by severity
+
+**Blocking: none.** The architecture is sound:
+- `WorkspaceSession` owns `base_external_defs` (sifr_frontend/src/workspace_session.rs:216) and clones it into `FrontendContext` on every reload (workspace_session.rs:345-360).
+- `FrontendContext` carries its own `base_external_defs` and, on signature-affecting edits, resets `external_defs = base_external_defs.clone()` then re-extends from lowered modules (graph_cache_and_queries.rs:561-562, 890-896). Stdlib defs survive both project reloads and partial invalidations.
+- All four AnalysisHost entry points pass `sifr_driver::stdlib_external_defs()` (host/implementation.rs:40,48 and host/overlay_updates.rs:14,32) — no LSP path bypasses the seed.
+- Crate dependency graph is unchanged: `sifr_analysis` already depends on `sifr_driver`, so the new `pub use stdlib::external_defs as stdlib_external_defs` (sifr_driver/src/lib.rs:34) is a pure re-export with no layering change.
+- `compile_stdlib()` is `OnceLock`-cached, so `stdlib_external_defs()` is one compile + one ExternalDefs clone per host open.
+
+**Non-blocking suggestions:**
+
+1. **TYPE-0002 proxy is fragile.** `host/stdlib_tests.rs:38-41` and `lsp_protocol_smoke.py:350-353` use the presence of `SIFR-TYPE-0002` as positive evidence that the import resolved. That works only because `sifr.random.randint` returns `Result[int, ValueError]` (lib/sifr/random.sifr:349) and the sample assigns it to `int`. If that signature is ever loosened to return bare `int`, the test will fail not because of a regression but because the deliberate mismatch evaporated. Consider asserting "no IMPORT/NAME diagnostic at the import or call site" plus a positive symbol-resolution probe (e.g. hover/definition on `randint`) rather than depending on a TYPE diagnostic landing.
+
+2. **Double clone per reload.** `WorkspaceSession::reload` clones `base_external_defs` (workspace_session.rs:348), then `FrontendContext::load_project_with_provider_and_external_defs` clones the value again into its own `base_external_defs` (graph_cache_and_queries.rs:498-499). For ExternalDefs containing the full stdlib BTreeMaps this is two O(n) copies per reload. Wrapping `base_external_defs` in `Arc<ExternalDefs>` (with copy-on-write at the signature-invalidation point) would halve allocation cost per edit cycle without changing semantics.
+
+3. **Error surface change.** Previously `AnalysisHost::open_*` could succeed when stdlib was broken; now they propagate any stdlib compile failure (host/implementation.rs:42, 50). Matches CLI and is arguably more correct, but is a behavior change worth a sentence in `internal_docs/lsp_server.md` ("LSP will surface stdlib compile errors at host open").
+
+4. **No project-mode Rust unit test.** `stdlib_tests.rs` exercises only `open_single_file`. The project path is covered transitively by the Python smoke, but a `cfg(test)` fixture using a tempdir + ProjectRoot would catch project-specific regressions (e.g., wiring `with_external_defs` into `project_with_external_defs`) without requiring the LSP harness. Cheap to add.
+
+5. **Verification doesn't replicate the scribbles repro path.** The three covered contexts (standalone, `sifr.toml` workspace, Cargo-backed package) are functionally equivalent to the original bug, but the explicit scribbles `SIFR_LSP_COMMAND` check is recorded only as ad-hoc validation, not as a committed test. The standalone tempdir case is the right surrogate; just noting that the literal repro is not in the suite.
+
+6. **`stdlib/mod.rs` now mixes wiring with logic.** `external_defs()` (sifr_driver/src/stdlib/mod.rs:16-18) lives in mod.rs alongside `mod`/`pub use` lines. Style-only — moving the helper next to `compile_stdlib` in `bootstrap.rs` and re-exporting through mod.rs would keep mod.rs as wiring.
+
+7. **Manifest schema in smoke uses forbidden production keys.** `write_cargo_backed_sifr_package` emits `[exports]` and `[[bin]]` (lsp_protocol_smoke.py:386-391), which `check_package_manager_guardrails.py:329-332` rejects for production manifests. This is allowed for a synthetic test fixture, and validation passed — but if the package-management guardrail ever expands to scan verification fixtures, this would trip. Worth a one-line comment in the smoke noting the fixture is intentionally non-production.

--- a/plans/reviews/active/lsp-stdlib-analysis-context-claude-review-2.md
+++ b/plans/reviews/active/lsp-stdlib-analysis-context-claude-review-2.md
@@ -1,0 +1,25 @@
+## Review: LSP stdlib analysis-context fix
+
+### Blocking findings
+
+**None.** The wiring is consistent, the base defs are preserved correctly across reloads, and the regression tests cover both single-file and project modes plus three LSP layouts (loose file, `sifr.toml` workspace, `sifr.toml` + `Cargo.toml`). I traced:
+
+- All four `AnalysisHost` entry points (`open_project`, `open_single_file`, `open_project_with_overlays`, `open_single_file_overlay`) now route through the `_with_external_defs` constructors — `implementation.rs:39-53`, `overlay_updates.rs:10-40`.
+- `WorkspaceSession` stores the caller-provided `base_external_defs` and the only assignment to `self.external_defs` after construction is the reset at `graph_cache_and_queries.rs:561` (`= self.base_external_defs.clone()`), so reloads and graph-structure invalidations keep stdlib defs.
+- `FrontendContext::load_single_file_with_external_defs` / `load_project_with_provider_and_external_defs` seed both `base_external_defs` and `external_defs` with the caller's defs (`graph_cache_and_queries.rs:368-369`, `498-499`), so the very first lowering already sees `sifr.*`.
+- `sifr_driver::stdlib_external_defs()` reuses the existing `OnceLock` cache (`cache.rs:8-13` → `bootstrap.rs:19-21`), so failures are propagated deterministically and successes are amortized.
+- LSP error handling already treats `AnalysisHost::open_*` failures as load diagnostics (`analysis_workspace.rs:288-297`, `:454-458`), which matches the new doc claim that bootstrap failure surfaces as compiler diagnostics rather than empty context.
+
+### Non-blocking suggestions
+
+1. **Defs cache shape.** `stdlib_external_defs()` (`bootstrap.rs:19-21`) clones the entire cached `StdlibCompiled` (defs + the much larger `StdlibCode`) on every call only to drop `code`. For `AnalysisHost` opens this is a wasted clone; consider memoizing the `defs` separately or returning by `Arc<ExternalDefs>`.
+
+2. **Hot-path reload clones.** `base_external_defs` is cloned at `workspace_session.rs:300, 304, 345, 357` plus the reset path at `graph_cache_and_queries.rs:561`. `ExternalDefs` is ~10 nested `HashMap`s; wrapping it in `Arc<ExternalDefs>` would make session reloads near-free without changing semantics, since the reset path treats it as immutable.
+
+3. **"Cargo-backed" fixture framing.** `write_cargo_backed_sifr_package` (`lsp_protocol_smoke.py:376-416`) adds `Cargo.toml` and `src/lib.rs`, but `workspace_root_for` (`crates/sifr_lsp/src/analysis_workspace.rs:580-590`) only keys off `sifr.toml`. So this fixture and `write_sifr_workspace_manifest` exercise the same LSP code path; the value is the richer manifest (`[exports]`, `[[bin]]`), not the Cargo files. The comment at `lsp_protocol_smoke.py:377-379` could clarify that — otherwise a future reader may assume the LSP looks at `Cargo.toml`.
+
+4. **Trace CLI consistency.** `crates/sifr/src/trace_cli.rs:39,43` still calls `WorkspaceSession::open_project` / `open_single_file` with default empty defs. This is out of the LSP scope of this PR and not a regression, but it's the same shape of bug — a `sifr trace foo.sifr` where `foo.sifr` imports `sifr.random` would carry the old behavior. Worth a follow-up.
+
+5. **Temp-dir leak on failure.** `crates/sifr_analysis/src/host/stdlib_tests.rs:80` only removes the project dir on the success path. A panicking assertion above leaves the temp tree behind. Minor — the same pattern exists in `trace_cli.rs` tests — but a `defer`-style guard would be cleaner.
+
+6. **Doc nit.** `internal_docs/typescript_go_architecture_transfer_workspace_session.md:35-40` says "Default frontend constructors use an empty base for low-level tests" — strictly true, but the default-constructor callers still include `trace_cli.rs` and `WorkspaceSession::project()`/`single_file()` in `workspace_session_tests.rs`. Phrasing it as "callers that don't supply defs (low-level tests, trace CLI) keep the empty base" is more accurate.

--- a/verification/areas/developer_tooling/lsp_protocol_smoke.py
+++ b/verification/areas/developer_tooling/lsp_protocol_smoke.py
@@ -49,6 +49,15 @@ def main() -> int:
     return value
 """
 
+STDLIB_IMPORT_SAMPLE = """\
+from sifr.random import randint
+
+def main() -> int:
+    value = randint(0, 100)
+    mismatch: int = "not int"
+    return mismatch
+"""
+
 def initialize(
     client: LspClient,
     root: Path,
@@ -327,6 +336,104 @@ def run_utf16_diagnostic_range_check(root: Path) -> None:
         client.close()
 
 
+def run_stdlib_import_check(root: Path, source: Path) -> None:
+    source.write_text(STDLIB_IMPORT_SAMPLE, encoding="utf-8")
+    client = LspClient()
+    try:
+        initialize(client, root)
+        diagnostics = open_document(client, source, STDLIB_IMPORT_SAMPLE)
+        codes = {item.get("code") for item in diagnostics}
+        forbidden = {"SIFR-IMPORT-0002", "SIFR-NAME-0002"}
+        if codes & forbidden:
+            raise LspProtocolError(
+                f"stdlib import was diagnosed as unresolved in {root}: {diagnostics}"
+            )
+        if "SIFR-TYPE-0002" not in codes:
+            raise LspProtocolError(
+                f"stdlib import sample did not reach semantic type checking in {root}: {diagnostics}"
+            )
+        client.request("shutdown", {})
+        client.notify("exit", {})
+    finally:
+        client.close()
+
+
+def write_sifr_workspace_manifest(root: Path) -> None:
+    (root / "sifr.toml").write_text(
+        """\
+[package]
+name = "lsp-stdlib-smoke"
+edition = "2026"
+sifr-version = ">=0.3,<0.4"
+
+[source]
+roots = ["."]
+""",
+        encoding="utf-8",
+    )
+
+
+def write_cargo_backed_sifr_package(root: Path) -> None:
+    # Synthetic package-app layout: this fixture intentionally includes
+    # manifest bin/export tables so LSP stdlib resolution is exercised in a
+    # Cargo-backed folder, not only in loose source directories. LSP workspace
+    # discovery keys off sifr.toml; Cargo.toml verifies the same path in a
+    # realistic package directory shape.
+    (root / "sifr.toml").write_text(
+        """\
+[package]
+name = "lsp-stdlib-smoke"
+edition = "2026"
+sifr-version = ">=0.3,<0.4"
+
+[source]
+roots = ["."]
+
+[exports]
+modules = []
+
+[[bin]]
+name = "lsp-stdlib-smoke"
+path = "main.sifr"
+""",
+        encoding="utf-8",
+    )
+    (root / "src").mkdir()
+    (root / "src" / "lib.rs").write_text(
+        "// Pure Sifr package marker. Sifr source lives in sifr.toml source roots.\n",
+        encoding="utf-8",
+    )
+    (root / "Cargo.toml").write_text(
+        """\
+[package]
+name = "lsp-stdlib-smoke"
+version = "0.1.0"
+edition = "2021"
+include = ["Cargo.toml", "sifr.toml", "*.sifr", "src/lib.rs"]
+
+[package.metadata.sifr]
+manifest = "sifr.toml"
+""",
+        encoding="utf-8",
+    )
+
+
+def run_stdlib_import_context_checks() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-lsp-stdlib-single-") as raw:
+        root = Path(raw)
+        run_stdlib_import_check(root, root / "main.sifr")
+
+    with tempfile.TemporaryDirectory(prefix="sifr-lsp-stdlib-workspace-") as raw:
+        root = Path(raw)
+        write_sifr_workspace_manifest(root)
+        run_stdlib_import_check(root, root / "main.sifr")
+
+    with tempfile.TemporaryDirectory(prefix="sifr-lsp-stdlib-package-") as raw:
+        root = Path(raw)
+        write_cargo_backed_sifr_package(root)
+        run_stdlib_import_check(root, root / "main.sifr")
+
+
 def run_smoke() -> None:
     with tempfile.TemporaryDirectory(prefix="sifr-lsp-smoke-") as raw:
         root = Path(raw)
@@ -351,6 +458,7 @@ def run_smoke() -> None:
         run_utf8_negotiation_check(root)
         run_utf16_position_behavior_check(root)
         run_utf16_diagnostic_range_check(root)
+        run_stdlib_import_context_checks()
 
 
 def run_self_test() -> None:


### PR DESCRIPTION
## Summary

Fixes the LSP/editor analysis context so Sifr stdlib imports resolve the same way they do in CLI compilation.

Root cause: `sifr_analysis::AnalysisHost` opened project and single-file `WorkspaceSession`s with empty `ExternalDefs`, while the compiler driver bootstraps embedded stdlib definitions before lowering user code. That made LSP diagnostics report false unresolved import/name errors for imports such as `from sifr.random import randint`.

Changes:
- Thread compiler stdlib `ExternalDefs` from `sifr_driver::stdlib_external_defs()` into all `AnalysisHost` open paths, including overlay-backed sessions.
- Teach `WorkspaceSession` and `FrontendContext` to preserve caller-supplied base `ExternalDefs` across reloads and graph invalidation.
- Add single-file and project-mode Rust regressions for stdlib import resolution.
- Strengthen `verification/areas/developer_tooling/lsp_protocol_smoke.py` to cover standalone files, `sifr.toml` workspaces, and Cargo-backed package-shaped folders.
- Document the LSP stdlib context behavior and the bootstrap-failure surface.
- Include two Claude Opus review artifacts; round 2 reported no blocking findings.

## Validation

- `cargo test -p sifr_analysis stdlib_tests -- --nocapture`
- `python3 verification/areas/developer_tooling/lsp_protocol_smoke.py`
- `python3 scripts/check_file_size_guardrails.py`
- `cargo fmt --check`
- `python3 scripts/check_sifr_driver_maintainability_guardrails.py`
- `cargo test -p sifr_analysis -p sifr_lsp`
- `python3 verification/areas/developer_tooling/runner.py --suite lsp-smoke --suite analysis --suite static`
- Exact `/Users/yaseralnajjar/work/sifr/scribbles/main.sifr` LSP repro: no `SIFR-IMPORT-0002` or `SIFR-NAME-0002`; only the real `SIFR-TYPE-0002` remains.
- `scripts/run_all_tests.sh --profile create-pr` passed with `failures=0`, `blocking_failures=0`; advisory only: warm wall-time budget exceeded.
