### PR TITLE
Add Rust interop package examples

### DIFF
--- a/plans/reviews/active/rust_interop_package_examples_review.md
+++ b/plans/reviews/active/rust_interop_package_examples_review.md
@@ -1,0 +1,43 @@
+I've reviewed the validator, README, all 19 modified `fixture.json` files, and all 51 example `.sifr` files. Below are the findings — no blocking issues.
+
+## Code review — Rust interop package examples
+
+### Major (actionable, not blocking)
+
+**M1. The validator does not enforce that `@rust(...)` binds the crate the example claims to demonstrate.** `verification/areas/rust_interop/checks/check_fixture_matrix.py:368-372`
+- Line 368 accepts any line starting with `@rust(`, regardless of which crate token follows.
+- Line 371's "crate name in text" check is trivially satisfied by the `# required-crate: <crate>` header on line 3, so it adds no real signal.
+- Net effect: `examples/sha2.sifr` could contain `@rust(blake3.hash, ...)` and pass. All current examples bind the correct crate, but the matrix suite's promise of "every package surface is represented" is weaker than it looks.
+- Suggested tightening: require at least one `@rust(<crate_token>` (with `crate.replace("-", "_")`) before the panic mapping.
+
+**M2. The validator does not require `verify_<crate>_package` to actually invoke the bound function.** `check_fixture_matrix.py:373-374` and `README.md:34-35`
+- The check is purely `def verify_<crate_token>_package(` substring presence. A body of `return 42` would pass.
+- The README promises a "`verify_<crate>_package` function that exercises that binding," which is a stronger claim than what is enforced. Today's examples honor the spirit; future drift is not caught.
+- Suggested tightening: require the function body (text after the `def verify_...(` line) to reference the @rust-bound function name, or at least the crate token.
+
+### Minor
+
+**m1. 10-line floor is mostly absorbed by boilerplate.** `check_fixture_matrix.py:356`
+- The 5 required header comments + `class PackageExampleError(Error)` + `@rust(...)` line + `def verify_<crate>_package(...)` line already total 8 mandatory lines; a couple of blanks gets you to 10 with effectively zero "real example" content. Combined with M1/M2, this is the empty-example tricking vector. Not exploited today (smallest current example is 13 lines), but the floor isn't doing much work.
+
+**m2. `proc_macro_trust/examples/serde_derive.sifr` binds to a derive macro as if it were a callable.** `verification/areas/rust_interop/fixtures/proc_macro_trust/examples/serde_derive.sifr:12-13`
+- `serde_derive` exposes only `#[derive(...)]` proc macros; `serde_derive.Deserialize` is not a function and won't survive any future runtime escalation of this fixture. Acceptable while `execution_kind` stays at `cargo-probe`, but flag this for whoever lifts the tier.
+
+**m3. `direct_crate_negative_type/examples/regex.sifr` is byte-equivalent (modulo two header lines) to `direct_crate_matrix/examples/regex.sifr`.** Same `@rust(regex.Regex.is_match, ...)` binding, same verify body. The negative-type fixture's package example adds no surface coverage that the positive matrix fixture doesn't already provide. By the schema's letter this is fine (the package example demos crate surface, not the diagnostic); worth noting because it inflates the headline "51 examples" count.
+
+**m4. `opaque_resource_matrix/examples/tokio-postgres.sifr:16` and `.../reqwest.sifr` use `"https://127.0.0.1/health"` as a Postgres connect string.** Cosmetic — these are contract-only — but misleading on inspection. Cheap to swap `tokio-postgres` over to a `postgres://...` literal.
+
+### Informational
+
+**i1. `plans/reviews/active/rust_interop_package_examples_review.md` is a 0-byte placeholder.** Not loaded by any check; populate before merge to keep the planning trail intact.
+
+**i2. `class PackageExampleError(Error)` is redeclared in every example.** Fine as long as each example compiles standalone (which the present design assumes). Worth a one-line comment in the README if anyone ever wants to compile examples in batch.
+
+**i3. Hyphenated crates handled correctly.** `tokio-postgres`/`tokio-tungstenite`/`tower-http`/`http-body`/`prost-build`/`tracing-subscriber` consistently file as `<crate>.sifr` and bind `<crate_token>` (underscored) in `@rust(...)`. Validator's normalization (line 370) accommodates both, and the headers stay hyphenated. Consistent across all 51 files.
+
+**i4. README accurately describes the layout and the `package_examples` schema** (lines 27-35), modulo the M2 overpromise about "exercises that binding."
+
+**i5. Naming and pathing are stable and grep-friendly.** `examples/<crate>.sifr` + `verify_<crate_token>_package` + a fixture-id header makes adding new crates mechanical. Future maintenance looks fine.
+
+### Verdict
+No blocking findings. The two items worth doing before merge — both in `check_fixture_matrix.py` — are tightening the `@rust(...)` crate check (M1) and requiring the verify body to mention the binding (M2). They close the "validator can be tricked by stub examples" gap that the user explicitly asked about. The cosmetic items (m4, i1) are cheap to clear in the same PR if convenient; everything else can wait.

--- a/plans/reviews/active/rust_interop_package_examples_review_2.md
+++ b/plans/reviews/active/rust_interop_package_examples_review_2.md
@@ -1,0 +1,21 @@
+## Findings
+
+**M1 — partially addressed; one residual gap.** The `@rust(<crate_token>` prefix check in `verification/areas/rust_interop/checks/check_fixture_matrix.py:387` matches by `startswith` without a boundary, so a sibling crate whose normalized name starts with the target's name slips through. Concretely, in `tracing.sifr` (crate_token `tracing`), an `@rust(tracing_subscriber.fmt.init, …)` line `startswith("@rust(tracing")` → True; `_rust_bound_function_name` then returns the subscriber's `def` name, and the verifier-call check at line 379 is satisfied if `verify_tracing_package` calls that same wrong function. Five collision pairs in `REQUIRED_CRATES` (after `-`→`_` normalization) are exposed:
+- `serde` ↔ `serde_json`, `serde_derive`
+- `http` ↔ `http_body`
+- `tokio` ↔ `tokio_postgres`, `tokio_tungstenite`
+- `tracing` ↔ `tracing_subscriber`
+- `tower` ↔ `tower_http`
+
+The fix is small: require the char following `crate_token` in the `@rust(...)` head to be a non-identifier delimiter (e.g., one of `.`, `,`, `)`, `:`, whitespace) — `not (next_char.isalnum() or next_char == "_")`. The current example files all happen to use the correct crate, so the suite passes today; the gap only fires on a future copy-paste mistake, which is exactly what M1 was meant to catch.
+
+**M2 — effectively addressed.** `verify_<crate_token>_package` presence + bound-function call site are both enforced (lines 374–380). Two minor edge cases, neither actionable given current fixture shape:
+- Substring match: `f"{bound_function}("` could match a longer suffix-bearing identifier (e.g., `my_foo(` satisfies `foo(`). Not currently realizable in the small fixtures.
+- The "verifier body" is the entire file tail from the `def verify_…` line onward, not just that function's block; a stray call in a later definition would satisfy the check. Again not realizable in the current 1-function-per-file shape.
+
+If M1 is tightened to require a boundary character, these residual M2 edges become even less reachable, and I would not block on them.
+
+**URL literals — fixed.** Verified `redis://` (both fixtures), `postgres://` (opaque_resource_matrix), and `ws://` (callback_subscription_matrix) are in place.
+
+## Summary
+One actionable finding remains: tighten the `@rust(<crate_token>` match in `_rust_bound_function_name` to require a delimiter after the crate token, closing the sibling-crate bypass for the five collision pairs above. Everything else in this follow-up looks good.

