### PR TITLE
Expand Rust interop fixture examples

### DIFF
--- a/plans/reviews/active/rust_interop_fuller_examples_review.md
+++ b/plans/reviews/active/rust_interop_fuller_examples_review.md
@@ -1,0 +1,61 @@
+I've reviewed the validator and a representative sample of the modified fixtures across nearly every fixture family. Here are the actionable findings.
+
+## Actionable findings
+
+### Correctness — non-Sifr type names in `.sifr` fixtures
+
+Sifr's `resolve_type_annotation` (`crates/sifr_type_system/src/infer.rs:27`) recognizes only `uintN`, `intN`, `float`, `bytes`, etc. Several new fuller examples use Rust-style aliases that are not valid Sifr types. Even though these are contract-only / cargo-probe fixtures that don't fully type-check, they are now the canonical "fuller examples" readers will copy from, so they should use the real Sifr type names.
+
+- `verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/tokio.sifr:14` — `delay_ms: u64` and `tokio_spawn(1)` should be `uint64` (cf. `tokio.sifr:10` which already uses `uint64` for `task_id`).
+- `verification/areas/rust_interop/fixtures/direct_crate_crc32/examples/crc32fast.sifr:10,12,13` — `u32` should be `uint32` (and the matching positive fixture `…/positive/crc32fast_hash_uint32.sifr` already uses `uint32`).
+- `verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/http-body.sifr:10,12,13` — `u64` should be `uint64`.
+- `verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/rayon.sifr:10,12,13` — `i32` should be `int32`.
+- `verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/indexmap.sifr:10,12,13` — `i32` should be `int32`.
+- `verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/futures.sifr:10,12,13` — `tuple[i32, i32]` should be `tuple[int32, int32]`.
+- `verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/candle.sifr:14,17` — `list[f32]` (parameter annotation) is not a Sifr type. Sifr has only `float`; consider `list[float]`. (The `dtype=f32` inside `@rust.view(...)` kwargs is a decorator argument, not a Sifr type annotation, and is fine.)
+- `verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/ndarray.sifr:14,17` and `verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/examples/ndarray.sifr:14,17` — same `list[f32]` issue.
+
+### Correctness — undeclared / forward-referenced types in evidence files
+
+The matrix validator only checks for a `verify_…` function and that it calls every `@rust`-decorated binding — it does not check that referenced classes exist. Multiple new fuller evidence files reference types that are never declared in the file or are declared after first use, which is exactly the "still skeletal" smell the task is trying to remove for readers.
+
+- Never declared in the file:
+  - `verification/areas/rust_interop/fixtures/advanced_data_matrix/positive/advanced_data_metadata.sifr:11,13,14` — `DataFrame`.
+  - `verification/areas/rust_interop/fixtures/advanced_data_matrix/negative/dtype_shape_mismatch.sifr:9,11,12` — `DataFrame`.
+  - `verification/areas/rust_interop/fixtures/arrow_record_batch/positive/arrow_schema_identity.sifr:12,14,15` — `ArrowRecordBatch`.
+  - `verification/areas/rust_interop/fixtures/arrow_record_batch/negative/invalid_arrow_metadata.sifr:9,11,12` — `ArrowRecordBatch`.
+  - `verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/positive/explicit_tensor_ownership.sifr:12,14,15` — `Tensor`.
+  - `verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/negative/implicit_dlpack_ownership_rejected.sifr:9,11,12` — `Tensor`.
+  - `verification/areas/rust_interop/fixtures/proc_macro_trust/positive/trusted_proc_macro.sifr:9,14,15` — `GeneratedMessage` is referenced three times but never declared.
+- Declared after first use (Sifr scoping aside, this looks bad in a "fuller example" intended to be readable):
+  - `verification/areas/rust_interop/fixtures/panic_boundary/negative/panic_payload_not_exposed.sifr:8` uses `UserError` before declaring it on line 10.
+  - `verification/areas/rust_interop/fixtures/dotted_path_resolution/positive/valid_structured_paths.sifr:7` uses `HashError` before declaring it on line 9.
+  - `verification/areas/rust_interop/fixtures/native_build_script/positive/trusted_build_script_native_evidence.sifr:9` uses `NativeError` before declaring it on line 11.
+  - `verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/negative/invalid_map_error_signature_rejected.sifr:8` uses `PanicMapped` before declaring it on line 10.
+  - `verification/areas/rust_interop/fixtures/proc_macro_trust/positive/trusted_proc_macro.sifr:9` uses `DecodeError` before declaring it on line 11.
+
+### Consistency — async crates with non-async package examples
+
+The fuller-evidence change made the evidence files use `async def` + `await` where appropriate, but the matching package examples are still sync. This is misleading for readers studying the async-runtime/async-ecosystem families.
+
+- `verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/reqwest.sifr:14,16` — `reqwest.Client.get` is naturally async and the sibling positive evidence (`async_reqwest_loopback.sifr`) uses `async def` + `await`, but the package example declares a plain `def reqwest_get(...)` and a plain `def verify_reqwest_package()`.
+- `verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/tokio.sifr:14,16` — `tokio.spawn` is naturally async, declared as plain `def`.
+- `verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/futures.sifr:10,12` — `futures::future::join` is async-only; declared sync.
+
+### Verifier-enforcement gaps in `check_fixture_matrix.py`
+
+These are gaps in the new enforcement that allow exactly the kind of skeletal-evidence regressions the task is trying to prevent.
+
+- `verification/areas/rust_interop/checks/check_fixture_matrix.py:368-369` — The `\n    pass\n` placeholder-class-body rejection runs only inside `_validate_package_example_text`. `_validate_evidence_example_text` (the new function added at line 496) does not apply the same check, so a positive/negative evidence file can re-introduce empty `class Foo:\n    pass` bodies without tripping the validator. Easy fix: hoist the `pass` check into a shared helper or duplicate it inside `_validate_evidence_example_text`.
+- `verification/areas/rust_interop/checks/check_fixture_matrix.py:383-384` — The "must bind sample inputs before returning" rule rejects only the literal pattern `return {bound_function}(`. `return wrap(bound_function(...))`, `return [bound_function(x) for x in xs]`, or any one-line composition would all pass while still being effectively skeletal. If the goal is "the verifier must contain a `name = bound_function(...)` assignment", check for that positively rather than negatively.
+- `verification/areas/rust_interop/checks/check_fixture_matrix.py:387-403` — `_rust_bound_function_name` returns only the first `@rust(<crate>...)` binding it finds. If a package example declares two bindings against the same crate, only the first has to be called by the verifier. Consider returning all bindings and asserting each is invoked, mirroring how `_rust_bound_declaration_names` is used for evidence files.
+- `verification/areas/rust_interop/checks/check_fixture_matrix.py:522-543` — `_rust_bound_declaration_names` requires `stripped.endswith(": ...")`. If anyone adds a multi-line stub (e.g., `def foo(\n    x: int,\n) -> int: ...`) the binding will silently be dropped from the "must be called" set. Not present in the current diff, but worth a future tightening.
+- `verification/areas/rust_interop/checks/check_fixture_matrix.py:466-468` — The existing "must exercise a Rust interop declaration" check accepts any `@rust*` decorator (e.g., a lone `@rust.view(...)` without an accompanying `@rust(...)` binding). The new evidence-example check happens to also run, so this isn't currently exploitable, but if `_validate_evidence_example_text`'s name extractor returns an empty list (which it will for a file containing only decorators without a `def …: ...` body), the verifier check becomes vacuous. Consider requiring at least one bound name to be collected.
+
+### Lower priority / observations
+
+- `verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/regex.sifr` and `verification/areas/rust_interop/fixtures/direct_crate_negative_type/examples/regex.sifr` are byte-identical except for the `# execution-kind:` header. Not a validator issue, but worth flagging as a copy-paste smell in the new package-example layout.
+- `verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/negative/unsatisfied_send_or_copy_rejected.sifr` declares `close=close` in `@rust.opaque(...)` but does not define a `close` method on the class. The matrix validator does not check `close=` is satisfied, so this is silent; if the future intent is for this fixture to demonstrate handle aliasing (per the file name) rather than missing close, the discrepancy is fine, but the diagnostic family for this evidence (`SIFR-RUST-HANDLE-0001`) and the file name make the intent ambiguous.
+- README at `verification/areas/rust_interop/README.md:30-37` correctly describes the new rule, but does not mention that the matrix validator only catches `\n    pass\n` (4-space indent). If you adopt 2-space or tab indentation anywhere, the check would silently miss it. Either widen the regex or note the indent assumption.
+
+Nothing in the diff is obviously broken by the matrix validator today — all the items above are either real semantic mistakes in fixture text that the validator does not yet catch, or gaps in the validator that future contributors could exploit.

--- a/plans/reviews/active/rust_interop_fuller_examples_review_2.md
+++ b/plans/reviews/active/rust_interop_fuller_examples_review_2.md
@@ -1,0 +1,38 @@
+All four suites pass. Here are my review findings:
+
+## Actionable Findings
+
+### Correctness — async-only crate functions still declared sync in 3 package examples
+
+The prior review fixed `async def` + `await` in `async_runtime_reqwest/examples/reqwest.sifr`, `async_runtime_reqwest/examples/tokio.sifr`, and `async_ecosystem_matrix/examples/futures.sifr`, but the same pattern remains in three other package examples whose Rust upstreams are async-only:
+
+- `verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/reqwest.sifr:14,16` — `reqwest.Client.get` declared as plain `def reqwest_get`, returning `Result[HttpResponse, ...]`. Obtaining a response requires sending and awaiting; the sibling fixture's reqwest example uses `async def`. Inconsistent and incorrect.
+- `verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/tokio-postgres.sifr:14,16` — `tokio_postgres.connect` is async-only; declared as plain `def`.
+- `verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/tokio-tungstenite.sifr:14,16` — `tokio_tungstenite.connect_async` is literally named `_async`; declared as plain `def`.
+
+### Validator gap — evidence-example check missing the "bind result" enforcement that package-example check has
+
+`verification/areas/rust_interop/checks/check_fixture_matrix.py:510-538` (`_validate_evidence_example_text`) enforces that each `@rust`-bound name is called inside the verifier, but unlike the package-example check at lines 388–389 (`_verifier_binds_call`), it does **not** require the result to be assigned to a variable before returning. An evidence file could regress to `return bound_function(args)` — exactly the skeletal-evidence smell this work is trying to prevent. I confirmed this by running the helper directly: a file with `return foo()` inside `verify_test` passes evidence validation today. No current fixture exploits this asymmetry, but it is a latent re-entry path.
+
+Easy fix: factor the package-example `_verifier_binds_call` check into a shared helper and call it from `_validate_evidence_example_text`, or duplicate the assignment-pattern requirement inline.
+
+### Lower priority (carried over from prior review)
+
+- `verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/regex.sifr` and `verification/areas/rust_interop/fixtures/direct_crate_negative_type/examples/regex.sifr` are still byte-identical except for the `# fixture:` and `# execution-kind:` headers (copy-paste smell, not a correctness issue).
+- `verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/negative/unsatisfied_send_or_copy_rejected.sifr:7` — `@rust.opaque(...close=close)` still references a `close` method that isn't defined on `Tokenizer`. Matrix validator doesn't check `close=` is satisfied, so it's silent.
+
+## Items confirmed addressed since prior review
+
+- Rust-style type names (`u32/u64/i32/list[f32]`) are gone from the called-out package examples (`grep` for `\b(u8|u16|u32|u64|i8|i16|i32|i64|f32|f64)\b` outside `dtype=/rank=/strides=` returns zero hits).
+- All previously forward-referenced classes (`DataFrame`, `ArrowRecordBatch`, `Tensor`, `GeneratedMessage`, `UserError`, `HashError`, `NativeError`, `PanicMapped`, `DecodeError`) are now declared before first use in their respective evidence files.
+- `_validate_evidence_example_text` correctly rejects `pass`-only class bodies (and the `_contains_empty_pass_body` regex was widened to be indent-agnostic via `line.strip() == "pass"`, addressing the previous README/indent caveat).
+- `_rust_bound_function_names` now returns every binding for the same crate, requiring the verifier to call each, and async verifier forms are accepted.
+- A multi-line `def foo(\n    x,\n) -> int: ...` stub now falls through to "must include a Rust-decorated binding declaration" (no longer silently empty), because the evidence check requires `bound_names` to be non-empty.
+
+## Validation
+
+All four required commands pass:
+- `python3 verification/areas/rust_interop/checks/check_fixture_matrix.py` → `fixtures=31 diagnostics=10 crates=44 package_examples=51`
+- `python3 -m py_compile verification/areas/rust_interop/checks/check_fixture_matrix.py` → OK
+- `git diff --check` → clean
+- `uv run --project verification --locked python -m sifr_verify areas run …` → `variants=4, failures=0`

