### PR TITLE
Remove LSP fallback analysis owner

### DIFF
--- a/crates/sifr_lsp/src/analysis_workspace.rs
+++ b/crates/sifr_lsp/src/analysis_workspace.rs
@@ -29,6 +29,11 @@ struct LspProjectAnalysis {
     open_uris: BTreeSet<String>,
 }
 
+enum ProjectDocumentFailure {
+    DocumentUnavailable,
+    HostUnavailable,
+}
+
 pub(crate) struct LspFileMaps {
     uri_by_file: BTreeMap<u32, String>,
     source_by_file: BTreeMap<u32, String>,
@@ -45,18 +50,15 @@ impl LspAnalysisWorkspace {
     pub(crate) fn open_document(&mut self, document: &DocumentState) -> bool {
         if let Some(root) = workspace_root_for(document.path()) {
             self.documents.remove(document.uri());
-            match self.projects.get_mut(&root) {
-                Some(project) => {
-                    if project.open_document(document).is_ok() {
-                        false
-                    } else {
-                        let analysis = LspDocumentAnalysis::open(document);
-                        self.documents.insert(document.uri().to_string(), analysis);
-                        false
+            if let Some(project) = self.projects.get_mut(&root) {
+                match project.open_document(document) {
+                    Ok(()) | Err(ProjectDocumentFailure::DocumentUnavailable) => return false,
+                    Err(ProjectDocumentFailure::HostUnavailable) => {
+                        self.projects.remove(&root);
                     }
                 }
-                None => true,
             }
+            true
         } else {
             let analysis = LspDocumentAnalysis::open(document);
             self.documents.insert(document.uri().to_string(), analysis);
@@ -67,22 +69,19 @@ impl LspAnalysisWorkspace {
     pub(crate) fn update_document(&mut self, document: &DocumentState) -> bool {
         let uri = document.uri().to_string();
         if let Some(root) = workspace_root_for(document.path()) {
-            if let Some(analysis) = self.documents.get_mut(&uri) {
-                analysis.update(document);
-                return false;
-            }
-            match self.projects.get_mut(&root) {
-                Some(project) => {
-                    if project.update_document(document).is_ok() {
-                        false
-                    } else {
-                        let analysis = LspDocumentAnalysis::open(document);
-                        self.documents.insert(uri, analysis);
-                        false
+            self.documents.remove(&uri);
+            if let Some(project) = self.projects.get_mut(&root) {
+                if project.update_document(document).is_ok() {
+                    return false;
+                }
+                match project.open_document(document) {
+                    Ok(()) | Err(ProjectDocumentFailure::DocumentUnavailable) => return false,
+                    Err(ProjectDocumentFailure::HostUnavailable) => {
+                        self.projects.remove(&root);
                     }
                 }
-                None => true,
             }
+            true
         } else {
             if let Some(analysis) = self.documents.get_mut(&uri) {
                 analysis.update(document);
@@ -117,12 +116,7 @@ impl LspAnalysisWorkspace {
             }
             let analysis = LspProjectAnalysis::open(root.clone(), &documents);
             for document in &documents {
-                if analysis.files_by_uri.contains_key(document.uri()) {
-                    self.documents.remove(document.uri());
-                } else {
-                    let fallback = LspDocumentAnalysis::open(document);
-                    self.documents.insert(document.uri().to_string(), fallback);
-                }
+                self.documents.remove(document.uri());
             }
             self.projects.insert(root, analysis);
         }
@@ -223,6 +217,11 @@ impl LspAnalysisWorkspace {
             .flat_map(|project| project.files_by_uri.keys().cloned())
             .collect()
     }
+
+    #[cfg(test)]
+    pub(crate) fn has_standalone_document(&self, uri: &str) -> bool {
+        self.documents.contains_key(uri)
+    }
 }
 
 impl LspFileMaps {
@@ -297,44 +296,70 @@ impl LspProjectAnalysis {
         }
     }
 
-    fn open_document(&mut self, document: &DocumentState) -> Result<(), ()> {
+    fn open_document(&mut self, document: &DocumentState) -> Result<(), ProjectDocumentFailure> {
+        self.reload_document(document)
+    }
+
+    fn update_document(&mut self, document: &DocumentState) -> Result<(), ProjectDocumentFailure> {
+        let Some(file) = self.files_by_uri.get(document.uri()).copied() else {
+            return Err(ProjectDocumentFailure::DocumentUnavailable);
+        };
         let Some(host) = self.host.as_mut() else {
-            return Err(());
+            return Err(ProjectDocumentFailure::HostUnavailable);
         };
         let started = Instant::now();
-        host.upsert_overlay_document(
+        if host
+            .update_document(
+                file,
+                document_version(document),
+                SourceText::new(document.text().to_string()),
+            )
+            .is_err()
+        {
+            self.files_by_uri.remove(document.uri());
+            self.load_diagnostics
+                .entry(document.uri().to_string())
+                .or_default();
+            self.open_uris.insert(document.uri().to_string());
+            return Err(ProjectDocumentFailure::DocumentUnavailable);
+        }
+        host.record_update_latency_ms(elapsed_ms(started));
+        self.load_diagnostics.remove(document.uri());
+        Ok(())
+    }
+
+    fn reload_document(&mut self, document: &DocumentState) -> Result<(), ProjectDocumentFailure> {
+        let Some(host) = self.host.as_mut() else {
+            return Err(ProjectDocumentFailure::HostUnavailable);
+        };
+        let started = Instant::now();
+        if let Err(diagnostics) = host.upsert_overlay_document(
             SourcePath::new(document.path().to_path_buf()),
             Some(document.uri().to_string()),
             document_version(document),
             SourceText::new(document.text().to_string()),
-        )
-        .map_err(|_| ())?;
-        let file = host
-            .document_file_for_path(document.path())
-            .map_err(|_| ())?;
+        ) {
+            self.files_by_uri.remove(document.uri());
+            self.load_diagnostics
+                .insert(document.uri().to_string(), diagnostics);
+            self.open_uris.insert(document.uri().to_string());
+            return Err(ProjectDocumentFailure::DocumentUnavailable);
+        }
+        let file = match host.document_file_for_path(document.path()) {
+            Ok(file) => file,
+            Err(_) => {
+                self.files_by_uri.remove(document.uri());
+                self.load_diagnostics
+                    .entry(document.uri().to_string())
+                    .or_default();
+                self.open_uris.insert(document.uri().to_string());
+                return Err(ProjectDocumentFailure::DocumentUnavailable);
+            }
+        };
         host.record_update_latency_ms(elapsed_ms(started));
         self.files_by_uri.insert(document.uri().to_string(), file);
         self.load_diagnostics.remove(document.uri());
         self.open_uris.insert(document.uri().to_string());
-        Ok(())
-    }
-
-    fn update_document(&mut self, document: &DocumentState) -> Result<(), ()> {
-        let Some(file) = self.files_by_uri.get(document.uri()).copied() else {
-            return Err(());
-        };
-        let Some(host) = self.host.as_mut() else {
-            return Err(());
-        };
-        let started = Instant::now();
-        host.update_document(
-            file,
-            document_version(document),
-            SourceText::new(document.text().to_string()),
-        )
-        .map_err(|_| ())?;
-        host.record_update_latency_ms(elapsed_ms(started));
-        self.load_diagnostics.remove(document.uri());
         Ok(())
     }
 

--- a/crates/sifr_lsp/src/session.rs
+++ b/crates/sifr_lsp/src/session.rs
@@ -386,6 +386,9 @@ mod tests {
     use serde_json::json;
     use sifr_analysis::WorkspaceTracePhase;
 
+    #[path = "project_ownership_tests.rs"]
+    mod project_ownership_tests;
+
     #[test]
     fn open_document_analysis_uses_unsaved_overlay_text() {
         let temp = tempfile::tempdir().expect("temp dir");
@@ -450,154 +453,6 @@ mod tests {
             session.store().document(&uri).expect("document").version(),
             Some(2)
         );
-    }
-
-    #[test]
-    fn unmapped_project_file_fallback_survives_project_refresh() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let src = temp.path().join("src");
-        std::fs::create_dir(&src).expect("create src");
-        std::fs::write(
-            temp.path().join("sifr.toml"),
-            "[package]\nname = \"lsp-secondary-open\"\nedition = \"2026\"\n",
-        )
-        .expect("write manifest");
-        let main_path = src.join("main.sifr");
-        let orphan_path = src.join("orphan.sifr");
-        std::fs::write(&main_path, "def main() -> int:\n    return 1\n")
-            .expect("write main source");
-        std::fs::write(
-            &orphan_path,
-            "def orphan(value: int) -> int:\n    return value + 1\n",
-        )
-        .expect("write orphan source");
-        let main_uri = url::Url::from_file_path(&main_path)
-            .expect("main file uri")
-            .to_string();
-        let orphan_uri = url::Url::from_file_path(&orphan_path)
-            .expect("orphan file uri")
-            .to_string();
-        let mut session = Session::new();
-        session
-            .open_document(
-                main_uri,
-                crate::capabilities::LANGUAGE_ID,
-                Some(1),
-                std::fs::read_to_string(&main_path).expect("read main source"),
-            )
-            .expect("open project entrypoint");
-        session
-            .open_document(
-                orphan_uri.clone(),
-                crate::capabilities::LANGUAGE_ID,
-                Some(1),
-                std::fs::read_to_string(&orphan_path).expect("read orphan source"),
-            )
-            .expect("open unmapped project file");
-        session
-            .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
-                assert!(source.contains("def orphan"));
-                Ok(())
-            })
-            .expect("unmapped project file should have fallback analysis");
-        assert!(session.close_document(
-            &url::Url::from_file_path(&main_path)
-                .expect("main file uri")
-                .to_string()
-        ));
-        session
-            .open_document(
-                url::Url::from_file_path(&main_path)
-                    .expect("main file uri")
-                    .to_string(),
-                crate::capabilities::LANGUAGE_ID,
-                Some(2),
-                std::fs::read_to_string(&main_path).expect("read main source"),
-            )
-            .expect("reopen project entrypoint");
-        session
-            .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
-                assert!(source.contains("def orphan"));
-                Ok(())
-            })
-            .expect("fallback analysis should survive project refresh");
-    }
-
-    #[test]
-    fn unmapped_project_file_fallback_survives_unrelated_root_refresh() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let first_root = temp.path().join("first");
-        let second_root = temp.path().join("second");
-        let first_src = first_root.join("src");
-        let second_src = second_root.join("src");
-        std::fs::create_dir_all(&first_src).expect("create first src");
-        std::fs::create_dir_all(&second_src).expect("create second src");
-        for (root, name) in [(&first_root, "first"), (&second_root, "second")] {
-            std::fs::write(
-                root.join("sifr.toml"),
-                format!("[package]\nname = \"{name}\"\nedition = \"2026\"\n"),
-            )
-            .expect("write manifest");
-        }
-        let first_main_path = first_src.join("main.sifr");
-        let orphan_path = first_src.join("orphan.sifr");
-        let second_main_path = second_src.join("main.sifr");
-        std::fs::write(&first_main_path, "def main() -> int:\n    return 1\n")
-            .expect("write first main");
-        std::fs::write(
-            &orphan_path,
-            "def orphan(value: int) -> int:\n    return value + 1\n",
-        )
-        .expect("write orphan");
-        std::fs::write(&second_main_path, "def main() -> int:\n    return 2\n")
-            .expect("write second main");
-        let first_main_uri = url::Url::from_file_path(&first_main_path)
-            .expect("first main file uri")
-            .to_string();
-        let orphan_uri = url::Url::from_file_path(&orphan_path)
-            .expect("orphan file uri")
-            .to_string();
-        let second_main_uri = url::Url::from_file_path(&second_main_path)
-            .expect("second main file uri")
-            .to_string();
-        let mut session = Session::new();
-        session
-            .open_document(
-                first_main_uri,
-                crate::capabilities::LANGUAGE_ID,
-                Some(1),
-                std::fs::read_to_string(&first_main_path).expect("read first main"),
-            )
-            .expect("open first entrypoint");
-        session
-            .open_document(
-                orphan_uri.clone(),
-                crate::capabilities::LANGUAGE_ID,
-                Some(1),
-                std::fs::read_to_string(&orphan_path).expect("read orphan"),
-            )
-            .expect("open orphan");
-        session
-            .open_document(
-                second_main_uri.clone(),
-                crate::capabilities::LANGUAGE_ID,
-                Some(1),
-                std::fs::read_to_string(&second_main_path).expect("read second main"),
-            )
-            .expect("open second entrypoint");
-        session
-            .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
-                assert!(source.contains("def orphan"));
-                Ok(())
-            })
-            .expect("orphan should have fallback analysis after second root opens");
-        assert!(session.close_document(&second_main_uri));
-        session
-            .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
-                assert!(source.contains("def orphan"));
-                Ok(())
-            })
-            .expect("orphan fallback should survive unrelated root close refresh");
     }
 
     #[test]

--- a/crates/sifr_lsp/src/session/tests/project_ownership_tests.rs
+++ b/crates/sifr_lsp/src/session/tests/project_ownership_tests.rs
@@ -1,0 +1,228 @@
+use crate::session::Session;
+use serde_json::json;
+
+#[test]
+fn project_save_without_version_keeps_project_owner_current() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    std::fs::write(
+        temp.path().join("sifr.toml"),
+        "[package]\nname = \"lsp-save-owner\"\nedition = \"2026\"\n",
+    )
+    .expect("write manifest");
+    let path = temp.path().join("main.sifr");
+    let initial = "def main() -> int:\n    if True:\n        return 1\n    return 0\n";
+    let saved = concat!(
+        "def helper(value: int) -> int:\n",
+        "    return value + 1\n\n",
+        "def main() -> int:\n",
+        "    result: int = helper(41)\n",
+        "    return result\n",
+    );
+    let shortened = "def main():\n    print(1)\n";
+    std::fs::write(&path, initial).expect("write source");
+    let uri = url::Url::from_file_path(&path)
+        .expect("file uri")
+        .to_string();
+
+    let mut session = Session::new();
+    session
+        .open_document(
+            uri.clone(),
+            crate::capabilities::LANGUAGE_ID,
+            Some(1),
+            initial.to_string(),
+        )
+        .expect("open document");
+    session
+        .change_compacted(&uri, Some(2), &[json!({"text": saved})])
+        .expect("change to saved text");
+    assert!(!session.analysis.has_standalone_document(&uri));
+    session
+        .save_document(&uri, Some(saved.to_string()))
+        .expect("save document");
+    assert!(!session.analysis.has_standalone_document(&uri));
+    session
+        .with_document_analysis(&uri, |_snapshot, _host, _file, source| {
+            assert_eq!(source, saved);
+            Ok(())
+        })
+        .expect("saved text should be served by project owner");
+    session
+        .change_compacted(&uri, Some(3), &[json!({"text": shortened})])
+        .expect("change to shortened text");
+    assert!(!session.analysis.has_standalone_document(&uri));
+    let file = session
+        .with_document_analysis(&uri, |_snapshot, _host, file, source| {
+            assert_eq!(source, shortened);
+            Ok(file)
+        })
+        .expect("shortened text should be served by project owner");
+    let file_maps = session.file_maps_for_uri(&uri).expect("file maps");
+    assert_eq!(
+        file_maps.source_for(file).expect("source for project file"),
+        shortened
+    );
+}
+
+#[test]
+fn unmapped_project_file_does_not_create_standalone_project_fallback() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let src = temp.path().join("src");
+    std::fs::create_dir(&src).expect("create src");
+    std::fs::write(
+        temp.path().join("sifr.toml"),
+        "[package]\nname = \"lsp-secondary-open\"\nedition = \"2026\"\n",
+    )
+    .expect("write manifest");
+    let main_path = src.join("main.sifr");
+    let orphan_path = src.join("orphan.sifr");
+    std::fs::write(&main_path, "def main() -> int:\n    return 1\n").expect("write main source");
+    std::fs::write(
+        &orphan_path,
+        "def orphan(value: int) -> int:\n    return value + 1\n",
+    )
+    .expect("write orphan source");
+    let main_uri = url::Url::from_file_path(&main_path)
+        .expect("main file uri")
+        .to_string();
+    let orphan_uri = url::Url::from_file_path(&orphan_path)
+        .expect("orphan file uri")
+        .to_string();
+    let mut session = Session::new();
+    session
+        .open_document(
+            main_uri,
+            crate::capabilities::LANGUAGE_ID,
+            Some(1),
+            std::fs::read_to_string(&main_path).expect("read main source"),
+        )
+        .expect("open project entrypoint");
+    session
+        .open_document(
+            orphan_uri.clone(),
+            crate::capabilities::LANGUAGE_ID,
+            Some(1),
+            std::fs::read_to_string(&orphan_path).expect("read orphan source"),
+        )
+        .expect("open unmapped project file");
+    let error = session
+        .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
+            assert!(source.contains("def orphan"));
+            Ok(())
+        })
+        .expect_err("unmapped project file should not have standalone fallback analysis");
+    assert!(
+        error.message().contains("analysis is unavailable"),
+        "unexpected error: {error:?}"
+    );
+    assert!(session.close_document(
+        &url::Url::from_file_path(&main_path)
+            .expect("main file uri")
+            .to_string()
+    ));
+    session
+        .open_document(
+            url::Url::from_file_path(&main_path)
+                .expect("main file uri")
+                .to_string(),
+            crate::capabilities::LANGUAGE_ID,
+            Some(2),
+            std::fs::read_to_string(&main_path).expect("read main source"),
+        )
+        .expect("reopen project entrypoint");
+    let error = session
+        .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
+            assert!(source.contains("def orphan"));
+            Ok(())
+        })
+        .expect_err("project refresh should not create standalone fallback analysis");
+    assert!(
+        error.message().contains("analysis is unavailable"),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[test]
+fn unmapped_project_file_does_not_fallback_after_unrelated_root_refresh() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let first_root = temp.path().join("first");
+    let second_root = temp.path().join("second");
+    let first_src = first_root.join("src");
+    let second_src = second_root.join("src");
+    std::fs::create_dir_all(&first_src).expect("create first src");
+    std::fs::create_dir_all(&second_src).expect("create second src");
+    for (root, name) in [(&first_root, "first"), (&second_root, "second")] {
+        std::fs::write(
+            root.join("sifr.toml"),
+            format!("[package]\nname = \"{name}\"\nedition = \"2026\"\n"),
+        )
+        .expect("write manifest");
+    }
+    let first_main_path = first_src.join("main.sifr");
+    let orphan_path = first_src.join("orphan.sifr");
+    let second_main_path = second_src.join("main.sifr");
+    std::fs::write(&first_main_path, "def main() -> int:\n    return 1\n")
+        .expect("write first main");
+    std::fs::write(
+        &orphan_path,
+        "def orphan(value: int) -> int:\n    return value + 1\n",
+    )
+    .expect("write orphan");
+    std::fs::write(&second_main_path, "def main() -> int:\n    return 2\n")
+        .expect("write second main");
+    let first_main_uri = url::Url::from_file_path(&first_main_path)
+        .expect("first main file uri")
+        .to_string();
+    let orphan_uri = url::Url::from_file_path(&orphan_path)
+        .expect("orphan file uri")
+        .to_string();
+    let second_main_uri = url::Url::from_file_path(&second_main_path)
+        .expect("second main file uri")
+        .to_string();
+    let mut session = Session::new();
+    session
+        .open_document(
+            first_main_uri,
+            crate::capabilities::LANGUAGE_ID,
+            Some(1),
+            std::fs::read_to_string(&first_main_path).expect("read first main"),
+        )
+        .expect("open first entrypoint");
+    session
+        .open_document(
+            orphan_uri.clone(),
+            crate::capabilities::LANGUAGE_ID,
+            Some(1),
+            std::fs::read_to_string(&orphan_path).expect("read orphan"),
+        )
+        .expect("open orphan");
+    session
+        .open_document(
+            second_main_uri.clone(),
+            crate::capabilities::LANGUAGE_ID,
+            Some(1),
+            std::fs::read_to_string(&second_main_path).expect("read second main"),
+        )
+        .expect("open second entrypoint");
+    let error = session
+        .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
+            assert!(source.contains("def orphan"));
+            Ok(())
+        })
+        .expect_err("orphan should not have fallback analysis after second root opens");
+    assert!(
+        error.message().contains("analysis is unavailable"),
+        "unexpected error: {error:?}"
+    );
+    assert!(session.close_document(&second_main_uri));
+    let error = session
+        .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
+            assert!(source.contains("def orphan"));
+            Ok(())
+        })
+        .expect_err("orphan should not gain fallback analysis after unrelated root close");
+    assert!(
+        error.message().contains("analysis is unavailable"),
+        "unexpected error: {error:?}"
+    );
+}