--- a/plans/reviews/active/rust_interop_package_examples_review_3.md
+++ b/plans/reviews/active/rust_interop_package_examples_review_3.md
@@ -1,0 +1,18 @@
+I verified the fix by tracing the logic through the actual fixture files.
+
+**Verification of the fix in `check_fixture_matrix.py:383-406`:**
+
+The `_rust_bound_function_name` builds `binding_prefix = f"@rust({crate_token}"` then calls `_has_crate_token_boundary(stripped, len(binding_prefix))`. The boundary helper rejects when the next character is alphanumeric or `_`, accepts everything else (and end-of-string).
+
+Walked through the previously vulnerable crate pairs against their actual examples:
+
+- crate `tracing` vs `@rust(tracing_subscriber.fmt.init, ...)`: `stripped[len("@rust(tracing")]` = `_` → boundary fail → correctly skipped. (`fixtures/ecosystem_cli_certification/examples/tracing-subscriber.sifr:9`)
+- crate `tracing` vs `@rust(tracing.info, ...)`: next char = `.` → accepted. (`fixtures/ecosystem_cli_certification/examples/tracing.sifr:9`)
+- crate `http` vs `@rust(http.Request.builder, ...)`: next char = `.` → accepted. `http-body` (token `http_body`) won't match the `http` prefix scan because `http_body` itself fails the boundary on `_`. (`fixtures/async_ecosystem_matrix/examples/http.sifr:12`)
+- Same boundary protection now correctly partitions `serde` / `serde_derive` / `serde_json`, `tokio` / `tokio_postgres` / `tokio_tungstenite`, and `tower` / `tower_http`.
+
+Delimiters appearing in real examples — `.`, `,`, `)`, whitespace — all pass `_has_crate_token_boundary`. Identifier continuations (`_`, alnum) all fail. End-of-string returns True so a bare `@rust(crate` line wouldn't be rejected on length alone (no such case in fixtures, but the behavior is consistent).
+
+The runner output (`fixtures=31 diagnostics=10 crates=44 package_examples=51`) matches `REQUIRED_FIXTURES` (31) and `REQUIRED_CRATES` (44), confirming coverage is intact.
+
+No remaining actionable findings.

--- a/verification/areas/rust_interop/README.md
+++ b/verification/areas/rust_interop/README.md
@@ -24,10 +24,15 @@ Each directory under `fixtures/` is required to contain:
   matrix row.
 - `positive/<positive_evidence.id>.sifr`: the positive evidence source.
 - `negative/<negative_evidence.id>.sifr`: the negative evidence source.
+- `examples/<crate>.sifr`: one full package example for each crate listed in
+  the fixture row's `required_crates`.
 
 The `matrix` suite validates this layout, verifies that fixture metadata
 matches `data/rust_interop_fixture_matrix.json`, and rejects empty README-only
-fixture directories.
+fixture directories. Package examples must be referenced from
+`fixture.json.package_examples`, must use the exact `examples/<crate>.sifr`
+path, and must include a concrete `@rust(...)` declaration plus a
+`verify_<crate>_package` function that exercises that binding.
 
 The area-level `network_mode` is `offline` for compile/probe and contract
 checks. Runtime-observed fixtures that need services such as Redis or
@@ -37,8 +42,8 @@ fixture evidence; they must not silently degrade to compile-only coverage.
 ## Suites
 
 - `matrix`: verifies the fixture matrix, required fixture directories, crate
-  coverage, evidence objects, fixture READMEs, fixture source files, and
-  diagnostic family inventory.
+  coverage, evidence objects, fixture READMEs, fixture source files, package
+  examples for every required Rust crate, and diagnostic family inventory.
 - `tiers`: verifies tier definitions and fixture tier assignments.
 - `compatibility-matrix`: verifies that public compatibility rows match fixture
   evidence and that no fixture family is omitted.

--- a/verification/areas/rust_interop/checks/check_fixture_matrix.py
+++ b/verification/areas/rust_interop/checks/check_fixture_matrix.py
@@ -168,6 +168,7 @@ def main() -> int:
             failures.append(f"{fixture_id}: fixture.json is required for evidence files")
 
     covered_crates: set[str] = set()
+    package_example_count = 0
     for fixture in fixtures:
         if not isinstance(fixture, dict):
             failures.append("fixture entries must be objects")
@@ -188,7 +189,7 @@ def main() -> int:
         _validate_feature_policies(failures, fixture_id, fixture.get("features"), crates)
         _validate_evidence(failures, fixture_id, fixture.get("positive_evidence"), "positive_evidence")
         _validate_evidence(failures, fixture_id, fixture.get("negative_evidence"), "negative_evidence")
-        _validate_fixture_files(failures, fixture)
+        package_example_count += _validate_fixture_files(failures, fixture, crates)
 
     failures.extend(f"required crate lacks fixture coverage: {crate}" for crate in sorted(REQUIRED_CRATES - covered_crates))
 
@@ -198,7 +199,8 @@ def main() -> int:
         return 1
     print(
         "rust interop fixture matrix ok: "
-        f"fixtures={len(fixture_id_set)} diagnostics={len(diagnostics)} crates={len(covered_crates)}"
+        f"fixtures={len(fixture_id_set)} diagnostics={len(diagnostics)} "
+        f"crates={len(covered_crates)} package_examples={package_example_count}"
     )
     return 0
 
@@ -238,20 +240,20 @@ def _validate_feature_policies(
             )
 
 
-def _validate_fixture_files(failures: list[str], fixture: dict[str, Any]) -> None:
+def _validate_fixture_files(failures: list[str], fixture: dict[str, Any], crates: list[Any]) -> int:
     fixture_id = str(fixture.get("id"))
     fixture_dir = FIXTURES_ROOT / fixture_id
     manifest_path = fixture_dir / "fixture.json"
     if not manifest_path.is_file():
-        return
+        return 0
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as error:
         failures.append(f"{fixture_id}: fixture.json is not valid JSON: {error}")
-        return
+        return 0
     if not isinstance(manifest, dict):
         failures.append(f"{fixture_id}: fixture.json must be an object")
-        return
+        return 0
 
     for field in ("id", "capability", "tier", "execution_kind", "required_crates"):
         if manifest.get(field) != fixture.get(field):
@@ -266,7 +268,7 @@ def _validate_fixture_files(failures: list[str], fixture: dict[str, Any]) -> Non
     evidence = manifest.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(f"{fixture_id}: fixture.json evidence must be an object")
-        return
+        return 0
     _validate_fixture_evidence_file(
         failures,
         fixture_id,
@@ -285,6 +287,123 @@ def _validate_fixture_files(failures: list[str], fixture: dict[str, Any]) -> Non
         fixture.get("execution_kind"),
         "negative",
     )