--- a/plans/reviews/active/rust_interop_fuller_examples_review_3.md
+++ b/plans/reviews/active/rust_interop_fuller_examples_review_3.md
@@ -1,0 +1,34 @@
+I have enough to deliver the review. The user asked me not to modify files — they have an empty `rust_interop_fuller_examples_review_3.md` waiting but the instruction was explicit, so I'll only respond.
+
+## Review (round 3) — Rust interop fuller examples
+
+### Actionable finding: one remaining async-only crate still declared sync
+
+`verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/tower.sifr:9-13`
+
+```
+@rust(tower.Service.call, panic=map_error(bridge.tower.map_panic))
+def tower_service_call(request: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+```
+
+`tower::Service::call` returns `Self::Future`, i.e. the result is only reachable by awaiting — exactly the shape that drove the round-2 fixes for `reqwest.Client.get`, `tokio_postgres.connect`, and `tokio_tungstenite.connect_async`. The sibling example in this same fixture (`async_ecosystem_matrix/examples/futures.sifr`) was already converted to `async def`/`await`, so this is an oversight rather than a deliberate exception. Convert to `async def tower_service_call(...)` and `await` in the verifier for consistency. (Execution-kind is `cargo-probe`, so this doesn't affect validation results — it's a fidelity bug in the example.)
+
+### Validator gap from review 2 is closed (no further action)
+
+`check_fixture_matrix.py:542-543` now invokes `_verifier_binds_call(verifier_body, name)` for every non-`None` Rust-decorated binding inside `_validate_evidence_example_text`. I traced the helper against the round-2 regression case:
+
+- `return foo()` → `before_call = "    return "` → no `=` → fails (correctly rejected).
+- `encode_result: bytes = resource.encode("x")` → split on `encode(` gives `before_call = "    encode_result: bytes = resource."` with `=` and not starting with `return ` → passes (method call correctly accepted).
+- `resource.encode("x")` without binding (non-None return) → `before_call = "    resource."` → no `=` → fails (correctly rejected).
+
+`None`-returning bindings (e.g. `close(own self) -> None`) are exempted via the `return_type != "None"` guard, so the new `close` in `opaque_handle_tokenizer/negative/unsatisfied_send_or_copy_rejected.sifr` is exercised by call (`resource.close()`) without needing assignment. The fixture matrix run confirms: `fixtures=31 diagnostics=10 crates=44 package_examples=51`.
+
+### Previously carried-over items — addressed
+
+- `direct_crate_matrix/examples/regex.sifr` now uses `regex.Regex.is_match`; `direct_crate_negative_type/examples/regex.sifr` now uses `regex.Regex.replace_all`. No longer byte-twins.
+- `opaque_handle_tokenizer/negative/unsatisfied_send_or_copy_rejected.sifr` now declares `def close(own self) -> None` on `Tokenizer`, so `close=close` in the `@rust.opaque(...)` decorator points at a real method.
+
+### Minor (non-blocking, do with it what you will)
+
+- The `_verifier_binds_call` helper splits on `f"{bound_function}("` rather than the more specific `f".{bound_function}("` when the line contains the dotted form. This is robust for current fixtures but would false-positive if a method binding `encode` co-existed with an unrelated `super_encode(...)` call on the same line containing `=`. Unlikely given the current naming conventions; flag here only as a latent fragility, not something to chase.
+- `ecosystem_backend_certification/examples/sqlx.sifr` models `sqlx.query` as sync returning `Result[SqlRows]`, conflating `query()` (sync builder) with `.fetch_*().await`. Same shape as the round-2 reqwest fix but with a sync entry point; the prior reviewer did not flag it, so noting only — not actionable unless you want strict parity with the new policy.

--- a/plans/reviews/active/rust_interop_fuller_examples_review_4.md
+++ b/plans/reviews/active/rust_interop_fuller_examples_review_4.md
@@ -1,0 +1,27 @@
+I've verified the three fixes against the actual code.
+
+## Review (round 4) — Rust interop fuller examples
+
+**No remaining actionable blockers.**
+
+I traced each of the three fixes against the code on disk:
+
+### 1. `tower.sifr` async conversion — correct
+`async_ecosystem_matrix/examples/tower.sifr:10,12-13` now declares `async def tower_service_call(...)` and the verifier awaits via `sample_result: Result[bytes, PackageExampleError | RustPanicError] = await tower_service_call(b"GET / HTTP/1.1")`. Matches the round-2 policy for `reqwest.Client.get` / `tokio_postgres.connect` / `tokio_tungstenite.connect_async`. Closes the round-3 finding.
+
+### 2. `sqlx.sifr` async conversion — correct and intentional
+`ecosystem_backend_certification/examples/sqlx.sifr:14,16-17` is now async-shaped. As noted in round 3, `sqlx::query()` is technically a sync builder, but the conversion brings it under the same async-only policy applied to reqwest — a deliberate consistency choice you flagged in the request. No further action.
+
+### 3. `_verifier_binds_call` token/path boundary — correct
+`check_fixture_matrix.py:413-444` now skips bare-call matches when the preceding character is alnum/`_`/`.` and emits the method-call prefix only on `.name(` hits. Traced adversarial cases:
+
+- `super_encode_result = super_encode("x")` with bound `encode`: bare hit at `_encode(` rejected (preceded by `_`); no `.encode(` → no prefix → correctly **not bound**.
+- `result = base.super_encode(encode_arg)` with bound `encode`: bare hit inside `super_encode(` rejected by `_`; no `.encode(` substring; bare hit on the inner `encode(` is preceded by `(` → adds prefix `result = base.super_encode(` containing `=` → bound (the call is genuinely there).
+- `result = handle.encode("x")` with bound `encode`: bare hit rejected by leading `.`; method marker `.encode(` matches → prefix `result = handle.` contains `=`, doesn't start with `return ` → bound ✓.
+- `return inner.encode("x")` with bound `encode`: method-marker prefix `return inner.` has no `=` and starts with `return ` → not bound ✓.
+- `await tower_service_call(...)` lines in the new async fixtures: bare hit preceded by space → prefix containing `=` → bound ✓.
+
+Validation independently confirms: `python3 verification/areas/rust_interop/checks/check_fixture_matrix.py` reports `fixtures=31 diagnostics=10 crates=44 package_examples=51`; `py_compile` clean; `git diff --check` clean.
+
+### Residual notes (not actionable)
+- The earlier "must call" existence check at `check_fixture_matrix.py:563` still uses naive substring containment (`f"{name}(" not in verifier_body`). For non-None bindings the new boundary-aware `_verifier_binds_call` catches mismatches downstream, so combined behavior is correct. The naive existence check only matters in isolation for None-returning bindings (`close`), and no current fixture pairs a `close` binding with a sibling like `super_close` — so this remains latent. Not worth chasing now; calling it out only so a future None-returning bound name pair doesn't surprise you.

--- a/verification/areas/rust_interop/README.md
+++ b/verification/areas/rust_interop/README.md
@@ -29,7 +29,9 @@ Each directory under `fixtures/` is required to contain:
 
 The `matrix` suite validates this layout, verifies that fixture metadata
 matches `data/rust_interop_fixture_matrix.json`, and rejects empty README-only
-fixture directories. Package examples must be referenced from
+fixture directories. Positive and negative evidence files must include a
+`verify_<evidence-id>` function that calls every Rust-decorated binding in the
+file, including opaque-handle methods. Package examples must be referenced from
 `fixture.json.package_examples`, must use the exact `examples/<crate>.sifr`
 path, and must include a concrete `@rust(...)` declaration plus a
 `verify_<crate>_package` function that exercises that binding.

