### PR TITLE
Close M12 migration closure guard wave

### DIFF
--- a/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
+++ b/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
@@ -21,14 +21,14 @@ In progress.
 | M9-M13 | in progress | M9 wave 1 merged in [PR #2757](https://github.com/sifr-lang/sifr/pull/2757), migrating `_sifr.platform` and `_sifr.html` to private Rust interop declarations backed by `sifr_stdlib` features. M9 wave 2 merged in [PR #2759](https://github.com/sifr-lang/sifr/pull/2759), migrating `_sifr.calendar` the same way. M9 wave 3 merged in [PR #2761](https://github.com/sifr-lang/sifr/pull/2761), migrating `_sifr.uuid` the same way. M9 wave 4 merged in [PR #2763](https://github.com/sifr-lang/sifr/pull/2763), migrating `_sifr.math` the same way. M9 wave 5 merged in [PR #2765](https://github.com/sifr-lang/sifr/pull/2765), migrating `_sifr.crypto` hash functions used by `sifr.hashlib` while retaining intrinsic fallback for unmigrated crypto helpers. M9 wave 6 merged in [PR #2767](https://github.com/sifr-lang/sifr/pull/2767), migrating infallible base64/base32 encoders while explicitly deferring fallible decode/options to M10. M10 wave 1 merged in [PR #2769](https://github.com/sifr-lang/sifr/pull/2769), migrating fallible base64/base32 decode/options through typed result-error direct interop. M10 wave 2 merged in [PR #2771](https://github.com/sifr-lang/sifr/pull/2771), migrating `_sifr.regex`/`sifr.re` through private Rust interop backed by `sifr_stdlib::regex` while retaining the separate direct regex dependency for `sifr.pathlib` glob lowering. M10 wave 3 merged in [PR #2776](https://github.com/sifr-lang/sifr/pull/2776), migrating `_sifr.url`/`sifr.url` through private Rust interop backed by `sifr_stdlib::url`. M10 wave 4 merged in [PR #2778](https://github.com/sifr-lang/sifr/pull/2778), migrating `_sifr.toml`/`sifr.tomllib` through private Rust interop backed by `sifr_stdlib::toml`. M10 wave 5 merged in [PR #2780](https://github.com/sifr-lang/sifr/pull/2780), migrating `_sifr.json`/`sifr.json` through private Rust interop backed by `sifr_stdlib::json` token adapters while preserving `JSONDecodeError` location fields and JSON integer profile errors. M10 wave 6 merged in [PR #2781](https://github.com/sifr-lang/sifr/pull/2781), migrating `_sifr.encoding`/`sifr.encoding` through private Rust interop backed by `sifr_stdlib::encoding` while preserving public `DecodeError`/`EncodeError` wrappers. M10 wave 7 merged in [PR #2782](https://github.com/sifr-lang/sifr/pull/2782), migrating `_sifr.unicode`/`sifr.unicode` through private Rust interop backed by `sifr_stdlib::unicode` while preserving public `UnicodeDataError` wrappers and Unicode segmentation tuple payloads. M10 wave 8 merged in [PR #2784](https://github.com/sifr-lang/sifr/pull/2784), migrating `_sifr.i18n`/`sifr.i18n` through private Rust interop backed by `sifr_stdlib::i18n` while preserving public i18n error wrappers. M10 wave 9 merged in [PR #2785](https://github.com/sifr-lang/sifr/pull/2785), migrating `_sifr.compress`/`sifr.gzip`/`sifr.zipfile` through private Rust interop backed by `sifr_stdlib` gzip and zipfile adapters. M10 wave 10 merged in [PR #2787](https://github.com/sifr-lang/sifr/pull/2787), migrating `_sifr.datetime` through private Rust interop backed by the `sifr_stdlib` time feature and fixing grouped E2E fixture planning for datetime/compression stdlib features. M10 wave 11 merged in [PR #2789](https://github.com/sifr-lang/sifr/pull/2789), splitting `_sifr.bytes` so `encode_utf8` and `bytes_to_hex` move to private `sifr_stdlib::bytes` adapters while first-class bytes constructors, hex parsing, strict hex formatting, and encode/decode method glue remain compiler-owned. M10 wave 12 merged in [PR #2791](https://github.com/sifr-lang/sifr/pull/2791), splitting `_sifr.collections` so set helpers and legacy JSON-string `defaultdict_*` helpers move to private `sifr_stdlib::collections` adapters while Counter/defaultdict language glue and core collection behavior remain compiler-owned. |
 | Post-M10 Adapter Policy Adherence Audit | completed, merged | Merged in [PR #2774](https://github.com/sifr-lang/sifr/pull/2774). The audit classified completed M9/M10 private bindings, added executable guards for direct `sifr_stdlib` targets and trust separation, documented residual `_sifr.crypto` random scope, and passed Opus review pass 2 plus local `scripts/run_all_tests.sh --profile create-pr` with only the warm wall-time advisory. |
 
-Latest merged wave: M12 wave 3 native ownership registry retirement merged in
-[PR #2799](https://github.com/sifr-lang/sifr/pull/2799). The broad
-`internal_docs/stdlib_native_surface_ownership.toml` registry is deleted,
-resource-sensitive migration is pinned directly to the Rust interop matrix, and
-retained compiler-native glue remains tracked by
-`internal_docs/stdlib_retained_compiler_intrinsics.toml`.
-Next local wave: M12 migrated-intrinsic closure guard and stale deleted-registry
-wording cleanup. Current branch: `m12-migration-closure-guard`.
+Latest merged wave: M12 wave 4 migrated-intrinsic closure guard merged in
+[PR #2803](https://github.com/sifr-lang/sifr/pull/2803). The broad
+`internal_docs/stdlib_native_surface_ownership.toml` registry remains deleted,
+active migrated native intrinsic names are blocked from reappearing in the
+compiler dispatcher, and stale deleted-registry architecture wording is guarded
+by create-pr core guardrails.
+Next local wave: M13 release-candidate certification. Current branch:
+`m12-migration-closure-close`.
 
 ## PR Log
 
@@ -64,6 +64,7 @@ wording cleanup. Current branch: `m12-migration-closure-guard`.
 - M12 wave 1 retained intrinsic allowlist guard: [PR #2795](https://github.com/sifr-lang/sifr/pull/2795) merged after local implementation, Opus review pass 2, and create-pr validation completed on `m12-retained-intrinsic-allowlist`.
 - M12 wave 2 verification target-binary normalization: [PR #2797](https://github.com/sifr-lang/sifr/pull/2797) merged after local implementation, Opus review pass 2, and create-pr validation completed on `m12-target-binary-normalization`.
 - M12 wave 3 native ownership registry retirement: [PR #2799](https://github.com/sifr-lang/sifr/pull/2799) merged after local implementation, Opus review pass 1, and create-pr validation completed on `m12-remove-native-ownership-registry`.
+- M12 wave 4 migrated-intrinsic closure guard: [PR #2803](https://github.com/sifr-lang/sifr/pull/2803) merged after local implementation, Opus review pass 4, and create-pr validation completed on `m12-migration-closure-guard`.
 
 ## Design Reference
 
@@ -2123,9 +2124,8 @@ M12 wave 3 implementation evidence:
   `runtime_platform_suites` (`859326ms`). The e2e pass suite completed
   `132/132` fixtures with report signature `5edef8cd4b961ef8`.
 
-M12 wave 4 status: local implementation, Opus review, and create-pr validation
-passed on
-`m12-migration-closure-guard`.
+M12 wave 4 status: completed and merged in
+[PR #2803](https://github.com/sifr-lang/sifr/pull/2803).
 
 This wave closes the documentation/guardrail gap left after deleting the broad
 native-surface ownership registry. Because resource/runtime/callback rows are


### PR DESCRIPTION
## Summary

- record merged M12 wave 4 implementation PR #2803 in the active phase tracker
- update the latest-wave pointer to M12 wave 4 and set the next local wave to M13 release-candidate certification
- add the wave 4 PR log entry

## Validation

- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`