+    return _validate_package_examples(
+        failures,
+        fixture_id,
+        fixture_dir,
+        manifest.get("package_examples"),
+        crates,
+        fixture.get("execution_kind"),
+    )
+
+
+def _validate_package_examples(
+    failures: list[str],
+    fixture_id: str,
+    fixture_dir: Path,
+    raw_examples: Any,
+    crates: list[Any],
+    execution_kind: Any,
+) -> int:
+    expected_crates = {str(crate) for crate in crates}
+    if not expected_crates:
+        if raw_examples not in ({}, None):
+            failures.append(f"{fixture_id}: package_examples must be empty when required_crates is empty")
+        return 0
+    if not isinstance(raw_examples, dict):
+        failures.append(f"{fixture_id}: fixture.json package_examples must cover every required crate")
+        return 0
+
+    actual_crates = {str(crate) for crate in raw_examples}
+    for crate in sorted(expected_crates - actual_crates):
+        failures.append(f"{fixture_id}: missing package example for crate {crate}")
+    for crate in sorted(actual_crates - expected_crates):
+        failures.append(f"{fixture_id}: unexpected package example for crate {crate}")
+
+    valid_examples = 0
+    for crate in sorted(expected_crates & actual_crates):
+        raw_path = raw_examples.get(crate)
+        if not isinstance(raw_path, str) or not raw_path:
+            failures.append(f"{fixture_id}: package_examples.{crate} path is required")
+            continue
+        raw_source_path = Path(raw_path)
+        expected_path = Path("examples") / f"{crate}.sifr"
+        if raw_source_path.is_absolute() or ".." in raw_source_path.parts:
+            failures.append(f"{fixture_id}: package_examples.{crate} must stay inside the fixture directory")
+            continue
+        if raw_source_path != expected_path:
+            failures.append(f"{fixture_id}: package_examples.{crate} must be {expected_path.as_posix()}")
+            continue
+
+        source_path = fixture_dir / raw_source_path
+        if not source_path.is_file():
+            failures.append(f"{fixture_id}: missing package example source {raw_path}")
+            continue
+        text = source_path.read_text(encoding="utf-8")
+        _validate_package_example_text(failures, fixture_id, raw_path, text, crate, execution_kind)
+        valid_examples += 1
+    return valid_examples
+
+
+def _validate_package_example_text(
+    failures: list[str],
+    fixture_id: str,
+    raw_path: str,
+    text: str,
+    crate: str,
+    execution_kind: Any,
+) -> None:
+    if len(text.strip().splitlines()) < 10:
+        failures.append(f"{fixture_id}: {raw_path} must contain a full package example")
+    required_headers = (
+        f"# fixture: {fixture_id}",
+        f"# package-example: {crate}",
+        f"# required-crate: {crate}",
+        f"# execution-kind: {execution_kind}",
+        "# expected-result: package-example",
+    )
+    for header in required_headers:
+        if header not in text:
+            failures.append(f"{fixture_id}: {raw_path} missing header {header!r}")
+    crate_token = crate.replace("-", "_")
+    bound_function = _rust_bound_function_name(text, crate_token)
+    if bound_function is None:
+        failures.append(f"{fixture_id}: {raw_path} must declare a Rust binding for crate {crate}")
+        return
+
+    verifier_marker = f"def verify_{crate_token}_package("
+    if verifier_marker not in text:
+        failures.append(f"{fixture_id}: {raw_path} must include verify_{crate_token}_package")
+        return
+    verifier_body = text[text.index(verifier_marker) :]
+    if f"{bound_function}(" not in verifier_body:
+        failures.append(f"{fixture_id}: {raw_path} verifier must call {bound_function}")
+
+
+def _rust_bound_function_name(text: str, crate_token: str) -> str | None:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        binding_prefix = f"@rust({crate_token}"
+        if not stripped.startswith(binding_prefix):
+            continue
+        if not _has_crate_token_boundary(stripped, len(binding_prefix)):
+            continue
+        for following in lines[index + 1 :]:
+            following_stripped = following.lstrip()
+            if following_stripped.startswith("@"):
+                continue
+            if not following_stripped.startswith("def "):
+                return None
+            return following_stripped.removeprefix("def ").split("(", maxsplit=1)[0].strip()
+    return None
+
+
+def _has_crate_token_boundary(text: str, index: int) -> bool:
+    if index >= len(text):
+        return True
+    next_char = text[index]
+    return not (next_char.isalnum() or next_char == "_")
 
 
 def _validate_fixture_evidence_file(

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/candle.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/candle.sifr
@@ -1,0 +1,16 @@
+# fixture: advanced_data_matrix
+# package-example: candle
+# required-crate: candle
+# execution-kind: contract-only
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class Tensor:
+    pass
+
+@rust(candle.Tensor.from_vec, panic=map_error(bridge.candle.map_panic))
+def candle_tensor_from_vec(input: list[f32]) -> Result[Tensor, PackageExampleError | RustPanicError]: ...
+
+def verify_candle_package() -> Result[Tensor, PackageExampleError | RustPanicError]:
+    return candle_tensor_from_vec([1.0, 2.0, 3.0, 4.0])

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/datafusion.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/datafusion.sifr
@@ -1,0 +1,16 @@
+# fixture: advanced_data_matrix
+# package-example: datafusion
+# required-crate: datafusion
+# execution-kind: contract-only
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class DataFrame:
+    pass
+
+@rust(datafusion.SessionContext.new, panic=map_error(bridge.datafusion.map_panic))
+def datafusion_context(query: str) -> Result[DataFrame, PackageExampleError | RustPanicError]: ...
+
+def verify_datafusion_package() -> Result[DataFrame, PackageExampleError | RustPanicError]:
+    return datafusion_context("select 1")

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/ndarray.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/ndarray.sifr
@@ -1,0 +1,16 @@
+# fixture: advanced_data_matrix
+# package-example: ndarray
+# required-crate: ndarray
+# execution-kind: contract-only
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class NdArray2:
+    pass
+
+@rust(ndarray.Array2.from_shape_vec, panic=map_error(bridge.ndarray.map_panic))
+def ndarray_array2(input: list[f32]) -> Result[NdArray2, PackageExampleError | RustPanicError]: ...
+
+def verify_ndarray_package() -> Result[NdArray2, PackageExampleError | RustPanicError]:
+    return ndarray_array2([1.0, 2.0, 3.0, 4.0])

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/polars.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/polars.sifr
@@ -1,0 +1,16 @@
+# fixture: advanced_data_matrix
+# package-example: polars
+# required-crate: polars
+# execution-kind: contract-only
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class DataFrame:
+    pass
+
+@rust(polars.DataFrame.new, panic=map_error(bridge.polars.map_panic))
+def polars_dataframe(input: bytes) -> Result[DataFrame, PackageExampleError | RustPanicError]: ...
+
+def verify_polars_package() -> Result[DataFrame, PackageExampleError | RustPanicError]:
+    return polars_dataframe(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/fixture.json
@@ -25,6 +25,12 @@
     }
   },
   "id": "advanced_data_matrix",
