### PR TITLE
Speed up generated code quality smoke

### DIFF
--- a/crates/sifr_driver/src/build/mod.rs
+++ b/crates/sifr_driver/src/build/mod.rs
@@ -23,6 +23,7 @@ mod rust_interop_digest;
 #[cfg(test)]
 mod rust_interop_panic_contract_tests;
 mod rust_interop_probe;
+mod rust_interop_probe_cache;
 #[cfg(test)]
 mod rust_interop_tests;
 mod rust_interop_trust;

--- a/crates/sifr_driver/src/build/rust_interop_probe.rs
+++ b/crates/sifr_driver/src/build/rust_interop_probe.rs
@@ -1,4 +1,5 @@
 use super::rust_interop_digest::fnv1a64_hex;
+use super::rust_interop_probe_cache::{mark_probe_cache_hit, probe_cache_file, probe_cache_key};
 use sifr_codegen::{
     RustBridgeParamConvention, RustBridgeSignatureContract, RustInteropPlanDeclaration,
 };
@@ -47,6 +48,22 @@ pub(super) fn execute_direct_cargo_probe(
     let Some(backend_root) = probe.backend.cargo_manifest_path.parent() else {
         return Ok(());
     };
+    let dependency_features =
+        dependency_features(&probe.backend.dependency_name, backend_root, &probe.path);
+    let probe_manifest = probe_cargo_toml(
+        &probe.backend.dependency_name,
+        backend_root,
+        probe.sysroot_runtime_crate_manifest.as_deref(),
+        &dependency_features,
+    );
+    let probe_source = probe_source(probe);
+    let invocation_cwd = env::current_dir()
+        .map_err(|error| probe_io_failure(format!("failed to resolve Rust probe cwd: {error}")))?;
+    let cache_key = probe_cache_key(probe, backend_root, &probe_manifest, &probe_source);
+    let cache_file = probe_cache_file(&cache_key, &invocation_cwd);
+    if cache_file.as_ref().is_some_and(|path| path.is_file()) {
+        return Ok(());
+    }
     let probe_root = std::env::temp_dir().join(format!(
         "sifr_rust_probe_{}_{}_{}",
         std::process::id(),
@@ -66,21 +83,12 @@ pub(super) fn execute_direct_cargo_probe(
     fs::create_dir_all(probe_root.join("src")).map_err(|error| {
         probe_io_failure(format!("failed to create Rust probe project: {error}"))
     })?;
-    fs::write(
-        probe_root.join("Cargo.toml"),
-        probe_cargo_toml(
-            &probe.backend.dependency_name,
-            backend_root,
-            probe.sysroot_runtime_crate_manifest.as_deref(),
-            &dependency_features(&probe.backend.dependency_name, backend_root, &probe.path),
-        ),
-    )
-    .map_err(|error| probe_io_failure(format!("failed to write Rust probe manifest: {error}")))?;
-    fs::write(probe_root.join("src/lib.rs"), probe_source(probe))
+    fs::write(probe_root.join("Cargo.toml"), probe_manifest).map_err(|error| {
+        probe_io_failure(format!("failed to write Rust probe manifest: {error}"))
+    })?;
+    fs::write(probe_root.join("src/lib.rs"), probe_source)
         .map_err(|error| probe_io_failure(format!("failed to write Rust probe source: {error}")))?;
 
-    let invocation_cwd = env::current_dir()
-        .map_err(|error| probe_io_failure(format!("failed to resolve Rust probe cwd: {error}")))?;
     let mut command = Command::new("cargo");
     command
         .args(cargo_vendor_args(probe.sysroot_vendor_dir.as_deref()))
@@ -94,6 +102,9 @@ pub(super) fn execute_direct_cargo_probe(
         .map_err(|error| probe_io_failure(format!("failed to run Rust probe: {error}")))?;
     let _ = fs::remove_dir_all(&probe_root);
     if output.status.success() {
+        if let Some(path) = cache_file {
+            mark_probe_cache_hit(&path);
+        }
         return Ok(());
     }
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -234,7 +245,7 @@ fn inherited_cargo_target_dir(invocation_cwd: &Path) -> Option<PathBuf> {
     ))
 }
 
-fn normalize_cargo_target_dir(invocation_cwd: &Path, target_dir: PathBuf) -> PathBuf {
+pub(super) fn normalize_cargo_target_dir(invocation_cwd: &Path, target_dir: PathBuf) -> PathBuf {
     if target_dir.is_absolute() {
         target_dir
     } else {

--- a/crates/sifr_driver/src/build/rust_interop_probe_cache.rs
+++ b/crates/sifr_driver/src/build/rust_interop_probe_cache.rs
@@ -1,0 +1,128 @@
+use super::rust_interop_digest::{digest_file, digest_path, fnv1a64_hex, push_cache_bytes};
+use super::rust_interop_probe::{normalize_cargo_target_dir, PendingRustBridgeProbe};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+use std::{env, fs};
+
+pub(super) fn probe_cache_file(cache_key: &str, invocation_cwd: &Path) -> Option<PathBuf> {
+    let raw = env::var_os("SIFR_RUST_BRIDGE_PROBE_CACHE_DIR")?;
+    let root = normalize_cargo_target_dir(invocation_cwd, PathBuf::from(raw));
+    Some(root.join(format!("{cache_key}.ok")))
+}
+
+pub(super) fn mark_probe_cache_hit(path: &Path) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(path, b"ok\n");
+}
+
+pub(super) fn probe_cache_key(
+    probe: &PendingRustBridgeProbe,
+    backend_root: &Path,
+    probe_manifest: &str,
+    probe_source: &str,
+) -> String {
+    let mut input = Vec::new();
+    for value in [
+        "sifr-rust-bridge-probe-cache-v1",
+        &toolchain_signature(),
+        &probe.backend.cargo_package_id.0,
+        &probe.backend.dependency_name,
+        &probe.backend.cargo_package_name,
+        &probe.backend.cargo_version,
+        probe.backend.cargo_source.as_deref().unwrap_or("<path>"),
+        &probe.backend.cargo_manifest_path.display().to_string(),
+        &probe.path.dotted(),
+        probe_manifest,
+        probe_source,
+        &cached_digest_path(backend_root),
+        &nearest_lock_digest(backend_root),
+        &optional_manifest_root_digest(probe.sysroot_runtime_crate_manifest.as_deref()),
+        &optional_vendor_identity(probe.sysroot_vendor_dir.as_deref()),
+    ] {
+        push_cache_bytes(&mut input, value);
+    }
+    fnv1a64_hex(&input)
+}
+
+fn toolchain_signature() -> String {
+    static TOOLCHAIN_SIGNATURE: OnceLock<String> = OnceLock::new();
+    TOOLCHAIN_SIGNATURE
+        .get_or_init(|| {
+            let mut input = Vec::new();
+            for value in [
+                command_output("cargo", &["-V"]).unwrap_or_else(|| "cargo:unavailable".into()),
+                command_output("rustc", &["-Vv"]).unwrap_or_else(|| "rustc:unavailable".into()),
+                env_signature("RUSTFLAGS"),
+                env_signature("CARGO_BUILD_TARGET"),
+                env_signature("RUSTC_WRAPPER"),
+            ] {
+                push_cache_bytes(&mut input, &value);
+            }
+            fnv1a64_hex(&input)
+        })
+        .clone()
+}
+
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn env_signature(name: &str) -> String {
+    env::var(name).map_or_else(
+        |_| format!("{name}=<unset>"),
+        |value| format!("{name}={value}"),
+    )
+}
+
+fn cached_digest_path(path: &Path) -> String {
+    static DIGESTS: OnceLock<Mutex<BTreeMap<PathBuf, String>>> = OnceLock::new();
+    let cache = DIGESTS.get_or_init(|| Mutex::new(BTreeMap::new()));
+    if let Ok(mut digests) = cache.lock() {
+        if let Some(digest) = digests.get(path) {
+            return digest.clone();
+        }
+        let digest = digest_path(path);
+        digests.insert(path.to_path_buf(), digest.clone());
+        return digest;
+    }
+    digest_path(path)
+}
+
+fn optional_manifest_root_digest(manifest: Option<&Path>) -> String {
+    manifest
+        .and_then(Path::parent)
+        .map_or_else(|| "<no-sysroot-runtime>".to_string(), cached_digest_path)
+}
+
+fn optional_vendor_identity(vendor_dir: Option<&Path>) -> String {
+    let Some(vendor_dir) = vendor_dir else {
+        return "<no-sysroot-vendor>".to_string();
+    };
+    nearest_lock_digest(vendor_dir)
+}
+
+fn nearest_lock_digest(path: &Path) -> String {
+    nearest_ancestor_file(path, "Cargo.lock")
+        .and_then(|lock| digest_file(&lock))
+        .unwrap_or_else(|| "<no-cargo-lock>".to_string())
+}
+
+fn nearest_ancestor_file(start: &Path, file_name: &str) -> Option<PathBuf> {
+    let mut current = Some(start);
+    while let Some(path) = current {
+        let candidate = path.join(file_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        current = path.parent();
+    }
+    None
+}

--- a/plans/reviews/active/create-pr-fastlane-gcq-probe-cache-review-pass-1.md
+++ b/plans/reviews/active/create-pr-fastlane-gcq-probe-cache-review-pass-1.md
@@ -1,0 +1,9 @@
+**Verdict: satisfied for PR 1 as scoped, with follow-ups.** The change is coherent, well-scoped to smoke restoration + supporting cache, and does not touch the migration-closure work or the merged Python interop trim. Local validation is thorough and the numbers demonstrate the intended speedup (411s → 22.6s for the corpus gate).
+
+Key notes:
+- The five findings are all cache/scope concerns, not correctness bugs in the smoke gate itself. The most substantive is #1 (missing `sifr_runtime` digest in dev mode); it degrades probe-diagnostic quality but downstream `cargo check` in GCQ still catches type breakage, so the aggregate gate remains sound.
+- The `validate_smoke_profile` guard is a good invariant to have — it prevents future edits from silently reintroducing `max_entries`-based smoke selection.
+- Smoke correctly drops `clippy` (heavyweight) — consistent with the stated goal of a fast enforcement lane.
+- No user-facing CLI changes; both `SIFR_GCQ_ENTRY_IDS` and `SIFR_RUST_BRIDGE_PROBE_CACHE_DIR` are opt-in and default to prior behavior when unset.
+
+Recommend addressing finding #1 in a follow-up PR by adding a `crates/sifr_runtime` source digest to `probe_cache_key` for the workspace-dev fallback path, and adding at least one unit test in `rust_interop_probe_cache.rs` covering cache-key stability across sensitive input changes.

--- a/verification/areas/generated_code_quality/generated_code_quality.py
+++ b/verification/areas/generated_code_quality/generated_code_quality.py
@@ -351,6 +351,22 @@ def load_manifest(path: Path) -> list[Entry]:
 
 
 def selected_positive_entries(entries: list[Entry], groups: Iterable[str]) -> list[Entry]:
+    explicit_ids = explicit_entry_ids()
+    if explicit_ids:
+        if os.environ.get("SIFR_GCQ_MAX_ENTRIES"):
+            raise SystemExit("SIFR_GCQ_ENTRY_IDS cannot be combined with SIFR_GCQ_MAX_ENTRIES")
+        if list(groups):
+            raise SystemExit("SIFR_GCQ_ENTRY_IDS cannot be combined with --group filters")
+        entries_by_id = {entry.id: entry for entry in entries}
+        missing = [entry_id for entry_id in explicit_ids if entry_id not in entries_by_id]
+        if missing:
+            raise SystemExit(f"unknown SIFR_GCQ_ENTRY_IDS entries: {missing}")
+        selected = [entries_by_id[entry_id] for entry_id in explicit_ids]
+        non_positive = [entry.id for entry in selected if entry.group not in POSITIVE_GROUPS]
+        if non_positive:
+            raise SystemExit(f"SIFR_GCQ_ENTRY_IDS must select positive entries: {non_positive}")
+        return selected
+
     selected_groups = set(groups)
     limit_raw = os.environ.get("SIFR_GCQ_MAX_ENTRIES")
     limit = int(limit_raw) if limit_raw else 0
@@ -364,6 +380,19 @@ def selected_positive_entries(entries: list[Entry], groups: Iterable[str]) -> li
     if not selected:
         raise SystemExit("no positive manifest entries selected")
     return selected
+
+
+def explicit_entry_ids() -> list[str]:
+    raw = os.environ.get("SIFR_GCQ_ENTRY_IDS", "")
+    if not raw.strip():
+        return []
+    ids = [entry_id.strip() for entry_id in raw.split(",")]
+    if any(not entry_id for entry_id in ids):
+        raise SystemExit("SIFR_GCQ_ENTRY_IDS contains an empty entry id")
+    duplicates = sorted({entry_id for entry_id in ids if ids.count(entry_id) > 1})
+    if duplicates:
+        raise SystemExit(f"SIFR_GCQ_ENTRY_IDS contains duplicate entries: {duplicates}")
+    return ids
 
 
 def run_id(mode: str) -> str:
@@ -427,12 +456,7 @@ def run_command(
 ) -> subprocess.CompletedProcess[str]:
     env = command_env()
     shared_root = shared_artifact_root()
-    if (
-        shared_root is not None
-        and len(args) >= 2
-        and args[0] == "cargo"
-        and args[1] in {"check", "clippy"}
-    ):
+    if shared_root is not None and args and args[0] == "cargo":
         env["CARGO_TARGET_DIR"] = str(shared_root / "cargo-target")
     result = subprocess.run(
         args,

--- a/verification/areas/generated_code_quality/runner.py
+++ b/verification/areas/generated_code_quality/runner.py
@@ -18,31 +18,38 @@ CORPUS_MANIFEST = AREA_ROOT / "data" / "corpus_manifest.json"
 GATE_SCRIPT = AREA_ROOT / "generated_code_quality.py"
 RESULT_JSON = REPO_ROOT / "target" / "verification" / "areas" / "generated-code-quality-results.json"
 
+SMOKE_ENTRY_IDS = (
+    "demo-001-codegen-output",
+    "demo-002-codegen-structural-passes",
+)
+SMOKE_ALLOWED_GROUPS = {"demos-required"}
+POSITIVE_ENTRY_GATES = {"corpus", "panic-scan", "rustfmt", "clippy", "determinism"}
+
 PROFILE_SUITES = {
     "smoke": [
-        ("corpus", "2"),
-        ("panic-scan", "2"),
-        ("intrinsic-panic-lint", None),
-        ("rustfmt", "2"),
-        ("determinism", "2"),
+        ("corpus", None, SMOKE_ENTRY_IDS),
+        ("panic-scan", None, SMOKE_ENTRY_IDS),
+        ("intrinsic-panic-lint", None, None),
+        ("rustfmt", None, SMOKE_ENTRY_IDS),
+        ("determinism", None, SMOKE_ENTRY_IDS),
     ],
     "representative": [
-        ("corpus", "12"),
-        ("panic-scan", "12"),
-        ("intrinsic-panic-lint", None),
-        ("rustfmt", "12"),
-        ("clippy", "12"),
-        ("determinism", "12"),
-        ("demos", None),
+        ("corpus", "12", None),
+        ("panic-scan", "12", None),
+        ("intrinsic-panic-lint", None, None),
+        ("rustfmt", "12", None),
+        ("clippy", "12", None),
+        ("determinism", "12", None),
+        ("demos", None, None),
     ],
     "full": [
-        ("corpus", None),
-        ("panic-scan", None),
-        ("intrinsic-panic-lint", None),
-        ("rustfmt", None),
-        ("clippy", None),
-        ("determinism", None),
-        ("demos", None),
+        ("corpus", None, None),
+        ("panic-scan", None, None),
+        ("intrinsic-panic-lint", None, None),
+        ("rustfmt", None, None),
+        ("clippy", None, None),
+        ("determinism", None, None),
+        ("demos", None, None),
     ],
 }
 GATE_SUITES = {
@@ -78,6 +85,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.bless:
         raise SystemExit("generated_code_quality area does not support --bless")
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    validate_smoke_profile(CORPUS_MANIFEST)
     selected = select_suites(manifest, set(args.suite))
 
     print("Running generated-code quality verification area", flush=True)
@@ -151,8 +159,11 @@ def run_suite(area_suite: dict[str, Any]) -> dict[str, Any]:
     if suite_name in GATE_SUITES and command != "generated-code-quality-gate":
         raise SystemExit(f"gate suite '{suite_name}' must use generated-code-quality-gate")
 
-    gate_plan = PROFILE_SUITES.get(suite_name, [(suite_name, None)])
-    variants = [run_gate(suite_name, gate, max_entries) for gate, max_entries in gate_plan]
+    gate_plan = PROFILE_SUITES.get(suite_name, [(suite_name, None, None)])
+    variants = [
+        run_gate(suite_name, gate, max_entries, entry_ids)
+        for gate, max_entries, entry_ids in gate_plan
+    ]
     failed_variants = sum(1 for variant in variants if variant["status"] != "pass")
     return {
         "name": suite_name,
@@ -173,12 +184,21 @@ def run_suite(area_suite: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def run_gate(suite_name: str, gate: str, max_entries: str | None) -> dict[str, Any]:
+def run_gate(
+    suite_name: str,
+    gate: str,
+    max_entries: str | None,
+    entry_ids: tuple[str, ...] | None,
+) -> dict[str, Any]:
     env = os.environ.copy()
     if max_entries is None:
         env.pop("SIFR_GCQ_MAX_ENTRIES", None)
     else:
         env["SIFR_GCQ_MAX_ENTRIES"] = max_entries
+    if entry_ids is None:
+        env.pop("SIFR_GCQ_ENTRY_IDS", None)
+    else:
+        env["SIFR_GCQ_ENTRY_IDS"] = ",".join(entry_ids)
     argv = [sys.executable, str(GATE_SCRIPT), gate, "--manifest", str(CORPUS_MANIFEST)]
     started = time.perf_counter()
     proc = subprocess.run(argv, cwd=REPO_ROOT, env=env, text=True, check=False)
@@ -194,6 +214,7 @@ def run_gate(suite_name: str, gate: str, max_entries: str | None) -> dict[str, A
         "expected_exit_code": 0,
         "actual_exit_code": proc.returncode,
         "duration_ms": round(elapsed_ms, 3),
+        "entry_ids": list(entry_ids) if entry_ids is not None else None,
     }
 
 
@@ -208,6 +229,35 @@ def emit_case_timing(suite_name: str, gate: str, elapsed_ms: float, status: str)
 
 def timing_token(value: object) -> str:
     return "".join(char if char.isalnum() or char in "_.:/+-" else "_" for char in str(value))
+
+
+def validate_smoke_profile(corpus_manifest: Path) -> None:
+    payload = json.loads(corpus_manifest.read_text(encoding="utf-8"))
+    raw_entries = payload.get("entries")
+    if not isinstance(raw_entries, list):
+        raise SystemExit("generated-code quality smoke validation requires manifest entries")
+    entries_by_id = {
+        str(entry.get("id")): entry for entry in raw_entries if isinstance(entry, dict)
+    }
+    smoke_plan = PROFILE_SUITES["smoke"]
+    for gate, max_entries, entry_ids in smoke_plan:
+        if gate not in POSITIVE_ENTRY_GATES:
+            continue
+        if max_entries is not None:
+            raise SystemExit(
+                f"generated-code quality smoke gate {gate} must use explicit entry IDs, not max_entries"
+            )
+        if not entry_ids:
+            raise SystemExit(f"generated-code quality smoke gate {gate} is missing explicit entry IDs")
+        for entry_id in entry_ids:
+            entry = entries_by_id.get(entry_id)
+            if entry is None:
+                raise SystemExit(f"generated-code quality smoke entry is unknown: {entry_id}")
+            group = str(entry.get("group"))
+            if group not in SMOKE_ALLOWED_GROUPS:
+                raise SystemExit(
+                    f"generated-code quality smoke entry {entry_id} uses heavyweight group {group}"
+                )
 
 
 if __name__ == "__main__":

--- a/verification/runner/sifr_verify/profile_runner.py
+++ b/verification/runner/sifr_verify/profile_runner.py
@@ -125,6 +125,9 @@ class ProfileRunner:
         self.legacy = legacy_facade(self.profile)
         self.forward_args = forward_args
         self.env = os.environ.copy()
+        probe_cache_root = REPO_ROOT / "target" / "sifr_rust_bridge_probe_cache" / self.profile_name
+        self.env["SIFR_RUST_BRIDGE_PROBE_CACHE_DIR"] = str(probe_cache_root)
+        os.environ["SIFR_RUST_BRIDGE_PROBE_CACHE_DIR"] = str(probe_cache_root)
         if self.profile.get("cargo_policy", {}).get("offline") is True:
             self.env["CARGO_NET_OFFLINE"] = "true"
             os.environ["CARGO_NET_OFFLINE"] = "true"
@@ -437,7 +440,6 @@ class ProfileRunner:
                 f"unsupported generated-code quality mode: {self.generated_code_quality_mode}"
             )
         shared_root = REPO_ROOT / "target" / "sifr_generated_code_quality" / f"{self.profile_name}.shared"
-        shutil.rmtree(shared_root, ignore_errors=True)
         env = self.env | {"SIFR_GCQ_SHARED_ROOT": str(shared_root.relative_to(REPO_ROOT))}
         run_command(
             uv_area_command(


### PR DESCRIPTION
## Summary
- replace generated-code-quality smoke's positional first-2 selection with explicit cheap demo entry IDs and a smoke-profile guardrail
- preserve and reuse the GCQ shared root, and propagate its Cargo target dir through validation-internal Cargo/Sifr invocations
- add opt-in Rust bridge probe result caching for validation profiles via SIFR_RUST_BRIDGE_PROBE_CACHE_DIR

## Validation
- python3 -m py_compile verification/areas/generated_code_quality/runner.py verification/areas/generated_code_quality/generated_code_quality.py verification/runner/sifr_verify/profile_runner.py
- cargo fmt --check
- cargo check -p sifr_driver --locked
- cargo test -p sifr_driver rust_interop_probe --locked
- python3 scripts/check_file_size_guardrails.py
- SIFR_GCQ_SHARED_ROOT=target/sifr_generated_code_quality/manual.shared SIFR_RUST_BRIDGE_PROBE_CACHE_DIR=target/sifr_rust_bridge_probe_cache/manual uv run --project verification --locked python -m sifr_verify areas run --area generated_code_quality --suite smoke --hardening-summary

## Review
- Claude Opus review: satisfied for PR 1 as scoped, with follow-ups recorded in plans/reviews/active/create-pr-fastlane-gcq-probe-cache-review-pass-1.md