### PR TITLE
Document sysroot stdlib ellipsis-only Rust interop declarations

### DIFF
--- a/docs/rust-interop.mdx
+++ b/docs/rust-interop.mdx
@@ -51,6 +51,9 @@ sifr repair
 ## Direct Bindings
 
 Use `@rust(...)` when a public Rust function has a bridge-compatible signature. The target is a dotted path, not a string.
+Package-authored Rust interop declarations use an ellipsis-only stub body:
+exactly `...`. Generated behavior comes from the validated Rust interop
+metadata.
 
 ```sifr
 @rust(crc32fast.hash, panic=trusted_no_panic)

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -96,6 +96,12 @@ def crc32(data: bytes) -> uint32: ...
 
 Direct binding is allowed only when the target signature is bridge-compatible without adaptation. If the Rust crate exposes a non-compatible API, the package author must write a package-local bridge. Non-`Result` direct bindings require an explicit panic policy such as `panic=trusted_no_panic`; otherwise they must expose `Result[..., RustPanicError]`.
 
+The body of a Rust interop declaration is an ellipsis-only stub body: exactly
+one ellipsis statement. The compiler derives generated behavior from the
+validated Rust interop metadata rather than from Sifr statements in the
+declaration body. Ellipsis is public Rust interop declaration syntax, not a
+general Sifr function body form.
+
 ### Package-Local Bridge Binding
 
 ```sifr
@@ -561,7 +567,8 @@ Every fallible Rust call exposed to Sifr returns `Result`. Panics are not user e
 
 ## Panic Surface Policy
 
-Every `@rust` declaration has an explicit panic surface.
+Every package-authored `@rust` declaration declares its panic surface in the
+Sifr source.
 
 Result-returning functions convert caught Rust panics to `RustPanicError`, and that error must enter the declared Sifr error channel through one of:
 
@@ -584,7 +591,7 @@ If the mapper panics, generated glue ignores the failed mapper and surfaces the 
 
 The initial compile-time panic contract validates the public panic surface and `panic=map_error(path)` shape. Full generated wrapper emission, mapper signature validation, and mapper-panic fallback behavior are future-owned by [`plans/issues/active/rust-interop-runtime-ecosystem-certification.md`](../plans/issues/active/rust-interop-runtime-ecosystem-certification.md) through the `panic_boundary_wrapper_emission` compatibility row.
 
-Non-`Result` functions cannot return a recoverable panic without changing their public type. They are rejected unless they declare `panic=trusted_no_panic` or `panic=abort` and satisfy the corresponding trust policy. `panic=trusted_no_panic` is a package trust assertion, not a compiler proof, and requires `[trust].rust-no-panic`. `panic=abort` opts into process-aborting behavior through `[trust].rust-panic-abort` and does not preserve recoverable interop semantics.
+Non-`Result` functions cannot return a recoverable panic without changing their public type. Package-authored declarations are rejected unless they declare `panic=trusted_no_panic` or `panic=abort` and satisfy the corresponding trust policy. `panic=trusted_no_panic` is a package trust assertion, not a compiler proof, and requires `[trust].rust-no-panic`. `panic=abort` opts into process-aborting behavior through `[trust].rust-panic-abort` and does not preserve recoverable interop semantics.
 
 Generated wrappers catch panics at the boundary:
 
@@ -604,7 +611,16 @@ pub fn call_encode(text: &str) -> Result<Tokenized, NativeErrorOr<TokenizeError>
 
 Generated wrappers use `AssertUnwindSafe` at the boundary because opaque handles and mutable bridge state are commonly not `UnwindSafe`. The generated wrapper marks the opaque receiver plus any mutable or owned opaque handles passed to the Rust call as poisoned automatically when `catch_unwind` returns `Err`; bridge authors do not implement poisoning manually and must not depend on additional bridge code running after a panic. Re-entering a poisoned handle returns a stable `SIFR-RUST-PANIC-*` error instead of calling Rust again.
 
-The initial panic-boundary contract surface enforces that Result-returning Rust interop declarations either expose `RustPanicError`, declare `panic=map_error(path)`, or use an explicit trusted/abort panic policy. Non-Result declarations require `panic=trusted_no_panic` or `panic=abort`; `panic=abort` requires both `[trust].rust-panic-abort` evidence and a selected Cargo profile whose panic strategy is `abort`. Runtime bridge helpers redact panic payloads when converting caught panics into `RustPanicErrorBridge`.
+The initial panic-boundary contract surface enforces that package-authored Result-returning Rust interop declarations either expose `RustPanicError`, declare `panic=map_error(path)`, or use an explicit trusted/abort panic policy. Package-authored non-`Result` declarations require `panic=trusted_no_panic` or `panic=abort`; `panic=abort` requires both `[trust].rust-panic-abort` evidence and a selected Cargo profile whose panic strategy is `abort`. Runtime bridge helpers redact panic payloads when converting caught panics into `RustPanicErrorBridge`.
+
+Private sysroot stdlib declarations are compiled in a synthetic compiler-owned
+package context. A private `_sifr.*` declaration that targets a direct
+`sifr_stdlib.*` path uses the compiler-owned sysroot no-panic trust policy as
+its effective panic surface. The effective policy is recorded in Rust interop
+trust metadata, bridge probes, dependency-plan cache fingerprints, and audit
+diagnostics. This sysroot policy is restricted to canonical private stdlib
+declarations and does not apply to user packages, package-local bridges,
+`Self`, `sifr_runtime`, or arbitrary Cargo dependency roots.
 
 `Drop` panics are backend contract violations. Fallible cleanup must be modeled as explicit `close` or `aclose`, not as hidden destructor failure.
 

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -133,15 +133,29 @@ owns those conversions before calling lower-level implementation code.
 The compiler should not add per-declaration converter pipelines for the stdlib
 rewrite. Generated glue validates the single `@rust(...)` target signature,
 records the sysroot interop dependency and trust metadata, and lets
