### PR TITLE
Add sysroot stdlib resource certification gate

### DIFF
--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -142,6 +142,11 @@ trust.
 Resource, async, callback, and runtime-state surfaces stay behind the active
 Rust interop runtime certification gate until their lifecycle behavior is
 executable evidence, not just adapter code.
+`scripts/check_sysroot_stdlib_resource_certification_gate.py` enforces this
+boundary during validation by comparing
+`internal_docs/stdlib_native_surface_ownership.toml` with the Rust interop
+compatibility matrix. A resource-sensitive stdlib surface cannot be marked
+movable while its required matrix rows remain `future-owned-by-separate-phase`.
 
 ## Installed Layout
 
@@ -730,6 +735,9 @@ through private declarations and Rust interop.
 Runtime/resource/callback surfaces follow the Rust interop certification gate.
 Surfaces still marked future-owned or uncertified in the compatibility matrix
 must not be claimed as stable stdlib interop support.
+The sysroot stdlib resource certification gate is part of core validation so
+resource migration cannot advance a resource-shaped surface ahead of the
+runtime evidence recorded by the Rust interop matrix.
 
 Private stdlib Rust interop uses the normal Rust interop contract plus a
 compiler-owned sysroot trust policy. That trust does not extend to arbitrary

--- a/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
+++ b/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
@@ -23,7 +23,8 @@ In progress.
 
 Current local wave: M11 certification-gate audit. Local implementation, Opus
 review, and create-pr validation are complete on