--- a/plans/reviews/active/lsp_single_analysis_owner_review.md
+++ b/plans/reviews/active/lsp_single_analysis_owner_review.md
@@ -1,0 +1,54 @@
+I've traced the patch end-to-end against the architecture goal. Below are findings ordered by severity.
+
+## Findings
+
+### 1. Stress test asserts shape but not range validity — medium
+
+`verification/areas/developer_tooling/lsp_protocol_stress.py:242-247` checks only that `foldingRange` returns a list and `semanticTokens/full` returns a dict with a `"data"` key. The original bug surfaced as "semantic token end/start is outside the document" / "range outside the document" — i.e. ill-formed *values* within an otherwise well-shaped response. A regression that re-introduces a stale-text owner could still return `{"data": [...]}` whose deltas exceed the new (shorter) text, and the test would pass.
+
+Strengthen by either:
+- Decoding the returned tokens (5-tuple deltas) and asserting every position is within the `shortened` text's line/char bounds; or
+- Asserting `foldingRange` entries' `endLine` ≤ last line of `shortened`.
+
+Either check directly closes the bug class instead of relying on transport errors.
+
+### 2. Static split-brain check is narrow — medium
+
+`verification/areas/developer_tooling/check_lsp_split_brain.py:56-77` only inspects two methods (`open_document`, `update_document`) and only when they contain the literal `match self.projects.get_mut(&root)` and the literal `None => true` sentinel. Gaps:
+
+- A future refactor like `if let Some(project) = self.projects.get_mut(&root)` silently makes `project_match == -1` and the check returns no failures (line 67 — `continue` with no warning). The "unverifiable" branch only fires when `match` is found but the `None => true` arm is missing.
+- `refresh_projects` (analysis_workspace.rs:91-114) is not inspected. The patch removed the fallback branch there, but a future regression that adds `LspDocumentAnalysis::open(document)` inside that loop would not be caught.
+- Any new method that mutates `self.documents` from a project-routed path is not inspected.
+
+Suggested tightening: scan the *whole* `impl LspAnalysisWorkspace` block for any `LspDocumentAnalysis::open(document)` call sites and only allow them inside the `else { /* no workspace root */ }` branches that the static check can identify. Or add a positive assertion that `refresh_projects` always calls `self.documents.remove(...)` after `LspProjectAnalysis::open`.
+
+### 3. No focused Rust unit test for the didSave same-version path — low
+
+The semantic-equivalent of the bug repro lives only in the protocol stress test. A `cargo test -p sifr_lsp` test that:
+
+1. opens a project document at v1,
+2. `change_compacted(uri, Some(2), ...)`,
+3. `save_document(uri, Some(text_at_v2))` (note: `DocumentStore::save` does *not* bump version and returns `true` even when text is unchanged — document_store.rs:107-115),
+4. asserts `session.analysis` has no entry in its `documents` map for that URI and that `file_maps_for_uri`/`with_document_analysis` succeed against the project owner,
+
+would deterministically exercise the new fallback re-open without requiring the LSP subprocess. This is the cheapest way to lock down the fix.
+
+### 4. `update_document` allows a pre-existing standalone to keep owning a project-rooted URI — low
+
+analysis_workspace.rs:62-65 short-circuits to the standalone if one already exists, before consulting the project. This is only reachable in the transition state where a document was opened before `sifr.toml` existed and the project has not yet been built. In that state no project owns the URI, so it isn't split-brain. But it is brittle: if any future code path inserts a standalone for a project-rooted URI (the static check above will not always catch it), this branch will silently route around the project and serve stale text indefinitely until the next `open`/`close` triggers `refresh_projects`.
+
+Two cheap hardenings:
+- Restructure to *prefer* the project when `workspace_root_for` returned `Some(root)` and only fall back to standalone for `else`; drop the standalone branch in the project arm.
+- Or, at least, `self.documents.remove(&uri)` upfront in the project-rooted branch (mirroring `open_document` at line 47) so a leftover standalone is never reused for a project-rooted URI.
+
+### 5. `LspProjectAnalysis::open_document` wipes prior load diagnostics on file-lookup failure — low
+
+analysis_workspace.rs:302-310: when `host.document_file_for_path` returns `Err`, the code calls `self.load_diagnostics.remove(document.uri())`. The comment in the task says "load diagnostics are stored where available". On the upsert-failure branch (line 297) we *insert* diagnostics; on this branch we *delete* whatever was there. If a previous open had stashed real load diagnostics for this URI and a later open got past `upsert_overlay_document` but failed the file-id lookup, the user loses those diagnostics and gets nothing. Either store the (non-existent) diagnostics consistently or leave the prior set in place — the current asymmetry is easy to misread.
+
+### 6. Recovery for projects that opened with `host: None` is implicit — low (pre-existing, surfaced by this patch)
+
+`LspProjectAnalysis::open_document` returns `Err` without touching `open_uris` when `host` is `None` (analysis_workspace.rs:286-288). The workspace's `open_document` returns `true` in that case, triggering `refresh_projects`, which rebuilds because `open_uris` now differs — that's the recovery hook. But for `update_document` against the same broken project, the first failure path also returns `true` and goes through `refresh_projects`, which on the *next* round will see `open_uris == open_uris` and skip the rebuild forever (the rebuild during the previous round already synced the set). A document edited in a project whose host failed to open will never get analysis again in this session, even if the failure was transient (e.g., an invalid file that the user then fixes via overlay edits). Removing the fallback is the architectural intent, but the silent "broken forever" UX is worth either documenting (in `internal_docs/architecture.md`) or addressing with a content-hash-based rebuild trigger.
+
+## Bottom line
+
+No remaining split-brain route in the project-owned path: `open_document`/`update_document` no longer materialize a standalone for a project-rooted URI; the project's own `open_document` removes `files_by_uri` and stores `load_diagnostics` on overlay failure so stale ranges can't be served; `refresh_projects` unconditionally drops standalone entries for grouped URIs. The remaining items above are about *defending* that invariant (#1, #2, #3, #4) and about edge-case behavior after project-level failure (#5, #6), not about a still-open split-brain hole.

--- a/plans/reviews/active/lsp_single_analysis_owner_review_2.md
+++ b/plans/reviews/active/lsp_single_analysis_owner_review_2.md
@@ -1,0 +1,55 @@
+I've inspected the patched files, the new unit tests, the static check (including its self-test), and the protocol-stress checks. Findings below, ordered by severity.
+
+## Findings
+
+### 1. (medium) Static check's `if let` boundary is brittle and self-test does not cover the shape the production code now uses
+
+`check_lsp_split_brain.py:80-95` chooses a boundary by string position:
+
+```python
+elif project_if_let != -1:
+    project_arm_start = project_if_let
+    project_arm_end = method_text.find("} else {", project_if_let)
+```
+
+The actual production code in `analysis_workspace.rs:62-85` (`update_document`) has a *nested* `} else {` inside the no-project branch (the inner `if let Some(analysis) = self.documents.get_mut(&uri) { … } else { … }`). Today that nested `} else {` appears *after* the outer one in source order, so the boundary lands on the right delimiter — but the invariant the check relies on is "no closer `} else {` appears before the one closing `if let Some(root)`." Any future reformatting or refactor that inserts a `} else {` inside the project arm (e.g., a nested guard) will silently shrink `project_arm` and a fallback `LspDocumentAnalysis::open(document)` placed *after* that inner else but still inside the project arm would slip past the check.
+
+Compounding this, `run_self_test` at `check_lsp_split_brain.py:111-162` only seeds the `match self.projects.get_mut(&root) { … None => true }` shape. The actual code uses `if let Some(project) = self.projects.get_mut(&root)`, so the dominant branch of the detector has no regression-detection self-test. A future edit that breaks the `if let` branch (e.g., removes the `project_if_let` lookup, swaps the boundary string) would not be caught by `--self-test`.
+
+Two cheap hardenings:
+- Seed a second self-test fixture using the `if let Some(project) = self.projects.get_mut(&root)` shape with a fallback inside the arm, asserting it is flagged with `"standalone analysis from a project-owned path"`.
+- Replace the heuristic boundary with a structural one: scan every `LspDocumentAnalysis::open(document)` site in the file, and assert each appears within an `else { … }` branch of `if let Some(_) = workspace_root_for(...)`. That makes the invariant explicit instead of inferring it from `} else {` positions.
+
+### 2. (low/medium) Workspace tears down the entire project on a single-document overlay failure
+
+`LspAnalysisWorkspace::open_document` / `update_document` (`analysis_workspace.rs:45-85`) now treat any `Err(())` from `LspProjectAnalysis::{open_document,update_document}` as cause to `self.projects.remove(&root)` and force a full `refresh_projects` rebuild. But `LspProjectAnalysis::open_document` (`analysis_workspace.rs:290-323`) returns `Err(())` for three distinct reasons:
+
+1. `host` is `None` (project never opened).
+2. `upsert_overlay_document` failed for *this one* document — but the method has already stored `load_diagnostics` for the failed URI, removed it from `files_by_uri`, and added it to `open_uris`.
+3. `document_file_for_path` failed after a successful overlay upsert.
+
+For (1), tearing down and rebuilding is the recovery hook (the fix you intended for first-round finding #6). For (2) and (3), the project's other documents are healthy and the per-document diagnostics the project just stored are immediately discarded when the project is removed — `refresh_projects` rebuilds from overlays, losing the granular load diagnostics. If `AnalysisHost::open_project_with_overlays` is intolerant of per-overlay parse errors (i.e., it returns `Err` when *any* overlay fails to load), every transient syntax error during typing will collapse the entire project to `host: None` until the user fixes it — a regression in editing UX driven by a fallback removal that was intended only to enforce single ownership.
+
+Recommendation: distinguish "host is None" failure from "per-document overlay failure" at the workspace boundary. Add a typed error variant or two separate methods on `LspProjectAnalysis` so the workspace only `remove`s the project when the host itself is gone; leave the project intact when only the per-document upsert path failed (state is already recorded inside the project). At minimum, document the rebuild cost in `analysis_workspace.rs` or `internal_docs/architecture.md` if the current intent is "rebuild on every overlay error."
+
+### 3. (low) New Rust unit test does not exercise `file_maps_for_uri`
+
+`project_save_without_version_keeps_project_owner_current` (`session.rs:455-511`) covers `with_document_analysis` (which routes through `with_document` → `LspProjectAnalysis::with_host`) and `has_standalone_document`, but never calls `session.file_maps_for_uri(&uri)` against the shortened source. `file_maps_for_uri` is the other path that consumed stale standalone text in the original symptom (semantic-token ranges resolved against the wrong source). Adding `let maps = session.file_maps_for_uri(&uri).expect(...); assert_eq!(maps.source_for(file)?, shortened)` after the v3 didChange would close the second arm of the bug class at the unit level.
+
+### 4. (low) Self-test assertion only verifies one of the two seeded violations
+
+The seed in `check_lsp_split_brain.py:113-159` contains both a project-arm fallback *and* a `refresh_projects` fallback, but the assertion at line 161 only checks for `"standalone analysis from a project-owned path"`. A regression that disables the `refresh_projects`-specific detector at lines 67-72 would still pass `--self-test`. Add a second assertion: `assert any("refresh_projects creates standalone project fallback" in item for item in found)` (and a separate seed/assertion for the missing-`self.documents.remove(...)` check at line 71-72).
+
+### 5. (low) Stress test broadens range checks but only on two query types
+
+`assert_ranges_within_source` / `assert_semantic_tokens_within_source` at `lsp_protocol_stress.py:263-299` directly close the original "range outside the document" bug class for `foldingRange` and `semanticTokens/full`. They do not exercise any other position-sensitive query (`hover`, `documentSymbol`, `references`, `rename`) against the shortened v3 text. A future regression that re-introduces stale standalone analysis only through a path that bypasses file-maps (e.g., a query that goes straight to `with_document_analysis` and returns positions computed from snapshot text) would be invisible. Cheapest broadening: a `documentSymbol` request against `shortened` asserting every reported range falls within `line_lengths(shortened)`.
+
+## Notes that did not become findings
+
+- `LspAnalysisWorkspace::with_document` (`analysis_workspace.rs:184-203`) falls back to `self.documents` when the project doesn't yet contain the URI. That is only reachable when a document was opened before `sifr.toml` existed and a query lands in the window before the next document event triggers `refresh_projects`. Out of scope for "project-rooted documents," but worth noting if a future task touches manifest-watcher behavior.
+- `LspProjectAnalysis::open_document` storing `diagnostics.clone()` for *all* documents in the constructor's `Err` branch (`analysis_workspace.rs:281-285`) is unchanged by this patch and not a split-brain concern.
+- The `fallback_calls != 2` count in `project_fallback_violations` correctly pins the two legitimate no-project branches and would fail open if any third site is added; this works as intended.
+
+## Bottom line
+
+No remaining split-brain *route* for project-rooted documents in steady state: `open_document`, `update_document`, and `refresh_projects` all wipe `self.documents[uri]` before/while routing to a project, and `with_document` prefers the project when present. The actionable items above are about (a) the verification harness being narrower than the invariant it claims to enforce (#1, #4, #5), (b) one missing unit-level assertion (#3), and (c) one behavioral concern introduced by removing the fallback (#2). #1 and #2 are worth addressing before merge; the rest are quality-of-detection improvements.

--- a/plans/reviews/active/lsp_single_analysis_owner_review_3.md
+++ b/plans/reviews/active/lsp_single_analysis_owner_review_3.md
@@ -1,0 +1,30 @@
+Inspection complete. Here are the actionable findings, ordered by severity.
+
+## 1. Blocking — `session.rs` now exceeds the 900-line file-size cap
+
+`crates/sifr_lsp/src/session.rs` is **967 lines** (was 882 before this patch). The file-size guardrail confirms the failure:
+
+```
+file-size guardrails: FAIL
+- crates/sifr_lsp/src/session.rs: 967 lines (limit 900, category rust)
+```
+
+Per `AGENTS.md`, "Hand-maintained first-party source files must stay under 900 lines" and "Run the file-size guardrail before considering work complete." `scripts/run_all_tests.sh` invokes this check, so the PR will fail the mandatory local-validation gate.
+
+The reported validation list doesn't include `scripts/check_file_size_guardrails.py` or `scripts/run_all_tests.sh`, which is why this slipped through. The patch added three sizable tests (~+85 lines) to a file that was already close to the cap. The fix is to split the tests by responsibility (e.g., move the three project-ownership tests into a sibling test module file such as `session/tests/project_ownership.rs` or `session_tests.rs`, since `Session::analysis` is module-private but a `#[cfg(test)] pub(crate) fn` accessor already exists for the new `has_standalone_document` helper and the rest of the test API is `pub(crate)`).
+
+## 2. Minor — `LspProjectAnalysis::update_document` still returns `Result<(), ()>`
+
+`analysis_workspace.rs:334-351` keeps the untyped failure return even though the patch introduced `ProjectDocumentFailure` specifically to distinguish `HostUnavailable` (drop the project) from `DocumentUnavailable` (keep the project, drop the URI).
+
+It happens to compose correctly today because the caller in `LspAnalysisWorkspace::update_document` recovers via `project.open_document(document)` (which IS typed) — so a missing host still bubbles up as `HostUnavailable` on the second call. But this leaves a latent footgun: a future change that adds a non-recovery path after `project.update_document` would silently treat both failure modes the same. Convert it to return `Result<(), ProjectDocumentFailure>` for symmetry with `open_document`.
+
+## 3. Minor — `update_document` recovery silently re-runs the same overlay on parse-fail
+
+In `LspAnalysisWorkspace::update_document` (lines 73-83), when `project.update_document` fails because `host.update_document` returned diagnostics (parse error on a mapped file), the patch then calls `project.open_document` which calls `host.upsert_overlay_document` with the identical text — almost certainly producing the same diagnostics and discarding the originals on the way through `update_document`. The end state (diagnostics stored, file unmapped) is correct, but it does redundant analyzer work and obscures intent. Consider preserving the typed failure from `update_document` so the caller can either store the original diagnostics directly or skip the redundant upsert when the failure is a parse error rather than a mapping miss.
+
+## 4. Minor — `check_lsp_split_brain.py` self-tests are lexically brittle
+
+The guardrail recognizes only two routing shapes literally: `match self.projects.get_mut(&root)` and `if let Some(project) = self.projects.get_mut(&root)`. Any future refactor — renaming the binding, extracting a helper like `self.project_mut(root)`, switching to `.entry(root).or_insert_with(…)` — emits `"unverifiable project ownership routing"` rather than passing. That's acceptable as a deliberate backstop, but worth documenting (a short comment in the script naming the two accepted shapes and what to update if either changes) so the next maintainer doesn't read a false failure as evidence that fallback returned.
+
+No correctness bugs found in the Rust ownership change itself: removal of `LspDocumentAnalysis::open(document)` from project-routed paths is complete, `refresh_projects` no longer plants a fallback, `file_maps_for_document`/`with_document` consistently return `"analysis is unavailable"` for unmapped project URIs, and the typed `ProjectDocumentFailure` correctly partitions remove-project vs keep-project recovery. The three new session tests assert source state through both `with_document_analysis` and `file_maps_for_uri(...).source_for(file)`, which actually exercises the host's per-file source — not just the document store.

--- a/verification/areas/developer_tooling/check_lsp_split_brain.py
+++ b/verification/areas/developer_tooling/check_lsp_split_brain.py
@@ -38,7 +38,8 @@ def rust_files() -> list[Path]:
 def violations(paths: list[Path]) -> list[str]:
     failures: list[str] = []
     for path in paths:
-        for line_number, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for line_number, line in enumerate(text.splitlines(), 1):
             if any(snippet in line for snippet in ALLOWED_SNIPPETS):
                 continue
             for pattern, reason in FORBIDDEN_PATTERNS.items():
@@ -47,6 +48,59 @@ def violations(paths: list[Path]) -> list[str]:
                         f"{path.relative_to(REPO_ROOT)}:{line_number} contains {pattern!r}: {reason}"
                     )
                     break
+        if path.name == "analysis_workspace.rs":
+            failures.extend(project_fallback_violations(path, text))
+    return failures
+
+
+def project_fallback_violations(path: Path, text: str) -> list[str]:
+    failures: list[str] = []
+    fallback_calls = text.count("LspDocumentAnalysis::open(document)")
+    if fallback_calls != 2:
+        failures.append(
+            f"{path.relative_to(REPO_ROOT)} has {fallback_calls} standalone document open call(s); expected 2 no-project branches"
+        )
+    refresh_start = text.find("pub(crate) fn refresh_projects(")
+    if refresh_start == -1:
+        failures.append(f"{path.relative_to(REPO_ROOT)} missing refresh_projects; cannot verify LSP ownership")
+    else:
+        refresh_next = text.find("pub(crate) fn", refresh_start + 1)
+        refresh_text = text[refresh_start:] if refresh_next == -1 else text[refresh_start:refresh_next]
+        if "LspDocumentAnalysis::open(document)" in refresh_text:
+            failures.append(f"{path.relative_to(REPO_ROOT)} refresh_projects creates standalone project fallback")
+        if "self.documents.remove(document.uri())" not in refresh_text:
+            failures.append(f"{path.relative_to(REPO_ROOT)} refresh_projects must drop standalone project entries")
+    for method in ["open_document", "update_document"]:
+        method_start = text.find(f"pub(crate) fn {method}(")
+        if method_start == -1:
+            failures.append(f"{path.relative_to(REPO_ROOT)} missing {method}; cannot verify LSP ownership")
+            continue
+        next_method = text.find("pub(crate) fn", method_start + 1)
+        method_text = text[method_start:] if next_method == -1 else text[method_start:next_method]
+        # This guard intentionally recognizes only the two reviewed project-routing
+        # shapes. If routing is refactored, update this check with the new shape
+        # instead of letting project-rooted standalone analysis slip through.
+        project_match = method_text.find("match self.projects.get_mut(&root)")
+        project_if_let = method_text.find("if let Some(project) = self.projects.get_mut(&root)")
+        if project_match != -1:
+            project_arm_start = project_match
+            project_arm_end = method_text.find("None => true", project_match)
+            boundary_label = "project match arm"
+        elif project_if_let != -1:
+            project_arm_start = project_if_let
+            project_arm_end = method_text.find("} else {", project_if_let)
+            boundary_label = "no-project boundary"
+        else:
+            failures.append(f"{path.relative_to(REPO_ROOT)} {method} has unverifiable project ownership routing")
+            continue
+        if project_arm_end == -1:
+            failures.append(f"{path.relative_to(REPO_ROOT)} {method} has unverifiable {boundary_label}")
+            continue
+        project_arm = method_text[project_arm_start:project_arm_end]
+        if "LspDocumentAnalysis::open(document)" in project_arm:
+            failures.append(
+                f"{path.relative_to(REPO_ROOT)} {method} creates standalone analysis from a project-owned path"
+            )
     return failures
 
 
@@ -57,6 +111,132 @@ def run_self_test() -> None:
         found = violations([seed])
     if not found:
         raise SystemExit("LSP split-brain self-test failed: seeded direct HIR path passed")
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT / "target") as tmp:
+        seed = Path(tmp) / "analysis_workspace.rs"
+        seed.write_text(
+            """
+impl LspAnalysisWorkspace {
+    pub(crate) fn open_document(&mut self, document: &DocumentState) -> bool {
+        match self.projects.get_mut(&root) {
+            Some(project) => {
+                if project.open_document(document).is_ok() {
+                    false
+                } else {
+                    let analysis = LspDocumentAnalysis::open(document);
+                    self.documents.insert(document.uri().to_string(), analysis);
+                    false
+                }
+            }
+            None => true,
+        }
+    } else {
+        let analysis = LspDocumentAnalysis::open(document);
+        self.documents.insert(document.uri().to_string(), analysis);
+    }
+
+    pub(crate) fn update_document(&mut self, document: &DocumentState) -> bool {
+        match self.projects.get_mut(&root) {
+            Some(project) => {
+                if project.update_document(document).is_ok() {
+                    false
+                } else {
+                    let analysis = LspDocumentAnalysis::open(document);
+                    self.documents.insert(uri, analysis);
+                    false
+                }
+            }
+            None => true,
+        }
+    } else {
+        let analysis = LspDocumentAnalysis::open(document);
+        self.documents.insert(uri, analysis);
+    }
+
+    pub(crate) fn refresh_projects(&mut self, documents: &DocumentStore) {
+        let fallback = LspDocumentAnalysis::open(document);
+        self.documents.insert(document.uri().to_string(), fallback);
+    }
+}
+""",
+            encoding="utf-8",
+        )
+        found = violations([seed])
+    if not any("standalone analysis from a project-owned path" in item for item in found):
+        raise SystemExit("LSP split-brain self-test failed: seeded match project fallback passed")
+    if not any("refresh_projects creates standalone project fallback" in item for item in found):
+        raise SystemExit("LSP split-brain self-test failed: seeded refresh fallback passed")
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT / "target") as tmp:
+        seed = Path(tmp) / "analysis_workspace.rs"
+        seed.write_text(
+            """
+impl LspAnalysisWorkspace {
+    pub(crate) fn open_document(&mut self, document: &DocumentState) -> bool {
+        if let Some(project) = self.projects.get_mut(&root) {
+            let analysis = LspDocumentAnalysis::open(document);
+            self.documents.insert(document.uri().to_string(), analysis);
+            return false;
+        } else {
+            let analysis = LspDocumentAnalysis::open(document);
+            self.documents.insert(document.uri().to_string(), analysis);
+        }
+    }
+
+    pub(crate) fn update_document(&mut self, document: &DocumentState) -> bool {
+        if let Some(project) = self.projects.get_mut(&root) {
+            let analysis = LspDocumentAnalysis::open(document);
+            self.documents.insert(uri, analysis);
+            return false;
+        } else {
+            let analysis = LspDocumentAnalysis::open(document);
+            self.documents.insert(uri, analysis);
+        }
+    }
+
+    pub(crate) fn refresh_projects(&mut self, documents: &DocumentStore) {
+        let analysis = LspProjectAnalysis::open(root.clone(), &documents);
+        self.projects.insert(root, analysis);
+    }
+}
+""",
+            encoding="utf-8",
+        )
+        found = violations([seed])
+    if not any("standalone analysis from a project-owned path" in item for item in found):
+        raise SystemExit("LSP split-brain self-test failed: seeded if-let project fallback passed")
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT / "target") as tmp:
+        seed = Path(tmp) / "analysis_workspace.rs"
+        seed.write_text(
+            """
+impl LspAnalysisWorkspace {
+    pub(crate) fn open_document(&mut self, document: &DocumentState) -> bool {
+        if let Some(project) = self.projects.get_mut(&root) {
+            return false;
+        } else {
+            let analysis = LspDocumentAnalysis::open(document);
+            self.documents.insert(document.uri().to_string(), analysis);
+        }
+    }
+
+    pub(crate) fn update_document(&mut self, document: &DocumentState) -> bool {
+        if let Some(project) = self.projects.get_mut(&root) {
+            return false;
+        } else {
+            let analysis = LspDocumentAnalysis::open(document);
+            self.documents.insert(uri, analysis);
+        }
+    }
+
+    pub(crate) fn refresh_projects(&mut self, documents: &DocumentStore) {
+        let analysis = LspProjectAnalysis::open(root.clone(), &documents);
+        self.projects.insert(root, analysis);
+    }
+}
+""",
+            encoding="utf-8",
+        )
+        found = violations([seed])
+    if not any("refresh_projects must drop standalone project entries" in item for item in found):
+        raise SystemExit("LSP split-brain self-test failed: seeded missing refresh remove passed")
     print("LSP split-brain self-test: PASS")
 
 