-`sifr_stdlib` own implementation adaptation. These migrations are committed to
+`sifr_stdlib` own implementation adaptation. Sysroot stdlib interop uses
 `bridge-version = 1`; any future callee-injection form requires a new
-bridge-versioned design and must not add fallback conversion behavior to existing
+bridge-versioned design and must not add fallback conversion behavior to
 sysroot interop declarations.
 
 Private stdlib declarations rely on the compiler-owned sysroot trust policy and
-`sifr_stdlib` crate-level no-panic conventions for public APIs whose error
-surface does not include `RustPanicError`; user packages do not inherit that
-trust.
+`sifr_stdlib` crate-level no-panic conventions. User packages do not inherit
+that trust.
+
+Canonical private stdlib Rust interop declarations use an ellipsis-only stub
+body and target direct `sifr_stdlib.*` paths:
+
+```sifr
+@rust(sifr_stdlib.math.sqrt)
+def sqrt(x: float) -> float: ...
+```
+
+For private `_sifr.*` declarations loaded from the resolved sysroot, a direct
+`sifr_stdlib.*` target has an effective compiler-owned no-panic policy. The
+compiler records that effective policy in trust metadata and dependency-plan
+fingerprints even though the source declaration remains a pure declaration
+stub. This rule is package-keyed to the synthetic sysroot package context and
+does not extend to user packages or non-stdlib Rust targets.
 
 Resource, async, callback, and runtime-state surfaces stay behind the active
 Rust interop runtime certification gate until their lifecycle behavior is
@@ -756,10 +770,12 @@ file, and preamble file until that entry is migrated, deleted, or explicitly
 kept as compiler-language glue.
 
 Private stdlib Rust interop uses the normal Rust interop contract plus a
-compiler-owned sysroot trust policy. That trust does not extend to arbitrary
-user crates. Sysroot declarations may target only version-matched sysroot
-crates unless an explicit architecture decision adds a new trusted crate
-boundary.
+compiler-owned sysroot trust policy. A canonical private `_sifr.*` declaration
+that targets direct `sifr_stdlib.*` uses the sysroot no-panic policy as its
+effective panic surface and is written as an ellipsis-only declaration stub.
+That trust does not extend to arbitrary user crates. Sysroot declarations may
+target only version-matched sysroot crates unless an explicit architecture
+decision adds a new trusted crate boundary.
 
 Private `_sifr` declaration interop uses a synthetic compiler-owned package
 context rather than a user package. The context maps private declaration

