### PR TITLE
Codegen bodyless package bridge interop

### DIFF
--- a/crates/sifr_codegen/src/class_method_emitter.rs
+++ b/crates/sifr_codegen/src/class_method_emitter.rs
@@ -2,6 +2,7 @@ use crate::{
     function_emitter::{is_result_int_type, result_int_return_type_to_sifr_int, result_method_key},
     helpers::{body_contains_field_assign_codegen, collect_mutated_vars_with_sigs},
     hir_analysis::traversal::{self, TraversalConfig},
+    rust_interop_direct::rust_interop_method_body,
     RustEmitter, RustExpr, RustItem, RustParam, RustStmt, RustType, RustTypeParam, Visibility,
 };
 use sifr_ir::{HirClass, HirExpr, HirFunction, HirStmt, MethodKind};
@@ -668,7 +669,9 @@ impl RustEmitter {
             );
         }
 
-        let mut body = if method.method_kind == MethodKind::Regular && method.name == "new" {
+        let mut body = if let Some(interop_body) = rust_interop_method_body(method) {
+            interop_body
+        } else if method.method_kind == MethodKind::Regular && method.name == "new" {
             self.lower_constructor_body(method, class)
         } else {
             let mut lowered = Vec::new();

--- a/crates/sifr_codegen/src/function_emitter/generator_bodies.rs
+++ b/crates/sifr_codegen/src/function_emitter/generator_bodies.rs
@@ -3,7 +3,7 @@ use super::{
     HirStmt, OwnershipKind, RustEmitter, RustExpr, RustItem, RustLiteral, RustParam, RustStmt,
     RustType, Type, Visibility,
 };
-use crate::rust_interop_direct::direct_rust_function_body;
+use crate::rust_interop_direct::rust_interop_function_body;
 impl RustEmitter {
     pub(crate) fn lower_generator_function_body(
         &mut self,
@@ -321,8 +321,10 @@ impl RustEmitter {
             })
             .collect::<Vec<_>>();
 
-        let mut lowered_body = if let Some(direct_body) = direct_rust_function_body(func) {
-            direct_body
+        let interop_body = rust_interop_function_body(func);
+        let interop_body_supplied = interop_body.is_some();
+        let mut lowered_body = if let Some(interop_body) = interop_body {
+            interop_body
         } else if is_async_generator {
             self.lower_async_generator_function_body(func, &mutable_param_shadows)
         } else if is_generator {
@@ -339,6 +341,7 @@ impl RustEmitter {
         };
 
         if !is_generator
+            && !interop_body_supplied
             && Self::returns_result_none(&func.return_type)
             && !matches!(
                 func.body.last(),

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -84,6 +84,8 @@ mod render;
 pub use render::*;
 mod rust_interop_bridge_contract;
 mod rust_interop_direct;
+#[cfg(test)]
+mod rust_interop_direct_tests;
 mod rust_interop_plan;
 pub use rust_interop_bridge_contract::{
     RustBridgeContractPlan, RustBridgeParamContract, RustBridgeParamConvention,

--- a/crates/sifr_codegen/src/rust_interop_direct.rs
+++ b/crates/sifr_codegen/src/rust_interop_direct.rs
@@ -8,11 +8,18 @@ use crate::{RustExpr, RustParam, RustStmt, RustType};
 const BRIDGE_ROOT: &str = "bridge";
 const SELF_ROOT: &str = "Self";
 
-pub(crate) fn direct_rust_function_body(func: &HirFunction) -> Option<Vec<RustStmt>> {
-    let declaration = direct_rust_function_declaration(func)?;
+pub(crate) fn rust_interop_function_body(func: &HirFunction) -> Option<Vec<RustStmt>> {
+    let declaration = rust_interop_function_declaration(func)?;
     let target = declaration.target.as_ref()?;
+    if target
+        .segments
+        .first()
+        .is_some_and(|root| root == SELF_ROOT)
+    {
+        return None;
+    }
     let call = RustExpr::FnCall {
-        func: Box::new(RustExpr::Path(target.segments.clone())),
+        func: Box::new(RustExpr::Path(rust_function_path(target))),
         args: func.params.iter().map(direct_rust_arg_expr).collect(),
     };
     let value = if direct_rust_function_is_async(func, declaration) {
@@ -20,14 +27,21 @@ pub(crate) fn direct_rust_function_body(func: &HirFunction) -> Option<Vec<RustSt
     } else {
         call
     };
-    if func.return_type == sifr_type_system::Type::None {
-        Some(vec![RustStmt::Expr(value)])
-    } else {
-        Some(vec![RustStmt::Return(Some(direct_rust_return_expr(
-            value,
-            &func.return_type,
-        )))])
+    Some(return_stmt_for_type(value, &func.return_type))
+}
+
+#[cfg(test)]
+fn direct_rust_function_body(func: &HirFunction) -> Option<Vec<RustStmt>> {
+    let declaration = rust_interop_function_declaration(func)?;
+    let target = declaration.target.as_ref()?;
+    if target
+        .segments
+        .first()
+        .is_some_and(|root| root == BRIDGE_ROOT || root == SELF_ROOT)
+    {
+        return None;
     }
+    rust_interop_function_body(func)
 }
 
 fn direct_rust_arg_expr(param: &HirParam) -> RustExpr {
@@ -102,6 +116,53 @@ fn direct_rust_return_expr(value: RustExpr, return_type: &Type) -> RustExpr {
         }
         Type::Result(ok, err) => bridge_result_expr(value, ok, err),
         _ => value,
+    }
+}
+
+pub(crate) fn rust_interop_method_body(func: &HirFunction) -> Option<Vec<RustStmt>> {
+    let declaration = rust_interop_function_declaration(func)?;
+    let target = declaration.target.as_ref()?;
+    let root = target.segments.first()?;
+    let value = if root == SELF_ROOT {
+        self_method_call(func, declaration, target)?
+    } else {
+        RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(rust_function_path(target))),
+            args: func.params.iter().map(direct_rust_arg_expr).collect(),
+        }
+    };
+    let value = if direct_rust_function_is_async(func, declaration) {
+        RustExpr::Await(Box::new(value))
+    } else {
+        value
+    };
+    Some(return_stmt_for_type(value, &func.return_type))
+}
+
+fn self_method_call(
+    func: &HirFunction,
+    _declaration: &RustInteropDeclaration,
+    target: &RustTargetPath,
+) -> Option<RustExpr> {
+    let method = target.segments.get(1)?.clone();
+    Some(RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::Field {
+            expr: Box::new(RustExpr::Ident("self".to_string())),
+            field: "_handle".to_string(),
+        }),
+        method,
+        args: func.params.iter().map(direct_rust_arg_expr).collect(),
+    })
+}
+
+fn return_stmt_for_type(value: RustExpr, return_type: &Type) -> Vec<RustStmt> {
+    if return_type == &sifr_type_system::Type::None {
+        vec![RustStmt::Expr(value)]
+    } else {
+        vec![RustStmt::Return(Some(direct_rust_return_expr(
+            value,
+            return_type,
+        )))]
     }
 }
 
@@ -358,27 +419,27 @@ fn sifr_int_bridge_path(method: &str) -> RustExpr {
     ])
 }
 
-fn direct_rust_function_declaration(func: &HirFunction) -> Option<&RustInteropDeclaration> {
+fn rust_interop_function_declaration(func: &HirFunction) -> Option<&RustInteropDeclaration> {
     func.rust_interop
         .iter()
-        .find(|declaration| is_direct_function_declaration(declaration))
+        .find(|declaration| is_function_declaration(declaration))
 }
 
-fn is_direct_function_declaration(declaration: &RustInteropDeclaration) -> bool {
+fn is_function_declaration(declaration: &RustInteropDeclaration) -> bool {
     matches!(
         declaration.kind,
         RustInteropDecoratorKind::Function | RustInteropDecoratorKind::Async
-    ) && declaration
-        .target
-        .as_ref()
-        .is_some_and(is_direct_cargo_target)
+    ) && declaration.target.is_some()
 }
 
-fn is_direct_cargo_target(target: &RustTargetPath) -> bool {
-    target
-        .segments
-        .first()
-        .is_some_and(|root| root != BRIDGE_ROOT && root != SELF_ROOT)
+fn rust_function_path(target: &RustTargetPath) -> Vec<String> {
+    let Some(root) = target.segments.first() else {
+        return Vec::new();
+    };
+    if root == BRIDGE_ROOT {
+        return target.segments.clone();
+    }
+    target.segments.clone()
 }
 
 fn direct_rust_function_is_async(func: &HirFunction, declaration: &RustInteropDeclaration) -> bool {

--- a/crates/sifr_codegen/src/rust_interop_direct_tests.rs
+++ b/crates/sifr_codegen/src/rust_interop_direct_tests.rs
@@ -1,0 +1,151 @@
+use crate::rust_interop_direct::{rust_interop_function_body, rust_interop_method_body};
+use crate::{generate_rust_with_metadata, render_expr, RustStmt};
+use ruff_text_size::TextRange;
+use sifr_ir::{
+    HirClass, HirClassKind, HirFunction, HirModule, HirParam, MethodKind,
+    RustInteropAbiRequirements, RustInteropDeclaration, RustInteropDecoratorKind,
+    RustInteropEffect, RustTargetPath,
+};
+use sifr_type_system::{FixedIntType, ParamConvention, Type};
+use std::collections::HashMap;
+
+#[test]
+fn rust_interop_function_body_emits_package_bridge_root() {
+    let func = HirFunction {
+        name: "digest".to_string(),
+        params: vec![HirParam {
+            name: "data".to_string(),
+            ty: Type::Bytes,
+            default: None,
+            keyword_only: false,
+            convention: ParamConvention::borrow(),
+        }],
+        return_type: Type::Bytes,
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        decorators: Vec::new(),
+        rust_interop: vec![declaration(
+            RustInteropDecoratorKind::Function,
+            &["bridge", "hash", "digest"],
+        )],
+        type_params: Vec::new(),
+    };
+
+    let body =
+        rust_interop_function_body(&func).expect("bridge interop metadata should lower to a body");
+    let [RustStmt::Return(Some(expr))] = body.as_slice() else {
+        panic!("bridge interop should lower to a return expression");
+    };
+
+    assert_eq!(render_expr(expr), "bridge::hash::digest(data)");
+}
+
+#[test]
+fn rust_interop_method_body_emits_self_handle_call() {
+    let func = HirFunction {
+        name: "encode".to_string(),
+        params: vec![HirParam {
+            name: "text".to_string(),
+            ty: Type::Str,
+            default: None,
+            keyword_only: false,
+            convention: ParamConvention::borrow(),
+        }],
+        return_type: Type::List(Box::new(Type::FixedInt(FixedIntType::U32))),
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        decorators: Vec::new(),
+        rust_interop: vec![declaration(
+            RustInteropDecoratorKind::Function,
+            &["Self", "encode"],
+        )],
+        type_params: Vec::new(),
+    };
+
+    let body =
+        rust_interop_method_body(&func).expect("Self interop metadata should lower to a body");
+    let [RustStmt::Return(Some(expr))] = body.as_slice() else {
+        panic!("Self interop should lower to a return expression");
+    };
+
+    assert_eq!(render_expr(expr), "self._handle.encode(text)");
+}
+
+#[test]
+fn emitted_direct_result_none_interop_does_not_append_ok_tail() {
+    let error_ty = Type::Class {
+        name: "ZipError".to_string(),
+        fields: vec![("message".to_string(), Type::Str)],
+        methods: Vec::new(),
+        parent_class: Some("Error".to_string()),
+    };
+    let module = HirModule {
+        functions: vec![HirFunction {
+            name: "zip_close".to_string(),
+            params: vec![HirParam {
+                name: "path".to_string(),
+                ty: Type::Str,
+                default: None,
+                keyword_only: false,
+                convention: ParamConvention::borrow(),
+            }],
+            return_type: Type::Result(Box::new(Type::None), Box::new(error_ty)),
+            body: Vec::new(),
+            is_async: false,
+            method_kind: MethodKind::Regular,
+            decorators: Vec::new(),
+            rust_interop: vec![declaration(
+                RustInteropDecoratorKind::Function,
+                &["sifr_stdlib", "zip", "zip_close"],
+            )],
+            type_params: Vec::new(),
+        }],
+        classes: vec![zip_error_class()],
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: HashMap::new(),
+        type_param_bounds: HashMap::new(),
+    };
+
+    let generated = generate_rust_with_metadata(&module).rust_source;
+
+    assert!(generated.contains("sifr_stdlib::zip::zip_close(path)"));
+    assert!(!generated.contains("return Ok(());"), "{generated}");
+}
+
+fn zip_error_class() -> HirClass {
+    HirClass {
+        name: "ZipError".to_string(),
+        fields: vec![("message".to_string(), Type::Str)],
+        methods: Vec::new(),
+        is_hashable: false,
+        is_error_type: true,
+        kind: HirClassKind::Regular,
+        operator_impls: Vec::new(),
+        newtype_inner: None,
+        implements_protocols: Vec::new(),
+        parent_class: Some("Error".to_string()),
+        type_params: Vec::new(),
+        enum_variants: Vec::new(),
+        rust_interop: Vec::new(),
+    }
+}
+
+fn declaration(kind: RustInteropDecoratorKind, segments: &[&str]) -> RustInteropDeclaration {
+    RustInteropDeclaration {
+        kind,
+        target: Some(RustTargetPath {
+            segments: segments
+                .iter()
+                .map(|segment| (*segment).to_string())
+                .collect(),
+            span: TextRange::default(),
+        }),
+        arguments: Vec::new(),
+        span: TextRange::default(),
+        effect: RustInteropEffect::Sync,
+        abi_requirements: RustInteropAbiRequirements::default(),
+    }
+}

--- a/crates/sifr_codegen/src/rust_interop_plan.rs
+++ b/crates/sifr_codegen/src/rust_interop_plan.rs
@@ -130,6 +130,9 @@ pub enum RustInteropResolvedRoot {
     },
     PackageBridge {
         package_id: String,
+        dependency_name: String,
+        cargo_package_name: String,
+        cargo_manifest_path: String,
         bridge_roots: Vec<String>,
     },
     SelfMethod {
@@ -443,10 +446,19 @@ fn push_resolved_target(out: &mut String, target: &RustInteropResolvedTarget) {
         }
         RustInteropResolvedRoot::PackageBridge {
             package_id,
+            dependency_name,
+            cargo_package_name,
+            cargo_manifest_path,
             bridge_roots,
         } => {
             out.push_str("bridge:");
             out.push_str(package_id);
+            out.push(':');
+            out.push_str(dependency_name);
+            out.push(':');
+            out.push_str(cargo_package_name);
+            out.push(':');
+            out.push_str(cargo_manifest_path);
             out.push(':');
             out.push_str(&bridge_roots.join(","));
         }

--- a/crates/sifr_driver/src/build/cargo_manifest.rs
+++ b/crates/sifr_driver/src/build/cargo_manifest.rs
@@ -94,9 +94,15 @@ fn rust_interop_path_dependencies(interop: &InteropBuildPlan) -> BTreeMap<String
                 ..
             } => direct_dependency_line(dependency_name, cargo_package_name, cargo_manifest_path)
                 .map(|line| (dependency_name.clone(), line)),
+            RustInteropResolvedRoot::PackageBridge {
+                dependency_name,
+                cargo_package_name,
+                cargo_manifest_path,
+                ..
+            } => direct_dependency_line(dependency_name, cargo_package_name, cargo_manifest_path)
+                .map(|line| (dependency_name.clone(), line)),
             RustInteropResolvedRoot::SysrootCrate { .. } => None,
-            RustInteropResolvedRoot::PackageBridge { .. }
-            | RustInteropResolvedRoot::SelfMethod { .. } => None,
+            RustInteropResolvedRoot::SelfMethod { .. } => None,
         })
         .collect()
 }
@@ -146,8 +152,8 @@ fn sysroot_interop_crates(interop: &InteropBuildPlan) -> BTreeSet<SysrootCrate> 
                 _ => None,
             },
             RustInteropResolvedRoot::DirectCargoDependency { .. }
-            | RustInteropResolvedRoot::PackageBridge { .. }
             | RustInteropResolvedRoot::SelfMethod { .. } => None,
+            RustInteropResolvedRoot::PackageBridge { .. } => None,
         })
         .collect();
 
