### PR TITLE
Normalize verification Sifr binary resolution

### DIFF
--- a/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
+++ b/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
@@ -26,6 +26,9 @@ Latest merged wave: M12 wave 1 retained intrinsic allowlist guard merged in
 compiler-native intrinsic names, prefix dispatchers, registry files, and
 preamble files are now frozen by a core guardrail while follow-up M12 waves
 delete, split, or explicitly retain remaining compiler-language glue.
+Current local wave: M12 wave 2 verification target-binary normalization on
+`m12-target-binary-normalization`; local implementation, Opus review pass 2,
+and full create-pr validation are complete.
 
 ## PR Log
 
@@ -2006,6 +2009,68 @@ M12 wave 1 implementation evidence:
   subdirectories rebuilt under crate-local target roots. Future long validation
   reruns for this wave should prefer an absolute `CARGO_TARGET_DIR` while
   preserving the same `SIFR_LSP_COMMAND` binary pairing.
+
+M12 wave 2 status: local implementation, focused validation, Opus review pass
+2, and full create-pr validation complete on
+`m12-target-binary-normalization`; PR is next.
+
+This wave closes the stale `target/debug/sifr` hazard found during M12 wave 1
+review. The affected verification helpers now resolve an explicit tool env var
+first, then build or use `<CARGO_TARGET_DIR>/debug/sifr` with relative target
+dirs normalized against the repo root, and only then fall back to the default
+repo target.
+
+M12 wave 2 implementation evidence:
+
+- `verification/areas/common/sifr_binary.py` centralizes Sifr binary
+  resolution/building for direct verification tools.
+- `verification/areas/developer_tooling/check_rule_suppression_rules.py`
+  uses the shared resolver for `SIFR_RULE_SUPPRESSION_BIN` and
+  `CARGO_TARGET_DIR`.
+- `verification/areas/stdlib_parity/tools/check_stdlib_module_parity.py` uses
+  the shared resolver for `SIFR_STDLIB_MODULE_BIN` and `CARGO_TARGET_DIR`.
+- `verification/areas/stdlib_parity/tools/run_stdlib_namespace_corpus_validation.py`
+  uses the shared resolver when its default Sifr binary is selected.
+- `verification/areas/algorithmic_compatibility/runner.py` uses the shared
+  resolver for representative, full-corpus, and leetcode-check suites instead
+  of forcing `target/debug/sifr`.
+- Opus review pass 1 in
+  `plans/reviews/active/m12-target-binary-normalization-review-pass1.md`
+  returned `VERDICT: PASS` with no blockers. Low-severity findings requested
+  recording the actual resolved binary in algorithmic result `argv` fields and
+  preserving explicit `--sifr-bin target/debug/sifr` intent when
+  `CARGO_TARGET_DIR` is also set; both were fixed before pass 2.
+- Opus review pass 2 in
+  `plans/reviews/active/m12-target-binary-normalization-review-pass2.md`
+  returned `VERDICT: PASS` with no blockers.
+- Focused validation passed:
+  `python3 -m py_compile verification/areas/common/sifr_binary.py verification/areas/developer_tooling/check_rule_suppression_rules.py verification/areas/stdlib_parity/tools/check_stdlib_module_parity.py verification/areas/stdlib_parity/tools/run_stdlib_namespace_corpus_validation.py verification/areas/algorithmic_compatibility/runner.py`;
+  `CARGO_TARGET_DIR="$(pwd)/target/m12-target-bin-normalization-check" CARGO_BUILD_JOBS=1 python3 verification/areas/developer_tooling/check_rule_suppression_rules.py --self-test`;
+  `CARGO_TARGET_DIR="$(pwd)/target/m12-target-bin-normalization-check" CARGO_BUILD_JOBS=1 python3 verification/areas/developer_tooling/check_rule_suppression_rules.py`;
+  `CARGO_TARGET_DIR="$(pwd)/target/m12-target-bin-normalization-check" CARGO_BUILD_JOBS=1 python3 verification/areas/stdlib_parity/tools/check_stdlib_module_parity.py --scope merge`;
+  `CARGO_TARGET_DIR="$(pwd)/target/m12-target-bin-normalization-check" CARGO_BUILD_JOBS=1 python3 verification/areas/stdlib_parity/tools/run_stdlib_namespace_corpus_validation.py --scope leetcode --command check --fail-fast`;
+  `CARGO_TARGET_DIR="$(pwd)/target/m12-target-bin-normalization-check" CARGO_BUILD_JOBS=1 uv run --project verification --locked python -m sifr_verify areas run --area algorithmic_compatibility --suite representative-subset`;
+  reruns after the pass-1 fixes of
+  `CARGO_TARGET_DIR="$(pwd)/target/m12-target-bin-normalization-check" CARGO_BUILD_JOBS=1 python3 verification/areas/stdlib_parity/tools/run_stdlib_namespace_corpus_validation.py --scope leetcode --command check --fail-fast`
+  and
+  `CARGO_TARGET_DIR="$(pwd)/target/m12-target-bin-normalization-check" CARGO_BUILD_JOBS=1 uv run --project verification --locked python -m sifr_verify areas run --area algorithmic_compatibility --suite representative-subset`;
+  `python3 scripts/check_file_size_guardrails.py`;
+  `git diff --check`.
+- Local create-pr validation passed with zero failures:
+  `ABS_TARGET="$(pwd)/target/m12-target-bin-normalization-create-pr"; SIFR_LSP_COMMAND="${ABS_TARGET}/debug/sifr lsp --stdio" CARGO_TARGET_DIR="${ABS_TARGET}" CARGO_BUILD_JOBS=1 scripts/run_all_tests.sh --profile create-pr`.
+  The lane wrote `target/validation_lane_reports/create-pr.latest.json`;
+  profile `create-pr`, real time `6644.10s`, CPU `4824.79s`, max RSS
+  `613.7MiB`, hardening variants `6`, blocking failures `0`, and advisory
+  `warm wall-time budget exceeded`. Slowest step was `python_interop`
+  (`2239993ms`); other long steps were `crate_tests` (`1369637ms`),
+  `generated_code_quality_checks` (`1148774ms`), `runtime_platform_suites`
+  (`872230ms`), and `e2e_pass_suite` (`401748ms`, 132/132 pass).
+- The apparent long no-commit period was validation runtime, not an idle loop:
+  Python interop library examples took `1373594ms`, generated-code determinism
+  took `814734ms`, runtime-platform golden locale formatting took `270443ms`,
+  and crate/e2e suites performed repeated nested Cargo builds. This run used an
+  absolute `CARGO_TARGET_DIR`, avoiding the earlier relative target-dir rebuild
+  hazard while preserving LSP/binary pairing.
 
 ### M13. Release Candidate Certification
 

