### PR TITLE
Certify sysroot doctor and self-update pairing

### DIFF
--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -8,7 +8,7 @@ use super::explain_cli::cmd_explain;
 use super::formatter_cli::FmtArgs;
 use super::lint_cli::{cmd_lint, LintArgs};
 use super::self_update_cli::{cmd_self, SelfArgs};
-use super::sysroot_cli::{cmd_print, PrintKind};
+use super::sysroot_cli::{cmd_doctor, cmd_print, PrintKind};
 use super::trace_cli::cmd_trace;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, RenderedDiagnostic, Severity};
@@ -118,6 +118,12 @@ pub(crate) enum Commands {
         /// Combine --locked and --offline
         #[arg(long)]
         frozen: bool,
+    },
+    /// Inspect the resolved Sifr sysroot and install health
+    Doctor {
+        /// Print doctor output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Create a new Sifr package
     Init {
@@ -441,6 +447,7 @@ fn run_cli(cli: Cli) -> i32 {
             lock_mode_from_flags(locked, offline, frozen),
             diagnostic_format,
         ),
+        Commands::Doctor { json } => cmd_doctor(json, diagnostic_format),
         Commands::Init {
             path,
             lib,

--- a/crates/sifr/src/sysroot_cli.rs
+++ b/crates/sifr/src/sysroot_cli.rs
@@ -17,6 +17,78 @@ pub(super) fn cmd_print(print: PrintKind, json: bool, diagnostic_format: Diagnos
     }
 }
 
+pub(super) fn cmd_doctor(json: bool, diagnostic_format: DiagnosticFormat) -> i32 {
+    match sifr_sysroot::resolve_sysroot(None) {
+        Ok(sysroot) => {
+            if json {
+                let value = serde_json::json!({
+                    "schema_version": 1,
+                    "status": "ok",
+                    "root": sysroot.root,
+                    "toolchain_id": sysroot.toolchain_id(),
+                    "sifr_version": sysroot.manifest.sifr_version,
+                    "target_triple": sysroot.manifest.target_triple,
+                    "checks": [
+                        {"name": "manifest", "status": "ok", "path": sysroot.paths.manifest},
+                        {"name": "stdlib_public_sources", "status": "ok", "path": sysroot.paths.stdlib_public_sources},
+                        {"name": "stdlib_private_sources", "status": "ok", "path": sysroot.paths.stdlib_private_sources},
+                        {"name": "runtime_crate", "status": "ok", "path": sysroot.paths.runtime_crate},
+                        {"name": "stdlib_crate", "status": "ok", "path": sysroot.paths.stdlib_crate},
+                        {"name": "cargo_lock", "status": "ok", "path": sysroot.paths.cargo_lock},
+                        {"name": "vendor", "status": "ok", "path": sysroot.paths.vendor},
+                    ],
+                });
+                let _ = writeln!(
+                    io::stdout(),
+                    "{}",
+                    serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_string())
+                );
+            } else {
+                let _ = writeln!(io::stdout(), "Sifr doctor: ok");
+                let _ = writeln!(io::stdout(), "sysroot: {}", sysroot.root.display());
+                let _ = writeln!(io::stdout(), "toolchain: {}", sysroot.toolchain_id());
+                let _ = writeln!(io::stdout(), "target: {}", sysroot.manifest.target_triple);
+                let _ = writeln!(
+                    io::stdout(),
+                    "runtime crate: {}",
+                    sysroot.paths.runtime_crate.display()
+                );
+                let _ = writeln!(
+                    io::stdout(),
+                    "stdlib crate: {}",
+                    sysroot.paths.stdlib_crate.display()
+                );
+                let _ = writeln!(io::stdout(), "vendor: {}", sysroot.paths.vendor.display());
+            }
+            EXIT_SUCCESS
+        }
+        Err(error) => {
+            if json {
+                let value = serde_json::json!({
+                    "schema_version": 1,
+                    "status": "error",
+                    "error_kind": format!("{:?}", error.kind),
+                    "message": error.message,
+                    "binary_path": error.binary_path,
+                    "attempted_sysroot": error.attempted_sysroot,
+                    "asset_path": error.asset_path,
+                });
+                let _ = writeln!(
+                    io::stdout(),
+                    "{}",
+                    serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_string())
+                );
+            }
+            let diagnostic = diagnostic_with_code(
+                error.boundary_message(),
+                DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+            );
+            render_diagnostics(&[diagnostic], diagnostic_format);
+            EXIT_USAGE_OR_CONFIG
+        }
+    }
+}
+
 fn print_sysroot(json: bool, diagnostic_format: DiagnosticFormat) -> i32 {
     match sifr_sysroot::resolve_sysroot(None) {
         Ok(sysroot) => {

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -865,8 +865,10 @@ paths, and other `CARGO_MANIFEST_DIR`-derived source paths in release artifacts.
 The installed-toolchain certification area owns the executable version of this
 contract. Its fast merge suite extracts a version-matched release archive
 outside the repository, verifies installed sysroot JSON, emits a migrated
-stdlib fixture from the installed sysroot, runs the installed LSP lifecycle, and
-scans those artifacts plus the archive. Its long-running suite adds broad
+stdlib fixture from the installed sysroot, runs the installed LSP lifecycle,
+captures healthy and broken `sifr doctor` snapshots, verifies standalone
+self-update receipt/version/dry-run output preserves binary/sysroot pairing,
+and scans those artifacts plus the archive. Its long-running suite adds broad
 stdlib check/emit coverage, a real installed stdlib build/run, and offline
 Cargo `metadata`, `tree -e features`, and frozen build checks for the generated
 project.

--- a/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
+++ b/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
@@ -27,9 +27,9 @@ Latest merged wave: M12 wave 4 migrated-intrinsic closure guard merged in
 active migrated native intrinsic names are blocked from reappearing in the
 compiler dispatcher, and stale deleted-registry architecture wording is guarded
 by create-pr core guardrails.
-Current local wave: M13 wave 1 installed toolchain certification on branch
-`m13-installed-toolchain-certification`, fast-forwarded to `origin/main`
-commit `16f920f9f` before final validation.
+Current local wave: M13 wave 2 doctor and self-update certification on branch
+`m13-doctor-self-update-certification`, based on M13 wave 1 merged in
+[PR #2808](https://github.com/sifr-lang/sifr/pull/2808).
 
 ## PR Log
 
@@ -2282,6 +2282,34 @@ M13 wave 1 focused validation:
   `39749ms`/`120000ms` pass. Advisory only: warm wall-time budget exceeded.
 - Opus review pass 4 reported no blocking findings and one cleanup; pass 5
   confirmed the cleanup and marked the wave ready to proceed.
+
+M13 wave 2 status: local implementation, installed smoke validation, Opus
+review pass 2, and full create-pr validation are complete on
+`m13-doctor-self-update-certification`; PR publication is next.
+
+This wave adds `sifr doctor` as the user-facing installed sysroot health
+command and extends the installed smoke certification to capture healthy text
+and JSON doctor snapshots plus a broken-sysroot diagnostic snapshot. The same
+suite now writes a schema-2 standalone install receipt for the extracted
+archive and verifies `sifr self version --format json` and version-pinned
+`sifr self update --dry-run --format json` preserve the installed binary and
+sysroot pairing without fetching channel metadata.
+
+M13 wave 2 focused validation:
+
+- `CARGO_TARGET_DIR=target/validation-m13-wave2 CARGO_INCREMENTAL=0 cargo check -q -p sifr`
+- `python3 -m py_compile verification/areas/sysroot_release/runner.py`
+- `cargo fmt --check`
+- `CARGO_TARGET_DIR=target/validation-m13-wave2 CARGO_INCREMENTAL=0 uv run --project verification --locked python -m sifr_verify areas run --area sysroot_release --suite host-installed-smoke` passed with installed doctor/self-update snapshots, broken `doctor --json`, installed LSP, installed emit, and repo/home path-leakage scans; elapsed `104168ms`, repository scan covered 10 artifacts.
+- Opus review pass 1 reported no blockers and suggested three tightening checks; pass 2 confirmed those checks and marked the wave ready for PR.
+- Full create-pr validation:
+  `CARGO_TARGET_DIR=target/validation-create-pr-m13-wave2 CARGO_INCREMENTAL=0
+  scripts/run_all_tests.sh --profile create-pr` passed all blocking checks.
+  Lane report: wall time `327.23s`, max RSS `750.2MiB`, slowest step
+  `crate_tests` `102216ms`/`600000ms` pass, `runtime_platform_suites`
+  `40523ms`/`120000ms` pass, and e2e pass suite `132/132` fixtures with
+  report signature `5edef8cd4b961ef8`. Advisory only: warm wall-time budget
+  exceeded.
 
 Tasks:
 

--- a/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
+++ b/plans/issues/active/ad-hoc-sifr-sysroot-stdlib-toolchain.md
@@ -67,6 +67,7 @@ Current local wave: M13 wave 2 doctor and self-update certification on branch
 - M12 wave 3 native ownership registry retirement: [PR #2799](https://github.com/sifr-lang/sifr/pull/2799) merged after local implementation, Opus review pass 1, and create-pr validation completed on `m12-remove-native-ownership-registry`.
 - M12 wave 4 migrated-intrinsic closure guard: [PR #2803](https://github.com/sifr-lang/sifr/pull/2803) merged after local implementation, Opus review pass 4, and create-pr validation completed on `m12-migration-closure-guard`.
 - M13 wave 1 installed toolchain certification: [PR #2808](https://github.com/sifr-lang/sifr/pull/2808) opened after post-main local implementation, Opus review pass 5, installed sysroot smoke/heavy certification, and create-pr validation completed on `m13-installed-toolchain-certification`.
+- M13 wave 2 doctor and self-update certification: [PR #2809](https://github.com/sifr-lang/sifr/pull/2809) opened after local implementation, Opus review pass 2, installed smoke certification, and create-pr validation completed on `m13-doctor-self-update-certification`.
 
 ## Design Reference
 
@@ -2284,8 +2285,9 @@ M13 wave 1 focused validation:
   confirmed the cleanup and marked the wave ready to proceed.
 
 M13 wave 2 status: local implementation, installed smoke validation, Opus
-review pass 2, and full create-pr validation are complete on
-`m13-doctor-self-update-certification`; PR publication is next.
+review pass 2, and full create-pr validation are complete in
+[PR #2809](https://github.com/sifr-lang/sifr/pull/2809) on
+`m13-doctor-self-update-certification`.
 
 This wave adds `sifr doctor` as the user-facing installed sysroot health
 command and extends the installed smoke certification to capture healthy text

--- a/plans/reviews/active/m13-doctor-self-update-certification-review-pass1.md
+++ b/plans/reviews/active/m13-doctor-self-update-certification-review-pass1.md
@@ -1,0 +1,30 @@
+## M13 Wave 2 Review — Doctor and Self-Update Certification
+
+**Verdict:** No blockers. Wave 2 is satisfactory for PR readiness.
+
+The `sifr doctor` implementation is honestly scoped, the installed-smoke additions actually exercise the receipt/version/dry-run pairing offline, the broken-sysroot snapshot is meaningful, and the docs/manifest updates match what the code and runner now do. Local validation ran to completion in the sysroot_release area (109s elapsed).
+
+Non-blocking suggestions, ordered by likely benefit:
+
+1. **`validate_self_update_dry_run_json` does not assert `binary_path` pairing** — `verification/areas/sysroot_release/runner.py:565-575`. It checks `sysroot_path` resolves to `install_root` but not that dry-run JSON's `binary_path` resolves to `install_root/bin/sifr`. The pairing is already enforced by `discover_install_receipt` and covered explicitly in `validate_self_version_json`, so pairing IS proven end-to-end — but tightening the dry-run check for parity would remove that indirection. Cheap follow-up.
+
+2. **`write_install_receipt` swallows a missing `sysroot_content_sha256`** — `verification/areas/sysroot_release/runner.py:506`. `str(sysroot_payload.get("sysroot_content_sha256"))` yields the literal `"None"` if the field disappears from `--print sysroot --json`; the failure then surfaces late as an unhelpful `is_sha256_hex` diagnostic from `self_update_receipt.rs`. A defensive assertion in `validate_sysroot_json` (which is now returning the payload anyway) would fail closer to the cause.
+
+3. **`cli_model_and_entrypoint.rs` is at 881 / 900 lines** — `crates/sifr/src/cli_model_and_entrypoint.rs`. Wave 2 added 9 lines. Still within cap, but the next CLI addition in that file may push it over the guardrail; consider peeling off the `Commands` enum or the dispatch table into its own module before the next wave.
+
+4. **JSON-mode doctor error branch is uncovered** — `crates/sifr/src/sysroot_cli.rs:66-88`. The broken-sysroot smoke exercises only `broken_sifr doctor` (text mode). The `doctor --json` error emitter (with `error_kind`, `attempted_sysroot`, `asset_path` fields) is untested in the release suite. Adding a `broken_sifr doctor --json` step and asserting `status == "error"` plus `asset_path` would close that gap and pin the JSON schema.
+
+5. **`cmd_doctor` and `print_sysroot` share resolve→render structure** — `crates/sifr/src/sysroot_cli.rs:20-90` vs `92-138`. Not a duplicate resolution path (both call the single `sifr_sysroot::resolve_sysroot(None)` entrypoint, so wave 2 does not introduce a second sysroot resolver), but the render layer is duplicated. Extractable later if a third caller lands; not worth churn now.
+
+6. **UX inconsistency: `sifr doctor --json` bool vs `sifr self ... --format {text,json}`** — `crates/sifr/src/cli_model_and_entrypoint.rs:123-127`. Two flag shapes for the same "give me JSON" idea. Mirrors the pre-existing `sifr --json --print sysroot` bool style, so wave 2 didn't create the inconsistency, but future harmonization would be nice.
+
+7. **Home-path leakage scan omits the new snapshots** — `verification/areas/sysroot_release/runner.py:246-258`. The repo-path scan (line 224-243) covers the five new files; the home-path scan is limited to archive + emit. Because install_root is a `tempfile.TemporaryDirectory` outside `$HOME`, doctor and self-update outputs would only leak home paths if the compiler baked them at build time — which the emit + archive scan already covers. Cosmetic parity only.
+
+**Answers to the specific review questions**
+
+1. Yes — `cmd_doctor` goes through the same `sifr_sysroot::resolve_sysroot(None)` entrypoint as `--print sysroot`; `--sysroot` is applied globally via `set_process_sysroot_override`, so no second resolution path.
+2. Yes — every check reported `ok` in the JSON `checks` array corresponds to an assertion that `layout.rs::validate` actually enforces (manifest read, stdlib public/private source dirs, runtime and stdlib crate manifests, cargo lock, vendor).
+3. Yes — `--dry-run --version 0.1.0-beta.1301` takes the `TargetRequest::Version` path in `self_update_cli.rs:184-189`, which `cmd_update` explicitly does NOT fetch metadata for (`self_update_cli.rs:89-101`). Receipt discovery + version validation both assert `sysroot_path`/`binary_path` pairing.
+4. Yes — the broken scenario deletes exactly the file whose absence trips `require_file(...runtime_crate_manifest...)` before validate_workspace_manifest runs; the assertion pins both `missing or invalid asset` and `sifr_runtime/Cargo.toml`. Leakage scanning of the new snapshots is meaningful because those outputs contain resolved paths generated at runtime.
+5. Yes — the architecture doc, issue plan, and manifest description all reflect what the code and runner now do; no aspirational claims.
+6. No file-size violations. The `cli_model_and_entrypoint.rs` proximity to 900 is the only maintainability signal worth watching.

--- a/plans/reviews/active/m13-doctor-self-update-certification-review-pass2.md
+++ b/plans/reviews/active/m13-doctor-self-update-certification-review-pass2.md
@@ -1,0 +1,38 @@
+I inspected the delta against pass 1. All three tightenings are correctly implemented and I have no remaining blockers for PR readiness.
+
+## Confirmation of the three tightenings
+
+**1. Dry-run `binary_path` pairing** — `verification/areas/sysroot_release/runner.py:581-582`
+```python
+if Path(str(payload.get("binary_path"))).resolve() != (install_root / "bin" / "sifr").resolve():
+    raise CertificationError("self update dry-run json did not preserve the installed binary path")
+```
+Symmetric with the existing `sysroot_path` assertion above it and with `validate_self_version_json`. Good.
+
+**2. Early `sysroot_content_sha256` assertion** — `verification/areas/sysroot_release/runner.py:493-494`, called before `write_install_receipt` at `runner.py:192-193`
+```python
+if not isinstance(payload.get("sysroot_content_sha256"), str):
+    raise CertificationError("installed sysroot json omitted sysroot_content_sha256")
+```
+Fails with a specific message at the point the field is missing, instead of surfacing later as an `is_sha256_hex` diagnostic. Good.
+
+**3. Broken doctor `--json` snapshot + leakage scan coverage** — `verification/areas/sysroot_release/runner.py:627-631, 654-663`
+- Runs `broken_sifr doctor --json`, writes `installed-doctor-broken.json` (stdout+stderr, `runner.py:628`)
+- Asserts exit code ≠ 0, `status == "error"`, and `"sifr_runtime/Cargo.toml" in asset_path`
+- Added to the repo path-leakage `check_no_path_leakage.py` invocation at `runner.py:239`
+
+The CLI's JSON-error branch it exercises is `crates/sifr/src/sysroot_cli.rs:66-80`, which serializes `error.asset_path` — so the runner assertion pins the field that closes the gap flagged in pass 1.
+
+## Additional checks
+
+- **File-size guardrail**: `cli_model_and_entrypoint.rs` is still 881 lines (no change from wave 2's original 9-line addition); `sysroot_cli.rs` is 139; `runner.py` grew to 784. All under 900.
+- **JSON parse safety**: `broken_json.stdout` is the sole content of the JSON pretty-print block; `render_diagnostics` writes to stderr, which is why concatenating stdout+stderr to file works and stdout alone parses cleanly.
+- **Ordering**: `validate_sysroot_json` now returns the payload (`runner.py:482,495`) and `write_install_receipt` consumes it downstream, so tightening 2 provably fires before the receipt is written.
+- **Validation record**: your reported run (elapsed_ms=104168, 10 artifacts scanned, home scan passed) is consistent with the six new snapshot paths joining the four pre-existing ones in the repo-scan list at `runner.py:232-241`.
+
+## Non-blocking observations (do not gate the PR)
+
+- `write_install_receipt` at `runner.py:511` still wraps the sysroot sha in `str(...)`; now that the validator guarantees it's a string, the `str()` is a no-op. Purely cosmetic.
+- Pass 1 items 3 (881/900 proximity), 4 was closed by tightening 3, 5, 6, and 7 remain as follow-up polish, not wave 2 concerns.
+
+**Verdict:** Ready for PR. No blockers.

--- a/verification/areas/sysroot_release/manifest.json
+++ b/verification/areas/sysroot_release/manifest.json
@@ -2,7 +2,7 @@
   "schema_version": 2,
   "name": "sysroot_release",
   "owner": "release/distribution",
-  "description": "Installed sysroot release certification for source-checkout-independent CLI, LSP, offline Cargo, and path-leakage behavior.",
+  "description": "Installed sysroot release certification for source-checkout-independent CLI, doctor, self-update pairing, LSP, offline Cargo, and path-leakage behavior.",
   "parallel_safe": false,
   "resource_classes": [
     "default-local",

--- a/verification/areas/sysroot_release/runner.py
+++ b/verification/areas/sysroot_release/runner.py
@@ -167,6 +167,12 @@ def run_host_installed_smoke() -> tuple[int, list[str]]:
             lsp_trace = ACTUAL_ROOT / "lsp-trace.jsonl"
             sysroot_json_path = ACTUAL_ROOT / "installed-sysroot.json"
             emit_path = ACTUAL_ROOT / "installed-smoke-emit.rs"
+            doctor_text_path = ACTUAL_ROOT / "installed-doctor-healthy.txt"
+            doctor_json_path = ACTUAL_ROOT / "installed-doctor-healthy.json"
+            broken_doctor_path = ACTUAL_ROOT / "installed-doctor-broken.txt"
+            broken_doctor_json_path = ACTUAL_ROOT / "installed-doctor-broken.json"
+            self_version_path = ACTUAL_ROOT / "installed-self-version.json"
+            self_update_dry_run_path = ACTUAL_ROOT / "installed-self-update-dry-run.json"
             extract_archive(archive_path, install_root)
             work_root.mkdir()
             build_root.mkdir()
@@ -183,7 +189,27 @@ def run_host_installed_smoke() -> tuple[int, list[str]]:
                 label="installed sysroot json",
             )
             sysroot_json_path.write_text(sysroot_output.stdout, encoding="utf-8")
-            validate_sysroot_json(sysroot_output.stdout, install_root, host)
+            sysroot_payload = validate_sysroot_json(sysroot_output.stdout, install_root, host)
+            write_install_receipt(install_root, host, sysroot_payload)
+            run_self_update_snapshots(
+                installed_sifr,
+                install_root,
+                work_root,
+                env,
+                self_version_path,
+                self_update_dry_run_path,
+            )
+            run_doctor_snapshots(
+                installed_sifr,
+                install_root,
+                temp_root,
+                work_root,
+                env,
+                doctor_text_path,
+                doctor_json_path,
+                broken_doctor_path,
+                broken_doctor_json_path,
+            )
 
             emit = run_checked(
                 [str(installed_sifr), "emit", str(compile_fixture)],
@@ -207,6 +233,12 @@ def run_host_installed_smoke() -> tuple[int, list[str]]:
                     str(sysroot_json_path),
                     str(emit_path),
                     str(lsp_trace),
+                    str(doctor_text_path),
+                    str(doctor_json_path),
+                    str(broken_doctor_path),
+                    str(broken_doctor_json_path),
+                    str(self_version_path),
+                    str(self_update_dry_run_path),
                 ],
                 cwd=REPO_ROOT,
                 env=env,
@@ -447,7 +479,7 @@ def extract_archive(archive_path: Path, install_root: Path) -> None:
             archive.extractall(install_root)
 
 
-def validate_sysroot_json(raw: str, install_root: Path, host: str) -> None:
+def validate_sysroot_json(raw: str, install_root: Path, host: str) -> dict[str, Any]:
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError as error:
@@ -458,6 +490,177 @@ def validate_sysroot_json(raw: str, install_root: Path, host: str) -> None:
         raise CertificationError("installed sysroot version did not match packaged compiler version")
     if payload.get("target_triple") != host:
         raise CertificationError("installed sysroot target triple did not match host")
+    if not isinstance(payload.get("sysroot_content_sha256"), str):
+        raise CertificationError("installed sysroot json omitted sysroot_content_sha256")
+    return payload
+
+
+def write_install_receipt(install_root: Path, host: str, sysroot_payload: dict[str, Any]) -> None:
+    receipt = {
+        "schema_version": 2,
+        "name": "sifr",
+        "version": RELEASE_VERSION,
+        "channel": "beta",
+        "target": host,
+        "install_dir": str(install_root / "bin"),
+        "binary_path": str(install_root / "bin" / "sifr"),
+        "sysroot_path": str(install_root),
+        "sysroot_schema_version": 1,
+        "sysroot_sifr_version": RELEASE_VERSION,
+        "sysroot_target_triple": host,
+        "sysroot_content_sha256": str(sysroot_payload.get("sysroot_content_sha256")),
+        "artifact": f"sifr-{RELEASE_VERSION}-{host}.tar.gz",
+        "modify_path": False,
+    }
+    (install_root / "install.json").write_text(json.dumps(receipt, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def run_self_update_snapshots(
+    installed_sifr: Path,
+    install_root: Path,
+    work_root: Path,
+    env: dict[str, str],
+    self_version_path: Path,
+    self_update_dry_run_path: Path,
+) -> None:
+    version = run_checked(
+        [str(installed_sifr), "self", "version", "--format", "json"],
+        cwd=work_root,
+        env=env,
+        label="self version json",
+        stdout_path=self_version_path,
+        echo_output=False,
+    )
+    validate_self_version_json(version.stdout, install_root)
+    dry_run = run_checked(
+        [
+            str(installed_sifr),
+            "self",
+            "update",
+            "--dry-run",
+            "--version",
+            "0.1.0-beta.1301",
+            "--format",
+            "json",
+        ],
+        cwd=work_root,
+        env=env,
+        label="self update dry-run json",
+        stdout_path=self_update_dry_run_path,
+        echo_output=False,
+    )
+    validate_self_update_dry_run_json(dry_run.stdout, install_root)
+
+
+def validate_self_version_json(raw: str, install_root: Path) -> None:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise CertificationError(f"self version json did not parse: {error}") from error
+    if payload.get("current_version") != RELEASE_VERSION or payload.get("receipt_version") != RELEASE_VERSION:
+        raise CertificationError("self version json did not preserve the installed receipt version")
+    if Path(str(payload.get("sysroot_path"))).resolve() != install_root.resolve():
+        raise CertificationError("self version json did not preserve the installed sysroot path")
+    if Path(str(payload.get("binary_path"))).resolve() != (install_root / "bin" / "sifr").resolve():
+        raise CertificationError("self version json did not preserve the installed binary path")
+    if payload.get("matches_receipt") is not True:
+        raise CertificationError("self version json did not report a matching receipt")
+
+
+def validate_self_update_dry_run_json(raw: str, install_root: Path) -> None:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise CertificationError(f"self update dry-run json did not parse: {error}") from error
+    if payload.get("current_version") != RELEASE_VERSION or payload.get("target_version") != "0.1.0-beta.1301":
+        raise CertificationError("self update dry-run json did not preserve requested version transition")
+    if payload.get("action") != "update" or payload.get("would_run_installer") is not True:
+        raise CertificationError("self update dry-run json did not plan an update action")
+    if Path(str(payload.get("sysroot_path"))).resolve() != install_root.resolve():
+        raise CertificationError("self update dry-run json did not preserve the installed sysroot path")
+    if Path(str(payload.get("binary_path"))).resolve() != (install_root / "bin" / "sifr").resolve():
+        raise CertificationError("self update dry-run json did not preserve the installed binary path")
+
+
+def run_doctor_snapshots(
+    installed_sifr: Path,
+    install_root: Path,
+    temp_root: Path,
+    work_root: Path,
+    env: dict[str, str],
+    doctor_text_path: Path,
+    doctor_json_path: Path,
+    broken_doctor_path: Path,
+    broken_doctor_json_path: Path,
+) -> None:
+    text = run_checked(
+        [str(installed_sifr), "doctor"],
+        cwd=work_root,
+        env=env,
+        label="doctor healthy",
+        stdout_path=doctor_text_path,
+        echo_output=False,
+    )
+    if "Sifr doctor: ok" not in text.stdout or str(install_root) not in text.stdout:
+        raise CertificationError("installed doctor text output did not report the extracted sysroot")
+    raw_json = run_checked(
+        [str(installed_sifr), "doctor", "--json"],
+        cwd=work_root,
+        env=env,
+        label="doctor healthy json",
+        stdout_path=doctor_json_path,
+        echo_output=False,
+    )
+    validate_doctor_json(raw_json.stdout, install_root)
+
+    broken_root = temp_root / "broken-install"
+    shutil.copytree(install_root, broken_root)
+    broken_runtime_manifest = broken_root / "crates" / "sifr_runtime" / "Cargo.toml"
+    broken_runtime_manifest.unlink()
+    broken_sifr = broken_root / "bin" / "sifr"
+    broken = run_command([str(broken_sifr), "doctor"], cwd=work_root, env=env, timeout=60)
+    broken_doctor_path.write_text(broken.stdout + broken.stderr, encoding="utf-8")
+    if broken.returncode == 0:
+        raise CertificationError("doctor unexpectedly accepted a broken installed sysroot")
+    if "missing or invalid asset" not in broken.stderr or "sifr_runtime/Cargo.toml" not in broken.stderr:
+        raise CertificationError("broken doctor output did not identify the missing runtime manifest")
+    broken_json = run_command([str(broken_sifr), "doctor", "--json"], cwd=work_root, env=env, timeout=60)
+    broken_doctor_json_path.write_text(broken_json.stdout + broken_json.stderr, encoding="utf-8")
+    if broken_json.returncode == 0:
+        raise CertificationError("doctor --json unexpectedly accepted a broken installed sysroot")
+    validate_broken_doctor_json(broken_json.stdout)
+
+
+def validate_doctor_json(raw: str, install_root: Path) -> None:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise CertificationError(f"doctor json did not parse: {error}") from error
+    if payload.get("status") != "ok":
+        raise CertificationError("doctor json did not report ok status")
+    if Path(str(payload.get("root"))).resolve() != install_root.resolve():
+        raise CertificationError("doctor json root did not match the extracted archive")
+    check_names = {
+        str(check.get("name"))
+        for check in payload.get("checks", [])
+        if isinstance(check, dict) and check.get("status") == "ok"
+    }
+    required = {"manifest", "runtime_crate", "stdlib_crate", "cargo_lock", "vendor"}
+    missing = sorted(required.difference(check_names))
+    if missing:
+        raise CertificationError(f"doctor json omitted required ok check(s): {', '.join(missing)}")
+
+
+def validate_broken_doctor_json(raw: str) -> None:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise CertificationError(f"broken doctor json did not parse: {error}") from error
+    if payload.get("status") != "error":
+        raise CertificationError("broken doctor json did not report error status")
+    asset_path = str(payload.get("asset_path"))
+    if "sifr_runtime/Cargo.toml" not in asset_path:
+        raise CertificationError("broken doctor json did not identify the missing runtime manifest")
 
 
 def run_lsp_smoke(installed_sifr: Path, work_root: Path, env: dict[str, str], trace_path: Path) -> None:
@@ -496,6 +699,7 @@ def installed_env(temp_root: Path) -> dict[str, str]:
     env = base_env()
     env.pop("SIFR_SYSROOT", None)
     env.pop("SIFR_RUNTIME_PATH", None)
+    env.pop("SIFR_INSTALL_MANIFEST_DIR", None)
     env["CARGO_NET_OFFLINE"] = "true"
     probe_cache_root = ACTUAL_ROOT / "probe-cache"
     probe_cache_root.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- add `sifr doctor` for resolved sysroot health in text and JSON forms
- extend installed sysroot smoke certification with healthy/broken doctor snapshots, including broken `doctor --json`
- generate a standalone install receipt in the extracted archive and verify `sifr self version` plus version-pinned `self update --dry-run` preserve binary/sysroot pairing offline
- include the new doctor/self-update snapshots in installed repo path-leakage scanning
- update M13 architecture and issue tracking docs for the expanded certification coverage

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR=target/validation-m13-wave2 CARGO_INCREMENTAL=0 cargo check -q -p sifr`
- `python3 -m py_compile verification/areas/sysroot_release/runner.py`
- `python3 -m json.tool verification/areas/sysroot_release/manifest.json >/dev/null`
- `uv run --project verification --locked python -m sifr_verify areas check`
- `CARGO_TARGET_DIR=target/validation-m13-wave2 CARGO_INCREMENTAL=0 uv run --project verification --locked python -m sifr_verify areas run --area sysroot_release --suite host-installed-smoke`
- `CARGO_TARGET_DIR=target/validation-create-pr-m13-wave2 CARGO_INCREMENTAL=0 scripts/run_all_tests.sh --profile create-pr`

`create-pr` passed all blocking checks. Lane report: wall time `327.23s`, max RSS `750.2MiB`, slowest step `crate_tests` `102216ms`/`600000ms` pass, e2e `132/132` pass fixtures. Advisory only: warm wall-time budget exceeded.

## Review

- Opus pass 1: no blockers; three tightening suggestions.
- Opus pass 2: tightening checks confirmed; reviewer marked PR ready.