@@ -269,7 +275,8 @@ mod tests {
     use super::*;
     use sifr_codegen::{
         RustBridgeContractPlan, RustGeneratedBridgeField, RustGeneratedBridgeType,
-        RustGeneratedBridgeTypeKind,
+        RustGeneratedBridgeTypeKind, RustInteropOwner, RustInteropResolvedRoot,
+        RustInteropResolvedTarget,
     };
     use sifr_stdlib_model::{SysrootCrate, SysrootCrateDependency};
     use std::path::PathBuf;
@@ -371,6 +378,38 @@ mod tests {
             .crates
             .iter()
             .any(|dependency| dependency.krate == SysrootCrate::SifrRuntime));
+    }
+
+    #[test]
+    fn generated_cargo_toml_includes_package_bridge_dependency_alias() {
+        let dependency_plan = test_dependency_plan(
+            CargoVendorMode::PackageOwned,
+            PathBuf::from("/opt/sifr/vendor"),
+        );
+        let mut interop = InteropBuildPlan::default();
+        interop.rust.resolved_targets = vec![RustInteropResolvedTarget {
+            module_name: Some("main".to_string()),
+            owner: RustInteropOwner::Function {
+                name: "hash_bytes".to_string(),
+            },
+            written_path: "bridge.blake3.hash_bytes".to_string(),
+            canonical_target_path: "main::hash_bytes".to_string(),
+            root: RustInteropResolvedRoot::PackageBridge {
+                package_id: "local-blake3-bridge@0.1.0#path".to_string(),
+                dependency_name: "__sifr_bridge_package_local_blake3_bridge".to_string(),
+                cargo_package_name: "local-blake3-bridge".to_string(),
+                cargo_manifest_path: "/ws/local_blake3_bridge/Cargo.toml".to_string(),
+                bridge_roots: vec!["src/bridges".to_string()],
+            },
+            span: Default::default(),
+        }];
+
+        let cargo_toml =
+            generate_dependency_cargo_toml_for_cache_key("sifr_output", &dependency_plan, &interop);
+
+        assert!(cargo_toml.contains(
+            "__sifr_bridge_package_local_blake3_bridge = { package = \"local-blake3-bridge\", path = \"/ws/local_blake3_bridge\" }"
+        ));
     }
 
     #[test]