--- a/plans/issues/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup.md
+++ b/plans/issues/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup.md
@@ -1,0 +1,434 @@
+# Ad Hoc Phase: Sysroot Stdlib Interop Declaration Cleanup
+
+## Status
+
+Active planning phase.
+
+## Objective
+
+Make private sysroot stdlib Rust interop declarations read as pure checked
+declarations. A canonical private `_sifr.*` declaration that targets
+`sifr_stdlib.*` uses the compiler-owned sysroot no-panic trust policy, and its
+body is an ellipsis-only Rust interop stub. User and package Rust interop keeps
+its explicit panic-surface contract.
+
+This phase makes the compiler-owned stdlib declaration surface concise while
+preserving Sifr's no user-triggerable panic guarantee. It also makes the
+ellipsis stub body a checked Rust interop declaration form instead of an
+ordinary Sifr expression body.
+
+## Design Rules
+
+- A private sysroot stdlib declaration may omit `panic=` only when all of these
+  are true:
+  - the source module is a private `_sifr.*` stdlib module loaded from the
+    resolved sysroot,
+  - the declaration resolves through the compiler-owned synthetic sysroot
+    package context,
+  - the Rust target root is exactly `sifr_stdlib`,
+  - the declaration is recorded as satisfying a sysroot-owned no-panic trust
+    requirement.
+- User package declarations, package-local bridge declarations, and non-stdlib
+  private declarations continue to use the normal Rust interop panic-surface
+  contract.
+- A Rust interop declaration stub body is exactly one ellipsis statement:
+
+  ```sifr
+  @rust(sifr_stdlib.math.sqrt)
+  def sqrt(x: float) -> float: ...
+  ```
+
+- Ellipsis is accepted only as the complete body of an eligible Rust interop
+  declaration. It is not a general Sifr expression body, and mixed bodies such
+  as `...` plus `return` are rejected.
+- Lowering preserves the annotated function shape: parameters, return type,
+  async flag, method receiver shape, decorators, source spans, and Rust interop
+  metadata.
+- Codegen must never infer behavior from an empty declaration body. Rust
+  interop codegen emits the target call from Rust interop metadata for every
+  supported Rust interop root.
+- Trust metadata, cache fingerprints, probes, and diagnostics use the effective
+  panic policy so omitted sysroot policy is still visible to compiler-owned
+  validation and auditing.
+
+## Non-Goals
+
+- No change to public user/package panic-policy requirements or target-root
+  semantics.
+- No implicit panic trust for arbitrary Cargo dependencies.
+- No new Rust interop target roots or bridge-version changes.
+- No converter pipeline or callee-injection design.
+- No migration of runtime, resource, async, callback, TLS, HTTP, or retained
+  compiler-native stdlib surfaces.
+
+## Implementation Status
+
+| Milestone | Status | Evidence |
+| --- | --- | --- |
+| M0. Contract and Guardrail Documentation | planned | This phase plus architecture docs define the canonical declaration form and validation boundaries. |
+| M1. Lowering Support for Ellipsis Interop Stubs | planned | Pending. |
+| M2. Effective Sysroot Panic Policy | planned | Pending. |
+| M3. Codegen and Plan Hardening | planned | Pending. |
+| M4. Stdlib Source Migration and Executable Guards | planned | Pending. |
+| M5. Closeout Validation and Review | planned | Pending. |
+
+## Affected Inventory
+
+Private `sifr_stdlib.*` declarations are currently present in these stdlib
+private modules and are in phase scope:
+
+- `stdlib/_sifr/bytes.sifr`
+- `stdlib/_sifr/calendar.sifr`
+- `stdlib/_sifr/collections.sifr`
+- `stdlib/_sifr/compress.sifr`
+- `stdlib/_sifr/crypto.sifr`
+- `stdlib/_sifr/datetime.sifr`
+- `stdlib/_sifr/encoding.sifr`
+- `stdlib/_sifr/html.sifr`
+- `stdlib/_sifr/i18n.sifr`
+- `stdlib/_sifr/json.sifr`
+- `stdlib/_sifr/math.sifr`
+- `stdlib/_sifr/platform.sifr`
+- `stdlib/_sifr/regex.sifr`
+- `stdlib/_sifr/toml.sifr`
+- `stdlib/_sifr/unicode.sifr`
+- `stdlib/_sifr/url.sifr`
+- `stdlib/_sifr/uuid.sifr`
+
+Private `_sifr` runtime/resource modules remain out of scope unless they
+already target canonical `sifr_stdlib.*` direct declarations and satisfy the
+same stateless/data-leaf boundary as the migrated modules.
+
+Compiler surfaces expected to change:
+
+- `crates/sifr_lowering/src/lower/rust_interop.rs`
+- `crates/sifr_lowering/src/lower/typing_and_functions/annotations_and_function_lowering.rs`
+- `crates/sifr_lowering/src/lower/statements/statement_dispatch.rs`
+- `crates/sifr_lowering/src/lower/classes/class_body_lowering.rs`
+- `crates/sifr_lowering/src/lower/expressions/core_and_calls.rs`
+- `crates/sifr_driver/src/build/rust_interop/panic_validation.rs`
+- `crates/sifr_driver/src/build/rust_interop.rs`
+- `crates/sifr_driver/src/build/rust_interop_trust.rs`
+- `crates/sifr_driver/src/build/sysroot_interop.rs`
+- `crates/sifr_codegen/src/function_emitter/generator_bodies.rs`
+- `crates/sifr_codegen/src/rust_interop_direct.rs`
+- `crates/sifr_codegen/src/rust_interop_bridge_contract.rs`
+- `crates/sifr_codegen/src/rust_interop_plan.rs`
+
+Primary tests and guards expected to change:
+
+- `crates/sifr_lowering/src/lower/rust_interop_tests.rs`
+- `crates/sifr_driver/src/build/sysroot_interop_tests.rs`
+- `crates/sifr_driver/src/build/rust_interop_panic_contract_tests.rs`
+- `crates/sifr_driver/src/build/rust_interop_tests.rs`
+- `crates/sifr_driver/src/stdlib/stateless_private_adapter_policy_tests.rs`
+- `crates/sifr_driver/src/stdlib/stateless_private_codegen_tests.rs`
+- `crates/sifr_codegen/src/function_emitter/tests.rs`
+- `crates/sifr_codegen/src/rust_interop_plan_tests.rs`
+- `verification/areas/rust_interop/fixtures/**`
+
+## Milestones
+
+### M0. Contract and Guardrail Documentation
+
+Lock the intended model before code movement.
+
+Tasks:
+
+- Document the canonical private stdlib Rust interop declaration form in
+  `internal_docs/sifr_sysroot_and_stdlib_architecture.md`.
+- Document the package/sysroot panic-surface distinction in
+  `internal_docs/rust_interop_architecture.md`.
+- State that private `_sifr.*` declarations targeting `sifr_stdlib.*` use a
+  compiler-owned effective no-panic policy, recorded in trust metadata.
+- State that the declaration body for Rust interop stubs is exactly `...`.
+- State that user and package declarations continue to declare their own panic
+  surface.
+- State in `docs/rust-interop.mdx` that package-authored Rust interop
+  declarations use ellipsis-only stub bodies.
+- Keep public-facing docs focused on package-authored Rust interop; do not
+  expose sysroot shorthand as a user feature.
+- Sweep `internal_docs/architecture.md`, `plans/phases/`, and retained stdlib
+  ownership documents for stale private-stdlib policy examples.
+
+Acceptance:
+
+- A reviewer can determine which declarations may omit a panic policy without
+  reading implementation code.
+- A reviewer can determine where ellipsis is legal and where it remains an
+  error.
+- Documentation describes the stable contract directly, without migration
+  history or transitional forms.
+
+Validation:
+
+- Documentation review.
+- `rg -n '@rust\(sifr_stdlib\.[^)]*panic=' internal_docs docs
+  plans/issues/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup.md`
+  should return no canonical private-stdlib examples.
+- `rg -n 'ellipsis-only|effective compiler-owned no-panic|package-authored'
+  internal_docs/rust_interop_architecture.md
+  internal_docs/sifr_sysroot_and_stdlib_architecture.md docs/rust-interop.mdx`
+  should show the durable contract in the architecture and public Rust interop
+  docs.
+- `rg -n 'panic=trusted_no_panic' docs/rust-interop.mdx
+  internal_docs/rust_interop_architecture.md` should show only package-authored
+  panic-policy examples.
+
+### M1. Lowering Support for Ellipsis Interop Stubs
+
+Teach lowering to recognize Rust interop declaration stubs before normal body
+checking.
+
+Tasks:
+
+- Add a single helper that identifies an exact ellipsis-only function body from
+  Ruff AST statements.
+- Add a single helper that determines whether a function-like declaration has a
+  Rust interop decorator, reusing `collect_rust_interop_declarations` parsing
+  where possible to avoid drift.
+- Apply the helper consistently to:
+  - top-level functions,
+  - nested functions,
+  - class methods,
+  - enum/newtype methods handled by class body lowering.
+- For eligible Rust interop stubs, skip normal statement lowering, missing
+  return checking, and return-type inference from body expressions.
+- In top-level function lowering, bypass both `requires_exhaustive_return_annotation`
+  and `infer_function_return_type` for eligible interop stubs because the
+  declared return type is authoritative.
+- Apply the same authoritative-return-type path to nested functions and class,
+  enum, and newtype method lowering.
+- Populate `HirFunction.return_type` from the annotation before body lowering
+  runs, so ellipsis stubs still expose the `Result[T, E]` and error class
+  metadata needed by direct Rust interop mapping.
+- Preserve the explicit annotated return type as the HIR return type.
+- Emit a targeted diagnostic when ellipsis appears in a non-interop function
+  body.
+- Emit a targeted diagnostic when a Rust interop stub mixes ellipsis with any
+  other statement.
+- Add a targeted diagnostic in expression lowering for `Expr::EllipsisLiteral`
+  outside this specialized declaration path.
+
+Acceptance:
+
+- `@rust(...)\ndef f(...) -> T: ...` lowers without body diagnostics.
+- `def f() -> int: ...` remains rejected.
+- `@rust(...)\ndef f() -> int:\n    ...\n    return 1` is rejected.
+- Existing non-stub Rust interop declarations continue to lower normally.
+
+Validation:
+
+- Focused lowering unit tests in
+  `crates/sifr_lowering/src/lower/rust_interop_tests.rs`.
+- `cargo test -p sifr_lowering rust_interop`
+- `cargo test -p sifr -- rust_interop`
+
+### M2. Effective Sysroot Panic Policy
+
+Make omitted panic policy in canonical private stdlib declarations resolve to a
+compiler-owned effective no-panic policy.
+
+Tasks:
+
+- Add an effective panic policy resolver that receives declaration context,
+  resolved target path, package identity, and source origin.
+- Return effective no-panic only for private sysroot `_sifr.*` declarations
+  targeting direct `sifr_stdlib.*` paths.
+- Keep explicit policy parsing unchanged for user/package declarations.
+- Make panic validation consume the effective policy.
+- Make trust requirement recording consume the effective policy.
+- Include the effective trust requirement in the Rust interop plan and cache
+  fingerprint.
+- Ensure diagnostics distinguish user/package missing policy from invalid
+  sysroot target/context.
+- Reserve a targeted `SIFR-RUST-PANIC-*` or `SIFR-RUST-TRUST-*` diagnostic for
+  private sysroot declarations that omit `panic=` outside canonical
+  `sifr_stdlib.*` targets; the diagnostic should state that the sysroot
+  no-panic policy applies only to canonical private `sifr_stdlib.*` targets.
+- Keep `sifr_runtime.*`, `bridge.*`, `Self`, and arbitrary Cargo roots outside
+  the implicit policy boundary.
+
+Acceptance:
+
+- Canonical private `_sifr.*` declarations targeting `sifr_stdlib.*` pass panic
+  validation without a decorator-level policy argument.
+- The resolved declaration still records a no-panic trust requirement satisfied
+  by the sysroot trust policy.
+- User/package non-`Result` declarations without a panic policy continue to
+  fail with the existing Rust panic contract diagnostic.
+- User/package `Result` declarations that do not expose or map
+  `RustPanicError` continue to fail unless they declare an accepted panic
+  policy.
+
+Validation:
+
+- Unit tests in `crates/sifr_driver/src/build/sysroot_interop_tests.rs`.
+- Unit tests in
+  `crates/sifr_driver/src/build/rust_interop_panic_contract_tests.rs`.
+- Unit tests in `crates/sifr_driver/src/build/rust_interop_tests.rs`.
+- `cargo test -p sifr -- sysroot_interop`
+- `cargo test -p sifr -- rust_interop_panic`
+
+### M3. Codegen and Plan Hardening
+
+Ensure bodyless declarations are represented as declarations, not as empty
+implementation bodies.
+
+Tasks:
+
+- Audit `direct_rust_function_body`, package-local bridge emission, `Self`
+  method emission, and the function body generator for declaration stubs.
+- Prevent synthetic `Ok(())` insertion from being appended after a direct Rust
+  interop call emitted for a bodyless `Result[None, E]` declaration.
+- Implement that guard against the emitted Rust body source, not the original
+  HIR body. When `direct_rust_function_body(func)` supplies the function body,
+  the `Result[None, E]` tail-insertion path must be suppressed or delegated to
+  the direct-body emitter.
+- Emit bodyless package-local bridge calls from Rust interop metadata instead of
+  relying on lowered Sifr statements.
+- Emit bodyless `Self` calls for opaque method declarations from Rust interop
+  metadata where that root is already part of the accepted interop contract.
+- Reject bodyless declarations whose Rust interop target is not an accepted
+  target root before Rust IR lowering.
+- Ensure direct-interop error subclass field mapping derives from the annotated
+  `Result[T, E]` return type and class metadata, not from a declaration body.
+- Ensure Rust interop plan declarations expose enough policy/trust metadata for
+  sysroot audits and cache keys.
+- Add regression coverage for `Result[None, E]` direct stdlib calls.
+- Add regression coverage for message-shaped error mappings such as regex and
+  JSON decode errors with ellipsis-only declaration bodies.
+
+Acceptance:
+
+- Bodyless interop declarations generate exactly the Rust call wrapper body
+  appropriate for their accepted target root and return type.
+- No codegen panic is reachable from a bodyless declaration that lowering
+  accepts.
+- Unsupported Rust interop targets produce Sifr diagnostics before Rust IR
+  lowering.
+- Dependency-plan cache fingerprints change when effective trust policy changes.
+
+Validation:
+
+- Focused codegen unit tests for direct interop body generation.
+- Focused codegen unit tests for package-local bridge body generation.
+- Existing stdlib codegen tests in
+  `crates/sifr_driver/src/stdlib/stateless_private_codegen_tests.rs`.
+- Snapshot or assertion coverage for `zip_create`/`zip_add_file` style
+  `Result[None, E]` declarations proving no duplicate `Ok(())` tail is emitted.
+- Snapshot or assertion coverage for `re_find`/`re_replace` style
+  `Result[..., RegexError]` declarations proving error fields still map from
+  type metadata.
+- Representative compile/run checks for `compress` and `json` declarations that
+  return `Result[None, E]`.
+
+### M4. Stdlib Source Migration and Executable Guards
+
+Apply the canonical declaration form to migrated stateless/data private stdlib
+modules and make drift impossible.
+
+Tasks:
+
+- Update every in-scope `stdlib/_sifr/*.sifr` declaration targeting
+  `sifr_stdlib.*` to omit decorator-level panic policy.
+- Replace implementation-shaped placeholder bodies in those declarations with
+  ellipsis-only stub bodies.
+- Keep retained compiler-native declarations and runtime/resource declarations
+  unchanged unless they satisfy the phase's direct `sifr_stdlib.*` criteria.
+- Strengthen
+  `crates/sifr_driver/src/stdlib/stateless_private_adapter_policy_tests.rs`
+  with a guard such as
+  `completed_private_declarations_use_ellipsis_stub_and_no_panic_policy`, so
+  each completed private declaration:
+  - targets `sifr_stdlib.*`,
+  - has no decorator-level panic policy,
+  - uses an ellipsis-only body,
+  - contains no placeholder `return` or `raise` body.
+- Replace the existing adapter-policy panic assertion with this guard in the
+  same change, so the completed-private-declaration invariant is enforced
+  throughout the refactor.
+- Update sysroot interop tests to use canonical private declaration examples.
+- Keep user/package rust interop negative fixtures proving missing policy is
+  still rejected.
+- Update private stdlib file comments so completed declaration files describe
+  their current ownership without incremental migration notes.
+
+Acceptance:
+
+- All completed private stateless/data declarations use the canonical form.
+- The adapter policy guard fails on policy arguments or implementation-shaped
+  placeholder bodies in completed private declaration files.
+- Public stdlib behavior remains unchanged.
+
+Validation:
+
+- `cargo test -p sifr -- stateless_private_adapter_policy`
+- `cargo test -p sifr -- stateless_private_codegen`
+- `verification/runner/e2e/run_e2e_pass.sh`
+- Representative `cargo run -q -p sifr -- check` on migrated stdlib-dependent
+  demos.
+
+### M5. Closeout Validation and Review
+
+Close the phase only after local validation and external design review agree.
+
+Tasks:
+
+- Run Opus review on the phase, docs, and implementation.
+- Address all actionable review findings or document why they are intentionally
+  out of scope.
+- Run the authoritative create-pr validation profile.
+- Run the file-size guardrail and refactor any touched oversized hand-maintained
+  source file by responsibility.
+- Update this phase status with completed evidence and PR link after merge.
+- Link closeout evidence from the archived sysroot stdlib toolchain phase or
+  roadmap entry that owns follow-up cleanup for private stdlib interop.
+- Update roadmap/phase tracking if this phase is added to a tracked milestone.
+
+Acceptance:
+
+- Opus review has no unresolved actionable findings.
+- Local validation passes.
+- The phase document records implementation evidence and merged PR link.
+
+Validation:
+
+- `cargo fmt --check`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- `scripts/run_all_tests.sh --profile create-pr`
+- `scripts/run_all_tests.sh` before merge if the change touches shared compiler
+  behavior broadly enough to warrant full gate coverage.
+
+## Review Checklist
+
+- [ ] Ellipsis is accepted only for complete Rust interop stubs.
+- [ ] Ellipsis in a non-interop function body produces a targeted diagnostic.
+- [ ] Lowering handles top-level, nested, and method declarations consistently.
+- [ ] User/package missing panic policy remains rejected.
+- [ ] Private sysroot `sifr_stdlib.*` omitted policy records effective no-panic
+      trust metadata.
+- [ ] `sifr_runtime.*`, `bridge.*`, `Self`, and arbitrary package roots do not
+      receive implicit sysroot no-panic policy.
+- [ ] Bodyless direct interop codegen does not append synthetic `Ok(())`.
+- [ ] Direct-interop `Result[None, E]` declarations do not double-emit
+      `Ok(())`.
+- [ ] Bodyless package-local bridge and accepted `Self` targets emit from
+      metadata, not lowered Sifr statements.
+- [ ] Unsupported Rust interop targets fail before Rust IR lowering.
+- [ ] Cache fingerprints change when a declaration uses explicit package panic
+      policy versus effective sysroot policy.
+- [ ] Completed private stdlib declarations are guarded against drift.
+- [ ] Architecture docs describe only the durable declaration contract.
+- [ ] Public user docs do not expose sysroot-only shorthand as package syntax.
+
+## Closeout Notes
+
+Populate after implementation:
+
+- PR:
+- Opus review:
+- Create-pr validation:
+- Full validation:
+- Remaining follow-up:

