### PR TITLE
Split generated build crate tests from smoke

### DIFF
--- a/crates/sifr/src/diagnostics_and_packages_tests.rs
+++ b/crates/sifr/src/diagnostics_and_packages_tests.rs
@@ -378,6 +378,7 @@ pub(super) fn test_check_entrypoint_project_mode_error_parity_with_compile_entry
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 pub(super) fn test_compile_entrypoint_single_file_ignores_unrelated_sibling_parse_errors() {
     let dir = mktemp_dir("single_file_sibling_isolation");
     let main = dir.join("main.sifr");
@@ -396,6 +397,7 @@ pub(super) fn test_compile_entrypoint_single_file_ignores_unrelated_sibling_pars
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 pub(super) fn test_compile_entrypoint_non_main_input_stays_single_file() {
     let dir = mktemp_dir("non_main_single_file_boundary");
     let app = dir.join("app.sifr");
@@ -416,6 +418,7 @@ pub(super) fn test_compile_entrypoint_non_main_input_stays_single_file() {
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 pub(super) fn test_emit_entrypoint_uses_project_mode_for_project_like_main() {
     let dir = mktemp_dir("emit_project_boundary");
     let main = dir.join("main.sifr");

--- a/crates/sifr/src/mode_resolution_tests.rs
+++ b/crates/sifr/src/mode_resolution_tests.rs
@@ -374,6 +374,7 @@ pub(super) fn test_package_cli_parses_run_script_bin_and_app_args() {
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 pub(super) fn test_package_cli_run_selects_workspace_package_from_root() {
     let project = TestProject::new("package_cli_workspace_run_selection");
     project.write(

--- a/crates/sifr_driver/src/build/entrypoint.rs
+++ b/crates/sifr_driver/src/build/entrypoint.rs
@@ -619,6 +619,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "generated build integration coverage runs in full validation profiles"]
     fn test_single_file_entrypoint_plan_generates_main_only_project() {
         let plan = RootedEntrypointPlan::from_entrypoint(&RootedEntrypoint::SingleFile {
             source: "def main():\n    print(\"ok\")\n",
@@ -638,6 +639,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "generated build integration coverage runs in full validation profiles"]
     fn test_project_entrypoint_plan_generates_support_modules() {
         let dir = mktemp_dir("project_positive");
         let main_file = dir.join("main.sifr");
@@ -704,6 +706,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "generated build integration coverage runs in full validation profiles"]
     fn test_project_entrypoint_plan_aggregates_reachable_dependency_metadata() {
         let dir = mktemp_dir("project_metadata_positive");
         let main_file = dir.join("main.sifr");
@@ -742,6 +745,7 @@ def helper() -> bigint:\n    return bigint(1)\n",
     }
 
     #[test]
+    #[ignore = "generated build integration coverage runs in full validation profiles"]
     fn test_project_entrypoint_plan_ignores_unreachable_dependency_metadata() {
         let dir = mktemp_dir("project_metadata_negative");
         let main_file = dir.join("main.sifr");
@@ -778,6 +782,7 @@ def helper() -> bigint:\n    return bigint(1)\n",
     }
 
     #[test]
+    #[ignore = "generated build integration coverage runs in full validation profiles"]
     fn test_cached_project_binary_reuses_workspace_for_unchanged_input() {
         let dir = mktemp_dir("cached_project_reuse");
         let main_file = dir.join("main.sifr");
@@ -818,6 +823,7 @@ def helper() -> bigint:\n    return bigint(1)\n",
     }
 
     #[test]
+    #[ignore = "generated build integration coverage runs in full validation profiles"]
     fn test_cached_project_binary_invalidates_when_sources_change() {
         let dir = mktemp_dir("cached_project_invalidation");
         let main_file = dir.join("main.sifr");

--- a/crates/sifr_driver/src/tests/package_project_build_check.rs
+++ b/crates/sifr_driver/src/tests/package_project_build_check.rs
@@ -296,6 +296,7 @@ def main():\n    assert parse_json() == 1\n    assert decode_json() == 2\n",
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_cached_package_project_materializes_namespace_roots() {
     let dir = mktemp_dir("package_namespace_build");
     let mut app = production_package(&dir, "app", "sifr-demo-app", "demo_app");
@@ -351,6 +352,7 @@ fn generated_project_root(binary_path: &Path) -> PathBuf {
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_cached_package_project_links_direct_rust_interop_dependency() {
     let dir = mktemp_dir("package_direct_rust_interop");
     let app = production_package(&dir, "app", "sifr-demo-app", "demo_app");

--- a/crates/sifr_driver/src/tests/project_build_check.rs
+++ b/crates/sifr_driver/src/tests/project_build_check.rs
@@ -105,6 +105,7 @@ fn test_check_project_resolves_workspace_source_import_for_non_main_entry() {
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_project_materializes_dotted_workspace_modules() {
     let dir = mktemp_dir("workspace_dotted_build");
     let main_file = dir.join("cases/app.sifr");
@@ -140,6 +141,7 @@ fn test_build_project_materializes_dotted_workspace_modules() {
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_project_preserves_imported_class_constructors_and_signatures() {
     let dir = mktemp_dir("workspace_imported_class_codegen");
     let main_file = dir.join("cases/app.sifr");
@@ -197,6 +199,7 @@ def node_value(node: LinkedNode | None) -> int:
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_emit_project_includes_workspace_support_modules() {
     let dir = mktemp_dir("workspace_emit");
     let main_file = dir.join("cases/app.sifr");
@@ -228,6 +231,7 @@ fn test_emit_project_includes_workspace_support_modules() {
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_cached_project_invalidates_when_workspace_helper_changes() {
     let dir = mktemp_dir("workspace_cache_invalidation");
     let main_file = dir.join("cases/app.sifr");
@@ -356,6 +360,7 @@ def broken() -> int:
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_project_includes_support_module_required_features_in_manifest() {
     let dir = mktemp_dir("manifest_positive");
     let main_file = dir.join("main.sifr");
@@ -384,6 +389,7 @@ fn test_build_project_includes_support_module_required_features_in_manifest() {
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_project_manifest_ignores_unreachable_required_features() {
     let dir = mktemp_dir("manifest_negative");
     let main_file = dir.join("main.sifr");
@@ -417,6 +423,7 @@ fn test_build_project_manifest_ignores_unreachable_required_features() {
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_project_includes_reachable_support_module_stdlib_crates_in_manifest() {
     let dir = mktemp_dir("stdlib_positive");
     let main_file = dir.join("main.sifr");
@@ -450,6 +457,7 @@ def render() -> str:\n    try:\n        parsed: TomlValue = loads(\"name = \\\"f
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_project_manifest_ignores_unreachable_support_module_stdlib_crates() {
     let dir = mktemp_dir("stdlib_negative");
     let main_file = dir.join("main.sifr");
@@ -483,6 +491,7 @@ def unused() -> str:\n    try:\n        parsed: str = loads(\"name = \\\"unused\
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_project_includes_transitive_dependency_closure_in_manifest() {
     let dir = mktemp_dir("transitive_positive");
     let main_file = dir.join("main.sifr");
@@ -517,6 +526,7 @@ def render() -> str:\n    return render_value()\n",
 }
 
 #[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_project_manifest_ignores_unreachable_transitive_dependency_chain() {
     let dir = mktemp_dir("transitive_negative");
     let main_file = dir.join("main.sifr");

--- a/plans/reviews/active/create-pr-fastlane-crate-test-split-review-pass-1.md
+++ b/plans/reviews/active/create-pr-fastlane-crate-test-split-review-pass-1.md
@@ -1,0 +1,39 @@
+# create-pr fastlane crate-test split review pass 1
+
+Please review the current working tree for the create-pr fastlane crate-test split milestone.
+
+Context:
+- Previous merged PRs already fixed generated-code-quality smoke selection/cache behavior and replaced repeated validation-internal `cargo run -p sifr` compiler launches with a resolved/prebuilt Sifr binary.
+- This milestone addresses the `crate_tests` regression by moving slow generated artifact/build success-path tests out of smoke crate suites while keeping that coverage in full/merge/nightly/release profiles.
+- Do not modify files. Review only.
+
+Current changes to review:
+- Marked generated artifact/build success-path tests as `#[ignore]` in:
+  - `crates/sifr_driver/src/build/entrypoint.rs`
+  - `crates/sifr_driver/src/tests/project_build_check.rs`
+  - `crates/sifr_driver/src/tests/package_project_build_check.rs`
+  - `crates/sifr/src/diagnostics_and_packages_tests.rs`
+  - `crates/sifr/src/mode_resolution_tests.rs`
+- Added full-only profile suites in `create-pr`, `merge`, `nightly`, and `release`:
+  - `sifr_cli_generated_builds`: `cargo test -p sifr --bin sifr -- --ignored --test-threads=1`
+  - `sifr_driver_generated_builds`: `cargo test -p sifr_driver --lib -- --ignored --test-threads=1`
+- Added a runner self-test guardrail that these suites exist in full profiles and do not run in smoke.
+- Changed profile runner crate-test execution to pass `self.env`, so crate tests inherit the lane's offline/probe-cache/resolved-binary environment.
+
+Validation already run:
+- `cargo fmt --check`: pass
+- `python3 -m py_compile verification/runner/sifr_verify/profile_runner.py verification/runner/sifr_verify/selftest.py`: pass
+- `uv run --project verification --locked python -m sifr_verify --self-test`: pass
+- `python3 scripts/check_file_size_guardrails.py`: pass
+- `SIFR_RUST_BRIDGE_PROBE_CACHE_DIR=target/sifr_rust_bridge_probe_cache/create-pr /usr/bin/time -p cargo test -p sifr --bin sifr --locked`: pass, `98 passed; 4 ignored`, ~8.5s
+- `SIFR_RUST_BRIDGE_PROBE_CACHE_DIR=target/sifr_rust_bridge_probe_cache/create-pr /usr/bin/time -p cargo test -p sifr_driver --lib --locked`: pass, `285 passed; 18 ignored`, ~31.3s
+
+Validation attempted but intentionally stopped:
+- Full ignored CLI suite was started twice. The first parallel run spent ~6m without finishing because all generated build/probe cases contended. After adding `--test-threads=1`, a cold serial run still spent ~9m in the first generated probe/build path, confirming this is full-only generated-build coverage and not practical as milestone smoke validation. No failures were observed before interruption; orphaned temp subprocesses from the interrupted run were cleaned up.
+
+Review questions:
+1. Is any meaningful coverage lost from create-pr smoke rather than moved to full/merge/nightly/release?
+2. Are any ignored tests too broad or misplaced?
+3. Are the profile additions correct and sufficient to retain displaced coverage?
+4. Is passing `self.env` into crate-test commands correct, or does it have unintended side effects?
+5. Are there any blockers before opening this milestone PR?

--- a/plans/reviews/active/create-pr-fastlane-crate-test-split-review-pass-2.md
+++ b/plans/reviews/active/create-pr-fastlane-crate-test-split-review-pass-2.md
@@ -1,0 +1,19 @@
+# create-pr fastlane crate-test split review pass 2
+
+Second Claude Opus review pass on the updated crate-test split diff.
+
+Changes since pass 1:
+- Standardized all generated-build `#[ignore]` reason strings.
+- Added self-test assertions that the generated-build suites remain blocking and merge-executed in all four profiles.
+- Documented the `#[ignore]` policy in `verification/policy/profile_policy.md`.
+- Exercised the profile-runner env path with a tiny cargo test launched through `ProfileRunner`'s prepared environment.
+
+Claude verdict:
+
+> No blocking issues.
+>
+> Satisfied for PR. Both remaining items are advisory coverage-hardening notes, not defects in the diff. The change is internally consistent, the self-test enforces the invariants that matter, and the policy documents intent.
+
+Advisory follow-ups from Claude:
+- A future lint could ensure ignored generated-build tests live in targets covered by the full-only suites.
+- A one-time full generated-build ignored-suite run before merge would close the remaining validation gap, but the cold run is very slow and was not required for this PR verdict.

--- a/verification/policy/profile_policy.md
+++ b/verification/policy/profile_policy.md
@@ -60,7 +60,14 @@ not part of the current stable readiness surface.
 - generated-code quality smoke over a bounded fixture subset
 - library crate unit tests, CLI unit tests, and representative e2e pass fixtures
 
-It intentionally excludes editor packaging, editor asset release checks, distribution/self-update checks, LSP stress, LSP large-session smoke, broad verification hardening, broad project-mode matrices, full generated clippy/corpus, full performance budgets, and the slower `sifr` integration/e2e-support crate tests.
+It intentionally excludes editor packaging, editor asset release checks, distribution/self-update checks, LSP stress, LSP large-session smoke, broad verification hardening, broad project-mode matrices, full generated clippy/corpus, full performance budgets, and the slower generated-build crate integration tests.
+
+Generated-build crate tests use Rust `#[ignore]` only to keep the default smoke
+crate commands fast. They are not disabled tests: full profiles run the
+`sifr_cli_generated_builds` and `sifr_driver_generated_builds` suites with
+`--ignored --test-threads=1`. Do not use `#[ignore]` in the `sifr` binary or
+`sifr_driver` lib suites for broken/quarantined tests; add a separate explicit
+profile suite instead.
 
 ## Merge Profile
 
@@ -73,7 +80,7 @@ It intentionally excludes editor packaging, editor asset release checks, distrib
 - representative generated-code quality checks with shared generated artifacts and Cargo target reuse
 - distribution representative checks
 - formatter, analysis, static tooling, and LSP smoke checks
-- full crate tests, including the slower `sifr` integration/e2e-support tests
+- full crate tests, including the slower generated-build crate integration suites
 
 ## Change-Aware Ownership
 

--- a/verification/profiles/create-pr.json
+++ b/verification/profiles/create-pr.json
@@ -59,7 +59,9 @@
       {"id": "sifr_ir", "package": "sifr_ir", "command": ["test", "-p", "sifr_ir"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_cli_bin", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr"], "modes": ["smoke"], "status": "blocking", "executed_in_merge": false},
       {"id": "sifr_cli_full", "package": "sifr", "command": ["test", "-p", "sifr", "--", "--skip", "test_e2e_pass"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
+      {"id": "sifr_cli_generated_builds", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr", "--", "--ignored", "--test-threads=1"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_driver_lib", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib"], "modes": ["smoke", "full"], "status": "blocking", "executed_in_merge": true},
+      {"id": "sifr_driver_generated_builds", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib", "--", "--ignored", "--test-threads=1"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "blocking", "executed_in_merge": true}
     ]
   },

--- a/verification/profiles/merge.json
+++ b/verification/profiles/merge.json
@@ -60,7 +60,9 @@
       {"id": "sifr_ir", "package": "sifr_ir", "command": ["test", "-p", "sifr_ir"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_cli_bin", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr"], "modes": ["smoke"], "status": "blocking", "executed_in_merge": false},
       {"id": "sifr_cli_full", "package": "sifr", "command": ["test", "-p", "sifr", "--", "--skip", "test_e2e_pass"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
+      {"id": "sifr_cli_generated_builds", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr", "--", "--ignored", "--test-threads=1"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_driver_lib", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib"], "modes": ["smoke", "full"], "status": "blocking", "executed_in_merge": true},
+      {"id": "sifr_driver_generated_builds", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib", "--", "--ignored", "--test-threads=1"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "blocking", "executed_in_merge": true}
     ]
   },

--- a/verification/profiles/nightly.json
+++ b/verification/profiles/nightly.json
@@ -62,7 +62,9 @@
       {"id": "sifr_ir", "package": "sifr_ir", "command": ["test", "-p", "sifr_ir"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_cli_bin", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr"], "modes": ["smoke"], "status": "blocking", "executed_in_merge": false},
       {"id": "sifr_cli_full", "package": "sifr", "command": ["test", "-p", "sifr", "--", "--skip", "test_e2e_pass"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
+      {"id": "sifr_cli_generated_builds", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr", "--", "--ignored", "--test-threads=1"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_driver_lib", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib"], "modes": ["smoke", "full"], "status": "blocking", "executed_in_merge": true},
+      {"id": "sifr_driver_generated_builds", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib", "--", "--ignored", "--test-threads=1"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "blocking", "executed_in_merge": true}
     ]
   },

--- a/verification/profiles/release.json
+++ b/verification/profiles/release.json
@@ -61,7 +61,9 @@
       {"id": "sifr_ir", "package": "sifr_ir", "command": ["test", "-p", "sifr_ir"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_cli_bin", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr"], "modes": ["smoke"], "status": "blocking", "executed_in_merge": false},
       {"id": "sifr_cli_full", "package": "sifr", "command": ["test", "-p", "sifr", "--", "--skip", "test_e2e_pass"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
+      {"id": "sifr_cli_generated_builds", "package": "sifr", "command": ["test", "-p", "sifr", "--bin", "sifr", "--", "--ignored", "--test-threads=1"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_driver_lib", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib"], "modes": ["smoke", "full"], "status": "blocking", "executed_in_merge": true},
+      {"id": "sifr_driver_generated_builds", "package": "sifr_driver", "command": ["test", "-p", "sifr_driver", "--lib", "--", "--ignored", "--test-threads=1"], "modes": ["full"], "status": "blocking", "executed_in_merge": true},
       {"id": "sifr_codegen", "package": "sifr_codegen", "command": ["test", "-p", "sifr_codegen"], "modes": ["full"], "status": "blocking", "executed_in_merge": true}
     ]
   },

--- a/verification/runner/sifr_verify/profile_runner.py
+++ b/verification/runner/sifr_verify/profile_runner.py
@@ -487,7 +487,7 @@ class ProfileRunner:
             if not isinstance(command, list) or not all(isinstance(arg, str) for arg in command):
                 raise ProfileRunnerError(f"crate test suite {suite_id} has invalid command")
             print(f"Running crate test suite {suite_id}")
-            run_command(cargo_command(*command))
+            run_command(cargo_command(*command), env=self.env)
 
     def run_validation_suites(self) -> None:
         if not self.matrix_suites:

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -109,6 +109,7 @@ def _crate_membership_self_test() -> None:
     for profile_name in ("create-pr", "merge", "nightly", "release"):
         profile = profiles[profile_name]
         profile_full_suites = crate_test_suites_for_mode(profile, "full")
+        profile_smoke_suites = crate_test_suites_for_mode(profile, "smoke")
         profile_by_id = {str(suite.get("id")): suite for suite in profile_full_suites}
         codegen = profile_by_id.get("sifr_codegen")
         if not isinstance(codegen, dict):
@@ -116,6 +117,29 @@ def _crate_membership_self_test() -> None:
         if codegen.get("status") != "blocking" or codegen.get("executed_in_merge") is not True:
             raise AssertionError(
                 f"sifr_codegen is not blocking/executed in {profile_name}: {codegen}",
+            )
+        generated_build_suites = {
+            "sifr_cli_generated_builds",
+            "sifr_driver_generated_builds",
+        }
+        missing_generated = sorted(generated_build_suites.difference(profile_by_id))
+        if missing_generated:
+            raise AssertionError(
+                f"generated-build crate suites missing from {profile_name}: {missing_generated}",
+            )
+        for suite_id in sorted(generated_build_suites):
+            suite = profile_by_id[suite_id]
+            if suite.get("status") != "blocking" or suite.get("executed_in_merge") is not True:
+                raise AssertionError(
+                    f"generated-build crate suite is not blocking/executed in {profile_name}: "
+                    f"{suite}",
+                )
+        smoke_ids = {str(suite.get("id")) for suite in profile_smoke_suites}
+        misplaced_generated = sorted(generated_build_suites.intersection(smoke_ids))
+        if misplaced_generated:
+            raise AssertionError(
+                f"generated-build crate suites must not run in smoke for {profile_name}: "
+                f"{misplaced_generated}",
             )
 
     duplicate_profile = {


### PR DESCRIPTION
## Summary
- move generated build/artifact success-path crate tests out of smoke by marking them ignored
- add full-only generated-build suites for sifr CLI and sifr_driver across create-pr/merge/nightly/release
- pass the profile runner environment into crate-test subprocesses and guard the generated-build suite placement in self-test
- document the generated-build #[ignore] policy in profile policy

## Validation
- cargo fmt --check
- python3 -m py_compile verification/runner/sifr_verify/profile_runner.py verification/runner/sifr_verify/selftest.py
- uv run --project verification --locked python -m sifr_verify --self-test
- python3 scripts/check_file_size_guardrails.py
- SIFR_RUST_BRIDGE_PROBE_CACHE_DIR=target/sifr_rust_bridge_probe_cache/create-pr /usr/bin/time -p cargo test -p sifr --bin sifr --locked (~8.5s, 98 passed; 4 ignored)
- SIFR_RUST_BRIDGE_PROBE_CACHE_DIR=target/sifr_rust_bridge_probe_cache/create-pr /usr/bin/time -p cargo test -p sifr_driver --lib --locked (~31.3s, 285 passed; 18 ignored)
- profile runner env path exercised via ProfileRunner-created env and a tiny cargo test

## Review
- Claude pass 1: satisfied for PR with recommendations
- Claude pass 2: satisfied for PR, no blocking issues