--- a/plans/reviews/active/m12-target-binary-normalization-review-pass1.md
+++ b/plans/reviews/active/m12-target-binary-normalization-review-pass1.md
@@ -1,0 +1,42 @@
+## Findings (severity-ordered)
+
+### 1. Low — `argv` fields in algorithmic compatibility result variants still hardcode `target/debug/sifr`
+
+**File:** `verification/areas/algorithmic_compatibility/runner.py:360, 394`
+
+The actual invocations in `run_manifest_fixture` and `run_leetcode_full` use the `sifr_bin` returned by `ensure_sifr_bin(DEFAULT_SIFR_BIN)` (which now honors `CARGO_TARGET_DIR`), but the recorded variant argv is a static `["target/debug/sifr", ...]`. Compare with `run_leetcode_check` at line 543 which correctly records `[str(sifr_bin), ...]`.
+
+**Impact:** The JSON result payload advertises a binary path different from the one actually executed. A reader who tries to reproduce a failure by copy-pasting the argv from the result artifact would run the wrong binary when `CARGO_TARGET_DIR` is set, potentially masking the issue or hitting a stale binary. Not a runtime hazard for the current suite because execution is correct; strictly a data-fidelity gap.
+
+Note: `validate_representative_row` at line 310 also asserts the manifest's `command` field is literally `f"target/debug/sifr check {...}"`. That's a manifest schema constraint on the JSON file rather than a live command; leaving it alone is consistent with the "narrow wave" scope.
+
+### 2. Low — `resolve_sifr_binary` does not validate the explicit-env-var path
+
+**File:** `verification/areas/common/sifr_binary.py:18-21`
+
+If `SIFR_RULE_SUPPRESSION_BIN` / `SIFR_STDLIB_MODULE_BIN` is set to a non-existent or non-executable path, the helper returns it verbatim and the downstream `subprocess.run` fails with a cryptic OS-level error rather than the helper's own "Sifr verification binary was not produced" diagnostic. This matches the "explicit override trusts the caller" idiom, but it's a slight friendliness gap versus the target-dir and fallback branches, both of which build-then-verify.
+
+### 3. Low — `--sifr-bin` explicit flag can be silently redirected when it equals the default
+
+**File:** `verification/areas/stdlib_parity/tools/run_stdlib_namespace_corpus_validation.py:143-148`
+
+Because `--sifr-bin` defaults to `str(DEFAULT_SIFR_BIN)`, the code cannot distinguish "user did not pass the flag" from "user explicitly passed `--sifr-bin target/debug/sifr`". In the second case, if `CARGO_TARGET_DIR` is also set, the explicit CLI value is dropped in favor of the CARGO_TARGET_DIR-derived binary. Setting `argparse` default to `None` and testing `if args.sifr_bin is None` would preserve explicit-flag intent. Not exercised by focused validation runs, so not blocking.
+
+### 4. Info — Dead / inconsistent branches in the two `ensure_sifr_bin` shims
+
+- `verification/areas/algorithmic_compatibility/runner.py:552-557` — always called with `DEFAULT_SIFR_BIN`, so the `elif not sifr_bin.exists()` and the trailing `return sifr_bin` are unreachable in current usage.
+- `verification/areas/stdlib_parity/tools/run_stdlib_namespace_corpus_validation.py:102-106` — only called in the `!= DEFAULT_SIFR_BIN` branch of `main()`, so the `if sifr_bin == DEFAULT_SIFR_BIN` branch there is dead. Return types also differ between the two (`Path` vs `None`).
+
+Code hygiene only; no runtime consequence.
+
+## Review Question Summary
+
+1. **Shared helper correctness.** `resolve_sifr_binary` honors `explicit_env_var` first, then normalizes `CARGO_TARGET_DIR` (absolute passed through; relative resolved against `repo_root`, matching cargo's own cwd-relative resolution because the helper always runs `cargo build` with `cwd=repo_root`), then falls back to `default_binary` / `target/debug/sifr`. When the configured or fallback binary is missing, it builds (subprocess inherits env, so `CARGO_TARGET_DIR` propagates to cargo). The stale-binary hazard identified in wave 1 is genuinely closed for the CARGO_TARGET_DIR path; there is no silent fallback to `target/debug/sifr` when a configured target dir is set.
+
+2. **All four tools use the configured target binary.** Confirmed: rule/suppression rules, stdlib module parity, namespace corpus validation, and algorithmic-compat representative/full/leetcode-check paths all now go through the shared resolver for their actual Sifr invocations.
+
+3. **Wave scope discipline.** Changes are appropriately narrow. Algorithmic-compat result argv fields (finding 1) were left as-is, which keeps the wave focused; the resulting data-fidelity gap is minor. Namespace corpus `--sifr-bin` semantics have shifted slightly (finding 3), but only in the edge case where a user explicitly re-types the default value while also setting `CARGO_TARGET_DIR`.
+
+4. **Focused validation sufficiency.** The focused runs cover: py_compile, the developer-tooling tool (with and without `--self-test`), stdlib module parity `--scope merge`, the full 411-fixture leetcode namespace corpus run, the algorithmic representative subset via `sifr_verify`, file-size guardrail, and `git diff --check`. Combined with the fact that each affected tool was exercised with a fresh `CARGO_TARGET_DIR` that did not initially contain `debug/sifr` (forcing the build path), the resolver's build-if-missing behavior is directly demonstrated. No additional focused test is required before PR; run the create-pr profile as the merge gate per project convention.
+
+VERDICT: PASS

--- a/plans/reviews/active/m12-target-binary-normalization-review-pass2.md
+++ b/plans/reviews/active/m12-target-binary-normalization-review-pass2.md
@@ -1,0 +1,5 @@
+## Summary
+
+Pass-1 findings 1, 3, and 4 are cleanly resolved with the diffs described. Finding 2 (explicit env-var not validated) is unchanged; pass 1 already classified it as an "explicit override trusts the caller" idiom and it's not a runtime hazard, so it remains a non-blocker. No new blockers introduced. Wave scope, focused validation, and file-size guardrail are all satisfied.
+
+VERDICT: PASS

--- a/verification/areas/algorithmic_compatibility/runner.py
+++ b/verification/areas/algorithmic_compatibility/runner.py
@@ -25,6 +25,9 @@ LEETCODE_ROOT = AREA_ROOT / "corpora" / "leetcode" / "src"
 TAXONOMY_SMOKE_RESULTS = AREA_ROOT / "data" / "taxonomy_smoke_results.json"
 PROFILE_MANIFEST = AREA_ROOT / "data" / "leetcode_profile_manifest.json"
 DEFAULT_SIFR_BIN = REPO_ROOT / "target" / "debug" / "sifr"
+sys.path.insert(0, str(REPO_ROOT / "verification" / "areas" / "common"))
+
+from sifr_binary import resolve_sifr_binary  # noqa: E402
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -322,23 +325,26 @@ def required_string(payload: dict[str, Any], key: str) -> str:
 
 def run_representative_subset() -> list[dict[str, Any]]:
     payload = load_profile_manifest()
-    ensure_sifr_bin(DEFAULT_SIFR_BIN)
+    sifr_bin = resolve_default_sifr_bin()
     result_path = REPO_ROOT / payload["representative_subset"][0]["result_artifact"]
     results = []
     variants = []
     for row in payload["representative_subset"]:
-        variant, result_entry = run_manifest_fixture(row)
+        variant, result_entry = run_manifest_fixture(row, sifr_bin)
         variants.append(variant)
         results.append(result_entry)
     write_results_artifact(result_path, results)
     return variants
 
 
-def run_manifest_fixture(row: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+def run_manifest_fixture(
+    row: dict[str, Any],
+    sifr_bin: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
     path = REPO_ROOT / str(row["path"])
     started = time.perf_counter()
     try:
-        result = run_fixture(DEFAULT_SIFR_BIN, path, timeout_seconds=int(row["timeout_seconds"]))
+        result = run_fixture(sifr_bin, path, timeout_seconds=int(row["timeout_seconds"]))
         elapsed_ms = (time.perf_counter() - started) * 1000.0
         status = "pass" if result.returncode == 0 else "fail"
         failures = [] if result.returncode == 0 else [f"exit={result.returncode} expected=0"]
@@ -351,7 +357,7 @@ def run_manifest_fixture(row: dict[str, Any]) -> tuple[dict[str, Any], dict[str,
     result_entry = result_entry_for_fixture(path, result)
     variant = {
         "label": str(row["id"]),
-        "argv": ["target/debug/sifr", "check", str(path.relative_to(REPO_ROOT))],
+        "argv": [str(sifr_bin), "check", str(path.relative_to(REPO_ROOT))],
         "status": status,
         "mismatches": failures,
         "expected_exit_code": 0,
@@ -372,12 +378,12 @@ def run_leetcode_full() -> list[dict[str, Any]]:
     taxonomy_path = REPO_ROOT / str(full_corpus["taxonomy_artifact"])
     taxonomy_md = REPO_ROOT / str(full_corpus["taxonomy_markdown"])
     delta_md = REPO_ROOT / str(full_corpus["delta_markdown"])
-    ensure_sifr_bin(DEFAULT_SIFR_BIN)
+    sifr_bin = resolve_default_sifr_bin()
     variants = []
     results = []
     for path in sorted(LEETCODE_ROOT.glob("*.sifr")):
         started = time.perf_counter()
-        result = run_fixture(DEFAULT_SIFR_BIN, path, timeout_seconds=30)
+        result = run_fixture(sifr_bin, path, timeout_seconds=30)
         elapsed_ms = (time.perf_counter() - started) * 1000.0
         status = "pass" if result.returncode == 0 else "fail"
         failures = [] if result.returncode == 0 else [f"exit={result.returncode} expected=0"]
@@ -385,7 +391,7 @@ def run_leetcode_full() -> list[dict[str, Any]]:
         variants.append(
             {
                 "label": path.stem,
-                "argv": ["target/debug/sifr", "check", str(path.relative_to(REPO_ROOT))],
+                "argv": [str(sifr_bin), "check", str(path.relative_to(REPO_ROOT))],
                 "status": status,
                 "mismatches": failures,
                 "expected_exit_code": 0,
@@ -518,12 +524,12 @@ def run_leetcode_check() -> tuple[list[str], subprocess.CompletedProcess[str]]:
     paths = sorted(LEETCODE_ROOT.glob("*.sifr"))
     if not paths:
         raise SystemExit(f"no LeetCode fixtures found under {LEETCODE_ROOT.relative_to(REPO_ROOT)}")
-    ensure_sifr_bin(DEFAULT_SIFR_BIN)
+    sifr_bin = resolve_default_sifr_bin()
     failures: list[tuple[Path, subprocess.CompletedProcess[str]]] = []
     stdout_lines = [f"validating {len(paths)} LeetCode fixture(s) with sifr check"]
     started = time.monotonic()
     for index, path in enumerate(paths, start=1):
-        result = run_fixture(DEFAULT_SIFR_BIN, path)
+        result = run_fixture(sifr_bin, path)
         if result.returncode == 0:
             stdout_lines.append(f"[{index}/{len(paths)}] PASS {path.relative_to(REPO_ROOT)}")
             continue
@@ -534,7 +540,7 @@ def run_leetcode_check() -> tuple[list[str], subprocess.CompletedProcess[str]]:
         f"LeetCode corpus check completed: {len(paths) - len(failures)}/{len(paths)} passed in {elapsed:.1f}s"
     )
     stderr = render_failures(failures)
-    argv = [str(DEFAULT_SIFR_BIN), "check", str(LEETCODE_ROOT.relative_to(REPO_ROOT))]
+    argv = [str(sifr_bin), "check", str(LEETCODE_ROOT.relative_to(REPO_ROOT))]
     return argv, subprocess.CompletedProcess(
         args=argv,
         returncode=1 if failures else 0,
@@ -543,11 +549,8 @@ def run_leetcode_check() -> tuple[list[str], subprocess.CompletedProcess[str]]:
     )
 
 
-def ensure_sifr_bin(sifr_bin: Path) -> None:
-    if sifr_bin == DEFAULT_SIFR_BIN:
-        subprocess.run(["cargo", "build", "--locked", "-q", "-p", "sifr"], cwd=REPO_ROOT, check=True)
-    elif not sifr_bin.exists():
-        raise SystemExit(f"missing Sifr CLI binary: {sifr_bin}")
+def resolve_default_sifr_bin() -> Path:
+    return resolve_sifr_binary(REPO_ROOT, default_binary=DEFAULT_SIFR_BIN)
 
 
 def run_fixture(sifr_bin: Path, path: Path, *, timeout_seconds: int | None = None) -> subprocess.CompletedProcess[str]:

--- a/verification/areas/common/sifr_binary.py
+++ b/verification/areas/common/sifr_binary.py
@@ -1,0 +1,62 @@
+"""Helpers for verification tools that need a Sifr CLI binary."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def resolve_sifr_binary(
+    repo_root: Path,
+    *,
+    explicit_env_var: str | None = None,
+    default_binary: Path | None = None,
+) -> Path:
+    """Return a Sifr binary path, building the configured target if needed."""
+    if explicit_env_var:
+        configured_bin = os.environ.get(explicit_env_var)
+        if configured_bin:
+            return Path(configured_bin)
+
+    target_bin = _configured_target_binary(repo_root)
+    if target_bin is not None:
+        if not target_bin.is_file():
+            _build_sifr_binary(repo_root, target_bin)
+        return target_bin
+
+    fallback = default_binary or repo_root / "target" / "debug" / "sifr"
+    if not fallback.is_file():
+        _build_sifr_binary(repo_root, fallback)
+    return fallback
+
+
+def _configured_target_binary(repo_root: Path) -> Path | None:
+    configured_target_dir = os.environ.get("CARGO_TARGET_DIR")
+    if not configured_target_dir:
+        return None
+    target_dir = Path(configured_target_dir)
+    if not target_dir.is_absolute():
+        target_dir = repo_root / target_dir
+    return target_dir / "debug" / "sifr"
+
+
+def _build_sifr_binary(repo_root: Path, expected_binary: Path) -> None:
+    proc = subprocess.run(
+        ["cargo", "build", "--locked", "-q", "-p", "sifr"],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        print("failed to build Sifr verification binary", file=sys.stderr)
+        if proc.stdout:
+            print(proc.stdout, file=sys.stderr)
+        if proc.stderr:
+            print(proc.stderr, file=sys.stderr)
+        raise SystemExit(proc.returncode)
+    if not expected_binary.is_file():
+        print(f"Sifr verification binary was not produced: {expected_binary}", file=sys.stderr)
+        raise SystemExit(1)

--- a/verification/areas/developer_tooling/check_rule_suppression_rules.py
+++ b/verification/areas/developer_tooling/check_rule_suppression_rules.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 import subprocess
 import sys
 import tempfile
@@ -13,6 +12,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_SIFR_BIN = REPO_ROOT / "target" / "debug" / "sifr"
+sys.path.insert(0, str(REPO_ROOT / "verification" / "areas" / "common"))
+
+from sifr_binary import resolve_sifr_binary  # noqa: E402
 
 
 def run(command: list[str], *, expect: int = 0) -> subprocess.CompletedProcess[str]:
@@ -26,12 +28,12 @@ def run(command: list[str], *, expect: int = 0) -> subprocess.CompletedProcess[s
 
 
 def sifr_command(*args: str) -> list[str]:
-    configured_bin = os.environ.get("SIFR_RULE_SUPPRESSION_BIN")
-    if configured_bin:
-        return [configured_bin, *args]
-    if DEFAULT_SIFR_BIN.is_file():
-        return [str(DEFAULT_SIFR_BIN), *args]
-    return ["cargo", "run", "-q", "-p", "sifr", "--", *args]
+    binary = resolve_sifr_binary(
+        REPO_ROOT,
+        explicit_env_var="SIFR_RULE_SUPPRESSION_BIN",
+        default_binary=DEFAULT_SIFR_BIN,
+    )
+    return [str(binary), *args]
 
 
 def run_positive() -> None:

--- a/verification/areas/stdlib_parity/tools/check_stdlib_module_parity.py
+++ b/verification/areas/stdlib_parity/tools/check_stdlib_module_parity.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 import time
@@ -18,6 +17,9 @@ DEFAULT_TIMEOUT_SECONDS = 15
 DEFAULT_SIFR_BIN = REPO_ROOT / "target" / "debug" / "sifr"
 SUPPORTED_STATUSES = {"supported", "known_gap", "zero_example_inventory"}
 SUPPORTED_PROFILES = {"merge", "full", "inventory-only"}
+sys.path.insert(0, str(REPO_ROOT / "verification" / "areas" / "common"))
+
+from sifr_binary import resolve_sifr_binary  # noqa: E402
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -229,17 +231,12 @@ def run_entries(entries: list[dict[str, Any]]) -> list[str]:
 
 
 def stdlib_module_command_prefix() -> list[str]:
-    configured_bin = os.environ.get("SIFR_STDLIB_MODULE_BIN")
-    if configured_bin:
-        return [configured_bin]
-    configured_target_dir = os.environ.get("CARGO_TARGET_DIR")
-    if configured_target_dir:
-        target_bin = Path(configured_target_dir) / "debug" / "sifr"
-        if target_bin.is_file():
-            return [str(target_bin)]
-    if DEFAULT_SIFR_BIN.is_file():
-        return [str(DEFAULT_SIFR_BIN)]
-    return ["cargo", "run", "--locked", "-q", "-p", "sifr", "--"]
+    binary = resolve_sifr_binary(
+        REPO_ROOT,
+        explicit_env_var="SIFR_STDLIB_MODULE_BIN",
+        default_binary=DEFAULT_SIFR_BIN,
+    )
+    return [str(binary)]
 
 
 def string_field(entry: dict[str, Any], field: str, failures: list[str]) -> str | None:

--- a/verification/areas/stdlib_parity/tools/run_stdlib_namespace_corpus_validation.py
+++ b/verification/areas/stdlib_parity/tools/run_stdlib_namespace_corpus_validation.py
@@ -23,6 +23,9 @@ LEETCODE_ROOT = (
 )
 DEMOS_ROOT = REPO_ROOT / "demos"
 DEFAULT_SIFR_BIN = REPO_ROOT / "target" / "debug" / "sifr"
+sys.path.insert(0, str(REPO_ROOT / "verification" / "areas" / "common"))
+
+from sifr_binary import resolve_sifr_binary  # noqa: E402
 
 BARE_STDLIB_ATTR_RE = re.compile(
     r"(?<!sifr\.)\b(?P<module>math|heapq|collections)\.[A-Za-z_]"
@@ -45,8 +48,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--sifr-bin",
-        default=str(DEFAULT_SIFR_BIN),
-        help="Path to the Sifr CLI binary. Built with cargo if missing.",
+        default=None,
+        help=(
+            "Path to the Sifr CLI binary. Defaults to the configured "
+            "CARGO_TARGET_DIR binary, or the repository default target."
+        ),
     )
     parser.add_argument(
         "--fail-fast",
@@ -96,11 +102,13 @@ def scan_bare_stdlib_attrs(paths: list[Path]) -> list[str]:
     return failures
 
 
-def ensure_sifr_bin(sifr_bin: Path) -> None:
-    if sifr_bin == DEFAULT_SIFR_BIN:
-        subprocess.run(["cargo", "build", "-q", "-p", "sifr"], cwd=REPO_ROOT, check=True)
-    elif not sifr_bin.exists():
+def resolve_requested_sifr_bin(raw_sifr_bin: str | None) -> Path:
+    if raw_sifr_bin is None:
+        return resolve_sifr_binary(REPO_ROOT, default_binary=DEFAULT_SIFR_BIN)
+    sifr_bin = Path(raw_sifr_bin)
+    if not sifr_bin.exists():
         raise SystemExit(f"missing Sifr CLI binary: {sifr_bin}")
+    return sifr_bin
 
 
 def run_fixture(sifr_bin: Path, command: str, path: Path) -> subprocess.CompletedProcess[str]:
@@ -137,8 +145,7 @@ def main() -> int:
             print(f"  {failure}", file=sys.stderr)
         return 1
 
-    sifr_bin = Path(args.sifr_bin)
-    ensure_sifr_bin(sifr_bin)
+    sifr_bin = resolve_requested_sifr_bin(args.sifr_bin)
 
     start = time.monotonic()
     failures: list[tuple[Path, subprocess.CompletedProcess[str]]] = []


### PR DESCRIPTION
## Summary
- add a shared verification helper that resolves the intended Sifr binary from explicit env vars, absolute or repo-normalized CARGO_TARGET_DIR, or the repo default target
- update developer tooling, stdlib parity, namespace corpus, and algorithmic compatibility helpers to stop implicitly falling back to stale target/debug/sifr
- record M12 wave 2 focused validation, Opus pass 1/pass 2 reviews, and full create-pr evidence

## Validation
- Opus review pass 2: PASS, no blockers
- focused validation: py_compile, rule suppression self-test/full check, stdlib module parity merge, namespace corpus leetcode check, algorithmic representative subset, file-size guardrail, git diff --check
- full gate: ABS_TARGET="/Users/yaseralnajjar/work/sifr/codebase/target/m12-target-bin-normalization-create-pr" SIFR_LSP_COMMAND="${ABS_TARGET}/debug/sifr lsp --stdio" CARGO_TARGET_DIR="${ABS_TARGET}" CARGO_BUILD_JOBS=1 scripts/run_all_tests.sh --profile create-pr
- result: PASS, report target/validation_lane_reports/create-pr.latest.json, real 6644.10s, CPU 4824.79s, max RSS 613.7MiB, advisory warm wall-time budget exceeded