--- a/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-opus-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-opus-review-pass-1.md
@@ -1,0 +1,55 @@
+# Opus Review Pass 1 — Ad-Hoc Sysroot Stdlib Interop Declaration Cleanup
+
+## Overall
+
+The phase is coherent, its Design Rules match the durable contract, and the five milestones cover the right axes (lowering → policy → codegen → source migration → validation). Docs (`rust_interop_architecture.md`, `sifr_sysroot_and_stdlib_architecture.md`) now describe the ellipsis-only, sysroot-effective-policy contract in-place, largely without migration framing. The findings below are the gaps that would cause implementation to rediscover work or produce a subtly-wrong final state.
+
+## Actionable findings (ordered by severity)
+
+### 1. M3 does not close the synthetic `Ok(())` tail-append hole it claims to close
+`crates/sifr_codegen/src/function_emitter/generator_bodies.rs:341-352` appends `Ok(())` whenever the return type is `Result[None, _]` and `func.body.last()` is not a `HirStmt::Return`/`Raise`. That guard reads the **HIR** body (Sifr statements), not the direct-body Rust `Vec<RustStmt>` that `direct_rust_function_body(func)` returned at line 324. Once M4 replaces `raise IOError("")` placeholders with a single ellipsis stub, `func.body.last()` becomes an ellipsis (or is empty), so the tail-append will still fire and stack a bare `Ok(())` after the wrapped Rust call for e.g. every `_sifr.compress.zip_*` declaration. M3's "no codegen panic reachable from a bodyless declaration" acceptance criterion does not catch this — the code will type-check and emit doubled tails. Rewrite M3 to say explicitly: when `direct_rust_function_body(func)` supplies the body, the `Result[None, _]` tail-append must be suppressed (or the direct body must own its own tail). Add a `stateless_private_codegen_tests` case that snapshots `zip_create`/`zip_add_file` after the migration.
+
+### 2. Direct-interop error-field mapping loses its current input when the body becomes `...`
+`crates/sifr_codegen/src/rust_interop_direct.rs` today maps message-shaped error subclass fields (see `direct_rust_function_body_maps_string_error_fields`, `direct_rust_function_body_maps_json_decode_error_fields`) — used by e.g. `_sifr.regex.re_*` producing `Result[..., RegexError]`. That mapping is HIR-type-driven, but the phase never states this explicitly, and HIR construction currently walks the placeholder `raise RegexError("")` body to resolve the error type. Once the body is ellipsis-only, M1 must guarantee that (a) the annotated return type populates HIR unchanged and (b) any downstream direct-interop pass that resolves error-subclass field metadata does so from the annotated `Result[T, E]` alone. Add an explicit M1 task ("Populate `HirFunction.return_type` from the annotation before body lowering runs, so ellipsis stubs still expose the error class needed by direct-interop mapping") and add a codegen regression for `re_find`/`re_replace` returning `Result[..., RegexError]`.
+
+### 3. Ambiguity: is the ellipsis stub form public or sysroot-only?
+`internal_docs/rust_interop_architecture.md:99-103` says ellipsis "is accepted only for Rust interop declarations" without qualifying by package origin, while the phase's motivation ("compiler enforce the declaration form so the stdlib cannot drift") and M4's guard (adapter-policy test enforces "no placeholder `return` or `raise`" only for private declarations) point at a sysroot-only affordance in practice. The phase and doc must pick one:
+- If public: `@rust(crc32fast.hash, panic=trusted_no_panic) def crc32(...) -> uint32: ...` is a valid package declaration form, and the adapter-policy test in M4 must enforce ellipsis for user/package interop too (via a separate guard), and public docs (`docs/rust-interop.mdx`) must show it.
+- If sysroot-only: `rust_interop_architecture.md` must state that user/package `@rust(...)` declarations still require a concrete body (or the compiler must reject ellipsis in user code with a targeted diagnostic).
+As written today, packages could adopt the ellipsis form silently and lowering would accept it, contradicting "Keep public-facing docs focused on package-authored Rust interop; do not expose sysroot shorthand as a user feature."
+
+### 4. M0's rg validation command does not verify any of the invariants the milestone locks
+`rg -n "trusted_no_panic|panic surface|ellipsis|\\.\\.\\." …` produces text hits but asserts nothing. The invariants M0 is supposed to lock (declaration body is exactly `...`; sysroot omits `panic=`; user/package keeps `panic=`) are neither positive-matched nor negative-matched by that grep. Replace it with concrete checks a reviewer can run and interpret, e.g.:
+- `rg -n '@rust\(sifr_stdlib\.[^)]*panic=' internal_docs docs` (expect zero matches),
+- `rg -nF '@rust(sifr_stdlib.' stdlib/_sifr` (expect one match per migrated decl, no `panic=`),
+- explicit assertion that `docs/rust-interop.mdx` shows only package-scope `panic=` policies.
+
+### 5. Sysroot vs `sifr_runtime.*` and `Self` targets are excluded by inventory but not by design-rule wording
+Design Rules require the target root be "exactly `sifr_stdlib`", which is correct. But the phase does not spell out the diagnostic behavior for a private `_sifr.*` declaration that omits `panic=` and targets `sifr_runtime.*`, `bridge.*`, or `Self`. Per the architecture, `sifr_runtime.*` is a valid sysroot-owned root for private declarations (used for retained runtime glue), so a stray policy-omitted declaration there must fail with a *different* diagnostic than a user/package missing-policy failure. M2 says "Ensure diagnostics distinguish user/package missing policy from invalid sysroot target/context" but does not reserve a code. Reserve a new `SIFR-RUST-PANIC-*` or `SIFR-RUST-TRUST-*` variant (e.g. "sysroot no-panic policy applies only to canonical `sifr_stdlib.*` targets") so this branch is testable and auditable.
+
+### 6. Compiler-surface list is drifted vs. the tests/fixtures the milestones actually touch
+The Affected Inventory omits several files that M2/M3/M4 validation explicitly names:
+- `crates/sifr_driver/src/build/sysroot_interop_tests.rs` (M2 acceptance evidence),
+- `crates/sifr_driver/src/build/rust_interop_panic_contract_tests.rs` (M2),
+- `crates/sifr_driver/src/build/rust_interop_tests.rs` (M2),
+- `crates/sifr_driver/src/stdlib/stateless_private_adapter_policy_tests.rs` (M4 — the guard actually rewritten from "must have `panic=trusted_no_panic`" to "must not have `panic=`"; this is a **direction reversal** of an existing assertion, worth flagging explicitly),
+- `crates/sifr_codegen/src/rust_interop_direct.rs` unit tests (M3 body regression coverage),
+- `crates/sifr_lowering/src/lower/rust_interop_tests.rs` (M1).
+Add these so a reviewer can navigate the change set without reconstructing it from prose.
+
+### 7. `annotations_and_function_lowering.rs` return-type inference path is not wired to the ellipsis skip
+That module calls `infer_function_return_type` (line 649) and `requires_exhaustive_return_annotation` (line 616). Both currently walk `func.body` and will produce spurious diagnostics on an ellipsis-only body (e.g. "missing return in non-void function", "cannot infer return type from empty body"). M1's task list says "skip normal statement lowering, missing return checking, and return-type inference from body expressions" — which is the right idea, but "skip" is under-specified given both of those functions live *outside* the statement-lowering loop and are invoked unconditionally. Concretize M1 to name the two call sites and specify the skip as "for eligible interop stubs, bypass both `infer_function_return_type` and `requires_exhaustive_return_annotation` because the declared return type is authoritative."
+
+### 8. `Expr::EllipsisLiteral` diagnostic path does not exist today
+`grep -rn EllipsisLiteral crates/` returns zero matches; ordinary expression lowering doesn't touch ellipsis at all. M1 phrases the guard as "Keep ordinary expression lowering unsupported for ellipsis outside this specialized declaration path" — but there is nothing to keep; the diagnostic must be **added**. The listed surface `crates/sifr_lowering/src/lower/expressions/core_and_calls.rs` may not even be the right file (the expression dispatcher's default arm probably lives elsewhere). Fix the wording ("Add a targeted diagnostic in the expression-lowering default arm for `Expr::EllipsisLiteral`") and confirm the correct file — likely `crates/sifr_lowering/src/lower/expressions.rs` or its dispatch module.
+
+## Non-blocking polish
+
+- `internal_docs/sifr_sysroot_and_stdlib_architecture.md:141-144` still frames sysroot no-panic policy as covering "public APIs whose error surface does not include `RustPanicError`", which reads as scope-limited. Rewrite so the policy applies uniformly to canonical private `sifr_stdlib.*` bindings regardless of Result shape.
+- Same doc, line 137 "existing sysroot interop declarations" retains a migration voice. Prefer "sysroot stdlib interop is `bridge-version = 1`; callee-injection is a future bridge-versioned design and does not add fallback conversion behavior."
+- The `Pre-Migration Baseline` section (§ starting line 20) is explicitly transitional. It contradicts the criterion "Docs describe only the durable declaration contract." Either move the baseline table under `plans/phases/` or add a phase task to retire it in M4/M5.
+- Review Checklist is missing: (a) "Ellipsis in a non-interop function body produces a targeted diagnostic"; (b) "Direct-interop `Result[None, _]` body does not double-emit `Ok(())`"; (c) "Cache fingerprint changes when a declaration flips between explicit `panic=` and effective sysroot policy."
+- The phase does not mention scanning `internal_docs/architecture.md`, `plans/phases/`, and `internal_docs/stdlib_retained_compiler_intrinsics.toml` for stale references to `panic=trusted_no_panic` on private stdlib declarations. Add a sweep task to M0 or M5.
+- `_sifr.crypto.sifr:2-3` retains a comment "Random helpers still use compiler intrinsics during the incremental stateless-leaf migration." M4 should update or remove that comment since post-cleanup the file is a pure declaration module with no migration narrative.
+- M5 says "Update roadmap/phase tracking if this phase is added to a tracked milestone." Given `19e346f0f Archive sysroot stdlib toolchain phase` just landed, state explicitly whether this ad-hoc is a follow-up of that archived phase or independent, and where its closeout evidence should be linked from `plans/roadmap.md`.
+- Consider naming M4's test guard something like `completed_private_declarations_use_ellipsis_stub_and_no_panic_policy` so the reversed direction (was: must contain `panic=trusted_no_panic`; now: must not) is obvious from the test name.

