### PR TITLE
Populate Rust interop fixture sources

### DIFF
--- a/crates/sifr_lsp/Cargo.toml
+++ b/crates/sifr_lsp/Cargo.toml
@@ -21,5 +21,8 @@ url = { workspace = true }
 insta = { workspace = true }
 tempfile = "3.23.0"
 
+[lib]
+doctest = false
+
 [lints]
 workspace = true

--- a/plans/reviews/active/rust_interop_fixture_sources_review.md
+++ b/plans/reviews/active/rust_interop_fixture_sources_review.md
@@ -1,0 +1,48 @@
+## Code Review: Rust Interop Fixture Source Completion
+
+**No blocking findings.** The diff is shippable; one latent validator bug and a handful of contract-tightening opportunities below.
+
+### Findings (by severity)
+
+#### Low — defensive coding bug in validator
+
+**1. `_validate_fixture_evidence_file` crashes (AttributeError) when `expected_result` is missing instead of reporting cleanly** — `verification/areas/rust_interop/checks/check_fixture_matrix.py:339-346`
+
+```python
+expected_result = manifest_evidence.get("expected_result")
+if not isinstance(expected_result, str) or not expected_result:
+    failures.append(f"{fixture_id}: evidence.{side}.expected_result is required")
+status = matrix_evidence.get("status")
+if expected_result.startswith("future-owned") and status == "passing":   # crashes if None / non-str
+    ...
+if status != "passing" and not expected_result.startswith("future-owned"):  # same
+    ...
+```
+
+All current fixtures populate the field, so it's dormant — but the check is supposed to be defensive. Either `return` after the failure append, or guard the two `.startswith` calls with `isinstance(expected_result, str)`. Fix is one or two lines.
+
+#### Info — validator/README contract gaps (not blockers)
+
+**2. Validator doesn't enforce the `positive/<id>.sifr` / `negative/<id>.sifr` directory layout described in the README** — `check_fixture_matrix.py:305-318`. The validator accepts any in-tree `.sifr` path the manifest points to. A manifest with `evidence.positive.path: "stub.sifr"` at the top level (or worse, `negative/foo.sifr` declared as the positive evidence) would pass. Worth pinning to `Path(side) / f"{matrix_evidence['id']}.sifr"` so the layout match is enforced, not just documented.
+
+**3. Headers in `.sifr` files aren't cross-checked against the manifest's `expected_result` / `execution_kind`** — `check_fixture_matrix.py:328-337`. The required headers are `fixture`/`evidence`/`evidence-status` and (for diagnostic results) `expected-diagnostic`. `# expected-result:` and `# execution-kind:` are present in every file but not validated against the manifest — they can drift silently. Natural extension of the existing header gate.
+
+**4. The "non-empty stub" check is lexical and easy to satisfy** — `check_fixture_matrix.py:325-337`. A file with five comment lines, one of which contains the string `@rust`, `fixture-cargo:`, or `fixture-trust:`, passes. In practice all current fixtures have real decorator declarations, but the check should not be mistaken for "a real fixture exists" — it's "the words appear." Acceptable for contract tier; noting the limitation.
+
+#### Nits
+
+**5. No rationale comment alongside `[lib] doctest = false`** — `crates/sifr_lsp/Cargo.toml:24-25`. The change is consistent with existing precedent — `crates/sifr_analysis/Cargo.toml` and `crates/sifr_lint/Cargo.toml` both already set `doctest = false`, so this isn't unjustified. The only doc-style content in `crates/sifr_lsp/src/` is the module-level `//!` prose in `lib.rs` (no ` ``` ` code fences). A one-liner `# rustdoc tests hang in CI; no doc examples exist in this crate` would protect against a future revert. Not blocking; precedent crates don't have one either.
+
+**6. README documents the four required files but not the `fixture.json` schema** — `verification/areas/rust_interop/README.md`. A fixture author has to read the validator to learn the required keys (`schema_version`, `diagnostic_family`, `evidence.{side}.{id,status,path,expected_result,expected_diagnostic?}`). Minor docs gap.
+
+### What's verified clean
+
+- 31 fixture directories ↔ 31 matrix entries, 1:1; counts match the validation summary (31 `fixture.json`, 31 positive `.sifr`, 31 negative `.sifr`).
+- Every `fixture.json` I sampled mirrors the matrix `id`/`capability`/`tier`/`execution_kind`/`required_crates`/`features` and adds `schema_version`/`diagnostic_family` against the reserved SIFR-RUST-* set; validator confirms this for the full set.
+- Headers in sampled `.sifr` files (across all tiers and both execution kinds) match the validator's required form, and `# fixture-cargo:` / `# fixture-trust:` annotations are used correctly where `@rust(...)` isn't the policy surface (`cargo_locked_offline`, `proc_macro_trust`, `native_build_script`).
+- `status: planned` evidence consistently uses `expected_result: future-owned[-diagnostic]`; `status: passing` evidence consistently uses `pass` or `diagnostic`. The validator's pairing rule is satisfied across all 62 evidence entries.
+- `crates/sifr_lsp/src/` contains no rustdoc code fences, so `doctest = false` doesn't lose coverage.
+
+### Recommendation
+
+Land as-is. Optionally fix finding #1 in this PR (5-line change) since the validator is a CI gate and crashing on malformed input is worse than reporting it. Findings #2–#4 can be tightened in a follow-up — they harden the contract but don't change current behavior.

--- a/plans/reviews/active/rust_interop_fixture_sources_review_2.md
+++ b/plans/reviews/active/rust_interop_fixture_sources_review_2.md
@@ -1,0 +1,25 @@
+I've ignored the deferred MCP/tool reminders — they're harmless and unrelated to this review.
+
+## Follow-up Review: All Prior Findings Addressed
+
+### Finding #1 (defensive crash on missing `expected_result`) — fully fixed
+`check_fixture_matrix.py:346-349` now returns immediately after appending the failure, so the two `.startswith` calls below it can never see `None` or a non-string. The exact fix the prior review recommended.
+
+### Finding #2 (path layout not enforced) — fully fixed
+`check_fixture_matrix.py:316-319` now constructs `expected_path = Path(side) / f"{matrix_evidence['id']}.sifr"` and rejects anything else. A manifest pointing positive evidence at `negative/foo.sifr` or at a top-level stub is now caught.
+
+### Finding #3 (headers can drift from manifest) — fully fixed
+`check_fixture_matrix.py:350-357` now cross-checks `# execution-kind:` and `# expected-result:` against the manifest values, joining the existing `fixture`/`evidence`/`evidence-status`/`expected-diagnostic` gates.
+
+### Finding #4 (lexical "non-empty stub" check) — substantially tightened
+`check_fixture_matrix.py:343` now requires `line.lstrip().startswith("@rust")` — a token *inside a comment line* like `# uses @rust(...)` no longer satisfies it (comments start with `#`, not `@`). The "five lines containing the word @rust" loophole is closed for the decorator marker.
+
+### Potential false positives / blind spots in the new tightening
+- **None against current data.** The three fixtures previously called out as policy-marker-driven (`cargo_locked_offline`, `proc_macro_trust`, `native_build_script`) all carry real `@rust(...)` declarations at line start in both positive and negative sources, so the stricter `@rust` rule doesn't reject them. Validator still reports ok: 31/10/44.
+- **Minor (not actionable):** If `matrix_evidence["id"]` is missing, `expected_path` becomes `Path("positive/None.sifr")` and the error message reads `must be positive/None.sifr`. Confusing, but a separate `id is required` failure is already emitted upstream by `_validate_evidence`, so this only fires alongside that one.
+- **Minor (not actionable):** `# execution-kind:` / `# expected-result:` use `in text` substring matching, same as the existing `fixture`/`evidence` headers — a duplicate occurrence elsewhere in the file would still satisfy the check. Consistent with the prior contract, not a regression.
+- **Minor (not actionable):** `startswith("@rust")` would also match a hypothetical `@rusty(...)`. No such decorator exists today; no real risk.
+- **Unchanged caveat:** the `≥5 stripped lines` body-size heuristic is still lexical; combined with the new `@rust`-at-line-start gate, the realistic empty-stub attack is gone, but the count itself can still be padded with blank-ish lines. Not worth tightening further at the contract tier.
+
+### Verdict
+No remaining actionable findings. The diff is shippable as-is; the validator is now meaningfully harder to mislead than at the time of the prior review.

--- a/verification/areas/rust_interop/README.md
+++ b/verification/areas/rust_interop/README.md
@@ -8,9 +8,26 @@ required by the architecture, records tier assignment, reserves diagnostic
 families, and publishes the compatibility matrix used by docs and reviewers.
 
 The fixture matrix is contract-first. Every fixture must declare both positive
-and negative evidence. A compatibility row can use `supported`, `supported-through-bridge`, or
-`unsupported-by-design` only when both evidence directions are `passing`. Rows that are still `planned` or otherwise incomplete
+and negative evidence, and every fixture directory must contain concrete source
+files for those evidence IDs. A compatibility row can use `supported`,
+`supported-through-bridge`, or `unsupported-by-design` only when both evidence
+directions are `passing`. Rows that are still `planned` or otherwise incomplete
 must be categorized as `future-owned-by-separate-phase`.
+
+## Fixture Layout
+
+Each directory under `fixtures/` is required to contain:
+
+- `README.md`: human evidence notes and links to the owning implementation
+  checks.
+- `fixture.json`: machine-readable fixture metadata mirroring the fixture
+  matrix row.
+- `positive/<positive_evidence.id>.sifr`: the positive evidence source.
+- `negative/<negative_evidence.id>.sifr`: the negative evidence source.
+
+The `matrix` suite validates this layout, verifies that fixture metadata
+matches `data/rust_interop_fixture_matrix.json`, and rejects empty README-only
+fixture directories.
 
 The area-level `network_mode` is `offline` for compile/probe and contract
 checks. Runtime-observed fixtures that need services such as Redis or
