### PR TITLE
Record merged M12 target binary normalization

### DIFF
--- a/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
+++ b/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
@@ -21,14 +21,14 @@ In progress.
 | M9-M13 | in progress | M9 wave 1 merged in [PR #2757](https://github.com/sifr-lang/sifr/pull/2757), migrating `_sifr.platform` and `_sifr.html` to private Rust interop declarations backed by `sifr_stdlib` features. M9 wave 2 merged in [PR #2759](https://github.com/sifr-lang/sifr/pull/2759), migrating `_sifr.calendar` the same way. M9 wave 3 merged in [PR #2761](https://github.com/sifr-lang/sifr/pull/2761), migrating `_sifr.uuid` the same way. M9 wave 4 merged in [PR #2763](https://github.com/sifr-lang/sifr/pull/2763), migrating `_sifr.math` the same way. M9 wave 5 merged in [PR #2765](https://github.com/sifr-lang/sifr/pull/2765), migrating `_sifr.crypto` hash functions used by `sifr.hashlib` while retaining intrinsic fallback for unmigrated crypto helpers. M9 wave 6 merged in [PR #2767](https://github.com/sifr-lang/sifr/pull/2767), migrating infallible base64/base32 encoders while explicitly deferring fallible decode/options to M10. M10 wave 1 merged in [PR #2769](https://github.com/sifr-lang/sifr/pull/2769), migrating fallible base64/base32 decode/options through typed result-error direct interop. M10 wave 2 merged in [PR #2771](https://github.com/sifr-lang/sifr/pull/2771), migrating `_sifr.regex`/`sifr.re` through private Rust interop backed by `sifr_stdlib::regex` while retaining the separate direct regex dependency for `sifr.pathlib` glob lowering. M10 wave 3 merged in [PR #2776](https://github.com/sifr-lang/sifr/pull/2776), migrating `_sifr.url`/`sifr.url` through private Rust interop backed by `sifr_stdlib::url`. M10 wave 4 merged in [PR #2778](https://github.com/sifr-lang/sifr/pull/2778), migrating `_sifr.toml`/`sifr.tomllib` through private Rust interop backed by `sifr_stdlib::toml`. M10 wave 5 merged in [PR #2780](https://github.com/sifr-lang/sifr/pull/2780), migrating `_sifr.json`/`sifr.json` through private Rust interop backed by `sifr_stdlib::json` token adapters while preserving `JSONDecodeError` location fields and JSON integer profile errors. M10 wave 6 merged in [PR #2781](https://github.com/sifr-lang/sifr/pull/2781), migrating `_sifr.encoding`/`sifr.encoding` through private Rust interop backed by `sifr_stdlib::encoding` while preserving public `DecodeError`/`EncodeError` wrappers. M10 wave 7 merged in [PR #2782](https://github.com/sifr-lang/sifr/pull/2782), migrating `_sifr.unicode`/`sifr.unicode` through private Rust interop backed by `sifr_stdlib::unicode` while preserving public `UnicodeDataError` wrappers and Unicode segmentation tuple payloads. M10 wave 8 merged in [PR #2784](https://github.com/sifr-lang/sifr/pull/2784), migrating `_sifr.i18n`/`sifr.i18n` through private Rust interop backed by `sifr_stdlib::i18n` while preserving public i18n error wrappers. M10 wave 9 merged in [PR #2785](https://github.com/sifr-lang/sifr/pull/2785), migrating `_sifr.compress`/`sifr.gzip`/`sifr.zipfile` through private Rust interop backed by `sifr_stdlib` gzip and zipfile adapters. M10 wave 10 merged in [PR #2787](https://github.com/sifr-lang/sifr/pull/2787), migrating `_sifr.datetime` through private Rust interop backed by the `sifr_stdlib` time feature and fixing grouped E2E fixture planning for datetime/compression stdlib features. M10 wave 11 merged in [PR #2789](https://github.com/sifr-lang/sifr/pull/2789), splitting `_sifr.bytes` so `encode_utf8` and `bytes_to_hex` move to private `sifr_stdlib::bytes` adapters while first-class bytes constructors, hex parsing, strict hex formatting, and encode/decode method glue remain compiler-owned. M10 wave 12 merged in [PR #2791](https://github.com/sifr-lang/sifr/pull/2791), splitting `_sifr.collections` so set helpers and legacy JSON-string `defaultdict_*` helpers move to private `sifr_stdlib::collections` adapters while Counter/defaultdict language glue and core collection behavior remain compiler-owned. |
 | Post-M10 Adapter Policy Adherence Audit | completed, merged | Merged in [PR #2774](https://github.com/sifr-lang/sifr/pull/2774). The audit classified completed M9/M10 private bindings, added executable guards for direct `sifr_stdlib` targets and trust separation, documented residual `_sifr.crypto` random scope, and passed Opus review pass 2 plus local `scripts/run_all_tests.sh --profile create-pr` with only the warm wall-time advisory. |
 
-Latest merged wave: M12 wave 1 retained intrinsic allowlist guard merged in
-[PR #2795](https://github.com/sifr-lang/sifr/pull/2795). Retained
-compiler-native intrinsic names, prefix dispatchers, registry files, and
-preamble files are now frozen by a core guardrail while follow-up M12 waves
-delete, split, or explicitly retain remaining compiler-language glue.
-Current local wave: M12 wave 2 verification target-binary normalization on
-`m12-target-binary-normalization`; local implementation, Opus review pass 2,
-and full create-pr validation are complete.
+Latest merged wave: M12 wave 2 verification target-binary normalization merged
+in [PR #2797](https://github.com/sifr-lang/sifr/pull/2797). Direct
+verification helpers now resolve the intended Sifr binary from explicit tool
+env vars, repo-normalized `CARGO_TARGET_DIR`, or the repo default target
+instead of silently falling back to stale `target/debug/sifr`.
+Next local wave: continue M12 registry/preamble deletion or explicit-retention
+reduction using the retained intrinsic allowlist guard and normalized
+verification binary resolution.
 
 ## PR Log
 
@@ -62,6 +62,7 @@ and full create-pr validation are complete.
 - M10 wave 12 collections helper interop split: merged in [PR #2791](https://github.com/sifr-lang/sifr/pull/2791).
 - M11 certification-gate audit: [PR #2793](https://github.com/sifr-lang/sifr/pull/2793) merged.
 - M12 wave 1 retained intrinsic allowlist guard: [PR #2795](https://github.com/sifr-lang/sifr/pull/2795) merged after local implementation, Opus review pass 2, and create-pr validation completed on `m12-retained-intrinsic-allowlist`.
+- M12 wave 2 verification target-binary normalization: [PR #2797](https://github.com/sifr-lang/sifr/pull/2797) merged after local implementation, Opus review pass 2, and create-pr validation completed on `m12-target-binary-normalization`.
 
 ## Design Reference
 
@@ -2011,8 +2012,8 @@ M12 wave 1 implementation evidence:
   preserving the same `SIFR_LSP_COMMAND` binary pairing.
 
 M12 wave 2 status: local implementation, focused validation, Opus review pass
-2, and full create-pr validation complete on
-`m12-target-binary-normalization`; PR is next.
+2, full create-pr validation, and [PR #2797](https://github.com/sifr-lang/sifr/pull/2797)
+merge complete on `m12-target-binary-normalization`.
 
 This wave closes the stale `target/debug/sifr` hazard found during M12 wave 1
 review. The affected verification helpers now resolve an explicit tool env var


### PR DESCRIPTION
## Summary
- record PR #2797 as the latest merged M12 wave
- update the PR log and wave status to point to the merged verification target-binary normalization work
- mark the next local wave as M12 registry/preamble deletion or explicit-retention reduction

## Validation
- git diff --check