--- a/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-opus-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-opus-review-pass-2.md
@@ -1,0 +1,33 @@
+## Review pass 2 — remaining findings
+
+Pass 1 findings are substantively addressed in the phase document and docs (M3's tail-append guard is now anchored on the emitted Rust body, M1 seeds `HirFunction.return_type` before body lowering, M2 reserves a distinct diagnostic for sysroot-only policy misuse against non-`sifr_stdlib` targets, M0's rg checks are concrete, Affected Inventory now enumerates the touched test files, ellipsis is documented as public Rust interop declaration syntax, and the review checklist adds the three previously missing items). The following remains.
+
+## Actionable findings
+
+### 1. M0's own validation rg does not match the doc language it certifies
+
+Phase M0 Validation (`plans/issues/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup.md:168-172`):
+```
+rg -n 'ellipsis-only|effective compiler-owned no-panic|package-authored'
+   internal_docs/rust_interop_architecture.md
+   internal_docs/sifr_sysroot_and_stdlib_architecture.md
+   docs/rust-interop.mdx
+```
+
+Actual matches today:
+- `internal_docs/sifr_sysroot_and_stdlib_architecture.md`: hits `ellipsis-only` (:145, :775), `effective compiler-owned no-panic` (:154). ✓
+- `internal_docs/rust_interop_architecture.md`: **no hit** for any of the three terms. It says "exactly one ellipsis statement" (:100) and "package-authored" (:570, :614) — but not the M0 phrase `package-authored` in combination with the ellipsis contract, and no `ellipsis-only`.
+- `docs/rust-interop.mdx`: **no hit** for any of the three terms. It only says "The Sifr declaration body is exactly `...`" (:54-55).
+
+This directly contradicts the M0 task "State in `docs/rust-interop.mdx` that package-authored Rust interop declarations use ellipsis-only stub bodies." A reviewer running M0's own validation rg cannot confirm the durable contract is present in the public docs or in `rust_interop_architecture.md`. Either (a) tighten the docs to use the phrases M0 certifies against (add "ellipsis-only stub body" and "package-authored" language in both files), or (b) reword the rg to match the wording the docs actually use. The docs update is preferable because "ellipsis-only" is the distinguishing property against a general Sifr body form.
+
+### 2. M4's adapter-policy guard reverses an existing invariant without flagging the direction change
+
+`crates/sifr_driver/src/stdlib/stateless_private_adapter_policy_tests.rs` today asserts private stateless declarations **carry** `panic=trusted_no_panic`; M4 flips this to a guard that they **must not** carry `panic=` (i.e., must rely on effective sysroot policy) — and additionally must use an ellipsis-only body. The new test-name suggestion (`completed_private_declarations_use_ellipsis_stub_and_no_panic_policy`) implicitly signals the reversal, but the phase does not call out that the direction of an existing invariant is being inverted. This matters for reviewers of the M4 PR: without the callout they may assume the new guard is additive, miss the removal of the prior positive check, and merge a state where neither direction is enforced during the intermediate refactor. Add a one-line M4 note that the prior "must have `panic=trusted_no_panic`" assertion is being replaced (not augmented) so PR review understands the invariant switch.
+
+## Residual non-blocking risks
+
+- **`sifr_sysroot_and_stdlib_architecture.md` Pre-Migration Baseline (§ starting :20)** still uses migration voice and a "current owner → final owner → migration blocker" table shape. It does not frame the declaration cleanup itself as old-vs-new, so it does not violate the user's specific criterion — but it does keep migration framing adjacent to the durable contract. This was flagged in pass 1 as non-blocking polish and remains untouched; leave it or retire it in a broader stdlib-arch cleanup pass, not this ad-hoc.
+- **M5 origin link.** The phase doesn't state whether this ad-hoc is a follow-up to the recently archived `19e346f0f Archive sysroot stdlib toolchain phase` or independent, or where its closeout evidence should be linked from `plans/roadmap.md`. Pass 1 noted this; it's still unspecified. Non-blocking, but worth resolving before closeout.
+- **`crates/sifr_codegen/src/rust_interop_direct.rs` unit tests** are covered implicitly by listing the source file, but no separate `_tests.rs` module is called out in Affected Inventory. If tests live in the source file, this is fine; if a sibling tests file exists, add it for navigability. (Confirm during M3.)
+- **`_sifr.crypto.sifr`** file-comment cleanup is covered by M4's blanket "Update private stdlib file comments…" task but not called out by module. If more private modules retain migration-voice header comments beyond `_sifr.crypto`, the sweep should be explicit about scope so it is not silently limited to one file.

