### PR TITLE
Fix LSP semantic hover and signature help

### DIFF
--- a/crates/sifr_analysis/src/host.rs
+++ b/crates/sifr_analysis/src/host.rs
@@ -5,6 +5,9 @@ mod file_access;
 mod implementation;
 pub use implementation::*;
 mod overlay_updates;
+mod semantic_editor;
+#[cfg(test)]
+mod semantic_editor_tests;
 mod snapshot_queries;
 #[cfg(test)]
 mod stdlib_tests;

--- a/crates/sifr_analysis/src/host/implementation.rs
+++ b/crates/sifr_analysis/src/host/implementation.rs
@@ -208,10 +208,7 @@ impl AnalysisHost {
         file: FileId,
         position: &TextPosition,
     ) -> QueryResult<Option<HoverInfo>> {
-        let facts = self.editor_facts(file)?;
-        let hover = facts.token_at_position(position).map(|token| HoverInfo {
-            contents: format!("{} ({})", token.text, token.kind),
-        });
+        let hover = self.semantic_hover(file, position)?;
         Ok(self.result(AnalysisQueryKind::Hover, hover))
     }
 
@@ -220,11 +217,7 @@ impl AnalysisHost {
         file: FileId,
         position: &TextPosition,
     ) -> QueryResult<Option<SignatureHelp>> {
-        let facts = self.editor_facts(file)?;
-        let help = call_identifier_before_position(&facts, position).map(|label| SignatureHelp {
-            label,
-            active_parameter: Some(0),
-        });
+        let help = self.semantic_signature_help(file, position)?;
         Ok(self.result(AnalysisQueryKind::SignatureHelp, help))
     }
 
@@ -877,23 +870,4 @@ pub(super) fn frontend_diagnostics(diagnostics: &[RenderedDiagnostic]) -> Analys
         .map(|diagnostic| diagnostic.message.clone())
         .unwrap_or_else(|| "frontend query failed without diagnostics".to_string());
     AnalysisError::new(AnalysisErrorKind::FrontendDiagnostic, message)
-}
-
-pub(super) fn call_identifier_before_position(
-    facts: &EditorFacts,
-    position: &TextPosition,
-) -> Option<String> {
-    let token = facts.token_at_position(position)?;
-    if token.text != "(" {
-        return None;
-    }
-    facts
-        .tokens
-        .iter()
-        .rev()
-        .find(|candidate| {
-            candidate.range.end() <= token.range.start()
-                && crate::editor::is_identifier_token(candidate)
-        })
-        .map(|candidate| format!("{}(...)", candidate.text))
 }

--- a/crates/sifr_analysis/src/host/semantic_editor.rs
+++ b/crates/sifr_analysis/src/host/semantic_editor.rs
@@ -1,0 +1,100 @@
+use super::implementation::{unknown_file, AnalysisHost};
+use crate::queries::{HoverInfo, SignatureHelp};
+use crate::snapshot::{AnalysisError, AnalysisErrorKind};
+use ruff_text_size::{TextRange, TextSize};
+use sifr_frontend::{FileId, ModuleAnalysisView};
+use sifr_syntax::{SourceText as SyntaxSourceText, TextPosition};
+
+impl AnalysisHost {
+    pub(super) fn semantic_hover(
+        &mut self,
+        file: FileId,
+        position: &TextPosition,
+    ) -> Result<Option<HoverInfo>, AnalysisError> {
+        let source = self.source_text_for_semantic_query(file)?;
+        let Some(offset) = SyntaxSourceText::new(source).byte_offset(position) else {
+            return Ok(None);
+        };
+        let analysis = self.semantic_analysis_for_file(file)?;
+        Ok(analysis
+            .editor_semantics
+            .entries
+            .iter()
+            .filter(|entry| contains_offset(entry.range, offset))
+            .min_by_key(|entry| entry.range.len())
+            .map(|entry| HoverInfo {
+                contents: entry.detail.clone(),
+            }))
+    }
+
+    pub(super) fn semantic_signature_help(
+        &mut self,
+        file: FileId,
+        position: &TextPosition,
+    ) -> Result<Option<SignatureHelp>, AnalysisError> {
+        let source = self.source_text_for_semantic_query(file)?;
+        let Some(offset) = SyntaxSourceText::new(source).byte_offset(position) else {
+            return Ok(None);
+        };
+        let analysis = self.semantic_analysis_for_file(file)?;
+        Ok(analysis
+            .editor_semantics
+            .calls
+            .iter()
+            .filter(|call| {
+                contains_offset(call.call_range, offset) && call.callee_range.end() <= offset
+            })
+            .min_by_key(|call| call.call_range.len())
+            .map(|call| SignatureHelp {
+                label: call.signature.label.clone(),
+                parameters: call.signature.parameters.clone(),
+                active_parameter: Some(active_parameter(offset, &call.argument_ranges)),
+            }))
+    }
+
+    fn semantic_analysis_for_file(
+        &mut self,
+        file: FileId,
+    ) -> Result<ModuleAnalysisView, AnalysisError> {
+        let module = self
+            .file_to_module
+            .get(&file)
+            .copied()
+            .ok_or_else(|| unknown_file(file))?;
+        Ok(self
+            .session
+            .context_mut()
+            .ok_or_else(|| {
+                AnalysisError::new(
+                    AnalysisErrorKind::FrontendDiagnostic,
+                    "analysis workspace session has not loaded frontend state",
+                )
+            })?
+            .analysis_for_module(module)
+            .into_value())
+    }
+
+    fn source_text_for_semantic_query(&self, file: FileId) -> Result<String, AnalysisError> {
+        self.session
+            .context()
+            .and_then(|context| context.source_text_for_file(file))
+            .map(str::to_owned)
+            .ok_or_else(|| unknown_file(file))
+    }
+}
+
+fn contains_offset(range: TextRange, offset: TextSize) -> bool {
+    range.start() <= offset && offset <= range.end()
+}
+
+fn active_parameter(offset: TextSize, ranges: &[TextRange]) -> u32 {
+    if ranges.is_empty() {
+        return 0;
+    }
+    for (index, range) in ranges.iter().enumerate() {
+        if offset <= range.end() {
+            return u32::try_from(index).unwrap_or(u32::MAX);
+        }
+    }
+    u32::try_from(ranges.len().saturating_sub(1)).unwrap_or(u32::MAX)
+}

--- a/crates/sifr_analysis/src/host/semantic_editor_tests.rs
+++ b/crates/sifr_analysis/src/host/semantic_editor_tests.rs
@@ -1,0 +1,172 @@
+use super::*;
+use crate::{FrontendInput, SourceText, TextPosition};
+use sifr_frontend::{FrontendMode, SourcePath};
+
+fn single_file_input(source: &str) -> FrontendInput {
+    FrontendInput {
+        path: SourcePath::new("main.sifr"),
+        source: SourceText::new(source),
+        mode: FrontendMode::SingleFile,
+    }
+}
+
+#[test]
+fn hover_returns_semantic_function_and_binding_details() {
+    let source = "\
+def generate_random() -> int | None:
+    x: int = 1
+    return x
+
+def main() -> int:
+    y = generate_random()
+    return 0
+";
+    let mut host =
+        AnalysisHost::open_single_file(single_file_input(source)).expect("host should load");
+    let file = host.files()[0];
+
+    let function_hover = host
+        .hover(
+            file,
+            &TextPosition {
+                line: 5,
+                character: 8,
+            },
+        )
+        .expect("hover should query")
+        .into_value()
+        .expect("function call hover should exist");
+    assert!(function_hover.contents.contains("generate_random"));
+    assert!(function_hover.contents.contains("->"));
+    assert!(function_hover.contents.contains("int"));
+    assert!(function_hover.contents.contains("None"));
+    assert!(!function_hover.contents.contains("(Name)"));
+
+    let binding_hover = host
+        .hover(
+            file,
+            &TextPosition {
+                line: 5,
+                character: 4,
+            },
+        )
+        .expect("hover should query")
+        .into_value()
+        .expect("binding hover should exist");
+    assert!(binding_hover.contents.contains("y:"));
+    assert!(binding_hover.contents.contains("int"));
+    assert!(binding_hover.contents.contains("None"));
+}
+
+#[test]
+fn signature_help_returns_parameter_labels_and_active_parameter() {
+    let source = "\
+def combine(left: int, right: int) -> int:
+    return left + right
+
+def main() -> int:
+    return combine(1, 2)
+";
+    let mut host =
+        AnalysisHost::open_single_file(single_file_input(source)).expect("host should load");
+    let file = host.files()[0];
+    let help = host
+        .signature_help(
+            file,
+            &TextPosition {
+                line: 4,
+                character: 22,
+            },
+        )
+        .expect("signature help should query")
+        .into_value()
+        .expect("signature help should exist");
+
+    assert_eq!(help.parameters, vec!["left: int", "right: int"]);
+    assert_eq!(help.active_parameter, Some(1));
+    assert!(help.label.contains("combine"));
+    assert!(help.label.contains("-> int"));
+    assert!(!help.label.contains("..."));
+}
+
+#[test]
+fn hover_and_signature_cover_stdlib_calls_inside_try_blocks() {
+    let source = "\
+from sifr.random import randint
+
+def generate_random() -> int | None:
+    try:
+        x: int = randint(0, 100)
+        return x
+    except ValueError:
+        return None
+";
+    let mut host =
+        AnalysisHost::open_single_file(single_file_input(source)).expect("host should load");
+    let file = host.files()[0];
+
+    let call_hover = host
+        .hover(
+            file,
+            &TextPosition {
+                line: 4,
+                character: 17,
+            },
+        )
+        .expect("hover should query")
+        .into_value()
+        .expect("stdlib call hover should exist");
+    assert!(call_hover.contents.contains("randint"));
+    assert!(call_hover.contents.contains("minimum: int"));
+    assert!(call_hover.contents.contains("maximum: int"));
+    assert!(call_hover.contents.contains("Result[int, ValueError]"));
+
+    let help = host
+        .signature_help(
+            file,
+            &TextPosition {
+                line: 4,
+                character: 27,
+            },
+        )
+        .expect("signature help should query")
+        .into_value()
+        .expect("stdlib signature help should exist");
+    assert_eq!(help.parameters, vec!["minimum: int", "maximum: int"]);
+    assert_eq!(help.active_parameter, Some(1));
+}
+
+#[test]
+fn hover_returns_none_for_non_semantic_positions() {
+    let source = "\
+def main() -> int:
+    word: str = \"main\"
+    # main
+    return 0
+";
+    let mut host =
+        AnalysisHost::open_single_file(single_file_input(source)).expect("host should load");
+    let file = host.files()[0];
+
+    for position in [
+        TextPosition {
+            line: 0,
+            character: 0,
+        },
+        TextPosition {
+            line: 1,
+            character: 17,
+        },
+        TextPosition {
+            line: 2,
+            character: 6,
+        },
+    ] {
+        assert_eq!(
+            host.hover(file, &position)
+                .expect("hover should query")
+                .into_value(),
+            None
+        );
+    }
+}