--- a/verification/areas/developer_tooling/lsp_protocol_stress.py
+++ b/verification/areas/developer_tooling/lsp_protocol_stress.py
@@ -136,6 +136,7 @@ def run_stress() -> None:
         finally:
             client.close()
     run_project_cross_file_queries()
+    run_project_save_reuses_project_owner()
     run_multi_project_workspace_symbols()
 
 
@@ -183,6 +184,156 @@ def run_project_cross_file_queries() -> None:
             client.notify("exit", {})
         finally:
             client.close()
+
+
+def run_project_save_reuses_project_owner() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-lsp-project-save-") as raw:
+        root = Path(raw)
+        (root / "sifr.toml").write_text(
+            '[package]\nname = "lsp_project_save"\n[source]\nroots = ["."]\n',
+            encoding="utf-8",
+        )
+        main = root / "main.sifr"
+        initial = (
+            "from sifr.random import randint\n\n"
+            "def main() -> int:\n"
+            "    value: int = randint(0, 100)\n"
+            "    if value > 50:\n"
+            "        return value\n"
+            "    return 0\n"
+        )
+        saved = (
+            "def helper(value: int) -> int:\n"
+            "    return value + 1\n\n"
+            "def main() -> int:\n"
+            "    result: int = helper(41)\n"
+            "    return result\n"
+        )
+        shortened = (
+            "from sifr.random import randint\n\n"
+            "def main():\n"
+            "    value = randint(0, 100)\n"
+            "    print(value)\n"
+        )
+        main.write_text(initial, encoding="utf-8")
+        uri = file_uri(main)
+        client = LspClient()
+        try:
+            initialize(client, root)
+            open_document(client, main, initial)
+            client.notify(
+                "textDocument/didChange",
+                {
+                    "textDocument": {"uri": uri, "version": 2},
+                    "contentChanges": [{"text": saved}],
+                },
+            )
+            client.wait_for_notification("textDocument/publishDiagnostics")
+            client.notify("textDocument/didSave", {"textDocument": {"uri": uri}, "text": saved})
+            client.wait_for_notification("textDocument/publishDiagnostics")
+            client.notify(
+                "textDocument/didChange",
+                {
+                    "textDocument": {"uri": uri, "version": 3},
+                    "contentChanges": [{"text": shortened}],
+                },
+            )
+            client.wait_for_notification("textDocument/publishDiagnostics")
+            folding = client.request("textDocument/foldingRange", {"textDocument": {"uri": uri}})
+            if not isinstance(folding, list):
+                raise LspProtocolError(f"project foldingRange after save returned non-list: {folding}")
+            assert_ranges_within_source(folding, shortened, "project foldingRange after save")
+            semantic = client.request("textDocument/semanticTokens/full", {"textDocument": {"uri": uri}})
+            if not isinstance(semantic, dict) or "data" not in semantic:
+                raise LspProtocolError(f"project semantic tokens after save returned invalid payload: {semantic}")
+            assert_semantic_tokens_within_source(semantic["data"], shortened, "project semantic tokens after save")
+            symbols = client.request("textDocument/documentSymbol", {"textDocument": {"uri": uri}})
+            if not isinstance(symbols, list):
+                raise LspProtocolError(f"project documentSymbol after save returned non-list: {symbols}")
+            assert_document_symbols_within_source(symbols, shortened, "project documentSymbol after save")
+            client.request("shutdown", {})
+            client.notify("exit", {})
+        finally:
+            client.close()
+
+
+def line_lengths(source: str) -> list[int]:
+    lines = source.splitlines()
+    if source.endswith("\n"):
+        return [len(line) for line in lines] + [0]
+    return [len(line) for line in lines] or [0]
+
+
+def assert_ranges_within_source(ranges: list[dict], source: str, label: str) -> None:
+    lengths = line_lengths(source)
+    for item in ranges:
+        start_line = item.get("startLine")
+        end_line = item.get("endLine")
+        start_character = item.get("startCharacter", 0)
+        end_character = item.get("endCharacter", lengths[end_line] if isinstance(end_line, int) and end_line < len(lengths) else 0)
+        if not isinstance(start_line, int) or not isinstance(end_line, int):
+            raise LspProtocolError(f"{label} returned non-integer range lines: {item}")
+        if start_line < 0 or end_line < start_line or end_line >= len(lengths):
+            raise LspProtocolError(f"{label} returned range outside source lines: {item}")
+        if not isinstance(start_character, int) or not isinstance(end_character, int):
+            raise LspProtocolError(f"{label} returned non-integer range characters: {item}")
+        if start_character < 0 or start_character > lengths[start_line]:
+            raise LspProtocolError(f"{label} returned start outside source line: {item}")
+        if end_character < 0 or end_character > lengths[end_line]:
+            raise LspProtocolError(f"{label} returned end outside source line: {item}")
+
+
+def assert_lsp_range_within_source(item: dict, source: str, label: str) -> None:
+    lengths = line_lengths(source)
+    start = item.get("start")
+    end = item.get("end")
+    if not isinstance(start, dict) or not isinstance(end, dict):
+        raise LspProtocolError(f"{label} returned invalid LSP range: {item}")
+    start_line = start.get("line")
+    start_character = start.get("character")
+    end_line = end.get("line")
+    end_character = end.get("character")
+    if not all(isinstance(value, int) for value in [start_line, start_character, end_line, end_character]):
+        raise LspProtocolError(f"{label} returned non-integer LSP range: {item}")
+    if start_line < 0 or end_line < start_line or end_line >= len(lengths):
+        raise LspProtocolError(f"{label} returned range outside source lines: {item}")
+    if start_character < 0 or start_character > lengths[start_line]:
+        raise LspProtocolError(f"{label} returned start outside source line: {item}")
+    if end_character < 0 or end_character > lengths[end_line]:
+        raise LspProtocolError(f"{label} returned end outside source line: {item}")
+
+
+def assert_document_symbols_within_source(symbols: list[dict], source: str, label: str) -> None:
+    for symbol in symbols:
+        symbol_range = symbol.get("range")
+        if isinstance(symbol_range, dict):
+            assert_lsp_range_within_source(symbol_range, source, label)
+        selection_range = symbol.get("selectionRange")
+        if isinstance(selection_range, dict):
+            assert_lsp_range_within_source(selection_range, source, label)
+        children = symbol.get("children")
+        if isinstance(children, list):
+            assert_document_symbols_within_source(children, source, label)
+
+
+def assert_semantic_tokens_within_source(data: object, source: str, label: str) -> None:
+    if not isinstance(data, list) or len(data) % 5 != 0:
+        raise LspProtocolError(f"{label} returned invalid semantic token data: {data}")
+    lengths = line_lengths(source)
+    line = 0
+    start = 0
+    for index in range(0, len(data), 5):
+        delta_line, delta_start, length, _token_type, _modifiers = data[index:index + 5]
+        if not all(isinstance(value, int) for value in [delta_line, delta_start, length]):
+            raise LspProtocolError(f"{label} returned non-integer semantic token tuple: {data[index:index + 5]}")
+        if delta_line < 0 or delta_start < 0 or length < 0:
+            raise LspProtocolError(f"{label} returned negative semantic token tuple: {data[index:index + 5]}")
+        line += delta_line
+        start = start + delta_start if delta_line == 0 else delta_start
+        if line >= len(lengths):
+            raise LspProtocolError(f"{label} returned token outside source lines: {data[index:index + 5]}")
+        if start > lengths[line] or start + length > lengths[line]:
+            raise LspProtocolError(f"{label} returned token outside source line: {data[index:index + 5]}")
 
 
 def run_multi_project_workspace_symbols() -> None:


### PR DESCRIPTION
## Summary

- remove standalone `LspDocumentAnalysis` fallback ownership for project-rooted documents
- keep project ownership authoritative across open/update/save/refresh, with typed project document failures
- add regression coverage for save-without-version, unmapped project files, and unrelated root refreshes
- strengthen `verification/areas/developer_tooling` with LSP range validation and a static split-brain guard
- include Claude review artifacts from three review rounds

## Validation

Passed:

- `cargo fmt --check`
- `cargo test -p sifr_lsp`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 -m py_compile verification/areas/developer_tooling/check_lsp_split_brain.py verification/areas/developer_tooling/lsp_protocol_stress.py`
- `python3 verification/areas/developer_tooling/check_lsp_split_brain.py --self-test && python3 verification/areas/developer_tooling/check_lsp_split_brain.py`
- `SIFR_LSP_COMMAND='cargo run -q -p sifr -- lsp --stdio' python3 verification/areas/developer_tooling/lsp_protocol_stress.py`
- `scripts/run_all_tests.sh --profile create-pr` (pass; warm wall-time advisory only)

Merge-gate note:

- `scripts/run_all_tests.sh` failed in `developer_tooling:formatter/formatter-rules-manifests` because current `origin/main` pins `third_party/ruff` at `8111415495271a09f9ee89cb168fde669db240d8`, which is not contained in the manifest-required `sifr/0.15.12-maintenance` branch. This branch has the same submodule pointer as `origin/main`; the failure is not introduced by this PR.
