### PR TITLE
Migrate base encoding encoders to sysroot stdlib

### DIFF
--- a/crates/sifr/tests/e2e_support/fixture_cargo_toml.rs
+++ b/crates/sifr/tests/e2e_support/fixture_cargo_toml.rs
@@ -340,6 +340,7 @@ fn needs_sifr_stdlib_module_dependency(stdlib_modules: &BTreeSet<String>) -> boo
                 | "sifr.hash"
                 | "sifr.hashlib"
                 | "_sifr.crypto"
+                | "sifr.base64"
                 | "sifr.platform"
                 | "_sifr.platform"
         )

--- a/crates/sifr/tests/e2e_support/fixture_dependency_paths.rs
+++ b/crates/sifr/tests/e2e_support/fixture_dependency_paths.rs
@@ -68,6 +68,9 @@ pub(crate) fn sifr_stdlib_dependency_spec_for_modules(stdlib_modules: &BTreeSet<
     if has_module(&["sifr.hash", "sifr.hashlib", "_sifr.crypto"]) {
         features.push("hash");
     }
+    if has_module(&["sifr.base64", "_sifr.crypto"]) {
+        features.push("base64");
+    }
     sifr_stdlib_dependency_spec_with_features(&features)
 }
 

--- a/crates/sifr/tests/e2e_support/stateless_sysroot_cargo_toml_tests.rs
+++ b/crates/sifr/tests/e2e_support/stateless_sysroot_cargo_toml_tests.rs
@@ -10,6 +10,7 @@ pub(crate) fn test_generate_cargo_toml_stateless_sysroot_modules_enable_stdlib_f
             "sifr.uuid",
             "sifr.math",
             "sifr.hashlib",
+            "sifr.base64",
         ]
         .map(str::to_string),
     );
@@ -28,9 +29,15 @@ pub(crate) fn test_generate_cargo_toml_stateless_sysroot_modules_enable_stdlib_f
     assert!(hash_toml.contains("features = [\"hash\"]"));
     assert!(!hash_toml.contains("sha2 = "));
     assert!(!hash_toml.contains("md5 = "));
+    let base64_modules = normalize_dependency_set(vec!["sifr.base64".to_string()].into_iter());
+    let base64_toml = generate_cargo_toml(&base64_modules, &required_crates, "sifr_output");
+    assert!(base64_toml.contains("sifr_stdlib = { path = "));
+    assert!(base64_toml.contains("default-features = false"));
+    assert!(base64_toml.contains("features = [\"base64\"]"));
+    assert!(base64_toml.contains("base64 = \"0.22.1\""));
     let combined_toml = generate_cargo_toml(&combined_modules, &required_crates, "sifr_output");
     assert!(combined_toml.contains(
-        "features = [\"html\", \"calendar\", \"platform\", \"uuid\", \"math\", \"hash\"]"
+        "features = [\"html\", \"calendar\", \"platform\", \"uuid\", \"math\", \"hash\", \"base64\"]"
     ));
     assert_eq!(combined_toml.matches("sifr_stdlib = ").count(), 1);
 }

--- a/crates/sifr_codegen/src/intrinsics/registry.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry.rs
@@ -734,16 +734,8 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
             Some(StdlibFeature::Zip),
         ),
         "zip_namelist" => (zipfile::lower_zip_namelist(args), Some(StdlibFeature::Zip)),
-        "base64_encode" => (
-            base64::lower_base64_encode(args),
-            Some(StdlibFeature::Base64),
-        ),
         "base64_decode" => (
             base64::lower_base64_decode(args),
-            Some(StdlibFeature::Base64),
-        ),
-        "base64_encode_bytes" => (
-            base64::lower_base64_encode_bytes(args),
             Some(StdlibFeature::Base64),
         ),
         "base64_decode_bytes" => (
@@ -758,25 +750,15 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
             base64::lower_base64_decode_opts(args),
             Some(StdlibFeature::Base64),
         ),
-        "urlsafe_b64encode" => (
-            base64::lower_urlsafe_b64encode(args),
-            Some(StdlibFeature::Base64),
-        ),
         "urlsafe_b64decode" => (
             base64::lower_urlsafe_b64decode(args),
-            Some(StdlibFeature::Base64),
-        ),
-        "urlsafe_b64encode_bytes" => (
-            base64::lower_urlsafe_b64encode_bytes(args),
             Some(StdlibFeature::Base64),
         ),
         "urlsafe_b64decode_bytes" => (
             base64::lower_urlsafe_b64decode_bytes(args),
             Some(StdlibFeature::Base64),
         ),
-        "b32encode" => (base32::lower_b32encode(args), None),
         "b32decode" => (base32::lower_b32decode(args), None),
-        "b32hexencode" => (base32::lower_b32hexencode(args), None),
         "b32hexdecode" => (base32::lower_b32hexdecode(args), None),
         "set_global_level" => (logging::lower_set_global_level(args), None),
         "get_global_level" => (logging::lower_get_global_level(args), None),

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -437,114 +437,47 @@ pub(crate) fn lowers_zip_intrinsics_with_dependency_metadata() {
 }
 
 #[test]