@@ -20,7 +37,8 @@ fixture evidence; they must not silently degrade to compile-only coverage.
 ## Suites
 
 - `matrix`: verifies the fixture matrix, required fixture directories, crate
-  coverage, evidence objects, fixture READMEs, and diagnostic family inventory.
+  coverage, evidence objects, fixture READMEs, fixture source files, and
+  diagnostic family inventory.
 - `tiers`: verifies tier definitions and fixture tier assignments.
 - `compatibility-matrix`: verifies that public compatibility rows match fixture
   evidence and that no fixture family is omitted.

--- a/verification/areas/rust_interop/checks/check_fixture_matrix.py
+++ b/verification/areas/rust_interop/checks/check_fixture_matrix.py
@@ -164,6 +164,8 @@ def main() -> int:
     for fixture_id in sorted(REQUIRED_FIXTURES & discovered_dirs):
         if not (FIXTURES_ROOT / fixture_id / "README.md").is_file():
             failures.append(f"{fixture_id}: fixture README.md is required for evidence notes")
+        if not (FIXTURES_ROOT / fixture_id / "fixture.json").is_file():
+            failures.append(f"{fixture_id}: fixture.json is required for evidence files")
 
     covered_crates: set[str] = set()
     for fixture in fixtures:
@@ -186,6 +188,7 @@ def main() -> int:
         _validate_feature_policies(failures, fixture_id, fixture.get("features"), crates)
         _validate_evidence(failures, fixture_id, fixture.get("positive_evidence"), "positive_evidence")
         _validate_evidence(failures, fixture_id, fixture.get("negative_evidence"), "negative_evidence")
+        _validate_fixture_files(failures, fixture)
 
     failures.extend(f"required crate lacks fixture coverage: {crate}" for crate in sorted(REQUIRED_CRATES - covered_crates))
 
@@ -233,6 +236,137 @@ def _validate_feature_policies(
             failures.append(
                 f"{fixture_id}: feature policy for {crate} must be {expected!r}, got {actual!r}"
             )
+
+
+def _validate_fixture_files(failures: list[str], fixture: dict[str, Any]) -> None:
+    fixture_id = str(fixture.get("id"))
+    fixture_dir = FIXTURES_ROOT / fixture_id
+    manifest_path = fixture_dir / "fixture.json"
+    if not manifest_path.is_file():
+        return
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        failures.append(f"{fixture_id}: fixture.json is not valid JSON: {error}")
+        return
+    if not isinstance(manifest, dict):
+        failures.append(f"{fixture_id}: fixture.json must be an object")
+        return
+
+    for field in ("id", "capability", "tier", "execution_kind", "required_crates"):
+        if manifest.get(field) != fixture.get(field):
+            failures.append(f"{fixture_id}: fixture.json {field} must match fixture matrix")
+    if manifest.get("features", {}) != fixture.get("features", {}):
+        failures.append(f"{fixture_id}: fixture.json features must match fixture matrix")
+    if manifest.get("schema_version") != 1:
+        failures.append(f"{fixture_id}: fixture.json schema_version must be 1")
+    if manifest.get("diagnostic_family") not in REQUIRED_DIAGNOSTICS:
+        failures.append(f"{fixture_id}: fixture.json diagnostic_family must be a reserved SIFR-RUST code")
+
+    evidence = manifest.get("evidence")
+    if not isinstance(evidence, dict):
+        failures.append(f"{fixture_id}: fixture.json evidence must be an object")
+        return
+    _validate_fixture_evidence_file(
+        failures,
+        fixture_id,
+        fixture_dir,
+        evidence.get("positive"),
+        fixture.get("positive_evidence"),
+        fixture.get("execution_kind"),
+        "positive",
+    )
+    _validate_fixture_evidence_file(
+        failures,
+        fixture_id,
+        fixture_dir,
+        evidence.get("negative"),
+        fixture.get("negative_evidence"),
+        fixture.get("execution_kind"),
+        "negative",
+    )
+
+
+def _validate_fixture_evidence_file(
+    failures: list[str],
+    fixture_id: str,
+    fixture_dir: Path,
+    manifest_evidence: Any,
+    matrix_evidence: Any,
+    execution_kind: Any,
+    side: str,
+) -> None:
+    if not isinstance(manifest_evidence, dict):
+        failures.append(f"{fixture_id}: fixture.json evidence.{side} must be an object")
+        return
+    if not isinstance(matrix_evidence, dict):
+        return
+    for field in ("id", "status"):
+        if manifest_evidence.get(field) != matrix_evidence.get(field):
+            failures.append(f"{fixture_id}: fixture.json evidence.{side}.{field} must match fixture matrix")
+
+    raw_path = manifest_evidence.get("path")
+    if not isinstance(raw_path, str) or not raw_path:
+        failures.append(f"{fixture_id}: fixture.json evidence.{side}.path is required")
+        return
+    raw_source_path = Path(raw_path)
+    if raw_source_path.is_absolute() or ".." in raw_source_path.parts:
+        failures.append(f"{fixture_id}: evidence.{side}.path must stay inside the fixture directory")
+        return
+    expected_path = Path(side) / f"{matrix_evidence.get('id')}.sifr"
+    if raw_source_path != expected_path:
+        failures.append(f"{fixture_id}: evidence.{side}.path must be {expected_path.as_posix()}")
+        return
+    source_path = fixture_dir / raw_path
+    try:
+        source_path.relative_to(fixture_dir)
+    except ValueError:
+        failures.append(f"{fixture_id}: evidence.{side}.path must stay inside the fixture directory")
+        return
+    if source_path.suffix != ".sifr":
+        failures.append(f"{fixture_id}: evidence.{side}.path must point to a .sifr file")
+    if not source_path.is_file():
+        failures.append(f"{fixture_id}: missing evidence source {raw_path}")
+        return
+
+    text = source_path.read_text(encoding="utf-8")
+    if len(text.strip().splitlines()) < 5:
+        failures.append(f"{fixture_id}: {raw_path} must contain a concrete fixture, not an empty stub")
+    required_headers = (
+        f"# fixture: {fixture_id}",
+        f"# evidence: {side}/{matrix_evidence.get('id')}",
+        f"# evidence-status: {matrix_evidence.get('status')}",
+    )
+    for header in required_headers:
+        if header not in text:
+            failures.append(f"{fixture_id}: {raw_path} missing header {header!r}")
+    if not any(line.lstrip().startswith("@rust") for line in text.splitlines()):
+        failures.append(f"{fixture_id}: {raw_path} must exercise a Rust interop declaration")
+
+    expected_result = manifest_evidence.get("expected_result")
+    if not isinstance(expected_result, str) or not expected_result:
+        failures.append(f"{fixture_id}: evidence.{side}.expected_result is required")
+        return
+    expected_headers = (
+        f"# execution-kind: {execution_kind}",
+        f"# expected-result: {expected_result}",
+    )
+    if expected_headers[0] not in text:
+        failures.append(f"{fixture_id}: {raw_path} missing execution-kind header")
+    if expected_headers[1] not in text:
+        failures.append(f"{fixture_id}: {raw_path} missing expected-result header")
+    status = matrix_evidence.get("status")
+    if expected_result.startswith("future-owned") and status == "passing":
+        failures.append(f"{fixture_id}: passing {side} evidence cannot be marked future-owned")
+    if status != "passing" and not expected_result.startswith("future-owned"):
+        failures.append(f"{fixture_id}: non-passing {side} evidence must be marked future-owned")
+
+    expected_diagnostic = manifest_evidence.get("expected_diagnostic")
+    if expected_result in {"diagnostic", "future-owned-diagnostic"}:
+        if expected_diagnostic not in REQUIRED_DIAGNOSTICS:
+            failures.append(f"{fixture_id}: evidence.{side}.expected_diagnostic must be a reserved SIFR-RUST code")
+        elif f"# expected-diagnostic: {expected_diagnostic}" not in text:
+            failures.append(f"{fixture_id}: {raw_path} missing expected diagnostic marker {expected_diagnostic}")
 
 
 if __name__ == "__main__":

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/fixture.json
@@ -1,0 +1,36 @@
+{
+  "capability": "advanced data and tensor ecosystems",
+  "diagnostic_family": "SIFR-RUST-ZC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-ZC-0001",
+      "expected_result": "diagnostic",
+      "id": "dtype_shape_mismatch",
+      "path": "negative/dtype_shape_mismatch.sifr",
+      "scope": "contract-only",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "advanced_data_metadata",
+      "path": "positive/advanced_data_metadata.sifr",
+      "scope": "contract-only",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "contract-only",
+  "features": {
+    "candle": {
+      "backend": "cpu-only"
+    }
+  },
+  "id": "advanced_data_matrix",
+  "required_crates": [
+    "datafusion",
+    "polars",
+    "ndarray",
+    "candle"
+  ],
+  "schema_version": 1,
+  "tier": 4
+}

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/negative/dtype_shape_mismatch.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/negative/dtype_shape_mismatch.sifr
@@ -1,0 +1,9 @@
+# fixture: advanced_data_matrix
+# evidence: negative/dtype_shape_mismatch
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-ZC-0001
+@rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=tensor, dtype=f32, rank=2, shape=[2, 3], schema=bridge.data.Schema, ownership=borrowed)
+@rust(bridge.dataframe.view, panic=trusted_no_panic)
+def mismatched_metadata(input: bytes) -> DataFrame: ...

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/positive/advanced_data_metadata.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/positive/advanced_data_metadata.sifr
@@ -1,0 +1,11 @@
+# fixture: advanced_data_matrix
+# evidence: positive/advanced_data_metadata
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: pass
+class DataError(Error):
+    message: str
+
+@rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=dataframe, schema=bridge.data.Schema, ownership=borrowed)
+@rust(bridge.dataframe.view, panic=map_error(bridge.dataframe.map_panic))
+def dataframe_view(input: bytes) -> Result[DataFrame, DataError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/arrow_record_batch/fixture.json
+++ b/verification/areas/rust_interop/fixtures/arrow_record_batch/fixture.json
@@ -1,0 +1,29 @@
+{
+  "capability": "Arrow record batch exchange",
+  "diagnostic_family": "SIFR-RUST-ZC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-ZC-0001",
+      "expected_result": "diagnostic",
+      "id": "invalid_arrow_metadata",
+      "path": "negative/invalid_arrow_metadata.sifr",
+      "scope": "contract-only",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "arrow_schema_identity",
+      "path": "positive/arrow_schema_identity.sifr",
+      "scope": "contract-only",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "contract-only",
+  "features": {},
+  "id": "arrow_record_batch",
+  "required_crates": [
+    "arrow"
+  ],
+  "schema_version": 1,
+  "tier": 4
+}

--- a/verification/areas/rust_interop/fixtures/arrow_record_batch/negative/invalid_arrow_metadata.sifr
+++ b/verification/areas/rust_interop/fixtures/arrow_record_batch/negative/invalid_arrow_metadata.sifr
@@ -1,0 +1,9 @@
+# fixture: arrow_record_batch
+# evidence: negative/invalid_arrow_metadata
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-ZC-0001
+@rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=arrow_record_batch, ownership=borrowed)
+@rust(sifr_arrow_bridge.record_batch_from_bytes, panic=trusted_no_panic)
+def missing_schema(input: bytes) -> ArrowRecordBatch: ...