--- a/verification/areas/rust_interop/checks/check_fixture_matrix.py
+++ b/verification/areas/rust_interop/checks/check_fixture_matrix.py
@@ -365,22 +365,32 @@ def _validate_package_example_text(
     for header in required_headers:
         if header not in text:
             failures.append(f"{fixture_id}: {raw_path} missing header {header!r}")
+    if _contains_empty_pass_body(text):
+        failures.append(f"{fixture_id}: {raw_path} must not use empty placeholder class bodies")
     crate_token = crate.replace("-", "_")
-    bound_function = _rust_bound_function_name(text, crate_token)
-    if bound_function is None:
+    bound_functions = _rust_bound_function_names(text, crate_token)
+    if not bound_functions:
         failures.append(f"{fixture_id}: {raw_path} must declare a Rust binding for crate {crate}")
         return
 
     verifier_marker = f"def verify_{crate_token}_package("
-    if verifier_marker not in text:
+    async_verifier_marker = f"async def verify_{crate_token}_package("
+    if verifier_marker not in text and async_verifier_marker not in text:
         failures.append(f"{fixture_id}: {raw_path} must include verify_{crate_token}_package")
         return
-    verifier_body = text[text.index(verifier_marker) :]
-    if f"{bound_function}(" not in verifier_body:
-        failures.append(f"{fixture_id}: {raw_path} verifier must call {bound_function}")
+    verifier_start = min(
+        index for index in (text.find(verifier_marker), text.find(async_verifier_marker)) if index >= 0
+    )
+    verifier_body = text[verifier_start:]
+    for bound_function in bound_functions:
+        if f"{bound_function}(" not in verifier_body:
+            failures.append(f"{fixture_id}: {raw_path} verifier must call {bound_function}")
+        if not _verifier_binds_call(verifier_body, bound_function):
+            failures.append(f"{fixture_id}: {raw_path} verifier must bind {bound_function} result before returning")
 
 
-def _rust_bound_function_name(text: str, crate_token: str) -> str | None:
+def _rust_bound_function_names(text: str, crate_token: str) -> list[str]:
+    names: list[str] = []
     lines = text.splitlines()
     for index, line in enumerate(lines):
         stripped = line.lstrip()
@@ -393,10 +403,45 @@ def _rust_bound_function_name(text: str, crate_token: str) -> str | None:
             following_stripped = following.lstrip()
             if following_stripped.startswith("@"):
                 continue
-            if not following_stripped.startswith("def "):
-                return None
-            return following_stripped.removeprefix("def ").split("(", maxsplit=1)[0].strip()
-    return None
+            name = _decorated_function_name(following_stripped)
+            if name is not None and name not in names:
+                names.append(name)
+            break
+    return names
+
+
+def _verifier_binds_call(verifier_body: str, bound_function: str) -> bool:
+    for line in verifier_body.splitlines():
+        for before_call in _bound_call_prefixes(line, bound_function):
+            if "=" in before_call and not before_call.lstrip().startswith("return "):
+                return True
+    return False
+
+
+def _bound_call_prefixes(line: str, bound_function: str) -> list[str]:
+    prefixes: list[str] = []
+    marker = f"{bound_function}("
+    start = 0
+    while True:
+        index = line.find(marker, start)
+        if index < 0:
+            break
+        if index == 0 or not _is_identifier_or_path_char(line[index - 1]):
+            prefixes.append(line[:index])
+        start = index + len(marker)
+    method_marker = f".{bound_function}("
+    start = 0
+    while True:
+        index = line.find(method_marker, start)
+        if index < 0:
+            break
+        prefixes.append(line[: index + 1])
+        start = index + len(method_marker)
+    return prefixes
+
+
+def _is_identifier_or_path_char(char: str) -> bool:
+    return char.isalnum() or char in {"_", "."}
 
 
 def _has_crate_token_boundary(text: str, index: int) -> bool:
@@ -461,6 +506,7 @@ def _validate_fixture_evidence_file(
             failures.append(f"{fixture_id}: {raw_path} missing header {header!r}")
     if not any(line.lstrip().startswith("@rust") for line in text.splitlines()):
         failures.append(f"{fixture_id}: {raw_path} must exercise a Rust interop declaration")
+    _validate_evidence_example_text(failures, fixture_id, raw_path, text, str(matrix_evidence.get("id")))
 
     expected_result = manifest_evidence.get("expected_result")
     if not isinstance(expected_result, str) or not expected_result:
@@ -486,6 +532,85 @@ def _validate_fixture_evidence_file(
             failures.append(f"{fixture_id}: evidence.{side}.expected_diagnostic must be a reserved SIFR-RUST code")
         elif f"# expected-diagnostic: {expected_diagnostic}" not in text:
             failures.append(f"{fixture_id}: {raw_path} missing expected diagnostic marker {expected_diagnostic}")
+
+
+def _validate_evidence_example_text(
+    failures: list[str],
+    fixture_id: str,
+    raw_path: str,
+    text: str,
+    evidence_id: str,
+) -> None:
+    if len(text.strip().splitlines()) < 9:
+        failures.append(f"{fixture_id}: {raw_path} must include a binding and concrete verifier call site")
+    if _contains_empty_pass_body(text):
+        failures.append(f"{fixture_id}: {raw_path} must not use empty placeholder class bodies")
+
+    verifier_markers = (
+        f"def verify_{evidence_id}(",
+        f"async def verify_{evidence_id}(",
+    )
+    verifier_start = min((text.find(marker) for marker in verifier_markers if marker in text), default=-1)
+    if verifier_start < 0:
+        failures.append(f"{fixture_id}: {raw_path} must include verify_{evidence_id}")
+        return
+
+    verifier_body = text[verifier_start:]
+    bound_declarations = _rust_bound_declarations(text)
+    if not bound_declarations:
+        failures.append(f"{fixture_id}: {raw_path} must include a Rust-decorated binding declaration")
+    for name, return_type in bound_declarations:
+        if f"{name}(" not in verifier_body and f".{name}(" not in verifier_body:
+            failures.append(f"{fixture_id}: {raw_path} verifier must call {name}")
+        if return_type != "None" and not _verifier_binds_call(verifier_body, name):
+            failures.append(f"{fixture_id}: {raw_path} verifier must bind {name} result before returning")
+
+
+def _rust_bound_declaration_names(text: str) -> list[str]:
+    return [name for name, _return_type in _rust_bound_declarations(text)]
+
+
+def _rust_bound_declarations(text: str) -> list[tuple[str, str]]:
+    names: list[str] = []
+    declarations: list[tuple[str, str]] = []
+    decorators: list[str] = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("@"):
+            decorators.append(stripped)
+            continue
+        if _is_rust_decorated_binding(stripped, decorators):
+            name = _decorated_function_name(stripped)
+            if name is not None and name not in names:
+                names.append(name)
+                declarations.append((name, _decorated_function_return_type(stripped)))
+        if stripped and not stripped.startswith("@"):
+            decorators = []
+    return declarations
+
+
+def _is_rust_decorated_binding(stripped: str, decorators: list[str]) -> bool:
+    return (
+        any(decorator.startswith("@rust") for decorator in decorators)
+        and (stripped.startswith("def ") or stripped.startswith("async def "))
+        and stripped.endswith(": ...")
+    )
+
+
+def _decorated_function_name(stripped: str) -> str | None:
+    if stripped.startswith("async def "):
+        stripped = stripped.removeprefix("async ")
+    if not stripped.startswith("def "):
+        return None
+    return stripped.removeprefix("def ").split("(", maxsplit=1)[0].strip()
+
+
+def _decorated_function_return_type(stripped: str) -> str:
+    return stripped.split("->", maxsplit=1)[1].rsplit(":", maxsplit=1)[0].strip()
+
+
+def _contains_empty_pass_body(text: str) -> bool:
+    return any(line.strip() == "pass" for line in text.splitlines())
 
 
 if __name__ == "__main__":

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/candle.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/candle.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class Tensor:
-    pass
+    shape: list[uint64]
+    dtype: str
 
 @rust(candle.Tensor.from_vec, panic=map_error(bridge.candle.map_panic))
-def candle_tensor_from_vec(input: list[f32]) -> Result[Tensor, PackageExampleError | RustPanicError]: ...
+def candle_tensor_from_vec(input: list[float]) -> Result[Tensor, PackageExampleError | RustPanicError]: ...
 
 def verify_candle_package() -> Result[Tensor, PackageExampleError | RustPanicError]:
-    return candle_tensor_from_vec([1.0, 2.0, 3.0, 4.0])
+    sample_result: Result[Tensor, PackageExampleError | RustPanicError] = candle_tensor_from_vec([1.0, 2.0, 3.0, 4.0])
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/datafusion.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/datafusion.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class DataFrame:
-    pass
+    schema: str
+    row_count: uint64
 
 @rust(datafusion.SessionContext.new, panic=map_error(bridge.datafusion.map_panic))
 def datafusion_context(query: str) -> Result[DataFrame, PackageExampleError | RustPanicError]: ...
 
 def verify_datafusion_package() -> Result[DataFrame, PackageExampleError | RustPanicError]:
-    return datafusion_context("select 1")
+    sample_result: Result[DataFrame, PackageExampleError | RustPanicError] = datafusion_context("select 1")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/ndarray.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/ndarray.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class NdArray2:
-    pass
+    shape: list[uint64]
+    dtype: str
 
 @rust(ndarray.Array2.from_shape_vec, panic=map_error(bridge.ndarray.map_panic))
-def ndarray_array2(input: list[f32]) -> Result[NdArray2, PackageExampleError | RustPanicError]: ...
+def ndarray_array2(input: list[float]) -> Result[NdArray2, PackageExampleError | RustPanicError]: ...
 
 def verify_ndarray_package() -> Result[NdArray2, PackageExampleError | RustPanicError]:
-    return ndarray_array2([1.0, 2.0, 3.0, 4.0])
+    sample_result: Result[NdArray2, PackageExampleError | RustPanicError] = ndarray_array2([1.0, 2.0, 3.0, 4.0])
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/polars.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/examples/polars.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class DataFrame:
-    pass
+    schema: str
+    row_count: uint64
 
 @rust(polars.DataFrame.new, panic=map_error(bridge.polars.map_panic))
 def polars_dataframe(input: bytes) -> Result[DataFrame, PackageExampleError | RustPanicError]: ...
 
 def verify_polars_package() -> Result[DataFrame, PackageExampleError | RustPanicError]:
-    return polars_dataframe(b"sifr-rust-interop")
+    sample_result: Result[DataFrame, PackageExampleError | RustPanicError] = polars_dataframe(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/negative/dtype_shape_mismatch.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/negative/dtype_shape_mismatch.sifr
@@ -4,6 +4,14 @@
 # execution-kind: contract-only
 # expected-result: diagnostic
 # expected-diagnostic: SIFR-RUST-ZC-0001
+class DataFrame:
+    schema: str
+    row_count: uint64
+
 @rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=tensor, dtype=f32, rank=2, shape=[2, 3], schema=bridge.data.Schema, ownership=borrowed)
 @rust(bridge.dataframe.view, panic=trusted_no_panic)
 def mismatched_metadata(input: bytes) -> DataFrame: ...
+
+def verify_dtype_shape_mismatch() -> DataFrame:
+    mismatched_metadata_result: DataFrame = mismatched_metadata(b"sifr-rust-interop")
+    return mismatched_metadata_result

--- a/verification/areas/rust_interop/fixtures/advanced_data_matrix/positive/advanced_data_metadata.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_matrix/positive/advanced_data_metadata.sifr
@@ -6,6 +6,14 @@
 class DataError(Error):
     message: str
 
+class DataFrame:
+    schema: str
+    row_count: uint64
+
 @rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=dataframe, schema=bridge.data.Schema, ownership=borrowed)
 @rust(bridge.dataframe.view, panic=map_error(bridge.dataframe.map_panic))
 def dataframe_view(input: bytes) -> Result[DataFrame, DataError | RustPanicError]: ...
+
+def verify_advanced_data_metadata() -> Result[DataFrame, DataError | RustPanicError]:
+    dataframe_view_result: Result[DataFrame, DataError | RustPanicError] = dataframe_view(b"sifr-rust-interop")
+    return dataframe_view_result

--- a/verification/areas/rust_interop/fixtures/arrow_record_batch/examples/arrow.sifr
+++ b/verification/areas/rust_interop/fixtures/arrow_record_batch/examples/arrow.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class ArrowRecordBatch:
-    pass
+    schema: str
+    row_count: uint64
 
 @rust(arrow.array.Int32Array.from, panic=map_error(bridge.arrow.map_panic))
 def arrow_int32_array(input: bytes) -> Result[ArrowRecordBatch, PackageExampleError | RustPanicError]: ...
 
 def verify_arrow_package() -> Result[ArrowRecordBatch, PackageExampleError | RustPanicError]:
-    return arrow_int32_array(b"sifr-rust-interop")
+    sample_result: Result[ArrowRecordBatch, PackageExampleError | RustPanicError] = arrow_int32_array(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/arrow_record_batch/negative/invalid_arrow_metadata.sifr
+++ b/verification/areas/rust_interop/fixtures/arrow_record_batch/negative/invalid_arrow_metadata.sifr
@@ -4,6 +4,14 @@
 # execution-kind: contract-only
 # expected-result: diagnostic
 # expected-diagnostic: SIFR-RUST-ZC-0001
+class ArrowRecordBatch:
+    schema: str
+    row_count: uint64
+
 @rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=arrow_record_batch, ownership=borrowed)
 @rust(sifr_arrow_bridge.record_batch_from_bytes, panic=trusted_no_panic)
 def missing_schema(input: bytes) -> ArrowRecordBatch: ...
+
+def verify_invalid_arrow_metadata() -> ArrowRecordBatch:
+    missing_schema_result: ArrowRecordBatch = missing_schema(b"sifr-rust-interop")
+    return missing_schema_result

--- a/verification/areas/rust_interop/fixtures/arrow_record_batch/positive/arrow_schema_identity.sifr
+++ b/verification/areas/rust_interop/fixtures/arrow_record_batch/positive/arrow_schema_identity.sifr
@@ -6,7 +6,15 @@
 class ArrowError(Error):
     message: str
 
+class ArrowRecordBatch:
+    schema: str
+    row_count: uint64
+
 @rust.zero_copy(owner=input, view=sifr_arrow_bridge.record_batch.RecordBatchView)
 @rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=arrow_record_batch, schema=sifr_arrow_bridge.schema.RecordBatch, ownership=borrowed)
 @rust(sifr_arrow_bridge.record_batch_from_bytes, panic=map_error(sifr_arrow_bridge.panic.map))
 def record_batch(input: bytes) -> Result[ArrowRecordBatch, ArrowError | RustPanicError]: ...
+
+def verify_arrow_schema_identity() -> Result[ArrowRecordBatch, ArrowError | RustPanicError]:
+    record_batch_result: Result[ArrowRecordBatch, ArrowError | RustPanicError] = record_batch(b"sifr-rust-interop")
+    return record_batch_result

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/futures.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/futures.sifr
@@ -7,7 +7,8 @@ class PackageExampleError(Error):
     message: str
 
 @rust(futures.future.join, panic=map_error(bridge.futures.map_panic))
-def futures_join(left: i32, right: i32) -> Result[tuple[i32, i32], PackageExampleError | RustPanicError]: ...
+async def futures_join(left: int32, right: int32) -> Result[tuple[int32, int32], PackageExampleError | RustPanicError]: ...
 
-def verify_futures_package() -> Result[tuple[i32, i32], PackageExampleError | RustPanicError]:
-    return futures_join(40, 2)
+async def verify_futures_package() -> Result[tuple[int32, int32], PackageExampleError | RustPanicError]:
+    sample_result: Result[tuple[int32, int32], PackageExampleError | RustPanicError] = await futures_join(40, 2)
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/http-body.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/http-body.sifr
@@ -7,7 +7,8 @@ class PackageExampleError(Error):
     message: str
 
 @rust(http_body.Body.size_hint, panic=map_error(bridge.http_body.map_panic))
-def http_body_size_hint(body: bytes) -> Result[u64, PackageExampleError | RustPanicError]: ...
+def http_body_size_hint(body: bytes) -> Result[uint64, PackageExampleError | RustPanicError]: ...
 
-def verify_http_body_package() -> Result[u64, PackageExampleError | RustPanicError]:
-    return http_body_size_hint(b"body")
+def verify_http_body_package() -> Result[uint64, PackageExampleError | RustPanicError]:
+    sample_result: Result[uint64, PackageExampleError | RustPanicError] = http_body_size_hint(b"body")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/http.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/http.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class HttpRequest:
-    pass
+    method: str
+    uri: str
 
 @rust(http.Request.builder, panic=map_error(bridge.http.map_panic))
 def http_request_builder(url: str) -> Result[HttpRequest, PackageExampleError | RustPanicError]: ...
 
 def verify_http_package() -> Result[HttpRequest, PackageExampleError | RustPanicError]:
-    return http_request_builder("https://127.0.0.1/health")
+    sample_result: Result[HttpRequest, PackageExampleError | RustPanicError] = http_request_builder("https://127.0.0.1/health")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/tower.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/examples/tower.sifr
@@ -7,7 +7,8 @@ class PackageExampleError(Error):
     message: str
 
 @rust(tower.Service.call, panic=map_error(bridge.tower.map_panic))
-def tower_service_call(request: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
+async def tower_service_call(request: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
 
-def verify_tower_package() -> Result[bytes, PackageExampleError | RustPanicError]:
-    return tower_service_call(b"GET / HTTP/1.1")
+async def verify_tower_package() -> Result[bytes, PackageExampleError | RustPanicError]:
+    sample_result: Result[bytes, PackageExampleError | RustPanicError] = await tower_service_call(b"GET / HTTP/1.1")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/negative/non_send_future_without_affinity.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/negative/non_send_future_without_affinity.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-ASYNC-0001
 @rust(bridge.async_local.non_send_future, panic=trusted_no_panic)
 async def non_send_without_affinity() -> uint32: ...
+
+async def verify_non_send_future_without_affinity() -> uint32:
+    non_send_without_affinity_result: uint32 = await non_send_without_affinity()
+    return non_send_without_affinity_result

--- a/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/positive/current_thread_non_send_future.sifr
+++ b/verification/areas/rust_interop/fixtures/async_ecosystem_matrix/positive/current_thread_non_send_future.sifr
@@ -9,3 +9,7 @@ class AsyncError(Error):
 @rust.async(thread_affinity=tokio_current_thread)
 @rust(bridge.async_local.poll_once, panic=map_error(bridge.async_local.map_panic))
 async def poll_once() -> Result[uint32, AsyncError | RustPanicError]: ...
+
+async def verify_current_thread_non_send_future() -> Result[uint32, AsyncError | RustPanicError]:
+    poll_once_result: Result[uint32, AsyncError | RustPanicError] = await poll_once()
+    return poll_once_result

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/reqwest.sifr
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/reqwest.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class HttpResponse:
-    pass
+    status: uint32
+    body: bytes
 
 @rust(reqwest.Client.get, panic=map_error(bridge.reqwest.map_panic))
-def reqwest_get(url: str) -> Result[HttpResponse, PackageExampleError | RustPanicError]: ...
+async def reqwest_get(url: str) -> Result[HttpResponse, PackageExampleError | RustPanicError]: ...
 
-def verify_reqwest_package() -> Result[HttpResponse, PackageExampleError | RustPanicError]:
-    return reqwest_get("https://127.0.0.1/health")
+async def verify_reqwest_package() -> Result[HttpResponse, PackageExampleError | RustPanicError]:
+    sample_result: Result[HttpResponse, PackageExampleError | RustPanicError] = await reqwest_get("https://127.0.0.1/health")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/tokio.sifr
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/examples/tokio.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class TaskHandle:
-    pass
+    task_id: uint64
+    runtime: str
 
 @rust(tokio.spawn, panic=map_error(bridge.tokio.map_panic))
-def tokio_spawn(delay_ms: u64) -> Result[TaskHandle, PackageExampleError | RustPanicError]: ...
+async def tokio_spawn(delay_ms: uint64) -> Result[TaskHandle, PackageExampleError | RustPanicError]: ...
 
-def verify_tokio_package() -> Result[TaskHandle, PackageExampleError | RustPanicError]:
-    return tokio_spawn(1)
+async def verify_tokio_package() -> Result[TaskHandle, PackageExampleError | RustPanicError]:
+    sample_result: Result[TaskHandle, PackageExampleError | RustPanicError] = await tokio_spawn(1)
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/negative/hidden_block_on_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/negative/hidden_block_on_rejected.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-ASYNC-0001
 @rust(bridge.http.hidden_block_on, panic=trusted_no_panic)
 async def hidden_block_on(url: str) -> str: ...
+
+async def verify_hidden_block_on_rejected() -> str:
+    hidden_block_on_result: str = await hidden_block_on("https://127.0.0.1/health")
+    return hidden_block_on_result

--- a/verification/areas/rust_interop/fixtures/async_runtime_reqwest/positive/async_reqwest_loopback.sifr
+++ b/verification/areas/rust_interop/fixtures/async_runtime_reqwest/positive/async_reqwest_loopback.sifr
@@ -8,3 +8,7 @@ class HttpError(Error):
 
 @rust(bridge.http.fetch_text, panic=map_error(bridge.http.map_panic))
 async def fetch_text(url: str) -> Result[str, HttpError | RustPanicError]: ...
+
+async def verify_async_reqwest_loopback() -> Result[str, HttpError | RustPanicError]:
+    fetch_text_result: Result[str, HttpError | RustPanicError] = await fetch_text("https://127.0.0.1/health")
+    return fetch_text_result

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/flate2.sifr
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/flate2.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def flate2_deflate(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
 
 def verify_flate2_package() -> Result[bytes, PackageExampleError | RustPanicError]:
-    return flate2_deflate(b"sifr-rust-interop")
+    sample_result: Result[bytes, PackageExampleError | RustPanicError] = flate2_deflate(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/rayon.sifr
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/rayon.sifr
@@ -7,7 +7,8 @@ class PackageExampleError(Error):
     message: str
 
 @rust(rayon.join, panic=map_error(bridge.rayon.map_panic))
-def rayon_join(left: i32, right: i32) -> Result[i32, PackageExampleError | RustPanicError]: ...
+def rayon_join(left: int32, right: int32) -> Result[int32, PackageExampleError | RustPanicError]: ...
 
-def verify_rayon_package() -> Result[i32, PackageExampleError | RustPanicError]:
-    return rayon_join(40, 2)
+def verify_rayon_package() -> Result[int32, PackageExampleError | RustPanicError]:
+    sample_result: Result[int32, PackageExampleError | RustPanicError] = rayon_join(40, 2)
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/rusqlite.sifr
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/examples/rusqlite.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class SqlRows:
-    pass
+    columns: list[str]
+    row_count: uint64
 
 @rust(rusqlite.Connection.open_in_memory, panic=map_error(bridge.rusqlite.map_panic))
 def rusqlite_memory(query: str) -> Result[SqlRows, PackageExampleError | RustPanicError]: ...
 
 def verify_rusqlite_package() -> Result[SqlRows, PackageExampleError | RustPanicError]:
-    return rusqlite_memory("select 1")
+    sample_result: Result[SqlRows, PackageExampleError | RustPanicError] = rusqlite_memory("select 1")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/negative/classified_async_declarations_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/negative/classified_async_declarations_rejected.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-ASYNC-0001
 @rust(bridge.db.query_blocking, panic=trusted_no_panic)
 async def hidden_blocking_query(sql: str) -> list[str]: ...
+
+async def verify_classified_async_declarations_rejected() -> list[str]:
+    hidden_blocking_query_result: list[str] = await hidden_blocking_query("select 1")
+    return hidden_blocking_query_result

--- a/verification/areas/rust_interop/fixtures/blocking_diagnostics/positive/classified_sync_rust_effects.sifr
+++ b/verification/areas/rust_interop/fixtures/blocking_diagnostics/positive/classified_sync_rust_effects.sifr
@@ -10,3 +10,8 @@ def query_blocking(sql: str) -> list[str]: ...
 @cpu_heavy
 @rust(bridge.compress.deflate, panic=trusted_no_panic)
 def deflate(input: bytes) -> bytes: ...
+
+def verify_classified_sync_rust_effects() -> list[str]:
+    query_blocking_result: list[str] = query_blocking("select 1")
+    deflate_result: bytes = deflate(b"sifr-rust-interop")
+    return query_blocking_result

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/bytes.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/bytes.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def bytes_from_slice(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
 
 def verify_bytes_package() -> Result[bytes, PackageExampleError | RustPanicError]:
-    return bytes_from_slice(b"sifr-rust-interop")
+    sample_result: Result[bytes, PackageExampleError | RustPanicError] = bytes_from_slice(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/indexmap.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/indexmap.sifr
@@ -7,7 +7,8 @@ class PackageExampleError(Error):
     message: str
 
 @rust(indexmap.IndexMap.insert, panic=map_error(bridge.indexmap.map_panic))
-def indexmap_insert(key: str, value: i32) -> Result[i32, PackageExampleError | RustPanicError]: ...
+def indexmap_insert(key: str, value: int32) -> Result[int32, PackageExampleError | RustPanicError]: ...
 
-def verify_indexmap_package() -> Result[i32, PackageExampleError | RustPanicError]:
-    return indexmap_insert("answer", 42)
+def verify_indexmap_package() -> Result[int32, PackageExampleError | RustPanicError]:
+    sample_result: Result[int32, PackageExampleError | RustPanicError] = indexmap_insert("answer", 42)
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/serde.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/serde.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def serde_serialize(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
 
 def verify_serde_package() -> Result[bytes, PackageExampleError | RustPanicError]:
-    return serde_serialize(b"sifr-rust-interop")
+    sample_result: Result[bytes, PackageExampleError | RustPanicError] = serde_serialize(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/serde_json.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/serde_json.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class JsonValue:
-    pass
+    label: str
+    bridge_state: str
 
 @rust(serde_json.from_slice, panic=map_error(bridge.serde_json.map_panic))
 def serde_json_decode(input: bytes) -> Result[JsonValue, PackageExampleError | RustPanicError]: ...
 
 def verify_serde_json_package() -> Result[JsonValue, PackageExampleError | RustPanicError]:
-    return serde_json_decode(b"sifr-rust-interop")
+    sample_result: Result[JsonValue, PackageExampleError | RustPanicError] = serde_json_decode(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/thiserror.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/examples/thiserror.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class RustError:
-    pass
+    message: str
+    source: str
 
 @rust(thiserror.Error.from_display, panic=map_error(bridge.thiserror.map_panic))
 def thiserror_from_display(message: str) -> Result[RustError, PackageExampleError | RustPanicError]: ...
 
 def verify_thiserror_package() -> Result[RustError, PackageExampleError | RustPanicError]:
-    return thiserror_from_display("sifr error context")
+    sample_result: Result[RustError, PackageExampleError | RustPanicError] = thiserror_from_display("sifr error context")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/negative/unsupported_container_rejections.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/negative/unsupported_container_rejections.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-TYPE-0001
 @rust(bridge.types.unsupported, panic=trusted_no_panic)
 def unsupported(value: dict[str, list[object]]) -> object: ...
+
+def verify_unsupported_container_rejections() -> object:
+    unsupported_result: object = unsupported({"captures": ["sifr"]})
+    return unsupported_result

--- a/verification/areas/rust_interop/fixtures/bridge_type_matrix/positive/supported_type_roundtrips.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_type_matrix/positive/supported_type_roundtrips.sifr
@@ -12,3 +12,7 @@ class BridgeError(Error):
 
 @rust(bridge.types.roundtrip, panic=map_error(bridge.types.map_error))
 def roundtrip(value: HashRecord) -> Result[HashRecord, BridgeError | RustPanicError]: ...
+
+def verify_supported_type_roundtrips() -> Result[HashRecord, BridgeError | RustPanicError]:
+    roundtrip_result: Result[HashRecord, BridgeError | RustPanicError] = roundtrip(HashRecord(b"sifr-rust-interop", 18))
+    return roundtrip_result

--- a/verification/areas/rust_interop/fixtures/bridge_version_mismatch/negative/unsupported_bridge_version_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_version_mismatch/negative/unsupported_bridge_version_rejected.sifr
@@ -7,3 +7,7 @@
 # fixture-cargo: rust.bridge-version = 999
 @rust(bridge.version.rejected, panic=trusted_no_panic)
 def rejected() -> uint32: ...
+
+def verify_unsupported_bridge_version_rejected() -> uint32:
+    rejected_result: uint32 = rejected()
+    return rejected_result

--- a/verification/areas/rust_interop/fixtures/bridge_version_mismatch/positive/bridge_version_1_accepted.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_version_mismatch/positive/bridge_version_1_accepted.sifr
@@ -6,3 +6,7 @@
 # fixture-cargo: rust.bridge-version = 1
 @rust(bridge.version.accepted, panic=trusted_no_panic)
 def accepted() -> uint32: ...
+
+def verify_bridge_version_1_accepted() -> uint32:
+    accepted_result: uint32 = accepted()
+    return accepted_result

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/notify.sifr
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/notify.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class WatcherHandle:
-    pass
+    path: str
+    watch_id: uint64
 
 @rust(notify.recommended_watcher, panic=map_error(bridge.notify.map_panic))
 def notify_watcher(path: str) -> Result[WatcherHandle, PackageExampleError | RustPanicError]: ...
 
 def verify_notify_package() -> Result[WatcherHandle, PackageExampleError | RustPanicError]:
-    return notify_watcher("/tmp/sifr-rust-interop.bin")
+    sample_result: Result[WatcherHandle, PackageExampleError | RustPanicError] = notify_watcher("/tmp/sifr-rust-interop.bin")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/redis.sifr
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/redis.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class RedisClient:
-    pass
+    url: str
+    connection_id: uint64
 
 @rust(redis.Client.open, panic=map_error(bridge.redis.map_panic))
 def redis_client(url: str) -> Result[RedisClient, PackageExampleError | RustPanicError]: ...
 
 def verify_redis_package() -> Result[RedisClient, PackageExampleError | RustPanicError]:
-    return redis_client("redis://127.0.0.1:6379/0")
+    sample_result: Result[RedisClient, PackageExampleError | RustPanicError] = redis_client("redis://127.0.0.1:6379/0")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/tokio-tungstenite.sifr
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/examples/tokio-tungstenite.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class WebSocket:
-    pass
+    url: str
+    protocol: str
 
 @rust(tokio_tungstenite.connect_async, panic=map_error(bridge.tokio_tungstenite.map_panic))
-def tokio_tungstenite_connect(url: str) -> Result[WebSocket, PackageExampleError | RustPanicError]: ...
+async def tokio_tungstenite_connect(url: str) -> Result[WebSocket, PackageExampleError | RustPanicError]: ...
 
-def verify_tokio_tungstenite_package() -> Result[WebSocket, PackageExampleError | RustPanicError]:
-    return tokio_tungstenite_connect("ws://127.0.0.1:9001/stream")
+async def verify_tokio_tungstenite_package() -> Result[WebSocket, PackageExampleError | RustPanicError]:
+    sample_result: Result[WebSocket, PackageExampleError | RustPanicError] = await tokio_tungstenite_connect("ws://127.0.0.1:9001/stream")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/negative/invalid_thread_capture_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/negative/invalid_thread_capture_rejected.sifr
@@ -7,3 +7,10 @@
 @rust.callback(backpressure=bounded(256), overflow=error, shutdown=drain)
 @rust(bridge.events.subscribe_non_send_capture, panic=trusted_no_panic)
 def subscribe(handler: ThreadsafeCallback[[str], None]) -> None: ...
+
+def sample_event_callback(event: str) -> None:
+    return None
+
+def verify_invalid_thread_capture_rejected() -> None:
+    subscribe(sample_event_callback)
+    return None

--- a/verification/areas/rust_interop/fixtures/callback_subscription_matrix/positive/subscription_cancel_shutdown.sifr
+++ b/verification/areas/rust_interop/fixtures/callback_subscription_matrix/positive/subscription_cancel_shutdown.sifr
@@ -14,3 +14,11 @@ class Subscription:
 @rust.callback(backpressure=bounded(256), overflow=error, shutdown=drain)
 @rust(bridge.events.subscribe, panic=map_error(bridge.events.map_panic))
 def subscribe(handler: ThreadsafeCallback[[str], Result[None, SubscriptionError]]) -> Result[Subscription, SubscriptionError | RustPanicError]: ...
+
+def sample_result_callback(event: str) -> Result[None, SubscriptionError]:
+    return None
+
+async def verify_subscription_cancel_shutdown(subscription: Subscription) -> Result[Subscription, SubscriptionError | RustPanicError]:
+    subscribe_result: Result[Subscription, SubscriptionError | RustPanicError] = subscribe(sample_result_callback)
+    aclose_result: Result[None, SubscriptionError | RustPanicError] = await subscription.aclose()
+    return subscribe_result

--- a/verification/areas/rust_interop/fixtures/callbacks_call_scoped/negative/callback_storage_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/callbacks_call_scoped/negative/callback_storage_rejected.sifr
@@ -7,3 +7,10 @@
 @rust.callback(backpressure=bounded(32), overflow=error, shutdown=drain)
 @rust(bridge.callbacks.store_for_later, panic=trusted_no_panic)
 def store_for_later(handler: ThreadsafeCallback[[str], None]) -> None: ...
+
+def sample_event_callback(event: str) -> None:
+    return None
+
+def verify_callback_storage_rejected() -> None:
+    store_for_later(sample_event_callback)
+    return None

--- a/verification/areas/rust_interop/fixtures/callbacks_call_scoped/positive/callback_valid_during_call.sifr
+++ b/verification/areas/rust_interop/fixtures/callbacks_call_scoped/positive/callback_valid_during_call.sifr
@@ -9,3 +9,10 @@ class EventError(Error):
 @rust.callback(backpressure=bounded(32), overflow=error, shutdown=drain)
 @rust(bridge.callbacks.visit, panic=map_error(bridge.callbacks.map_panic))
 def visit(handler: ThreadsafeCallback[[str], Result[None, EventError]]) -> Result[None, EventError | RustPanicError]: ...
+
+def sample_result_callback(event: str) -> Result[None, EventError]:
+    return None
+
+def verify_callback_valid_during_call() -> Result[None, EventError | RustPanicError]:
+    visit_result: Result[None, EventError | RustPanicError] = visit(sample_result_callback)
+    return visit_result

--- a/verification/areas/rust_interop/fixtures/callbacks_threadsafe/negative/missing_backpressure_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/callbacks_threadsafe/negative/missing_backpressure_rejected.sifr
@@ -7,3 +7,10 @@
 @rust.callback(overflow=error, shutdown=drain)
 @rust(bridge.events.subscribe, panic=trusted_no_panic)
 def subscribe(handler: ThreadsafeCallback[[str], None]) -> None: ...
+
+def sample_event_callback(event: str) -> None:
+    return None
+
+def verify_missing_backpressure_rejected() -> None:
+    subscribe(sample_event_callback)
+    return None

--- a/verification/areas/rust_interop/fixtures/callbacks_threadsafe/positive/bounded_callback_policy.sifr
+++ b/verification/areas/rust_interop/fixtures/callbacks_threadsafe/positive/bounded_callback_policy.sifr
@@ -9,3 +9,10 @@ class EventError(Error):
 @rust.callback(backpressure=bounded(1024), overflow=error, shutdown=drain)
 @rust(bridge.events.subscribe, panic=map_error(bridge.events.map_panic))
 def subscribe(handler: ThreadsafeCallback[[str], Result[None, EventError]]) -> Result[None, EventError | RustPanicError]: ...
+
+def sample_result_callback(event: str) -> Result[None, EventError]:
+    return None
+
+def verify_bounded_callback_policy() -> Result[None, EventError | RustPanicError]:
+    subscribe_result: Result[None, EventError | RustPanicError] = subscribe(sample_result_callback)
+    return subscribe_result

--- a/verification/areas/rust_interop/fixtures/cargo_locked_offline/negative/lockfile_feature_drift_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/cargo_locked_offline/negative/lockfile_feature_drift_rejected.sifr
@@ -7,3 +7,7 @@
 # fixture-cargo: lockfile omits requested feature
 @rust(bridge.locked.feature_drift, panic=trusted_no_panic)
 def feature_drift() -> uint32: ...
+
+def verify_lockfile_feature_drift_rejected() -> uint32:
+    feature_drift_result: uint32 = feature_drift()
+    return feature_drift_result

--- a/verification/areas/rust_interop/fixtures/cargo_locked_offline/positive/locked_offline_cache_hit.sifr
+++ b/verification/areas/rust_interop/fixtures/cargo_locked_offline/positive/locked_offline_cache_hit.sifr
@@ -6,3 +6,7 @@
 # fixture-cargo: --locked --offline --frozen
 @rust(bridge.locked.cached, panic=trusted_no_panic)
 def cached() -> uint32: ...
+
+def verify_locked_offline_cache_hit() -> uint32:
+    cached_result: uint32 = cached()
+    return cached_result

--- a/verification/areas/rust_interop/fixtures/close_after_use/negative/double_close_and_poisoned_access.sifr
+++ b/verification/areas/rust_interop/fixtures/close_after_use/negative/double_close_and_poisoned_access.sifr
@@ -8,3 +8,7 @@
 class NativeHandle:
     @rust(bridge.handle.close, panic=trusted_no_panic)
     def close(self) -> None: ...
+
+def verify_double_close_and_poisoned_access(resource: NativeHandle) -> None:
+    resource.close()
+    return None

--- a/verification/areas/rust_interop/fixtures/close_after_use/positive/closed_handle_error_surface.sifr
+++ b/verification/areas/rust_interop/fixtures/close_after_use/positive/closed_handle_error_surface.sifr
@@ -10,3 +10,7 @@ class HandleError(Error):
 class NativeHandle:
     @rust(bridge.handle.close, panic=map_error(bridge.handle.map_panic))
     def close(own self) -> Result[None, HandleError | RustPanicError]: ...
+
+def verify_closed_handle_error_surface(resource: NativeHandle) -> Result[None, HandleError | RustPanicError]:
+    close_result: Result[None, HandleError | RustPanicError] = resource.close()
+    return close_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_crc32/examples/crc32fast.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_crc32/examples/crc32fast.sifr
@@ -7,7 +7,8 @@ class PackageExampleError(Error):
     message: str
 
 @rust(crc32fast.hash, panic=map_error(bridge.crc32fast.map_panic))
-def crc32fast_hash(input: bytes) -> Result[u32, PackageExampleError | RustPanicError]: ...
+def crc32fast_hash(input: bytes) -> Result[uint32, PackageExampleError | RustPanicError]: ...
 
-def verify_crc32fast_package() -> Result[u32, PackageExampleError | RustPanicError]:
-    return crc32fast_hash(b"sifr-rust-interop")
+def verify_crc32fast_package() -> Result[uint32, PackageExampleError | RustPanicError]:
+    sample_result: Result[uint32, PackageExampleError | RustPanicError] = crc32fast_hash(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_crc32/negative/crc32fast_missing_panic_policy.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_crc32/negative/crc32fast_missing_panic_policy.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-PANIC-0001
 @rust(crc32fast.hash)
 def crc32(data: bytes) -> uint32: ...
+
+def verify_crc32fast_missing_panic_policy() -> uint32:
+    crc32_result: uint32 = crc32(b"sifr-rust-interop")
+    return crc32_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_crc32/positive/crc32fast_hash_uint32.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_crc32/positive/crc32fast_hash_uint32.sifr
@@ -8,3 +8,7 @@ def crc32(data: bytes) -> uint32: ...
 
 def main() -> uint32:
     return crc32(b"sifr")
+
+def verify_crc32fast_hash_uint32() -> uint32:
+    crc32_result: uint32 = crc32(b"sifr-rust-interop")
+    return crc32_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/blake3.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/blake3.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def blake3_hash(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
 
 def verify_blake3_package() -> Result[bytes, PackageExampleError | RustPanicError]:
-    return blake3_hash(b"sifr-rust-interop")
+    sample_result: Result[bytes, PackageExampleError | RustPanicError] = blake3_hash(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/regex.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/regex.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def regex_is_match(pattern: str, text: str) -> Result[bool, PackageExampleError | RustPanicError]: ...
 
 def verify_regex_package() -> Result[bool, PackageExampleError | RustPanicError]:
-    return regex_is_match("^sifr", "sifr-rust")
+    sample_result: Result[bool, PackageExampleError | RustPanicError] = regex_is_match("^sifr", "sifr-rust")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/sha2.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/sha2.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def sha256_digest(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
 
 def verify_sha2_package() -> Result[bytes, PackageExampleError | RustPanicError]:
-    return sha256_digest(b"sifr-rust-interop")
+    sample_result: Result[bytes, PackageExampleError | RustPanicError] = sha256_digest(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/uuid.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/examples/uuid.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def uuid_parse(text: str) -> Result[str, PackageExampleError | RustPanicError]: ...
 
 def verify_uuid_package() -> Result[str, PackageExampleError | RustPanicError]:
-    return uuid_parse("550e8400-e29b-41d4-a716-446655440000")
+    sample_result: Result[str, PackageExampleError | RustPanicError] = uuid_parse("550e8400-e29b-41d4-a716-446655440000")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/negative/incompatible_direct_signatures.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/negative/incompatible_direct_signatures.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-TYPE-0001
 @rust(regex.Regex.captures, panic=trusted_no_panic)
 def captures(pattern: str, text: str) -> object: ...
+
+def verify_incompatible_direct_signatures() -> object:
+    captures_result: object = captures("^sifr", "sifr-rust")
+    return captures_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_matrix/positive/compatible_direct_signatures.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_matrix/positive/compatible_direct_signatures.sifr
@@ -14,3 +14,10 @@ def parse_uuid(text: str) -> Result[str, RustPanicError]: ...
 
 @rust(regex.Regex.is_match, panic=trusted_no_panic)
 def is_match(pattern: str, text: str) -> bool: ...
+
+def verify_compatible_direct_signatures() -> bytes:
+    blake3_digest_result: bytes = blake3_digest(b"sifr-rust-interop")
+    sha256_digest_result: bytes = sha256_digest(b"sifr-rust-interop")
+    parse_uuid_result: Result[str, RustPanicError] = parse_uuid("sifr-rust")
+    is_match_result: bool = is_match("^sifr", "sifr-rust")
+    return blake3_digest_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_negative_type/examples/regex.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_negative_type/examples/regex.sifr
@@ -6,8 +6,9 @@
 class PackageExampleError(Error):
     message: str
 
-@rust(regex.Regex.is_match, panic=map_error(bridge.regex.map_panic))
-def regex_is_match(pattern: str, text: str) -> Result[bool, PackageExampleError | RustPanicError]: ...
+@rust(regex.Regex.replace_all, panic=map_error(bridge.regex.map_panic))
+def regex_replace_all(pattern: str, text: str, replacement: str) -> Result[str, PackageExampleError | RustPanicError]: ...
 
-def verify_regex_package() -> Result[bool, PackageExampleError | RustPanicError]:
-    return regex_is_match("^sifr", "sifr-rust")
+def verify_regex_package() -> Result[str, PackageExampleError | RustPanicError]:
+    sample_result: Result[str, PackageExampleError | RustPanicError] = regex_replace_all("rust", "sifr-rust", "interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_negative_type/negative/unsupported_type_cannot_compile_silently.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_negative_type/negative/unsupported_type_cannot_compile_silently.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-TYPE-0001
 @rust(regex.Regex.captures, panic=trusted_no_panic)
 def captures_without_bridge(pattern: str, text: str) -> object: ...
+
+def verify_unsupported_type_cannot_compile_silently() -> object:
+    captures_without_bridge_result: object = captures_without_bridge("^sifr", "sifr-rust")
+    return captures_without_bridge_result

--- a/verification/areas/rust_interop/fixtures/direct_crate_negative_type/positive/unsupported_type_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/direct_crate_negative_type/positive/unsupported_type_rejected.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-TYPE-0001
 @rust(regex.Regex.captures, panic=trusted_no_panic)
 def captures(pattern: str, text: str) -> dict[str, object]: ...
+
+def verify_unsupported_type_rejected() -> dict[str, object]:
+    captures_result: dict[str, object] = captures("^sifr", "sifr-rust")
+    return captures_result

--- a/verification/areas/rust_interop/fixtures/dotted_path_resolution/negative/string_and_reserved_root_rejection.sifr
+++ b/verification/areas/rust_interop/fixtures/dotted_path_resolution/negative/string_and_reserved_root_rejection.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-CONFIG-0001
 @rust("bridge.hash.digest")
 def digest(data: bytes) -> bytes: ...
+
+def verify_string_and_reserved_root_rejection() -> bytes:
+    digest_result: bytes = digest(b"sifr-rust-interop")
+    return digest_result

--- a/verification/areas/rust_interop/fixtures/dotted_path_resolution/positive/valid_structured_paths.sifr
+++ b/verification/areas/rust_interop/fixtures/dotted_path_resolution/positive/valid_structured_paths.sifr
@@ -3,8 +3,12 @@
 # evidence-status: passing
 # execution-kind: compiler-diagnostic
 # expected-result: pass
+class HashError(Error):
+    message: str
+
 @rust(bridge.hash.digest, panic=map_error(bridge.hash.map_panic))
 def digest(data: bytes) -> Result[bytes, HashError | RustPanicError]: ...
 
-class HashError(Error):
-    message: str
+def verify_valid_structured_paths() -> Result[bytes, HashError | RustPanicError]:
+    digest_result: Result[bytes, HashError | RustPanicError] = digest(b"sifr-rust-interop")
+    return digest_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/axum.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/axum.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class AxumRouter:
-    pass
+    route: str
+    handler_count: uint64
 
 @rust(axum.Router.new, panic=map_error(bridge.axum.map_panic))
 def axum_router(route: str) -> Result[AxumRouter, PackageExampleError | RustPanicError]: ...
 
 def verify_axum_package() -> Result[AxumRouter, PackageExampleError | RustPanicError]:
-    return axum_router("/health")
+    sample_result: Result[AxumRouter, PackageExampleError | RustPanicError] = axum_router("/health")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/sqlx.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/sqlx.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class SqlRows:
-    pass
+    columns: list[str]
+    row_count: uint64
 
 @rust(sqlx.query, panic=map_error(bridge.sqlx.map_panic))
-def sqlx_query(sql: str) -> Result[SqlRows, PackageExampleError | RustPanicError]: ...
+async def sqlx_query(sql: str) -> Result[SqlRows, PackageExampleError | RustPanicError]: ...
 
-def verify_sqlx_package() -> Result[SqlRows, PackageExampleError | RustPanicError]:
-    return sqlx_query("select 1")
+async def verify_sqlx_package() -> Result[SqlRows, PackageExampleError | RustPanicError]:
+    sample_result: Result[SqlRows, PackageExampleError | RustPanicError] = await sqlx_query("select 1")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/tower-http.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/tower-http.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class TraceLayer:
-    pass
+    name: str
+    target: str
 
 @rust(tower_http.trace.TraceLayer.new, panic=map_error(bridge.tower_http.map_panic))
 def tower_http_trace_layer(name: str) -> Result[TraceLayer, PackageExampleError | RustPanicError]: ...
 
 def verify_tower_http_package() -> Result[TraceLayer, PackageExampleError | RustPanicError]:
-    return tower_http_trace_layer("sifr")
+    sample_result: Result[TraceLayer, PackageExampleError | RustPanicError] = tower_http_trace_layer("sifr")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/negative/sqlx_without_offline_artifacts.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/negative/sqlx_without_offline_artifacts.sifr
@@ -7,3 +7,7 @@
 # fixture-cargo: sqlx macros require offline artifacts
 @rust(bridge.backend.query_compile_time, panic=trusted_no_panic)
 def query_compile_time() -> uint32: ...
+
+def verify_sqlx_without_offline_artifacts() -> uint32:
+    query_compile_time_result: uint32 = query_compile_time()
+    return query_compile_time_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/positive/backend_probe_coverage.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/positive/backend_probe_coverage.sifr
@@ -8,3 +8,7 @@ class BackendError(Error):
 
 @rust(bridge.backend.route_probe, panic=map_error(bridge.backend.map_panic))
 async def route_probe(path: str) -> Result[str, BackendError | RustPanicError]: ...
+
+async def verify_backend_probe_coverage() -> Result[str, BackendError | RustPanicError]:
+    route_probe_result: Result[str, BackendError | RustPanicError] = await route_probe("/tmp/sifr-rust-interop.bin")
+    return route_probe_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/anyhow.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/anyhow.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def anyhow_context(message: str) -> Result[str, PackageExampleError | RustPanicError]: ...
 
 def verify_anyhow_package() -> Result[str, PackageExampleError | RustPanicError]:
-    return anyhow_context("sifr error context")
+    sample_result: Result[str, PackageExampleError | RustPanicError] = anyhow_context("sifr error context")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/clap.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/clap.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class CliCommand:
-    pass
+    name: str
+    argument_count: uint64
 
 @rust(clap.Command.new, panic=map_error(bridge.clap.map_panic))
 def clap_command(name: str) -> Result[CliCommand, PackageExampleError | RustPanicError]: ...
 
 def verify_clap_package() -> Result[CliCommand, PackageExampleError | RustPanicError]:
-    return clap_command("sifr")
+    sample_result: Result[CliCommand, PackageExampleError | RustPanicError] = clap_command("sifr")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/tracing-subscriber.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/tracing-subscriber.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def tracing_subscriber_init(filter: str) -> Result[None, PackageExampleError | RustPanicError]: ...
 
 def verify_tracing_subscriber_package() -> Result[None, PackageExampleError | RustPanicError]:
-    return tracing_subscriber_init("info")
+    sample_result: Result[None, PackageExampleError | RustPanicError] = tracing_subscriber_init("info")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/tracing.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/examples/tracing.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def tracing_info(message: str) -> Result[None, PackageExampleError | RustPanicError]: ...
 
 def verify_tracing_package() -> Result[None, PackageExampleError | RustPanicError]:
-    return tracing_info("sifr error context")
+    sample_result: Result[None, PackageExampleError | RustPanicError] = tracing_info("sifr error context")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/negative/unsupported_anyhow_surface.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/negative/unsupported_anyhow_surface.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-TYPE-0001
 @rust(anyhow.Error.downcast_ref, panic=trusted_no_panic)
 def expose_anyhow_trait_object(error: object) -> object: ...
+
+def verify_unsupported_anyhow_surface() -> object:
+    expose_anyhow_trait_object_result: object = expose_anyhow_trait_object("sifr-rust-interop")
+    return expose_anyhow_trait_object_result

--- a/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/positive/cli_tooling_probe_coverage.sifr
+++ b/verification/areas/rust_interop/fixtures/ecosystem_cli_certification/positive/cli_tooling_probe_coverage.sifr
@@ -8,3 +8,7 @@ class CliError(Error):
 
 @rust(bridge.cli.parse_and_trace, panic=map_error(bridge.cli.map_panic))
 def parse_and_trace(args: list[str]) -> Result[uint32, CliError | RustPanicError]: ...
+
+def verify_cli_tooling_probe_coverage() -> Result[uint32, CliError | RustPanicError]:
+    parse_and_trace_result: Result[uint32, CliError | RustPanicError] = parse_and_trace(["sifr", "--version"])
+    return parse_and_trace_result

--- a/verification/areas/rust_interop/fixtures/local_bridge_blake3/examples/blake3.sifr
+++ b/verification/areas/rust_interop/fixtures/local_bridge_blake3/examples/blake3.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def blake3_hash(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
 
 def verify_blake3_package() -> Result[bytes, PackageExampleError | RustPanicError]:
-    return blake3_hash(b"sifr-rust-interop")
+    sample_result: Result[bytes, PackageExampleError | RustPanicError] = blake3_hash(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/local_bridge_blake3/negative/missing_local_bridge_export.sifr
+++ b/verification/areas/rust_interop/fixtures/local_bridge_blake3/negative/missing_local_bridge_export.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-RESOLVE-0001
 @rust(bridge.blake3.missing_export, panic=trusted_no_panic)
 def missing_export(input: bytes) -> bytes: ...
+
+def verify_missing_local_bridge_export() -> bytes:
+    missing_export_result: bytes = missing_export(b"sifr-rust-interop")
+    return missing_export_result

--- a/verification/areas/rust_interop/fixtures/local_bridge_blake3/positive/local_bridge_hash_bytes.sifr
+++ b/verification/areas/rust_interop/fixtures/local_bridge_blake3/positive/local_bridge_hash_bytes.sifr
@@ -8,3 +8,7 @@ class HashError(Error):
 
 @rust(bridge.blake3.hash_bytes, panic=map_error(bridge.blake3.map_panic))
 def hash_bytes(input: bytes) -> Result[bytes, HashError | RustPanicError]: ...
+
+def verify_local_bridge_hash_bytes() -> Result[bytes, HashError | RustPanicError]:
+    hash_bytes_result: Result[bytes, HashError | RustPanicError] = hash_bytes(b"sifr-rust-interop")
+    return hash_bytes_result

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/bindgen.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/bindgen.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class BindgenBuilder:
-    pass
+    header: str
+    allowlist: list[str]
 
 @rust(bindgen.Builder.default, panic=map_error(bridge.bindgen.map_panic))
 def bindgen_builder(header: str) -> Result[BindgenBuilder, PackageExampleError | RustPanicError]: ...
 
 def verify_bindgen_package() -> Result[BindgenBuilder, PackageExampleError | RustPanicError]:
-    return bindgen_builder("wrapper.h")
+    sample_result: Result[BindgenBuilder, PackageExampleError | RustPanicError] = bindgen_builder("wrapper.h")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/cc.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/cc.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class BuildPlan:
-    pass
+    source: str
+    object: str
 
 @rust(cc.Build.new, panic=map_error(bridge.cc.map_panic))
 def cc_build_new(source: str) -> Result[BuildPlan, PackageExampleError | RustPanicError]: ...
 
 def verify_cc_package() -> Result[BuildPlan, PackageExampleError | RustPanicError]:
-    return cc_build_new("src/native.c")
+    sample_result: Result[BuildPlan, PackageExampleError | RustPanicError] = cc_build_new("src/native.c")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/cxx.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/cxx.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class CppHandle:
-    pass
+    name: str
+    owned: bool
 
 @rust(cxx.UniquePtr.new, panic=map_error(bridge.cxx.map_panic))
 def cxx_unique_ptr(name: str) -> Result[CppHandle, PackageExampleError | RustPanicError]: ...
 
 def verify_cxx_package() -> Result[CppHandle, PackageExampleError | RustPanicError]:
-    return cxx_unique_ptr("sifr")
+    sample_result: Result[CppHandle, PackageExampleError | RustPanicError] = cxx_unique_ptr("sifr")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/zstd.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/zstd.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def zstd_encode_all(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
 
 def verify_zstd_package() -> Result[bytes, PackageExampleError | RustPanicError]:
-    return zstd_encode_all(b"sifr-rust-interop")
+    sample_result: Result[bytes, PackageExampleError | RustPanicError] = zstd_encode_all(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/native_build_script/negative/untrusted_native_link_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/negative/untrusted_native_link_rejected.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-TRUST-0001
 @rust(bridge.native.compress, panic=trusted_no_panic)
 def compress_without_native_trust(input: bytes) -> bytes: ...
+
+def verify_untrusted_native_link_rejected() -> bytes:
+    compress_without_native_trust_result: bytes = compress_without_native_trust(b"sifr-rust-interop")
+    return compress_without_native_trust_result

--- a/verification/areas/rust_interop/fixtures/native_build_script/positive/trusted_build_script_native_evidence.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/positive/trusted_build_script_native_evidence.sifr
@@ -5,8 +5,12 @@
 # expected-result: future-owned
 # fixture-trust: rust-build-scripts = ["zstd", "cc", "bindgen", "cxx"]
 # fixture-trust: native-links = ["zstd"]
+class NativeError(Error):
+    message: str
+
 @rust(bridge.native.compress, panic=map_error(bridge.native.map_panic))
 def compress(input: bytes) -> Result[bytes, NativeError | RustPanicError]: ...
 
-class NativeError(Error):
-    message: str
+def verify_trusted_build_script_native_evidence() -> Result[bytes, NativeError | RustPanicError]:
+    compress_result: Result[bytes, NativeError | RustPanicError] = compress(b"sifr-rust-interop")
+    return compress_result

--- a/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/negative/unsatisfied_send_or_copy_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/negative/unsatisfied_send_or_copy_rejected.sifr
@@ -8,3 +8,11 @@
 class Tokenizer:
     @rust(Self.encode, panic=trusted_no_panic)
     def encode(self, text: str) -> bytes: ...
+
+    @rust(bridge.tokenizer.close, panic=trusted_no_panic)
+    def close(own self) -> None: ...
+
+def verify_unsatisfied_send_or_copy_rejected(resource: Tokenizer) -> bytes:
+    encode_result: bytes = resource.encode("sifr-rust")
+    resource.close()
+    return encode_result

--- a/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/positive/declared_send_sync_copy_handle.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_handle_tokenizer/positive/declared_send_sync_copy_handle.sifr
@@ -13,3 +13,8 @@ class Tokenizer:
 
     @rust(bridge.tokenizer.close, panic=map_error(bridge.tokenizer.map_panic))
     def close(own self) -> Result[None, TokenError | RustPanicError]: ...
+
+def verify_declared_send_sync_copy_handle(resource: Tokenizer) -> Result[list[uint32], TokenError | RustPanicError]:
+    encode_result: Result[list[uint32], TokenError | RustPanicError] = resource.encode("sifr-rust")
+    close_result: Result[None, TokenError | RustPanicError] = resource.close()
+    return encode_result

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/redis.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/redis.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class RedisClient:
-    pass
+    url: str
+    connection_id: uint64
 
 @rust(redis.Client.open, panic=map_error(bridge.redis.map_panic))
 def redis_client(url: str) -> Result[RedisClient, PackageExampleError | RustPanicError]: ...
 
 def verify_redis_package() -> Result[RedisClient, PackageExampleError | RustPanicError]:
-    return redis_client("redis://127.0.0.1:6379/0")
+    sample_result: Result[RedisClient, PackageExampleError | RustPanicError] = redis_client("redis://127.0.0.1:6379/0")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/reqwest.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/reqwest.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class HttpResponse:
-    pass
+    status: uint32
+    body: bytes
 
 @rust(reqwest.Client.get, panic=map_error(bridge.reqwest.map_panic))
-def reqwest_get(url: str) -> Result[HttpResponse, PackageExampleError | RustPanicError]: ...
+async def reqwest_get(url: str) -> Result[HttpResponse, PackageExampleError | RustPanicError]: ...
 
-def verify_reqwest_package() -> Result[HttpResponse, PackageExampleError | RustPanicError]:
-    return reqwest_get("https://127.0.0.1/health")
+async def verify_reqwest_package() -> Result[HttpResponse, PackageExampleError | RustPanicError]:
+    sample_result: Result[HttpResponse, PackageExampleError | RustPanicError] = await reqwest_get("https://127.0.0.1/health")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/rusqlite.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/rusqlite.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class SqlRows:
-    pass
+    columns: list[str]
+    row_count: uint64
 
 @rust(rusqlite.Connection.open_in_memory, panic=map_error(bridge.rusqlite.map_panic))
 def rusqlite_memory(query: str) -> Result[SqlRows, PackageExampleError | RustPanicError]: ...
 
 def verify_rusqlite_package() -> Result[SqlRows, PackageExampleError | RustPanicError]:
-    return rusqlite_memory("select 1")
+    sample_result: Result[SqlRows, PackageExampleError | RustPanicError] = rusqlite_memory("select 1")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/tokio-postgres.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/examples/tokio-postgres.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class PgClient:
-    pass
+    url: str
+    connection_id: uint64
 
 @rust(tokio_postgres.connect, panic=map_error(bridge.tokio_postgres.map_panic))
-def tokio_postgres_connect(url: str) -> Result[PgClient, PackageExampleError | RustPanicError]: ...
+async def tokio_postgres_connect(url: str) -> Result[PgClient, PackageExampleError | RustPanicError]: ...
 
-def verify_tokio_postgres_package() -> Result[PgClient, PackageExampleError | RustPanicError]:
-    return tokio_postgres_connect("postgres://sifr@127.0.0.1:5432/sifr")
+async def verify_tokio_postgres_package() -> Result[PgClient, PackageExampleError | RustPanicError]:
+    sample_result: Result[PgClient, PackageExampleError | RustPanicError] = await tokio_postgres_connect("postgres://sifr@127.0.0.1:5432/sifr")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/negative/invalid_resource_aliasing.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/negative/invalid_resource_aliasing.sifr
@@ -8,3 +8,7 @@
 class SharedResourceClient:
     @rust(bridge.resources.borrow_exclusive, panic=trusted_no_panic)
     def borrow_exclusive(self) -> bytes: ...
+
+def verify_invalid_resource_aliasing(resource: SharedResourceClient) -> bytes:
+    borrow_exclusive_result: bytes = resource.borrow_exclusive()
+    return borrow_exclusive_result

--- a/verification/areas/rust_interop/fixtures/opaque_resource_matrix/positive/resource_close_aclose_matrix.sifr
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_matrix/positive/resource_close_aclose_matrix.sifr
@@ -10,3 +10,7 @@ class ResourceError(Error):
 class ResourceClient:
     @rust(bridge.resources.aclose, panic=map_error(bridge.resources.map_panic))
     async def aclose(own self) -> Result[None, ResourceError | RustPanicError]: ...
+
+async def verify_resource_close_aclose_matrix(resource: ResourceClient) -> Result[None, ResourceError | RustPanicError]:
+    aclose_result: Result[None, ResourceError | RustPanicError] = await resource.aclose()
+    return aclose_result

--- a/verification/areas/rust_interop/fixtures/panic_abort_profile/negative/recoverable_abort_profile_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_abort_profile/negative/recoverable_abort_profile_rejected.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-PANIC-0001
 @rust(bridge.legacy.run, panic=abort)
 def run_legacy_without_trust() -> uint32: ...
+
+def verify_recoverable_abort_profile_rejected() -> uint32:
+    run_legacy_without_trust_result: uint32 = run_legacy_without_trust()
+    return run_legacy_without_trust_result

--- a/verification/areas/rust_interop/fixtures/panic_abort_profile/positive/explicit_abort_trust_and_strategy_declared.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_abort_profile/positive/explicit_abort_trust_and_strategy_declared.sifr
@@ -6,3 +6,7 @@
 # fixture-trust: rust-panic-abort = ["bridge.legacy.run"]
 @rust(bridge.legacy.run, panic=abort)
 def run_legacy() -> uint32: ...
+
+def verify_explicit_abort_trust_and_strategy_declared() -> uint32:
+    run_legacy_result: uint32 = run_legacy()
+    return run_legacy_result

--- a/verification/areas/rust_interop/fixtures/panic_boundary/negative/panic_payload_not_exposed.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_boundary/negative/panic_payload_not_exposed.sifr
@@ -4,8 +4,12 @@
 # execution-kind: contract-only
 # expected-result: diagnostic
 # expected-diagnostic: SIFR-RUST-PANIC-0001
+class UserError(Error):
+    message: str
+
 @rust(bridge.panic.may_panic)
 def may_panic() -> Result[uint32, UserError]: ...
 
-class UserError(Error):
-    message: str
+def verify_panic_payload_not_exposed() -> Result[uint32, UserError]:
+    may_panic_result: Result[uint32, UserError] = may_panic()
+    return may_panic_result

--- a/verification/areas/rust_interop/fixtures/panic_boundary/positive/result_declares_rust_panic_error_or_map_error.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_boundary/positive/result_declares_rust_panic_error_or_map_error.sifr
@@ -8,3 +8,7 @@ class PanicMapped(Error):
 
 @rust(bridge.panic.safe_result, panic=map_error(bridge.panic.map_panic))
 def safe_result() -> Result[uint32, PanicMapped | RustPanicError]: ...
+
+def verify_result_declares_rust_panic_error_or_map_error() -> Result[uint32, PanicMapped | RustPanicError]:
+    safe_result_result: Result[uint32, PanicMapped | RustPanicError] = safe_result()
+    return safe_result_result

--- a/verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/negative/invalid_map_error_signature_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/negative/invalid_map_error_signature_rejected.sifr
@@ -4,8 +4,12 @@
 # execution-kind: runtime-observed
 # expected-result: future-owned-diagnostic
 # expected-diagnostic: SIFR-RUST-PANIC-0001
+class PanicMapped(Error):
+    message: str
+
 @rust(bridge.wrapper.may_panic, panic=map_error(bridge.wrapper.invalid_mapper))
 def may_panic(input: str) -> Result[str, PanicMapped | RustPanicError]: ...
 
-class PanicMapped(Error):
-    message: str
+def verify_invalid_map_error_signature_rejected() -> Result[str, PanicMapped | RustPanicError]:
+    may_panic_result: Result[str, PanicMapped | RustPanicError] = may_panic("sifr-rust-interop")
+    return may_panic_result

--- a/verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/positive/generated_wrapper_maps_panic_to_declared_error.sifr
+++ b/verification/areas/rust_interop/fixtures/panic_boundary_wrapper_emission/positive/generated_wrapper_maps_panic_to_declared_error.sifr
@@ -8,3 +8,7 @@ class PanicMapped(Error):
 
 @rust(bridge.wrapper.may_panic, panic=map_error(bridge.wrapper.map_panic))
 def may_panic(input: str) -> Result[str, PanicMapped | RustPanicError]: ...
+
+def verify_generated_wrapper_maps_panic_to_declared_error() -> Result[str, PanicMapped | RustPanicError]:
+    may_panic_result: Result[str, PanicMapped | RustPanicError] = may_panic("sifr-rust-interop")
+    return may_panic_result

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/examples/prost-build.sifr
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/examples/prost-build.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class ProstConfig:
-    pass
+    proto: str
+    out_dir: str
 
 @rust(prost_build.Config.new, panic=map_error(bridge.prost_build.map_panic))
 def prost_build_config(proto: str) -> Result[ProstConfig, PackageExampleError | RustPanicError]: ...
 
 def verify_prost_build_package() -> Result[ProstConfig, PackageExampleError | RustPanicError]:
-    return prost_build_config("schema.proto")
+    sample_result: Result[ProstConfig, PackageExampleError | RustPanicError] = prost_build_config("schema.proto")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/examples/serde_derive.sifr
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/examples/serde_derive.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class SerdeRecord:
-    pass
+    name: str
+    version: uint32
 
 @rust(serde_derive.Deserialize, panic=map_error(bridge.serde_derive.map_panic))
 def serde_derive_decode(input: bytes) -> Result[SerdeRecord, PackageExampleError | RustPanicError]: ...
 
 def verify_serde_derive_package() -> Result[SerdeRecord, PackageExampleError | RustPanicError]:
-    return serde_derive_decode(b"sifr-rust-interop")
+    sample_result: Result[SerdeRecord, PackageExampleError | RustPanicError] = serde_derive_decode(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/negative/untrusted_proc_macro_rejected_pre_execution.sifr
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/negative/untrusted_proc_macro_rejected_pre_execution.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-TRUST-0001
 @rust(bridge.generated.decode, panic=trusted_no_panic)
 def decode_without_proc_macro_trust(input: bytes) -> bytes: ...
+
+def verify_untrusted_proc_macro_rejected_pre_execution() -> bytes:
+    decode_without_proc_macro_trust_result: bytes = decode_without_proc_macro_trust(b"sifr-rust-interop")
+    return decode_without_proc_macro_trust_result

--- a/verification/areas/rust_interop/fixtures/proc_macro_trust/positive/trusted_proc_macro.sifr
+++ b/verification/areas/rust_interop/fixtures/proc_macro_trust/positive/trusted_proc_macro.sifr
@@ -5,8 +5,16 @@
 # expected-result: future-owned
 # fixture-trust: rust-proc-macros = ["serde_derive"]
 # fixture-trust: rust-build-scripts = ["prost-build"]
+class DecodeError(Error):
+    message: str
+
+class GeneratedMessage:
+    id: uint64
+    payload: bytes
+
 @rust(bridge.generated.decode, panic=map_error(bridge.generated.map_panic))
 def decode(input: bytes) -> Result[GeneratedMessage, DecodeError | RustPanicError]: ...
 
-class DecodeError(Error):
-    message: str
+def verify_trusted_proc_macro() -> Result[GeneratedMessage, DecodeError | RustPanicError]:
+    decode_result: Result[GeneratedMessage, DecodeError | RustPanicError] = decode(b"sifr-rust-interop")
+    return decode_result

--- a/verification/areas/rust_interop/fixtures/same_workspace_crate/negative/undeclared_workspace_crate_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/same_workspace_crate/negative/undeclared_workspace_crate_rejected.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-CARGO-0001
 @rust(undeclared_workspace_hash.hash, panic=trusted_no_panic)
 def undeclared(input: bytes) -> uint64: ...
+
+def verify_undeclared_workspace_crate_rejected() -> uint64:
+    undeclared_result: uint64 = undeclared(b"sifr-rust-interop")
+    return undeclared_result

--- a/verification/areas/rust_interop/fixtures/same_workspace_crate/positive/declared_path_dependency_resolves.sifr
+++ b/verification/areas/rust_interop/fixtures/same_workspace_crate/positive/declared_path_dependency_resolves.sifr
@@ -5,3 +5,7 @@
 # expected-result: pass
 @rust(workspace_hash.hash, panic=trusted_no_panic)
 def workspace_hash(input: bytes) -> uint64: ...
+
+def verify_declared_path_dependency_resolves() -> uint64:
+    workspace_hash_result: uint64 = workspace_hash(b"sifr-rust-interop")
+    return workspace_hash_result

--- a/verification/areas/rust_interop/fixtures/shared_bridge_crate/negative/package_generated_type_import_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/shared_bridge_crate/negative/package_generated_type_import_rejected.sifr
@@ -6,3 +6,7 @@
 # expected-diagnostic: SIFR-RUST-RESOLVE-0001
 @rust(shared_bridge.generated_private_type, panic=trusted_no_panic)
 def imports_package_generated_type(input: bytes) -> bytes: ...
+
+def verify_package_generated_type_import_rejected() -> bytes:
+    imports_package_generated_type_result: bytes = imports_package_generated_type(b"sifr-rust-interop")
+    return imports_package_generated_type_result

--- a/verification/areas/rust_interop/fixtures/shared_bridge_crate/positive/stable_runtime_types_only.sifr
+++ b/verification/areas/rust_interop/fixtures/shared_bridge_crate/positive/stable_runtime_types_only.sifr
@@ -8,3 +8,7 @@ class SharedDigest:
 
 @rust(sifr_shared_hash_bridge.digest, panic=trusted_no_panic)
 def digest(input: bytes) -> SharedDigest: ...
+
+def verify_stable_runtime_types_only() -> SharedDigest:
+    digest_result: SharedDigest = digest(b"sifr-rust-interop")
+    return digest_result

--- a/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/examples/ndarray.sifr
+++ b/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/examples/ndarray.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class NdArray2:
-    pass
+    shape: list[uint64]
+    dtype: str
 
 @rust(ndarray.Array2.from_shape_vec, panic=map_error(bridge.ndarray.map_panic))
-def ndarray_array2(input: list[f32]) -> Result[NdArray2, PackageExampleError | RustPanicError]: ...
+def ndarray_array2(input: list[float]) -> Result[NdArray2, PackageExampleError | RustPanicError]: ...
 
 def verify_ndarray_package() -> Result[NdArray2, PackageExampleError | RustPanicError]:
-    return ndarray_array2([1.0, 2.0, 3.0, 4.0])
+    sample_result: Result[NdArray2, PackageExampleError | RustPanicError] = ndarray_array2([1.0, 2.0, 3.0, 4.0])
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/negative/implicit_dlpack_ownership_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/negative/implicit_dlpack_ownership_rejected.sifr
@@ -4,6 +4,14 @@
 # execution-kind: contract-only
 # expected-result: diagnostic
 # expected-diagnostic: SIFR-RUST-ZC-0001
+class Tensor:
+    shape: list[uint64]
+    dtype: str
+
 @rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=dlpack, dtype=f32, rank=2, shape=[2], layout=strided, strides=[3, 1], device=cpu, ownership=transfer, protocol=sifr_tensor_bridge.dlpack.Capsule)
 @rust(sifr_tensor_bridge.dlpack_from_bytes, panic=trusted_no_panic)
 def bad_shape(own input: bytes) -> Tensor: ...
+
+def verify_implicit_dlpack_ownership_rejected() -> Tensor:
+    bad_shape_result: Tensor = bad_shape(b"sifr-rust-interop")
+    return bad_shape_result

--- a/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/positive/explicit_tensor_ownership.sifr
+++ b/verification/areas/rust_interop/fixtures/tensor_dlpack_bridge/positive/explicit_tensor_ownership.sifr
@@ -6,7 +6,15 @@
 class TensorError(Error):
     message: str
 
+class Tensor:
+    shape: list[uint64]
+    dtype: str
+
 @rust.zero_copy(owner=input, view=sifr_tensor_bridge.dlpack.DlpackView)
 @rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True, data=dlpack, dtype=f32, rank=2, shape=[2, 3], layout=strided, strides=[3, 1], device=cpu, ownership=transfer, protocol=sifr_tensor_bridge.dlpack.Capsule)
 @rust(sifr_tensor_bridge.dlpack_from_bytes, panic=map_error(sifr_tensor_bridge.panic.map))
 def tensor(own input: bytes) -> Result[Tensor, TensorError | RustPanicError]: ...
+
+def verify_explicit_tensor_ownership() -> Result[Tensor, TensorError | RustPanicError]:
+    tensor_result: Result[Tensor, TensorError | RustPanicError] = tensor(b"sifr-rust-interop")
+    return tensor_result

--- a/verification/areas/rust_interop/fixtures/zero_copy_bytes/examples/bytes.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_bytes/examples/bytes.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def bytes_from_slice(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
 
 def verify_bytes_package() -> Result[bytes, PackageExampleError | RustPanicError]:
-    return bytes_from_slice(b"sifr-rust-interop")
+    sample_result: Result[bytes, PackageExampleError | RustPanicError] = bytes_from_slice(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/zero_copy_bytes/negative/copy_fallback_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_bytes/negative/copy_fallback_rejected.sifr
@@ -7,3 +7,7 @@
 @rust.zero_copy(owner=input, view=bridge.bytes.BytesView)
 @rust(bridge.bytes.copies_anyway, panic=trusted_no_panic)
 def copies_anyway(input: bytes) -> bytes: ...
+
+def verify_copy_fallback_rejected() -> bytes:
+    copies_anyway_result: bytes = copies_anyway(b"sifr-rust-interop")
+    return copies_anyway_result

--- a/verification/areas/rust_interop/fixtures/zero_copy_bytes/positive/borrowed_bytes_view.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_bytes/positive/borrowed_bytes_view.sifr
@@ -7,3 +7,7 @@
 @rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True)
 @rust(bridge.bytes.borrowed_view, panic=trusted_no_panic)
 def borrowed_view(input: bytes) -> bytes: ...
+
+def verify_borrowed_bytes_view() -> bytes:
+    borrowed_view_result: bytes = borrowed_view(b"sifr-rust-interop")
+    return borrowed_view_result

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/bytemuck.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/bytemuck.sifr
@@ -10,4 +10,5 @@ class PackageExampleError(Error):
 def bytemuck_cast_slice(input: bytes) -> Result[bytes, PackageExampleError | RustPanicError]: ...
 
 def verify_bytemuck_package() -> Result[bytes, PackageExampleError | RustPanicError]:
-    return bytemuck_cast_slice(b"sifr-rust-interop")
+    sample_result: Result[bytes, PackageExampleError | RustPanicError] = bytemuck_cast_slice(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/memmap2.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/memmap2.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class MmapView:
-    pass
+    path: str
+    length: uint64
 
 @rust(memmap2.MmapOptions.new, panic=map_error(bridge.memmap2.map_panic))
 def memmap2_view(path: str) -> Result[MmapView, PackageExampleError | RustPanicError]: ...
 
 def verify_memmap2_package() -> Result[MmapView, PackageExampleError | RustPanicError]:
-    return memmap2_view("/tmp/sifr-rust-interop.bin")
+    sample_result: Result[MmapView, PackageExampleError | RustPanicError] = memmap2_view("/tmp/sifr-rust-interop.bin")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/zerocopy.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/examples/zerocopy.sifr
@@ -7,10 +7,12 @@ class PackageExampleError(Error):
     message: str
 
 class ZeroCopyView:
-    pass
+    owner: str
+    length: uint64
 
 @rust(zerocopy.FromBytes.ref_from_bytes, panic=map_error(bridge.zerocopy.map_panic))
 def zerocopy_ref_from_bytes(input: bytes) -> Result[ZeroCopyView, PackageExampleError | RustPanicError]: ...
 
 def verify_zerocopy_package() -> Result[ZeroCopyView, PackageExampleError | RustPanicError]:
-    return zerocopy_ref_from_bytes(b"sifr-rust-interop")
+    sample_result: Result[ZeroCopyView, PackageExampleError | RustPanicError] = zerocopy_ref_from_bytes(b"sifr-rust-interop")
+    return sample_result

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/negative/mutable_alias_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/negative/mutable_alias_rejected.sifr
@@ -7,3 +7,7 @@
 @rust.view(owner=input, lifetime=owner, mutability=mutable, send=True, sync=True)
 @rust(bridge.views.mutable_from_shared, panic=trusted_no_panic)
 def mutable_from_shared(input: bytes) -> bytes: ...
+
+def verify_mutable_alias_rejected() -> bytes:
+    mutable_from_shared_result: bytes = mutable_from_shared(b"sifr-rust-interop")
+    return mutable_from_shared_result

--- a/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/positive/owner_lifetime_views.sifr
+++ b/verification/areas/rust_interop/fixtures/zero_copy_view_matrix/positive/owner_lifetime_views.sifr
@@ -7,3 +7,7 @@
 @rust.view(owner=input, lifetime=owner, mutability=immutable, send=True, sync=True)
 @rust(bridge.views.slice_view, panic=trusted_no_panic)
 def slice_view(input: bytes) -> bytes: ...
+
+def verify_owner_lifetime_views() -> bytes:
+    slice_view_result: bytes = slice_view(b"sifr-rust-interop")
+    return slice_view_result


### PR DESCRIPTION
## Summary
- Expand all 51 Rust interop package examples from declaration-only stubs into fuller examples with typed sample result bindings, concrete verifier bodies, richer placeholder resource classes, and async/await shape for async package surfaces.
- Add concrete verifier call sites to all positive/negative Rust interop evidence fixtures, including same_workspace_crate, opaque handles, callbacks, zero-copy, panic, proc macro, and native-build evidence.
- Strengthen the rust interop matrix validator so package examples cannot use empty pass class bodies or direct-return stubs, every crate-specific binding must be called and assigned, and evidence files must include verifier call sites for Rust-decorated bindings.
- Update the rust interop README to document evidence verifier requirements.

## Review
- Ran four Opus reviewer rounds via .cursor/skills/talk-to-claude-opus.
- Addressed findings around Sifr type names, missing record classes, async package examples, evidence result binding enforcement, regex duplicate examples, and opaque close coverage.
- Final review round reported no remaining actionable blockers.

## Validation
- python3 verification/areas/rust_interop/checks/check_fixture_matrix.py
- python3 -m py_compile verification/areas/rust_interop/checks/check_fixture_matrix.py
- uv run --project verification --locked python -m sifr_verify areas run --area rust_interop --suite matrix --suite tiers --suite compatibility-matrix --suite stale-drafts --result-json target/verification/areas/rust-interop-fuller-examples-results.json
- git diff --check
- git diff --cached --check
- python3 scripts/check_file_size_guardrails.py
- CARGO_INCREMENTAL=0 cargo build -q -p sifr
- CARGO_INCREMENTAL=0 scripts/run_all_tests.sh --profile create-pr

Note: the first create-pr run timed out in the diagnostic-source-canonicalization step while invoking cargo build -q -p sifr after 300s. A direct cargo build completed successfully, and the create-pr rerun passed fully with only the warm wall-time advisory.

Unrelated local dirty state: editor_integrations submodule remains unstaged and is not part of this PR.