--- a/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-opus-review-pass-3.md
+++ b/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-opus-review-pass-3.md
@@ -1,0 +1,20 @@
+All five pass-2 fixes verify cleanly against the current files:
+
+1. **`ellipsis-only` / `package-authored` in docs** — `rg -n 'ellipsis-only|effective compiler-owned no-panic|package-authored' internal_docs/rust_interop_architecture.md internal_docs/sifr_sysroot_and_stdlib_architecture.md docs/rust-interop.mdx` hits all three files: `docs/rust-interop.mdx:54` ("Package-authored… ellipsis-only stub body"), `internal_docs/rust_interop_architecture.md:99` ("ellipsis-only stub body") plus package-authored hits at :570/:614, `internal_docs/sifr_sysroot_and_stdlib_architecture.md:145,154,775`.
+
+2. **M0 `@rust(sifr_stdlib…panic=` scope** — the phase's rg (line 166-167) targets `internal_docs docs plans/issues/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup.md`, i.e. no archive/review paths. Running that grep against the current tree returns zero matches, so canonical private-stdlib examples are clean.
+
+3. **M4 replacement callout** — phase M4 line 349-351 explicitly says "Replace the existing adapter-policy panic assertion with this guard in the same change," making the invariant reversal visible to PR review.
+
+4. **No implicit panic trust to user packages, `sifr_runtime`, `bridge`, `Self`, arbitrary roots** — anchored in three places: Design Rules line 25-33, M2 task line 250-251 ("Keep `sifr_runtime.*`, `bridge.*`, `Self`, and arbitrary Cargo roots outside the implicit policy boundary"), and Review Checklist line 412-413. The architecture doc echoes the same restriction at line 620-623.
+
+5. **Docs state the durable contract directly** — `rust_interop_architecture.md:99-104`, `docs/rust-interop.mdx:53-56`, and `sifr_sysroot_and_stdlib_architecture.md:145-158/772-778` all read as present-tense declarative contract with no old-vs-new syntax framing.
+
+## Remaining actionable findings
+
+None. The phase and docs are ready for M0 signoff and M1 kickoff.
+
+## Non-actionable residuals (unchanged from prior passes, explicitly deferred)
+
+- `sifr_sysroot_and_stdlib_architecture.md` Pre-Migration Baseline (§ starting :20) still uses migration voice. Pass 1 and pass 2 both flagged this as non-blocking and out of scope for this ad-hoc — a broader stdlib-arch cleanup, not this phase.
+- M5 doesn't yet say whether this ad-hoc is a follow-up of the archived `19e346f0f Archive sysroot stdlib toolchain phase` or where closeout evidence should link from `plans/roadmap.md`. Non-blocking closeout item; resolve when populating the M5 Closeout Notes.


### PR DESCRIPTION
## Summary
- Document ellipsis-only stub bodies for package-authored and private sysroot `@rust` declarations in public and internal architecture docs.
- Clarify the compiler-owned sysroot no-panic trust policy for canonical private `_sifr.*` declarations targeting `sifr_stdlib.*`.
- Add the ad-hoc sysroot stdlib interop declaration cleanup phase plan and Opus review passes.

## Test plan
- [x] Docs-only change; no compiler or runtime behavior modified.

Made with [Cursor](https://cursor.com)