+  "package_examples": {
+    "candle": "examples/candle.sifr",
+    "datafusion": "examples/datafusion.sifr",
+    "ndarray": "examples/ndarray.sifr",
+    "polars": "examples/polars.sifr"
+  },
   "required_crates": [
     "datafusion",
     "polars",

--- a/verification/areas/rust_interop/fixtures/arrow_record_batch/examples/arrow.sifr
+++ b/verification/areas/rust_interop/fixtures/arrow_record_batch/examples/arrow.sifr
@@ -1,0 +1,16 @@
+# fixture: arrow_record_batch
+# package-example: arrow
+# required-crate: arrow
+# execution-kind: contract-only
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class ArrowRecordBatch:
+    pass
+
+@rust(arrow.array.Int32Array.from, panic=map_error(bridge.arrow.map_panic))
+def arrow_int32_array(input: bytes) -> Result[ArrowRecordBatch, PackageExampleError | RustPanicError]: ...
+
+def verify_arrow_package() -> Result[ArrowRecordBatch, PackageExampleError | RustPanicError]:
+    return arrow_int32_array(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/arrow_record_batch/fixture.json
+++ b/verification/areas/rust_interop/fixtures/arrow_record_batch/fixture.json
@@ -21,6 +21,9 @@
   "execution_kind": "contract-only",
   "features": {},
   "id": "arrow_record_batch",
+  "package_examples": {
+    "arrow": "examples/arrow.sifr"
+  },
   "required_crates": [
     "arrow"
   ],

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/futures.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/futures.sifr
@@ -1,0 +1,13 @@
+# fixture: async_ecosystem_matrix
+# package-example: futures
+# required-crate: futures
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(futures.future.join, panic=map_error(bridge.futures.map_panic))
+def futures_join(left: i32, right: i32) -> Result[tuple[i32, i32], PackageExampleError | RustPanicError]: ...
+
+def verify_futures_package() -> Result[tuple[i32, i32], PackageExampleError | RustPanicError]:
+    return futures_join(40, 2)

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/http-body.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/http-body.sifr
@@ -1,0 +1,13 @@
+# fixture: async_ecosystem_matrix
+# package-example: http-body
+# required-crate: http-body
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(http_body.Body.size_hint, panic=map_error(bridge.http_body.map_panic))
+def http_body_size_hint(body: bytes) -> Result[u64, PackageExampleError | RustPanicError]: ...
+
+def verify_http_body_package() -> Result[u64, PackageExampleError | RustPanicError]:
+    return http_body_size_hint(b"body")

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/http.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/http.sifr
@@ -1,0 +1,16 @@
+# fixture: async_ecosystem_matrix
+# package-example: http
+# required-crate: http
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class HttpRequest:
+    pass
+
+@rust(http.Request.builder, panic=map_error(bridge.http.map_panic))
+def http_request_builder(url: str) -> Result[HttpRequest, PackageExampleError | RustPanicError]: ...
+
+def verify_http_package() -> Result[HttpRequest, PackageExampleError | RustPanicError]:
+    return http_request_builder("https://127.0.0.1/health")

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/tower.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/tower.sifr
@@ -1,0 +1,13 @@
+# fixture: async_ecosystem_matrix
+# package-example: tower
+# required-crate: tower
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(tower.Service.call, panic=map_error(bridge.tower.map_panic))
+def tower_service_call(request: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+
+def verify_tower_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    return tower_service_call(b"GET / HTTP/1.1")

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/fixture.json
@@ -19,6 +19,12 @@
   "execution_kind": "cargo-probe",
   "features": {},
   "id": "async_ecosystem_matrix",
+  "package_examples": {
+    "futures": "examples/futures.sifr",
+    "http": "examples/http.sifr",
+    "http-body": "examples/http-body.sifr",
+    "tower": "examples/tower.sifr"
+  },
   "required_crates": [
     "futures",
     "tower",

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/reqwest.sifr
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/reqwest.sifr
@@ -1,0 +1,16 @@
+# fixture: async_runtime_reqwest
+# package-example: reqwest
+# required-crate: reqwest
+# execution-kind: runtime-observed
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class HttpResponse:
+    pass
+
+@rust(reqwest.Client.get, panic=map_error(bridge.reqwest.map_panic))
+def reqwest_get(url: str) -> Result[HttpResponse, PackageExampleError | RustPanicError]: ...
+
+def verify_reqwest_package() -> Result[HttpResponse, PackageExampleError | RustPanicError]:
+    return reqwest_get("https://127.0.0.1/health")

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/tokio.sifr
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/tokio.sifr
@@ -1,0 +1,16 @@
+# fixture: async_runtime_reqwest
+# package-example: tokio
+# required-crate: tokio
+# execution-kind: runtime-observed
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class TaskHandle:
+    pass
+
+@rust(tokio.spawn, panic=map_error(bridge.tokio.map_panic))
+def tokio_spawn(delay_ms: u64) -> Result[TaskHandle, PackageExampleError | RustPanicError]: ...
+
+def verify_tokio_package() -> Result[TaskHandle, PackageExampleError | RustPanicError]:
+    return tokio_spawn(1)

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/fixture.json
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/fixture.json
@@ -27,6 +27,10 @@
     }
   },
   "id": "async_runtime_reqwest",
+  "package_examples": {
+    "reqwest": "examples/reqwest.sifr",
+    "tokio": "examples/tokio.sifr"
+  },
   "required_crates": [
     "tokio",
     "reqwest"

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/flate2.sifr
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/flate2.sifr
@@ -1,0 +1,13 @@
+# fixture: blocking_diagnostics
+# package-example: flate2
+# required-crate: flate2
+# execution-kind: compiler-diagnostic
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(flate2.write.ZlibEncoder.new, panic=map_error(bridge.flate2.map_panic))
+def flate2_deflate(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+
+def verify_flate2_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    return flate2_deflate(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/rayon.sifr
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/rayon.sifr
@@ -1,0 +1,13 @@
+# fixture: blocking_diagnostics
+# package-example: rayon
+# required-crate: rayon
+# execution-kind: compiler-diagnostic
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(rayon.join, panic=map_error(bridge.rayon.map_panic))
+def rayon_join(left: i32, right: i32) -> Result[i32, PackageExampleError | RustPanicError]: ...
+
+def verify_rayon_package() -> Result[i32, PackageExampleError | RustPanicError]:
+    return rayon_join(40, 2)

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/rusqlite.sifr
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/rusqlite.sifr
@@ -1,0 +1,16 @@
+# fixture: blocking_diagnostics
+# package-example: rusqlite
+# required-crate: rusqlite
+# execution-kind: compiler-diagnostic
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class SqlRows:
+    pass
+
+@rust(rusqlite.Connection.open_in_memory, panic=map_error(bridge.rusqlite.map_panic))
+def rusqlite_memory(query: str) -> Result[SqlRows, PackageExampleError | RustPanicError]: ...
+
+def verify_rusqlite_package() -> Result[SqlRows, PackageExampleError | RustPanicError]:
+    return rusqlite_memory("select 1")

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/fixture.json
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/fixture.json
@@ -31,6 +31,11 @@
     }
   },
   "id": "blocking_diagnostics",
+  "package_examples": {
+    "flate2": "examples/flate2.sifr",
+    "rayon": "examples/rayon.sifr",
+    "rusqlite": "examples/rusqlite.sifr"
+  },
   "required_crates": [
     "rusqlite",
     "rayon",

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/bytes.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/bytes.sifr
@@ -1,0 +1,13 @@
+# fixture: bridge_type_matrix
+# package-example: bytes
+# required-crate: bytes
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(bytes.Bytes.copy_from_slice, panic=map_error(bridge.bytes.map_panic))
+def bytes_from_slice(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+
+def verify_bytes_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    return bytes_from_slice(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/indexmap.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/indexmap.sifr
@@ -1,0 +1,13 @@
+# fixture: bridge_type_matrix
+# package-example: indexmap
+# required-crate: indexmap
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(indexmap.IndexMap.insert, panic=map_error(bridge.indexmap.map_panic))
+def indexmap_insert(key: str, value: i32) -> Result[i32, PackageExampleError | RustPanicError]: ...
+
+def verify_indexmap_package() -> Result[i32, PackageExampleError | RustPanicError]:
+    return indexmap_insert("answer", 42)

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/serde.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/serde.sifr
@@ -1,0 +1,13 @@
+# fixture: bridge_type_matrix
+# package-example: serde
+# required-crate: serde
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(serde.Serialize.serialize, panic=map_error(bridge.serde.map_panic))
+def serde_serialize(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+
+def verify_serde_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    return serde_serialize(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/serde_json.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/serde_json.sifr
@@ -1,0 +1,16 @@
+# fixture: bridge_type_matrix
+# package-example: serde_json
+# required-crate: serde_json
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class JsonValue:
+    pass
+
+@rust(serde_json.from_slice, panic=map_error(bridge.serde_json.map_panic))
+def serde_json_decode(input: bytes) -> Result[JsonValue, PackageExampleError | RustPanicError]: ...
+
+def verify_serde_json_package() -> Result[JsonValue, PackageExampleError | RustPanicError]:
+    return serde_json_decode(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/thiserror.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/thiserror.sifr
@@ -1,0 +1,16 @@
+# fixture: bridge_type_matrix
+# package-example: thiserror
+# required-crate: thiserror
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class RustError:
+    pass
+
+@rust(thiserror.Error.from_display, panic=map_error(bridge.thiserror.map_panic))
+def thiserror_from_display(message: str) -> Result[RustError, PackageExampleError | RustPanicError]: ...
+
+def verify_thiserror_package() -> Result[RustError, PackageExampleError | RustPanicError]:
+    return thiserror_from_display("sifr error context")

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/fixture.json
@@ -19,6 +19,13 @@
   "execution_kind": "cargo-probe",
   "features": {},
   "id": "bridge_type_matrix",
+  "package_examples": {
+    "bytes": "examples/bytes.sifr",
+    "indexmap": "examples/indexmap.sifr",
+    "serde": "examples/serde.sifr",
+    "serde_json": "examples/serde_json.sifr",
+    "thiserror": "examples/thiserror.sifr"
+  },
   "required_crates": [
     "serde",
     "serde_json",

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/notify.sifr
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/notify.sifr
@@ -1,0 +1,16 @@
+# fixture: callback_subscription_matrix
+# package-example: notify
+# required-crate: notify
+# execution-kind: runtime-observed
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class WatcherHandle:
+    pass
+
+@rust(notify.recommended_watcher, panic=map_error(bridge.notify.map_panic))
+def notify_watcher(path: str) -> Result[WatcherHandle, PackageExampleError | RustPanicError]: ...
+
+def verify_notify_package() -> Result[WatcherHandle, PackageExampleError | RustPanicError]:
+    return notify_watcher("/tmp/sifr-rust-interop.bin")

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/redis.sifr
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/redis.sifr
@@ -1,0 +1,16 @@
+# fixture: callback_subscription_matrix
+# package-example: redis
+# required-crate: redis
+# execution-kind: runtime-observed
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class RedisClient:
+    pass
+
+@rust(redis.Client.open, panic=map_error(bridge.redis.map_panic))
+def redis_client(url: str) -> Result[RedisClient, PackageExampleError | RustPanicError]: ...
+
+def verify_redis_package() -> Result[RedisClient, PackageExampleError | RustPanicError]:
+    return redis_client("redis://127.0.0.1:6379/0")

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/tokio-tungstenite.sifr
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/tokio-tungstenite.sifr
@@ -1,0 +1,16 @@
+# fixture: callback_subscription_matrix
+# package-example: tokio-tungstenite
+# required-crate: tokio-tungstenite
+# execution-kind: runtime-observed
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class WebSocket:
+    pass
+
+@rust(tokio_tungstenite.connect_async, panic=map_error(bridge.tokio_tungstenite.map_panic))
+def tokio_tungstenite_connect(url: str) -> Result[WebSocket, PackageExampleError | RustPanicError]: ...
+
+def verify_tokio_tungstenite_package() -> Result[WebSocket, PackageExampleError | RustPanicError]:
+    return tokio_tungstenite_connect("ws://127.0.0.1:9001/stream")

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/fixture.json
@@ -29,6 +29,11 @@
     }
   },
   "id": "callback_subscription_matrix",
+  "package_examples": {
+    "notify": "examples/notify.sifr",
+    "redis": "examples/redis.sifr",
+    "tokio-tungstenite": "examples/tokio-tungstenite.sifr"
+  },
   "required_crates": [
     "tokio-tungstenite",
     "redis",

--- a/verification/areas/rust_interop/fixtures/direct_crate_crc32/examples/crc32fast.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_crc32/examples/crc32fast.sifr
@@ -1,0 +1,13 @@
+# fixture: direct_crate_crc32
+# package-example: crc32fast
+# required-crate: crc32fast
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(crc32fast.hash, panic=map_error(bridge.crc32fast.map_panic))
+def crc32fast_hash(input: bytes) -> Result[u32, PackageExampleError | RustPanicError]: ...
+
+def verify_crc32fast_package() -> Result[u32, PackageExampleError | RustPanicError]:
+    return crc32fast_hash(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/direct_crate_crc32/fixture.json
+++ b/verification/areas/rust_interop/fixtures/direct_crate_crc32/fixture.json
@@ -19,6 +19,9 @@
   "execution_kind": "cargo-probe",
   "features": {},
   "id": "direct_crate_crc32",
+  "package_examples": {
+    "crc32fast": "examples/crc32fast.sifr"
+  },
   "required_crates": [
     "crc32fast"
   ],

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/blake3.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/blake3.sifr
@@ -1,0 +1,13 @@
+# fixture: direct_crate_matrix
+# package-example: blake3
+# required-crate: blake3
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(blake3.hash, panic=map_error(bridge.blake3.map_panic))
+def blake3_hash(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+
+def verify_blake3_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    return blake3_hash(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/regex.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/regex.sifr
@@ -1,0 +1,13 @@
+# fixture: direct_crate_matrix
+# package-example: regex
+# required-crate: regex
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(regex.Regex.is_match, panic=map_error(bridge.regex.map_panic))
+def regex_is_match(pattern: str, text: str) -> Result[bool, PackageExampleError | RustPanicError]: ...
+
+def verify_regex_package() -> Result[bool, PackageExampleError | RustPanicError]:
+    return regex_is_match("^sifr", "sifr-rust")

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/sha2.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/sha2.sifr
@@ -1,0 +1,13 @@
+# fixture: direct_crate_matrix
+# package-example: sha2
+# required-crate: sha2
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(sha2.Sha256.digest, panic=map_error(bridge.sha2.map_panic))
+def sha256_digest(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+
+def verify_sha2_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    return sha256_digest(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/uuid.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/uuid.sifr
@@ -1,0 +1,13 @@
+# fixture: direct_crate_matrix
+# package-example: uuid
+# required-crate: uuid
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(uuid.Uuid.parse_str, panic=map_error(bridge.uuid.map_panic))
+def uuid_parse(text: str) -> Result[str, PackageExampleError | RustPanicError]: ...
+
+def verify_uuid_package() -> Result[str, PackageExampleError | RustPanicError]:
+    return uuid_parse("550e8400-e29b-41d4-a716-446655440000")

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/fixture.json
@@ -19,6 +19,12 @@
   "execution_kind": "cargo-probe",
   "features": {},
   "id": "direct_crate_matrix",
+  "package_examples": {
+    "blake3": "examples/blake3.sifr",
+    "regex": "examples/regex.sifr",
+    "sha2": "examples/sha2.sifr",
+    "uuid": "examples/uuid.sifr"
+  },
   "required_crates": [
     "blake3",
     "sha2",

--- a/verification/areas/rust_interop/fixtures/direct_crate_negative_type/examples/regex.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_negative_type/examples/regex.sifr
@@ -1,0 +1,13 @@
+# fixture: direct_crate_negative_type
+# package-example: regex
+# required-crate: regex
+# execution-kind: compiler-diagnostic
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(regex.Regex.is_match, panic=map_error(bridge.regex.map_panic))
+def regex_is_match(pattern: str, text: str) -> Result[bool, PackageExampleError | RustPanicError]: ...
+
+def verify_regex_package() -> Result[bool, PackageExampleError | RustPanicError]:
+    return regex_is_match("^sifr", "sifr-rust")

--- a/verification/areas/rust_interop/fixtures/direct_crate_negative_type/fixture.json
+++ b/verification/areas/rust_interop/fixtures/direct_crate_negative_type/fixture.json
@@ -20,6 +20,9 @@
   "execution_kind": "compiler-diagnostic",
   "features": {},
   "id": "direct_crate_negative_type",
+  "package_examples": {
+    "regex": "examples/regex.sifr"
+  },
   "required_crates": [
     "regex"
   ],

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/axum.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/axum.sifr
@@ -1,0 +1,16 @@
+# fixture: ecosystem_backend_certification
+# package-example: axum
+# required-crate: axum
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class AxumRouter:
+    pass
+
+@rust(axum.Router.new, panic=map_error(bridge.axum.map_panic))
+def axum_router(route: str) -> Result[AxumRouter, PackageExampleError | RustPanicError]: ...
+
+def verify_axum_package() -> Result[AxumRouter, PackageExampleError | RustPanicError]:
+    return axum_router("/health")

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/sqlx.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/sqlx.sifr
@@ -1,0 +1,16 @@
+# fixture: ecosystem_backend_certification
+# package-example: sqlx
+# required-crate: sqlx
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class SqlRows:
+    pass
+
+@rust(sqlx.query, panic=map_error(bridge.sqlx.map_panic))
+def sqlx_query(sql: str) -> Result[SqlRows, PackageExampleError | RustPanicError]: ...
+
+def verify_sqlx_package() -> Result[SqlRows, PackageExampleError | RustPanicError]:
+    return sqlx_query("select 1")

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/tower-http.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/tower-http.sifr
@@ -1,0 +1,16 @@
+# fixture: ecosystem_backend_certification
+# package-example: tower-http
+# required-crate: tower-http
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class TraceLayer:
+    pass
+
+@rust(tower_http.trace.TraceLayer.new, panic=map_error(bridge.tower_http.map_panic))
+def tower_http_trace_layer(name: str) -> Result[TraceLayer, PackageExampleError | RustPanicError]: ...
+
+def verify_tower_http_package() -> Result[TraceLayer, PackageExampleError | RustPanicError]:
+    return tower_http_trace_layer("sifr")

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/fixture.json
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/fixture.json
@@ -28,6 +28,11 @@
     }
   },
   "id": "ecosystem_backend_certification",
+  "package_examples": {
+    "axum": "examples/axum.sifr",
+    "sqlx": "examples/sqlx.sifr",
+    "tower-http": "examples/tower-http.sifr"
+  },
   "required_crates": [
     "axum",
     "tower-http",

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/anyhow.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/anyhow.sifr
@@ -1,0 +1,13 @@
+# fixture: ecosystem_cli_certification
+# package-example: anyhow
+# required-crate: anyhow
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(anyhow.Error.downcast_ref, panic=map_error(bridge.anyhow.map_panic))
+def anyhow_context(message: str) -> Result[str, PackageExampleError | RustPanicError]: ...
+
+def verify_anyhow_package() -> Result[str, PackageExampleError | RustPanicError]:
+    return anyhow_context("sifr error context")

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/clap.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/clap.sifr
@@ -1,0 +1,16 @@
+# fixture: ecosystem_cli_certification
+# package-example: clap
+# required-crate: clap
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class CliCommand:
+    pass
+
+@rust(clap.Command.new, panic=map_error(bridge.clap.map_panic))
+def clap_command(name: str) -> Result[CliCommand, PackageExampleError | RustPanicError]: ...
+
+def verify_clap_package() -> Result[CliCommand, PackageExampleError | RustPanicError]:
+    return clap_command("sifr")

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/tracing-subscriber.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/tracing-subscriber.sifr
@@ -1,0 +1,13 @@
+# fixture: ecosystem_cli_certification
+# package-example: tracing-subscriber
+# required-crate: tracing-subscriber
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(tracing_subscriber.fmt.init, panic=map_error(bridge.tracing_subscriber.map_panic))
+def tracing_subscriber_init(filter: str) -> Result[None, PackageExampleError | RustPanicError]: ...
+
+def verify_tracing_subscriber_package() -> Result[None, PackageExampleError | RustPanicError]:
+    return tracing_subscriber_init("info")

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/tracing.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/tracing.sifr
@@ -1,0 +1,13 @@
+# fixture: ecosystem_cli_certification
+# package-example: tracing
+# required-crate: tracing
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(tracing.info, panic=map_error(bridge.tracing.map_panic))
+def tracing_info(message: str) -> Result[None, PackageExampleError | RustPanicError]: ...
+
+def verify_tracing_package() -> Result[None, PackageExampleError | RustPanicError]:
+    return tracing_info("sifr error context")

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/fixture.json
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/fixture.json
@@ -25,6 +25,12 @@
     }
   },
   "id": "ecosystem_cli_certification",
+  "package_examples": {
+    "anyhow": "examples/anyhow.sifr",
+    "clap": "examples/clap.sifr",
+    "tracing": "examples/tracing.sifr",
+    "tracing-subscriber": "examples/tracing-subscriber.sifr"
+  },
   "required_crates": [
     "clap",
     "tracing",

--- a/verification/areas/rust_interop/fixtures/local_bridge_blake3/examples/blake3.sifr
+++ b/verification/areas/rust_interop/fixtures/local_bridge_blake3/examples/blake3.sifr
@@ -1,0 +1,13 @@
+# fixture: local_bridge_blake3
+# package-example: blake3
+# required-crate: blake3
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(blake3.hash, panic=map_error(bridge.blake3.map_panic))
+def blake3_hash(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+
+def verify_blake3_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    return blake3_hash(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/local_bridge_blake3/fixture.json
+++ b/verification/areas/rust_interop/fixtures/local_bridge_blake3/fixture.json
@@ -19,6 +19,9 @@
   "execution_kind": "cargo-probe",
   "features": {},
   "id": "local_bridge_blake3",
+  "package_examples": {
+    "blake3": "examples/blake3.sifr"
+  },
   "required_crates": [
     "blake3"
   ],

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/bindgen.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/bindgen.sifr
@@ -1,0 +1,16 @@
+# fixture: native_build_script
+# package-example: bindgen
+# required-crate: bindgen
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class BindgenBuilder:
+    pass
+
+@rust(bindgen.Builder.default, panic=map_error(bridge.bindgen.map_panic))
+def bindgen_builder(header: str) -> Result[BindgenBuilder, PackageExampleError | RustPanicError]: ...
+
+def verify_bindgen_package() -> Result[BindgenBuilder, PackageExampleError | RustPanicError]:
+    return bindgen_builder("wrapper.h")

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/cc.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/cc.sifr
@@ -1,0 +1,16 @@
+# fixture: native_build_script
+# package-example: cc
+# required-crate: cc
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class BuildPlan:
+    pass
+
+@rust(cc.Build.new, panic=map_error(bridge.cc.map_panic))
+def cc_build_new(source: str) -> Result[BuildPlan, PackageExampleError | RustPanicError]: ...
+
+def verify_cc_package() -> Result[BuildPlan, PackageExampleError | RustPanicError]:
+    return cc_build_new("src/native.c")

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/cxx.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/cxx.sifr
@@ -1,0 +1,16 @@
+# fixture: native_build_script
+# package-example: cxx
+# required-crate: cxx
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class CppHandle:
+    pass
+
+@rust(cxx.UniquePtr.new, panic=map_error(bridge.cxx.map_panic))
+def cxx_unique_ptr(name: str) -> Result[CppHandle, PackageExampleError | RustPanicError]: ...
+
+def verify_cxx_package() -> Result[CppHandle, PackageExampleError | RustPanicError]:
+    return cxx_unique_ptr("sifr")

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/zstd.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/zstd.sifr
@@ -1,0 +1,13 @@
+# fixture: native_build_script
+# package-example: zstd
+# required-crate: zstd
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(zstd.encode_all, panic=map_error(bridge.zstd.map_panic))
+def zstd_encode_all(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+
+def verify_zstd_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    return zstd_encode_all(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/native_build_script/fixture.json
+++ b/verification/areas/rust_interop/fixtures/native_build_script/fixture.json
@@ -19,6 +19,12 @@
   "execution_kind": "cargo-probe",
   "features": {},
   "id": "native_build_script",
+  "package_examples": {
+    "bindgen": "examples/bindgen.sifr",
+    "cc": "examples/cc.sifr",
+    "cxx": "examples/cxx.sifr",
+    "zstd": "examples/zstd.sifr"
+  },
   "required_crates": [
     "cc",
     "bindgen",

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/redis.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/redis.sifr
@@ -1,0 +1,16 @@
+# fixture: opaque_resource_matrix
+# package-example: redis
+# required-crate: redis
+# execution-kind: runtime-observed
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class RedisClient:
+    pass
+
+@rust(redis.Client.open, panic=map_error(bridge.redis.map_panic))
+def redis_client(url: str) -> Result[RedisClient, PackageExampleError | RustPanicError]: ...
+
+def verify_redis_package() -> Result[RedisClient, PackageExampleError | RustPanicError]:
+    return redis_client("redis://127.0.0.1:6379/0")

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/reqwest.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/reqwest.sifr
@@ -1,0 +1,16 @@
+# fixture: opaque_resource_matrix
+# package-example: reqwest
+# required-crate: reqwest
+# execution-kind: runtime-observed
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class HttpResponse:
+    pass
+
+@rust(reqwest.Client.get, panic=map_error(bridge.reqwest.map_panic))
+def reqwest_get(url: str) -> Result[HttpResponse, PackageExampleError | RustPanicError]: ...
+
+def verify_reqwest_package() -> Result[HttpResponse, PackageExampleError | RustPanicError]:
+    return reqwest_get("https://127.0.0.1/health")

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/rusqlite.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/rusqlite.sifr
@@ -1,0 +1,16 @@
+# fixture: opaque_resource_matrix
+# package-example: rusqlite
+# required-crate: rusqlite
+# execution-kind: runtime-observed
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class SqlRows:
+    pass
+
+@rust(rusqlite.Connection.open_in_memory, panic=map_error(bridge.rusqlite.map_panic))
+def rusqlite_memory(query: str) -> Result[SqlRows, PackageExampleError | RustPanicError]: ...
+
+def verify_rusqlite_package() -> Result[SqlRows, PackageExampleError | RustPanicError]:
+    return rusqlite_memory("select 1")

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/tokio-postgres.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/tokio-postgres.sifr
@@ -1,0 +1,16 @@
+# fixture: opaque_resource_matrix
+# package-example: tokio-postgres
+# required-crate: tokio-postgres
+# execution-kind: runtime-observed
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class PgClient:
+    pass
+
+@rust(tokio_postgres.connect, panic=map_error(bridge.tokio_postgres.map_panic))
+def tokio_postgres_connect(url: str) -> Result[PgClient, PackageExampleError | RustPanicError]: ...
+
+def verify_tokio_postgres_package() -> Result[PgClient, PackageExampleError | RustPanicError]:
+    return tokio_postgres_connect("postgres://sifr@127.0.0.1:5432/sifr")

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/fixture.json
@@ -44,6 +44,12 @@
     }
   },
   "id": "opaque_resource_matrix",
+  "package_examples": {
+    "redis": "examples/redis.sifr",
+    "reqwest": "examples/reqwest.sifr",
+    "rusqlite": "examples/rusqlite.sifr",
+    "tokio-postgres": "examples/tokio-postgres.sifr"
+  },
   "required_crates": [
     "reqwest",
     "rusqlite",

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/examples/prost-build.sifr
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/examples/prost-build.sifr
@@ -1,0 +1,16 @@
+# fixture: proc_macro_trust
+# package-example: prost-build
+# required-crate: prost-build
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class ProstConfig:
+    pass
+
+@rust(prost_build.Config.new, panic=map_error(bridge.prost_build.map_panic))
+def prost_build_config(proto: str) -> Result[ProstConfig, PackageExampleError | RustPanicError]: ...
+
+def verify_prost_build_package() -> Result[ProstConfig, PackageExampleError | RustPanicError]:
+    return prost_build_config("schema.proto")

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/examples/serde_derive.sifr
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/examples/serde_derive.sifr
@@ -1,0 +1,16 @@
+# fixture: proc_macro_trust
+# package-example: serde_derive
+# required-crate: serde_derive
+# execution-kind: cargo-probe
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class SerdeRecord:
+    pass
+
+@rust(serde_derive.Deserialize, panic=map_error(bridge.serde_derive.map_panic))
+def serde_derive_decode(input: bytes) -> Result[SerdeRecord, PackageExampleError | RustPanicError]: ...
+
+def verify_serde_derive_package() -> Result[SerdeRecord, PackageExampleError | RustPanicError]:
+    return serde_derive_decode(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/fixture.json
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/fixture.json
@@ -23,6 +23,10 @@
     }
   },
   "id": "proc_macro_trust",
+  "package_examples": {
+    "prost-build": "examples/prost-build.sifr",
+    "serde_derive": "examples/serde_derive.sifr"
+  },
   "required_crates": [
     "serde_derive",
     "prost-build"

--- a/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/examples/ndarray.sifr
+++ b/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/examples/ndarray.sifr
@@ -1,0 +1,16 @@
+# fixture: tensor_dlpack_bridge
+# package-example: ndarray
+# required-crate: ndarray
+# execution-kind: contract-only
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class NdArray2:
+    pass
+
+@rust(ndarray.Array2.from_shape_vec, panic=map_error(bridge.ndarray.map_panic))
+def ndarray_array2(input: list[f32]) -> Result[NdArray2, PackageExampleError | RustPanicError]: ...
+
+def verify_ndarray_package() -> Result[NdArray2, PackageExampleError | RustPanicError]:
+    return ndarray_array2([1.0, 2.0, 3.0, 4.0])

--- a/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/fixture.json
+++ b/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/fixture.json
@@ -21,6 +21,9 @@
   "execution_kind": "contract-only",
   "features": {},
   "id": "tensor_dlpack_bridge",
+  "package_examples": {
+    "ndarray": "examples/ndarray.sifr"
+  },
   "required_crates": [
     "ndarray"
   ],

--- a/verification/areas/rust_interop/fixtures/zero_copy_bytes/examples/bytes.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_bytes/examples/bytes.sifr
@@ -1,0 +1,13 @@
+# fixture: zero_copy_bytes
+# package-example: bytes
+# required-crate: bytes
+# execution-kind: contract-only
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(bytes.Bytes.copy_from_slice, panic=map_error(bridge.bytes.map_panic))
+def bytes_from_slice(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+
+def verify_bytes_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    return bytes_from_slice(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/zero_copy_bytes/fixture.json
+++ b/verification/areas/rust_interop/fixtures/zero_copy_bytes/fixture.json
@@ -19,6 +19,9 @@
   "execution_kind": "contract-only",
   "features": {},
   "id": "zero_copy_bytes",
+  "package_examples": {
+    "bytes": "examples/bytes.sifr"
+  },
   "required_crates": [
     "bytes"
   ],

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/bytemuck.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/bytemuck.sifr
@@ -1,0 +1,13 @@
+# fixture: zero_copy_view_matrix
+# package-example: bytemuck
+# required-crate: bytemuck
+# execution-kind: contract-only
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+@rust(bytemuck.cast_slice, panic=map_error(bridge.bytemuck.map_panic))
+def bytemuck_cast_slice(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+
+def verify_bytemuck_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    return bytemuck_cast_slice(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/memmap2.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/memmap2.sifr
@@ -1,0 +1,16 @@
+# fixture: zero_copy_view_matrix
+# package-example: memmap2
+# required-crate: memmap2
+# execution-kind: contract-only
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class MmapView:
+    pass
+
+@rust(memmap2.MmapOptions.new, panic=map_error(bridge.memmap2.map_panic))
+def memmap2_view(path: str) -> Result[MmapView, PackageExampleError | RustPanicError]: ...
+
+def verify_memmap2_package() -> Result[MmapView, PackageExampleError | RustPanicError]:
+    return memmap2_view("/tmp/sifr-rust-interop.bin")

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/zerocopy.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/zerocopy.sifr
@@ -1,0 +1,16 @@
+# fixture: zero_copy_view_matrix
+# package-example: zerocopy
+# required-crate: zerocopy
+# execution-kind: contract-only
+# expected-result: package-example
+class PackageExampleError(Error):
+    message: str
+
+class ZeroCopyView:
+    pass
+
+@rust(zerocopy.FromBytes.ref_from_bytes, panic=map_error(bridge.zerocopy.map_panic))
+def zerocopy_ref_from_bytes(input: bytes) -> Result[ZeroCopyView, PackageExampleError | RustPanicError]: ...
+
+def verify_zerocopy_package() -> Result[ZeroCopyView, PackageExampleError | RustPanicError]:
+    return zerocopy_ref_from_bytes(b"sifr-rust-interop")

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/fixture.json
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/fixture.json
@@ -19,6 +19,11 @@
   "execution_kind": "contract-only",
   "features": {},
   "id": "zero_copy_view_matrix",
+  "package_examples": {
+    "bytemuck": "examples/bytemuck.sifr",
+    "memmap2": "examples/memmap2.sifr",
+    "zerocopy": "examples/zerocopy.sifr"
+  },
   "required_crates": [
     "memmap2",
     "bytemuck",


### PR DESCRIPTION
## Summary
- Add 51 package-level Rust interop example fixtures covering all 51 required-crate occurrences across 44 unique Rust crates.
- Wire every nonempty required_crates fixture manifest through a package_examples map that points at examples/<crate>.sifr.
- Strengthen the fixture matrix validator to require exact example paths, package/example headers, crate-specific @rust bindings with token boundaries, and verifier functions that call the bound function.
- Document the package example contract in the rust_interop verification README.

## Review
- Ran three Opus reviewer rounds via .cursor/skills/talk-to-claude-opus.
- Fixed reviewer findings around crate-specific @rust validation, verifier call enforcement, and prefix-collision boundaries.
- Final reviewer pass reported no remaining actionable findings.

## Validation
- python3 verification/areas/rust_interop/checks/check_fixture_matrix.py
- python3 -m py_compile verification/areas/rust_interop/checks/check_fixture_matrix.py
- uv run --project verification --locked python -m sifr_verify areas run --area rust_interop --suite matrix --suite tiers --suite compatibility-matrix --suite stale-drafts --result-json target/verification/areas/rust-interop-package-examples-results.json
- git diff --check
- git diff --cached --check
- python3 scripts/check_file_size_guardrails.py
- CARGO_INCREMENTAL=0 cargo build -q -p sifr
- CARGO_INCREMENTAL=0 scripts/run_all_tests.sh --profile create-pr

Note: the first create-pr attempt timed out during the diagnostic-source-canonicalization cargo build after 300s. A direct cargo build completed successfully, and the rerun of the create-pr profile passed. The final lane reported all steps passing with only the warm wall-time advisory.

Unrelated local dirty state: editor_integrations submodule remains unstaged and is not part of this PR.