--- a/verification/areas/rust_interop/fixtures/arrow_record_batch/positive/arrow_schema_identity.sifr
+++ b/verification/areas/rust_interop/fixtures/arrow_record_batch/positive/arrow_schema_identity.sifr
@@ -1,0 +1,12 @@
+# fixture: arrow_record_batch
+# evidence: positive/arrow_schema_identity
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: pass
+class ArrowError(Error):
+    message: str
+
+@rust.zero_copy(owner=input, view=sifr_arrow_bridge.record_batch.RecordBatchView)
+@rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=arrow_record_batch, schema=sifr_arrow_bridge.schema.RecordBatch, ownership=borrowed)
+@rust(sifr_arrow_bridge.record_batch_from_bytes, panic=map_error(sifr_arrow_bridge.panic.map))
+def record_batch(input: bytes) -> Result[ArrowRecordBatch, ArrowError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/fixture.json
@@ -1,0 +1,30 @@
+{
+  "capability": "async ecosystem signature probing",
+  "diagnostic_family": "SIFR-RUST-ASYNC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-ASYNC-0001",
+      "expected_result": "diagnostic",
+      "id": "non_send_future_without_affinity",
+      "path": "negative/non_send_future_without_affinity.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "current_thread_non_send_future",
+      "path": "positive/current_thread_non_send_future.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {},
+  "id": "async_ecosystem_matrix",
+  "required_crates": [
+    "futures",
+    "tower",
+    "http",
+    "http-body"
+  ],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/negative/non_send_future_without_affinity.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/negative/non_send_future_without_affinity.sifr
@@ -1,0 +1,8 @@
+# fixture: async_ecosystem_matrix
+# evidence: negative/non_send_future_without_affinity
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-ASYNC-0001
+@rust(bridge.async_local.non_send_future, panic=trusted_no_panic)
+async def non_send_without_affinity() -> uint32: ...

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/positive/current_thread_non_send_future.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/positive/current_thread_non_send_future.sifr
@@ -1,0 +1,11 @@
+# fixture: async_ecosystem_matrix
+# evidence: positive/current_thread_non_send_future
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: pass
+class AsyncError(Error):
+    message: str
+
+@rust.async(thread_affinity=tokio_current_thread)
+@rust(bridge.async_local.poll_once, panic=map_error(bridge.async_local.map_panic))
+async def poll_once() -> Result[uint32, AsyncError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/fixture.json
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/fixture.json
@@ -1,0 +1,36 @@
+{
+  "capability": "async Rust bridge on Sifr Tokio runtime",
+  "diagnostic_family": "SIFR-RUST-ASYNC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-ASYNC-0001",
+      "expected_result": "future-owned-diagnostic",
+      "id": "hidden_block_on_rejected",
+      "path": "negative/hidden_block_on_rejected.sifr",
+      "status": "planned"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "async_reqwest_loopback",
+      "path": "positive/async_reqwest_loopback.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "runtime-observed",
+  "features": {
+    "reqwest": {
+      "default_features": false,
+      "features": [
+        "rustls-tls",
+        "json"
+      ]
+    }
+  },
+  "id": "async_runtime_reqwest",
+  "required_crates": [
+    "tokio",
+    "reqwest"
+  ],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/negative/hidden_block_on_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/negative/hidden_block_on_rejected.sifr
@@ -1,0 +1,8 @@
+# fixture: async_runtime_reqwest
+# evidence: negative/hidden_block_on_rejected
+# evidence-status: planned
+# execution-kind: runtime-observed
+# expected-result: future-owned-diagnostic
+# expected-diagnostic: SIFR-RUST-ASYNC-0001
+@rust(bridge.http.hidden_block_on, panic=trusted_no_panic)
+async def hidden_block_on(url: str) -> str: ...

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/positive/async_reqwest_loopback.sifr
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/positive/async_reqwest_loopback.sifr
@@ -1,0 +1,10 @@
+# fixture: async_runtime_reqwest
+# evidence: positive/async_reqwest_loopback
+# evidence-status: planned
+# execution-kind: runtime-observed
+# expected-result: future-owned
+class HttpError(Error):
+    message: str
+
+@rust(bridge.http.fetch_text, panic=map_error(bridge.http.map_panic))
+async def fetch_text(url: str) -> Result[str, HttpError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/fixture.json
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/fixture.json
@@ -1,0 +1,41 @@
+{
+  "capability": "blocking I/O and CPU-heavy classification",
+  "diagnostic_family": "SIFR-RUST-ASYNC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-ASYNC-0001",
+      "expected_result": "diagnostic",
+      "id": "classified_async_declarations_rejected",
+      "path": "negative/classified_async_declarations_rejected.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "classified_sync_rust_effects",
+      "path": "positive/classified_sync_rust_effects.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "compiler-diagnostic",
+  "features": {
+    "flate2": {
+      "default_features": false,
+      "features": [
+        "rust_backend"
+      ]
+    },
+    "rusqlite": {
+      "features": [
+        "bundled"
+      ]
+    }
+  },
+  "id": "blocking_diagnostics",
+  "required_crates": [
+    "rusqlite",
+    "rayon",
+    "flate2"
+  ],
+  "schema_version": 1,
+  "tier": 0
+}

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/negative/classified_async_declarations_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/negative/classified_async_declarations_rejected.sifr
@@ -1,0 +1,8 @@
+# fixture: blocking_diagnostics
+# evidence: negative/classified_async_declarations_rejected
+# evidence-status: passing
+# execution-kind: compiler-diagnostic
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-ASYNC-0001
+@rust(bridge.db.query_blocking, panic=trusted_no_panic)
+async def hidden_blocking_query(sql: str) -> list[str]: ...

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/positive/classified_sync_rust_effects.sifr
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/positive/classified_sync_rust_effects.sifr
@@ -1,0 +1,12 @@
+# fixture: blocking_diagnostics
+# evidence: positive/classified_sync_rust_effects
+# evidence-status: passing
+# execution-kind: compiler-diagnostic
+# expected-result: pass
+@blocking_io
+@rust(bridge.db.query_blocking, panic=trusted_no_panic)
+def query_blocking(sql: str) -> list[str]: ...
+
+@cpu_heavy
+@rust(bridge.compress.deflate, panic=trusted_no_panic)
+def deflate(input: bytes) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/fixture.json
@@ -1,0 +1,31 @@
+{
+  "capability": "bridge type generation and conversion",
+  "diagnostic_family": "SIFR-RUST-TYPE-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-TYPE-0001",
+      "expected_result": "diagnostic",
+      "id": "unsupported_container_rejections",
+      "path": "negative/unsupported_container_rejections.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "supported_type_roundtrips",
+      "path": "positive/supported_type_roundtrips.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {},
+  "id": "bridge_type_matrix",
+  "required_crates": [
+    "serde",
+    "serde_json",
+    "thiserror",
+    "bytes",
+    "indexmap"
+  ],
+  "schema_version": 1,
+  "tier": 1
+}

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/negative/unsupported_container_rejections.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/negative/unsupported_container_rejections.sifr
@@ -1,0 +1,8 @@
+# fixture: bridge_type_matrix
+# evidence: negative/unsupported_container_rejections
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-TYPE-0001
+@rust(bridge.types.unsupported, panic=trusted_no_panic)
+def unsupported(value: dict[str, list[object]]) -> object: ...

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/positive/supported_type_roundtrips.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/positive/supported_type_roundtrips.sifr
@@ -1,0 +1,14 @@
+# fixture: bridge_type_matrix
+# evidence: positive/supported_type_roundtrips
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned
+class HashRecord:
+    digest: bytes
+    length: uint64
+
+class BridgeError(Error):
+    message: str
+
+@rust(bridge.types.roundtrip, panic=map_error(bridge.types.map_error))
+def roundtrip(value: HashRecord) -> Result[HashRecord, BridgeError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/bridge_version_mismatch/fixture.json
+++ b/verification/areas/rust_interop/fixtures/bridge_version_mismatch/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "bridge-version validation",
+  "diagnostic_family": "SIFR-RUST-CARGO-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-CARGO-0001",
+      "expected_result": "diagnostic",
+      "id": "unsupported_bridge_version_rejected",
+      "path": "negative/unsupported_bridge_version_rejected.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "bridge_version_1_accepted",
+      "path": "positive/bridge_version_1_accepted.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "compiler-diagnostic",
+  "features": {},
+  "id": "bridge_version_mismatch",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 0
+}

--- a/verification/areas/rust_interop/fixtures/bridge_version_mismatch/negative/unsupported_bridge_version_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_version_mismatch/negative/unsupported_bridge_version_rejected.sifr
@@ -1,0 +1,9 @@
+# fixture: bridge_version_mismatch
+# evidence: negative/unsupported_bridge_version_rejected
+# evidence-status: passing
+# execution-kind: compiler-diagnostic
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-CARGO-0001
+# fixture-cargo: rust.bridge-version = 999
+@rust(bridge.version.rejected, panic=trusted_no_panic)
+def rejected() -> uint32: ...

--- a/verification/areas/rust_interop/fixtures/bridge_version_mismatch/positive/bridge_version_1_accepted.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_version_mismatch/positive/bridge_version_1_accepted.sifr
@@ -1,0 +1,8 @@
+# fixture: bridge_version_mismatch
+# evidence: positive/bridge_version_1_accepted
+# evidence-status: passing
+# execution-kind: compiler-diagnostic
+# expected-result: pass
+# fixture-cargo: rust.bridge-version = 1
+@rust(bridge.version.accepted, panic=trusted_no_panic)
+def accepted() -> uint32: ...

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/fixture.json
@@ -1,0 +1,39 @@
+{
+  "capability": "callback subscriptions and shutdown",
+  "diagnostic_family": "SIFR-RUST-CB-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-CB-0001",
+      "expected_result": "future-owned-diagnostic",
+      "id": "invalid_thread_capture_rejected",
+      "path": "negative/invalid_thread_capture_rejected.sifr",
+      "status": "planned"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "subscription_cancel_shutdown",
+      "path": "positive/subscription_cancel_shutdown.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "runtime-observed",
+  "features": {
+    "redis": {
+      "default_features": false,
+      "features": [
+        "tokio-comp"
+      ]
+    },
+    "tokio-tungstenite": {
+      "default_features": false
+    }
+  },
+  "id": "callback_subscription_matrix",
+  "required_crates": [
+    "tokio-tungstenite",
+    "redis",
+    "notify"
+  ],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/negative/invalid_thread_capture_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/negative/invalid_thread_capture_rejected.sifr
@@ -1,0 +1,9 @@
+# fixture: callback_subscription_matrix
+# evidence: negative/invalid_thread_capture_rejected
+# evidence-status: planned
+# execution-kind: runtime-observed
+# expected-result: future-owned-diagnostic
+# expected-diagnostic: SIFR-RUST-CB-0001
+@rust.callback(backpressure=bounded(256), overflow=error, shutdown=drain)
+@rust(bridge.events.subscribe_non_send_capture, panic=trusted_no_panic)
+def subscribe(handler: ThreadsafeCallback[[str], None]) -> None: ...

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/positive/subscription_cancel_shutdown.sifr
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/positive/subscription_cancel_shutdown.sifr
@@ -1,0 +1,16 @@
+# fixture: callback_subscription_matrix
+# evidence: positive/subscription_cancel_shutdown
+# evidence-status: planned
+# execution-kind: runtime-observed
+# expected-result: future-owned
+class SubscriptionError(Error):
+    message: str
+
+@rust.opaque(type=bridge.events.Subscription, send=True, sync=False, clone=none, close=async_close)
+class Subscription:
+    @rust(bridge.events.cancel, panic=map_error(bridge.events.map_panic))
+    async def aclose(own self) -> Result[None, SubscriptionError | RustPanicError]: ...
+
+@rust.callback(backpressure=bounded(256), overflow=error, shutdown=drain)
+@rust(bridge.events.subscribe, panic=map_error(bridge.events.map_panic))
+def subscribe(handler: ThreadsafeCallback[[str], Result[None, SubscriptionError]]) -> Result[Subscription, SubscriptionError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/callbacks_call_scoped/fixture.json
+++ b/verification/areas/rust_interop/fixtures/callbacks_call_scoped/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "call-scoped callback lifetime",
+  "diagnostic_family": "SIFR-RUST-CB-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-CB-0001",
+      "expected_result": "future-owned-diagnostic",
+      "id": "callback_storage_rejected",
+      "path": "negative/callback_storage_rejected.sifr",
+      "status": "planned"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "callback_valid_during_call",
+      "path": "positive/callback_valid_during_call.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "runtime-observed",
+  "features": {},
+  "id": "callbacks_call_scoped",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/callbacks_call_scoped/negative/callback_storage_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/callbacks_call_scoped/negative/callback_storage_rejected.sifr
@@ -1,0 +1,9 @@
+# fixture: callbacks_call_scoped
+# evidence: negative/callback_storage_rejected
+# evidence-status: planned
+# execution-kind: runtime-observed
+# expected-result: future-owned-diagnostic
+# expected-diagnostic: SIFR-RUST-CB-0001
+@rust.callback(backpressure=bounded(32), overflow=error, shutdown=drain)
+@rust(bridge.callbacks.store_for_later, panic=trusted_no_panic)
+def store_for_later(handler: ThreadsafeCallback[[str], None]) -> None: ...

--- a/verification/areas/rust_interop/fixtures/callbacks_call_scoped/positive/callback_valid_during_call.sifr
+++ b/verification/areas/rust_interop/fixtures/callbacks_call_scoped/positive/callback_valid_during_call.sifr
@@ -1,0 +1,11 @@
+# fixture: callbacks_call_scoped
+# evidence: positive/callback_valid_during_call
+# evidence-status: planned
+# execution-kind: runtime-observed
+# expected-result: future-owned
+class EventError(Error):
+    message: str
+
+@rust.callback(backpressure=bounded(32), overflow=error, shutdown=drain)
+@rust(bridge.callbacks.visit, panic=map_error(bridge.callbacks.map_panic))
+def visit(handler: ThreadsafeCallback[[str], Result[None, EventError]]) -> Result[None, EventError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/callbacks_threadsafe/fixture.json
+++ b/verification/areas/rust_interop/fixtures/callbacks_threadsafe/fixture.json
@@ -1,0 +1,27 @@
+{
+  "capability": "thread-safe callback policy",
+  "diagnostic_family": "SIFR-RUST-CB-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-CB-0001",
+      "expected_result": "diagnostic",
+      "id": "missing_backpressure_rejected",
+      "path": "negative/missing_backpressure_rejected.sifr",
+      "scope": "contract-only",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "bounded_callback_policy",
+      "path": "positive/bounded_callback_policy.sifr",
+      "scope": "contract-only",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "contract-only",
+  "features": {},
+  "id": "callbacks_threadsafe",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/callbacks_threadsafe/negative/missing_backpressure_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/callbacks_threadsafe/negative/missing_backpressure_rejected.sifr
@@ -1,0 +1,9 @@
+# fixture: callbacks_threadsafe
+# evidence: negative/missing_backpressure_rejected
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-CB-0001
+@rust.callback(overflow=error, shutdown=drain)
+@rust(bridge.events.subscribe, panic=trusted_no_panic)
+def subscribe(handler: ThreadsafeCallback[[str], None]) -> None: ...

--- a/verification/areas/rust_interop/fixtures/callbacks_threadsafe/positive/bounded_callback_policy.sifr
+++ b/verification/areas/rust_interop/fixtures/callbacks_threadsafe/positive/bounded_callback_policy.sifr
@@ -1,0 +1,11 @@
+# fixture: callbacks_threadsafe
+# evidence: positive/bounded_callback_policy
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: pass
+class EventError(Error):
+    message: str
+
+@rust.callback(backpressure=bounded(1024), overflow=error, shutdown=drain)
+@rust(bridge.events.subscribe, panic=map_error(bridge.events.map_panic))
+def subscribe(handler: ThreadsafeCallback[[str], Result[None, EventError]]) -> Result[None, EventError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/cargo_locked_offline/fixture.json
+++ b/verification/areas/rust_interop/fixtures/cargo_locked_offline/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "locked/offline/frozen Cargo behavior",
+  "diagnostic_family": "SIFR-RUST-CARGO-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-CARGO-0001",
+      "expected_result": "future-owned-diagnostic",
+      "id": "lockfile_feature_drift_rejected",
+      "path": "negative/lockfile_feature_drift_rejected.sifr",
+      "status": "planned"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "locked_offline_cache_hit",
+      "path": "positive/locked_offline_cache_hit.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {},
+  "id": "cargo_locked_offline",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 3
+}

--- a/verification/areas/rust_interop/fixtures/cargo_locked_offline/negative/lockfile_feature_drift_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/cargo_locked_offline/negative/lockfile_feature_drift_rejected.sifr
@@ -1,0 +1,9 @@
+# fixture: cargo_locked_offline
+# evidence: negative/lockfile_feature_drift_rejected
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned-diagnostic
+# expected-diagnostic: SIFR-RUST-CARGO-0001
+# fixture-cargo: lockfile omits requested feature
+@rust(bridge.locked.feature_drift, panic=trusted_no_panic)
+def feature_drift() -> uint32: ...

--- a/verification/areas/rust_interop/fixtures/cargo_locked_offline/positive/locked_offline_cache_hit.sifr
+++ b/verification/areas/rust_interop/fixtures/cargo_locked_offline/positive/locked_offline_cache_hit.sifr
@@ -1,0 +1,8 @@
+# fixture: cargo_locked_offline
+# evidence: positive/locked_offline_cache_hit
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned
+# fixture-cargo: --locked --offline --frozen
+@rust(bridge.locked.cached, panic=trusted_no_panic)
+def cached() -> uint32: ...

--- a/verification/areas/rust_interop/fixtures/close_after_use/fixture.json
+++ b/verification/areas/rust_interop/fixtures/close_after_use/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "closed and poisoned handle state transitions",
+  "diagnostic_family": "SIFR-RUST-HANDLE-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-HANDLE-0001",
+      "expected_result": "diagnostic",
+      "id": "double_close_and_poisoned_access",
+      "path": "negative/double_close_and_poisoned_access.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "closed_handle_error_surface",
+      "path": "positive/closed_handle_error_surface.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "runtime-observed",
+  "features": {},
+  "id": "close_after_use",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/close_after_use/negative/double_close_and_poisoned_access.sifr
+++ b/verification/areas/rust_interop/fixtures/close_after_use/negative/double_close_and_poisoned_access.sifr
@@ -1,0 +1,10 @@
+# fixture: close_after_use
+# evidence: negative/double_close_and_poisoned_access
+# evidence-status: passing
+# execution-kind: runtime-observed
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-HANDLE-0001
+@rust.opaque(type=bridge.handle.Handle, send=True, sync=False, clone=none, close=close)
+class NativeHandle:
+    @rust(bridge.handle.close, panic=trusted_no_panic)
+    def close(self) -> None: ...

--- a/verification/areas/rust_interop/fixtures/close_after_use/positive/closed_handle_error_surface.sifr
+++ b/verification/areas/rust_interop/fixtures/close_after_use/positive/closed_handle_error_surface.sifr
@@ -1,0 +1,12 @@
+# fixture: close_after_use
+# evidence: positive/closed_handle_error_surface
+# evidence-status: passing
+# execution-kind: runtime-observed
+# expected-result: pass
+class HandleError(Error):
+    message: str
+
+@rust.opaque(type=bridge.handle.Handle, send=True, sync=False, clone=none, close=close)
+class NativeHandle:
+    @rust(bridge.handle.close, panic=map_error(bridge.handle.map_panic))
+    def close(own self) -> Result[None, HandleError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/direct_crate_crc32/fixture.json
+++ b/verification/areas/rust_interop/fixtures/direct_crate_crc32/fixture.json
@@ -1,0 +1,27 @@
+{
+  "capability": "direct compatible function binding",
+  "diagnostic_family": "SIFR-RUST-PANIC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-PANIC-0001",
+      "expected_result": "diagnostic",
+      "id": "crc32fast_missing_panic_policy",
+      "path": "negative/crc32fast_missing_panic_policy.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "crc32fast_hash_uint32",
+      "path": "positive/crc32fast_hash_uint32.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {},
+  "id": "direct_crate_crc32",
+  "required_crates": [
+    "crc32fast"
+  ],
+  "schema_version": 1,
+  "tier": 1
+}

--- a/verification/areas/rust_interop/fixtures/direct_crate_crc32/negative/crc32fast_missing_panic_policy.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_crc32/negative/crc32fast_missing_panic_policy.sifr
@@ -1,0 +1,8 @@
+# fixture: direct_crate_crc32
+# evidence: negative/crc32fast_missing_panic_policy
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-PANIC-0001
+@rust(crc32fast.hash)
+def crc32(data: bytes) -> uint32: ...

--- a/verification/areas/rust_interop/fixtures/direct_crate_crc32/positive/crc32fast_hash_uint32.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_crc32/positive/crc32fast_hash_uint32.sifr
@@ -1,0 +1,10 @@
+# fixture: direct_crate_crc32
+# evidence: positive/crc32fast_hash_uint32
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: pass
+@rust(crc32fast.hash, panic=trusted_no_panic)
+def crc32(data: bytes) -> uint32: ...
+
+def main() -> uint32:
+    return crc32(b"sifr")

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/fixture.json
@@ -1,0 +1,30 @@
+{
+  "capability": "direct crate matrix",
+  "diagnostic_family": "SIFR-RUST-TYPE-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-TYPE-0001",
+      "expected_result": "diagnostic",
+      "id": "incompatible_direct_signatures",
+      "path": "negative/incompatible_direct_signatures.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "compatible_direct_signatures",
+      "path": "positive/compatible_direct_signatures.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {},
+  "id": "direct_crate_matrix",
+  "required_crates": [
+    "blake3",
+    "sha2",
+    "uuid",
+    "regex"
+  ],
+  "schema_version": 1,
+  "tier": 1
+}

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/negative/incompatible_direct_signatures.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/negative/incompatible_direct_signatures.sifr
@@ -1,0 +1,8 @@
+# fixture: direct_crate_matrix
+# evidence: negative/incompatible_direct_signatures
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-TYPE-0001
+@rust(regex.Regex.captures, panic=trusted_no_panic)
+def captures(pattern: str, text: str) -> object: ...

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/positive/compatible_direct_signatures.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/positive/compatible_direct_signatures.sifr
@@ -1,0 +1,16 @@
+# fixture: direct_crate_matrix
+# evidence: positive/compatible_direct_signatures
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: pass
+@rust(blake3.hash, panic=trusted_no_panic)
+def blake3_digest(data: bytes) -> bytes: ...
+
+@rust(sha2.Sha256.digest, panic=trusted_no_panic)
+def sha256_digest(data: bytes) -> bytes: ...
+
+@rust(uuid.Uuid.parse_str)
+def parse_uuid(text: str) -> Result[str, RustPanicError]: ...
+
+@rust(regex.Regex.is_match, panic=trusted_no_panic)
+def is_match(pattern: str, text: str) -> bool: ...

--- a/verification/areas/rust_interop/fixtures/direct_crate_negative_type/fixture.json
+++ b/verification/areas/rust_interop/fixtures/direct_crate_negative_type/fixture.json
@@ -1,0 +1,28 @@
+{
+  "capability": "invalid direct bridge type diagnostics",
+  "diagnostic_family": "SIFR-RUST-TYPE-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-TYPE-0001",
+      "expected_result": "diagnostic",
+      "id": "unsupported_type_cannot_compile_silently",
+      "path": "negative/unsupported_type_cannot_compile_silently.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_diagnostic": "SIFR-RUST-TYPE-0001",
+      "expected_result": "diagnostic",
+      "id": "unsupported_type_rejected",
+      "path": "positive/unsupported_type_rejected.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "compiler-diagnostic",
+  "features": {},
+  "id": "direct_crate_negative_type",
+  "required_crates": [
+    "regex"
+  ],
+  "schema_version": 1,
+  "tier": 0
+}

--- a/verification/areas/rust_interop/fixtures/direct_crate_negative_type/negative/unsupported_type_cannot_compile_silently.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_negative_type/negative/unsupported_type_cannot_compile_silently.sifr
@@ -1,0 +1,8 @@
+# fixture: direct_crate_negative_type
+# evidence: negative/unsupported_type_cannot_compile_silently
+# evidence-status: passing
+# execution-kind: compiler-diagnostic
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-TYPE-0001
+@rust(regex.Regex.captures, panic=trusted_no_panic)
+def captures_without_bridge(pattern: str, text: str) -> object: ...

--- a/verification/areas/rust_interop/fixtures/direct_crate_negative_type/positive/unsupported_type_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_negative_type/positive/unsupported_type_rejected.sifr
@@ -1,0 +1,8 @@
+# fixture: direct_crate_negative_type
+# evidence: positive/unsupported_type_rejected
+# evidence-status: passing
+# execution-kind: compiler-diagnostic
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-TYPE-0001
+@rust(regex.Regex.captures, panic=trusted_no_panic)
+def captures(pattern: str, text: str) -> dict[str, object]: ...

--- a/verification/areas/rust_interop/fixtures/dotted_path_resolution/fixture.json
+++ b/verification/areas/rust_interop/fixtures/dotted_path_resolution/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "structured Rust decorator paths",
+  "diagnostic_family": "SIFR-RUST-CONFIG-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-CONFIG-0001",
+      "expected_result": "diagnostic",
+      "id": "string_and_reserved_root_rejection",
+      "path": "negative/string_and_reserved_root_rejection.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "valid_structured_paths",
+      "path": "positive/valid_structured_paths.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "compiler-diagnostic",
+  "features": {},
+  "id": "dotted_path_resolution",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 0
+}

--- a/verification/areas/rust_interop/fixtures/dotted_path_resolution/negative/string_and_reserved_root_rejection.sifr
+++ b/verification/areas/rust_interop/fixtures/dotted_path_resolution/negative/string_and_reserved_root_rejection.sifr
@@ -1,0 +1,8 @@
+# fixture: dotted_path_resolution
+# evidence: negative/string_and_reserved_root_rejection
+# evidence-status: passing
+# execution-kind: compiler-diagnostic
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-CONFIG-0001
+@rust("bridge.hash.digest")
+def digest(data: bytes) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/dotted_path_resolution/positive/valid_structured_paths.sifr
+++ b/verification/areas/rust_interop/fixtures/dotted_path_resolution/positive/valid_structured_paths.sifr
@@ -1,0 +1,10 @@
+# fixture: dotted_path_resolution
+# evidence: positive/valid_structured_paths
+# evidence-status: passing
+# execution-kind: compiler-diagnostic
+# expected-result: pass
+@rust(bridge.hash.digest, panic=map_error(bridge.hash.map_panic))
+def digest(data: bytes) -> Result[bytes, HashError | RustPanicError]: ...
+
+class HashError(Error):
+    message: str

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/fixture.json
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/fixture.json
@@ -1,0 +1,38 @@
+{
+  "capability": "backend/service ecosystem certification",
+  "diagnostic_family": "SIFR-RUST-CARGO-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-CARGO-0001",
+      "expected_result": "future-owned-diagnostic",
+      "id": "sqlx_without_offline_artifacts",
+      "path": "negative/sqlx_without_offline_artifacts.sifr",
+      "status": "planned"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "backend_probe_coverage",
+      "path": "positive/backend_probe_coverage.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {
+    "sqlx": {
+      "default_features": false,
+      "features": [
+        "runtime-tokio-rustls",
+        "postgres",
+        "macros"
+      ]
+    }
+  },
+  "id": "ecosystem_backend_certification",
+  "required_crates": [
+    "axum",
+    "tower-http",
+    "sqlx"
+  ],
+  "schema_version": 1,
+  "tier": 4
+}

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/negative/sqlx_without_offline_artifacts.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/negative/sqlx_without_offline_artifacts.sifr
@@ -1,0 +1,9 @@
+# fixture: ecosystem_backend_certification
+# evidence: negative/sqlx_without_offline_artifacts
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned-diagnostic
+# expected-diagnostic: SIFR-RUST-CARGO-0001
+# fixture-cargo: sqlx macros require offline artifacts
+@rust(bridge.backend.query_compile_time, panic=trusted_no_panic)
+def query_compile_time() -> uint32: ...

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/positive/backend_probe_coverage.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/positive/backend_probe_coverage.sifr
@@ -1,0 +1,10 @@
+# fixture: ecosystem_backend_certification
+# evidence: positive/backend_probe_coverage
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned
+class BackendError(Error):
+    message: str
+
+@rust(bridge.backend.route_probe, panic=map_error(bridge.backend.map_panic))
+async def route_probe(path: str) -> Result[str, BackendError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/fixture.json
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/fixture.json
@@ -1,0 +1,36 @@
+{
+  "capability": "CLI/tooling ecosystem certification",
+  "diagnostic_family": "SIFR-RUST-TYPE-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-TYPE-0001",
+      "expected_result": "future-owned-diagnostic",
+      "id": "unsupported_anyhow_surface",
+      "path": "negative/unsupported_anyhow_surface.sifr",
+      "status": "planned"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "cli_tooling_probe_coverage",
+      "path": "positive/cli_tooling_probe_coverage.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {
+    "tracing-subscriber": {
+      "features": [
+        "env-filter"
+      ]
+    }
+  },
+  "id": "ecosystem_cli_certification",
+  "required_crates": [
+    "clap",
+    "tracing",
+    "tracing-subscriber",
+    "anyhow"
+  ],
+  "schema_version": 1,
+  "tier": 4
+}

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/negative/unsupported_anyhow_surface.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/negative/unsupported_anyhow_surface.sifr
@@ -1,0 +1,8 @@
+# fixture: ecosystem_cli_certification
+# evidence: negative/unsupported_anyhow_surface
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned-diagnostic
+# expected-diagnostic: SIFR-RUST-TYPE-0001
+@rust(anyhow.Error.downcast_ref, panic=trusted_no_panic)
+def expose_anyhow_trait_object(error: object) -> object: ...

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/positive/cli_tooling_probe_coverage.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/positive/cli_tooling_probe_coverage.sifr
@@ -1,0 +1,10 @@
+# fixture: ecosystem_cli_certification
+# evidence: positive/cli_tooling_probe_coverage
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned
+class CliError(Error):
+    message: str
+
+@rust(bridge.cli.parse_and_trace, panic=map_error(bridge.cli.map_panic))
+def parse_and_trace(args: list[str]) -> Result[uint32, CliError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/local_bridge_blake3/fixture.json
+++ b/verification/areas/rust_interop/fixtures/local_bridge_blake3/fixture.json
@@ -1,0 +1,27 @@
+{
+  "capability": "package-local bridge binding",
+  "diagnostic_family": "SIFR-RUST-RESOLVE-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-RESOLVE-0001",
+      "expected_result": "diagnostic",
+      "id": "missing_local_bridge_export",
+      "path": "negative/missing_local_bridge_export.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "local_bridge_hash_bytes",
+      "path": "positive/local_bridge_hash_bytes.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {},
+  "id": "local_bridge_blake3",
+  "required_crates": [
+    "blake3"
+  ],
+  "schema_version": 1,
+  "tier": 1
+}

--- a/verification/areas/rust_interop/fixtures/local_bridge_blake3/negative/missing_local_bridge_export.sifr
+++ b/verification/areas/rust_interop/fixtures/local_bridge_blake3/negative/missing_local_bridge_export.sifr
@@ -1,0 +1,8 @@
+# fixture: local_bridge_blake3
+# evidence: negative/missing_local_bridge_export
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-RESOLVE-0001
+@rust(bridge.blake3.missing_export, panic=trusted_no_panic)
+def missing_export(input: bytes) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/local_bridge_blake3/positive/local_bridge_hash_bytes.sifr
+++ b/verification/areas/rust_interop/fixtures/local_bridge_blake3/positive/local_bridge_hash_bytes.sifr
@@ -1,0 +1,10 @@
+# fixture: local_bridge_blake3
+# evidence: positive/local_bridge_hash_bytes
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: pass
+class HashError(Error):
+    message: str
+
+@rust(bridge.blake3.hash_bytes, panic=map_error(bridge.blake3.map_panic))
+def hash_bytes(input: bytes) -> Result[bytes, HashError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/native_build_script/fixture.json
+++ b/verification/areas/rust_interop/fixtures/native_build_script/fixture.json
@@ -1,0 +1,30 @@
+{
+  "capability": "build-script and native-link trust",
+  "diagnostic_family": "SIFR-RUST-TRUST-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-TRUST-0001",
+      "expected_result": "future-owned-diagnostic",
+      "id": "untrusted_native_link_rejected",
+      "path": "negative/untrusted_native_link_rejected.sifr",
+      "status": "planned"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "trusted_build_script_native_evidence",
+      "path": "positive/trusted_build_script_native_evidence.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {},
+  "id": "native_build_script",
+  "required_crates": [
+    "cc",
+    "bindgen",
+    "cxx",
+    "zstd"
+  ],
+  "schema_version": 1,
+  "tier": 3
+}

--- a/verification/areas/rust_interop/fixtures/native_build_script/negative/untrusted_native_link_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/negative/untrusted_native_link_rejected.sifr
@@ -1,0 +1,8 @@
+# fixture: native_build_script
+# evidence: negative/untrusted_native_link_rejected
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned-diagnostic
+# expected-diagnostic: SIFR-RUST-TRUST-0001
+@rust(bridge.native.compress, panic=trusted_no_panic)
+def compress_without_native_trust(input: bytes) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/native_build_script/positive/trusted_build_script_native_evidence.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/positive/trusted_build_script_native_evidence.sifr
@@ -1,0 +1,12 @@
+# fixture: native_build_script
+# evidence: positive/trusted_build_script_native_evidence
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned
+# fixture-trust: rust-build-scripts = ["zstd", "cc", "bindgen", "cxx"]
+# fixture-trust: native-links = ["zstd"]
+@rust(bridge.native.compress, panic=map_error(bridge.native.map_panic))
+def compress(input: bytes) -> Result[bytes, NativeError | RustPanicError]: ...
+
+class NativeError(Error):
+    message: str

--- a/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/fixture.json
+++ b/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "opaque Rust handle basics",
+  "diagnostic_family": "SIFR-RUST-HANDLE-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-HANDLE-0001",
+      "expected_result": "diagnostic",
+      "id": "unsatisfied_send_or_copy_rejected",
+      "path": "negative/unsatisfied_send_or_copy_rejected.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "declared_send_sync_copy_handle",
+      "path": "positive/declared_send_sync_copy_handle.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {},
+  "id": "opaque_handle_tokenizer",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/negative/unsatisfied_send_or_copy_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/negative/unsatisfied_send_or_copy_rejected.sifr
@@ -1,0 +1,10 @@
+# fixture: opaque_handle_tokenizer
+# evidence: negative/unsatisfied_send_or_copy_rejected
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-HANDLE-0001
+@rust.opaque(type=bridge.tokenizer.Tokenizer, send=True, sync=True, clone=copy, close=close)
+class Tokenizer:
+    @rust(Self.encode, panic=trusted_no_panic)
+    def encode(self, text: str) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/positive/declared_send_sync_copy_handle.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/positive/declared_send_sync_copy_handle.sifr
@@ -1,0 +1,15 @@
+# fixture: opaque_handle_tokenizer
+# evidence: positive/declared_send_sync_copy_handle
+# evidence-status: passing
+# execution-kind: cargo-probe
+# expected-result: pass
+class TokenError(Error):
+    message: str
+
+@rust.opaque(type=bridge.tokenizer.Tokenizer, send=True, sync=True, clone=copy, close=close)
+class Tokenizer:
+    @rust(Self.encode, panic=map_error(bridge.tokenizer.map_panic))
+    def encode(self, text: str) -> Result[list[uint32], TokenError | RustPanicError]: ...
+
+    @rust(bridge.tokenizer.close, panic=map_error(bridge.tokenizer.map_panic))
+    def close(own self) -> Result[None, TokenError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/fixture.json
@@ -1,0 +1,55 @@
+{
+  "capability": "resource-shaped opaque handles",
+  "diagnostic_family": "SIFR-RUST-HANDLE-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-HANDLE-0001",
+      "expected_result": "future-owned-diagnostic",
+      "id": "invalid_resource_aliasing",
+      "path": "negative/invalid_resource_aliasing.sifr",
+      "status": "planned"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "resource_close_aclose_matrix",
+      "path": "positive/resource_close_aclose_matrix.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "runtime-observed",
+  "features": {
+    "redis": {
+      "default_features": false,
+      "features": [
+        "tokio-comp"
+      ]
+    },
+    "reqwest": {
+      "default_features": false,
+      "features": [
+        "rustls-tls",
+        "json"
+      ]
+    },
+    "rusqlite": {
+      "features": [
+        "bundled"
+      ]
+    },
+    "tokio-postgres": {
+      "default_features": false,
+      "features": [
+        "runtime"
+      ]
+    }
+  },
+  "id": "opaque_resource_matrix",
+  "required_crates": [
+    "reqwest",
+    "rusqlite",
+    "tokio-postgres",
+    "redis"
+  ],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/negative/invalid_resource_aliasing.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/negative/invalid_resource_aliasing.sifr
@@ -1,0 +1,10 @@
+# fixture: opaque_resource_matrix
+# evidence: negative/invalid_resource_aliasing
+# evidence-status: planned
+# execution-kind: runtime-observed
+# expected-result: future-owned-diagnostic
+# expected-diagnostic: SIFR-RUST-HANDLE-0001
+@rust.opaque(type=bridge.resources.Client, send=True, sync=True, clone=arc, close=async_close)
+class SharedResourceClient:
+    @rust(bridge.resources.borrow_exclusive, panic=trusted_no_panic)
+    def borrow_exclusive(self) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/positive/resource_close_aclose_matrix.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/positive/resource_close_aclose_matrix.sifr
@@ -1,0 +1,12 @@
+# fixture: opaque_resource_matrix
+# evidence: positive/resource_close_aclose_matrix
+# evidence-status: planned
+# execution-kind: runtime-observed
+# expected-result: future-owned
+class ResourceError(Error):
+    message: str
+
+@rust.opaque(type=bridge.resources.Client, send=True, sync=False, clone=none, close=async_close)
+class ResourceClient:
+    @rust(bridge.resources.aclose, panic=map_error(bridge.resources.map_panic))
+    async def aclose(own self) -> Result[None, ResourceError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/panic_abort_profile/fixture.json
+++ b/verification/areas/rust_interop/fixtures/panic_abort_profile/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "abort-profile rejection and trust",
+  "diagnostic_family": "SIFR-RUST-PANIC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-PANIC-0001",
+      "expected_result": "diagnostic",
+      "id": "recoverable_abort_profile_rejected",
+      "path": "negative/recoverable_abort_profile_rejected.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "explicit_abort_trust_and_strategy_declared",
+      "path": "positive/explicit_abort_trust_and_strategy_declared.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "contract-only",
+  "features": {},
+  "id": "panic_abort_profile",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/panic_abort_profile/negative/recoverable_abort_profile_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_abort_profile/negative/recoverable_abort_profile_rejected.sifr
@@ -1,0 +1,8 @@
+# fixture: panic_abort_profile
+# evidence: negative/recoverable_abort_profile_rejected
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-PANIC-0001
+@rust(bridge.legacy.run, panic=abort)
+def run_legacy_without_trust() -> uint32: ...

--- a/verification/areas/rust_interop/fixtures/panic_abort_profile/positive/explicit_abort_trust_and_strategy_declared.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_abort_profile/positive/explicit_abort_trust_and_strategy_declared.sifr
@@ -1,0 +1,8 @@
+# fixture: panic_abort_profile
+# evidence: positive/explicit_abort_trust_and_strategy_declared
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: pass
+# fixture-trust: rust-panic-abort = ["bridge.legacy.run"]
+@rust(bridge.legacy.run, panic=abort)
+def run_legacy() -> uint32: ...

--- a/verification/areas/rust_interop/fixtures/panic_boundary/fixture.json
+++ b/verification/areas/rust_interop/fixtures/panic_boundary/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "panic-to-error behavior",
+  "diagnostic_family": "SIFR-RUST-PANIC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-PANIC-0001",
+      "expected_result": "diagnostic",
+      "id": "panic_payload_not_exposed",
+      "path": "negative/panic_payload_not_exposed.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "result_declares_rust_panic_error_or_map_error",
+      "path": "positive/result_declares_rust_panic_error_or_map_error.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "contract-only",
+  "features": {},
+  "id": "panic_boundary",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/panic_boundary/negative/panic_payload_not_exposed.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_boundary/negative/panic_payload_not_exposed.sifr
@@ -1,0 +1,11 @@
+# fixture: panic_boundary
+# evidence: negative/panic_payload_not_exposed
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-PANIC-0001
+@rust(bridge.panic.may_panic)
+def may_panic() -> Result[uint32, UserError]: ...
+
+class UserError(Error):
+    message: str

--- a/verification/areas/rust_interop/fixtures/panic_boundary/positive/result_declares_rust_panic_error_or_map_error.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_boundary/positive/result_declares_rust_panic_error_or_map_error.sifr
@@ -1,0 +1,10 @@
+# fixture: panic_boundary
+# evidence: positive/result_declares_rust_panic_error_or_map_error
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: pass
+class PanicMapped(Error):
+    message: str
+
+@rust(bridge.panic.safe_result, panic=map_error(bridge.panic.map_panic))
+def safe_result() -> Result[uint32, PanicMapped | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/fixture.json
+++ b/verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "generated panic wrapper emission, mapper signature validation, and mapper-panic fallback behavior",
+  "diagnostic_family": "SIFR-RUST-PANIC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-PANIC-0001",
+      "expected_result": "future-owned-diagnostic",
+      "id": "invalid_map_error_signature_rejected",
+      "path": "negative/invalid_map_error_signature_rejected.sifr",
+      "status": "planned"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "generated_wrapper_maps_panic_to_declared_error",
+      "path": "positive/generated_wrapper_maps_panic_to_declared_error.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "runtime-observed",
+  "features": {},
+  "id": "panic_boundary_wrapper_emission",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/negative/invalid_map_error_signature_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/negative/invalid_map_error_signature_rejected.sifr
@@ -1,0 +1,11 @@
+# fixture: panic_boundary_wrapper_emission
+# evidence: negative/invalid_map_error_signature_rejected
+# evidence-status: planned
+# execution-kind: runtime-observed
+# expected-result: future-owned-diagnostic
+# expected-diagnostic: SIFR-RUST-PANIC-0001
+@rust(bridge.wrapper.may_panic, panic=map_error(bridge.wrapper.invalid_mapper))
+def may_panic(input: str) -> Result[str, PanicMapped | RustPanicError]: ...
+
+class PanicMapped(Error):
+    message: str

--- a/verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/positive/generated_wrapper_maps_panic_to_declared_error.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/positive/generated_wrapper_maps_panic_to_declared_error.sifr
@@ -1,0 +1,10 @@
+# fixture: panic_boundary_wrapper_emission
+# evidence: positive/generated_wrapper_maps_panic_to_declared_error
+# evidence-status: planned
+# execution-kind: runtime-observed
+# expected-result: future-owned
+class PanicMapped(Error):
+    message: str
+
+@rust(bridge.wrapper.may_panic, panic=map_error(bridge.wrapper.map_panic))
+def may_panic(input: str) -> Result[str, PanicMapped | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/fixture.json
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/fixture.json
@@ -1,0 +1,32 @@
+{
+  "capability": "build-script and proc-macro trust",
+  "diagnostic_family": "SIFR-RUST-TRUST-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-TRUST-0001",
+      "expected_result": "future-owned-diagnostic",
+      "id": "untrusted_proc_macro_rejected_pre_execution",
+      "path": "negative/untrusted_proc_macro_rejected_pre_execution.sifr",
+      "status": "planned"
+    },
+    "positive": {
+      "expected_result": "future-owned",
+      "id": "trusted_proc_macro",
+      "path": "positive/trusted_proc_macro.sifr",
+      "status": "planned"
+    }
+  },
+  "execution_kind": "cargo-probe",
+  "features": {
+    "prost-build": {
+      "generated_output": "deterministic"
+    }
+  },
+  "id": "proc_macro_trust",
+  "required_crates": [
+    "serde_derive",
+    "prost-build"
+  ],
+  "schema_version": 1,
+  "tier": 3
+}

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/negative/untrusted_proc_macro_rejected_pre_execution.sifr
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/negative/untrusted_proc_macro_rejected_pre_execution.sifr
@@ -1,0 +1,8 @@
+# fixture: proc_macro_trust
+# evidence: negative/untrusted_proc_macro_rejected_pre_execution
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned-diagnostic
+# expected-diagnostic: SIFR-RUST-TRUST-0001
+@rust(bridge.generated.decode, panic=trusted_no_panic)
+def decode_without_proc_macro_trust(input: bytes) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/positive/trusted_proc_macro.sifr
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/positive/trusted_proc_macro.sifr
@@ -1,0 +1,12 @@
+# fixture: proc_macro_trust
+# evidence: positive/trusted_proc_macro
+# evidence-status: planned
+# execution-kind: cargo-probe
+# expected-result: future-owned
+# fixture-trust: rust-proc-macros = ["serde_derive"]
+# fixture-trust: rust-build-scripts = ["prost-build"]
+@rust(bridge.generated.decode, panic=map_error(bridge.generated.map_panic))
+def decode(input: bytes) -> Result[GeneratedMessage, DecodeError | RustPanicError]: ...
+
+class DecodeError(Error):
+    message: str

--- a/verification/areas/rust_interop/fixtures/same_workspace_crate/fixture.json
+++ b/verification/areas/rust_interop/fixtures/same_workspace_crate/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "same-workspace crate as ordinary Cargo dependency",
+  "diagnostic_family": "SIFR-RUST-CARGO-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-CARGO-0001",
+      "expected_result": "diagnostic",
+      "id": "undeclared_workspace_crate_rejected",
+      "path": "negative/undeclared_workspace_crate_rejected.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "declared_path_dependency_resolves",
+      "path": "positive/declared_path_dependency_resolves.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "contract-only",
+  "features": {},
+  "id": "same_workspace_crate",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 1
+}

--- a/verification/areas/rust_interop/fixtures/same_workspace_crate/negative/undeclared_workspace_crate_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/same_workspace_crate/negative/undeclared_workspace_crate_rejected.sifr
@@ -1,0 +1,8 @@
+# fixture: same_workspace_crate
+# evidence: negative/undeclared_workspace_crate_rejected
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-CARGO-0001
+@rust(undeclared_workspace_hash.hash, panic=trusted_no_panic)
+def undeclared(input: bytes) -> uint64: ...

--- a/verification/areas/rust_interop/fixtures/same_workspace_crate/positive/declared_path_dependency_resolves.sifr
+++ b/verification/areas/rust_interop/fixtures/same_workspace_crate/positive/declared_path_dependency_resolves.sifr
@@ -1,0 +1,7 @@
+# fixture: same_workspace_crate
+# evidence: positive/declared_path_dependency_resolves
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: pass
+@rust(workspace_hash.hash, panic=trusted_no_panic)
+def workspace_hash(input: bytes) -> uint64: ...

--- a/verification/areas/rust_interop/fixtures/shared_bridge_crate/fixture.json
+++ b/verification/areas/rust_interop/fixtures/shared_bridge_crate/fixture.json
@@ -1,0 +1,25 @@
+{
+  "capability": "shared bridge crate boundary",
+  "diagnostic_family": "SIFR-RUST-RESOLVE-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-RESOLVE-0001",
+      "expected_result": "diagnostic",
+      "id": "package_generated_type_import_rejected",
+      "path": "negative/package_generated_type_import_rejected.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "stable_runtime_types_only",
+      "path": "positive/stable_runtime_types_only.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "contract-only",
+  "features": {},
+  "id": "shared_bridge_crate",
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 1
+}

--- a/verification/areas/rust_interop/fixtures/shared_bridge_crate/negative/package_generated_type_import_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/shared_bridge_crate/negative/package_generated_type_import_rejected.sifr
@@ -1,0 +1,8 @@
+# fixture: shared_bridge_crate
+# evidence: negative/package_generated_type_import_rejected
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-RESOLVE-0001
+@rust(shared_bridge.generated_private_type, panic=trusted_no_panic)
+def imports_package_generated_type(input: bytes) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/shared_bridge_crate/positive/stable_runtime_types_only.sifr
+++ b/verification/areas/rust_interop/fixtures/shared_bridge_crate/positive/stable_runtime_types_only.sifr
@@ -1,0 +1,10 @@
+# fixture: shared_bridge_crate
+# evidence: positive/stable_runtime_types_only
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: pass
+class SharedDigest:
+    bytes: bytes
+
+@rust(sifr_shared_hash_bridge.digest, panic=trusted_no_panic)
+def digest(input: bytes) -> SharedDigest: ...

--- a/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/fixture.json
+++ b/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/fixture.json
@@ -1,0 +1,29 @@
+{
+  "capability": "tensor and DLPack handoff",
+  "diagnostic_family": "SIFR-RUST-ZC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-ZC-0001",
+      "expected_result": "diagnostic",
+      "id": "implicit_dlpack_ownership_rejected",
+      "path": "negative/implicit_dlpack_ownership_rejected.sifr",
+      "scope": "contract-only",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "explicit_tensor_ownership",
+      "path": "positive/explicit_tensor_ownership.sifr",
+      "scope": "contract-only",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "contract-only",
+  "features": {},
+  "id": "tensor_dlpack_bridge",
+  "required_crates": [
+    "ndarray"
+  ],
+  "schema_version": 1,
+  "tier": 4
+}

--- a/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/negative/implicit_dlpack_ownership_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/negative/implicit_dlpack_ownership_rejected.sifr
@@ -1,0 +1,9 @@
+# fixture: tensor_dlpack_bridge
+# evidence: negative/implicit_dlpack_ownership_rejected
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-ZC-0001
+@rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=dlpack, dtype=f32, rank=2, shape=[2], layout=strided, strides=[3, 1], device=cpu, ownership=transfer, protocol=sifr_tensor_bridge.dlpack.Capsule)
+@rust(sifr_tensor_bridge.dlpack_from_bytes, panic=trusted_no_panic)
+def bad_shape(own input: bytes) -> Tensor: ...

--- a/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/positive/explicit_tensor_ownership.sifr
+++ b/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/positive/explicit_tensor_ownership.sifr
@@ -1,0 +1,12 @@
+# fixture: tensor_dlpack_bridge
+# evidence: positive/explicit_tensor_ownership
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: pass
+class TensorError(Error):
+    message: str
+
+@rust.zero_copy(owner=input, view=sifr_tensor_bridge.dlpack.DlpackView)
+@rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=dlpack, dtype=f32, rank=2, shape=[2, 3], layout=strided, strides=[3, 1], device=cpu, ownership=transfer, protocol=sifr_tensor_bridge.dlpack.Capsule)
+@rust(sifr_tensor_bridge.dlpack_from_bytes, panic=map_error(sifr_tensor_bridge.panic.map))
+def tensor(own input: bytes) -> Result[Tensor, TensorError | RustPanicError]: ...

--- a/verification/areas/rust_interop/fixtures/zero_copy_bytes/fixture.json
+++ b/verification/areas/rust_interop/fixtures/zero_copy_bytes/fixture.json
@@ -1,0 +1,27 @@
+{
+  "capability": "zero-copy bytes view",
+  "diagnostic_family": "SIFR-RUST-ZC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-ZC-0001",
+      "expected_result": "diagnostic",
+      "id": "copy_fallback_rejected",
+      "path": "negative/copy_fallback_rejected.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "borrowed_bytes_view",
+      "path": "positive/borrowed_bytes_view.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "contract-only",
+  "features": {},
+  "id": "zero_copy_bytes",
+  "required_crates": [
+    "bytes"
+  ],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/zero_copy_bytes/negative/copy_fallback_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_bytes/negative/copy_fallback_rejected.sifr
@@ -1,0 +1,9 @@
+# fixture: zero_copy_bytes
+# evidence: negative/copy_fallback_rejected
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-ZC-0001
+@rust.zero_copy(owner=input, view=bridge.bytes.BytesView)
+@rust(bridge.bytes.copies_anyway, panic=trusted_no_panic)
+def copies_anyway(input: bytes) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/zero_copy_bytes/positive/borrowed_bytes_view.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_bytes/positive/borrowed_bytes_view.sifr
@@ -1,0 +1,9 @@
+# fixture: zero_copy_bytes
+# evidence: positive/borrowed_bytes_view
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: pass
+@rust.zero_copy(owner=input, view=bridge.bytes.BytesView)
+@rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True)
+@rust(bridge.bytes.borrowed_view, panic=trusted_no_panic)
+def borrowed_view(input: bytes) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/fixture.json
@@ -1,0 +1,29 @@
+{
+  "capability": "core zero-copy views",
+  "diagnostic_family": "SIFR-RUST-ZC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-ZC-0001",
+      "expected_result": "diagnostic",
+      "id": "mutable_alias_rejected",
+      "path": "negative/mutable_alias_rejected.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "owner_lifetime_views",
+      "path": "positive/owner_lifetime_views.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "contract-only",
+  "features": {},
+  "id": "zero_copy_view_matrix",
+  "required_crates": [
+    "memmap2",
+    "bytemuck",
+    "zerocopy"
+  ],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/negative/mutable_alias_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/negative/mutable_alias_rejected.sifr
@@ -1,0 +1,9 @@
+# fixture: zero_copy_view_matrix
+# evidence: negative/mutable_alias_rejected
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-ZC-0001
+@rust.view(owner=input, lifetime=owner, mutability=mutable, send=True, sync=True)
+@rust(bridge.views.mutable_from_shared, panic=trusted_no_panic)
+def mutable_from_shared(input: bytes) -> bytes: ...

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/positive/owner_lifetime_views.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/positive/owner_lifetime_views.sifr
@@ -1,0 +1,9 @@
+# fixture: zero_copy_view_matrix
+# evidence: positive/owner_lifetime_views
+# evidence-status: passing
+# execution-kind: contract-only
+# expected-result: pass
+@rust.zero_copy(owner=input, view=bridge.views.SliceView)
+@rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True)
+@rust(bridge.views.slice_view, panic=trusted_no_panic)
+def slice_view(input: bytes) -> bytes: ...


### PR DESCRIPTION
## Summary
- Add concrete Rust interop fixture manifests and source files for all 31 fixture matrix rows: 31 `fixture.json`, 31 positive `.sifr`, and 31 negative `.sifr` files.
- Strengthen the Rust interop matrix validator so README-only fixture directories, missing sources, path/layout drift, stale headers, missing diagnostics, and comment-only interop stubs are rejected.
- Document the required fixture layout and record the Opus review passes.
- Disable empty `sifr_lsp` doctests to avoid rustdoc hangs; the crate has no rustdoc code examples and unit tests remain covered.

## Validation
- `python3 verification/areas/rust_interop/checks/check_fixture_matrix.py` -> `rust interop fixture matrix ok: fixtures=31 diagnostics=10 crates=44`
- `python3 -m py_compile verification/areas/rust_interop/checks/check_fixture_matrix.py`
- Direct fixture counts: 31 manifests, 31 positive sources, 31 negative sources
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/run_all_tests.sh --profile create-pr` -> passed; e2e 132 passed, 0 failed; final report `target/validation_lane_reports/create-pr.latest.json`

## Reviews
- `plans/reviews/active/rust_interop_fixture_sources_review.md`
- `plans/reviews/active/rust_interop_fixture_sources_review_2.md` -> no remaining actionable findings

Note: local worktree still has an unrelated dirty `editor_integrations` submodule, intentionally excluded from this PR.