### PR TITLE
Trim full Python interop examples from create-pr

### DIFF
--- a/verification/areas/python_interop/manifest.json
+++ b/verification/areas/python_interop/manifest.json
@@ -125,7 +125,13 @@
           "command": "python-interop-dataframes",
           "expect_exit_code": 0,
           "diagnostic_formats": []
-        },
+        }
+      ]
+    },
+    {
+      "name": "dataframe-examples",
+      "kind": "adapter",
+      "cases": [
         {
           "id": "dataframe-examples",
           "entry": "verification/areas/python_interop/runner/run.py",

--- a/verification/profiles/create-pr.json
+++ b/verification/profiles/create-pr.json
@@ -91,8 +91,6 @@
         "tier1",
         "callbacks",
         "dataframes",
-        "ml",
-        "libraries",
         "cloud-boto3"
       ],
       "resource_classes": [

--- a/verification/profiles/merge.json
+++ b/verification/profiles/merge.json
@@ -108,6 +108,7 @@
         "tier4",
         "callbacks",
         "dataframes",
+        "dataframe-examples",
         "ml",
         "libraries",
         "cloud-boto3"

--- a/verification/profiles/nightly.json
+++ b/verification/profiles/nightly.json
@@ -121,6 +121,9 @@
         "tier4",
         "callbacks",
         "dataframes",
+        "dataframe-examples",
+        "ml",
+        "libraries",
         "cloud-boto3"
       ],
       "resource_classes": [

--- a/verification/profiles/release.json
+++ b/verification/profiles/release.json
@@ -120,6 +120,7 @@
         "tier4",
         "callbacks",
         "dataframes",
+        "dataframe-examples",
         "ml",
         "libraries",
         "cloud-boto3"


### PR DESCRIPTION
## Summary
- split `dataframe-examples` into its own Python interop suite
- remove full Python interop examples from the fast `create-pr` profile
- keep full examples selected in `merge`, `nightly`, and `release`

## Validation
- `uv run --project verification --locked python -m sifr_verify profiles check` ✅
- `scripts/run_all_tests.sh --profile create-pr --emit-plan | rg -n 'python_interop|dataframe-examples|ml|libraries|cloud-boto3|dataframes'` ✅ confirmed `create-pr` no longer lists `dataframe-examples`, `ml`, or `libraries`
- `uv run --project verification --locked python -m sifr_verify areas run --area python_interop --suite self-test --suite scaffold --suite env --suite tier1 --suite callbacks --suite dataframes --suite cloud-boto3` ✅ variants=7
- `scripts/run_all_tests.sh --profile create-pr` ⚠️ clean validation worktree failed in existing `core_language` audit fixtures before this change's Python interop path; lane completed in 22.53s and no Python interop slow step was present

## Review
- Claude Opus review: no blocking or plausible defects; reviewer satisfied.