--- a/crates/sifr_analysis/src/queries.rs
+++ b/crates/sifr_analysis/src/queries.rs
@@ -26,6 +26,7 @@ pub struct HoverInfo {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SignatureHelp {
     pub label: String,
+    pub parameters: Vec<String>,
     pub active_parameter: Option<u32>,
 }
 

--- a/crates/sifr_analysis/src/symbols.rs
+++ b/crates/sifr_analysis/src/symbols.rs
@@ -344,6 +344,7 @@ mod tests {
             modules: vec![
                 ModuleAnalysisView {
                     module: ModuleId::new(1),
+                    editor_semantics: Default::default(),
                     symbols: vec![
                         SymbolView {
                             name: main_name.to_string(),
@@ -357,6 +358,7 @@ mod tests {
                 },
                 ModuleAnalysisView {
                     module: ModuleId::new(2),
+                    editor_semantics: Default::default(),
                     symbols: vec![SymbolView {
                         name: helper_name.to_string(),
                         kind: SymbolKind::Constant,
@@ -491,6 +493,7 @@ mod tests {
         let mut index = SymbolIndex::build(revision(1, 1), &graph, &analysis);
         analysis.modules.push(ModuleAnalysisView {
             module: ModuleId::new(3),
+            editor_semantics: Default::default(),
             symbols: vec![SymbolView {
                 name: "extra".to_string(),
                 kind: SymbolKind::Function,

--- a/crates/sifr_frontend/src/analysis_views.rs
+++ b/crates/sifr_frontend/src/analysis_views.rs
@@ -1,0 +1,27 @@
+use crate::{EditorSemanticView, ModuleId};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SymbolView {
+    pub name: String,
+    pub kind: SymbolKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SymbolKind {
+    Function,
+    Class,
+    Constant,
+    Import,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModuleAnalysisView {
+    pub module: ModuleId,
+    pub symbols: Vec<SymbolView>,
+    pub editor_semantics: EditorSemanticView,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProjectAnalysisView {
+    pub modules: Vec<ModuleAnalysisView>,
+}

--- a/crates/sifr_frontend/src/editor_semantics.rs
+++ b/crates/sifr_frontend/src/editor_semantics.rs
@@ -1,0 +1,684 @@
+use crate::ModuleId;
+use ruff_text_size::{Ranged, TextRange};
+use sifr_lowering::{ExternalDefs, HirExpr, HirFunction, HirModule, HirStmt};
+use sifr_python_ast::{Expr, Stmt};
+use sifr_type_system::{FunctionType, Type};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EditorSemanticView {
+    pub entries: Vec<EditorSemanticEntry>,
+    pub calls: Vec<EditorCallExpressionView>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EditorSemanticEntry {
+    pub range: TextRange,
+    pub name: String,
+    pub detail: String,
+    pub kind: EditorSemanticKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EditorSemanticKind {
+    Function,
+    Binding,
+    Parameter,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EditorCallableSignatureView {
+    pub label: String,
+    pub parameters: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EditorCallExpressionView {
+    pub callee_range: TextRange,
+    pub call_range: TextRange,
+    pub argument_ranges: Vec<TextRange>,
+    pub signature: EditorCallableSignatureView,
+}
+
+pub(super) fn editor_semantics_from_module(
+    module_id: ModuleId,
+    module_name: &str,
+    source: &str,
+    suite: &[Stmt],
+    module: &HirModule,
+    external_defs: &ExternalDefs,
+) -> EditorSemanticView {
+    let signatures = callable_signatures(module_name, module, external_defs);
+    let mut collector = EditorSemanticCollector {
+        signatures,
+        source: source.to_string(),
+        view: EditorSemanticView::default(),
+    };
+    for stmt in suite {
+        match stmt {
+            Stmt::ImportFrom(import_from) => {
+                collector.import_from(import_from);
+            }
+            Stmt::FunctionDef(function) => {
+                if let Some(hir_function) = module
+                    .functions
+                    .iter()
+                    .find(|candidate| candidate.name == function.name.as_str())
+                {
+                    collector.function(function, hir_function);
+                }
+            }
+            _ => {}
+        }
+    }
+    collector.sort(module_id);
+    collector.view
+}
+
+struct EditorSemanticCollector {
+    signatures: BTreeMap<String, EditorCallableSignatureView>,
+    source: String,
+    view: EditorSemanticView,
+}
+
+impl EditorSemanticCollector {
+    fn import_from(&mut self, import_from: &sifr_python_ast::StmtImportFrom) {
+        for alias in &import_from.names {
+            let local_name = alias
+                .asname
+                .as_ref()
+                .map_or_else(|| alias.name.to_string(), ToString::to_string);
+            if let Some(signature) = self.signatures.get(&local_name).cloned() {
+                let range = alias
+                    .asname
+                    .as_ref()
+                    .map_or_else(|| alias.name.range(), Ranged::range);
+                self.entry(
+                    range,
+                    local_name,
+                    signature.label,
+                    EditorSemanticKind::Function,
+                );
+            }
+        }
+    }
+
+    fn function(&mut self, function: &sifr_python_ast::StmtFunctionDef, hir: &HirFunction) {
+        if let Some(signature) = self.signatures.get(&hir.name).cloned() {
+            self.entry(
+                function.name.range(),
+                hir.name.clone(),
+                signature.label,
+                EditorSemanticKind::Function,
+            );
+        }
+        for parameter in function.parameters.iter_non_variadic_params() {
+            if let Some(hir_param) = hir
+                .params
+                .iter()
+                .find(|candidate| candidate.name == parameter.parameter.name.as_str())
+            {
+                self.entry(
+                    parameter.parameter.name.range(),
+                    hir_param.name.clone(),
+                    binding_detail(&hir_param.name, &hir_param.ty),
+                    EditorSemanticKind::Parameter,
+                );
+            }
+        }
+        for (stmt, hir_stmt) in function.body.iter().zip(&hir.body) {
+            self.stmt(stmt, hir_stmt);
+        }
+        for stmt in &function.body {
+            self.ast_call_semantics_from_stmt(stmt);
+        }
+        let mut binding_details = collect_hir_binding_types(&hir.body)
+            .into_iter()
+            .map(|(name, ty)| {
+                let detail = binding_detail(&name, &ty);
+                (name, detail)
+            })
+            .collect::<BTreeMap<_, _>>();
+        collect_ast_annotation_details(&function.body, &self.source, &mut binding_details);
+        for stmt in &function.body {
+            self.ast_names_from_bindings(stmt, &binding_details);
+        }
+    }
+
+    fn stmt(&mut self, stmt: &Stmt, hir: &HirStmt) {
+        match (stmt, hir) {
+            (
+                Stmt::AnnAssign(assign),
+                HirStmt::Let {
+                    name, ty, value, ..
+                },
+            ) => {
+                self.binding_target(&assign.target, name, ty);
+                if let Some(value_expr) = &assign.value {
+                    self.expr(value_expr, value);
+                }
+            }
+            (
+                Stmt::Assign(assign),
+                HirStmt::Let {
+                    name, ty, value, ..
+                },
+            ) => {
+                if let Some(target) = assign.targets.first() {
+                    self.binding_target(target, name, ty);
+                }
+                self.expr(&assign.value, value);
+            }
+            (Stmt::Assign(assign), HirStmt::Assign { name, value }) => {
+                if let Some(target) = assign.targets.first() {
+                    self.binding_target(target, name, value.ty());
+                }
+                self.expr(&assign.value, value);
+            }
+            (Stmt::Return(ret), HirStmt::Return { value }) => {
+                if let (Some(expr), Some(hir_expr)) = (&ret.value, value) {
+                    self.expr(expr, hir_expr);
+                }
+            }
+            (Stmt::Expr(expr_stmt), HirStmt::Expr { expr }) => {
+                self.expr(&expr_stmt.value, expr);
+            }
+            (Stmt::Try(try_stmt), HirStmt::TryExcept { body, handlers, .. }) => {
+                for (stmt, hir_stmt) in try_stmt.body.iter().zip(body) {
+                    self.stmt(stmt, hir_stmt);
+                }
+                for (handler, hir_handler) in try_stmt.handlers.iter().zip(handlers) {
+                    let sifr_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    for (stmt, hir_stmt) in handler.body.iter().zip(&hir_handler.body) {
+                        self.stmt(stmt, hir_stmt);
+                    }
+                }
+            }
+            (
+                Stmt::If(if_stmt),
+                HirStmt::If {
+                    condition,
+                    then_body,
+                    elif_clauses,
+                    else_body,
+                },
+            ) => {
+                self.expr(&if_stmt.test, condition);
+                for (stmt, hir_stmt) in if_stmt.body.iter().zip(then_body) {
+                    self.stmt(stmt, hir_stmt);
+                }
+                for (clause, (hir_condition, hir_body)) in
+                    if_stmt.elif_else_clauses.iter().zip(elif_clauses)
+                {
+                    if let Some(test) = &clause.test {
+                        self.expr(test, hir_condition);
+                    }
+                    for (stmt, hir_stmt) in clause.body.iter().zip(hir_body) {
+                        self.stmt(stmt, hir_stmt);
+                    }
+                }
+                if let Some(last_clause) = if_stmt.elif_else_clauses.last() {
+                    if last_clause.test.is_none() {
+                        if let Some(hir_else) = else_body {
+                            for (stmt, hir_stmt) in last_clause.body.iter().zip(hir_else) {
+                                self.stmt(stmt, hir_stmt);
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn expr(&mut self, expr: &Expr, hir: &HirExpr) {
+        match (expr, hir) {
+            (Expr::Name(name), HirExpr::Name { name: hir_name, ty })
+                if name.id.as_str() == hir_name =>
+            {
+                self.entry(
+                    name.range(),
+                    hir_name.clone(),
+                    binding_detail(hir_name, ty),
+                    EditorSemanticKind::Binding,
+                );
+            }
+            (Expr::Call(call), HirExpr::Call { func, args, .. }) => {
+                if let Expr::Name(name) = call.func.as_ref() {
+                    if let Some(signature) = self.signatures.get(func).cloned() {
+                        self.entry(
+                            name.range(),
+                            func.clone(),
+                            signature.label.clone(),
+                            EditorSemanticKind::Function,
+                        );
+                        self.call(EditorCallExpressionView {
+                            callee_range: name.range(),
+                            call_range: call.range(),
+                            argument_ranges: call_argument_ranges(call),
+                            signature,
+                        });
+                    }
+                }
+                for (arg, hir_arg) in call.arguments.args.iter().zip(args) {
+                    self.expr(arg, hir_arg);
+                }
+            }
+            (Expr::BinOp(binop), HirExpr::BinOp { left, right, .. }) => {
+                self.expr(&binop.left, left);
+                self.expr(&binop.right, right);
+            }
+            (
+                Expr::Compare(compare),
+                HirExpr::Compare {
+                    left, comparators, ..
+                },
+            ) => {
+                self.expr(&compare.left, left);
+                for (expr, hir_expr) in compare.comparators.iter().zip(comparators) {
+                    self.expr(expr, hir_expr);
+                }
+            }
+            (
+                Expr::If(if_expr),
+                HirExpr::IfExpr {
+                    condition,
+                    then_expr,
+                    else_expr,
+                    ..
+                },
+            ) => {
+                self.expr(&if_expr.test, condition);
+                self.expr(&if_expr.body, then_expr);
+                self.expr(&if_expr.orelse, else_expr);
+            }
+            _ => {}
+        }
+    }
+
+    fn ast_call_semantics_from_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::AnnAssign(assign) => {
+                if let Some(value) = &assign.value {
+                    self.ast_call_semantics_from_expr(value);
+                }
+            }
+            Stmt::Assign(assign) => {
+                self.ast_call_semantics_from_expr(&assign.value);
+            }
+            Stmt::Return(ret) => {
+                if let Some(value) = &ret.value {
+                    self.ast_call_semantics_from_expr(value);
+                }
+            }
+            Stmt::Expr(expr_stmt) => {
+                self.ast_call_semantics_from_expr(&expr_stmt.value);
+            }
+            Stmt::Try(try_stmt) => {
+                for stmt in &try_stmt.body {
+                    self.ast_call_semantics_from_stmt(stmt);
+                }
+                for handler in &try_stmt.handlers {
+                    let sifr_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    for stmt in &handler.body {
+                        self.ast_call_semantics_from_stmt(stmt);
+                    }
+                }
+            }
+            Stmt::If(if_stmt) => {
+                self.ast_call_semantics_from_expr(&if_stmt.test);
+                for stmt in &if_stmt.body {
+                    self.ast_call_semantics_from_stmt(stmt);
+                }
+                for clause in &if_stmt.elif_else_clauses {
+                    if let Some(test) = &clause.test {
+                        self.ast_call_semantics_from_expr(test);
+                    }
+                    for stmt in &clause.body {
+                        self.ast_call_semantics_from_stmt(stmt);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn ast_call_semantics_from_expr(&mut self, expr: &Expr) {
+        match expr {
+            Expr::Call(call) => {
+                if let Expr::Name(name) = call.func.as_ref() {
+                    if let Some(signature) = self.signatures.get(name.id.as_str()).cloned() {
+                        self.entry(
+                            name.range(),
+                            name.id.to_string(),
+                            signature.label.clone(),
+                            EditorSemanticKind::Function,
+                        );
+                        self.call(EditorCallExpressionView {
+                            callee_range: name.range(),
+                            call_range: call.range(),
+                            argument_ranges: call_argument_ranges(call),
+                            signature,
+                        });
+                    }
+                } else {
+                    self.ast_call_semantics_from_expr(&call.func);
+                }
+                for arg in &call.arguments.args {
+                    self.ast_call_semantics_from_expr(arg);
+                }
+            }
+            Expr::BinOp(binop) => {
+                self.ast_call_semantics_from_expr(&binop.left);
+                self.ast_call_semantics_from_expr(&binop.right);
+            }
+            Expr::Compare(compare) => {
+                self.ast_call_semantics_from_expr(&compare.left);
+                for comparator in &compare.comparators {
+                    self.ast_call_semantics_from_expr(comparator);
+                }
+            }
+            Expr::If(if_expr) => {
+                self.ast_call_semantics_from_expr(&if_expr.test);
+                self.ast_call_semantics_from_expr(&if_expr.body);
+                self.ast_call_semantics_from_expr(&if_expr.orelse);
+            }
+            _ => {}
+        }
+    }
+
+    fn binding_target(&mut self, target: &Expr, name: &str, ty: &Type) {
+        if let Expr::Name(target_name) = target {
+            if target_name.id.as_str() == name {
+                self.entry(
+                    target_name.range(),
+                    name.to_string(),
+                    binding_detail(name, ty),
+                    EditorSemanticKind::Binding,
+                );
+            }
+        }
+    }
+
+    fn ast_names_from_bindings(&mut self, stmt: &Stmt, binding_details: &BTreeMap<String, String>) {
+        match stmt {
+            Stmt::AnnAssign(assign) => {
+                self.ast_expr_names(&assign.target, binding_details);
+                if let Some(value) = &assign.value {
+                    self.ast_expr_names(value, binding_details);
+                }
+            }
+            Stmt::Assign(assign) => {
+                for target in &assign.targets {
+                    self.ast_expr_names(target, binding_details);
+                }
+                self.ast_expr_names(&assign.value, binding_details);
+            }
+            Stmt::Return(ret) => {
+                if let Some(value) = &ret.value {
+                    self.ast_expr_names(value, binding_details);
+                }
+            }
+            Stmt::Expr(expr_stmt) => {
+                self.ast_expr_names(&expr_stmt.value, binding_details);
+            }
+            Stmt::Try(try_stmt) => {
+                for stmt in &try_stmt.body {
+                    self.ast_names_from_bindings(stmt, binding_details);
+                }
+                for handler in &try_stmt.handlers {
+                    let sifr_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    for stmt in &handler.body {
+                        self.ast_names_from_bindings(stmt, binding_details);
+                    }
+                }
+            }
+            Stmt::If(if_stmt) => {
+                self.ast_expr_names(&if_stmt.test, binding_details);
+                for stmt in &if_stmt.body {
+                    self.ast_names_from_bindings(stmt, binding_details);
+                }
+                for clause in &if_stmt.elif_else_clauses {
+                    if let Some(test) = &clause.test {
+                        self.ast_expr_names(test, binding_details);
+                    }
+                    for stmt in &clause.body {
+                        self.ast_names_from_bindings(stmt, binding_details);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn ast_expr_names(&mut self, expr: &Expr, binding_details: &BTreeMap<String, String>) {
+        match expr {
+            Expr::Name(name) => {
+                if let Some(detail) = binding_details.get(name.id.as_str()) {
+                    self.entry(
+                        name.range(),
+                        name.id.to_string(),
+                        detail.clone(),
+                        EditorSemanticKind::Binding,
+                    );
+                }
+            }
+            Expr::Call(call) => {
+                for arg in &call.arguments.args {
+                    self.ast_expr_names(arg, binding_details);
+                }
+            }
+            Expr::BinOp(binop) => {
+                self.ast_expr_names(&binop.left, binding_details);
+                self.ast_expr_names(&binop.right, binding_details);
+            }
+            Expr::Compare(compare) => {
+                self.ast_expr_names(&compare.left, binding_details);
+                for comparator in &compare.comparators {
+                    self.ast_expr_names(comparator, binding_details);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn entry(&mut self, range: TextRange, name: String, detail: String, kind: EditorSemanticKind) {
+        if self
+            .view
+            .entries
+            .iter()
+            .any(|entry| entry.range == range && entry.name == name && entry.detail == detail)
+        {
+            return;
+        }
+        self.view.entries.push(EditorSemanticEntry {
+            range,
+            name,
+            detail,
+            kind,
+        });
+    }
+
+    fn call(&mut self, call: EditorCallExpressionView) {
+        if self.view.calls.iter().any(|existing| {
+            existing.callee_range == call.callee_range && existing.call_range == call.call_range
+        }) {
+            return;
+        }
+        self.view.calls.push(call);
+    }
+
+    fn sort(&mut self, _module: ModuleId) {
+        self.view.entries.sort_by_key(|entry| {
+            (
+                entry.range.start(),
+                entry.range.len(),
+                entry.name.clone(),
+                entry.detail.clone(),
+            )
+        });
+        self.view
+            .calls
+            .sort_by_key(|call| (call.call_range.start(), call.call_range.len()));
+    }
+}
+
+fn callable_signatures(
+    module_name: &str,
+    module: &HirModule,
+    external_defs: &ExternalDefs,
+) -> BTreeMap<String, EditorCallableSignatureView> {
+    let mut signatures = BTreeMap::new();
+    if let Some(exports) = external_defs.functions.get(module_name) {
+        for (name, function_type) in exports {
+            signatures.insert(
+                name.clone(),
+                signature_from_function_type(name, function_type),
+            );
+        }
+    }
+    for function in &module.functions {
+        signatures.entry(function.name.clone()).or_insert_with(|| {
+            let function_type = FunctionType {
+                params: function
+                    .params
+                    .iter()
+                    .map(|param| (param.name.clone(), param.ty.clone(), param.convention))
+                    .collect(),
+                return_type: Box::new(function.return_type.clone()),
+            };
+            signature_from_function_type(&function.name, &function_type)
+        });
+    }
+    signatures
+}
+
+fn signature_from_function_type(
+    name: &str,
+    function_type: &FunctionType,
+) -> EditorCallableSignatureView {
+    let parameters = function_type
+        .params
+        .iter()
+        .map(|(param_name, ty, _)| binding_detail(param_name, ty))
+        .collect::<Vec<_>>();
+    EditorCallableSignatureView {
+        label: format!(
+            "{}({}) -> {}",
+            name,
+            parameters.join(", "),
+            function_type.return_type.display_name()
+        ),
+        parameters,
+    }
+}
+
+fn binding_detail(name: &str, ty: &Type) -> String {
+    format!("{}: {}", name, ty.display_name())
+}
+
+fn collect_ast_annotation_details(
+    stmts: &[Stmt],
+    source: &str,
+    details: &mut BTreeMap<String, String>,
+) {
+    for stmt in stmts {
+        match stmt {
+            Stmt::AnnAssign(assign) => {
+                if let Expr::Name(name) = assign.target.as_ref() {
+                    if let Some(annotation) =
+                        source_text_for_range(source, assign.annotation.range())
+                    {
+                        details
+                            .entry(name.id.to_string())
+                            .or_insert_with(|| format!("{}: {annotation}", name.id));
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                collect_ast_annotation_details(&try_stmt.body, source, details);
+                for handler in &try_stmt.handlers {
+                    let sifr_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    collect_ast_annotation_details(&handler.body, source, details);
+                }
+            }
+            Stmt::If(if_stmt) => {
+                collect_ast_annotation_details(&if_stmt.body, source, details);
+                for clause in &if_stmt.elif_else_clauses {
+                    collect_ast_annotation_details(&clause.body, source, details);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn source_text_for_range(source: &str, range: TextRange) -> Option<String> {
+    let start = usize::try_from(range.start().to_u32()).ok()?;
+    let end = usize::try_from(range.end().to_u32()).ok()?;
+    Some(source.get(start..end)?.trim().to_string())
+}
+
+fn collect_hir_binding_types(stmts: &[HirStmt]) -> BTreeMap<String, Type> {
+    let mut bindings = BTreeMap::new();
+    for stmt in stmts {
+        match stmt {
+            HirStmt::Let { name, ty, .. } => {
+                bindings.insert(name.clone(), ty.clone());
+            }
+            HirStmt::For {
+                target,
+                target_ty,
+                body,
+                else_body,
+                ..
+            }
+            | HirStmt::AsyncFor {
+                target,
+                target_ty,
+                body,
+                else_body,
+                ..
+            } => {
+                bindings.insert(target.clone(), target_ty.clone());
+                bindings.extend(collect_hir_binding_types(body));
+                if let Some(else_body) = else_body {
+                    bindings.extend(collect_hir_binding_types(else_body));
+                }
+            }
+            HirStmt::If {
+                then_body,
+                elif_clauses,
+                else_body,
+                ..
+            } => {
+                bindings.extend(collect_hir_binding_types(then_body));
+                for (_, body) in elif_clauses {
+                    bindings.extend(collect_hir_binding_types(body));
+                }
+                if let Some(else_body) = else_body {
+                    bindings.extend(collect_hir_binding_types(else_body));
+                }
+            }
+            HirStmt::TryExcept { body, handlers, .. } => {
+                bindings.extend(collect_hir_binding_types(body));
+                for handler in handlers {
+                    bindings.extend(collect_hir_binding_types(&handler.body));
+                }
+            }
+            _ => {}
+        }
+    }
+    bindings
+}
+
+fn call_argument_ranges(call: &sifr_python_ast::ExprCall) -> Vec<TextRange> {
+    let mut ranges = call
+        .arguments
+        .args
+        .iter()
+        .map(Ranged::range)
+        .collect::<Vec<_>>();
+    ranges.extend(call.arguments.keywords.iter().map(Ranged::range));
+    ranges
+}

--- a/crates/sifr_frontend/src/graph_cache_and_queries.rs
+++ b/crates/sifr_frontend/src/graph_cache_and_queries.rs
@@ -1,13 +1,13 @@
 use super::{
-    collect_module_exports, diagnostic_with_code, hir_diagnostic_to_rendered,
-    local_import_dependencies, module_state, reveal_type_diagnostics, source_hash,
-    symbols_from_hir, warning_diagnostics, CacheFamily, CacheKeyContext, DiagnosticsCacheKey,
-    DiskSourceProvider, DocumentVersion, FileId, HirLoweringCacheKey, ParseCacheKey,
-    SourceDependency, SourceFileView, SourceHash, SourceMapCacheKey, SourceMapView, SourcePath,
-    SourceProvider, SourceRevision, SourceText, SymbolBucketScope, SymbolBucketsCacheKey,
-    TrackingSourceProvider, WorkspaceCompilerOptions, WorkspaceDirtyReason, WorkspaceDirtyScope,
-    WorkspaceDirtyScopeReport, WorkspacePackageConfigIdentity, WorkspaceSessionTarget,
-    WorkspaceSingleFileTarget,
+    collect_module_exports, diagnostic_with_code, editor_semantics_from_module,
+    hir_diagnostic_to_rendered, local_import_dependencies, module_state, reveal_type_diagnostics,
+    source_hash, symbols_from_hir, warning_diagnostics, CacheFamily, CacheKeyContext,
+    DiagnosticsCacheKey, DiskSourceProvider, DocumentVersion, FileId, HirLoweringCacheKey,
+    ModuleAnalysisView, ParseCacheKey, ProjectAnalysisView, SourceDependency, SourceFileView,
+    SourceHash, SourceMapCacheKey, SourceMapView, SourcePath, SourceProvider, SourceRevision,
+    SourceText, SymbolBucketScope, SymbolBucketsCacheKey, TrackingSourceProvider,
+    WorkspaceCompilerOptions, WorkspaceDirtyReason, WorkspaceDirtyScope, WorkspaceDirtyScopeReport,
+    WorkspacePackageConfigIdentity, WorkspaceSessionTarget, WorkspaceSingleFileTarget,
 };
 use crate::frontend_reuse::FrontendReuseCaches;
 use crate::module_signatures::{module_signature, ModuleSignature};
@@ -210,31 +210,6 @@ pub struct ModuleDiagnostics {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProjectDiagnostics {
     pub diagnostics: Vec<RenderedDiagnostic>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SymbolView {
-    pub name: String,
-    pub kind: SymbolKind,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SymbolKind {
-    Function,
-    Class,
-    Constant,
-    Import,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ModuleAnalysisView {
-    pub module: ModuleId,
-    pub symbols: Vec<SymbolView>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ProjectAnalysisView {
-    pub modules: Vec<ModuleAnalysisView>,
 }
 
 pub(super) struct ModuleState {
@@ -808,10 +783,30 @@ impl FrontendContext {
             .as_ref()
             .map(|lowered| symbols_from_hir(&lowered.module))
             .unwrap_or_default();
-        self.modules[index].analysis = Some(
-            self.reuse_caches
-                .insert_index(index_key, ModuleAnalysisView { module, symbols }),
-        );
+        let editor_semantics = self.modules[index]
+            .lowered
+            .as_ref()
+            .and_then(|lowered| {
+                self.modules[index].parsed.as_ref().map(|parsed| {
+                    editor_semantics_from_module(
+                        module,
+                        &self.modules[index].module_name,
+                        self.modules[index].source.as_str(),
+                        parsed.suite(),
+                        &lowered.module,
+                        &self.external_defs,
+                    )
+                })
+            })
+            .unwrap_or_default();
+        self.modules[index].analysis = Some(self.reuse_caches.insert_index(
+            index_key,
+            ModuleAnalysisView {
+                module,
+                symbols,
+                editor_semantics,
+            },
+        ));
         CacheStatus::Miss
     }
 

--- a/crates/sifr_frontend/src/graph_cache_and_queries/reuse.rs
+++ b/crates/sifr_frontend/src/graph_cache_and_queries/reuse.rs
@@ -99,6 +99,7 @@ impl FrontendContext {
                 .unwrap_or(ModuleAnalysisView {
                     module,
                     symbols: Vec::new(),
+                    editor_semantics: Default::default(),
                 }),
             self.metadata(QueryKind::ModuleAnalysis, cache_status),
         )

--- a/crates/sifr_frontend/src/lib.rs
+++ b/crates/sifr_frontend/src/lib.rs
@@ -7,6 +7,10 @@
 
 mod cache_keys;
 pub use cache_keys::*;
+mod analysis_views;
+pub use analysis_views::*;
+mod editor_semantics;
+pub use editor_semantics::*;
 mod frontend_reuse;
 pub use frontend_reuse::{FrontendCacheEntryIdentity, FrontendReuseStats};
 mod graph_cache_and_queries;

--- a/crates/sifr_lsp/src/conversion.rs
+++ b/crates/sifr_lsp/src/conversion.rs
@@ -207,8 +207,13 @@ pub(crate) fn hover(info: HoverInfo) -> Value {
 }
 
 pub(crate) fn signature_help(help: SignatureHelp) -> Value {
+    let parameters = help
+        .parameters
+        .into_iter()
+        .map(|label| json!({ "label": label }))
+        .collect::<Vec<_>>();
     json!({
-        "signatures": [{ "label": help.label, "parameters": [] }],
+        "signatures": [{ "label": help.label, "parameters": parameters }],
         "activeSignature": 0,
         "activeParameter": help.active_parameter.unwrap_or(0)
     })
@@ -545,10 +550,12 @@ fn token_modifier_bits(modifiers: &[String]) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{completion_item, lsp_range_with_encoding, text_range_with_encoding};
+    use super::{
+        completion_item, lsp_range_with_encoding, signature_help, text_range_with_encoding,
+    };
     use ruff_text_size::{TextRange, TextSize};
     use serde_json::json;
-    use sifr_analysis::CompletionItem;
+    use sifr_analysis::{CompletionItem, SignatureHelp};
     use sifr_source::PositionEncoding;
 
     #[test]
@@ -591,5 +598,19 @@ mod tests {
             detail: Some("Rust interop policy key".to_string()),
         });
         assert_eq!(property["kind"], json!(10));
+    }
+
+    #[test]
+    fn signature_help_conversion_includes_parameter_labels() {
+        let help = signature_help(SignatureHelp {
+            label: "combine(left: int, right: int) -> int".to_string(),
+            parameters: vec!["left: int".to_string(), "right: int".to_string()],
+            active_parameter: Some(1),
+        });
+        let signature = &help["signatures"][0];
+        assert_eq!(signature["label"], "combine(left: int, right: int) -> int");
+        assert_eq!(signature["parameters"][0]["label"], "left: int");
+        assert_eq!(signature["parameters"][1]["label"], "right: int");
+        assert_eq!(help["activeParameter"], 1);
     }
 }

--- a/plans/issues/ad-hoc-lsp-semantic-hover-signature-plan.md
+++ b/plans/issues/ad-hoc-lsp-semantic-hover-signature-plan.md
@@ -1,0 +1,126 @@
+# LSP Semantic Hover And Signature Verification Plan
+
+## Problem
+
+Sifr LSP hover currently leaks lexer-token metadata such as `generate_random (Name)` and `x (Name)`. That is not a semantic editor feature. It passed existing checks because the LSP smoke and stress tests only required hover to be non-null or to contain the token text.
+
+The same root cause affects `textDocument/signatureHelp`: it returns heuristic labels such as `generate_random(...)` instead of the callable signature produced by Sifr analysis.
+
+## Principle
+
+No fallback and no backward-compatibility behavior for semantic editor answers. If a hover or signature answer is available, it must come from Sifr semantic analysis. If semantic analysis cannot produce an answer, the LSP should return `null` rather than token-kind placeholder text.
+
+`sifr_lsp` remains a protocol adapter. `sifr_analysis` remains an editor-query
+facade. Semantic authority belongs in `sifr_frontend` and the compiler data it
+owns. Analysis may map an LSP position to a frontend semantic view, but it must
+not traverse HIR, re-render compiler types, or infer signatures itself.
+
+## Reference Expectations
+
+TypeScript language server:
+- Hover delegates to tsserver `quickinfo` and renders `displayString` as a typed code block.
+- Signature help delegates to tsserver `signatureHelp`, returns full signatures, parameter labels, active signature, and active parameter.
+- Completion resolve uses semantic details, not lexer token names.
+
+Python/Pyright-style editor expectation:
+- Hover over functions shows callable signature and return type.
+- Hover over variables and parameters shows inferred or declared type.
+- Signature help shows parameter labels and the active argument.
+- Unknown or unsupported semantic positions should return no hover, not token-class text.
+
+## Verification Area Additions
+
+### 1. Static Guard: Semantic Placeholder Rejection
+
+Add or extend a developer tooling guard that fails if production hover/signature help formats raw lexer kinds for user-facing semantic content.
+
+Required checks:
+- Forbid production hover content containing `token.kind` or equivalent raw token-kind formatting.
+- Forbid signature help labels that are only `name(...)`.
+- Forbid `sifr_analysis` from importing compiler semantic construction types such as `FunctionType` or `Type`.
+- Allow token inspection only as a locator for the identifier/call site, not as the final answer.
+- Keep self-tests that seed the forbidden patterns and prove the guard catches them.
+
+### 2. LSP Protocol Semantic Corpus
+
+Create a protocol-level corpus under `verification/areas/developer_tooling` that opens a real Sifr project and asserts exact semantic responses.
+
+Cases:
+- Function definition hover includes `generate_random`, `->`, and the canonical `int | None` return type.
+- Function call hover returns the same callable semantic signature as the definition.
+- Local variable hover from annotation includes `x: int`.
+- Local variable hover from call result includes `x: int | None`.
+- Parameter hover includes the parameter name and declared type.
+- Imported project function hover/signature works across files.
+- Imported stdlib function hover/signature for `randint` uses the real public signature `randint(minimum: int, maximum: int) -> Result[int, ValueError]`.
+- Shadowed local names resolve to the nearest semantic binding, not the first token with the same text.
+- Signature help for zero-arg call exposes no parameters and the callable return type.
+- Signature help for multi-arg calls emits parameter labels and updates active parameter before/after comma, including a multi-line call.
+- Negative hover over keywords, whitespace, strings, and comments returns `null`.
+- UTF-16 positions still resolve when non-ASCII text appears before the query target.
+- No placeholder leakage: response text must not contain raw lexer labels such as `(Name)`, `(Identifier)`, or `NonLogicalNewline`.
+
+### 3. Analysis Unit Tests
+
+Add focused `sifr_analysis` tests for semantic editor answers without LSP JSON conversion:
+- Hover over local function definition and call returns the same function signature.
+- Hover over annotated local binding returns the declared type.
+- Hover over inferred local binding returns the inferred type.
+- Hover over function parameter returns the parameter type.
+- Signature help returns labels and parameter labels from the same semantic source as hover.
+- Unsupported positions return `None`.
+
+### 4. Conversion Tests
+
+Keep `sifr_lsp` conversion thin but covered:
+- Hover renders semantic contents as a `sifr` markdown code block.
+- Signature help includes signature label and parameter labels.
+- No conversion path introduces placeholder labels.
+
+### 5. Regression Stress
+
+Extend the existing LSP stress test to run semantic hover and signature help after open/change/save sequences, including shortened documents, so semantic ranges and answers stay current after project owner refreshes.
+
+### 6. Related LSP Defects To Track
+
+This work fixes hover and signature help. It should also document the same
+position-resolution weakness in definition/declaration/type-definition,
+references, rename, type hierarchy, and source-derived inlay hints. Do not add
+fallbacks to those paths in this PR; either reuse the new semantic surface where
+low-risk, or leave explicit follow-up notes.
+
+## Implementation Shape
+
+1. Extend `sifr_frontend::ModuleAnalysisView` with frontend-owned editor semantic entries, including callable signatures, binding types, source ranges, and callable call ranges.
+2. Build those entries while frontend has both parsed AST ranges and lowered HIR semantic types available.
+3. Expose fully rendered source-level semantic text from frontend views so `sifr_analysis` does not import HIR or type-system construction APIs.
+4. Resolve identifier/call positions in `sifr_analysis` by querying the frontend semantic entries for the file/module.
+5. Resolve signature help active parameter from frontend-owned call argument ranges, including multi-line and UTF-16-positioned calls.
+6. Remove token-kind hover rendering entirely.
+7. Keep token scanning only for non-semantic editor features such as semantic token coloring, selection ranges, and as a last-mile locator when the semantic view already owns the final answer.
+
+## Acceptance
+
+- The `scribbles` example returns semantic hover for `generate_random` and `x`.
+- The direct LSP protocol tests assert semantic content, not only non-null responses.
+- Static guards reject reintroducing token-kind placeholder hover or `name(...)` signature help.
+- Shadowed variables, project imports, stdlib imports, active parameter, unsupported hover positions, and post-change refresh are covered in verification.
+- No project-rooted fallback and no semantic fallback paths are introduced.
+- Local validation passes for focused tests and `scripts/run_all_tests.sh --profile create-pr`.
+
+## Current Status
+
+- Implemented frontend-owned `EditorSemanticView` for semantic hover entries and callable signature entries.
+- Removed token-kind hover/signature responses from `sifr_analysis`; unsupported semantic positions now return `None`.
+- Kept `sifr_lsp` as a JSON conversion layer for hover/signature data, including parameter labels.
+- Added `lsp-semantic-editor` verification with function, variable, parameter, project import, stdlib import, try/except stdlib call, active-parameter, UTF-16/non-ASCII, null-hover, and post-change cases.
+- Extended LSP smoke/stress checks and static split-brain guards.
+- Direct protocol probe of `/Users/yaseralnajjar/work/sifr/scribbles/main.sifr` copied into a temp package with `sifr.toml` returns semantic hover/signature for `generate_random`, local `x`, and `randint`.
+
+## Review Disposition
+
+- Claude implementation review artifact: `plans/reviews/active/lsp_semantic_hover_implementation_review_4.md`.
+- Position encoding risk addressed with a UTF-16 corpus case containing non-ASCII text before the hover target.
+- The supplementary AST walk is constrained to frontend semantic view construction and uses the frontend callable signature table; analysis and LSP do not infer or render semantics. It fills source call ranges for lowered constructs whose HIR statement pairing is transformed, without adding a fallback answer path.
+- Incremental rebuild risk is covered by post-change semantic corpus checks; requests use the current `WorkspaceSession` analysis view and no shared mutable semantic cache is added outside frontend query caching.
+- Remaining Claude suggestions for keyword/named-argument active-parameter behavior, recursive callable signatures, and memory sizing are useful follow-up coverage, but not blocking for this root-cause fix.

--- a/plans/reviews/active/lsp_semantic_hover_implementation_review_4.md
+++ b/plans/reviews/active/lsp_semantic_hover_implementation_review_4.md
@@ -1,0 +1,25 @@
+## Blocking risks
+
+1. **LSP position encoding (UTF‑16 vs bytes).** The summary says positions are mapped to byte offsets. LSP defaults to UTF‑16 code units; servers must either advertise/accept `positionEncoding=utf-8` during initialize or translate. If the conversion treats `character` as a byte index, every non‑ASCII source (strings, identifiers, comments) will produce off‑by‑N offsets and pick the wrong "smallest containing" entry. The verification corpus is described in ASCII terms only, so this class of bug won't be caught by the current tests. Confirm: (a) initialize negotiates encoding, (b) the position→offset path matches what was negotiated, (c) at least one test uses a multi‑byte character before the hover/signature target.
+
+2. **Supplementary AST walk is patching a deeper HIR issue.** The justification — "stdlib Result calls inside try/except don't align one‑to‑one with transformed HIR statements" — means the HIR has lost source‑range fidelity for a specific construct, and the editor view re‑derives it from the AST instead. That's a split‑brain in disguise: two range sources, only one of which is the ground truth the rest of the compiler uses, and which one wins depends on the call's syntactic position. The honest fix is to preserve source ranges through `try/except` lowering in HIR. If that's out of scope here, the AST walk needs a sharply‑scoped predicate (only fills gaps where HIR has no range for a call whose callee resolves to a known external), not a general second pass, otherwise future HIR lowering changes will silently re‑introduce overlap or shadow real entries.
+
+3. **`EditorSemanticView` invalidation across incremental edits.** The view is built during frontend analysis from HIR + AST + externals. Confirm that (a) it is rebuilt — not patched — on every analysis revision, (b) the LSP handler reads the view that corresponds to the *exact* document version the request quoted (LSP requests carry `textDocument.version`; serving from a newer or older snapshot will yield wrong ranges with no error), and (c) there is no shared mutable state across requests. The "after‑change refresh" test is necessary but not sufficient — it doesn't catch a request that races a re‑analysis.
+
+4. **`sifr_type_system`/`FunctionType` static guard scope.** Rejecting the symbol in `sifr_analysis` and `sifr_lsp` is good, but HIR almost certainly transitively exposes type‑system types through its own surface (e.g. `hir::Type`, generic parameter info). Confirm the guard isn't bypassable via re‑exports or `pub use`; otherwise the rule reads "don't import directly" rather than "this layer cannot see type‑system data," and the next refactor will quietly re‑introduce the coupling.
+
+## Suggestions
+
+5. **Active‑parameter computation.** Verify behavior for: trailing comma, named/keyword arguments (do parameters get matched by position or name?), nested calls where the cursor is inside an inner arg, lambdas as arguments, and the cursor sitting on the `(` itself vs. after it. The corpus mentions "active parameters" generically — a checklist of these would harden it.
+
+6. **Signature parameter labels.** LSP allows `ParameterInformation.label` to be either a string or `[start, end]` offsets into the signature label. Offsets are more robust for duplicate parameter names and styled labels, but require the same encoding as `positionEncoding` for the label string. Worth pinning down which form is emitted and whether the offsets are bytes or UTF‑16 units.
+
+7. **Partial‑state UX.** "AST walk only runs after successful frontend analysis" and "no fallback" together mean hover/signature go completely dark whenever the user is mid‑edit with a type error. That's consistent with the stated architecture, but unusual for an LSP. If the product wants this, document it; if not, the last successful view per document is a low‑risk concession that doesn't reintroduce placeholders.
+
+8. **Concurrency / memory.** Spell out the ownership story: is `EditorSemanticView` cloned per request or shared `Arc`? For large projects with many open files, per‑file views can add up — worth a back‑of‑envelope number in the issue plan.
+
+9. **Import aliases.** Confirm both sides of `from m import X as Y` resolve: hover on `X` (the original name at the import site) and hover on `Y` (the alias at use sites) should both work, and they should report distinct entries (alias points to original, original points to definition).
+
+10. **Verification gap — recursion and forward references.** Self‑calls and mutually‑recursive functions exercise the case where the signature table must be populated before the body is fully analyzed. Not mentioned in the corpus; one test would be cheap.
+
+11. **Validation list omits `run_all_tests.sh`.** Per AGENTS.md, `scripts/run_all_tests.sh --profile create-pr` is the authoritative pre‑PR gate. The summary lists targeted `cargo` and runner suites but not that script. Run it before opening the PR; CI mirrors it exactly, so skipping it just delays the same failure.

--- a/plans/reviews/active/lsp_semantic_hover_verification_plan_review.md
+++ b/plans/reviews/active/lsp_semantic_hover_verification_plan_review.md
@@ -1,0 +1,84 @@
+Here's the review. The plan captures the right principle and most of the verification axes, but it has a hard architectural mismatch, a few missing concrete deletions, and three classes of weak-assertion coverage that will let the same regression slip back in.
+
+## Architectural risk (must fix before implementation)
+
+**`sifr_analysis` does not own HIR or `FunctionType`.** Step 2 ("Build callable signatures from Sifr `FunctionType`/HIR data already owned by analysis") is misframed:
+- `check_analysis_split_brain.py:15–27` forbids `HirModule`, `lower_module(`, and `compile_module_hir` inside `crates/sifr_analysis/**`.
+- What analysis actually receives from the frontend is `ProjectAnalysisView { modules: Vec<ModuleAnalysisView { symbols: Vec<SymbolView { name, kind }> }> }` (`crates/sifr_frontend/src/graph_cache_and_queries.rs:215–238`). That is a name + kind tuple. There are no types, no parameter labels, no parameter types, no return type, no defining range.
+
+The plan must explicitly require a new query in `sifr_frontend` (alongside `analysis_for_module` in `graph_cache_and_queries/reuse.rs:91`) that returns position-keyed semantic info: signature display string, parameter ranges within the signature label, parameter types, declared/inferred binding types, and span back to the source. HIR traversal stays in `sifr_frontend::query_diagnostics` (where `symbols_from_hir` already lives) so analysis stays split-brain-clean.
+
+Without this, either the implementation violates the existing analysis guard, or it falls back to the very token rendering the plan tries to ban.
+
+## Position-to-symbol resolution is unspecified
+
+Step 3 says "Resolve identifier at cursor to a semantic symbol" but does not say where the bridge lives. The current path (`implementation.rs:702–713`) uses token-text identifier matching, which is name-only and scope-blind — two locals named `result` resolve identically.
+
+Pin the contract: a frontend query keyed by `(FileId, TextSize)` returns a typed `SemanticInfoAtPosition` enum (function | parameter | local-binding | module | type | none) with display strings already rendered by the type printer. Without this, the LSP gets identifier-text equality and the corpus will only catch the obvious cases.
+
+## Concrete deletions are missing from the plan
+
+The plan says "guard against" patterns that should be *deleted*:
+- `crates/sifr_analysis/src/host/implementation.rs:212–214` (`format!("{} ({})", token.text, token.kind)`) — delete.
+- `crates/sifr_analysis/src/host/implementation.rs:882–899` (`call_identifier_before_position` returning `name(...)`) — delete, not "guard."
+- `crates/sifr_analysis/src/host/implementation.rs:226` hard-coded `active_parameter: Some(0)` — must come from semantic analysis or be `None`.
+- `crates/sifr_lsp/src/conversion.rs:209–215` `signature_help` always emits `"parameters": []` and `"activeSignature": 0` — that is a placeholder fallback identical in spirit to the bug. Must propagate real parameter labels and require the analysis schema (`queries.rs::SignatureHelp`) to carry them.
+
+State these as deletions in section 5 (Implementation Shape) so reviewers know what disappears.
+
+## Schema gap in `sifr_analysis::SignatureHelp`
+
+`queries.rs:26–30` has only `label` + `active_parameter`. Plan section 4 says "include … parameter labels" but the schema cannot carry them today. Require a field like `parameters: Vec<ParameterLabel { range_in_label: (u32, u32) }>` so:
+- The LSP `parameters` array is no longer a permanent `[]`.
+- Active parameter index has something to index into.
+- A static guard can reject `parameters: []` for callables with arity > 0.
+
+## Static guard (section 1) is too abstract
+
+Make the pattern set concrete, and add the negative direction:
+- Reject any source line where `.kind` of an `EditorToken` is interpolated into a `HoverInfo::contents` or `SignatureHelp::label` initializer.
+- Reject `format!("{}(...)", *)` constructing a `SignatureHelp { label: … }`.
+- Reject `active_parameter: Some(0)` literal in any signature-help builder.
+- Reject `SignatureHelp { … parameters: vec![] }` and the equivalent `"parameters": []` literal in `sifr_lsp/src/conversion.rs`.
+- Self-test must include both directions: seeded-bad fails, seeded-good passes. The plan only requires the failing direction.
+
+## Existing weak assertions the plan does not tighten
+
+The same class of "non-null / contains-name" weakness that hid the original bug is in three more places — the plan must explicitly tighten them, not just add a parallel corpus:
+- `verification/areas/developer_tooling/editor_query_snapshots/single_file_editor_queries.json:5–7` asserts `"hover": { "token": "value" }` — `value (Name)` would pass. Update the schema to require a typed semantic string and to forbid `(Name)` / `(Identifier)` / `NonLogicalNewline` suffixes.
+- `verification/areas/developer_tooling/lsp_protocol_smoke.py:309–310` checks only `"helper" in contents.get("value", "")` — `helper (Name)` passes. Replace with an exact semantic-form check (`def helper(value: int) -> int` inside the `sifr` code block).
+- `verification/areas/developer_tooling/lsp_marker_corpus/manifest.json` declares `hover` and `signature-help` *coverage* (lines 9, 27, 33) but the marker schema has no payload assertion. Either extend the manifest to carry per-marker expected payloads and update `check_lsp_marker_corpus.py` accordingly, or pivot those markers to the new corpus. The plan doesn't acknowledge the marker corpus exists.
+
+## Stress / large-session coverage (section 5) is too vague
+
+"Run hover and signature help after open/change/save" can pass even if responses are still token placeholders. Require:
+- Typed-after-edit assertions: change `value: int = …` to `value: str = …` and assert hover flips from `value: int` to `value: str` on the same offset.
+- Version coherence: hover and signature responses for version N must reflect version N, not N-1, after `didChange`.
+- The shortened-document case must assert that hover at a still-valid offset returns the typed value and at a now-removed range returns `null` (not a stale token answer).
+
+This is the only verification that catches a stale-snapshot regression, which is the natural failure mode once semantic data joins the snapshot queries.
+
+## Stdlib (`randint`) acceptance is unsafe as written
+
+`ModuleAnalysisView::symbols` is built by `symbols_from_hir` (`crates/sifr_frontend/src/query_diagnostics.rs:79–94`) over the active module only. Stdlib external defs flow in via `sifr_driver::stdlib_external_defs()` (`host/implementation.rs:41–43, 49–51`) but they are not surfaced as part of the per-module symbols view. The plan promises `randint(start: int, stop: int) -> int` hover but does not specify how external-def `FunctionType`s reach the new semantic-info query. Either:
+- Extend the new frontend query to resolve cross-module / external-def symbols and pin that as an explicit deliverable, OR
+- Downgrade the acceptance case to require `null` for stdlib symbols until a follow-up — consistent with "no fallback."
+
+Right now this looks like an implicit fallback waiting to fail.
+
+## Coverage gaps
+
+- **`host/snapshot_queries.rs`.** Section 5 mentions snapshot stress but not that `snapshot_queries.rs` exists and must route hover/signature through the same semantic source. Add to implementation shape: "snapshot-rooted variants share the semantic path; no token rendering on either path."
+- **UTF-16 parameter ranges.** The corpus already exercises UTF-16 positions for hover, but signature-label parameter ranges are a new wire-level concern. Add a Unicode parameter-name case (`def 🦀(x: int)` style or a string literal with `🦀` adjacent to params) to confirm parameter ranges report UTF-16 code units when negotiated.
+- **`check_lsp_transcript_replay.py`.** Not mentioned. If transcripts contain golden hover/signature payloads, they must be regenerated; the guard should refuse a transcript whose hover response matches `\([A-Z][a-zA-Z]+\)` or whose signature label is exactly `<name>\(\.\.\.\)`.
+- **In-tree fixture for the scribbles repro.** Acceptance cites the user's `scribbles/main.sifr`, which is outside the repo. Add an in-tree fixture under `verification/areas/developer_tooling/editor_query_corpus/semantic_hover/` that reproduces `def generate_random() -> int | None` + `x = generate_random()` so the regression has a permanent home.
+
+## Summary
+
+The principle and the verification *axes* are right. To prevent both regressions (token-kind hover returning, semantic ownership split-brain returning), the plan needs three concrete fixes:
+
+1. Re-home the semantic data: a new frontend query (not "HIR already owned by analysis") returning typed `SemanticInfoAtPosition`, position-keyed, with rendered display strings — analysis stays thin.
+2. Schema-update `sifr_analysis::SignatureHelp` to carry parameter labels and ranges; require the LSP conversion test to assert non-empty parameters; forbid the existing hard-coded `parameters: []` and `active_parameter: Some(0)`.
+3. Tighten the three existing weak assertions (`editor_query_snapshots`, `lsp_protocol_smoke` UTF-16 check, `lsp_marker_corpus` coverage list) instead of only adding a new corpus alongside them — and add typed-after-edit assertions to the stress test.
+
+Treat the `randint` acceptance bullet as load-bearing: either extend the new query to resolve external defs, or remove it and accept `null` for stdlib hover until a follow-up.

--- a/plans/reviews/active/lsp_semantic_hover_verification_plan_review_2.md
+++ b/plans/reviews/active/lsp_semantic_hover_verification_plan_review_2.md
@@ -1,0 +1,71 @@
+I have enough context. Here is the review.
+
+## Review of `plans/issues/ad-hoc-lsp-semantic-hover-signature-plan.md`
+
+### 1. Root cause: partially correct, missing the layer underneath
+
+You've correctly identified that hover/signature‑help render lexer metadata. But the deeper defect the plan glosses over is that `sifr_analysis` has **no name‑resolution surface at all** today — all "semantic" queries (`definition`, `declaration`, `references`, `rename`, `document_highlights`) currently work by string‑matching token text across every file. Hover/signature is just the most visible symptom. If the plan only renames the symptom (token‑kind → semantic text) without surfacing real position‑to‑symbol resolution, those other queries stay defective and "split brain" will reappear the moment two locals share a name.
+
+Architectural observation that should drive the plan:
+
+- `crates/sifr_ir/src/hir_nodes.rs` `HirFunction`/`HirParam`/`HirStmt`/`HirExpr` carry **no `TextRange`** today. Spans live only on diagnostic types and `RustInteropDeclaration`. There is no existing offset→HIR map.
+- `sifr_frontend::SymbolView` is `{ name, kind }` only — no params, no types, no spans.
+- `crates/sifr_analysis/src/host/implementation.rs:681` `editor_facts` is the only "lookup at position" primitive and it's pure parser tokens.
+
+So "build callable signatures from `FunctionType`/HIR data already owned by analysis" is misleading — analysis doesn't own HIR (it's explicitly forbidden by `verification/areas/developer_tooling/check_analysis_split_brain.py:23` which bans `HirModule` references). The plan must say: **`sifr_frontend` exposes new typed views (callable signatures, binding types, position→binding map); `sifr_analysis` only consumes them.**
+
+### 2. Architecture risk: plan wording invites a split‑brain re‑introduction
+
+The plan says "Add semantic editor query data in `sifr_analysis`" and "Build callable signatures from Sifr `FunctionType`/HIR data already owned by analysis". As written, an implementer would reach for `HirModule` inside `sifr_analysis` and trip the existing guard, then might "fix it" by importing `sifr_type_system::format_type` or by re‑deriving signatures from `analysis_for_project()` blobs — both options would still leave analysis as the semantic authority, exactly what the principle forbids.
+
+Recommended rewording:
+- New frontend queries (e.g. `callable_signature_for(module, name)`, `binding_at_position(file, offset)`, `type_at_position(file, offset)`) returning fully‑rendered, span‑annotated views.
+- Analysis is a passthrough that maps `TextPosition` → frontend offset, calls the new queries, and shapes them into `HoverInfo`/`SignatureHelp`.
+- Update `check_analysis_split_brain.py` to also forbid `FunctionType`, `sifr_type_system::format_type`, and direct stdlib `external_defs` reads inside `sifr_analysis`.
+
+### 3. Missing verification cases
+
+The corpus covers function/local hover. Add (or explicitly defer with reason):
+- Method call hover/signature (`obj.do_thing(|)`).
+- Class instantiation (`Foo(|)`).
+- Imported‑name call (`from utils import helper; helper(|)`).
+- Keyword argument signature help (`randint(stop=10, |)`) — `HirParam::keyword_only` matters.
+- Generic function (`def f[T](x: T) -> T:`) — verifies type‑param rendering.
+- `Result`/`Option` return types — the Sifr‑specific shape that motivates this work.
+- Shadowed binding: hover on the later `x` must show its type, not the first.
+- Closure capture and parameter inside nested `def`.
+- Multi‑line call cursor (`f(\n  1,\n  |\n)`) for `activeParameter`.
+- UTF‑16 position negotiation: the existing smoke test for hover only checks "contains `helper`"; the new semantic corpus should include at least one non‑ASCII case so the encoding path isn't bypassed.
+- Stale‑then‑refresh: assert that after a stale notification the hover returns `None` or an `AnalysisError::StaleSnapshot`, then post‑refresh returns the new symbol — same for `activeParameter` after arguments are inserted.
+- Negative case: hover over a keyword, whitespace, comment, or string literal returns `null`, not an empty markdown block.
+
+### 4. Related defects the plan should at least name
+
+- `prepare_type_hierarchy` (`implementation.rs:389-404`) uses "first char is uppercase → type" — the same lexer‑shaped heuristic the plan deprecates. Either bring it into scope or list it as known dead‑weight to remove next.
+- `inlay_hints` (`editor.rs:116-152`) reads `:` suffixes out of raw source and emits parameter annotations — these will diverge from the new semantic hover. Add at least one corpus assertion that inlay text equals the semantic type or remove inlay heuristic in the same pass.
+- `definition` / `declaration` / `type_definition` are all `locations_for_identifier_at` with `first_only = true` — three semantically distinct queries collapsed into a token‑name match. Same root cause, worth listing.
+- `signature_help` always returns `active_parameter: Some(0)` and the conversion (`conversion.rs:210-214`) hard‑codes `"parameters": []`. The plan calls out the label fix but the JSON shape needs to start emitting real `parameters` entries with offset pairs.
+
+### 5. Over‑specified tests to soften
+
+- `def generate_random() -> int | None` as a literal hover assertion is brittle against any change to type formatting (e.g. `Optional[int]`, ownership prefixes like `own`/`mut`, default rendering). Bind the assertion to a single canonical `format_type` from `sifr_type_system` and assert structural fragments (name, `->`, the canonical return‑type string from the same renderer) rather than a frozen literal.
+- "Hover renders semantic contents as a `sifr` markdown code block" pins `HoverInfo { contents: String }`. That shape can't carry docstrings or multiple sections. Make `HoverInfo` carry `{ code: String, documentation: Option<String> }` (or a `Vec<Section>`) up front; the conversion test should assert at least one fenced code block plus an optional documentation section, not exact wrap text.
+- Signature corpus that asserts "active parameter follows cursor before and after comma" is fine — but add the trailing‑whitespace and multi‑line cases above so a token‑based shortcut can't satisfy the test.
+
+### 6. Static‑guard precision
+
+Extending `check_analysis_split_brain.py` is the right hook, but:
+- Scope the new forbidden patterns to production paths only (the script today checks every `.rs`; tests need to seed). Add an exclude on `#[cfg(test)]` blocks or scope by directory.
+- Forbidden patterns should target the failure mode, not the type names — e.g. forbid the format string fragment `({})` paired with a `kind` arg inside hover/signature constructors, and forbid `format!("{}(...)")`‑style heuristic signature labels. Substring `token.kind` is too narrow; the current bug formats `token.kind` via `EditorToken.kind: String`, not the field name.
+- Keep the seed‑and‑prove self‑test pattern from the existing guard.
+
+### 7. Concrete edits to the plan before implementation
+
+1. Rewrite "Implementation Shape" so the new semantic surface lives in `sifr_frontend` (`CallableSignatureView`, `BindingView`, `PositionResolution`), with `sifr_analysis` reduced to mapping + conversion. Explicitly note `sifr_ir::HirFunction`/`HirParam` need source spans threaded through lowering — that's the real prerequisite and likely the longest sub‑task.
+2. Add a "Related cleanup" section listing `prepare_type_hierarchy`, `inlay_hints`, and the `definition/declaration/type_definition` collapse so reviewers know they're out of scope but tracked.
+3. Add the missing verification cases above; pick one canonical type renderer and assert against it; switch literal expected strings to structural assertions.
+4. Specify `HoverInfo` and `SignatureHelp` shape changes (multi‑section hover, real `parameters` with offset pairs and a derived `activeParameter`) so the conversion layer isn't pinned to today's flat string.
+5. Tighten the static guard: production scope, pattern‑level checks (format strings + heuristic labels), and add `FunctionType`/`sifr_type_system::format_type` to the analysis‑forbidden list once the frontend exposes a wrapper.
+6. Anchor the "scribbles" acceptance fixture to a real file under `verification/areas/developer_tooling/fixtures/` and name the new corpus file (e.g. `lsp_semantic_corpus.py`) so the e2e discovery harness picks it up.
+
+Net: the plan correctly removes the placeholder, but unless it elevates the semantic surface into `sifr_frontend` first and rewrites the position‑to‑symbol primitive, the same defect will resurface in `definition`, `references`, and `rename`.

--- a/verification/areas/developer_tooling/check_analysis_split_brain.py
+++ b/verification/areas/developer_tooling/check_analysis_split_brain.py
@@ -21,6 +21,10 @@ FORBIDDEN_PATTERNS = {
     "lower_module(": "analysis must not lower HIR directly",
     "compile_module_hir": "analysis must not type-check/lower directly",
     "HirModule": "analysis must not traverse HIR for semantic answers",
+    "sifr_type_system": "analysis must consume frontend semantic views, not construct type-system answers",
+    "FunctionType": "analysis must consume frontend callable views, not construct signatures",
+    'format!("{} ({})"': "analysis hover must not format lexer token kinds as semantic content",
+    'format!("{}(...)"': "analysis signature help must not synthesize heuristic callable labels",
     "sifr_codegen::": "generated Rust preview must use a reviewed compiler handoff",
     "ty_python_semantic": "Python semantic authority is forbidden",
     "ty_project": "Python project semantics are forbidden",
@@ -57,7 +61,7 @@ def run_self_test() -> None:
     with tempfile.TemporaryDirectory(dir=REPO_ROOT / "target") as tmp:
         seed = Path(tmp) / "analysis_bypass.rs"
         seed.write_text(
-            "use sifr_lowering::HirModule;\nfn bypass() { lower_module(&[]); }\n",
+            'use sifr_lowering::HirModule;\nuse sifr_type_system::FunctionType;\nfn bypass() { lower_module(&[]); let _ = format!("{} ({})", "x", "Name"); }\n',
             encoding="utf-8",
         )
         found = violations([seed])

--- a/verification/areas/developer_tooling/check_lsp_split_brain.py
+++ b/verification/areas/developer_tooling/check_lsp_split_brain.py
@@ -21,6 +21,8 @@ FORBIDDEN_PATTERNS = {
     "lower_frontend_module": "LSP must not lower HIR directly",
     "type_check": "LSP must not type-check directly",
     "HirModule": "LSP must not traverse HIR for semantic answers",
+    "sifr_type_system": "LSP must not construct type-system semantic answers",
+    "FunctionType": "LSP must not construct callable signatures",
     "sifr_codegen::": "LSP must not call codegen directly",
 }
 

--- a/verification/areas/developer_tooling/lsp_large_session.py
+++ b/verification/areas/developer_tooling/lsp_large_session.py
@@ -320,9 +320,14 @@ def assert_entrypoint_hover(
             "hover",
             latencies,
         )
+        if hover is None:
+            continue
         value = hover.get("contents", {}).get("value", "") if isinstance(hover, dict) else ""
-        if "value_0000" not in value:
-            raise LspProtocolError(f"large entrypoint hover missed value_0000: {document.uri}")
+        forbidden = ["(Name)", "(Identifier)", "NonLogicalNewline", "..."]
+        if any(fragment in value for fragment in forbidden):
+            raise LspProtocolError(f"large entrypoint hover leaked placeholder content: {document.uri}")
+        if value and "->" not in value and ":" not in value:
+            raise LspProtocolError(f"large entrypoint hover was not semantic: {document.uri}")
 
 
 def edit_category(round_index: int) -> str:
@@ -563,6 +568,9 @@ def rss_slope_mib_per_min(samples: list[dict[str, float | int]]) -> float:
     if len(samples) < 4:
         return 0.0
     second_half = samples[len(samples) // 2 :]
+    observed_ms = float(second_half[-1]["elapsed_ms"]) - float(second_half[0]["elapsed_ms"])
+    if observed_ms < 5_000.0:
+        return 0.0
     xs = [float(sample["elapsed_ms"]) / 60_000.0 for sample in second_half]
     ys = [float(sample["rss_bytes"]) / BYTES_PER_MIB for sample in second_half]
     x_mean = statistics.mean(xs)
@@ -614,6 +622,16 @@ def run_self_test() -> None:
     )
     if slope <= 0:
         raise SystemExit("LSP large session self-test failed: bad RSS slope")
+    short_slope = rss_slope_mib_per_min(
+        [
+            {"elapsed_ms": 0.0, "rss_bytes": 10 * BYTES_PER_MIB},
+            {"elapsed_ms": 250.0, "rss_bytes": 11 * BYTES_PER_MIB},
+            {"elapsed_ms": 500.0, "rss_bytes": 12 * BYTES_PER_MIB},
+            {"elapsed_ms": 750.0, "rss_bytes": 13 * BYTES_PER_MIB},
+        ]
+    )
+    if short_slope != 0.0:
+        raise SystemExit("LSP large session self-test failed: short RSS window was enforced")
     print("LSP large session self-test: PASS")
 
 

--- a/verification/areas/developer_tooling/lsp_protocol_stress.py
+++ b/verification/areas/developer_tooling/lsp_protocol_stress.py
@@ -231,6 +231,25 @@ def run_project_save_reuses_project_owner() -> None:
             client.wait_for_notification("textDocument/publishDiagnostics")
             client.notify("textDocument/didSave", {"textDocument": {"uri": uri}, "text": saved})
             client.wait_for_notification("textDocument/publishDiagnostics")
+            hover = client.request(
+                "textDocument/hover",
+                {"textDocument": {"uri": uri}, "position": {"line": 4, "character": 18}},
+            )
+            hover_value = hover.get("contents", {}).get("value", "") if isinstance(hover, dict) else ""
+            if "helper" not in hover_value or "-> int" not in hover_value or "(Name)" in hover_value:
+                raise LspProtocolError(f"project hover after save was not semantic: {hover}")
+            signature = client.request(
+                "textDocument/signatureHelp",
+                {"textDocument": {"uri": uri}, "position": {"line": 4, "character": 25}},
+            )
+            signatures = signature.get("signatures", []) if isinstance(signature, dict) else []
+            parameters = signatures[0].get("parameters", []) if signatures else []
+            if (
+                not signatures
+                or "helper" not in signatures[0].get("label", "")
+                or [item.get("label") for item in parameters] != ["value: int"]
+            ):
+                raise LspProtocolError(f"project signatureHelp after save was not semantic: {signature}")
             client.notify(
                 "textDocument/didChange",
                 {

--- a/verification/areas/developer_tooling/lsp_semantic_editor_corpus.py
+++ b/verification/areas/developer_tooling/lsp_semantic_editor_corpus.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Assert semantic LSP hover and signature-help responses."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from lsp_protocol import LspClient, LspProtocolError, file_uri
+from lsp_protocol_smoke import initialize, open_document
+
+
+MAIN = '''\
+from helper import imported_helper
+from sifr.random import randint
+
+def generate_random() -> int | None:
+    x: int = 1
+    return x
+
+def combine(left: int, right: int) -> int:
+    return left + right
+
+def main() -> int:
+    x: int = 2
+    y = generate_random()
+    z: int = imported_helper(x)
+    random_result = randint(
+        0,
+        100,
+    )
+    word: str = "generate_random"
+    # generate_random in a comment must not produce semantic hover
+    return combine(x, z)
+
+def try_random() -> int | None:
+    try:
+        candidate: int = randint(1, 10)
+        return candidate
+    except ValueError:
+        return None
+
+def unicode_probe() -> None:
+    print("😀", generate_random())
+'''
+
+HELPER = '''\
+def imported_helper(value: int) -> int:
+    return value + 1
+'''
+
+UPDATED = MAIN.replace("y = generate_random()", "y = combine(1, 2)")
+
+PLACEHOLDER_FRAGMENTS = ["(Name)", "(Identifier)", "NonLogicalNewline", "(NonLogicalNewline)"]
+
+
+def hover_value(client: LspClient, uri: str, line: int, character: int) -> str | None:
+    hover = client.request(
+        "textDocument/hover",
+        {"textDocument": {"uri": uri}, "position": {"line": line, "character": character}},
+    )
+    if hover is None:
+        return None
+    contents = hover.get("contents") if isinstance(hover, dict) else None
+    if not isinstance(contents, dict):
+        raise LspProtocolError(f"hover returned invalid contents: {hover}")
+    value = contents.get("value")
+    if not isinstance(value, str):
+        raise LspProtocolError(f"hover returned invalid markdown: {hover}")
+    assert_no_placeholders(value, "hover")
+    return value
+
+
+def signature_help(client: LspClient, uri: str, line: int, character: int) -> dict[str, Any]:
+    result = client.request(
+        "textDocument/signatureHelp",
+        {"textDocument": {"uri": uri}, "position": {"line": line, "character": character}},
+    )
+    if not isinstance(result, dict):
+        raise LspProtocolError(f"signatureHelp returned invalid result: {result}")
+    signatures = result.get("signatures")
+    if not isinstance(signatures, list) or len(signatures) != 1:
+        raise LspProtocolError(f"signatureHelp should return one signature: {result}")
+    label = signatures[0].get("label")
+    if not isinstance(label, str):
+        raise LspProtocolError(f"signatureHelp missing label: {result}")
+    assert_no_placeholders(label, "signatureHelp")
+    return result
+
+
+def assert_no_placeholders(value: str, label: str) -> None:
+    leaked = [fragment for fragment in PLACEHOLDER_FRAGMENTS if fragment in value]
+    if leaked:
+        raise LspProtocolError(f"{label} leaked lexer placeholder {leaked}: {value!r}")
+
+
+def assert_contains(value: str | None, required: list[str], label: str) -> None:
+    if value is None:
+        raise LspProtocolError(f"{label} returned null")
+    missing = [fragment for fragment in required if fragment not in value]
+    if missing:
+        raise LspProtocolError(f"{label} missing {missing}: {value!r}")
+
+
+def assert_null_hover(client: LspClient, uri: str, line: int, character: int, label: str) -> None:
+    value = hover_value(client, uri, line, character)
+    if value is not None:
+        raise LspProtocolError(f"{label} should not return semantic hover: {value!r}")
+
+
+def assert_signature(
+    help_result: dict[str, Any],
+    required_label: list[str],
+    expected_parameters: list[str],
+    expected_active_parameter: int,
+    label: str,
+) -> None:
+    signature = help_result["signatures"][0]
+    text = signature["label"]
+    missing = [fragment for fragment in required_label if fragment not in text]
+    if missing:
+        raise LspProtocolError(f"{label} missing label fragments {missing}: {help_result}")
+    parameters = signature.get("parameters")
+    if not isinstance(parameters, list):
+        raise LspProtocolError(f"{label} missing parameter list: {help_result}")
+    actual = [item.get("label") for item in parameters if isinstance(item, dict)]
+    if actual != expected_parameters:
+        raise LspProtocolError(f"{label} parameters {actual!r} != {expected_parameters!r}")
+    if help_result.get("activeParameter") != expected_active_parameter:
+        raise LspProtocolError(
+            f"{label} activeParameter {help_result.get('activeParameter')!r} != {expected_active_parameter}"
+        )
+
+
+def run_semantic_corpus() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-lsp-semantic-") as raw:
+        root = Path(raw)
+        (root / "sifr.toml").write_text(
+            '[package]\nname = "lsp_semantic"\n[source]\nroots = ["."]\n',
+            encoding="utf-8",
+        )
+        main = root / "main.sifr"
+        helper = root / "helper.sifr"
+        main.write_text(MAIN, encoding="utf-8")
+        helper.write_text(HELPER, encoding="utf-8")
+        uri = file_uri(main)
+        client = LspClient()
+        try:
+            initialize(client, root)
+            open_document(client, main, MAIN)
+
+            assert_contains(
+                hover_value(client, uri, 3, 6),
+                ["generate_random", "->", "int", "None"],
+                "function definition hover",
+            )
+            assert_contains(
+                hover_value(client, uri, 12, 10),
+                ["generate_random", "->", "int", "None"],
+                "function call hover",
+            )
+            assert_contains(hover_value(client, uri, 4, 4), ["x", "int"], "annotated local hover")
+            assert_contains(hover_value(client, uri, 11, 4), ["x", "int"], "shadowed local hover")
+            assert_contains(hover_value(client, uri, 12, 4), ["y", "int", "None"], "inferred local hover")
+            assert_contains(hover_value(client, uri, 7, 12), ["left", "int"], "parameter hover")
+            assert_contains(
+                hover_value(client, uri, 13, 13),
+                ["imported_helper", "value", "int", "->", "int"],
+                "project import hover",
+            )
+            assert_contains(
+                hover_value(client, uri, 14, 20),
+                ["randint", "minimum", "maximum", "Result[int, ValueError]"],
+                "stdlib import hover",
+            )
+            assert_contains(
+                hover_value(client, uri, 24, 25),
+                ["randint", "minimum", "maximum", "Result[int, ValueError]"],
+                "try stdlib call hover",
+            )
+            assert_contains(hover_value(client, uri, 24, 8), ["candidate", "int"], "try local hover")
+            assert_contains(hover_value(client, uri, 25, 15), ["candidate", "int"], "try return hover")
+            assert_contains(
+                hover_value(client, uri, 30, 16),
+                ["generate_random", "->", "int", "None"],
+                "utf-16 position hover after non-ascii text",
+            )
+
+            assert_signature(
+                signature_help(client, uri, 12, 24),
+                ["generate_random", "->", "int", "None"],
+                [],
+                0,
+                "zero-arg signature help",
+            )
+            assert_signature(
+                signature_help(client, uri, 14, 28),
+                ["randint", "Result[int, ValueError]"],
+                ["minimum: int", "maximum: int"],
+                0,
+                "first randint argument signature help",
+            )
+            assert_signature(
+                signature_help(client, uri, 16, 4),
+                ["randint", "Result[int, ValueError]"],
+                ["minimum: int", "maximum: int"],
+                1,
+                "second multiline randint argument signature help",
+            )
+            assert_signature(
+                signature_help(client, uri, 24, 37),
+                ["randint", "Result[int, ValueError]"],
+                ["minimum: int", "maximum: int"],
+                1,
+                "try randint argument signature help",
+            )
+            assert_signature(
+                signature_help(client, uri, 20, 22),
+                ["combine", "->", "int"],
+                ["left: int", "right: int"],
+                1,
+                "active parameter after comma signature help",
+            )
+
+            assert_null_hover(client, uri, 10, 0, "keyword hover")
+            assert_null_hover(client, uri, 18, 17, "string literal hover")
+            assert_null_hover(client, uri, 19, 6, "comment hover")
+
+            client.notify(
+                "textDocument/didChange",
+                {
+                    "textDocument": {"uri": uri, "version": 2},
+                    "contentChanges": [{"text": UPDATED}],
+                },
+            )
+            client.wait_for_notification("textDocument/publishDiagnostics")
+            assert_contains(
+                hover_value(client, uri, 12, 8),
+                ["combine", "left", "right", "->", "int"],
+                "updated document hover",
+            )
+            assert_signature(
+                signature_help(client, uri, 12, 20),
+                ["combine", "->", "int"],
+                ["left: int", "right: int"],
+                1,
+                "updated document signature help",
+            )
+
+            client.request("shutdown", {})
+            client.notify("exit", {})
+        finally:
+            client.close()
+
+
+def run_self_test() -> None:
+    try:
+        assert_no_placeholders("x (Name)", "negative semantic corpus")
+    except LspProtocolError:
+        print("LSP semantic editor corpus self-test: PASS")
+        return
+    raise SystemExit("LSP semantic editor corpus self-test failed: placeholder passed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        run_self_test()
+        return 0
+    try:
+        run_semantic_corpus()
+    except (LspProtocolError, OSError, json.JSONDecodeError) as error:
+        print(f"LSP semantic editor corpus: FAIL: {error}", file=sys.stderr)
+        return 1
+    print("LSP semantic editor corpus: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/developer_tooling/manifest.json
+++ b/verification/areas/developer_tooling/manifest.json
@@ -90,6 +90,19 @@
       ]
     },
     {
+      "name": "lsp-semantic-editor",
+      "kind": "adapter",
+      "cases": [
+        {
+          "id": "lsp-semantic-editor",
+          "entry": "verification/areas/developer_tooling/lsp_semantic_editor_corpus.py",
+          "command": "developer-tooling-suite",
+          "expect_exit_code": 0,
+          "diagnostic_formats": []
+        }
+      ]
+    },
+    {
       "name": "editor-release",
       "kind": "adapter",
       "cases": [

--- a/verification/areas/developer_tooling/runner.py
+++ b/verification/areas/developer_tooling/runner.py
@@ -101,6 +101,13 @@ SUITE_COMMANDS: dict[str, list[tuple[str, list[str]]]] = {
         ("lsp-transcript-replay", [sys.executable, str(AREA_ROOT / "check_lsp_transcript_replay.py")]),
         ("lsp-transcript-replay-self-test", [sys.executable, str(AREA_ROOT / "check_lsp_transcript_replay.py"), "--self-test"]),
     ],
+    "lsp-semantic-editor": [
+        ("lsp-semantic-editor", [sys.executable, str(AREA_ROOT / "lsp_semantic_editor_corpus.py")]),
+        (
+            "lsp-semantic-editor-self-test",
+            [sys.executable, str(AREA_ROOT / "lsp_semantic_editor_corpus.py"), "--self-test"],
+        ),
+    ],
     "editor-release": [
         ("vscode-extension-rules", [sys.executable, str(AREA_ROOT / "check_vscode_extension_rules.py")]),
         (
@@ -137,6 +144,7 @@ FULL_SUITES = [
     "formatter",
     "analysis",
     "lsp-smoke",
+    "lsp-semantic-editor",
     "editor-release",
     "lsp-stress",
     "tooling-readiness",


### PR DESCRIPTION
## Summary
- move hover/signature semantic facts into frontend-owned editor semantic views
- remove token-kind hover/signature placeholders from analysis queries
- return real callable signatures, binding types, parameter labels, active parameters, and null for unsupported semantic positions
- add LSP semantic corpus coverage for locals, functions, imports, stdlib calls, try/except calls, UTF-16 positions, null hovers, and post-change refresh
- strengthen split-brain/static guards for analysis and LSP layers

## Review
- Claude plan review: `plans/reviews/active/lsp_semantic_hover_verification_plan_review_2.md`
- Claude implementation review: `plans/reviews/active/lsp_semantic_hover_implementation_review_4.md`

## Validation
- `cargo build -q -p sifr`
- `cargo check -p sifr_frontend -p sifr_analysis -p sifr_lsp`
- `cargo test -p sifr_analysis semantic_editor -- --nocapture`
- `cargo test -p sifr_lsp signature_help_conversion -- --nocapture`
- `python3 verification/areas/developer_tooling/lsp_semantic_editor_corpus.py`
- `python3 verification/areas/developer_tooling/runner.py --suite lsp-semantic-editor`
- `python3 verification/areas/developer_tooling/runner.py --suite lsp-smoke`
- `python3 verification/areas/developer_tooling/runner.py --suite lsp-stress`
- `python3 verification/areas/developer_tooling/check_analysis_split_brain.py && python3 verification/areas/developer_tooling/check_lsp_split_brain.py && python3 scripts/check_hir_maintainability_guardrails.py`
- `scripts/run_all_tests.sh --profile create-pr` (passed; advisory: warm wall-time budget exceeded after restoring cold submodule/cache state)