-pub(crate) fn lowers_base64_intrinsics_with_dependency_metadata() {
-    let enc = lower_intrinsic("base64_encode", &["text".to_string()]).expect("base64_encode");
-    assert_eq!(
-        enc.required_feature,
-        Some(sifr_stdlib_model::StdlibFeature::Base64)
-    );
-    assert!(render_expr(&enc.expr).contains("base64::Engine::encode"));
-    assert!(render_expr(&enc.expr).contains("general_purpose::STANDARD"));
+pub(crate) fn base_encoding_intrinsics_are_owned_by_compiled_stdlib_declarations() {
+    for (name, args) in [
+        ("base64_encode", &["payload"][..]),
+        ("base64_encode_bytes", &["payload"][..]),
+        ("urlsafe_b64encode", &["payload"][..]),
+        ("urlsafe_b64encode_bytes", &["payload"][..]),
+        ("b32encode", &["payload"][..]),
+        ("b32hexencode", &["payload"][..]),
+    ] {
+        let args = args
+            .iter()
+            .map(|arg| (*arg).to_string())
+            .collect::<Vec<_>>();
+        assert!(
+            lower_intrinsic(name, &args).is_none(),
+            "{name} should lower through _sifr.crypto private Rust interop declarations"
+        );
+    }
 
-    let dec = lower_intrinsic("base64_decode", &["s".to_string()]).expect("base64_decode");
-    assert_eq!(
-        dec.required_feature,
-        Some(sifr_stdlib_model::StdlibFeature::Base64)
-    );
-    assert!(render_expr(&dec.expr).contains("base64::Engine::decode"));
-    assert!(render_expr(&dec.expr).contains("general_purpose::STANDARD"));
-
-    let enc_bytes =
-        lower_intrinsic("base64_encode_bytes", &["b".to_string()]).expect("base64_encode_bytes");
-    assert_eq!(
-        enc_bytes.required_feature,
-        Some(sifr_stdlib_model::StdlibFeature::Base64)
-    );
-    assert!(render_expr(&enc_bytes.expr).contains("into_bytes"));
-
-    let dec_bytes =
-        lower_intrinsic("base64_decode_bytes", &["b".to_string()]).expect("base64_decode_bytes");
-    assert_eq!(
-        dec_bytes.required_feature,
-        Some(sifr_stdlib_model::StdlibFeature::Base64)
-    );
-    assert!(render_expr(&dec_bytes.expr).contains("base64::Engine::decode"));
-
-    let enc_opts = lower_intrinsic(
-        "base64_encode_opts",
-        &["s".to_string(), "alt".to_string(), "wrap".to_string()],
-    )
-    .expect("base64_encode_opts");
-    assert_eq!(
-        enc_opts.required_feature,
-        Some(sifr_stdlib_model::StdlibFeature::Base64)
-    );
-    assert!(render_expr(&enc_opts.expr).contains("wrapcol must be >= 0"));
-
-    let dec_opts = lower_intrinsic(
-        "base64_decode_opts",
-        &[
-            "s".to_string(),
-            "alt".to_string(),
-            "validate".to_string(),
-            "ignore".to_string(),
-        ],
-    )
-    .expect("base64_decode_opts");
-    assert_eq!(
-        dec_opts.required_feature,
-        Some(sifr_stdlib_model::StdlibFeature::Base64)
-    );
-    assert!(render_expr(&dec_opts.expr).contains("invalid base64 character"));
-
-    let url_enc =
-        lower_intrinsic("urlsafe_b64encode", &["s".to_string()]).expect("urlsafe_b64encode");
-    assert_eq!(
-        url_enc.required_feature,
-        Some(sifr_stdlib_model::StdlibFeature::Base64)
-    );
-    assert!(render_expr(&url_enc.expr).contains("base64::Engine::encode"));
-    assert!(render_expr(&url_enc.expr).contains("general_purpose::URL_SAFE"));
-
-    let url_dec =
-        lower_intrinsic("urlsafe_b64decode", &["s".to_string()]).expect("urlsafe_b64decode");
-    assert_eq!(
-        url_dec.required_feature,
-        Some(sifr_stdlib_model::StdlibFeature::Base64)
-    );
-    assert!(render_expr(&url_dec.expr).contains("base64::Engine::decode"));
-    assert!(render_expr(&url_dec.expr).contains("general_purpose::URL_SAFE"));
-
-    let url_enc_bytes = lower_intrinsic("urlsafe_b64encode_bytes", &["b".to_string()])
-        .expect("urlsafe_b64encode_bytes");
-    assert_eq!(
-        url_enc_bytes.required_feature,
-        Some(sifr_stdlib_model::StdlibFeature::Base64)
-    );
-    assert!(render_expr(&url_enc_bytes.expr).contains("into_bytes"));
-
-    let url_dec_bytes = lower_intrinsic("urlsafe_b64decode_bytes", &["b".to_string()])
-        .expect("urlsafe_b64decode_bytes");
-    assert_eq!(
-        url_dec_bytes.required_feature,
-        Some(sifr_stdlib_model::StdlibFeature::Base64)
-    );
-    assert!(render_expr(&url_dec_bytes.expr).contains("base64::Engine::decode"));
-}
-
-#[test]
-pub(crate) fn lowers_base32_intrinsics_via_registry() {
-    let b32e = lower_intrinsic("b32encode", &["s".to_string()]).expect("b32encode");
-    assert!(render_expr(&b32e.expr).contains("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"));
-
-    let b32d = lower_intrinsic("b32decode", &["s".to_string()]).expect("b32decode");
-    assert!(render_expr(&b32d.expr).contains("invalid base32 char"));
-
-    let b32he = lower_intrinsic("b32hexencode", &["s".to_string()]).expect("b32hexencode");
-    assert!(render_expr(&b32he.expr).contains("0123456789ABCDEFGHIJKLMNOPQRSTUV"));
-
-    let b32hd = lower_intrinsic("b32hexdecode", &["s".to_string()]).expect("b32hexdecode");
-    assert!(render_expr(&b32hd.expr).contains("invalid base32hex char"));
+    for (name, args) in [
+        ("base64_decode", &["payload"][..]),
+        ("base64_decode_bytes", &["payload"][..]),
+        ("base64_encode_opts", &["payload", "alt", "wrap"][..]),
+        (
+            "base64_decode_opts",
+            &["payload", "alt", "validate", "ignore"][..],
+        ),
+        ("urlsafe_b64decode", &["payload"][..]),
+        ("urlsafe_b64decode_bytes", &["payload"][..]),
+        ("b32decode", &["payload"][..]),
+        ("b32hexdecode", &["payload"][..]),
+    ] {
+        let args = args
+            .iter()
+            .map(|arg| (*arg).to_string())
+            .collect::<Vec<_>>();
+        assert!(
+            lower_intrinsic(name, &args).is_some(),
+            "{name} should keep intrinsic fallback until typed error bridge work"
+        );
+    }
 }
 
 #[test]

--- a/crates/sifr_driver/src/stdlib/stateless_private_codegen_tests.rs
+++ b/crates/sifr_driver/src/stdlib/stateless_private_codegen_tests.rs
@@ -188,6 +188,27 @@ fn crypto_hash_private_declarations_codegen_through_sifr_stdlib() {
     assert!(private_code.contains("sifr_stdlib::hash::sha256(s)"));
     assert!(private_code.contains("sifr_stdlib::hash::sha256_bytes(data)"));
     assert!(private_code.contains("sifr_stdlib::hash::blake2s_bytes(data)"));
+    assert!(private_code.contains("sifr_stdlib::base64::base64_encode(s)"));
+    assert!(private_code.contains("sifr_stdlib::base64::base64_encode_bytes(data)"));
+    assert!(private_code.contains("sifr_stdlib::base64::urlsafe_b64encode(s)"));
+    assert!(private_code.contains("sifr_stdlib::base64::urlsafe_b64encode_bytes(data)"));
+    assert!(private_code.contains("sifr_stdlib::base64::b32encode(s)"));
+    assert!(private_code.contains("sifr_stdlib::base64::b32hexencode(s)"));
+    for fallback_name in [
+        "base64_decode",
+        "base64_decode_bytes",
+        "base64_encode_opts",
+        "base64_decode_opts",
+        "urlsafe_b64decode",
+        "urlsafe_b64decode_bytes",
+        "b32decode",
+        "b32hexdecode",
+    ] {
+        assert!(
+            !private_code.contains(&format!("sifr_stdlib::base64::{fallback_name}")),
+            "{fallback_name} should stay on intrinsic fallback until typed error bridge work"
+        );
+    }
     assert!(compiled
         .code
         .intrinsic_names
@@ -203,6 +224,22 @@ fn crypto_hash_private_declarations_codegen_through_sifr_stdlib() {
         .intrinsic_names
         .get("sifr.hashlib")
         .is_some_and(|names| !names.contains("sha256") && !names.contains("_sha256_impl")));
+    assert!(compiled
+        .code
+        .transitive_deps
+        .get("sifr.base64")
+        .is_some_and(|deps| deps.contains("_sifr.crypto")));
+    assert!(compiled
+        .code
+        .intrinsic_names
+        .get("sifr.base64")
+        .is_some_and(|names| names.contains("base64_decode")
+            && names.contains("base64_encode_opts")
+            && names.contains("b32decode")
+            && !names.contains("base64_encode")
+            && !names.contains("_base64_encode_impl")
+            && !names.contains("b32encode")
+            && !names.contains("_b32encode_impl")));
     let hashlib_exports = compiled
         .defs
         .functions
@@ -210,9 +247,13 @@ fn crypto_hash_private_declarations_codegen_through_sifr_stdlib() {
         .expect("sifr.hashlib exports should be collected");
     assert!(hashlib_exports.contains_key("sha256"));
     assert!(!hashlib_exports.contains_key("_sha256_impl"));
-    assert!(compiled
-        .code
-        .intrinsic_names
+    let base64_exports = compiled
+        .defs
+        .functions
         .get("sifr.base64")
-        .is_some_and(|names| names.contains("base64_encode")));
+        .expect("sifr.base64 exports should be collected");
+    assert!(base64_exports.contains_key("base64_encode"));
+    assert!(base64_exports.contains_key("b32decode"));
+    assert!(!base64_exports.contains_key("_base64_encode_impl"));
+    assert!(!base64_exports.contains_key("_b32encode_impl"));
 }

--- a/crates/sifr_stdlib/src/base64.rs
+++ b/crates/sifr_stdlib/src/base64.rs
@@ -1,4 +1,214 @@
+use base64::{engine::general_purpose, Engine as _};
+use std::collections::HashSet;
+
 #[must_use]
 pub const fn feature_name() -> &'static str {
     "base64"
+}
+
+pub fn base64_encode(input: &str) -> String {
+    general_purpose::STANDARD.encode(input.as_bytes())
+}
+
+pub fn base64_encode_bytes(data: &[u8]) -> Vec<u8> {
+    general_purpose::STANDARD.encode(data).into_bytes()
+}
+
+pub fn base64_decode(input: &str) -> Result<String, String> {
+    let bytes = general_purpose::STANDARD
+        .decode(input.as_bytes())
+        .map_err(|error| error.to_string())?;
+    String::from_utf8(bytes).map_err(|error| error.to_string())
+}
+
+pub fn base64_decode_bytes(data: &[u8]) -> Result<Vec<u8>, String> {
+    general_purpose::STANDARD
+        .decode(data)
+        .map_err(|error| error.to_string())
+}
+
+pub fn base64_encode_opts(input: &str, altchars: &str, wrapcol: i64) -> Result<String, String> {
+    if wrapcol < 0 {
+        return Err("wrapcol must be >= 0".to_string());
+    }
+    let mut encoded = base64_encode(input);
+    if !altchars.is_empty() {
+        let mut chars = altchars.chars();
+        let first = chars.next();
+        let second = chars.next();
+        if first.is_none() || second.is_none() || chars.next().is_some() {
+            return Err(format!("invalid altchars: {altchars}"));
+        }
+        let alt_plus = first.unwrap_or('+');
+        let alt_slash = second.unwrap_or('/');
+        encoded = encoded
+            .chars()
+            .map(|ch| {
+                if ch == '+' {
+                    alt_plus
+                } else if ch == '/' {
+                    alt_slash
+                } else {
+                    ch
+                }
+            })
+            .collect();
+    }
+    if wrapcol == 0 {
+        return Ok(encoded);
+    }
+    let width = usize::try_from(wrapcol).map_err(|_| "wrapcol must be >= 0".to_string())?;
+    let mut wrapped = String::new();
+    for (index, ch) in encoded.chars().enumerate() {
+        if index > 0 && index % width == 0 {
+            wrapped.push('\n');
+        }
+        wrapped.push(ch);
+    }
+    Ok(wrapped)
+}
+
+pub fn base64_decode_opts(
+    input: &str,
+    altchars: &str,
+    validate: bool,
+    ignorechars: &str,
+) -> Result<String, String> {
+    let (has_alt, alt_plus, alt_slash) = parse_altchars(altchars)?;
+    let ignore_set = ignorechars.chars().collect::<HashSet<_>>();
+    let mut normalized = String::new();
+    for ch in input.chars() {
+        if ignore_set.contains(&ch) {
+            continue;
+        }
+        let mapped = if has_alt && ch == alt_plus {
+            '+'
+        } else if has_alt && ch == alt_slash {
+            '/'
+        } else {
+            ch
+        };
+        if is_base64_char(mapped) {
+            normalized.push(mapped);
+        } else if validate {
+            return Err(format!("invalid base64 character: {ch}"));
+        }
+    }
+    base64_decode(&normalized)
+}
+
+pub fn urlsafe_b64encode(input: &str) -> String {
+    general_purpose::URL_SAFE.encode(input.as_bytes())
+}
+
+pub fn urlsafe_b64encode_bytes(data: &[u8]) -> Vec<u8> {
+    general_purpose::URL_SAFE.encode(data).into_bytes()
+}
+
+pub fn urlsafe_b64decode(input: &str) -> Result<String, String> {
+    let bytes = general_purpose::URL_SAFE
+        .decode(input.as_bytes())
+        .map_err(|error| error.to_string())?;
+    String::from_utf8(bytes).map_err(|error| error.to_string())
+}
+
+pub fn urlsafe_b64decode_bytes(data: &[u8]) -> Result<Vec<u8>, String> {
+    general_purpose::URL_SAFE
+        .decode(data)
+        .map_err(|error| error.to_string())
+}
+
+pub fn b32encode(input: &str) -> String {
+    encode_base32(input.as_bytes(), b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
+}
+
+pub fn b32decode(input: &str) -> Result<String, String> {
+    decode_base32(
+        input,
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567",
+        "invalid base32 char: {}",
+    )
+}
+
+pub fn b32hexencode(input: &str) -> String {
+    encode_base32(input.as_bytes(), b"0123456789ABCDEFGHIJKLMNOPQRSTUV")
+}
+
+pub fn b32hexdecode(input: &str) -> Result<String, String> {
+    decode_base32(
+        input,
+        b"0123456789ABCDEFGHIJKLMNOPQRSTUV",
+        "invalid base32hex char: {}",
+    )
+}
+
+fn parse_altchars(altchars: &str) -> Result<(bool, char, char), String> {
+    if altchars.is_empty() {
+        return Ok((false, '+', '/'));
+    }
+    let mut chars = altchars.chars();
+    let Some(alt_plus) = chars.next() else {
+        return Ok((false, '+', '/'));
+    };
+    let Some(alt_slash) = chars.next() else {
+        return Err(format!("invalid altchars: {altchars}"));
+    };
+    if chars.next().is_some() {
+        return Err(format!("invalid altchars: {altchars}"));
+    }
+    Ok((true, alt_plus, alt_slash))
+}
+
+fn is_base64_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '+' || ch == '/' || ch == '='
+}
+
+fn encode_base32(data: &[u8], alphabet: &[u8; 32]) -> String {
+    let mut out = String::new();
+    let mut index = 0;
+    while index < data.len() {
+        let remaining = data.len() - index;
+        let chunk_len = remaining.min(5);
+        let mut buffer = 0_u64;
+        for offset in 0..5 {
+            let byte = data.get(index + offset).copied().unwrap_or(0);
+            buffer = (buffer << 8) | u64::from(byte);
+        }
+        let useful_chars = (chunk_len * 8).div_ceil(5);
+        for shift_index in 0..8 {
+            if shift_index < useful_chars {
+                let alphabet_index = ((buffer >> (35 - shift_index * 5)) & 0x1f) as usize;
+                out.push(char::from(alphabet[alphabet_index]));
+            } else {
+                out.push('=');
+            }
+        }
+        index += 5;
+    }
+    out
+}
+
+fn decode_base32(
+    input: &str,
+    alphabet: &[u8; 32],
+    invalid_message: &str,
+) -> Result<String, String> {
+    let trimmed = input.trim_end_matches('=');
+    let mut bits = 0_u64;
+    let mut bit_count = 0_u8;
+    let mut out = Vec::new();
+    for ch in trimmed.chars() {
+        let upper = ch.to_ascii_uppercase();
+        let value = alphabet
+            .iter()
+            .position(|byte| char::from(*byte) == upper)
+            .ok_or_else(|| invalid_message.replace("{}", &ch.to_string()))?;
+        bits = (bits << 5) | value as u64;
+        bit_count += 5;
+        if bit_count >= 8 {
+            bit_count -= 8;
+            out.push(((bits >> bit_count) & 0xff) as u8);
+        }
+    }
+    String::from_utf8(out).map_err(|error| error.to_string())
 }

--- a/crates/sifr_stdlib/tests/api_behavior.rs
+++ b/crates/sifr_stdlib/tests/api_behavior.rs
@@ -185,6 +185,62 @@ fn hash_leaf_matches_known_digest_vectors() {
     assert_eq!(sifr_stdlib::hash::feature_name(), "hash");
 }
 
+#[cfg(feature = "base64")]
+#[test]
+fn base64_leaf_matches_rfc_vectors_and_error_paths() {
+    assert_eq!(sifr_stdlib::base64::base64_encode(""), "");
+    assert_eq!(sifr_stdlib::base64::base64_encode("f"), "Zg==");
+    assert_eq!(sifr_stdlib::base64::base64_encode("fo"), "Zm8=");
+    assert_eq!(sifr_stdlib::base64::base64_encode("foo"), "Zm9v");
+    assert_eq!(sifr_stdlib::base64::base64_encode("foobar"), "Zm9vYmFy");
+    assert_eq!(
+        sifr_stdlib::base64::base64_decode("Zm9v").expect("decode foo"),
+        "foo"
+    );
+    assert_eq!(
+        sifr_stdlib::base64::base64_encode_bytes(b"foo"),
+        b"Zm9v".to_vec()
+    );
+    assert_eq!(
+        sifr_stdlib::base64::base64_decode_bytes(b"Zm9v").expect("decode bytes"),
+        b"foo".to_vec()
+    );
+    assert!(sifr_stdlib::base64::base64_decode("@@@@").is_err());
+    assert_eq!(
+        sifr_stdlib::base64::base64_encode_opts("foo", "-_", 0).expect("alt encode"),
+        "Zm9v"
+    );
+    assert_eq!(
+        sifr_stdlib::base64::base64_encode_opts("foobar", "", 4).expect("wrapped"),
+        "Zm9v\nYmFy"
+    );
+    assert!(sifr_stdlib::base64::base64_encode_opts("x", "+", 0).is_err());
+    assert!(sifr_stdlib::base64::base64_encode_opts("x", "", -1).is_err());
+    assert!(sifr_stdlib::base64::base64_decode_opts("YWJj!", "", true, "").is_err());
+    assert_eq!(
+        sifr_stdlib::base64::base64_decode_opts("Y W\nJj!", "", false, " \n!")
+            .expect("ignore decode"),
+        "abc"
+    );
+    assert_eq!(sifr_stdlib::base64::urlsafe_b64encode("hello"), "aGVsbG8=");
+    assert_eq!(
+        sifr_stdlib::base64::urlsafe_b64decode("aGVsbG8=").expect("urlsafe decode"),
+        "hello"
+    );
+    assert_eq!(sifr_stdlib::base64::b32encode("foo"), "MZXW6===");
+    assert_eq!(
+        sifr_stdlib::base64::b32decode("mzxw6===").expect("base32 casefold"),
+        "foo"
+    );
+    assert_eq!(sifr_stdlib::base64::b32hexencode("foo"), "CPNMU===");
+    assert_eq!(
+        sifr_stdlib::base64::b32hexdecode("cpnmu===").expect("base32hex casefold"),
+        "foo"
+    );
+    assert!(sifr_stdlib::base64::b32decode("@").is_err());
+    assert_eq!(sifr_stdlib::base64::feature_name(), "base64");
+}
+
 #[cfg(feature = "runtime-observability")]
 #[test]
 fn runtime_observability_emits_diagnostic_without_subscriber() {

--- a/crates/sifr_stdlib_model/src/features/generated_stdlib_features.rs
+++ b/crates/sifr_stdlib_model/src/features/generated_stdlib_features.rs
@@ -47,7 +47,7 @@ fn features_for_module(module_name: &str) -> &'static [&'static str] {
         "sifr.signal" | "_sifr.signal" => &["signals"],
         "sifr.runtime" | "_sifr.runtime" => &["runtime-observability"],
         "sifr.random" => &["random"],
-        "_sifr.crypto" => &["hash", "random"],
+        "_sifr.crypto" => &["base64", "hash", "random"],
         "sifr.time" | "sifr.datetime" | "_sifr.time" | "_sifr.datetime" => &["time"],
         "sifr.encoding" | "_sifr.encoding" => &["encoding"],
         _ => &[],

--- a/crates/sifr_stdlib_model/src/features_tests.rs
+++ b/crates/sifr_stdlib_model/src/features_tests.rs
@@ -205,6 +205,11 @@ fn planned_sysroot_stdlib_features_are_minimal_for_representative_modules() {
             &["hash"][..],
             &["json", "regex", "http", "python"][..],
         ),
+        (
+            "sifr.base64",
+            &["base64"][..],
+            &["json", "regex", "http", "python"][..],
+        ),
     ];
 
     for (module, expected, must_not_include) in cases {

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -393,16 +393,18 @@ crate behind the same feature names.
 
 Current migrated leaves include the stateless `_sifr.platform`, `_sifr.html`,
 `_sifr.calendar`, `_sifr.uuid`, and `_sifr.math` private declaration modules,
-plus the hash helper subset of the shared `_sifr.crypto` private module used by
-`sifr.hashlib`. Their public wrappers continue to live in
+plus the hash helper subset and infallible base encoding encoder subset of the
+shared `_sifr.crypto` private module used by `sifr.hashlib` and `sifr.base64`.
+Their public wrappers continue to live in
 `stdlib/sifr/platform.sifr`, `stdlib/sifr/html.sifr`,
 `stdlib/sifr/calendar.sifr`, `stdlib/sifr/uuid.sifr`,
-`stdlib/sifr/math.sifr`, and `stdlib/sifr/hashlib.sifr`, while generated code
-emits the private preamble functions and calls `sifr_stdlib::platform::*`,
-`sifr_stdlib::html::*`, `sifr_stdlib::calendar::*`,
-`sifr_stdlib::uuid::*`, `sifr_stdlib::math::*`, and
-`sifr_stdlib::hash::*` through feature-gated sysroot dependencies. Direct Rust
-interop wrappers bridge Sifr `int` values through
+`stdlib/sifr/math.sifr`, `stdlib/sifr/hashlib.sifr`, and
+`stdlib/sifr/base64.sifr`, while generated code emits the private preamble
+functions and calls `sifr_stdlib::platform::*`, `sifr_stdlib::html::*`,
+`sifr_stdlib::calendar::*`, `sifr_stdlib::uuid::*`,
+`sifr_stdlib::math::*`, `sifr_stdlib::hash::*`, and
+`sifr_stdlib::base64::*` through feature-gated sysroot dependencies. Direct
+Rust interop wrappers bridge Sifr `int` values through
 `sifr_runtime::interop::SifrIntBridge` at this boundary, including `list[int]`
 calendar returns. Public math aggregate helpers such as `dist`, `fsum`, and
 `sumprod` keep read-only list parameters in `stdlib/sifr/math.sifr` and copy
@@ -411,9 +413,12 @@ does not leak into the public API. `stdlib/sifr/hashlib.sifr` uses the same
 boundary pattern for string and bytes helpers: public `sha*`, `md5`, and
 `blake2*` functions wrap private underscored aliases imported from
 `_sifr.crypto`, keeping borrowed Rust interop parameters out of public generated
-call sites. During the incremental `_sifr.crypto` migration, base64/base32 and
-random helpers still use compiler intrinsic fallback declarations for names not
-supplied by the compiled private module.
+call sites. `stdlib/sifr/base64.sifr` uses the same pattern for infallible
+base64, URL-safe base64, base32, and base32hex encoders. Fallible
+base64/base32 decode and option helpers still use compiler intrinsic fallback
+declarations until the typed error bridge standardizes conversion for
+`Result[..., ParseError]`; random helpers also remain on intrinsic fallback
+until their stateful surface is migrated.
 
 When sysroot Rust interop activates native-link evidence validation in a
 generated project that also embeds Python, the selected packaged Python runtime

--- a/internal_docs/stdlib_native_surface_ownership.toml
+++ b/internal_docs/stdlib_native_surface_ownership.toml
@@ -21,7 +21,7 @@ deletion_stage = "stateless-native-leaf migration"
 [[surface]]
 id = "_sifr.crypto"
 public_modules = ["sifr.base64", "sifr.hashlib", "sifr.random", "sifr.secrets", "sifr.tempfile"]
-current_owner = "mixed: hash helpers via crates/sifr_stdlib private declarations; base64/base32/random helpers still use compiler intrinsic fallback plus direct generated dependencies"
+current_owner = "mixed: hash helpers and infallible base64/base32 encoders via crates/sifr_stdlib private declarations; fallible base64/base32 decode/options and random helpers still use compiler intrinsic fallback plus direct generated dependencies"
 final_owner = "crates/sifr_stdlib for base encodings, hash, UUID/random-facing helpers; crates/sifr_runtime only for language/runtime state that remains shared"
 reason = "Stateless encodings and hashes are stdlib leaves; random module state requires explicit retained or migrated ownership."
 certification_state = "mixed-stateless-supported-resource-state-needs-review"

--- a/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
+++ b/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
@@ -18,7 +18,7 @@ In progress.
 | M7. LSP and Tooling Sysroot Source/Navigation Integration | completed, merged | Merged in [PR #2754](https://github.com/sifr-lang/sifr/pull/2754). Sysroot public/private stdlib files now flow into frontend source maps with source origins, analysis/LSP overlay hosts consume sysroot tooling sources, the stdlib symbol bucket is populated from parser-backed installed public sources, public stdlib import/call-site definitions route to installed sysroot URIs, and public stdlib implementation files can navigate to private declaration files without exposing `_sifr` declarations to user completion. Opus review pass 3 was satisfied after splitting proactive sysroot diagnostics and generated/synthetic origin production to M7b; local `scripts/run_all_tests.sh --profile create-pr` passed with only the warm wall-time advisory. |
 | M7b. Tooling Sysroot Diagnostics and Synthetic Origins | completed, merged | Merged in [PR #2755](https://github.com/sifr-lang/sifr/pull/2755). Tooling sysroot probes now feed proactive LSP diagnostics and structured `sifr/sysroot` broken/mismatch responses with observed paths; development LSP/CLI root and toolchain comparison coverage verifies local build parity; generated Rust preview metadata now carries production `GeneratedSupport` and `CompilerSynthetic` source-map entries from real compiler output. Opus review pass 2 was satisfied; local `scripts/run_all_tests.sh --profile create-pr` passed with only the warm wall-time advisory. |
 | M8. Rust Interop Context for Private Stdlib Declarations | completed, merged | Merged in [PR #2756](https://github.com/sifr-lang/sifr/pull/2756). The branch adds a compiler-owned synthetic package context for private `_sifr` Rust interop declarations, resolves private targets only to canonical sysroot `sifr_stdlib`/`sifr_runtime` crates, applies sysroot trust without extending trust to user packages, keeps sysroot interop in sysroot-only vendor mode, and routes probes through sysroot runtime/vendor inputs. Opus review pass 2 is satisfied after hardening merged user+sysroot context validation and sysroot interop dependency-plan cache fingerprints; local `scripts/run_all_tests.sh --profile create-pr` passed with only the warm wall-time advisory. |
-| M9-M13 | in progress | M9 wave 1 merged in [PR #2757](https://github.com/sifr-lang/sifr/pull/2757), migrating `_sifr.platform` and `_sifr.html` to private Rust interop declarations backed by `sifr_stdlib` features. M9 wave 2 merged in [PR #2759](https://github.com/sifr-lang/sifr/pull/2759), migrating `_sifr.calendar` the same way. M9 wave 3 merged in [PR #2761](https://github.com/sifr-lang/sifr/pull/2761), migrating `_sifr.uuid` the same way. M9 wave 4 merged in [PR #2763](https://github.com/sifr-lang/sifr/pull/2763), migrating `_sifr.math` the same way. M9 wave 5 merged in [PR #2765](https://github.com/sifr-lang/sifr/pull/2765), migrating `_sifr.crypto` hash functions used by `sifr.hashlib` while retaining intrinsic fallback for unmigrated crypto helpers. Remaining M9 stateless leaves continue in follow-up waves. |
+| M9-M13 | in progress | M9 wave 1 merged in [PR #2757](https://github.com/sifr-lang/sifr/pull/2757), migrating `_sifr.platform` and `_sifr.html` to private Rust interop declarations backed by `sifr_stdlib` features. M9 wave 2 merged in [PR #2759](https://github.com/sifr-lang/sifr/pull/2759), migrating `_sifr.calendar` the same way. M9 wave 3 merged in [PR #2761](https://github.com/sifr-lang/sifr/pull/2761), migrating `_sifr.uuid` the same way. M9 wave 4 merged in [PR #2763](https://github.com/sifr-lang/sifr/pull/2763), migrating `_sifr.math` the same way. M9 wave 5 merged in [PR #2765](https://github.com/sifr-lang/sifr/pull/2765), migrating `_sifr.crypto` hash functions used by `sifr.hashlib` while retaining intrinsic fallback for unmigrated crypto helpers. M9 wave 6 is locally validated for PR, migrating infallible base64/base32 encoders while explicitly deferring fallible decode/options to M10. Remaining M9 stateless leaves continue in follow-up waves. |
 
 ## PR Log
 
@@ -618,7 +618,9 @@ migrated `html`/`platform` modules.
 Tasks:
 
 - Move math leaves to private declarations backed by `sifr_stdlib`. (wave 4 complete)
-- Move base64/base32, hash, regex, and TOML leaves. (hash wave 5 in local review)
+- Move base64/base32, hash, regex, and TOML leaves. (hash wave 5 complete;
+  base64/base32 encoder wave 6 locally validated; fallible base64/base32
+  decode/options, regex, and TOML are deferred to the M10 typed error bridge)
 - Move UUID leaf. (wave 3 complete)
 - Move calendar leaf. (wave 2 complete)
 - Move HTML and platform leaves. (wave 1 complete)
@@ -847,6 +849,53 @@ Wave 5 implementation evidence:
   `_sifr.crypto` fallback behavior.
 - Local create-pr validation passed with zero failures:
   `CARGO_TARGET_DIR=target/m9-hash-create-pr CARGO_BUILD_JOBS=1 scripts/run_all_tests.sh --profile create-pr`.
+  The run reported the warm wall-time advisory only.
+
+Wave 6 status: the infallible base64/base32 encoder subset of
+`_sifr.crypto` is migrated to private `@rust(sifr_stdlib.base64.*)`
+declarations backed by the narrow `base64` feature in `sifr_stdlib`. The
+active compiler intrinsic registry no longer owns `base64_encode`,
+`base64_encode_bytes`, `urlsafe_b64encode`, `urlsafe_b64encode_bytes`,
+`b32encode`, or `b32hexencode`. Fallible base64/base32 decode and option
+helpers still use compiler intrinsic fallback declarations until M10
+standardizes bridge error conversion for `Result[..., ParseError]`.
+
+Wave 6 implementation evidence:
+
+- `stdlib/_sifr/crypto.sifr` declares private
+  `@rust(sifr_stdlib.base64.*)` leaves for the infallible base64, URL-safe
+  base64, base32, and base32hex encoders.
+- `stdlib/sifr/base64.sifr` wraps migrated encoder imports with private
+  underscored aliases such as `_base64_encode_impl`, while re-exporting
+  fallback decoder/option helpers under their original names so active
+  intrinsic dispatch still owns the fallible API surface.
+- `crates/sifr_stdlib/src/base64.rs` owns the migrated encoder behavior behind
+  the `base64` Cargo feature and carries parity coverage for the full Rust
+  helper module, including decode/error helpers that remain inactive at the
+  Sifr interop boundary until M10.
+- `sifr_codegen` no longer registers the migrated encoder names in active
+  intrinsic dispatch; registry tests assert decoder/option names remain
+  fallback intrinsics with M10 rationale.
+- The e2e fixture harness enables the `base64` feature for fixtures that import
+  `sifr.base64` or `_sifr.crypto`, while preserving the direct `base64` crate
+  dependency required by fallback decode/option lowering during the partial
+  migration.
+- Focused validation passed:
+  `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr_stdlib --features base64 --locked`;
+  `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr_codegen base_encoding_intrinsics_are_owned_by_compiled_stdlib_declarations --locked`;
+  `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr_driver crypto_hash_private_declarations_codegen_through_sifr_stdlib --locked`;
+  `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr_stdlib_model planned_sysroot_stdlib_features_are_minimal_for_representative_modules --locked`;
+  `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr_stdlib_model stateless_sysroot_leaves_do_not_emit_direct_third_party_dependencies --locked`;
+  `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr test_generate_cargo_toml_stateless_sysroot_modules_enable_stdlib_features --locked`;
+  `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cpython_base64_rfc4648_vectors.sifr`;
+  `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cpython_base64_strictness_subset.sifr`;
+  `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/base64_bytes_decode_errors.sifr`.
+- Opus review pass 5 returned `VERDICT: PASS` for the base64/base32 encoder
+  migration boundary, including the M10 deferral for fallible decode/option
+  helpers and the temporary direct `base64` dependency retained for fallback
+  lowering.
+- Local create-pr validation passed with zero failures:
+  `CARGO_TARGET_DIR=target/m9-base-encoding-create-pr CARGO_BUILD_JOBS=1 scripts/run_all_tests.sh --profile create-pr`.
   The run reported the warm wall-time advisory only.
 
 Acceptance:

--- a/plans/reviews/active/m9-base-encoding-opus-review-pass5.md
+++ b/plans/reviews/active/m9-base-encoding-opus-review-pass5.md
@@ -1,0 +1,11 @@
+Both pass4 blockers are resolved and the described delta matches the working tree:
+
+- `base32_fallback.rs` / `base64_fallback.rs` are absent from `crates/sifr_codegen/src/intrinsics/registry/` and no source references them (`grep` is empty).
+- `crates/sifr_codegen/src/intrinsics/rust_interop_probe.rs` has no diff against HEAD.
+- `registry.rs` (lines 737–762) dispatches only the fallible names (`base64_decode`, `base64_decode_bytes`, `base64_encode_opts`, `base64_decode_opts`, `urlsafe_b64decode`, `urlsafe_b64decode_bytes`, `b32decode`, `b32hexdecode`) via the original `base32::`/`base64::` modules. Infallible encoders are gone from active lowering.
+- `stdlib/_sifr/crypto.sifr` declares the six encoders as `@rust(sifr_stdlib.base64.*)`; `stdlib/sifr/base64.sifr` imports them and re-exports public encoders plus CPython-compat aliases.
+- `sifr_stdlib::base64` implements the encoder/decoder leaf; `_sifr.crypto` manifest adds the `base64` feature; tests assert: (a) the six encoder names lower to `None` while the eight fallible names still lower to `Some` (`registry_extended_tests.rs`); (b) generated private code calls `sifr_stdlib::base64::*encode*` but not `sifr_stdlib::base64::*decode*` (`stateless_private_codegen_tests.rs`); (c) RFC vectors and error paths covered in `api_behavior.rs`.
+
+No new blocker introduced.
+
+VERDICT: PASS

--- a/stdlib/_sifr/crypto.sifr
+++ b/stdlib/_sifr/crypto.sifr
@@ -1,6 +1,30 @@
 # Private _sifr.crypto native declaration module.
-# Random and base encoding helpers still use compiler intrinsics during the
-# incremental stateless-leaf migration.
+# Random helpers and fallible base encoding helpers still use compiler
+# intrinsics during the incremental stateless-leaf migration.
+
+@rust(sifr_stdlib.base64.base64_encode, panic=trusted_no_panic)
+def base64_encode(s: str) -> str:
+    return ""
+
+@rust(sifr_stdlib.base64.base64_encode_bytes, panic=trusted_no_panic)
+def base64_encode_bytes(data: bytes) -> bytes:
+    return b""
+
+@rust(sifr_stdlib.base64.urlsafe_b64encode, panic=trusted_no_panic)
+def urlsafe_b64encode(s: str) -> str:
+    return ""
+
+@rust(sifr_stdlib.base64.urlsafe_b64encode_bytes, panic=trusted_no_panic)
+def urlsafe_b64encode_bytes(data: bytes) -> bytes:
+    return b""
+
+@rust(sifr_stdlib.base64.b32encode, panic=trusted_no_panic)
+def b32encode(s: str) -> str:
+    return ""
+
+@rust(sifr_stdlib.base64.b32hexencode, panic=trusted_no_panic)
+def b32hexencode(s: str) -> str:
+    return ""
 
 @rust(sifr_stdlib.hash.sha256, panic=trusted_no_panic)
 def sha256(s: str) -> str:

--- a/stdlib/sifr/base64.sifr
+++ b/stdlib/sifr/base64.sifr
@@ -1,11 +1,35 @@
 # sifr.base64 — Base64 encoding/decoding (renamed from sifr.encoding)
+from _sifr.crypto import base64_encode as _base64_encode_impl
+from _sifr.crypto import base64_encode_bytes as _base64_encode_bytes_impl
+from _sifr.crypto import urlsafe_b64encode as _urlsafe_b64encode_impl
+from _sifr.crypto import urlsafe_b64encode_bytes as _urlsafe_b64encode_bytes_impl
+from _sifr.crypto import b32encode as _b32encode_impl
+from _sifr.crypto import b32hexencode as _b32hexencode_impl
 from _sifr.crypto import (
-    base64_encode, base64_decode, base64_encode_opts, base64_decode_opts,
-    base64_encode_bytes, base64_decode_bytes,
-    urlsafe_b64encode, urlsafe_b64decode, urlsafe_b64encode_bytes, urlsafe_b64decode_bytes,
-    b32encode, b32decode, b32hexencode, b32hexdecode
+    base64_decode, base64_encode_opts, base64_decode_opts,
+    base64_decode_bytes,
+    urlsafe_b64decode, urlsafe_b64decode_bytes,
+    b32decode, b32hexdecode
 )
 from sifr.bytes import encode_utf8, decode_utf8, bytes_to_hex, bytes_from_hex
+
+def base64_encode(s: str) -> str:
+    return _base64_encode_impl(s)
+
+def base64_encode_bytes(data: bytes) -> bytes:
+    return _base64_encode_bytes_impl(data)
+
+def urlsafe_b64encode(s: str) -> str:
+    return _urlsafe_b64encode_impl(s)
+
+def urlsafe_b64encode_bytes(data: bytes) -> bytes:
+    return _urlsafe_b64encode_bytes_impl(data)
+
+def b32encode(s: str) -> str:
+    return _b32encode_impl(s)
+
+def b32hexencode(s: str) -> str:
+    return _b32hexencode_impl(s)
 
 # CPython-compatible aliases
 def b64encode(s: str) -> str:


### PR DESCRIPTION
## Summary
- migrate infallible base64/base32 encoder helpers to private `_sifr.crypto` Rust interop declarations backed by `sifr_stdlib::base64`
- keep fallible decode/options on compiler intrinsic fallback until typed error bridge work
- update sysroot feature/dependency planning, docs, and review evidence for the partial base-encoding boundary

## Validation
- `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr_stdlib --features base64 --locked`
- `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr_codegen base_encoding_intrinsics_are_owned_by_compiled_stdlib_declarations --locked`
- `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr_driver crypto_hash_private_declarations_codegen_through_sifr_stdlib --locked`
- `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr_stdlib_model planned_sysroot_stdlib_features_are_minimal_for_representative_modules --locked`
- `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr_stdlib_model stateless_sysroot_leaves_do_not_emit_direct_third_party_dependencies --locked`
- `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo test -p sifr test_generate_cargo_toml_stateless_sysroot_modules_enable_stdlib_features --locked`
- `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cpython_base64_rfc4648_vectors.sifr`
- `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cpython_base64_strictness_subset.sifr`
- `CARGO_TARGET_DIR=target/m9-base-encoding CARGO_BUILD_JOBS=1 cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/base64_bytes_decode_errors.sifr`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`
- `CARGO_TARGET_DIR=target/m9-base-encoding-create-pr CARGO_BUILD_JOBS=1 scripts/run_all_tests.sh --profile create-pr` (passed with warm wall-time advisory)

## Review
- Opus review pass 5: `VERDICT: PASS`