-`m11-resource-certification-gate`; PR publication is next.
+`m11-resource-certification-gate`; [PR #2793](https://github.com/sifr-lang/sifr/pull/2793)
+is open.
 Runtime/resource/callback surfaces remain compiler-owned or explicitly
 deferred while their Rust interop compatibility rows are still future-owned by
 `plans/issues/active/rust-interop-runtime-ecosystem-certification.md`.
@@ -58,7 +59,7 @@ deferred while their Rust interop compatibility rows are still future-owned by
 - M10 wave 10 datetime interop migration: merged in [PR #2787](https://github.com/sifr-lang/sifr/pull/2787).
 - M10 wave 11 bytes helper interop split: merged in [PR #2789](https://github.com/sifr-lang/sifr/pull/2789).
 - M10 wave 12 collections helper interop split: merged in [PR #2791](https://github.com/sifr-lang/sifr/pull/2791).
-- M11 certification-gate audit: local implementation/review/create-pr validation complete on `m11-resource-certification-gate`; PR publication is next.
+- M11 certification-gate audit: opened [PR #2793](https://github.com/sifr-lang/sifr/pull/2793) after local implementation, Opus review, and create-pr validation passed.
 
 ## Design Reference
 
@@ -1851,8 +1852,8 @@ Validation:
 - Per-family compatibility matrix updates before each submilestone closes.
 
 M11 gate audit status: local implementation, Opus review, and create-pr
-validation complete on `m11-resource-certification-gate`; PR publication is
-next.
+validation complete on `m11-resource-certification-gate`;
+[PR #2793](https://github.com/sifr-lang/sifr/pull/2793) is open.
 
 The M11 resource submilestones are not safe to migrate yet. The Rust interop
 compatibility matrix still marks `opaque_resource_matrix`,

--- a/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
+++ b/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
@@ -21,10 +21,12 @@ In progress.
 | M9-M13 | in progress | M9 wave 1 merged in [PR #2757](https://github.com/sifr-lang/sifr/pull/2757), migrating `_sifr.platform` and `_sifr.html` to private Rust interop declarations backed by `sifr_stdlib` features. M9 wave 2 merged in [PR #2759](https://github.com/sifr-lang/sifr/pull/2759), migrating `_sifr.calendar` the same way. M9 wave 3 merged in [PR #2761](https://github.com/sifr-lang/sifr/pull/2761), migrating `_sifr.uuid` the same way. M9 wave 4 merged in [PR #2763](https://github.com/sifr-lang/sifr/pull/2763), migrating `_sifr.math` the same way. M9 wave 5 merged in [PR #2765](https://github.com/sifr-lang/sifr/pull/2765), migrating `_sifr.crypto` hash functions used by `sifr.hashlib` while retaining intrinsic fallback for unmigrated crypto helpers. M9 wave 6 merged in [PR #2767](https://github.com/sifr-lang/sifr/pull/2767), migrating infallible base64/base32 encoders while explicitly deferring fallible decode/options to M10. M10 wave 1 merged in [PR #2769](https://github.com/sifr-lang/sifr/pull/2769), migrating fallible base64/base32 decode/options through typed result-error direct interop. M10 wave 2 merged in [PR #2771](https://github.com/sifr-lang/sifr/pull/2771), migrating `_sifr.regex`/`sifr.re` through private Rust interop backed by `sifr_stdlib::regex` while retaining the separate direct regex dependency for `sifr.pathlib` glob lowering. M10 wave 3 merged in [PR #2776](https://github.com/sifr-lang/sifr/pull/2776), migrating `_sifr.url`/`sifr.url` through private Rust interop backed by `sifr_stdlib::url`. M10 wave 4 merged in [PR #2778](https://github.com/sifr-lang/sifr/pull/2778), migrating `_sifr.toml`/`sifr.tomllib` through private Rust interop backed by `sifr_stdlib::toml`. M10 wave 5 merged in [PR #2780](https://github.com/sifr-lang/sifr/pull/2780), migrating `_sifr.json`/`sifr.json` through private Rust interop backed by `sifr_stdlib::json` token adapters while preserving `JSONDecodeError` location fields and JSON integer profile errors. M10 wave 6 merged in [PR #2781](https://github.com/sifr-lang/sifr/pull/2781), migrating `_sifr.encoding`/`sifr.encoding` through private Rust interop backed by `sifr_stdlib::encoding` while preserving public `DecodeError`/`EncodeError` wrappers. M10 wave 7 merged in [PR #2782](https://github.com/sifr-lang/sifr/pull/2782), migrating `_sifr.unicode`/`sifr.unicode` through private Rust interop backed by `sifr_stdlib::unicode` while preserving public `UnicodeDataError` wrappers and Unicode segmentation tuple payloads. M10 wave 8 merged in [PR #2784](https://github.com/sifr-lang/sifr/pull/2784), migrating `_sifr.i18n`/`sifr.i18n` through private Rust interop backed by `sifr_stdlib::i18n` while preserving public i18n error wrappers. M10 wave 9 merged in [PR #2785](https://github.com/sifr-lang/sifr/pull/2785), migrating `_sifr.compress`/`sifr.gzip`/`sifr.zipfile` through private Rust interop backed by `sifr_stdlib` gzip and zipfile adapters. M10 wave 10 merged in [PR #2787](https://github.com/sifr-lang/sifr/pull/2787), migrating `_sifr.datetime` through private Rust interop backed by the `sifr_stdlib` time feature and fixing grouped E2E fixture planning for datetime/compression stdlib features. M10 wave 11 merged in [PR #2789](https://github.com/sifr-lang/sifr/pull/2789), splitting `_sifr.bytes` so `encode_utf8` and `bytes_to_hex` move to private `sifr_stdlib::bytes` adapters while first-class bytes constructors, hex parsing, strict hex formatting, and encode/decode method glue remain compiler-owned. M10 wave 12 merged in [PR #2791](https://github.com/sifr-lang/sifr/pull/2791), splitting `_sifr.collections` so set helpers and legacy JSON-string `defaultdict_*` helpers move to private `sifr_stdlib::collections` adapters while Counter/defaultdict language glue and core collection behavior remain compiler-owned. |
 | Post-M10 Adapter Policy Adherence Audit | completed, merged | Merged in [PR #2774](https://github.com/sifr-lang/sifr/pull/2774). The audit classified completed M9/M10 private bindings, added executable guards for direct `sifr_stdlib` targets and trust separation, documented residual `_sifr.crypto` random scope, and passed Opus review pass 2 plus local `scripts/run_all_tests.sh --profile create-pr` with only the warm wall-time advisory. |
 
-Latest merged wave: M10 wave 12 split `_sifr.collections` helper leaves so set
-helpers and legacy JSON-string `defaultdict_*` helpers move to private
-`sifr_stdlib::collections` adapters while Counter/defaultdict language glue and
-core collection behavior remain compiler-owned.
+Current local wave: M11 certification-gate audit. Local implementation, Opus
+review, and create-pr validation are complete on
+`m11-resource-certification-gate`; PR publication is next.
+Runtime/resource/callback surfaces remain compiler-owned or explicitly
+deferred while their Rust interop compatibility rows are still future-owned by
+`plans/issues/active/rust-interop-runtime-ecosystem-certification.md`.
 
 ## PR Log
 
@@ -56,6 +58,7 @@ core collection behavior remain compiler-owned.
 - M10 wave 10 datetime interop migration: merged in [PR #2787](https://github.com/sifr-lang/sifr/pull/2787).
 - M10 wave 11 bytes helper interop split: merged in [PR #2789](https://github.com/sifr-lang/sifr/pull/2789).
 - M10 wave 12 collections helper interop split: merged in [PR #2791](https://github.com/sifr-lang/sifr/pull/2791).
+- M11 certification-gate audit: local implementation/review/create-pr validation complete on `m11-resource-certification-gate`; PR publication is next.
 
 ## Design Reference
 
@@ -1846,6 +1849,57 @@ Validation:
 - Leak/close/error-path fixtures for file, process, net, TLS, HTTP, and Python
   object handles.
 - Per-family compatibility matrix updates before each submilestone closes.
+
+M11 gate audit status: local implementation, Opus review, and create-pr
+validation complete on `m11-resource-certification-gate`; PR publication is
+next.
+
+The M11 resource submilestones are not safe to migrate yet. The Rust interop
+compatibility matrix still marks `opaque_resource_matrix`,
+`async_runtime_reqwest`, `callbacks_call_scoped`, and
+`callback_subscription_matrix` as `future-owned-by-separate-phase`, with
+positive or negative executable evidence still planned. Those rows are owned by
+`plans/issues/active/rust-interop-runtime-ecosystem-certification.md`.
+
+M11 gate audit implementation evidence:
+
+- `scripts/check_sysroot_stdlib_resource_certification_gate.py` compares
+  `internal_docs/stdlib_native_surface_ownership.toml` against
+  `verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json`
+  and fails if an M11 resource-sensitive stdlib surface is marked movable while
+  its required matrix rows remain future-owned.
+- The guard covers `_sifr.crypto`, `_sifr.time`, `_sifr.logging`, `_sifr.fs`,
+  `_sifr.process`, `_sifr.sys`, `_sifr.signal`, `_sifr.net`, `_sifr.tls`,
+  `_sifr.http`, and `_sifr.python`.
+- `verification/runner/sifr_verify/profile_runner.py` runs the guard as part
+  of the core guardrails used by `scripts/run_all_tests.sh --profile create-pr`.
+- `verification/policy/guardrails.json` records the guardrail in the policy
+  inventory.
+- Focused validation passed:
+  `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py`;
+  `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py --self-test`;
+  `uv run --project verification --locked python -m sifr_verify areas run --area rust_interop --suite matrix`;
+  `python3 scripts/check_hir_maintainability_guardrails.py`;
+  `python3 scripts/check_file_size_guardrails.py`;
+  `git diff --check`.
+- Opus review pass 1 and pass 2 returned `VERDICT: PASS` with no required
+  fixes. Pass 2 left only cosmetic/non-blocking suggestions; the script now
+  includes the blank-line cleanup noted there.
+- The first full create-pr attempt caught delivery-plan taxonomy wording in
+  durable docs/scripts. The script and architecture prose now use
+  lifecycle-neutral "resource certification" wording outside the issue plan,
+  and the coverage-matrix readiness check passed after that fix.
+- Local create-pr validation passed with zero failures:
+  `SIFR_LSP_COMMAND="$(pwd)/target/m10-collections-create-pr/debug/sifr lsp --stdio" CARGO_TARGET_DIR=target/m10-collections-create-pr CARGO_BUILD_JOBS=1 scripts/run_all_tests.sh --profile create-pr`.
+  The lane wrote `target/validation_lane_reports/create-pr.latest.json`;
+  profile `create-pr`, real time `8992.08s`, CPU `5870.36s`, max RSS
+  `698.1MiB`, hardening `variants=6 failures=0 blocking_failures=0`, e2e
+  pass suite `132 passed, 0 failed`, and only the warm wall-time advisory was
+  reported. The slowest lane step was `python_interop` at `3737804ms`; the
+  slowest recorded cases were `python_interop:library-examples` at `2313688ms`,
+  `generated_code_quality:smoke/determinism` at `1420088ms`, and
+  `runtime_platform:platform-golden/locale_host_limited_formatting.sifr` at
+  `383799ms`.
 
 ### M12. Preamble and Intrinsic Registry Deletion
 

--- a/plans/reviews/active/m11-resource-certification-gate-review-pass1.md
+++ b/plans/reviews/active/m11-resource-certification-gate-review-pass1.md
@@ -1,0 +1,25 @@
+I have gathered enough context to finalize the review.
+
+VERDICT: PASS
+
+The gate correctly enforces the intended invariant: M11 resource-sensitive surfaces cannot be flipped to movable while their required Rust interop matrix rows are still `future-owned-by-separate-phase`. It reads the correct two sources of truth (`internal_docs/stdlib_native_surface_ownership.toml` + `verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json`), and is wired into `run_core_guardrails` at `verification/runner/sifr_verify/profile_runner.py:289-290`, so `create-pr` and `merge` (both legacy-facade profiles) will execute it — not just list it. The docs explicitly defer migration ("cannot advance a resource-shaped surface ahead of the runtime evidence") and never claim resource support. The self-refreshing backstop at `scripts/check_sysroot_stdlib_resource_certification_gate.py:90-99` correctly forces this guard to be revisited when the last future-owned row lands.
+
+Row mapping cross-check against the ownership registry: every entry the guard flags (`_sifr.crypto`, `_sifr.time`, `_sifr.logging`, `_sifr.fs`, `_sifr.process`, `_sifr.sys`, `_sifr.signal`, `_sifr.net`, `_sifr.tls`, `_sifr.http`, `_sifr.python`) has `can_move_before_runtime_certification = false` and a `certification_state` that matches one of the three accepted prefixes (`future-owned-by-runtime-resource-certification` / `mixed-` / `retained-compiler-language-glue`). A flip to `true` or a `certification_state = can-move-before-runtime-certification` or `migration_blocker = "none"` on any of these rows produces a failure — verified by walking the logic against each surface.
+
+`verification/policy/guardrails.json` is a documentation registry that is not actually consumed by the profile runner today, but the guard runs via explicit invocation in `profile_runner.py`, so this is fine and matches the pattern of the other guards.
+
+Non-blocking notes:
+
+1. **No self-test.** Sibling guards (e.g., `scripts/check_source_crate_dependency_direction.py`, `scripts/check_submodule_ownership.py`) support `--self-test`. Adding a small self-test that synthesizes an ownership/matrix pair to prove the "movable while future-owned" and "missing backstop row" failure paths would harden this against silent breakage from future schema changes.
+
+2. **Surface→row mapping is hard-coded Python.** If the compatibility matrix renames a row, `_matrix_category` fails loudly (good). But if the ownership TOML adds a new resource surface (e.g., a hypothetical `_sifr.database`), it will silently be uncovered. Consider driving `SURFACE_CERTIFICATION_ROWS` from a field in the ownership TOML (e.g., `required_matrix_rows = ["opaque_resource_matrix"]`) so the source of truth stays in one place.
+
+3. **`_sifr.runtime` / `_sifr.task` / `generated-runtime-integer-glue` are not in the guard.** They're `retained-compiler-language-glue` with `can_move_before_runtime_certification = false`, so today it doesn't matter — but the guard wouldn't catch a bad flip. Consider a companion check that "retained-compiler-language-glue must not be movable" independent of matrix state.
+
+4. **`mixed-` prefix is permissive.** `certification_state.startswith("mixed-")` accepts any string starting with `mixed-`. Currently fine because content is curated, but a small allowlist (`mixed-stateless-supported-resource-state-needs-review`, `mixed-stateless-supported-runtime-sensitive`, `mixed-stdlib-leaf-plus-runtime-sensitive`) would prevent typo-drift.
+
+5. **Duplicate error reporting.** If `opaque_resource_matrix` were missing from the matrix, `_matrix_category` appends a "missing row" failure once per surface that requires it (8 times). Cosmetic only.
+
+6. **`_sifr.python` does not require `async_runtime_reqwest`.** Python interop today is typically synchronous at the boundary and the ownership blocker doesn't mention async runtime, so this is defensible — but worth a sanity check with the certification owner if Python asyncio bridging is on the roadmap.
+
+No required fixes. The wave is ready to open a PR as-is.

--- a/plans/reviews/active/m11-resource-certification-gate-review-pass2.md
+++ b/plans/reviews/active/m11-resource-certification-gate-review-pass2.md
@@ -1,0 +1,31 @@
+Reviewed the hardening changes. The gate now:
+- Enforces the mixed-state allowlist by exact match (no more `startswith("mixed-")` typo drift).
+- Adds an explicit `RETAINED_COMPILER_GLUE_SURFACES` loop that requires `_sifr.runtime`, `_sifr.task`, and `generated-runtime-integer-glue` to keep `retained-compiler-language-glue` state and remain non-movable.
+- Ships a `--self-test` covering three failure paths: movable future-owned surface, movable retained compiler glue, missing future-owned backstop row.
+- Runs both the guard and `--self-test` inside `run_core_guardrails` in `profile_runner.py:289-291`, so `create-pr` and `merge` execute both.
+- Documents the guard in `verification/policy/guardrails.json` and in the architecture / issue tracking docs.
+
+Sanity checks I ran:
+- `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py` → PASS (surfaces=11, future_runtime_rows=11).
+- `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py --self-test` → PASS.
+- Cross-checked each of the three `MIXED_CERTIFICATION_STATES` against `stdlib_native_surface_ownership.toml`: `_sifr.crypto` → `mixed-stateless-supported-resource-state-needs-review`, `_sifr.time` → `mixed-stateless-supported-runtime-sensitive`, `_sifr.sys` → `mixed-stdlib-leaf-plus-runtime-sensitive`. All three states are in the allowlist and their rows still reference future-owned matrix ids — the invariant holds.
+- Confirmed the self-test's ordering assumptions: `surface[0]` = `_sifr.crypto` (first key of `SURFACE_CERTIFICATION_ROWS`) → triggers "must not be movable"; `surface[-1]` = `generated-runtime-integer-glue` (last entry of `RETAINED_COMPILER_GLUE_SURFACES`) → triggers "retained compiler glue must not be movable". Both assertions match their expected failure substrings.
+- Verified the retained-glue loop actually fails on a flip: it checks both `certification_state` drift and `can_move_before_runtime_certification` flip, independently of matrix state.
+
+---
+
+**VERDICT: PASS**
+
+Findings (none blocking):
+
+1. **cosmetic** — `scripts/check_sysroot_stdlib_resource_certification_gate.py:183-184` is missing the PEP 8 blank line between `_matrix_category` and `_self_test`. Scripts aren't lint-gated in this repo, so it's cosmetic, but a blank line matches the rest of the file's style.
+
+2. **self-test coverage gap** — the self-test covers movable-flip on both surface classes and the backstop, but doesn't exercise: (a) the `MIXED_CERTIFICATION_STATES` allowlist rejecting a typo like `"mixed-typo"`, (b) empty/`"none"` `migration_blocker` while future-owned, (c) `certification_state` drift on retained glue (only the movable flip is tested). Adding those would make the self-test a fuller regression fence. Non-blocking.
+
+3. **argv parsing is exact-match** — `if sys.argv[1:] == ["--self-test"]` at line 240 means any typo (e.g., `--selftest` or `--self-test --verbose`) silently falls through to `main()`. Sibling scripts use `argparse`. Non-blocking cosmetic drift.
+
+4. **`SURFACE_CERTIFICATION_ROWS` is still hardcoded in Python** — carried over from pass 1 note #2. A new resource surface added to the ownership TOML is silently uncovered. Consider driving this from a `required_matrix_rows = [...]` field on each ownership entry in a follow-up. Non-blocking.
+
+5. **`guardrails.json` doesn't record the `--self-test` invocation** — the JSON registry only lists the primary entrypoint. Since the profile runner runs both explicitly and this file is a documentation registry (not consumed by the runner), this is documentation drift only. Non-blocking.
+
+**Required fixes: none.** The wave is ready to open a PR.

--- a/scripts/check_sysroot_stdlib_resource_certification_gate.py
+++ b/scripts/check_sysroot_stdlib_resource_certification_gate.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Guard stdlib resource migrations behind Rust interop certification."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OWNERSHIP_PATH = REPO_ROOT / "internal_docs" / "stdlib_native_surface_ownership.toml"
+MATRIX_PATH = (
+    REPO_ROOT
+    / "verification"
+    / "areas"
+    / "rust_interop"
+    / "data"
+    / "rust_interop_compatibility_matrix.json"
+)
+CERTIFICATION_ISSUE = "plans/issues/active/rust-interop-runtime-ecosystem-certification.md"
+FUTURE_OWNED = "future-owned-by-separate-phase"
+MIXED_CERTIFICATION_STATES = {
+    "mixed-stateless-supported-resource-state-needs-review",
+    "mixed-stateless-supported-runtime-sensitive",
+    "mixed-stdlib-leaf-plus-runtime-sensitive",
+}
+RETAINED_COMPILER_GLUE_SURFACES = (
+    "_sifr.runtime",
+    "_sifr.task",
+    "generated-runtime-integer-glue",
+)
+
+SURFACE_CERTIFICATION_ROWS: dict[str, tuple[str, ...]] = {
+    "_sifr.crypto": ("opaque_resource_matrix",),
+    "_sifr.time": ("async_runtime_reqwest",),
+    "_sifr.logging": ("callback_subscription_matrix",),
+    "_sifr.fs": ("opaque_resource_matrix",),
+    "_sifr.process": ("opaque_resource_matrix", "async_runtime_reqwest"),
+    "_sifr.sys": ("opaque_resource_matrix",),
+    "_sifr.signal": ("callback_subscription_matrix",),
+    "_sifr.net": ("opaque_resource_matrix", "async_runtime_reqwest"),
+    "_sifr.tls": ("opaque_resource_matrix", "async_runtime_reqwest"),
+    "_sifr.http": ("opaque_resource_matrix", "async_runtime_reqwest"),
+    "_sifr.python": (
+        "opaque_resource_matrix",
+        "callbacks_call_scoped",
+        "callback_subscription_matrix",
+    ),
+}
+
+
+def main() -> int:
+    ownership = tomllib.loads(OWNERSHIP_PATH.read_text(encoding="utf-8"))
+    matrix = json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+    return _run(ownership, matrix)
+
+
+def _run(ownership: dict[str, Any], matrix: dict[str, Any]) -> int:
+    failures = _validate(ownership, matrix)
+
+    if failures:
+        for failure in failures:
+            print(f"sysroot stdlib resource certification gate error: {failure}", file=sys.stderr)
+        return 1
+
+    future_runtime_rows = _future_runtime_rows(matrix)
+    print(
+        "sysroot stdlib resource certification gate: PASS "
+        f"(surfaces={len(SURFACE_CERTIFICATION_ROWS)}, future_runtime_rows={len(future_runtime_rows)})"
+    )
+    return 0
+
+
+def _validate(ownership: dict[str, Any], matrix: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    rows_by_id = _rows_by_id(failures, matrix)
+    surfaces_by_id = _surfaces_by_id(failures, ownership)
+
+    for surface_id, required_rows in SURFACE_CERTIFICATION_ROWS.items():
+        surface = surfaces_by_id.get(surface_id)
+        if surface is None:
+            failures.append(f"{surface_id}: missing native surface ownership entry")
+            continue
+
+        future_rows = [
+            row_id
+            for row_id in required_rows
+            if _matrix_category(failures, rows_by_id, row_id) == FUTURE_OWNED
+        ]
+        if not future_rows:
+            continue
+
+        if surface.get("can_move_before_runtime_certification") is not False:
+            failures.append(
+                f"{surface_id}: must not be movable while matrix rows remain future-owned: "
+                + ", ".join(future_rows)
+            )
+
+        state = str(surface.get("certification_state", ""))
+        if not (
+            state.startswith("future-owned-by-runtime-resource-certification")
+            or state in MIXED_CERTIFICATION_STATES
+            or state == "retained-compiler-language-glue"
+        ):
+            failures.append(
+                f"{surface_id}: certification_state must record runtime/resource retention "
+                f"while {', '.join(future_rows)} remain future-owned"
+            )
+
+        blocker = str(surface.get("migration_blocker", "")).strip().lower()
+        if not blocker or blocker == "none":
+            failures.append(
+                f"{surface_id}: migration_blocker must name the certification blocker "
+                f"while {', '.join(future_rows)} remain future-owned"
+            )
+
+    for surface_id in RETAINED_COMPILER_GLUE_SURFACES:
+        surface = surfaces_by_id.get(surface_id)
+        if surface is None:
+            failures.append(f"{surface_id}: missing retained compiler-language surface entry")
+            continue
+        if surface.get("certification_state") != "retained-compiler-language-glue":
+            failures.append(f"{surface_id}: retained compiler glue must keep retained certification_state")
+        if surface.get("can_move_before_runtime_certification") is not False:
+            failures.append(f"{surface_id}: retained compiler glue must not be movable before certification")
+
+    future_runtime_rows = _future_runtime_rows(matrix)
+    if not future_runtime_rows:
+        failures.append(
+            "expected at least one runtime/resource compatibility row to remain future-owned; "
+            "update this guard when resource certification lands"
+        )
+    return failures
+
+
+def _future_runtime_rows(matrix: dict[str, Any]) -> list[str]:
+    return [
+        row_id
+        for row_id, row in sorted(_rows_by_id([], matrix).items())
+        if row.get("category") == FUTURE_OWNED and row.get("future_owner") == CERTIFICATION_ISSUE
+    ]
+
+
+def _rows_by_id(failures: list[str], matrix: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    rows: dict[str, dict[str, Any]] = {}
+    for row in matrix.get("rows", []):
+        if not isinstance(row, dict):
+            failures.append("compatibility matrix rows must be objects")
+            continue
+        row_id = row.get("id")
+        if not isinstance(row_id, str) or not row_id:
+            failures.append("compatibility matrix row id is required")
+            continue
+        rows[row_id] = row
+    return rows
+
+
+def _surfaces_by_id(failures: list[str], ownership: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    surfaces: dict[str, dict[str, Any]] = {}
+    for surface in ownership.get("surface", []):
+        if not isinstance(surface, dict):
+            failures.append("native surface ownership entries must be objects")
+            continue
+        surface_id = surface.get("id")
+        if not isinstance(surface_id, str) or not surface_id:
+            failures.append("native surface ownership id is required")
+            continue
+        surfaces[surface_id] = surface
+    return surfaces
+
+
+def _matrix_category(
+    failures: list[str],
+    rows_by_id: dict[str, dict[str, Any]],
+    row_id: str,
+) -> str:
+    row = rows_by_id.get(row_id)
+    if row is None:
+        failures.append(f"{row_id}: missing Rust interop compatibility matrix row")
+        return ""
+    return str(row.get("category", ""))
+
+
+def _self_test() -> int:
+    base_ownership = {
+        "surface": [
+            {
+                "id": surface_id,
+                "certification_state": "future-owned-by-runtime-resource-certification",
+                "can_move_before_runtime_certification": False,
+                "migration_blocker": "certification evidence required",
+            }
+            for surface_id in SURFACE_CERTIFICATION_ROWS
+        ]
+        + [
+            {
+                "id": surface_id,
+                "certification_state": "retained-compiler-language-glue",
+                "can_move_before_runtime_certification": False,
+                "migration_blocker": "final retained allowlist decision",
+            }
+            for surface_id in RETAINED_COMPILER_GLUE_SURFACES
+        ]
+    }
+    base_matrix = {
+        "rows": [
+            {"id": row_id, "category": FUTURE_OWNED, "future_owner": CERTIFICATION_ISSUE}
+            for row_id in sorted({row for rows in SURFACE_CERTIFICATION_ROWS.values() for row in rows})
+        ]
+    }
+
+    if _validate(base_ownership, base_matrix):
+        print("self-test seed should pass", file=sys.stderr)
+        return 1
+
+    movable_ownership = json.loads(json.dumps(base_ownership))
+    movable_ownership["surface"][0]["can_move_before_runtime_certification"] = True
+    if not any("must not be movable" in failure for failure in _validate(movable_ownership, base_matrix)):
+        print("self-test movable future-owned surface was not rejected", file=sys.stderr)
+        return 1
+
+    retained_ownership = json.loads(json.dumps(base_ownership))
+    retained_ownership["surface"][-1]["can_move_before_runtime_certification"] = True
+    if not any(
+        "retained compiler glue must not be movable" in failure
+        for failure in _validate(retained_ownership, base_matrix)
+    ):
+        print("self-test movable retained compiler glue was not rejected", file=sys.stderr)
+        return 1
+
+    completed_matrix = json.loads(json.dumps(base_matrix))
+    for row in completed_matrix["rows"]:
+        row["category"] = "supported"
+    if not any(
+        "expected at least one runtime/resource compatibility row" in failure
+        for failure in _validate(base_ownership, completed_matrix)
+    ):
+        print("self-test missing future-owned backstop was not rejected", file=sys.stderr)
+        return 1
+
+    print("sysroot stdlib resource certification gate self-test: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--self-test"]:
+        raise SystemExit(_self_test())
+    raise SystemExit(main())

--- a/verification/policy/guardrails.json
+++ b/verification/policy/guardrails.json
@@ -42,6 +42,13 @@
       "args": [],
       "timeout_seconds": 60,
       "report": "stdout"
+    },
+    {
+      "name": "sysroot-stdlib-resource-certification-gate",
+      "entrypoint": "scripts/check_sysroot_stdlib_resource_certification_gate.py",
+      "args": [],
+      "timeout_seconds": 60,
+      "report": "stdout"
     }
   ]
 }

--- a/verification/runner/sifr_verify/profile_runner.py
+++ b/verification/runner/sifr_verify/profile_runner.py
@@ -286,6 +286,10 @@ class ProfileRunner:
         run_python("scripts/check_submodule_ownership.py")
         run_python("scripts/check_submodule_ownership.py", "--self-test")
 
+        print("Running sysroot stdlib resource certification gate")
+        run_python("scripts/check_sysroot_stdlib_resource_certification_gate.py")
+        run_python("scripts/check_sysroot_stdlib_resource_certification_gate.py", "--self-test")
+
         print("Running audit fixture smoke suites")
         run_command(uv_area_command("--area", "core_language", "--suite", "audit-fixtures"))
         run_command(uv_area_command("--area", "project_workspace", "--suite", "audit-fixtures"))


### PR DESCRIPTION
## Summary
- Add `scripts/check_sysroot_stdlib_resource_certification_gate.py` to keep resource/runtime/callback-shaped stdlib surfaces non-movable while their Rust interop compatibility rows remain future-owned.
- Wire the guard and `--self-test` into create-pr/merge core guardrails, and add the guardrail registry entry.
- Document the M11 certification-gate audit result and Opus review passes in the phase tracker and architecture docs.

## Reviews
- Opus pass 1: `plans/reviews/active/m11-resource-certification-gate-review-pass1.md` returned `VERDICT: PASS`.
- Opus pass 2: `plans/reviews/active/m11-resource-certification-gate-review-pass2.md` returned `VERDICT: PASS` with no required fixes.

## Validation
- `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py`
- `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py --self-test`
- `uv run --project verification --locked python -m sifr_verify areas run --area rust_interop --suite matrix`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `python3 scripts/check_file_size_guardrails.py`
- `uv run --project verification --locked python verification/areas/coverage_matrix/runner.py --suite readiness`
- `git diff --check`
- `SIFR_LSP_COMMAND="$(pwd)/target/m10-collections-create-pr/debug/sifr lsp --stdio" CARGO_TARGET_DIR=target/m10-collections-create-pr CARGO_BUILD_JOBS=1 scripts/run_all_tests.sh --profile create-pr`

Full create-pr lane: `target/validation_lane_reports/create-pr.latest.json`, profile `create-pr`, real time `8992.08s`, hardening `variants=6 failures=0 blocking_failures=0`, e2e pass suite `132 passed, 0 failed`, advisory only: warm wall-time budget exceeded.