--- a/crates/sifr_driver/src/build/rust_interop.rs
+++ b/crates/sifr_driver/src/build/rust_interop.rs
@@ -36,6 +36,8 @@ use std::collections::{BTreeSet, HashMap};
 mod advanced_data_validation;
 #[path = "rust_interop/async_validation.rs"]
 mod async_validation;
+#[path = "rust_interop/bridge_aliases.rs"]
+mod bridge_aliases;
 #[path = "rust_interop/callback_validation.rs"]
 mod callback_validation;
 #[path = "rust_interop/opaque_contract.rs"]
@@ -51,6 +53,7 @@ mod target_resolution;
 #[path = "rust_interop/zero_copy_validation.rs"]
 mod zero_copy_validation;
 
+use bridge_aliases::{inject_package_bridge_aliases, package_bridge_dependency_name};
 use target_resolution::{
     backend_for_root, canonical_sifr_target_path, canonical_trust_target_path, declaration_paths,
     trust_kind_name, uses_bridge_root,
@@ -204,6 +207,7 @@ impl<'a> RustInteropResolver<'a> {
             }
         }
         generated.interop.rust.cargo_inputs = Some(cargo_input);
+        inject_package_bridge_aliases(generated);
         Ok(())
     }
 
@@ -293,6 +297,13 @@ impl<'a> RustInteropResolver<'a> {
         let resolved_root = match root.as_str() {
             "bridge" => RustInteropResolvedRoot::PackageBridge {
                 package_id: package_id.0.clone(),
+                dependency_name: package_bridge_dependency_name(package),
+                cargo_package_name: package.cargo_package_name.clone(),
+                cargo_manifest_path: package
+                    .package_root
+                    .join("Cargo.toml")
+                    .display()
+                    .to_string(),
                 bridge_roots: package
                     .manifest
                     .rust
@@ -302,10 +313,35 @@ impl<'a> RustInteropResolver<'a> {
                     .collect(),
             },
             "Self" => match &declaration.owner {
-                RustInteropOwner::Method { class_name, .. } => {
+                RustInteropOwner::Method { class_name, .. }
+                    if self.opaque_contracts.contains_key(&format!(
+                        "{}.{}",
+                        declaration.module_name.as_deref().unwrap_or("main"),
+                        class_name
+                    )) =>
+                {
                     RustInteropResolvedRoot::SelfMethod {
                         class_name: class_name.clone(),
                     }
+                }
+                RustInteropOwner::Method { class_name, .. } => {
+                    self.push_diagnostic(
+                        declaration,
+                        path.span,
+                        DiagnosticCode::RUST_RESOLVE_TARGET_ROOT,
+                        "unresolved Rust target root `{root}`",
+                        vec![
+                            ("root", root.clone()),
+                            ("target", path.dotted()),
+                            ("class", class_name.clone()),
+                        ],
+                        vec![
+                            "`Self` target roots are valid only on methods for classes declared with `@rust.opaque(...)`"
+                                .to_string(),
+                        ],
+                        None,
+                    );
+                    return;
                 }
                 _ => {
                     self.push_diagnostic(

--- a/crates/sifr_driver/src/build/rust_interop/bridge_aliases.rs
+++ b/crates/sifr_driver/src/build/rust_interop/bridge_aliases.rs
@@ -1,0 +1,68 @@
+use crate::build::project_codegen::GeneratedBinaryProject;
+use sifr_codegen::RustInteropResolvedRoot;
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(super) fn package_bridge_dependency_name(
+    package: &sifr_package::SifrPackageMetadata,
+) -> String {
+    let mut dependency = "__sifr_bridge_package_".to_string();
+    for ch in package.cargo_package_name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            dependency.push(ch);
+        } else {
+            dependency.push('_');
+        }
+    }
+    dependency
+}
+
+pub(super) fn inject_package_bridge_aliases(generated: &mut GeneratedBinaryProject) {
+    let mut aliases_by_module: BTreeMap<Option<String>, BTreeSet<String>> = BTreeMap::new();
+    for target in &generated.interop.rust.resolved_targets {
+        let RustInteropResolvedRoot::PackageBridge {
+            dependency_name, ..
+        } = &target.root
+        else {
+            continue;
+        };
+        aliases_by_module
+            .entry(target.module_name.clone())
+            .or_default()
+            .insert(dependency_name.clone());
+    }
+
+    for (module_name, dependencies) in aliases_by_module {
+        // Bridge roots are resolved from the declaring module's owning package, so a
+        // generated module can only need one package bridge alias. The set dedupes
+        // repeated bridge declarations from that same module/package.
+        let prefix = bridge_alias_prefix(&dependencies);
+        if prefix.is_empty() {
+            continue;
+        }
+        match module_name.as_deref() {
+            None | Some("main") => prepend_once(&mut generated.main_rs, &prefix),
+            Some(module_name) => {
+                if let Some(source) = generated.support_modules.get_mut(module_name) {
+                    prepend_once(source, &prefix);
+                }
+            }
+        }
+    }
+}
+
+fn bridge_alias_prefix(dependencies: &BTreeSet<String>) -> String {
+    let mut prefix = String::new();
+    for dependency in dependencies {
+        prefix.push_str("use ");
+        prefix.push_str(dependency);
+        prefix.push_str("::bridges as bridge;\n");
+    }
+    prefix
+}
+
+fn prepend_once(source: &mut String, prefix: &str) {
+    if source.starts_with(prefix) {
+        return;
+    }
+    *source = format!("{prefix}{source}");
+}

--- a/crates/sifr_driver/src/build/rust_interop_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_tests.rs
@@ -157,6 +157,58 @@ fn package_rust_interop_resolves_bridge_root() {
         generated.interop.rust.generated_bridge_modules[0].bridge_version,
         1
     );
+    assert!(generated
+        .interop
+        .cache_key_fragment()
+        .contains("__sifr_bridge_package_sifr_app"));
+}
+
+#[test]
+fn package_rust_interop_injects_bridge_alias_into_declaring_module() {
+    let mut generated = base_project(vec![declaration_entry(
+        "bridge.hash",
+        RustInteropDecoratorKind::Function,
+    )]);
+    generated
+        .support_modules
+        .insert("app".to_string(), "pub fn hash() {}\n".to_string());
+    let mut context = package_context(TrustPolicy::default(), Vec::new());
+    set_bridge_roots(&mut context, vec![PathBuf::from("src/bridges")]);
+
+    let generated = apply_package_rust_interop_metadata(generated, Some(context))
+        .expect("bridge root should resolve");
+
+    assert_eq!(
+        generated.support_modules.get("app").map(String::as_str),
+        Some("use __sifr_bridge_package_sifr_app::bridges as bridge;\npub fn hash() {}\n")
+    );
+}
+
+#[test]
+fn package_rust_interop_injects_one_bridge_alias_per_module() {
+    let mut generated = base_project(vec![
+        declaration_entry("bridge.hash", RustInteropDecoratorKind::Function),
+        declaration_entry("bridge.codec", RustInteropDecoratorKind::Function),
+    ]);
+    generated
+        .support_modules
+        .insert("app".to_string(), "pub fn hash() {}\n".to_string());
+    let mut context = package_context(TrustPolicy::default(), Vec::new());
+    set_bridge_roots(&mut context, vec![PathBuf::from("src/bridges")]);
+
+    let generated = apply_package_rust_interop_metadata(generated, Some(context))
+        .expect("bridge roots should resolve");
+
+    let support_module = generated
+        .support_modules
+        .get("app")
+        .expect("support module should remain");
+    assert_eq!(
+        support_module
+            .matches("use __sifr_bridge_package_sifr_app::bridges as bridge;")
+            .count(),
+        1
+    );
 }
 
 #[test]
@@ -279,19 +331,45 @@ fn package_rust_interop_resolves_same_workspace_path_dependency() {
 
 #[test]
 fn package_rust_interop_resolves_self_method_root() {
+    let generated = base_project(vec![
+        opaque_class_declaration_entry(),
+        method_declaration_entry("Self.poll", RustInteropDecoratorKind::Function),
+    ]);
+    let context = package_context(TrustPolicy::default(), Vec::new());
+
+    let generated = apply_package_rust_interop_metadata(generated, Some(context))
+        .expect("Self method root should resolve");
+
+    assert!(generated
+        .interop
+        .rust
+        .resolved_targets
+        .iter()
+        .any(|target| matches!(
+            target.root,
+            sifr_codegen::RustInteropResolvedRoot::SelfMethod { .. }
+        )));
+}
+
+#[test]
+fn package_rust_interop_rejects_self_method_root_without_opaque_class() {
     let generated = base_project(vec![method_declaration_entry(
         "Self.poll",
         RustInteropDecoratorKind::Function,
     )]);
     let context = package_context(TrustPolicy::default(), Vec::new());
 
-    let generated = apply_package_rust_interop_metadata(generated, Some(context))
-        .expect("Self method root should resolve");
+    let diagnostics = interop_errors(
+        generated,
+        Some(context),
+        "Self root without opaque class should fail",
+    );
 
-    assert!(matches!(
-        generated.interop.rust.resolved_targets[0].root,
-        sifr_codegen::RustInteropResolvedRoot::SelfMethod { .. }
-    ));
+    assert_eq!(diagnostics[0].code, "SIFR-RUST-RESOLVE-0001");
+    assert!(diagnostics[0]
+        .children
+        .iter()
+        .any(|child| child.message.contains("@rust.opaque")));
 }
 
 #[test]
@@ -598,6 +676,40 @@ fn method_declaration_entry(
     entry
 }
 
+fn opaque_class_declaration_entry() -> RustInteropPlanDeclaration {
+    RustInteropPlanDeclaration {
+        module_name: Some("app".to_string()),
+        owner: RustInteropOwner::Class {
+            name: "Consumer".to_string(),
+        },
+        declaration: RustInteropDeclaration {
+            kind: RustInteropDecoratorKind::Opaque,
+            target: None,
+            arguments: vec![
+                RustInteropArgument {
+                    name: Some("type".to_string()),
+                    value: RustInteropValue::TargetPath(target_path("bridge.consumer.Consumer")),
+                    span: span(),
+                },
+                RustInteropArgument {
+                    name: Some("send".to_string()),
+                    value: RustInteropValue::Boolean(false),
+                    span: span(),
+                },
+                RustInteropArgument {
+                    name: Some("sync".to_string()),
+                    value: RustInteropValue::Boolean(false),
+                    span: span(),
+                },
+                symbol_arg("clone", "none"),
+            ],
+            span: span(),
+            effect: RustInteropEffect::Sync,
+            abi_requirements: RustInteropAbiRequirements::default(),
+        },
+    }
+}
+
 fn declaration_entry_with_args(
     target: &str,
     kind: RustInteropDecoratorKind,
@@ -610,15 +722,19 @@ fn declaration_entry_with_args(
         },
         declaration: RustInteropDeclaration {
             kind,
-            target: Some(RustTargetPath {
-                segments: target.split('.').map(str::to_string).collect(),
-                span: span(),
-            }),
+            target: Some(target_path(target)),
             arguments,
             span: span(),
             effect: RustInteropEffect::Sync,
             abi_requirements: RustInteropAbiRequirements::default(),
         },
+    }
+}
+
+fn target_path(target: &str) -> RustTargetPath {
+    RustTargetPath {
+        segments: target.split('.').map(str::to_string).collect(),
+        span: span(),
     }
 }
 

--- a/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-m3-opus-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-m3-opus-review-pass-1.md
@@ -1,0 +1,17 @@
+Reviewing the summary without touching the tree. Findings ordered by likely severity:
+
+**1. `use <alias>::bridges as bridge` collides when a module has bridge targets from two different packages.** The bind name is fixed as `bridge`, so a second `use other_alias::bridges as bridge` in the same generated module is a duplicate-import error. Worth confirming the emitter either deduplicates by alias per module or scopes the rename per call site (e.g., `<alias>::bridges::…` inline). The listed tests only cover single-alias injection.
+
+**2. Synthetic `Ok(())` suppression may be too eager for `Result[None, E]` bodies whose interop expression doesn't itself yield a `Result`.** If the interop body was supplied but ends in a `()` expression (e.g., a void FFI call) rather than an `Ok(())` / `Result` expression, suppressing the tail leaves a type mismatch against the declared `Result[None, E]` return. The rule should be "suppress only when the interop body already returns a Result-typed tail," not "suppress whenever an interop body was supplied." Test named "direct Result[None,E] no extra Ok tail" likely covers the good case but not this failure mode.
+
+**3. `self._handle.<method>(args)` assumes every `Self`-targeted class has a `_handle` field of the opaque wrapper shape.** Classes generated without `_handle` (e.g., value-type wrappers, classmethods dispatched on `Self`, or future shapes) will emit an unresolved field access. Worth verifying (a) HIR guarantees `_handle` exists for every class reachable as a Rust-interop `Self` target, and (b) `cls`/staticmethod paths are routed elsewhere and don't fall into this branch.
+
+**4. Result-error mapping from annotated return types depends on the annotation, not the interop signature.** If the annotated return type is `Result[T, E]` but the interop function returns `T` directly (or vice-versa), the emitted `.map_err(…)` / wrap will not compile. This should be validated in HIR (annotation must match interop signature shape) before codegen, otherwise the failure surfaces as a rustc error rather than a Sifr diagnostic. Tests don't appear to cover annotation/signature-shape mismatch.
+
+**5. Dependency alias dedupe in `Cargo.toml`.** Two `PackageBridge` roots resolving to the same package via the same alias should collapse to one `[dependencies]` entry; two roots with the same package but *different* aliases must both be emitted and must not clobber each other. Also worth confirming: alias sanitization (Cargo dependency-key rules — hyphens, leading digits) matches whatever the `use <alias>::bridges` path expects.
+
+**6. Cache fragment uniqueness.** If two roots share package name + alias but differ by manifest path (e.g., path-dep vs. registry, or two workspaces), the cache fragment must key on manifest path, not just package name, to avoid cross-project cache poisoning. Summary lists manifest path in the resolved-root record — worth confirming the fragment derivation includes it.
+
+**7. Bodyless top-level call + panic policy.** Recent commit `61d3b5c90` added an effective sysroot panic policy. Bodyless emission that forwards straight to the interop function bypasses any wrapper — confirm the panic-policy assertions still fire on the direct-root path (the "driver panic focused suite passes" line suggests coverage but doesn't specify the direct-root variant).
+
+If those seven all hold under inspection, no further actionable findings from the summary alone — the rest reads as mechanical plumbing with matching tests.

--- a/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-m3-opus-review-pass-3.md
+++ b/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-m3-opus-review-pass-3.md
@@ -1,0 +1,9 @@
+One plausible blocker surfaces from the summary; everything else looks internally consistent.
+
+**Potential alias collision — `crates/sifr_driver/src/build/rust_interop/bridge_aliases.rs`**
+
+The injected import is described as `use <bridge_dependency_alias>::bridges as bridge;` and the dedupe test only covers "repeated bridge declarations" (same alias). If a single generated module declares interop against **two different** bridge packages, both imports would be renamed `as bridge`, causing a Rust `E0252` (name defined multiple times) collision. The "one bridge alias per module for repeated bridge declarations" test wouldn't catch the multi-bridge case.
+
+If M3 explicitly forbids multiple bridge packages per module, this is not a blocker — but the summary doesn't state that constraint, and the local name `bridge` looks fragile for future multi-bridge modules. Consider renaming the local binding to be alias-derived (e.g. `as <bridge_dependency_alias>_bridge`) or asserting single-bridge-per-module.
+
+Everything else in the summary (bodyless codegen suppression of the synthetic `Ok(())` tail, opaque-contract gating for `Self.*`, cache-fragment fields, `self._handle.method(...)` for Self methods, package-bridge Cargo.toml aliases) reads coherently and is backed by tests.

--- a/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-m3-opus-review-pass-4.md
+++ b/plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-m3-opus-review-pass-4.md
@@ -1,0 +1,1 @@
+Reviewer satisfied for M3.


### PR DESCRIPTION
## Summary
- emit bodyless Rust interop calls for package bridge roots and opaque `Self.*` methods
- add package bridge dependency alias/path metadata to resolved targets, Cargo.toml generation, and cache fragments
- suppress the synthetic `return Ok(());` tail when a Rust interop body already supplies a `Result[None, E]` function body
- gate `Self.*` targets to methods whose owning class has an accepted `@rust.opaque(...)` contract

## Review
- Opus pass 1 found issues around `Self.*` gating and possible bridge alias collisions
- addressed `Self.*` by requiring an opaque owner class and adding positive/negative tests
- documented the one-package-per-generated-module bridge alias invariant
- Opus final pass: `Reviewer satisfied for M3.`

## Validation
- `scripts/run_all_tests.sh --profile create-pr` passed
  - e2e pass suite: 132 passed, 0 failed
  - note: warm wall-time advisory exceeded, but all blocking lane steps passed

## Artifacts
- `plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-m3-opus-review-pass-1.md`
- `plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-m3-opus-review-pass-3.md`
- `plans/reviews/active/ad-hoc-sysroot-stdlib-interop-declaration-cleanup-m3-opus-review-pass-4.md`
