### PR TITLE
Plan stdlib native boundary completion

### DIFF
--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -152,7 +152,7 @@ Sifr is Python-syntax and CPython-behavior-informed, but it is not Python-source
 
 | Import root | Owner | Resolution |
 | --- | --- | --- |
-| `_sifr.*` | Sysroot-private stdlib declaration source | Available only to sysroot stdlib implementation files; user/package imports are rejected. |
+| `_sifr.*` | Sysroot-private stdlib declaration source | Naming convention for modules loaded with `SysrootPrivateDeclaration` origin. Importability is source-origin based: only `SysrootPublicStdlib` sources may import private declarations. |
 | `sifr.*` | Sifr standard library | Resolved from the active sysroot public stdlib source inventory; never package-manager resolution. |
 | top-level | User code and third-party packages | Workspace/package resolution. |
 

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -273,7 +273,7 @@ sifr/
     sifr_ir/                (High-level IR data rules, public lowered views, CFG/flow graph data)
     sifr_lowering/          (AST-to-IR lowering, name/type/ownership/async analysis, lowering diagnostics)
     sifr_stdlib_manifest/   (target compiler-host stdlib source inventory, private declaration inventory, feature planning, sysroot validation, and import suggestions; split out from current sifr_stdlib_model)
-    sifr_ipc/               (target shared IPC protocol/frame/schema/request-tracking crate if IPC remains needed by compiler, driver, tooling, and runtime)
+    sifr_ipc/               (target shared IPC protocol/frame/schema/request-tracking crate split out from the current stdlib model)
     sifr_type_system/       (type definitions, inference, checking, subtyping)
     sifr_codegen/           (Rust source code generation from HIR via structured Rust IR)
     sifr_driver/            (CLI/project orchestration, split into diagnostics.rs + stdlib/ frontend/ project/ build/ test_runner/)

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -53,7 +53,7 @@
 - Network/TLS/URL/HTTP substrate architecture is tracked in [`network_http_architecture.md`](./network_http_architecture.md). The public boundary is `sifr.net`, `sifr.tls`, `sifr.url`, and `sifr.http`; CPython-shaped networking modules remain unsupported diagnostics or rejected surfaces.
 - Embedded CPython interop is production-grade complete as a separate lane from Rust-backed packages, raw C ABI interop, and CPython source-parity adaptation. Package metadata records Python environment selection, declared import roots, and Python trust roots; the package layer resolves a single selected environment and validates canonical CPython probe JSON before runtime embedding consumes it. Runtime lifecycle, GIL/refcount ownership, blocking/offload, callbacks, resources, and zero-copy rules are documented in [`python_interop_architecture.md`](./python_interop_architecture.md), with verification under [`verification/areas/python_interop/`](../verification/areas/python_interop/).
 - Rust interop is designed as declaration-level Cargo integration, not a runtime `dlopen` layer or Rust ABI FFI surface. Rust-backed Sifr packages expose normal Sifr declarations annotated with `@rust(...)`, direct Cargo bindings are allowed only for checked bridge-compatible signatures, and package-local/shared bridge crates own adaptation. The source of truth is [`rust_interop_architecture.md`](./rust_interop_architecture.md).
-- The sysroot and stdlib toolchain migration is tracked in [`sifr_sysroot_and_stdlib_architecture.md`](./sifr_sysroot_and_stdlib_architecture.md). The baseline inventory keeps the current embedded `lib/sifr` and compiler-side `crates/sifr_stdlib_model` ownership explicit; `crates/sifr_stdlib` is now the generated-program stdlib crate foundation while later implementation stages move release builds to a versioned `lib/sifr` sysroot and migrate native stdlib surfaces through private `_sifr` declarations and Rust interop. The broad native-surface migration registry has been deleted; retained compiler-native glue is now tracked by `stdlib_retained_compiler_intrinsics.toml`, and resource-sensitive surfaces are blocked by the Rust interop resource certification gate until executable lifecycle evidence lands.
+- The sysroot and stdlib toolchain migration is tracked in [`sifr_sysroot_and_stdlib_architecture.md`](./sifr_sysroot_and_stdlib_architecture.md). The final stdlib boundary is checked Sifr source plus trusted sysroot Rust interop: public APIs live in `stdlib/sifr`, sysroot-private declaration source lives in `stdlib/_sifr`, stdlib behavior lives in `crates/sifr_stdlib`, and reusable runtime substrate lives in `crates/sifr_runtime`. The compiler may emit language scaffolding, Rust interop bridge glue, panic wrappers, exact-int conversions, entrypoint machinery, and runtime call glue; it must not implement stdlib behavior through intrinsic dispatch, pasted preambles, or handwritten Rust literals. Existing compiler-native stdlib glue survives only as exhaustive, migration-state-tracked exceptions in `stdlib_retained_compiler_intrinsics.toml`.
 
 ## Vision
 
@@ -152,8 +152,8 @@ Sifr is Python-syntax and CPython-behavior-informed, but it is not Python-source
 
 | Import root | Owner | Resolution |
 | --- | --- | --- |
-| `_sifr.*` | Compiler intrinsics | Embedded only; never filesystem or package-manager resolution. |
-| `sifr.*` | Sifr standard library | Embedded `sifr_stdlib_model::STDLIB_SOURCES`; never filesystem or package-manager resolution. |
+| `_sifr.*` | Sysroot-private stdlib declaration source | Available only to sysroot stdlib implementation files; user/package imports are rejected. |
+| `sifr.*` | Sifr standard library | Resolved from the active sysroot public stdlib source inventory; never package-manager resolution. |
 | top-level | User code and third-party packages | Workspace/package resolution. |
 
 Bare CPython stdlib roots such as `math`, `json`, `os`, `heapq`, and `collections` are not aliases for `sifr.*`. A real top-level user or package module named `math`, `json`, or similar wins normal resolution. If no real top-level module resolves and the written import root matches an embedded Sifr stdlib module tail, the compiler emits `SIFR-IMPORT-0008` with a suggestion to use `sifr.*`.
@@ -272,7 +272,8 @@ sifr/
     sifr_diagnostics/       (canonical diagnostic codes, source-map spans, model, render schema, and sink)
     sifr_ir/                (High-level IR data rules, public lowered views, CFG/flow graph data)
     sifr_lowering/          (AST-to-IR lowering, name/type/ownership/async analysis, lowering diagnostics)
-    sifr_stdlib_model/      (compiler-host stdlib source inventory, intrinsic signatures, generated dependency feature specs)
+    sifr_stdlib_manifest/   (target compiler-host stdlib source inventory, private declaration inventory, feature planning, sysroot validation, and import suggestions; split out from current sifr_stdlib_model)
+    sifr_ipc/               (target shared IPC protocol/frame/schema/request-tracking crate if IPC remains needed by compiler, driver, tooling, and runtime)
     sifr_type_system/       (type definitions, inference, checking, subtyping)
     sifr_codegen/           (Rust source code generation from HIR via structured Rust IR)
     sifr_driver/            (CLI/project orchestration, split into diagnostics.rs + stdlib/ frontend/ project/ build/ test_runner/)

--- a/internal_docs/network_http_architecture.md
+++ b/internal_docs/network_http_architecture.md
@@ -5,7 +5,7 @@ The production network/HTTP substrate is split by ownership boundary:
 - `sifr.net` provides async TCP listeners, streams, owned split halves, write-side half-close, DNS lookup, typed `NetError`, and no public raw descriptor or selector API.
 - `sifr.tls` wraps the TCP substrate with Rustls-backed client/server configs, ALPN, SNI, mTLS fixture coverage, `close_notify`, owned split halves, and typed `TlsError`.
 - `sifr.url` owns URL, query, percent, authority, redaction, and IDNA guard behavior. Unicode/IDNA behavior remains blocked until the text/i18n provider accepts the Unicode version and normalization policy.
-- `sifr.http` owns protocol values and body streams. process runtime transport is implemented in the runtime through Hyper/H2 and validated by the e2e-only `sifr.http_transport` harness.
+- `sifr.http` owns protocol values and body streams. Process runtime transport is implemented in the runtime through Hyper/H2. The current synthetic `sifr.http_transport` harness is a temporary verification bridge and is scheduled to be deleted in favor of a verification-owned Rust fixture by the stdlib native boundary completion phase.
 
 ## Runtime Boundary
 

--- a/internal_docs/network_http_architecture.md
+++ b/internal_docs/network_http_architecture.md
@@ -5,7 +5,7 @@ The production network/HTTP substrate is split by ownership boundary:
 - `sifr.net` provides async TCP listeners, streams, owned split halves, write-side half-close, DNS lookup, typed `NetError`, and no public raw descriptor or selector API.
 - `sifr.tls` wraps the TCP substrate with Rustls-backed client/server configs, ALPN, SNI, mTLS fixture coverage, `close_notify`, owned split halves, and typed `TlsError`.
 - `sifr.url` owns URL, query, percent, authority, redaction, and IDNA guard behavior. Unicode/IDNA behavior remains blocked until the text/i18n provider accepts the Unicode version and normalization policy.
-- `sifr.http` owns protocol values and body streams. Process runtime transport is implemented in the runtime through Hyper/H2. The current synthetic `sifr.http_transport` harness is a temporary verification bridge and is scheduled to be deleted in favor of a verification-owned Rust fixture by the stdlib native boundary completion phase.
+- `sifr.http` owns protocol values and body streams. Process runtime transport is implemented in the runtime through Hyper/H2. The current synthetic `sifr.http_transport` harness is a temporary verification bridge; the stdlib native boundary completion phase moves equivalent coverage into a verification-owned Rust fixture, proves parity, and then deletes the synthetic module.
 
 ## Runtime Boundary
 

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -56,7 +56,7 @@ state. Later implementation stages update the implementation toward the architec
 | --- | --- | --- | --- | --- |
 | Public Sifr stdlib sources | `stdlib/sifr/*.sifr`, validated by `crates/sifr_stdlib_model` and loaded from the resolved source-tree or installed sysroot path | `stdlib/sifr/*.sifr` copied into `<sysroot>/lib/sifr/stdlib/sifr` and loaded through `ResolvedSysroot` | complete for source layout; packaging copy remains later | yes |
 | Private stdlib declarations | `stdlib/_sifr/*.sifr` declaration files are loaded from the resolved sysroot; completed stateless/data leaves bind through private Rust interop while retained runtime/resource/callback leaves remain compiler-owned and allowlisted | `stdlib/_sifr/*.sifr` declarations copied into `<sysroot>/lib/sifr/stdlib/_sifr` and loaded through the same sysroot source inventory | concrete Rust interop declarations, synthetic stdlib interop context, retained-glue allowlist | mixed |
-| Compiler-side stdlib model | `crates/sifr_stdlib_model` currently owns source inventory, private intrinsic metadata, feature/dependency mapping, IPC metadata, and legacy module suggestions | Split into a manifest/sysroot crate for source inventory, private declarations, feature planning, sysroot validation, migration-state loading, and import suggestions; move IPC protocol/frame/schema/request tracking into `sifr_ipc` or `sifr_runtime::ipc`; delete fallback intrinsic signature tables as families migrate | manifest/model split and intrinsic signature deletion | yes |
+| Compiler-side stdlib model | `crates/sifr_stdlib_model` currently owns source inventory, private intrinsic metadata, feature/dependency mapping, IPC metadata, and legacy module suggestions | Split into `crates/sifr_stdlib_manifest` for source inventory, private declarations, feature planning, sysroot validation, migration-state loading, and import suggestions; move shared IPC protocol/frame/schema/request tracking into `crates/sifr_ipc`; delete fallback intrinsic signature tables as surfaces migrate | manifest/model split and intrinsic signature deletion | yes |
 | Generated-program stdlib implementation crate | `crates/sifr_stdlib` exists as the generated-program crate foundation with empty defaults, narrow additive leaf features, runtime-backed wrapper APIs for existing runtime primitives, and feature-plan expectations in `sifr_stdlib_model` | `crates/sifr_stdlib`, shipped under `<sysroot>/crates/sifr_stdlib` | full native leaf migration, generated Cargo sysroot dependency emission, and installed sysroot packaging | yes |
 | Runtime crate | `crates/sifr_runtime` under the resolved development or installed sysroot; generated Cargo and Rust interop probes receive the explicit `ResolvedSysroot` runtime crate path | `<sysroot>/crates/sifr_runtime` path dependency selected by `ResolvedSysroot` | Sysroot resolver, generated dependency plan | yes |
 | Generated Cargo planning | `sifr_codegen::generate_project_with_deps_and_crates` asked `sifr_stdlib_model::generated_cargo_dependencies` for dependency strings | `SysrootDependencyPlan` from the manifest/sysroot planning layer, consumed by codegen, driver, cache keys, reports, and LSP traces | manifest/model split and dependency planner | yes |
@@ -606,8 +606,7 @@ The current `sifr_stdlib_model` crate is transitional. Its final shape is not a
 compiler-side behavior model for the standard library; it is a manifest and
 sysroot planning layer.
 
-The final manifest layer may be named `sifr_stdlib_manifest` or
-`sifr_sysroot_manifest`. It owns:
+The final manifest layer is `sifr_stdlib_manifest`. It owns:
 
 - stdlib source inventory and module metadata,
 - public `sifr.*` import policy and private `_sifr.*` rejection policy,
@@ -625,9 +624,8 @@ truth for migrated families. A migrated or closed surface must not keep a
 parallel intrinsic signature table in the manifest layer.
 
 IPC schema, frame encoding, transport, request tracking, and handshake metadata
-do not belong in the stdlib manifest. If IPC remains shared by compiler,
-driver, tooling, and runtime, it moves to a small `sifr_ipc` crate. If it is
-runtime-only, it moves under `sifr_runtime::ipc`.
+do not belong in the stdlib manifest. The current IPC modules are shared
+compiler/tooling protocol, so they move to a small `sifr_ipc` crate.
 
 The name `sifr_stdlib` is reserved for the generated-program stdlib
 implementation crate. The compiler manifest speaks in terms of resolved
@@ -709,6 +707,14 @@ requires such behavior. The sysroot vendor config exists for generated
 std-library support, not as a hidden policy override for a user's dependency
 graph.
 
+If Cargo cannot unify a user-owned dependency with a crate version also used by
+Sifr-owned sysroot crates, the diagnostic reports a package dependency conflict
+against the user's package graph and names the sysroot feature that introduced
+the Sifr-owned requirement. Sifr does not silently rewrite the user's
+dependency to match the bundled sysroot version. In stdlib-only generated
+builds, the sysroot vendor set is the sole source for Sifr-owned third-party
+implementation crates.
+
 Generated Cargo must not expose third-party crates that are implementation
 details of Sifr-owned stdlib/runtime behavior. The final state for stdlib use is
 that generated manifests emit only sysroot crates such as `sifr_stdlib` and
@@ -724,20 +730,29 @@ resource-shaped surfaces stay blocked by
 `scripts/check_sysroot_stdlib_resource_certification_gate.py` until their Rust
 interop lifecycle evidence lands.
 
-Every `_sifr.*` family and every compiler-native exception must appear exactly
-once in the retained-glue manifest until the family is closed. Manifest states
-are:
+Every compiler-native stdlib surface must appear exactly once in the
+retained-glue manifest until the surface is closed. The row granularity is a
+leaf or subfamily, not necessarily a whole `_sifr.*` module, because several
+modules contain both migrated and retained leaves. Manifest states are:
 
 | State | Meaning |
 | --- | --- |
 | `retained` | Still compiler-native for now and scheduled for migration or final classification. |
 | `pilot` | The selected pilot implementation is underway and the retained compiler path is still present. |
-| `migrated` | Behavior now routes through checked stdlib source and sysroot Rust interop; compiler-native entries are deleted. |
-| `closed` | The old surface was removed, rejected, or replaced with a different supported API. |
+| `migrated` | Behavior now routes through checked stdlib source and sysroot Rust interop; the row stays as an audit tombstone with evidence after compiler-native entries are deleted. |
+| `closed` | The old surface was removed, rejected, or replaced with a different supported API; the row stays as an audit tombstone with evidence. |
 | `retained-by-design` | Permanently compiler-owned language, bridge, entrypoint, exact-int, test-harness, or runtime substrate glue. |
 
 The manifest is the only exception ledger. Do not add a second registry for
-compiler-native stdlib migration state.
+compiler-native stdlib migration state. Prefix retainers are temporary
+coarse-grained rows. Migrating any intrinsic covered by a prefix must either
+narrow the prefix in the same change or record the retired name in a
+`retired_prefix_intrinsics` field so the prefix cannot keep migrated behavior
+alive.
+
+Resource certification rows are also recorded in this manifest. The resource
+certification gate reads `certification_rows` from the retained-glue manifest
+rather than maintaining a parallel surface-to-matrix table.
 
 Some surfaces are intentionally split while migration is underway. For example,
 `_sifr.collections` set helpers and legacy JSON-string defaultdict helper
@@ -816,12 +831,34 @@ allowlisted retained runtime/resource glue. Completed native stdlib leaves must
 route through private declarations and Rust interop, and the migration closure
 guard fails if those retired intrinsic names reappear in the active dispatcher.
 
+Direct generated calls to `sifr_runtime::*` are permitted only for language,
+bridge, entrypoint, exact-int, test-harness, or retained-by-design runtime
+substrate glue. A codegen path that emits a direct `sifr_runtime::*` call for
+stdlib behavior must instead route through `stdlib/_sifr` declarations and
+`sifr_stdlib`, or it must be listed as a retained-by-design manifest exception.
+
 Generated stdlib Rust has a provenance requirement. `StdlibCode.module_rust_code`
 is valid as a transport for Rust code produced by compiling checked Sifr stdlib
 source. It must not be populated from handwritten Rust string literals except
 for manifest-tracked temporary migration exceptions. The final representation
 should make provenance structural so guards can distinguish compiled stdlib
 output from raw compiler injection.
+
+The structural target is:
+
+```rust
+enum StdlibRustSource {
+    CompiledFromSifr { module: String, source_path: PathBuf, rust: String },
+    HandwrittenExemption { manifest_key: String, rust: String },
+}
+```
+
+`StdlibCode.module_rust_code` should carry `StdlibRustSource` values rather than
+plain strings once provenance hardening lands. Guards then reject any
+`HandwrittenExemption` whose `manifest_key` is absent from the retained-glue
+manifest. `CompiledFromSifr.source_path` is normalized to the same
+repo-relative path form used by manifest `declaration_files`, so the guard can
+cross-check generated stdlib Rust provenance against declaration source.
 
 Runtime/resource/callback surfaces follow the Rust interop certification gate.
 Surfaces still marked future-owned or uncertified in the compatibility matrix

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -16,6 +16,36 @@ paths, gives CLI and LSP the same view of the installed standard library, and
 provides a stable substrate for moving compiler-special native stdlib plumbing
 onto Rust interop.
 
+## Final Stdlib Boundary
+
+The completed stdlib architecture is checked Sifr source plus trusted sysroot
+Rust interop:
+
+```text
+user code
+  -> stdlib/sifr/*.sifr
+  -> stdlib/_sifr/*.sifr
+  -> @rust(sifr_stdlib.*)
+  -> crates/sifr_stdlib
+  -> crates/sifr_runtime, only for reusable substrate
+```
+
+Public APIs live in `stdlib/sifr`. Sysroot-private declarations live in
+`stdlib/_sifr`; user and package code cannot import them. `crates/sifr_stdlib`
+owns stdlib behavior, including public wrapper policy, Sifr-facing error
+taxonomy, CPython-compatibility adaptation, and module-specific resource
+semantics. `crates/sifr_runtime` owns reusable substrate only: executors,
+opaque handle storage, poisoning, panic boundaries, exact-int bridge helpers,
+and low-level process, network, TLS, HTTP, and Python runtime state.
+
+The compiler may still emit language scaffolding, Rust interop bridge glue,
+panic wrappers, exact-int conversions, entrypoint machinery, and runtime call
+glue. It must not implement stdlib behavior through intrinsic dispatch, pasted
+preambles, or handwritten Rust source literals. During migration, compiler
+native stdlib glue is permitted only as an explicit, reviewed, shrinking,
+machine-readable exception in
+`internal_docs/stdlib_retained_compiler_intrinsics.toml`.
+
 ## Pre-Migration Baseline
 
 This section records the current implementation boundary before sysroot and
@@ -26,10 +56,10 @@ state. Later implementation stages update the implementation toward the architec
 | --- | --- | --- | --- | --- |
 | Public Sifr stdlib sources | `stdlib/sifr/*.sifr`, validated by `crates/sifr_stdlib_model` and loaded from the resolved source-tree or installed sysroot path | `stdlib/sifr/*.sifr` copied into `<sysroot>/lib/sifr/stdlib/sifr` and loaded through `ResolvedSysroot` | complete for source layout; packaging copy remains later | yes |
 | Private stdlib declarations | `stdlib/_sifr/*.sifr` declaration files are loaded from the resolved sysroot; completed stateless/data leaves bind through private Rust interop while retained runtime/resource/callback leaves remain compiler-owned and allowlisted | `stdlib/_sifr/*.sifr` declarations copied into `<sysroot>/lib/sifr/stdlib/_sifr` and loaded through the same sysroot source inventory | concrete Rust interop declarations, synthetic stdlib interop context, retained-glue allowlist | mixed |
-| Compiler-side stdlib model | `crates/sifr_stdlib_model` owns source inventory, private intrinsic metadata, feature/dependency mapping, and legacy module suggestions | `crates/sifr_stdlib_model` | complete | yes |
+| Compiler-side stdlib model | `crates/sifr_stdlib_model` currently owns source inventory, private intrinsic metadata, feature/dependency mapping, IPC metadata, and legacy module suggestions | Split into a manifest/sysroot crate for source inventory, private declarations, feature planning, sysroot validation, migration-state loading, and import suggestions; move IPC protocol/frame/schema/request tracking into `sifr_ipc` or `sifr_runtime::ipc`; delete fallback intrinsic signature tables as families migrate | manifest/model split and intrinsic signature deletion | yes |
 | Generated-program stdlib implementation crate | `crates/sifr_stdlib` exists as the generated-program crate foundation with empty defaults, narrow additive leaf features, runtime-backed wrapper APIs for existing runtime primitives, and feature-plan expectations in `sifr_stdlib_model` | `crates/sifr_stdlib`, shipped under `<sysroot>/crates/sifr_stdlib` | full native leaf migration, generated Cargo sysroot dependency emission, and installed sysroot packaging | yes |
 | Runtime crate | `crates/sifr_runtime` under the resolved development or installed sysroot; generated Cargo and Rust interop probes receive the explicit `ResolvedSysroot` runtime crate path | `<sysroot>/crates/sifr_runtime` path dependency selected by `ResolvedSysroot` | Sysroot resolver, generated dependency plan | yes |
-| Generated Cargo planning | `sifr_codegen::generate_project_with_deps_and_crates` asked `sifr_stdlib_model::generated_cargo_dependencies` for dependency strings | `SysrootDependencyPlan` from `sifr_stdlib_model`, consumed by codegen, driver, cache keys, reports, and LSP traces | dependency planner | yes |
+| Generated Cargo planning | `sifr_codegen::generate_project_with_deps_and_crates` asked `sifr_stdlib_model::generated_cargo_dependencies` for dependency strings | `SysrootDependencyPlan` from the manifest/sysroot planning layer, consumed by codegen, driver, cache keys, reports, and LSP traces | manifest/model split and dependency planner | yes |
 | Third-party stdlib/runtime dependencies | Generated projects emit registry dependencies directly, for example `regex`, `serde_json`, `tokio`, `url`, `zip`, and others | Vendored under `<sysroot>/vendor` from the sysroot workspace lockfile for Sifr-owned dependencies | vendor and Cargo config mode matrix | yes |
 | Distribution packaging | Preview/self-update artifacts and receipts pair the standalone binary with installer metadata; no sysroot contract is validated | Release archive contains `bin/sifr` plus the complete sysroot tree and replaces them atomically | installer and release artifact update | yes |
 | CLI stdlib loading | `sifr_driver::compile_stdlib` resolves `ResolvedSysroot`, validates the public/private stdlib inventory, and compiles physical public stdlib files with source paths | CLI resolves `ResolvedSysroot` and loads physical sysroot stdlib files | complete for public source loading; private declaration lowering remains later | yes |
@@ -570,30 +600,40 @@ runtime-observability
 Feature tests and generated Cargo snapshots prove that using one stdlib module
 does not enable unrelated capability groups.
 
-### `sifr_stdlib_model`
+### Compiler Manifest and IPC Split
 
-`sifr_stdlib_model` is the compiler-side model of the standard library. It is
-linked into the compiler and is not shipped as a generated-program dependency.
-It was renamed from the compiler crate previously named `sifr_stdlib`.
+The current `sifr_stdlib_model` crate is transitional. Its final shape is not a
+compiler-side behavior model for the standard library; it is a manifest and
+sysroot planning layer.
 
-It owns:
+The final manifest layer may be named `sifr_stdlib_manifest` or
+`sifr_sysroot_manifest`. It owns:
 
 - stdlib source inventory and module metadata,
 - public `sifr.*` import policy and private `_sifr.*` rejection policy,
 - legacy CPython-shaped module suggestions,
 - private declaration module metadata,
-- mapping from stdlib declarations and codegen requirements to generated Cargo
-  dependencies and sysroot crate features,
-- IPC schema/protocol metadata needed by compiler analysis and verification.
+- migration-state loading from
+  `internal_docs/stdlib_retained_compiler_intrinsics.toml`,
+- mapping from stdlib declarations, language requirements, and Rust interop
+  requirements to generated Cargo sysroot crate features,
+- sysroot inventory validation and deterministic stdlib bootstrap ordering.
 
-The name `sifr_stdlib` is reserved for the generated-program stdlib crate. The
-compiler model uses a distinct name so crate names communicate runtime
-responsibility rather than internal implementation history.
+It does not own stdlib behavior, Rust implementation policy, fallback
+signatures, or compiler-native dispatch. Declaration source is the signature
+truth for migrated families. A migrated or closed surface must not keep a
+parallel intrinsic signature table in the manifest layer.
 
-`sifr_stdlib_model` speaks in terms of resolved sysroot/module metadata rather
-than hard-coded include paths. Released tools must not use embedded fallback
-sources for normal stdlib resolution. If the sysroot is missing or invalid,
-released tools fail with a sysroot diagnostic.
+IPC schema, frame encoding, transport, request tracking, and handshake metadata
+do not belong in the stdlib manifest. If IPC remains shared by compiler,
+driver, tooling, and runtime, it moves to a small `sifr_ipc` crate. If it is
+runtime-only, it moves under `sifr_runtime::ipc`.
+
+The name `sifr_stdlib` is reserved for the generated-program stdlib
+implementation crate. The compiler manifest speaks in terms of resolved
+sysroot/module metadata rather than hard-coded include paths. Released tools
+must not use embedded fallback sources for normal stdlib resolution. If the
+sysroot is missing or invalid, released tools fail with a sysroot diagnostic.
 
 ## Standard Library Source Layers
 
@@ -670,10 +710,12 @@ std-library support, not as a hidden policy override for a user's dependency
 graph.
 
 Generated Cargo must not expose third-party crates that are implementation
-details of Sifr-owned stdlib/runtime behavior. It may still emit user/package
-dependencies, explicit Rust interop dependencies, and temporary direct
-third-party dependencies for unmigrated compiler-special paths when the
-corresponding migration stage has a deletion plan and validation coverage.
+details of Sifr-owned stdlib/runtime behavior. The final state for stdlib use is
+that generated manifests emit only sysroot crates such as `sifr_stdlib` and
+`sifr_runtime`; third-party crates are transitive implementation details of
+those sysroot crates. Generated manifests may still emit user/package
+dependencies and explicit Rust interop dependencies because those belong to the
+user package graph, not to Sifr-owned stdlib behavior.
 
 The broad native stdlib migration registry has been deleted. Current ownership
 is checked by location and by targeted guardrails: retained compiler-native
@@ -681,6 +723,21 @@ glue is listed in `internal_docs/stdlib_retained_compiler_intrinsics.toml`, and
 resource-shaped surfaces stay blocked by
 `scripts/check_sysroot_stdlib_resource_certification_gate.py` until their Rust
 interop lifecycle evidence lands.
+
+Every `_sifr.*` family and every compiler-native exception must appear exactly
+once in the retained-glue manifest until the family is closed. Manifest states
+are:
+
+| State | Meaning |
+| --- | --- |
+| `retained` | Still compiler-native for now and scheduled for migration or final classification. |
+| `pilot` | The selected pilot implementation is underway and the retained compiler path is still present. |
+| `migrated` | Behavior now routes through checked stdlib source and sysroot Rust interop; compiler-native entries are deleted. |
+| `closed` | The old surface was removed, rejected, or replaced with a different supported API. |
+| `retained-by-design` | Permanently compiler-owned language, bridge, entrypoint, exact-int, test-harness, or runtime substrate glue. |
+
+The manifest is the only exception ledger. Do not add a second registry for
+compiler-native stdlib migration state.
 
 Some surfaces are intentionally split while migration is underway. For example,
 `_sifr.collections` set helpers and legacy JSON-string defaultdict helper
@@ -705,9 +762,10 @@ The generated project is still a normal Cargo project: user package
 dependencies, explicit Rust interop package dependencies, and user-selected
 registries remain controlled by Cargo and package metadata.
 
-The generated dependency planner is owned by `sifr_stdlib_model`. It maps
-stdlib modules, private declarations, language runtime requirements, and Rust
-interop bridge requirements to one compiler-facing artifact:
+The generated dependency planner is owned by the manifest/sysroot planning
+layer. It maps stdlib modules, private declarations, language runtime
+requirements, and Rust interop bridge requirements to one compiler-facing
+artifact:
 
 ```rust
 SysrootDependencyPlan {
@@ -757,6 +815,13 @@ Compiler-special codegen intrinsics are restricted to language semantics and
 allowlisted retained runtime/resource glue. Completed native stdlib leaves must
 route through private declarations and Rust interop, and the migration closure
 guard fails if those retired intrinsic names reappear in the active dispatcher.
+
+Generated stdlib Rust has a provenance requirement. `StdlibCode.module_rust_code`
+is valid as a transport for Rust code produced by compiling checked Sifr stdlib
+source. It must not be populated from handwritten Rust string literals except
+for manifest-tracked temporary migration exceptions. The final representation
+should make provenance structural so guards can distinguish compiled stdlib
+output from raw compiler injection.
 
 Runtime/resource/callback surfaces follow the Rust interop certification gate.
 Surfaces still marked future-owned or uncertified in the compatibility matrix

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -850,16 +850,19 @@ The structural target is:
 ```rust
 struct StdlibRustSource {
     module: String,
-    source_path: PathBuf,
+    source_path: SysrootRelativePath,
+    source_sha256: String,
     rust: String,
 }
 ```
 
 `StdlibCode.module_rust_code` should carry `StdlibRustSource` values rather than
-plain strings once provenance hardening lands. `source_path` is normalized to
-the same repo-relative path form used by manifest `declaration_files`, so the
-guard can cross-check generated stdlib Rust provenance against declaration
-source. Compiled checked stdlib source is the only valid producer.
+plain strings once provenance hardening lands. `source_path` is normalized to a
+canonical sysroot-relative path form used by manifest `declaration_files`, and
+`source_sha256` is computed from the checked source content that produced the
+Rust payload. The guard cross-checks generated stdlib Rust provenance against
+declaration source and digest evidence. Compiled checked stdlib source is the
+only valid producer.
 
 Runtime/resource/callback surfaces follow the Rust interop certification gate.
 Surfaces still marked future-owned or uncertified in the compatibility matrix

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -463,9 +463,9 @@ foundational runtime primitives and shared substrates:
   must call directly.
 
 Generated code may depend on `sifr_runtime` directly when language glue needs
-runtime primitives. Public stdlib wrappers should prefer `sifr_stdlib` where a
-native operation is part of the standard library surface rather than language
-runtime glue.
+runtime primitives. Public stdlib wrappers must route through `sifr_stdlib`
+where a native operation is part of the standard library surface rather than
+language runtime glue.
 
 ### `sifr_stdlib`
 
@@ -609,7 +609,8 @@ sysroot planning layer.
 The final manifest layer is `sifr_stdlib_manifest`. It owns:
 
 - stdlib source inventory and module metadata,
-- public `sifr.*` import policy and private `_sifr.*` rejection policy,
+- public stdlib import policy and source-origin-based private declaration
+  import policy,
 - legacy CPython-shaped module suggestions,
 - private declaration module metadata,
 - migration-state loading from
@@ -620,8 +621,8 @@ The final manifest layer is `sifr_stdlib_manifest`. It owns:
 
 It does not own stdlib behavior, Rust implementation policy, fallback
 signatures, or compiler-native dispatch. Declaration source is the signature
-truth for migrated families. A migrated or closed surface must not keep a
-parallel intrinsic signature table in the manifest layer.
+truth for migrated families. A closing surface must not keep a parallel
+intrinsic signature table in the manifest layer.
 
 IPC schema, frame encoding, transport, request tracking, and handshake metadata
 do not belong in the stdlib manifest. The current IPC modules are shared
@@ -664,8 +665,10 @@ Private declaration modules live under:
 <sysroot>/lib/sifr/stdlib/_sifr/*.sifr
 ```
 
-Only sysroot stdlib modules may import `_sifr.*`. User code importing `_sifr.*`
-is rejected. Private declaration modules declare native stdlib operations using
+Only sources loaded with `SysrootPublicStdlib` origin may import modules loaded
+with `SysrootPrivateDeclaration` origin. `_sifr.*` is the naming convention and
+on-disk layout for those private declaration modules, not the semantic trust
+boundary. Private declaration modules declare native stdlib operations using
 Rust interop annotations such as direct functions, opaque handles, async
 functions, view/zero-copy contracts, and callback policies.
 
@@ -678,7 +681,8 @@ calls, callback policy, views, and error conversion.
 Stdlib-private rules are limited to:
 
 - declarations live under `stdlib/_sifr/`,
-- only sysroot stdlib sources can import `_sifr.*`,
+- only `SysrootPublicStdlib` sources can import `SysrootPrivateDeclaration`
+  modules,
 - targets resolve only to canonical crates under the resolved sysroot,
 - user packages cannot shadow private declarations or sysroot crate targets,
 - diagnostics point to private declarations only in internal/developer
@@ -739,16 +743,14 @@ modules contain both migrated and retained leaves. Manifest states are:
 | --- | --- |
 | `retained` | Still compiler-native for now and scheduled for migration or final classification. |
 | `pilot` | The selected pilot implementation is underway and the retained compiler path is still present. |
-| `migrated` | Behavior now routes through checked stdlib source and sysroot Rust interop; the row stays as an audit tombstone with evidence after compiler-native entries are deleted. |
-| `closed` | The old surface was removed, rejected, or replaced with a different supported API; the row stays as an audit tombstone with evidence. |
+| `closing` | Temporary closeout state while deletion or replacement evidence lands; the row is removed once guards prove the old compiler-native surface cannot reappear. |
 | `retained-by-design` | Permanently compiler-owned language, bridge, entrypoint, exact-int, test-harness, or runtime substrate glue. |
 
 The manifest is the only exception ledger. Do not add a second registry for
-compiler-native stdlib migration state. Prefix retainers are temporary
-coarse-grained rows. Migrating any intrinsic covered by a prefix must either
-narrow the prefix in the same change or record the retired name in a
-`retired_prefix_intrinsics` field so the prefix cannot keep migrated behavior
-alive.
+compiler-native stdlib migration state. Prefix retainers are transitional
+compatibility with the current dispatcher shape only; the first schema-hardening
+milestone exact-enumerates those dispatchers and deletes prefix concepts from
+the manifest schema.
 
 Resource certification rows are also recorded in this manifest. The resource
 certification gate reads `certification_rows` from the retained-glue manifest
@@ -839,26 +841,25 @@ stdlib behavior must instead route through `stdlib/_sifr` declarations and
 
 Generated stdlib Rust has a provenance requirement. `StdlibCode.module_rust_code`
 is valid as a transport for Rust code produced by compiling checked Sifr stdlib
-source. It must not be populated from handwritten Rust string literals except
-for manifest-tracked temporary migration exceptions. The final representation
-should make provenance structural so guards can distinguish compiled stdlib
-output from raw compiler injection.
+source. It must not be populated from handwritten Rust string literals. The
+temporary HTTP transport harness is removed before provenance hardening lands,
+so the final provenance model does not contain a handwritten-exemption concept.
 
 The structural target is:
 
 ```rust
-enum StdlibRustSource {
-    CompiledFromSifr { module: String, source_path: PathBuf, rust: String },
-    HandwrittenExemption { manifest_key: String, rust: String },
+struct StdlibRustSource {
+    module: String,
+    source_path: PathBuf,
+    rust: String,
 }
 ```
 
 `StdlibCode.module_rust_code` should carry `StdlibRustSource` values rather than
-plain strings once provenance hardening lands. Guards then reject any
-`HandwrittenExemption` whose `manifest_key` is absent from the retained-glue
-manifest. `CompiledFromSifr.source_path` is normalized to the same
-repo-relative path form used by manifest `declaration_files`, so the guard can
-cross-check generated stdlib Rust provenance against declaration source.
+plain strings once provenance hardening lands. `source_path` is normalized to
+the same repo-relative path form used by manifest `declaration_files`, so the
+guard can cross-check generated stdlib Rust provenance against declaration
+source. Compiled checked stdlib source is the only valid producer.
 
 Runtime/resource/callback surfaces follow the Rust interop certification gate.
 Surfaces still marked future-owned or uncertified in the compatibility matrix
@@ -868,8 +869,8 @@ resource migration cannot advance a resource-shaped surface ahead of the
 runtime evidence recorded by the Rust interop matrix.
 The stdlib native intrinsic allowlist guard is also part of core validation:
 it freezes every retained compiler intrinsic name, prefix dispatcher, registry
-file, and preamble file until that entry is migrated, deleted, or explicitly
-kept as compiler-language glue.
+file, and preamble file until that entry is closing, deleted, or explicitly kept
+as compiler-language glue.
 
 Private stdlib Rust interop uses the normal Rust interop contract plus a
 compiler-owned sysroot trust policy. A canonical private `_sifr.*` declaration

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -56,7 +56,7 @@ state. Later implementation stages update the implementation toward the architec
 | --- | --- | --- | --- | --- |
 | Public Sifr stdlib sources | `stdlib/sifr/*.sifr`, validated by `crates/sifr_stdlib_model` and loaded from the resolved source-tree or installed sysroot path | `stdlib/sifr/*.sifr` copied into `<sysroot>/lib/sifr/stdlib/sifr` and loaded through `ResolvedSysroot` | complete for source layout; packaging copy remains later | yes |
 | Private stdlib declarations | `stdlib/_sifr/*.sifr` declaration files are loaded from the resolved sysroot; completed stateless/data leaves bind through private Rust interop while retained runtime/resource/callback leaves remain compiler-owned and allowlisted | `stdlib/_sifr/*.sifr` declarations copied into `<sysroot>/lib/sifr/stdlib/_sifr` and loaded through the same sysroot source inventory | concrete Rust interop declarations, synthetic stdlib interop context, retained-glue allowlist | mixed |
-| Compiler-side stdlib model | `crates/sifr_stdlib_model` currently owns source inventory, private intrinsic metadata, feature/dependency mapping, IPC metadata, and legacy module suggestions | Split into `crates/sifr_stdlib_manifest` for source inventory, private declarations, feature planning, sysroot validation, migration-state loading, and import suggestions; move shared IPC protocol/frame/schema/request tracking into `crates/sifr_ipc`; delete fallback intrinsic signature tables as surfaces migrate | manifest/model split and intrinsic signature deletion | yes |
+| Compiler-side stdlib model | `crates/sifr_stdlib_model` currently owns source inventory, private intrinsic metadata, feature/dependency mapping, IPC metadata, and legacy module suggestions | Split into `crates/sifr_stdlib_manifest` for source inventory, private declarations, feature planning, sysroot validation, migration-state loading, and inventory data queried by diagnostics; move suggestion policy/rendering to the frontend or diagnostics boundary; move shared IPC protocol/frame/schema/request tracking into `crates/sifr_ipc`; delete fallback intrinsic signature tables as surfaces migrate | manifest/model split and intrinsic signature deletion | yes |
 | Generated-program stdlib implementation crate | `crates/sifr_stdlib` exists as the generated-program crate foundation with empty defaults, narrow additive leaf features, runtime-backed wrapper APIs for existing runtime primitives, and feature-plan expectations in `sifr_stdlib_model` | `crates/sifr_stdlib`, shipped under `<sysroot>/crates/sifr_stdlib` | full native leaf migration, generated Cargo sysroot dependency emission, and installed sysroot packaging | yes |
 | Runtime crate | `crates/sifr_runtime` under the resolved development or installed sysroot; generated Cargo and Rust interop probes receive the explicit `ResolvedSysroot` runtime crate path | `<sysroot>/crates/sifr_runtime` path dependency selected by `ResolvedSysroot` | Sysroot resolver, generated dependency plan | yes |
 | Generated Cargo planning | `sifr_codegen::generate_project_with_deps_and_crates` asked `sifr_stdlib_model::generated_cargo_dependencies` for dependency strings | `SysrootDependencyPlan` from the manifest/sysroot planning layer, consumed by codegen, driver, cache keys, reports, and LSP traces | manifest/model split and dependency planner | yes |
@@ -115,9 +115,11 @@ data, while user/package dependencies remain package-owned Cargo inputs.
 Current generated code and preamble call into `sifr_runtime::*` from these
 families. This table groups retained call sites by migration concern; active
 compiler-owned stdlib glue is frozen by
-`internal_docs/stdlib_retained_compiler_intrinsics.toml`, and migrated native
-leaves are protected from reappearing in the dispatcher by
-`scripts/check_stdlib_migration_closure.py`.
+`internal_docs/stdlib_retained_compiler_intrinsics.toml`. The final guard
+protects migrated native leaves by requiring every observed dispatcher,
+registry, and preamble surface to be manifest-owned; the transitional
+retired-name closure script is folded into that allowlist guard and deleted at
+final closure.
 
 | Call-site family | Current call sites | Final owner |
 | --- | --- | --- |
@@ -192,9 +194,15 @@ Rust interop runtime certification gate until their lifecycle behavior is
 executable evidence, not just adapter code.
 `scripts/check_sysroot_stdlib_resource_certification_gate.py` enforces this
 boundary during validation by pinning each resource-sensitive stdlib surface to
-its required Rust interop compatibility matrix rows. Those rows must remain
-`future-owned-by-separate-phase` and owned by the runtime ecosystem
-certification issue until that separate work updates the gate deliberately.
+its required Rust interop compatibility matrix rows. Rows that directly block
+stdlib migration are handed off to the stdlib native boundary phase milestone
+that first consumes them: `opaque_resource_matrix` in the file/resource pilot,
+`async_runtime_reqwest` in the async runtime pilot,
+`callback_subscription_matrix` in the signal subscription pilot, and
+`callbacks_call_scoped` in the Python adapter migration. The separate runtime
+ecosystem certification issue continues to own rows for backend, database,
+messaging, CLI, native-link, proc-macro, and package-ecosystem certification
+that are not direct stdlib migration blockers.
 
 Retained compiler-native stdlib glue is guarded separately by
 `internal_docs/stdlib_retained_compiler_intrinsics.toml` and
@@ -611,7 +619,8 @@ The final manifest layer is `sifr_stdlib_manifest`. It owns:
 - stdlib source inventory and module metadata,
 - public stdlib import policy and source-origin-based private declaration
   import policy,
-- legacy CPython-shaped module suggestions,
+- legacy CPython-shaped module inventory data queried by frontend/diagnostics
+  suggestion policy,
 - private declaration module metadata,
 - migration-state loading from
   `internal_docs/stdlib_retained_compiler_intrinsics.toml`,

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -194,15 +194,17 @@ Rust interop runtime certification gate until their lifecycle behavior is
 executable evidence, not just adapter code.
 `scripts/check_sysroot_stdlib_resource_certification_gate.py` enforces this
 boundary during validation by pinning each resource-sensitive stdlib surface to
-its required Rust interop compatibility matrix rows. Rows that directly block
-stdlib migration are handed off to the stdlib native boundary phase milestone
-that first consumes them: `opaque_resource_matrix` in the file/resource pilot,
-`async_runtime_reqwest` in the async runtime pilot,
-`callback_subscription_matrix` in the signal subscription pilot, and
-`callbacks_call_scoped` in the Python adapter migration. The separate runtime
-ecosystem certification issue continues to own rows for backend, database,
-messaging, CLI, native-link, proc-macro, and package-ecosystem certification
-that are not direct stdlib migration blockers.
+its required Rust interop compatibility matrix rows. Broad ecosystem rows are
+not handed off wholesale. The stdlib native boundary phase splits and owns only
+the narrow stdlib-blocking core rows it proves, such as
+`opaque_resource_core`, `async_runtime_core`, `callback_subscription_core`, and
+possibly `callbacks_call_scoped_core`. The ecosystem portions, such as
+`opaque_resource_ecosystem`, `async_runtime_reqwest`, and
+`callback_subscription_ecosystem`, remain with the separate runtime ecosystem
+certification issue. `panic_boundary_wrapper_emission` also remains package
+interop certification unless a stdlib milestone needs generated panic-wrapper
+evidence; trusted sysroot declarations may instead keep panic handling as
+stdlib-owned poisoning or error-conversion evidence.
 
 Retained compiler-native stdlib glue is guarded separately by
 `internal_docs/stdlib_retained_compiler_intrinsics.toml` and

--- a/internal_docs/stdlib_retained_compiler_intrinsics.toml
+++ b/internal_docs/stdlib_retained_compiler_intrinsics.toml
@@ -7,14 +7,19 @@
 # State values:
 # - retained: still compiler-native for now and scheduled for migration or final classification.
 # - pilot: selected pilot implementation is underway while retained compiler glue remains.
-# - migrated: behavior routes through checked stdlib source and sysroot Rust interop.
-# - closed: old surface was removed, rejected, or replaced with a different supported API.
+# - migrated: behavior routes through checked stdlib source and sysroot Rust
+#   interop; row remains as an audit tombstone after compiler-native entries are deleted.
+# - closed: old surface was removed, rejected, or replaced with a different
+#   supported API; row remains as an audit tombstone after compiler-native entries are deleted.
 # - retained-by-design: permanently compiler-owned language, bridge, entrypoint,
 #   exact-int, test-harness, or runtime substrate glue.
+schema_version = 1
 
 [[surface]]
 id = "_sifr.sys"
 state = "retained"
+declaration_files = ["stdlib/_sifr/sys.sifr"]
+certification_rows = ["opaque_resource_matrix"]
 reason = "Process environment, argv, platform constants, and process-exit semantics remain compiler/runtime-owned pending the final retained-glue decision."
 registry_files = ["env.rs", "os.rs", "sys.rs"]
 exact_intrinsics = [
@@ -44,6 +49,8 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.fs"
 state = "retained"
+declaration_files = ["stdlib/_sifr/fs.sifr"]
+certification_rows = ["opaque_resource_matrix"]
 reason = "Filesystem paths, open handles, and IOError shaping remain compiler/runtime-owned until file-handle lifecycle certification is complete."
 registry_files = [
   "file_handles.rs",
@@ -104,8 +111,9 @@ exact_intrinsics = [
 ]
 
 [[surface]]
-id = "_sifr.collections"
-state = "retained"
+id = "_sifr.collections::counter_defaultdict"
+state = "retained-by-design"
+declaration_files = ["stdlib/_sifr/collections.sifr"]
 reason = "Counter/defaultdict semantics and core collection behavior remain language-owned after helper-leaf migration."
 registry_files = [
   "collections.rs",
@@ -124,8 +132,13 @@ exact_intrinsics = [
 ]
 
 [[surface]]
-id = "_sifr.http"
+id = "_sifr.http::transport_and_header_helpers"
 state = "retained"
+declaration_files = ["stdlib/_sifr/http.sifr"]
+certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
+raw_injections = [
+  { site = "crates/sifr_driver/src/stdlib/bootstrap.rs::HTTP_TRANSPORT_HARNESS_RUST", module = "sifr.http_transport" },
+]
 reason = "HTTP transport, protocol, and handle behavior remains behind runtime/resource certification; header helper shims still route through generated glue."
 registry_files = ["url_http.rs"]
 preamble_files = ["url_http_runtime.rs"]
@@ -137,10 +150,12 @@ exact_intrinsics = [
   "http_validate_header_value",
 ]
 prefix_intrinsics = ["http_", "http1_", "http2_"]
+retired_prefix_intrinsics = []
 
 [[surface]]
-id = "_sifr.encoding"
-state = "retained"
+id = "_sifr.encoding::utf8_bytes_string_glue"
+state = "retained-by-design"
+declaration_files = ["stdlib/_sifr/encoding.sifr"]
 reason = "UTF-8 encode/decode result glue is tied to first-class bytes/string wrapper behavior and shared runtime error shaping."
 registry_files = ["encoding.rs"]
 exact_intrinsics = [
@@ -151,8 +166,9 @@ exact_intrinsics = [
 ]
 
 [[surface]]
-id = "_sifr.bytes"
-state = "retained"
+id = "_sifr.bytes::first_class_constructors"
+state = "retained-by-design"
+declaration_files = ["stdlib/_sifr/bytes.sifr"]
 reason = "First-class bytes constructors, strict hex parsing/formatting, and method glue remain compiler-language behavior."
 registry_files = ["bytes.rs"]
 exact_intrinsics = [
@@ -165,6 +181,8 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.time"
 state = "retained"
+declaration_files = ["stdlib/_sifr/time.sifr"]
+certification_rows = ["async_runtime_reqwest"]
 reason = "Clock, sleep, and struct_time compatibility glue remains runtime-sensitive until async/runtime certification closes."
 registry_files = ["time.rs"]
 exact_intrinsics = [
@@ -185,8 +203,10 @@ exact_intrinsics = [
 ]
 
 [[surface]]
-id = "_sifr.crypto"
+id = "_sifr.crypto::random"
 state = "retained"
+declaration_files = ["stdlib/_sifr/crypto.sifr"]
+certification_rows = ["opaque_resource_matrix"]
 reason = "Random module state and random distribution helpers remain compiler/runtime-owned until resource/state semantics are certified."
 registry_files = ["random.rs"]
 exact_intrinsics = [
@@ -207,6 +227,8 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.process"
 state = "retained"
+declaration_files = ["stdlib/_sifr/process.sifr"]
+certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
 reason = "Process children, pipes, shell execution, async process handles, and timeout behavior remain resource/runtime-owned pending certification."
 registry_files = [
   "process.rs",
@@ -266,6 +288,8 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.net"
 state = "retained"
+declaration_files = ["stdlib/_sifr/net.sifr"]
+certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
 reason = "Network handles and split stream lifecycle behavior remain resource/runtime-owned pending certification."
 registry_files = ["net.rs"]
 preamble_files = ["net_runtime.rs"]
@@ -295,14 +319,19 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.tls"
 state = "retained"
+declaration_files = ["stdlib/_sifr/tls.sifr"]
+certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
 reason = "TLS configuration, handshakes, stream handles, and certificate state remain resource/runtime-owned pending certification."
 registry_files = ["tls.rs"]
 preamble_files = ["tls_runtime.rs"]
 prefix_intrinsics = ["tls_"]
+retired_prefix_intrinsics = []
 
 [[surface]]
 id = "_sifr.signal"
 state = "retained"
+declaration_files = ["stdlib/_sifr/signal.sifr"]
+certification_rows = ["callback_subscription_matrix"]
 reason = "Signal streams and shutdown coordination remain runtime-sensitive pending callback/resource certification."
 registry_files = ["signal.rs"]
 exact_intrinsics = [
@@ -312,8 +341,9 @@ exact_intrinsics = [
 ]
 
 [[surface]]
-id = "_sifr.runtime"
-state = "retained"
+id = "_sifr.runtime::observability_glue"
+state = "retained-by-design"
+declaration_files = ["stdlib/_sifr/runtime.sifr"]
 reason = "Runtime diagnostics and observability metadata are retained compiler/runtime glue rather than stdlib leaf behavior."
 registry_files = ["runtime.rs"]
 exact_intrinsics = ["runtime_emit_diagnostic"]
@@ -321,14 +351,22 @@ exact_intrinsics = ["runtime_emit_diagnostic"]
 [[surface]]
 id = "_sifr.python"
 state = "retained"
+declaration_files = ["stdlib/_sifr/python.sifr"]
+certification_rows = [
+  "opaque_resource_matrix",
+  "callbacks_call_scoped",
+  "callback_subscription_matrix",
+]
 reason = "Python object handles, callback adapters, and runtime initialization remain behind Python resource/callback certification."
 registry_files = ["python.rs"]
 exact_intrinsics = ["local_callback", "threadsafe_callback"]
 prefix_intrinsics = ["py_"]
+retired_prefix_intrinsics = []
 
 [[surface]]
-id = "_sifr.task"
-state = "retained"
+id = "_sifr.task::language_runtime_glue"
+state = "retained-by-design"
+declaration_files = ["stdlib/_sifr/task.sifr"]
 reason = "Task, cancellation, offload, join-set, and context propagation semantics are language/runtime glue."
 registry_files = ["task.rs"]
 preamble_files = [
@@ -344,6 +382,8 @@ exact_intrinsics = ["task_current_context"]
 [[surface]]
 id = "_sifr.logging"
 state = "retained"
+declaration_files = ["stdlib/_sifr/logging.sifr"]
+certification_rows = ["callback_subscription_matrix"]
 reason = "Global logging level state remains compiler/runtime glue until final observability ownership is settled."
 registry_files = ["logging.rs"]
 exact_intrinsics = ["get_global_level", "set_global_level"]

--- a/internal_docs/stdlib_retained_compiler_intrinsics.toml
+++ b/internal_docs/stdlib_retained_compiler_intrinsics.toml
@@ -7,12 +7,15 @@
 # State values:
 # - retained: still compiler-native for now and scheduled for migration or final classification.
 # - pilot: selected pilot implementation is underway while retained compiler glue remains.
-# - migrated: behavior routes through checked stdlib source and sysroot Rust
-#   interop; row remains as an audit tombstone after compiler-native entries are deleted.
-# - closed: old surface was removed, rejected, or replaced with a different
-#   supported API; row remains as an audit tombstone after compiler-native entries are deleted.
+# - closing: temporary state while deletion or replacement evidence lands; row
+#   is removed after guards prove the old compiler-native surface cannot reappear.
 # - retained-by-design: permanently compiler-owned language, bridge, entrypoint,
 #   exact-int, test-harness, or runtime substrate glue.
+#
+# `prefix_intrinsics` is a temporary compatibility field for the current
+# prefix-shaped dispatcher. The stdlib native boundary completion phase
+# exact-enumerates those dispatchers and removes this field from the final
+# manifest schema.
 schema_version = 1
 
 [[surface]]
@@ -136,9 +139,6 @@ id = "_sifr.http::transport_and_header_helpers"
 state = "retained"
 declaration_files = ["stdlib/_sifr/http.sifr"]
 certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
-raw_injections = [
-  { site = "crates/sifr_driver/src/stdlib/bootstrap.rs::HTTP_TRANSPORT_HARNESS_RUST", module = "sifr.http_transport" },
-]
 reason = "HTTP transport, protocol, and handle behavior remains behind runtime/resource certification; header helper shims still route through generated glue."
 registry_files = ["url_http.rs"]
 preamble_files = ["url_http_runtime.rs"]
@@ -150,7 +150,6 @@ exact_intrinsics = [
   "http_validate_header_value",
 ]
 prefix_intrinsics = ["http_", "http1_", "http2_"]
-retired_prefix_intrinsics = []
 
 [[surface]]
 id = "_sifr.encoding::utf8_bytes_string_glue"
@@ -325,7 +324,6 @@ reason = "TLS configuration, handshakes, stream handles, and certificate state r
 registry_files = ["tls.rs"]
 preamble_files = ["tls_runtime.rs"]
 prefix_intrinsics = ["tls_"]
-retired_prefix_intrinsics = []
 
 [[surface]]
 id = "_sifr.signal"
@@ -361,7 +359,6 @@ reason = "Python object handles, callback adapters, and runtime initialization r
 registry_files = ["python.rs"]
 exact_intrinsics = ["local_callback", "threadsafe_callback"]
 prefix_intrinsics = ["py_"]
-retired_prefix_intrinsics = []
 
 [[surface]]
 id = "_sifr.task::language_runtime_glue"

--- a/internal_docs/stdlib_retained_compiler_intrinsics.toml
+++ b/internal_docs/stdlib_retained_compiler_intrinsics.toml
@@ -3,9 +3,18 @@
 # This file is intentionally explicit. Core validation uses it to prevent new
 # compiler intrinsic or preamble stdlib behavior from appearing without review
 # while the remaining resource/runtime surfaces are certified or reduced.
+#
+# State values:
+# - retained: still compiler-native for now and scheduled for migration or final classification.
+# - pilot: selected pilot implementation is underway while retained compiler glue remains.
+# - migrated: behavior routes through checked stdlib source and sysroot Rust interop.
+# - closed: old surface was removed, rejected, or replaced with a different supported API.
+# - retained-by-design: permanently compiler-owned language, bridge, entrypoint,
+#   exact-int, test-harness, or runtime substrate glue.
 
 [[surface]]
 id = "_sifr.sys"
+state = "retained"
 reason = "Process environment, argv, platform constants, and process-exit semantics remain compiler/runtime-owned pending the final retained-glue decision."
 registry_files = ["env.rs", "os.rs", "sys.rs"]
 exact_intrinsics = [
@@ -34,6 +43,7 @@ exact_intrinsics = [
 
 [[surface]]
 id = "_sifr.fs"
+state = "retained"
 reason = "Filesystem paths, open handles, and IOError shaping remain compiler/runtime-owned until file-handle lifecycle certification is complete."
 registry_files = [
   "file_handles.rs",
@@ -80,6 +90,7 @@ exact_intrinsics = [
 
 [[surface]]
 id = "generated-test-glue"
+state = "retained-by-design"
 reason = "Sifr test assertions are generated harness glue, not public stdlib-native behavior."
 registry_files = ["test.rs"]
 exact_intrinsics = [
@@ -94,6 +105,7 @@ exact_intrinsics = [
 
 [[surface]]
 id = "_sifr.collections"
+state = "retained"
 reason = "Counter/defaultdict semantics and core collection behavior remain language-owned after helper-leaf migration."
 registry_files = [
   "collections.rs",
@@ -113,6 +125,7 @@ exact_intrinsics = [
 
 [[surface]]
 id = "_sifr.http"
+state = "retained"
 reason = "HTTP transport, protocol, and handle behavior remains behind runtime/resource certification; header helper shims still route through generated glue."
 registry_files = ["url_http.rs"]
 preamble_files = ["url_http_runtime.rs"]
@@ -127,6 +140,7 @@ prefix_intrinsics = ["http_", "http1_", "http2_"]
 
 [[surface]]
 id = "_sifr.encoding"
+state = "retained"
 reason = "UTF-8 encode/decode result glue is tied to first-class bytes/string wrapper behavior and shared runtime error shaping."
 registry_files = ["encoding.rs"]
 exact_intrinsics = [
@@ -138,6 +152,7 @@ exact_intrinsics = [
 
 [[surface]]
 id = "_sifr.bytes"
+state = "retained"
 reason = "First-class bytes constructors, strict hex parsing/formatting, and method glue remain compiler-language behavior."
 registry_files = ["bytes.rs"]
 exact_intrinsics = [
@@ -149,6 +164,7 @@ exact_intrinsics = [
 
 [[surface]]
 id = "_sifr.time"
+state = "retained"
 reason = "Clock, sleep, and struct_time compatibility glue remains runtime-sensitive until async/runtime certification closes."
 registry_files = ["time.rs"]
 exact_intrinsics = [
@@ -170,6 +186,7 @@ exact_intrinsics = [
 
 [[surface]]
 id = "_sifr.crypto"
+state = "retained"
 reason = "Random module state and random distribution helpers remain compiler/runtime-owned until resource/state semantics are certified."
 registry_files = ["random.rs"]
 exact_intrinsics = [
@@ -189,6 +206,7 @@ exact_intrinsics = [
 
 [[surface]]
 id = "_sifr.process"
+state = "retained"
 reason = "Process children, pipes, shell execution, async process handles, and timeout behavior remain resource/runtime-owned pending certification."
 registry_files = [
   "process.rs",
@@ -247,6 +265,7 @@ exact_intrinsics = [
 
 [[surface]]
 id = "_sifr.net"
+state = "retained"
 reason = "Network handles and split stream lifecycle behavior remain resource/runtime-owned pending certification."
 registry_files = ["net.rs"]
 preamble_files = ["net_runtime.rs"]
@@ -275,6 +294,7 @@ exact_intrinsics = [
 
 [[surface]]
 id = "_sifr.tls"
+state = "retained"
 reason = "TLS configuration, handshakes, stream handles, and certificate state remain resource/runtime-owned pending certification."
 registry_files = ["tls.rs"]
 preamble_files = ["tls_runtime.rs"]
@@ -282,6 +302,7 @@ prefix_intrinsics = ["tls_"]
 
 [[surface]]
 id = "_sifr.signal"
+state = "retained"
 reason = "Signal streams and shutdown coordination remain runtime-sensitive pending callback/resource certification."
 registry_files = ["signal.rs"]
 exact_intrinsics = [
@@ -292,12 +313,14 @@ exact_intrinsics = [
 
 [[surface]]
 id = "_sifr.runtime"
+state = "retained"
 reason = "Runtime diagnostics and observability metadata are retained compiler/runtime glue rather than stdlib leaf behavior."
 registry_files = ["runtime.rs"]
 exact_intrinsics = ["runtime_emit_diagnostic"]
 
 [[surface]]
 id = "_sifr.python"
+state = "retained"
 reason = "Python object handles, callback adapters, and runtime initialization remain behind Python resource/callback certification."
 registry_files = ["python.rs"]
 exact_intrinsics = ["local_callback", "threadsafe_callback"]
@@ -305,6 +328,7 @@ prefix_intrinsics = ["py_"]
 
 [[surface]]
 id = "_sifr.task"
+state = "retained"
 reason = "Task, cancellation, offload, join-set, and context propagation semantics are language/runtime glue."
 registry_files = ["task.rs"]
 preamble_files = [
@@ -319,21 +343,25 @@ exact_intrinsics = ["task_current_context"]
 
 [[surface]]
 id = "_sifr.logging"
+state = "retained"
 reason = "Global logging level state remains compiler/runtime glue until final observability ownership is settled."
 registry_files = ["logging.rs"]
 exact_intrinsics = ["get_global_level", "set_global_level"]
 
 [[surface]]
 id = "generated-feature-planning-glue"
+state = "retained-by-design"
 reason = "Additional feature planning is compiler-owned glue that selects retained runtime/sysroot dependencies for generated projects."
 registry_files = ["requirements.rs"]
 
 [[surface]]
 id = "shared-language-preamble"
+state = "retained-by-design"
 reason = "Generated Rust type conversion and error wrapper helpers are shared language/runtime glue."
 preamble_files = ["types_and_errors.rs"]
 
 [[surface]]
 id = "mixed-io-logging-random-preamble"
+state = "retained"
 reason = "Legacy generated preamble file contains mixed IOError, file-handle, logging, and random module state glue pending final decomposition."
 preamble_files = ["io_logging_random.rs"]

--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -46,11 +46,15 @@ merged, and documented before the next milestone starts.
   in source, not in fallback compiler tables.
 - `internal_docs/stdlib_retained_compiler_intrinsics.toml` is the only
   compiler-native stdlib exception ledger.
-- Every `_sifr.*` family and every compiler-native exception appears exactly
-  once in the retained-glue manifest until it is migrated, closed, or
-  explicitly retained by design.
+- Every compiler-native stdlib surface appears exactly once in the retained-glue
+  manifest until it is migrated, closed, or explicitly retained by design. Row
+  granularity is leaf or subfamily level when a `_sifr.*` module mixes migrated
+  and retained leaves.
 - Manifest states are `retained`, `pilot`, `migrated`, `closed`, and
-  `retained-by-design`.
+  `retained-by-design`. `migrated` and `closed` rows remain as audit
+  tombstones with evidence after compiler-native entries are deleted.
+- The retained-glue manifest is machine-parseable, schema-versioned, and
+  rejects unknown fields after M0 installs the schema validator.
 - Generated Cargo for stdlib usage emits only Sifr sysroot crates. Third-party
   crates used by stdlib behavior are transitive implementation details of the
   sysroot crates.
@@ -60,6 +64,10 @@ merged, and documented before the next milestone starts.
   produced from checked Sifr stdlib source. Handwritten stdlib Rust string
   injection is forbidden except for manifest-tracked temporary migration
   exceptions.
+- Direct generated `sifr_runtime::*` calls are allowed only for language,
+  bridge, entrypoint, exact-int, test-harness, or retained-by-design runtime
+  substrate glue. Stdlib behavior routes through `stdlib/_sifr` declarations
+  and `sifr_stdlib`.
 - No backward-compatibility shims, fallback paths, duplicate registries, or
   compatibility aliases are introduced. Unsupported or removed surfaces receive
   diagnostics instead of hidden fallback behavior.
@@ -90,10 +98,13 @@ merged, and documented before the next milestone starts.
 | M9. Process Family | planned |  |
 | M10. Network and TLS Families | planned |  |
 | M11. HTTP Family and Harness Relocation | planned |  |
-| M12. Callback and Subscription Pilot | planned |  |
+| M12. Signal Callback and Subscription Pilot | planned |  |
 | M13. Python Interop Adapters | planned |  |
 | M14. Task, Signal, Runtime Observability, and Test Helpers | planned |  |
 | M15. Final Closure | planned |  |
+
+Evidence cells use this format after each milestone lands:
+`PR #<n> · sha=<hex7> · manifest: <id old_state -> new_state>`.
 
 ## Affected Inventory
 
@@ -109,8 +120,8 @@ Architecture and planning:
 Compiler manifest, sysroot, and dependency planning:
 
 - `crates/sifr_stdlib_model/**`
-- target `crates/sifr_stdlib_manifest/**` or `crates/sifr_sysroot_manifest/**`
-- target `crates/sifr_ipc/**` if IPC remains shared
+- target `crates/sifr_stdlib_manifest/**`
+- target `crates/sifr_ipc/**`
 - `crates/sifr_driver/src/stdlib/**`
 - `crates/sifr_driver/src/build/**`
 - `crates/sifr_codegen/src/rust_interop_plan.rs`
@@ -140,6 +151,8 @@ Validation and guardrails:
 
 - `scripts/check_stdlib_native_intrinsic_allowlist.py`
 - `scripts/check_stdlib_migration_closure.py`
+- target `scripts/check_stdlib_manifest_schema.py`
+- target `scripts/check_stdlib_bootstrap_ordering.py`
 - `scripts/check_sysroot_stdlib_resource_certification_gate.py`
 - `scripts/check_hir_maintainability_guardrails.py`
 - `scripts/check_file_size_guardrails.py`
@@ -157,13 +170,39 @@ Tasks:
 - Update architecture docs with the final stdlib/compiler/runtime boundary.
 - Extend the retained-glue manifest schema with migration states, owner or
   issue fields, evidence links, registry entries, preamble entries, raw
-  injection entries, and certification rows.
+  injection entries, declaration files, `retired_prefix_intrinsics`, and
+  certification rows.
+- Reject unknown top-level and per-surface manifest fields in
+  `scripts/check_stdlib_manifest_schema.py`; the validator owns one explicit
+  allowed-field set.
 - Classify every existing retained surface as `retained`,
   `retained-by-design`, `pilot`, `migrated`, or `closed`.
+- Split mixed-family rows into leaf or subfamily rows, for example
+  `_sifr.collections::counter_defaultdict` rather than `_sifr.collections`.
+- Add tombstone-row support so `migrated` and `closed` entries can remain in the
+  manifest after their compiler-native registry, preamble, raw-injection, or
+  signature entries are deleted.
+- Backfill `migrated` tombstone rows for every already-migrated stdlib family
+  and subfamily currently described in the sysroot architecture doc, including
+  calendar, UUID, HTML, platform, math, regex, URL, TOML, datetime, compression,
+  `_sifr.crypto::hash`, `_sifr.crypto::base64`,
+  `_sifr.bytes::encode_utf8`, and `_sifr.bytes::bytes_to_hex`.
+- Collapse the migrated-leaf prose inventory in
+  `internal_docs/sifr_sysroot_and_stdlib_architecture.md` into a pointer to the
+  manifest after the tombstone backfill lands.
 - Add validation that every manifest entry has a valid state and every observed
   compiler-native stdlib exception is owned exactly once.
+- Add validation that manifest state transitions are monotonic by comparing the
+  current manifest with `main`.
 - Add validation that no `_sifr.*` family exists outside the manifest or the
   migrated declaration inventory.
+- Add validation that raw handwritten stdlib Rust injections are either absent
+  or named in the manifest.
+- Migrate `scripts/check_sysroot_stdlib_resource_certification_gate.py` to read
+  `certification_rows` from the manifest and delete its hardcoded
+  surface-to-matrix table. The gate aggregates subfamily rows by their `_sifr.*`
+  family prefix so rows such as `_sifr.crypto::random` satisfy family-level
+  gating without requiring a parallel family registry.
 - Record the sequential milestone order in this phase document and update
   status after each milestone lands.
 
@@ -175,11 +214,19 @@ Acceptance:
   migration state.
 - `retained-by-design` entries are narrow compiler-language or harness glue,
   not stdlib behavior.
+- `migrated` and `closed` entries are reachable states with evidence, not dead
+  schema values.
+- Wide prefix rows define how exact migrated names shrink out of the prefix.
+- Unknown manifest fields are rejected.
+- The resource certification gate consumes manifest `certification_rows`
+  instead of a parallel table, and its family/subfamily join is deterministic.
 
 Validation:
 
+- `python3 scripts/check_stdlib_manifest_schema.py`
 - `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
 - `python3 scripts/check_stdlib_migration_closure.py --self-test`
+- `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py`
 - `python3 scripts/check_hir_maintainability_guardrails.py`
 - `python3 scripts/check_file_size_guardrails.py`
 - `scripts/run_all_tests.sh --profile create-pr`
@@ -190,18 +237,18 @@ Turn the compiler-side stdlib model into a manifest/sysroot planning layer.
 
 Tasks:
 
-- Create or rename the final manifest crate as `sifr_stdlib_manifest` or
-  `sifr_sysroot_manifest`.
+- Create or rename the final manifest crate as `sifr_stdlib_manifest`.
 - Move source inventory, private declaration inventory, import suggestions,
   migration-state loading, feature planning, and sysroot validation into the
   manifest layer.
-- Move IPC frame/schema/transport/request tracking/handshake metadata into
-  `sifr_ipc` if shared, or `sifr_runtime::ipc` if runtime-only.
+- Move shared IPC frame/schema/transport/request tracking/handshake metadata
+  into `sifr_ipc`.
 - Remove fallback intrinsic signature tables for any surface already marked
   `migrated` or `closed`.
 - Add deterministic topological stdlib bootstrap ordering.
 - Reject cycles and forward references that would make private declarations
   order-dependent or nondeterministic.
+- Add a standalone bootstrap-ordering guard script.
 - Ensure codegen, driver, LSP traces, build reports, and cache keys consume one
   `SysrootDependencyPlan` rather than recomputing sysroot features.
 
@@ -216,6 +263,7 @@ Validation:
 
 - Focused manifest/sysroot unit tests.
 - Focused driver stdlib bootstrap tests.
+- `python3 scripts/check_stdlib_bootstrap_ordering.py`
 - Generated Cargo snapshot tests.
 - `cargo test -p sifr_driver -- stdlib`
 - `cargo test -p sifr_codegen -- rust_interop_plan`
@@ -259,7 +307,18 @@ Prevent new compiler-native stdlib behavior while migration proceeds.
 Tasks:
 
 - Add structural provenance to `StdlibCode.module_rust_code` producers.
+- Replace the plain string payload with a structural source representation:
+
+  ```rust
+  enum StdlibRustSource {
+      CompiledFromSifr { module: String, source_path: PathBuf, rust: String },
+      HandwrittenExemption { manifest_key: String, rust: String },
+  }
+  ```
+
 - Permit compiled checked stdlib source output.
+- Normalize `CompiledFromSifr.source_path` to the same repo-relative path form
+  used by manifest `declaration_files`.
 - Reject handwritten stdlib Rust literals unless they are manifest-tracked
   temporary exceptions.
 - Guard against new stdlib intrinsic dispatch entries.
@@ -270,6 +329,8 @@ Tasks:
 - Guard against private declaration targets outside approved sysroot crates.
 - Guard against fallback signature registries for `migrated` and `closed`
   surfaces.
+- Guard direct generated `sifr_runtime::*` calls so stdlib behavior cannot enter
+  through runtime glue.
 
 Acceptance:
 
@@ -278,6 +339,8 @@ Acceptance:
   intrinsic dispatch, direct generated dependencies, or fallback registries.
 - The HTTP transport harness is tracked as a temporary exception until it moves
   to verification-owned fixtures.
+- Every `HandwrittenExemption` references a manifest key, and unknown manifest
+  keys are rejected.
 
 Validation:
 
@@ -302,6 +365,9 @@ Tasks:
 - Prove handle nonforgeability, close poisoning, double-close behavior, and
   panic-boundary conversion.
 - Delete migrated file-handle registry, preamble, and signature entries.
+- Split the file-handle and IOError portions out of the mixed
+  IO/logging/random preamble so M4 can delete or tombstone only its migrated
+  slices.
 - Mark the relevant manifest entries `pilot` during implementation and
   `migrated` after deletion evidence lands.
 
@@ -330,6 +396,10 @@ Tasks:
 - Declare filesystem functions and errors in `stdlib/_sifr/fs.sifr`.
 - Route `sifr.os`, `sifr.pathlib`, `sifr.glob`, `sifr.shutil`,
   `sifr.tempfile`, and related wrappers through declarations.
+- Delete the direct `regex` dependency emitted for `sifr.pathlib`; route
+  path-glob regex behavior through `sifr_stdlib` behind the sysroot boundary.
+- Split and delete or tombstone filesystem/path slices from the mixed
+  IO/logging/random preamble.
 - Delete migrated `fs`, `io`, `pathlib`, and related intrinsic entries.
 - Keep only explicitly retained compiler-language or bridge glue.
 
@@ -360,6 +430,11 @@ Tasks:
   behavior into `sifr_stdlib`, using runtime substrate where needed.
 - Move global logging level behavior into `sifr_stdlib` or classify the exact
   runtime observability substrate as `retained-by-design`.
+- Split `_sifr.time` and `_sifr.logging` rows into migrated public behavior and
+  retained-by-design substrate rows if either family keeps compiler/runtime
+  substrate after public wrappers move.
+- Delete or tombstone the remaining logging/random slices from the mixed
+  IO/logging/random preamble after M4 and M5 have removed their slices.
 - Delete `random`, `time`, `logging`, and mixed preamble entries that are no
   longer compiler-owned.
 
@@ -368,7 +443,8 @@ Acceptance:
 - Random/time/logging public behavior routes through checked stdlib source and
   sysroot interop.
 - Runtime-only substrate is narrow and explicitly classified.
-- The mixed IO/logging/random preamble is decomposed or deleted.
+- The remaining random/logging slices of the mixed IO/logging/random preamble
+  are decomposed or deleted after M4 and M5 have already removed their slices.
 
 Validation:
 
@@ -500,8 +576,10 @@ Tasks:
 - Keep HTTP client runtime substrate in `sifr_runtime` only where reusable.
 - Declare HTTP resources, headers, requests, responses, and protocol operations
   in `stdlib/_sifr/http.sifr`.
-- Move `sifr.http_transport` and related harness behavior into
-  verification-owned fixtures.
+- Delete the synthetic `sifr.http_transport` module and its handwritten
+  `HTTP_TRANSPORT_HARNESS_RUST` literal from compiler stdlib output.
+- Rebuild the equivalent HTTP transport probe as a verification-owned Rust
+  fixture that is not exposed via `sifr.*`.
 - Delete HTTP prefix dispatch, registry entries, and preambles after migration.
 - Prove header validation, cookie parsing, HTTP/1, HTTP/2, transport, timeout,
   redirect, body, and error semantics.
@@ -520,17 +598,19 @@ Validation:
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M12. Callback and Subscription Pilot
+### M12. Signal Callback and Subscription Pilot
 
-Prove callback-shaped interop before Python and signal closure.
+Prove callback-shaped interop with the signal subscription surface before
+Python closure.
 
 Tasks:
 
-- Add or harden callback/subscription declaration support.
+- Add or harden callback/subscription declaration support for signal
+  subscriptions.
 - Prove callback lifetime, cancellation, thread-safety, panic conversion,
   reentrancy policy, and drop behavior.
 - Update resource and callback certification evidence.
-- Keep pilot evidence separate from Python and signal migration until complete.
+- Keep pilot evidence separate from Python migration until complete.
 
 Acceptance:
 
@@ -578,8 +658,10 @@ compiler-owned.
 
 Tasks:
 
-- Classify task, signal, runtime observability, and test-helper surfaces as
-  migrated, closed, or `retained-by-design`.
+- Reconfirm task, runtime observability, and test-helper surfaces as
+  `retained-by-design` only where they are language, bridge, or harness glue.
+- Classify any remaining signal public-wrapper behavior after M12 as migrated,
+  closed, or `retained-by-design`.
 - Move public stdlib wrapper behavior into `sifr_stdlib`.
 - Keep language task machinery, generated test harness mechanics, exact-int
   conversions, entrypoint wiring, and shared bridge glue compiler-owned.

--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -30,11 +30,10 @@ merged, and documented before the next milestone starts.
 
 ## Design Rules
 
-- Public APIs live under `stdlib/sifr`.
-- Sysroot-private declaration source lives under `stdlib/_sifr`.
-- User and package code cannot import `_sifr.*`.
-- `_sifr.*` is retained as the private sysroot declaration namespace; it is not
-  renamed.
+- Public stdlib source lives under `stdlib/sifr`; private declaration source
+  lives under `stdlib/_sifr`. Import is source-origin based: only
+  `SysrootPublicStdlib` sources may import `SysrootPrivateDeclaration` sources.
+  `_sifr.*` is a naming convention and on-disk layout, not the trust boundary.
 - `crates/sifr_stdlib` owns stdlib behavior, public wrapper policy,
   Sifr-facing error taxonomy, CPython-compatibility adaptation, and
   module-specific resource semantics.
@@ -47,12 +46,12 @@ merged, and documented before the next milestone starts.
 - `internal_docs/stdlib_retained_compiler_intrinsics.toml` is the only
   compiler-native stdlib exception ledger.
 - Every compiler-native stdlib surface appears exactly once in the retained-glue
-  manifest until it is migrated, closed, or explicitly retained by design. Row
-  granularity is leaf or subfamily level when a `_sifr.*` module mixes migrated
-  and retained leaves.
-- Manifest states are `retained`, `pilot`, `migrated`, `closed`, and
-  `retained-by-design`. `migrated` and `closed` rows remain as audit
-  tombstones with evidence after compiler-native entries are deleted.
+  manifest while it is `retained`, `pilot`, or `closing`; only
+  `retained-by-design` rows survive final closure. Row granularity is leaf or
+  subfamily level when a `_sifr.*` module mixes migrated and retained leaves.
+- Manifest states are `retained`, `pilot`, `closing`, and
+  `retained-by-design`. `closing` is temporary; final closure removes those rows
+  after guards prove the old compiler-native surface cannot reappear.
 - The retained-glue manifest is machine-parseable, schema-versioned, and
   rejects unknown fields after M0 installs the schema validator.
 - Generated Cargo for stdlib usage emits only Sifr sysroot crates. Third-party
@@ -62,8 +61,7 @@ merged, and documented before the next milestone starts.
   package-owned.
 - `StdlibCode.module_rust_code` is allowed only as transport for Rust code
   produced from checked Sifr stdlib source. Handwritten stdlib Rust string
-  injection is forbidden except for manifest-tracked temporary migration
-  exceptions.
+  injection is removed before provenance hardening and is forbidden afterward.
 - Direct generated `sifr_runtime::*` calls are allowed only for language,
   bridge, entrypoint, exact-int, test-harness, or retained-by-design runtime
   substrate glue. Stdlib behavior routes through `stdlib/_sifr` declarations
@@ -86,22 +84,20 @@ merged, and documented before the next milestone starts.
 
 | Milestone | Status | Evidence |
 | --- | --- | --- |
-| M0. Contract and Manifest State Foundation | planned |  |
-| M1. Manifest/Model Split and Bootstrap Ordering | planned |  |
-| M2. Declaration Infrastructure: Constants and Classes | planned |  |
-| M3. Provenance and Permanent Guardrails | planned |  |
-| M4. File Handle Opaque Resource Pilot | planned |  |
-| M5. Filesystem and Path Family | planned |  |
-| M6. Random, Time, and Logging | planned |  |
-| M7. Simple Sys and Environment | planned |  |
-| M8. Async Resource Pilot | planned |  |
-| M9. Process Family | planned |  |
-| M10. Network and TLS Families | planned |  |
-| M11. HTTP Family and Harness Relocation | planned |  |
-| M12. Signal Callback and Subscription Pilot | planned |  |
-| M13. Python Interop Adapters | planned |  |
-| M14. Task, Signal, Runtime Observability, and Test Helpers | planned |  |
-| M15. Final Closure | planned |  |
+| M0. Model Split and Raw-Injection Removal | planned |  |
+| M1. Manifest Schema and Normal-Path Guards | planned |  |
+| M2. Declaration Infrastructure and Provenance | planned |  |
+| M3. File and Filesystem Migration | planned |  |
+| M4. Random, Time, and Logging | planned |  |
+| M5. Simple Sys and Environment | planned |  |
+| M6. Async Resource Pilot | planned |  |
+| M7. Process Family | planned |  |
+| M8. Network and TLS Families | planned |  |
+| M9. HTTP Family | planned |  |
+| M10. Signal Callback and Subscription Pilot | planned |  |
+| M11. Python Interop Adapters | planned |  |
+| M12. Task, Signal, Runtime Observability, and Test Helpers | planned |  |
+| M13. Final Closure | planned |  |
 
 Evidence cells use this format after each milestone lands:
 `PR #<n> · sha=<hex7> · manifest: <id old_state -> new_state>`.
@@ -161,65 +157,111 @@ Validation and guardrails:
 
 ## Milestones
 
-### M0. Contract and Manifest State Foundation
+### M0. Model Split and Raw-Injection Removal
 
-Lock the final boundary before code movement.
+Remove large special cases before hardening the final manifest schema.
 
 Tasks:
 
-- Update architecture docs with the final stdlib/compiler/runtime boundary.
+- Create or rename the compiler manifest crate as `sifr_stdlib_manifest`.
+- Move source inventory, private declaration inventory, feature planning,
+  sysroot validation, and import policy into `sifr_stdlib_manifest`.
+- Move shared IPC frame/schema/transport/request tracking/handshake metadata
+  into `sifr_ipc`.
+- Move legacy CPython-shaped import suggestion policy out of the manifest crate
+  into the frontend or diagnostics boundary.
+- Move remaining retained intrinsic signature builders out of the manifest
+  crate and into the compiler codegen boundary that consumes them.
+- Delete the synthetic `sifr.http_transport` module and its handwritten
+  `HTTP_TRANSPORT_HARNESS_RUST` literal from compiler stdlib output.
+- Rebuild the equivalent HTTP transport probe as a verification-owned Rust
+  fixture that is not exposed via `sifr.*`.
+- Update architecture docs with the final stdlib/compiler/runtime boundary and
+  the source-origin privacy rule.
+- Remove temporary `sifr.http_transport` prose from
+  `internal_docs/network_http_architecture.md` after the verification-owned
+  fixture replaces it.
+
+Acceptance:
+
+- The compiler manifest crate contains metadata and planning only, not IPC
+  protocol code, diagnostics policy, retained intrinsic signatures, or stdlib
+  behavior.
+- `sifr_ipc` owns shared IPC protocol/frame/schema/request-tracking code.
+- Legacy CPython-shaped import suggestion policy lives outside the stdlib
+  manifest crate.
+- Remaining retained intrinsic signatures live at the codegen boundary that
+  consumes them, not in the manifest crate.
+- No handwritten Rust stdlib module injection remains in `StdlibCode`.
+- HTTP transport verification exists as a verification-owned fixture, not as a
+  synthetic `sifr.*` module.
+- `_sifr.*` privacy is documented and implemented as source-origin policy, not a
+  bespoke import-prefix trust rule.
+
+Validation:
+
+- Focused manifest/sysroot unit tests.
+- Focused HTTP verification fixture tests.
+- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- `python3 scripts/check_file_size_guardrails.py`
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M1. Manifest Schema and Normal-Path Guards
+
+Make the normal path strong enough that transitional special cases cannot grow.
+
+Tasks:
+
 - Extend the retained-glue manifest schema with migration states, owner or
-  issue fields, evidence links, registry entries, preamble entries, raw
-  injection entries, declaration files, `retired_prefix_intrinsics`, and
-  certification rows.
+  issue fields, evidence links, registry entries, preamble entries,
+  declaration files, and certification rows.
+- Do not add raw-injection fields; handwritten stdlib Rust injection was removed
+  in M0.
+- Exact-enumerate current prefix dispatchers and delete `prefix_intrinsics` from
+  the manifest schema and allowlist guard.
+- Split mixed-family rows into leaf or subfamily rows, for example
+  `_sifr.collections::counter_defaultdict` rather than `_sifr.collections`.
+- Split the mixed IO/logging/random preamble row into leaf rows so no retained
+  entry owns unrelated behavior.
+- Classify every retained surface as `retained`, `pilot`, `closing`, or
+  `retained-by-design`.
+- Treat `closing` as a temporary closeout state. Once deletion evidence lands,
+  remove the row; Git history and PR links are the audit trail.
 - Reject unknown top-level and per-surface manifest fields in
   `scripts/check_stdlib_manifest_schema.py`; the validator owns one explicit
   allowed-field set.
-- Classify every existing retained surface as `retained`,
-  `retained-by-design`, `pilot`, `migrated`, or `closed`.
-- Split mixed-family rows into leaf or subfamily rows, for example
-  `_sifr.collections::counter_defaultdict` rather than `_sifr.collections`.
-- Add tombstone-row support so `migrated` and `closed` entries can remain in the
-  manifest after their compiler-native registry, preamble, raw-injection, or
-  signature entries are deleted.
-- Backfill `migrated` tombstone rows for every already-migrated stdlib family
-  and subfamily currently described in the sysroot architecture doc, including
-  calendar, UUID, HTML, platform, math, regex, URL, TOML, datetime, compression,
-  `_sifr.crypto::hash`, `_sifr.crypto::base64`,
-  `_sifr.bytes::encode_utf8`, and `_sifr.bytes::bytes_to_hex`.
-- Collapse the migrated-leaf prose inventory in
-  `internal_docs/sifr_sysroot_and_stdlib_architecture.md` into a pointer to the
-  manifest after the tombstone backfill lands.
 - Add validation that every manifest entry has a valid state and every observed
   compiler-native stdlib exception is owned exactly once.
 - Add validation that manifest state transitions are monotonic by comparing the
   current manifest with `main`.
-- Add validation that no `_sifr.*` family exists outside the manifest or the
-  migrated declaration inventory.
-- Add validation that raw handwritten stdlib Rust injections are either absent
-  or named in the manifest.
 - Migrate `scripts/check_sysroot_stdlib_resource_certification_gate.py` to read
   `certification_rows` from the manifest and delete its hardcoded
-  surface-to-matrix table. The gate aggregates subfamily rows by their `_sifr.*`
-  family prefix so rows such as `_sifr.crypto::random` satisfy family-level
-  gating without requiring a parallel family registry.
-- Record the sequential milestone order in this phase document and update
-  status after each milestone lands.
+  surface-to-matrix table. Each manifest row carries its own certification rows;
+  the gate does not derive ownership from `_sifr.*` family prefixes.
+- Add deterministic topological stdlib bootstrap ordering.
+- Reject cycles and forward references that would make private declarations
+  order-dependent or nondeterministic.
+- Add a standalone bootstrap-ordering guard script.
+- Remove fallback intrinsic signature tables for any surface already marked
+  `closing`.
+- Ensure codegen, driver, LSP traces, build reports, and cache keys consume one
+  `SysrootDependencyPlan` rather than recomputing sysroot features.
 
 Acceptance:
 
 - A reviewer can identify the owner and migration state for every retained
   compiler-native stdlib surface from one manifest.
-- No second registry or informal checklist is needed to understand the
-  migration state.
+- No second registry or informal checklist is needed to understand migration
+  state or resource certification state.
 - `retained-by-design` entries are narrow compiler-language or harness glue,
   not stdlib behavior.
-- `migrated` and `closed` entries are reachable states with evidence, not dead
-  schema values.
-- Wide prefix rows define how exact migrated names shrink out of the prefix.
+- There are no prefix concepts in the manifest schema.
 - Unknown manifest fields are rejected.
 - The resource certification gate consumes manifest `certification_rows`
-  instead of a parallel table, and its family/subfamily join is deterministic.
+  instead of a parallel table and does not infer certification by prefix.
+- Stdlib bootstrap order is deterministic and validated.
+- Migrated families cannot keep compiler fallback signatures.
 
 Validation:
 
@@ -227,41 +269,6 @@ Validation:
 - `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
 - `python3 scripts/check_stdlib_migration_closure.py --self-test`
 - `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py`
-- `python3 scripts/check_hir_maintainability_guardrails.py`
-- `python3 scripts/check_file_size_guardrails.py`
-- `scripts/run_all_tests.sh --profile create-pr`
-
-### M1. Manifest/Model Split and Bootstrap Ordering
-
-Turn the compiler-side stdlib model into a manifest/sysroot planning layer.
-
-Tasks:
-
-- Create or rename the final manifest crate as `sifr_stdlib_manifest`.
-- Move source inventory, private declaration inventory, import suggestions,
-  migration-state loading, feature planning, and sysroot validation into the
-  manifest layer.
-- Move shared IPC frame/schema/transport/request tracking/handshake metadata
-  into `sifr_ipc`.
-- Remove fallback intrinsic signature tables for any surface already marked
-  `migrated` or `closed`.
-- Add deterministic topological stdlib bootstrap ordering.
-- Reject cycles and forward references that would make private declarations
-  order-dependent or nondeterministic.
-- Add a standalone bootstrap-ordering guard script.
-- Ensure codegen, driver, LSP traces, build reports, and cache keys consume one
-  `SysrootDependencyPlan` rather than recomputing sysroot features.
-
-Acceptance:
-
-- The manifest layer has no stdlib behavior implementation.
-- IPC is no longer bundled into the stdlib manifest boundary.
-- Stdlib bootstrap order is deterministic and validated.
-- Migrated families cannot keep compiler fallback signatures.
-
-Validation:
-
-- Focused manifest/sysroot unit tests.
 - Focused driver stdlib bootstrap tests.
 - `python3 scripts/check_stdlib_bootstrap_ordering.py`
 - Generated Cargo snapshot tests.
@@ -269,9 +276,10 @@ Validation:
 - `cargo test -p sifr_codegen -- rust_interop_plan`
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M2. Declaration Infrastructure: Constants and Classes
+### M2. Declaration Infrastructure and Provenance
 
-Make source declarations expressive enough to replace compiler signature tables.
+Make source declarations expressive enough to replace compiler signature tables,
+and lock codegen so new stdlib behavior cannot enter through side channels.
 
 Tasks:
 
@@ -284,6 +292,30 @@ Tasks:
   where they are stdlib behavior rather than language facts.
 - Add diagnostics for unsupported declaration forms instead of implicit
   fallbacks.
+- Add structural provenance to `StdlibCode.module_rust_code` producers.
+- Replace the plain string payload with compiled-source provenance:
+
+  ```rust
+  struct StdlibRustSource {
+      module: String,
+      source_path: PathBuf,
+      rust: String,
+  }
+  ```
+
+- Permit compiled checked stdlib source output.
+- Normalize `StdlibRustSource.source_path` to the same repo-relative path form
+  used by manifest `declaration_files`.
+- Reject handwritten stdlib Rust literals outright.
+- Guard against new stdlib intrinsic dispatch entries.
+- Guard against new stdlib implementation preambles.
+- Guard against new direct third-party generated dependencies for stdlib
+  behavior.
+- Guard against empty private declaration modules once marked `closing`.
+- Guard against private declaration targets outside approved sysroot crates.
+- Guard against fallback signature registries for `closing` surfaces.
+- Guard direct generated `sifr_runtime::*` calls so stdlib behavior cannot enter
+  through runtime glue.
 
 Acceptance:
 
@@ -291,6 +323,11 @@ Acceptance:
   be represented in checked declaration source.
 - Private declaration files can express the shape needed by upcoming pilots.
 - Migrated constants do not require compiler intrinsic Rust expressions.
+- The compiler can still emit language and bridge glue.
+- New stdlib behavior cannot enter through codegen strings, preambles,
+  intrinsic dispatch, direct generated dependencies, or fallback registries.
+- `StdlibCode.module_rust_code` has one producer kind: compiled checked Sifr
+  source.
 
 Validation:
 
@@ -298,60 +335,14 @@ Validation:
 - Focused Rust interop declaration tests.
 - Representative `sifr emit` snapshots for constants, methods, and opaque
   declarations.
-- `scripts/run_all_tests.sh --profile create-pr`
-
-### M3. Provenance and Permanent Guardrails
-
-Prevent new compiler-native stdlib behavior while migration proceeds.
-
-Tasks:
-
-- Add structural provenance to `StdlibCode.module_rust_code` producers.
-- Replace the plain string payload with a structural source representation:
-
-  ```rust
-  enum StdlibRustSource {
-      CompiledFromSifr { module: String, source_path: PathBuf, rust: String },
-      HandwrittenExemption { manifest_key: String, rust: String },
-  }
-  ```
-
-- Permit compiled checked stdlib source output.
-- Normalize `CompiledFromSifr.source_path` to the same repo-relative path form
-  used by manifest `declaration_files`.
-- Reject handwritten stdlib Rust literals unless they are manifest-tracked
-  temporary exceptions.
-- Guard against new stdlib intrinsic dispatch entries.
-- Guard against new stdlib implementation preambles.
-- Guard against new direct third-party generated dependencies for stdlib
-  behavior.
-- Guard against empty private declaration modules once marked `migrated`.
-- Guard against private declaration targets outside approved sysroot crates.
-- Guard against fallback signature registries for `migrated` and `closed`
-  surfaces.
-- Guard direct generated `sifr_runtime::*` calls so stdlib behavior cannot enter
-  through runtime glue.
-
-Acceptance:
-
-- The compiler can still emit language and bridge glue.
-- New stdlib behavior cannot enter through codegen strings, preambles,
-  intrinsic dispatch, direct generated dependencies, or fallback registries.
-- The HTTP transport harness is tracked as a temporary exception until it moves
-  to verification-owned fixtures.
-- Every `HandwrittenExemption` references a manifest key, and unknown manifest
-  keys are rejected.
-
-Validation:
-
 - Guard self-tests for each forbidden path.
 - Negative tests for raw stdlib Rust injection.
 - Generated Cargo dependency snapshots.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M4. File Handle Opaque Resource Pilot
+### M3. File and Filesystem Migration
 
-Migrate the first resource-shaped stdlib family end to end.
+Migrate file handles and the adjacent filesystem/path family end to end.
 
 Tasks:
 
@@ -362,35 +353,6 @@ Tasks:
 - Route public `sifr.io` wrappers through private declarations.
 - Migrate `builtin_open`, `builtin_open_text`, `open_file`, `file_read`,
   `file_write`, close, byte operations, and related methods.
-- Prove handle nonforgeability, close poisoning, double-close behavior, and
-  panic-boundary conversion.
-- Delete migrated file-handle registry, preamble, and signature entries.
-- Split the file-handle and IOError portions out of the mixed
-  IO/logging/random preamble so M4 can delete or tombstone only its migrated
-  slices.
-- Mark the relevant manifest entries `pilot` during implementation and
-  `migrated` after deletion evidence lands.
-
-Acceptance:
-
-- File handles are source-declared opaque resources.
-- Public file APIs behave through `sifr_stdlib`, not compiler dispatch.
-- The old file-handle compiler path is gone for migrated operations.
-
-Validation:
-
-- Focused file/resource lifecycle tests.
-- Representative `sifr.io` demos.
-- Resource certification gate.
-- Retained-glue allowlist guard.
-- `scripts/run_all_tests.sh --profile create-pr`
-
-### M5. Filesystem and Path Family
-
-Migrate stateless and handle-adjacent filesystem behavior after the file pilot.
-
-Tasks:
-
 - Move path, directory, glob, temporary directory, file copy, delete, rename,
   walk, metadata, and text helpers into `sifr_stdlib`.
 - Declare filesystem functions and errors in `stdlib/_sifr/fs.sifr`.
@@ -398,26 +360,33 @@ Tasks:
   `sifr.tempfile`, and related wrappers through declarations.
 - Delete the direct `regex` dependency emitted for `sifr.pathlib`; route
   path-glob regex behavior through `sifr_stdlib` behind the sysroot boundary.
-- Split and delete or tombstone filesystem/path slices from the mixed
-  IO/logging/random preamble.
-- Delete migrated `fs`, `io`, `pathlib`, and related intrinsic entries.
+- Prove handle nonforgeability, close poisoning, double-close behavior, and
+  panic-boundary conversion.
+- Delete migrated file, filesystem, path, and IO registry, preamble, and
+  signature entries.
 - Keep only explicitly retained compiler-language or bridge glue.
+- Mark the relevant manifest entries `pilot` during implementation and delete
+  them after migration evidence lands.
 
 Acceptance:
 
-- Filesystem and path behavior is stdlib-owned.
+- File handles are source-declared opaque resources.
+- Public file and filesystem APIs behave through `sifr_stdlib`, not compiler
+  dispatch.
 - Generated Cargo emits sysroot crate features only.
-- No migrated filesystem operation remains in intrinsic dispatch.
+- No migrated file/filesystem operation remains in intrinsic dispatch.
 
 Validation:
 
+- Focused file/resource lifecycle tests.
 - Focused fs/path tests.
 - Representative stdlib demos.
 - Generated Cargo feature snapshots.
+- Resource certification gate.
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M6. Random, Time, and Logging
+### M4. Random, Time, and Logging
 
 Migrate stateful but non-handle families after resource declaration patterns are
 established.
@@ -433,8 +402,8 @@ Tasks:
 - Split `_sifr.time` and `_sifr.logging` rows into migrated public behavior and
   retained-by-design substrate rows if either family keeps compiler/runtime
   substrate after public wrappers move.
-- Delete or tombstone the remaining logging/random slices from the mixed
-  IO/logging/random preamble after M4 and M5 have removed their slices.
+- Delete the remaining logging/random slices from the mixed
+  IO/logging/random preamble after M3 has removed file/filesystem slices.
 - Delete `random`, `time`, `logging`, and mixed preamble entries that are no
   longer compiler-owned.
 
@@ -444,7 +413,7 @@ Acceptance:
   sysroot interop.
 - Runtime-only substrate is narrow and explicitly classified.
 - The remaining random/logging slices of the mixed IO/logging/random preamble
-  are decomposed or deleted after M4 and M5 have already removed their slices.
+  are decomposed or deleted after M3 has already removed file/filesystem slices.
 
 Validation:
 
@@ -454,7 +423,7 @@ Validation:
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M7. Simple Sys and Environment
+### M5. Simple Sys and Environment
 
 Migrate process environment and platform surfaces that do not require process
 resource handles.
@@ -482,7 +451,7 @@ Validation:
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M8. Async Resource Pilot
+### M6. Async Resource Pilot
 
 Prove async resource declarations before migrating async-heavy families.
 
@@ -507,7 +476,7 @@ Validation:
 - Rust interop certification gate.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M9. Process Family
+### M7. Process Family
 
 Migrate process execution, child handles, pipes, and async process behavior.
 
@@ -536,7 +505,7 @@ Validation:
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M10. Network and TLS Families
+### M8. Network and TLS Families
 
 Migrate TCP and TLS resources after async/process evidence is in place.
 
@@ -566,9 +535,9 @@ Validation:
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M11. HTTP Family and Harness Relocation
+### M9. HTTP Family
 
-Migrate HTTP behavior and remove compiler-owned harness injection.
+Migrate HTTP behavior after network/TLS resource evidence exists.
 
 Tasks:
 
@@ -576,10 +545,6 @@ Tasks:
 - Keep HTTP client runtime substrate in `sifr_runtime` only where reusable.
 - Declare HTTP resources, headers, requests, responses, and protocol operations
   in `stdlib/_sifr/http.sifr`.
-- Delete the synthetic `sifr.http_transport` module and its handwritten
-  `HTTP_TRANSPORT_HARNESS_RUST` literal from compiler stdlib output.
-- Rebuild the equivalent HTTP transport probe as a verification-owned Rust
-  fixture that is not exposed via `sifr.*`.
 - Delete HTTP prefix dispatch, registry entries, and preambles after migration.
 - Prove header validation, cookie parsing, HTTP/1, HTTP/2, transport, timeout,
   redirect, body, and error semantics.
@@ -598,7 +563,7 @@ Validation:
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M12. Signal Callback and Subscription Pilot
+### M10. Signal Callback and Subscription Pilot
 
 Prove callback-shaped interop with the signal subscription surface before
 Python closure.
@@ -624,7 +589,7 @@ Validation:
 - Rust interop callback certification gate.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M13. Python Interop Adapters
+### M11. Python Interop Adapters
 
 Migrate Python adapter stdlib behavior while preserving Python runtime ownership.
 
@@ -651,7 +616,7 @@ Validation:
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M14. Task, Signal, Runtime Observability, and Test Helpers
+### M12. Task, Signal, Runtime Observability, and Test Helpers
 
 Finish the compiler/runtime boundary for surfaces that may stay partly
 compiler-owned.
@@ -660,8 +625,8 @@ Tasks:
 
 - Reconfirm task, runtime observability, and test-helper surfaces as
   `retained-by-design` only where they are language, bridge, or harness glue.
-- Classify any remaining signal public-wrapper behavior after M12 as migrated,
-  closed, or `retained-by-design`.
+- Classify any remaining signal public-wrapper behavior after M10 as `closing`
+  or `retained-by-design`.
 - Move public stdlib wrapper behavior into `sifr_stdlib`.
 - Keep language task machinery, generated test harness mechanics, exact-int
   conversions, entrypoint wiring, and shared bridge glue compiler-owned.
@@ -683,7 +648,7 @@ Validation:
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
-### M15. Final Closure
+### M13. Final Closure
 
 Remove the transitional migration machinery.
 
@@ -691,13 +656,11 @@ Tasks:
 
 - Delete remaining stdlib intrinsic dispatch and registry code that no longer
   represents retained-by-design language glue.
-- Delete fallback intrinsic signature tables for all migrated or closed
-  surfaces.
+- Delete fallback intrinsic signature tables for all `closing` surfaces.
 - Delete stdlib implementation preambles.
-- Delete handwritten stdlib Rust injection exceptions.
 - Delete direct generated third-party dependency paths for stdlib behavior.
-- Ensure every manifest entry is `migrated`, `closed`, or
-  `retained-by-design`.
+- Ensure every remaining manifest entry is `retained-by-design`; no `retained`,
+  `pilot`, or `closing` rows remain.
 - Convert temporary migration guards into permanent no-regression guards.
 - Update architecture, roadmap, phases, and issue docs with final status and
   merged PR links.
@@ -708,8 +671,10 @@ Acceptance:
 - The compiler has no stdlib behavior implementation path.
 - All remaining compiler-owned entries are intentional language, bridge,
   entrypoint, exact-int, test-harness, or runtime substrate glue.
-- The retained-glue manifest is exhaustive and has no `retained` or `pilot`
-  entries.
+- The retained-glue manifest is exhaustive and contains only
+  `retained-by-design` rows.
+- `StdlibCode.module_rust_code` provenance is a single compiled-from-Sifr source
+  struct, not an enum with temporary exemption variants.
 
 Validation:
 
@@ -729,7 +694,7 @@ Each milestone must finish with:
 
 - docs updated with status, checklist state, and merged PR links,
 - focused tests for the changed compiler/stdlib/runtime behavior,
-- guardrail updates for any newly closed path,
+- guardrail updates for any newly closing or deleted path,
 - `scripts/run_all_tests.sh --profile create-pr` before PR,
 - review and merge before starting the next milestone.
 

--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -66,6 +66,11 @@ merged, and documented before the next milestone starts.
   bridge, entrypoint, exact-int, test-harness, or retained-by-design runtime
   substrate glue. Stdlib behavior routes through `stdlib/_sifr` declarations
   and `sifr_stdlib`.
+- This phase takes ownership of the stdlib-blocking Rust interop certification
+  rows it consumes. The separate certification issue remains owner for unrelated
+  ecosystem crate certification, but rows used to unblock stdlib migration are
+  handed off by updating the compatibility matrix `future_owner`, milestone
+  evidence, and issue docs in the milestone that claims them.
 - No backward-compatibility shims, fallback paths, duplicate registries, or
   compatibility aliases are introduced. Unsupported or removed surfaces receive
   diagnostics instead of hidden fallback behavior.
@@ -101,6 +106,28 @@ merged, and documented before the next milestone starts.
 
 Evidence cells use this format after each milestone lands:
 `PR #<n> · sha=<hex7> · manifest: <id old_state -> new_state>`.
+
+## Certification Row Handoff
+
+The current Rust interop certification follow-up owns several
+`future-owned-by-separate-phase` rows that are also migration blockers for this
+phase. To avoid circular ownership, the milestone that first needs a row also
+takes responsibility for landing executable evidence and the matrix status
+change:
+
+| Row | Stdlib milestone owner | Scope transferred from the certification issue |
+| --- | --- | --- |
+| `opaque_resource_matrix` | M3 | Opaque resource nonforgeability, close/aclose lifecycle, alias rejection, and panic-boundary conversion for stdlib resource handles. |
+| `async_runtime_reqwest` | M6 | Async declaration/runtime behavior needed by stdlib async calls and resources, including hidden-blocking rejection and cancellation/drop evidence. |
+| `callback_subscription_matrix` | M10 | Subscription callback lifetime, cancellation, shutdown, thread-safety, reentrancy, and drop behavior needed by signal-style stdlib resources. |
+| `callbacks_call_scoped` | M11 | Call-scoped callback lifetime evidence needed by Python adapter stdlib behavior. |
+
+Any milestone that claims one of these rows must update
+`plans/issues/active/rust-interop-runtime-ecosystem-certification.md` and
+`verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json` in
+the same PR. The separate certification issue continues to own backend,
+database, messaging, CLI, native-link, proc-macro, and package-ecosystem rows
+that are not direct stdlib migration blockers.
 
 ## Affected Inventory
 
@@ -146,7 +173,9 @@ Runtime and stdlib crates:
 Validation and guardrails:
 
 - `scripts/check_stdlib_native_intrinsic_allowlist.py`
-- `scripts/check_stdlib_migration_closure.py`
+- `scripts/check_stdlib_migration_closure.py` until M13 folds any still-useful
+  checks into the observed-surface allowlist guard and deletes the retired-name
+  tombstone registry.
 - target `scripts/check_stdlib_manifest_schema.py`
 - target `scripts/check_stdlib_bootstrap_ordering.py`
 - `scripts/check_sysroot_stdlib_resource_certification_gate.py`
@@ -177,8 +206,9 @@ Tasks:
   second migration manifest; it shrinks to retained-by-design language glue or
   disappears by M13.
 - Rebuild the HTTP transport probe as a verification-owned Rust fixture that is
-  not exposed via `sifr.*`, prove equivalent coverage, then delete the
-  synthetic `sifr.http_transport` module and its handwritten
+  not exposed via `sifr.*`, prove equivalent runtime coverage, account for the
+  retired Sifr codegen/bootstrap-path coverage, then delete the synthetic
+  `sifr.http_transport` module and its handwritten
   `HTTP_TRANSPORT_HARNESS_RUST` literal from compiler stdlib output in the same
   milestone.
 - Update architecture docs with the final stdlib/compiler/runtime boundary and
@@ -194,8 +224,9 @@ milestone is merged:
 - M0b: create `sifr_ipc` and move shared IPC protocol code.
 - M0c: move import suggestion policy and retained signature builders to their
   final temporary compiler homes.
-- M0d: move the HTTP harness to verification, prove parity, and delete raw
-  stdlib module injection.
+- M0d: move the HTTP harness to verification, prove runtime parity, account for
+  retired codegen/bootstrap-path coverage, and delete raw stdlib module
+  injection.
 - M0e: update architecture docs and implement source-origin privacy.
 
 Acceptance:
@@ -212,8 +243,9 @@ Acceptance:
 - No handwritten Rust stdlib module injection remains in `StdlibCode`.
 - HTTP transport verification exists as a verification-owned fixture, not as a
   synthetic `sifr.*` module.
-- HTTP transport coverage parity is proven before the synthetic module and raw
-  Rust literal are deleted.
+- HTTP transport runtime coverage parity is proven, and the retired
+  codegen/bootstrap-path coverage is explicitly closed, before the synthetic
+  module and raw Rust literal are deleted.
 - `_sifr.*` privacy is documented and implemented as source-origin policy, not a
   bespoke import-prefix trust rule.
 
@@ -253,8 +285,13 @@ Tasks:
   allowed-field set.
 - Add validation that every manifest entry has a valid state and every observed
   compiler-native stdlib exception is owned exactly once.
-- Add validation that manifest state transitions are monotonic by comparing the
-  current manifest with `main`.
+- Add validation that manifest state transitions are explicit by comparing the
+  current manifest with `main`. Allowed transitions are:
+  `retained -> pilot`, `retained -> closing`,
+  `retained -> retained-by-design`, `pilot -> closing`,
+  `pilot -> retained-by-design`, and `closing -> deleted`.
+  Adding a new `retained` row after M1 is rejected unless the row is
+  `retained-by-design` language/runtime glue introduced by the same PR.
 - Add validation for row deletion: a removed `closing` row must have deletion
   evidence in the milestone evidence table or an explicit PR-linked closeout
   record, so row deletion cannot hide an unclosed compiler-native surface.
@@ -290,7 +327,8 @@ Validation:
 
 - `python3 scripts/check_stdlib_manifest_schema.py`
 - `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
-- `python3 scripts/check_stdlib_migration_closure.py --self-test`
+- `python3 scripts/check_stdlib_migration_closure.py --self-test` as a
+  transitional guard until its useful checks fold into the allowlist guard.
 - `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py`
 - Focused driver stdlib bootstrap tests.
 - `python3 scripts/check_stdlib_bootstrap_ordering.py`
@@ -341,6 +379,19 @@ Tasks:
 - Guard against fallback signature registries for `closing` surfaces.
 - Guard direct generated `sifr_runtime::*` calls so stdlib behavior cannot enter
   through runtime glue.
+
+M2 may land as ordered sub-PRs, but M3 must not start until the whole M2
+milestone is merged:
+
+- M2a: constants, module-level values, methods, constructors, errors, and
+  diagnostics for unsupported declaration forms.
+- M2b: opaque resources, value classes, nonforgeability, close/aclose lifecycle
+  metadata, and user-forgery negative tests.
+- M2c: structural `StdlibRustSource` provenance with canonical
+  sysroot-relative paths, source digests, and raw-string rejection.
+- M2d: permanent side-channel guards for new dispatch entries, preambles,
+  direct dependencies, fallback registries, private target escapes, and direct
+  stdlib-behavior `sifr_runtime::*` calls.
 
 Acceptance:
 
@@ -410,6 +461,8 @@ Validation:
 - Focused fs/path tests.
 - Representative stdlib demos.
 - Generated Cargo feature snapshots.
+- Generated-project cold/warm build-time evidence for representative `sifr run`
+  cases using the existing validation profile budget reports.
 - Resource certification gate.
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
@@ -423,8 +476,11 @@ Tasks:
 
 - Move random module state, distributions, sampling, shuffling, and seeding
   behavior into `sifr_stdlib`.
-- Move clock, formatting, parsing, sleeping, and struct-time compatibility
-  behavior into `sifr_stdlib`, using runtime substrate where needed.
+- Move wall-clock, formatting, parsing, and struct-time compatibility behavior
+  that does not depend on async runtime certification into `sifr_stdlib`.
+- Split `_sifr.time` so async/runtime-sensitive leaves such as `sleep` and
+  `monotonic` remain retained until M6 proves the async declaration/runtime
+  model.
 - Move global logging level behavior into `sifr_stdlib` or classify the exact
   runtime observability substrate as `retained-by-design`.
 - Split `_sifr.time` and `_sifr.logging` rows into migrated public behavior and
@@ -438,7 +494,9 @@ Tasks:
 Acceptance:
 
 - Random/time/logging public behavior routes through checked stdlib source and
-  sysroot interop.
+  sysroot interop for the leaves not blocked on async/runtime certification.
+- `sleep` and `monotonic` remain explicitly retained or split out until M6
+  closes their async/runtime evidence.
 - Runtime-only substrate is narrow and explicitly classified.
 - The remaining random/logging slices of the mixed IO/logging/random preamble
   are decomposed or deleted after M3 has already removed file/filesystem slices.
@@ -446,8 +504,11 @@ Acceptance:
 Validation:
 
 - Deterministic random tests.
-- Clock/sleep tests with bounded timing assertions.
+- Clock and struct-time tests with bounded timing assertions for the migrated
+  sync leaves.
 - Logging state tests.
+- Generated-project cold/warm build-time evidence for representative `sifr run`
+  cases using the existing validation profile budget reports.
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
@@ -476,6 +537,8 @@ Validation:
 
 - Focused sys/env tests.
 - Generated Cargo feature snapshots.
+- Generated-project cold/warm build-time evidence for representative `sifr run`
+  cases using the existing validation profile budget reports.
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
@@ -486,8 +549,12 @@ Prove async resource declarations before migrating async-heavy families.
 Tasks:
 
 - Add or harden async resource declaration support.
+- Add or harden basic async function declaration support needed by
+  async-sensitive stdlib leaves.
 - Prove cancellation, poisoning, join/drop semantics, blocking boundaries, and
   panic conversion for an intentionally small async resource.
+- Migrate the async/runtime-sensitive `_sifr.time` leaves retained from M4,
+  including `sleep` and `monotonic`, only after async runtime evidence lands.
 - Update Rust interop certification evidence with executable lifecycle tests.
 - Keep the pilot isolated from process, network, TLS, and HTTP migration until
   evidence lands.
@@ -497,10 +564,15 @@ Acceptance:
 - Async resources have a checked declaration and lifecycle model.
 - Cancellation and drop behavior is deterministic and documented.
 - Resource certification can distinguish sync and async resource evidence.
+- `sleep` and `monotonic` no longer require compiler-native stdlib dispatch
+  once their async/runtime evidence lands.
 
 Validation:
 
 - Focused async resource tests.
+- Clock/sleep tests with bounded timing assertions.
+- Generated-project cold/warm build-time evidence for representative `sifr run`
+  cases using the existing validation profile budget reports.
 - Rust interop certification gate.
 - `scripts/run_all_tests.sh --profile create-pr`
 
@@ -529,6 +601,8 @@ Validation:
 
 - Focused process lifecycle tests.
 - Async process tests.
+- Generated-project cold/warm build-time evidence for representative `sifr run`
+  cases using the existing validation profile budget reports.
 - Resource certification gate.
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
@@ -559,6 +633,8 @@ Validation:
 
 - Focused loopback network tests.
 - TLS fixture tests.
+- Generated-project cold/warm build-time evidence for representative `sifr run`
+  cases using the existing validation profile budget reports.
 - Resource certification gate.
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
@@ -588,6 +664,8 @@ Validation:
 - Focused HTTP tests.
 - Verification-owned transport fixtures.
 - Generated Cargo dependency snapshots.
+- Generated-project cold/warm build-time evidence for representative `sifr run`
+  cases using the existing validation profile budget reports.
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
@@ -614,6 +692,8 @@ Acceptance:
 Validation:
 
 - Focused callback lifecycle tests.
+- Generated-project cold/warm build-time evidence for representative `sifr run`
+  cases using the existing validation profile budget reports.
 - Rust interop callback certification gate.
 - `scripts/run_all_tests.sh --profile create-pr`
 
@@ -641,6 +721,8 @@ Validation:
 
 - Python interop certification tests.
 - Callback/resource gates.
+- Generated-project cold/warm build-time evidence for representative `sifr run`
+  cases using the existing validation profile budget reports.
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
@@ -673,6 +755,8 @@ Validation:
 
 - Focused task/signal/runtime observability tests.
 - Test harness tests.
+- Generated-project cold/warm build-time evidence for representative `sifr run`
+  cases using the existing validation profile budget reports.
 - Retained-glue and migration closure guards.
 - `scripts/run_all_tests.sh --profile create-pr`
 
@@ -689,6 +773,9 @@ Tasks:
 - Delete direct generated third-party dependency paths for stdlib behavior.
 - Ensure every remaining manifest entry is `retained-by-design`; no `retained`,
   `pilot`, or `closing` rows remain.
+- Fold any still-useful `scripts/check_stdlib_migration_closure.py` checks into
+  the observed-surface allowlist guard and delete the retired-name tombstone
+  registry.
 - Convert temporary migration guards into permanent no-regression guards.
 - Update architecture, roadmap, phases, and issue docs with final status and
   merged PR links.
@@ -711,7 +798,6 @@ Validation:
 - `python3 scripts/check_hir_maintainability_guardrails.py`
 - `python3 scripts/check_file_size_guardrails.py`
 - `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
-- `python3 scripts/check_stdlib_migration_closure.py`
 - `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py`
 - `scripts/run_all_tests.sh --profile create-pr`
 - `scripts/run_all_tests.sh`

--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -169,18 +169,34 @@ Tasks:
 - Move shared IPC frame/schema/transport/request tracking/handshake metadata
   into `sifr_ipc`.
 - Move legacy CPython-shaped import suggestion policy out of the manifest crate
-  into the frontend or diagnostics boundary.
+  into the frontend or diagnostics boundary. That boundary may query manifest
+  inventory data, but it owns the suggestion policy and rendered diagnostics.
 - Move remaining retained intrinsic signature builders out of the manifest
-  crate and into the compiler codegen boundary that consumes them.
-- Delete the synthetic `sifr.http_transport` module and its handwritten
-  `HTTP_TRANSPORT_HARNESS_RUST` literal from compiler stdlib output.
-- Rebuild the equivalent HTTP transport probe as a verification-owned Rust
-  fixture that is not exposed via `sifr.*`.
+  crate and into a temporary compiler-retained-glue boundary consumed by
+  lowering, driver bootstrap, and codegen as needed. This boundary is not a
+  second migration manifest; it shrinks to retained-by-design language glue or
+  disappears by M13.
+- Rebuild the HTTP transport probe as a verification-owned Rust fixture that is
+  not exposed via `sifr.*`, prove equivalent coverage, then delete the
+  synthetic `sifr.http_transport` module and its handwritten
+  `HTTP_TRANSPORT_HARNESS_RUST` literal from compiler stdlib output in the same
+  milestone.
 - Update architecture docs with the final stdlib/compiler/runtime boundary and
   the source-origin privacy rule.
 - Remove temporary `sifr.http_transport` prose from
   `internal_docs/network_http_architecture.md` after the verification-owned
   fixture replaces it.
+
+M0 may land as ordered sub-PRs, but M1 must not start until the whole M0
+milestone is merged:
+
+- M0a: create `sifr_stdlib_manifest` and move inventory/planning/import policy.
+- M0b: create `sifr_ipc` and move shared IPC protocol code.
+- M0c: move import suggestion policy and retained signature builders to their
+  final temporary compiler homes.
+- M0d: move the HTTP harness to verification, prove parity, and delete raw
+  stdlib module injection.
+- M0e: update architecture docs and implement source-origin privacy.
 
 Acceptance:
 
@@ -190,11 +206,14 @@ Acceptance:
 - `sifr_ipc` owns shared IPC protocol/frame/schema/request-tracking code.
 - Legacy CPython-shaped import suggestion policy lives outside the stdlib
   manifest crate.
-- Remaining retained intrinsic signatures live at the codegen boundary that
-  consumes them, not in the manifest crate.
+- Remaining retained intrinsic signatures live in a temporary
+  compiler-retained-glue boundary that can be consumed by lowering, driver
+  bootstrap, and codegen without making lowering depend on codegen.
 - No handwritten Rust stdlib module injection remains in `StdlibCode`.
 - HTTP transport verification exists as a verification-owned fixture, not as a
   synthetic `sifr.*` module.
+- HTTP transport coverage parity is proven before the synthetic module and raw
+  Rust literal are deleted.
 - `_sifr.*` privacy is documented and implemented as source-origin policy, not a
   bespoke import-prefix trust rule.
 
@@ -213,9 +232,10 @@ Make the normal path strong enough that transitional special cases cannot grow.
 
 Tasks:
 
-- Extend the retained-glue manifest schema with migration states, owner or
-  issue fields, evidence links, registry entries, preamble entries,
-  declaration files, and certification rows.
+- Extend the retained-glue manifest schema with migration states, owner fields,
+  issue fields, removal criteria for every non-`retained-by-design` row,
+  evidence links, registry entries, preamble entries, declaration files, and
+  certification rows.
 - Do not add raw-injection fields; handwritten stdlib Rust injection was removed
   in M0.
 - Exact-enumerate current prefix dispatchers and delete `prefix_intrinsics` from
@@ -235,6 +255,9 @@ Tasks:
   compiler-native stdlib exception is owned exactly once.
 - Add validation that manifest state transitions are monotonic by comparing the
   current manifest with `main`.
+- Add validation for row deletion: a removed `closing` row must have deletion
+  evidence in the milestone evidence table or an explicit PR-linked closeout
+  record, so row deletion cannot hide an unclosed compiler-native surface.
 - Migrate `scripts/check_sysroot_stdlib_resource_certification_gate.py` to read
   `certification_rows` from the manifest and delete its hardcoded
   surface-to-matrix table. Each manifest row carries its own certification rows;
@@ -298,14 +321,16 @@ Tasks:
   ```rust
   struct StdlibRustSource {
       module: String,
-      source_path: PathBuf,
+      source_path: SysrootRelativePath,
+      source_sha256: String,
       rust: String,
   }
   ```
 
 - Permit compiled checked stdlib source output.
-- Normalize `StdlibRustSource.source_path` to the same repo-relative path form
-  used by manifest `declaration_files`.
+- Normalize `StdlibRustSource.source_path` to a canonical sysroot-relative path
+  form used by manifest `declaration_files`, and compute `source_sha256` from
+  the checked source content that produced the Rust payload.
 - Reject handwritten stdlib Rust literals outright.
 - Guard against new stdlib intrinsic dispatch entries.
 - Guard against new stdlib implementation preambles.
@@ -322,12 +347,15 @@ Acceptance:
 - Functions, constants, methods, errors, opaque resources, and value classes can
   be represented in checked declaration source.
 - Private declaration files can express the shape needed by upcoming pilots.
+- A private declaration can define an opaque type that user code cannot forge.
+- A private declaration can attach close/aclose/lifecycle metadata without
+  compiler-specific per-surface behavior.
 - Migrated constants do not require compiler intrinsic Rust expressions.
 - The compiler can still emit language and bridge glue.
 - New stdlib behavior cannot enter through codegen strings, preambles,
   intrinsic dispatch, direct generated dependencies, or fallback registries.
 - `StdlibCode.module_rust_code` has one producer kind: compiled checked Sifr
-  source.
+  source with canonical sysroot-relative path and source digest provenance.
 
 Validation:
 

--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -109,20 +109,27 @@ Evidence cells use this format after each milestone lands:
 
 ## Certification Row Handoff
 
-The current Rust interop certification follow-up owns several
+The current Rust interop certification follow-up owns several broad
 `future-owned-by-separate-phase` rows that are also migration blockers for this
-phase. To avoid circular ownership, the milestone that first needs a row also
-takes responsibility for landing executable evidence and the matrix status
-change:
+phase. This phase must not reassign those rows wholesale because several rows
+also cover ecosystem crates that stdlib migration does not prove. Instead, the
+claiming milestone splits the broad row into a narrow stdlib-blocking core row
+and an ecosystem row that remains with the certification issue:
 
-| Row | Stdlib milestone owner | Scope transferred from the certification issue |
+| Current broad row | Stdlib milestone split row | Ecosystem row remains with certification issue |
 | --- | --- | --- |
-| `opaque_resource_matrix` | M3 | Opaque resource nonforgeability, close/aclose lifecycle, alias rejection, and panic-boundary conversion for stdlib resource handles. |
-| `async_runtime_reqwest` | M6 | Async declaration/runtime behavior needed by stdlib async calls and resources, including hidden-blocking rejection and cancellation/drop evidence. |
-| `callback_subscription_matrix` | M10 | Subscription callback lifetime, cancellation, shutdown, thread-safety, reentrancy, and drop behavior needed by signal-style stdlib resources. |
-| `callbacks_call_scoped` | M11 | Call-scoped callback lifetime evidence needed by Python adapter stdlib behavior. |
+| `opaque_resource_matrix` | M3 creates `opaque_resource_core` for opaque resource nonforgeability, close/aclose lifecycle, alias rejection, poisoning, and panic-boundary conversion for stdlib resource handles. | `opaque_resource_ecosystem` keeps `reqwest`, `rusqlite`, `tokio-postgres`, and `redis` handle evidence. |
+| `async_runtime_reqwest` | M6 creates `async_runtime_core` for async declaration/runtime behavior needed by stdlib async calls and resources, including hidden-blocking rejection, cancellation, drop, and the retained `_sifr.time` leaves. | `async_runtime_reqwest` keeps `tokio`/`reqwest` loopback behavior evidence. |
+| `callback_subscription_matrix` | M10 creates `callback_subscription_core` for signal-style subscription lifetime, cancellation, shutdown, thread-safety, reentrancy, and drop behavior. | `callback_subscription_ecosystem` keeps `tokio-tungstenite`, Redis pub/sub, and `notify` evidence. |
+| `callbacks_call_scoped` | M11 creates or claims a narrow `callbacks_call_scoped_core` row for call-scoped callback lifetime evidence needed by Python adapter stdlib behavior. | Any package/ecosystem callback row remains with the certification issue if broader evidence is needed. |
+| `panic_boundary_wrapper_emission` | M3 creates `panic_boundary_stdlib_core` only if stdlib private interop needs generated panic wrappers for resource migration. | `panic_boundary_wrapper_emission` keeps package Rust interop wrapper-emission and mapper-panic fallback evidence. |
 
-Any milestone that claims one of these rows must update
+If trusted sysroot declarations make generated panic wrappers unnecessary for a
+stdlib migration, the claiming milestone must state that explicitly in its
+evidence and keep panic handling as stdlib-owned poisoning or error conversion
+evidence instead of flipping `panic_boundary_wrapper_emission`.
+
+Any milestone that splits or claims one of these rows must update
 `plans/issues/active/rust-interop-runtime-ecosystem-certification.md` and
 `verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json` in
 the same PR. The separate certification issue continues to own backend,

--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -1,0 +1,655 @@
+# Ad Hoc Phase: Stdlib Native Boundary Completion
+
+## Status
+
+Planned.
+
+## Objective
+
+Finish the stdlib migration from compiler-native intrinsic dispatch, pasted
+preambles, fallback signature tables, and handwritten Rust source injection to
+the final sysroot architecture:
+
+```text
+user code
+  -> stdlib/sifr/*.sifr
+  -> stdlib/_sifr/*.sifr
+  -> @rust(sifr_stdlib.*)
+  -> crates/sifr_stdlib
+  -> crates/sifr_runtime, only for reusable substrate
+```
+
+The completed state is intentionally strict. Public stdlib behavior is checked
+Sifr source plus trusted sysroot Rust interop. The compiler remains responsible
+for language semantics, Rust interop bridge glue, panic wrappers, exact-int
+conversions, entrypoint machinery, generated test harness mechanics, and
+runtime call glue. It does not own stdlib behavior.
+
+This phase is sequential. Each milestone is implemented, validated, reviewed,
+merged, and documented before the next milestone starts.
+
+## Design Rules
+
+- Public APIs live under `stdlib/sifr`.
+- Sysroot-private declaration source lives under `stdlib/_sifr`.
+- User and package code cannot import `_sifr.*`.
+- `_sifr.*` is retained as the private sysroot declaration namespace; it is not
+  renamed.
+- `crates/sifr_stdlib` owns stdlib behavior, public wrapper policy,
+  Sifr-facing error taxonomy, CPython-compatibility adaptation, and
+  module-specific resource semantics.
+- `crates/sifr_runtime` owns reusable substrate only: executors, opaque handle
+  storage, poisoning, panic boundaries, exact-int bridge helpers, and low-level
+  process, network, TLS, HTTP, Python, and runtime state.
+- Declaration source is the signature truth for migrated families. Functions,
+  constants, methods, errors, opaque resources, and value classes are declared
+  in source, not in fallback compiler tables.
+- `internal_docs/stdlib_retained_compiler_intrinsics.toml` is the only
+  compiler-native stdlib exception ledger.
+- Every `_sifr.*` family and every compiler-native exception appears exactly
+  once in the retained-glue manifest until it is migrated, closed, or
+  explicitly retained by design.
+- Manifest states are `retained`, `pilot`, `migrated`, `closed`, and
+  `retained-by-design`.
+- Generated Cargo for stdlib usage emits only Sifr sysroot crates. Third-party
+  crates used by stdlib behavior are transitive implementation details of the
+  sysroot crates.
+- User package dependencies and explicit Rust interop dependencies remain
+  package-owned.
+- `StdlibCode.module_rust_code` is allowed only as transport for Rust code
+  produced from checked Sifr stdlib source. Handwritten stdlib Rust string
+  injection is forbidden except for manifest-tracked temporary migration
+  exceptions.
+- No backward-compatibility shims, fallback paths, duplicate registries, or
+  compatibility aliases are introduced. Unsupported or removed surfaces receive
+  diagnostics instead of hidden fallback behavior.
+
+## Non-Goals
+
+- No public user syntax for private sysroot declarations.
+- No CPython top-level module aliasing for `sifr.*`.
+- No new global Cargo registry policy for user dependencies.
+- No second migration manifest.
+- No blanket runtime facade that re-exports all stdlib behavior from
+  `sifr_runtime`.
+- No parallel implementation tracks. Work proceeds one milestone at a time.
+
+## Implementation Status
+
+| Milestone | Status | Evidence |
+| --- | --- | --- |
+| M0. Contract and Manifest State Foundation | planned |  |
+| M1. Manifest/Model Split and Bootstrap Ordering | planned |  |
+| M2. Declaration Infrastructure: Constants and Classes | planned |  |
+| M3. Provenance and Permanent Guardrails | planned |  |
+| M4. File Handle Opaque Resource Pilot | planned |  |
+| M5. Filesystem and Path Family | planned |  |
+| M6. Random, Time, and Logging | planned |  |
+| M7. Simple Sys and Environment | planned |  |
+| M8. Async Resource Pilot | planned |  |
+| M9. Process Family | planned |  |
+| M10. Network and TLS Families | planned |  |
+| M11. HTTP Family and Harness Relocation | planned |  |
+| M12. Callback and Subscription Pilot | planned |  |
+| M13. Python Interop Adapters | planned |  |
+| M14. Task, Signal, Runtime Observability, and Test Helpers | planned |  |
+| M15. Final Closure | planned |  |
+
+## Affected Inventory
+
+Architecture and planning:
+
+- `internal_docs/architecture.md`
+- `internal_docs/sifr_sysroot_and_stdlib_architecture.md`
+- `internal_docs/rust_interop_architecture.md`
+- `internal_docs/stdlib_retained_compiler_intrinsics.toml`
+- `plans/issues/active/**`
+- `plans/phases/**`
+
+Compiler manifest, sysroot, and dependency planning:
+
+- `crates/sifr_stdlib_model/**`
+- target `crates/sifr_stdlib_manifest/**` or `crates/sifr_sysroot_manifest/**`
+- target `crates/sifr_ipc/**` if IPC remains shared
+- `crates/sifr_driver/src/stdlib/**`
+- `crates/sifr_driver/src/build/**`
+- `crates/sifr_codegen/src/rust_interop_plan.rs`
+
+Lowering and declaration support:
+
+- `crates/sifr_lowering/src/lower/**`
+- `crates/sifr_hir/**`
+- `crates/sifr_type_system/**`
+- `stdlib/_sifr/*.sifr`
+- `stdlib/sifr/*.sifr`
+
+Codegen and retained compiler glue:
+
+- `crates/sifr_codegen/src/intrinsics/**`
+- `crates/sifr_codegen/src/preamble/**`
+- `crates/sifr_codegen/src/stdlib/**`
+- `crates/sifr_codegen/src/project/**`
+- `StdlibCode.module_rust_code` producers and consumers
+
+Runtime and stdlib crates:
+
+- `crates/sifr_stdlib/**`
+- `crates/sifr_runtime/**`
+
+Validation and guardrails:
+
+- `scripts/check_stdlib_native_intrinsic_allowlist.py`
+- `scripts/check_stdlib_migration_closure.py`
+- `scripts/check_sysroot_stdlib_resource_certification_gate.py`
+- `scripts/check_hir_maintainability_guardrails.py`
+- `scripts/check_file_size_guardrails.py`
+- `verification/areas/**`
+- `verification/runner/e2e/**`
+
+## Milestones
+
+### M0. Contract and Manifest State Foundation
+
+Lock the final boundary before code movement.
+
+Tasks:
+
+- Update architecture docs with the final stdlib/compiler/runtime boundary.
+- Extend the retained-glue manifest schema with migration states, owner or
+  issue fields, evidence links, registry entries, preamble entries, raw
+  injection entries, and certification rows.
+- Classify every existing retained surface as `retained`,
+  `retained-by-design`, `pilot`, `migrated`, or `closed`.
+- Add validation that every manifest entry has a valid state and every observed
+  compiler-native stdlib exception is owned exactly once.
+- Add validation that no `_sifr.*` family exists outside the manifest or the
+  migrated declaration inventory.
+- Record the sequential milestone order in this phase document and update
+  status after each milestone lands.
+
+Acceptance:
+
+- A reviewer can identify the owner and migration state for every retained
+  compiler-native stdlib surface from one manifest.
+- No second registry or informal checklist is needed to understand the
+  migration state.
+- `retained-by-design` entries are narrow compiler-language or harness glue,
+  not stdlib behavior.
+
+Validation:
+
+- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
+- `python3 scripts/check_stdlib_migration_closure.py --self-test`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- `python3 scripts/check_file_size_guardrails.py`
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M1. Manifest/Model Split and Bootstrap Ordering
+
+Turn the compiler-side stdlib model into a manifest/sysroot planning layer.
+
+Tasks:
+
+- Create or rename the final manifest crate as `sifr_stdlib_manifest` or
+  `sifr_sysroot_manifest`.
+- Move source inventory, private declaration inventory, import suggestions,
+  migration-state loading, feature planning, and sysroot validation into the
+  manifest layer.
+- Move IPC frame/schema/transport/request tracking/handshake metadata into
+  `sifr_ipc` if shared, or `sifr_runtime::ipc` if runtime-only.
+- Remove fallback intrinsic signature tables for any surface already marked
+  `migrated` or `closed`.
+- Add deterministic topological stdlib bootstrap ordering.
+- Reject cycles and forward references that would make private declarations
+  order-dependent or nondeterministic.
+- Ensure codegen, driver, LSP traces, build reports, and cache keys consume one
+  `SysrootDependencyPlan` rather than recomputing sysroot features.
+
+Acceptance:
+
+- The manifest layer has no stdlib behavior implementation.
+- IPC is no longer bundled into the stdlib manifest boundary.
+- Stdlib bootstrap order is deterministic and validated.
+- Migrated families cannot keep compiler fallback signatures.
+
+Validation:
+
+- Focused manifest/sysroot unit tests.
+- Focused driver stdlib bootstrap tests.
+- Generated Cargo snapshot tests.
+- `cargo test -p sifr_driver -- stdlib`
+- `cargo test -p sifr_codegen -- rust_interop_plan`
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M2. Declaration Infrastructure: Constants and Classes
+
+Make source declarations expressive enough to replace compiler signature tables.
+
+Tasks:
+
+- Add checked declaration support for constants used by private stdlib modules.
+- Add opaque resource declarations with nonforgeability and lifecycle metadata.
+- Add value class declarations for native-backed values that are not resources.
+- Add declaration support for methods, associated constructors, errors, and
+  module-level constants.
+- Move math and platform constants out of intrinsic constant Rust expressions
+  where they are stdlib behavior rather than language facts.
+- Add diagnostics for unsupported declaration forms instead of implicit
+  fallbacks.
+
+Acceptance:
+
+- Functions, constants, methods, errors, opaque resources, and value classes can
+  be represented in checked declaration source.
+- Private declaration files can express the shape needed by upcoming pilots.
+- Migrated constants do not require compiler intrinsic Rust expressions.
+
+Validation:
+
+- Focused lowering/type-system declaration tests.
+- Focused Rust interop declaration tests.
+- Representative `sifr emit` snapshots for constants, methods, and opaque
+  declarations.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M3. Provenance and Permanent Guardrails
+
+Prevent new compiler-native stdlib behavior while migration proceeds.
+
+Tasks:
+
+- Add structural provenance to `StdlibCode.module_rust_code` producers.
+- Permit compiled checked stdlib source output.
+- Reject handwritten stdlib Rust literals unless they are manifest-tracked
+  temporary exceptions.
+- Guard against new stdlib intrinsic dispatch entries.
+- Guard against new stdlib implementation preambles.
+- Guard against new direct third-party generated dependencies for stdlib
+  behavior.
+- Guard against empty private declaration modules once marked `migrated`.
+- Guard against private declaration targets outside approved sysroot crates.
+- Guard against fallback signature registries for `migrated` and `closed`
+  surfaces.
+
+Acceptance:
+
+- The compiler can still emit language and bridge glue.
+- New stdlib behavior cannot enter through codegen strings, preambles,
+  intrinsic dispatch, direct generated dependencies, or fallback registries.
+- The HTTP transport harness is tracked as a temporary exception until it moves
+  to verification-owned fixtures.
+
+Validation:
+
+- Guard self-tests for each forbidden path.
+- Negative tests for raw stdlib Rust injection.
+- Generated Cargo dependency snapshots.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M4. File Handle Opaque Resource Pilot
+
+Migrate the first resource-shaped stdlib family end to end.
+
+Tasks:
+
+- Implement the reusable opaque handle substrate needed by file handles in
+  `sifr_runtime`.
+- Implement file behavior and Sifr-facing errors in `crates/sifr_stdlib`.
+- Declare `FileHandle` and related operations in `stdlib/_sifr`.
+- Route public `sifr.io` wrappers through private declarations.
+- Migrate `builtin_open`, `builtin_open_text`, `open_file`, `file_read`,
+  `file_write`, close, byte operations, and related methods.
+- Prove handle nonforgeability, close poisoning, double-close behavior, and
+  panic-boundary conversion.
+- Delete migrated file-handle registry, preamble, and signature entries.
+- Mark the relevant manifest entries `pilot` during implementation and
+  `migrated` after deletion evidence lands.
+
+Acceptance:
+
+- File handles are source-declared opaque resources.
+- Public file APIs behave through `sifr_stdlib`, not compiler dispatch.
+- The old file-handle compiler path is gone for migrated operations.
+
+Validation:
+
+- Focused file/resource lifecycle tests.
+- Representative `sifr.io` demos.
+- Resource certification gate.
+- Retained-glue allowlist guard.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M5. Filesystem and Path Family
+
+Migrate stateless and handle-adjacent filesystem behavior after the file pilot.
+
+Tasks:
+
+- Move path, directory, glob, temporary directory, file copy, delete, rename,
+  walk, metadata, and text helpers into `sifr_stdlib`.
+- Declare filesystem functions and errors in `stdlib/_sifr/fs.sifr`.
+- Route `sifr.os`, `sifr.pathlib`, `sifr.glob`, `sifr.shutil`,
+  `sifr.tempfile`, and related wrappers through declarations.
+- Delete migrated `fs`, `io`, `pathlib`, and related intrinsic entries.
+- Keep only explicitly retained compiler-language or bridge glue.
+
+Acceptance:
+
+- Filesystem and path behavior is stdlib-owned.
+- Generated Cargo emits sysroot crate features only.
+- No migrated filesystem operation remains in intrinsic dispatch.
+
+Validation:
+
+- Focused fs/path tests.
+- Representative stdlib demos.
+- Generated Cargo feature snapshots.
+- Retained-glue and migration closure guards.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M6. Random, Time, and Logging
+
+Migrate stateful but non-handle families after resource declaration patterns are
+established.
+
+Tasks:
+
+- Move random module state, distributions, sampling, shuffling, and seeding
+  behavior into `sifr_stdlib`.
+- Move clock, formatting, parsing, sleeping, and struct-time compatibility
+  behavior into `sifr_stdlib`, using runtime substrate where needed.
+- Move global logging level behavior into `sifr_stdlib` or classify the exact
+  runtime observability substrate as `retained-by-design`.
+- Delete `random`, `time`, `logging`, and mixed preamble entries that are no
+  longer compiler-owned.
+
+Acceptance:
+
+- Random/time/logging public behavior routes through checked stdlib source and
+  sysroot interop.
+- Runtime-only substrate is narrow and explicitly classified.
+- The mixed IO/logging/random preamble is decomposed or deleted.
+
+Validation:
+
+- Deterministic random tests.
+- Clock/sleep tests with bounded timing assertions.
+- Logging state tests.
+- Retained-glue and migration closure guards.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M7. Simple Sys and Environment
+
+Migrate process environment and platform surfaces that do not require process
+resource handles.
+
+Tasks:
+
+- Move environment get/set/unset/items/keys/values into `sifr_stdlib`.
+- Move `get_args`, `getpid`, `which`, platform constants, separators, and
+  version strings into source declarations or classify them as
+  `retained-by-design` only when they are compiler facts.
+- Decide and document whether `sys_exit` is public stdlib behavior or
+  language/runtime termination glue.
+- Delete migrated environment and sys intrinsic entries.
+
+Acceptance:
+
+- Simple sys/env behavior is not compiler-dispatched.
+- Any retained sys entry has a precise compiler-owned reason.
+- Platform constants use declaration source where they are stdlib values.
+
+Validation:
+
+- Focused sys/env tests.
+- Generated Cargo feature snapshots.
+- Retained-glue and migration closure guards.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M8. Async Resource Pilot
+
+Prove async resource declarations before migrating async-heavy families.
+
+Tasks:
+
+- Add or harden async resource declaration support.
+- Prove cancellation, poisoning, join/drop semantics, blocking boundaries, and
+  panic conversion for an intentionally small async resource.
+- Update Rust interop certification evidence with executable lifecycle tests.
+- Keep the pilot isolated from process, network, TLS, and HTTP migration until
+  evidence lands.
+
+Acceptance:
+
+- Async resources have a checked declaration and lifecycle model.
+- Cancellation and drop behavior is deterministic and documented.
+- Resource certification can distinguish sync and async resource evidence.
+
+Validation:
+
+- Focused async resource tests.
+- Rust interop certification gate.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M9. Process Family
+
+Migrate process execution, child handles, pipes, and async process behavior.
+
+Tasks:
+
+- Implement process behavior and Sifr-facing errors in `sifr_stdlib`.
+- Keep low-level spawn, pipe, timeout, and async substrate in `sifr_runtime`.
+- Declare child handles, pipe handles, async child handles, and operations in
+  `stdlib/_sifr/process.sifr`.
+- Route public process wrappers through private declarations.
+- Delete process registry files and preambles after migration.
+- Prove timeout, kill, terminate, wait, output, pipe close, pipe read/write,
+  and async lifecycle semantics.
+
+Acceptance:
+
+- Process behavior is stdlib-owned.
+- Runtime owns only substrate.
+- No migrated process operation remains in intrinsic dispatch or preambles.
+
+Validation:
+
+- Focused process lifecycle tests.
+- Async process tests.
+- Resource certification gate.
+- Retained-glue and migration closure guards.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M10. Network and TLS Families
+
+Migrate TCP and TLS resources after async/process evidence is in place.
+
+Tasks:
+
+- Implement network and TLS behavior in `sifr_stdlib`.
+- Keep socket, reactor, TLS engine, certificate, and poisoning substrate in
+  `sifr_runtime`.
+- Declare listener, stream, split-half, TLS config, and TLS stream resources in
+  `stdlib/_sifr`.
+- Route public `sifr.net` and `sifr.tls` wrappers through declarations.
+- Delete network/TLS registry and preamble entries after migration.
+- Prove local/peer address, close, split, shutdown-write, read/write,
+  handshake, certificate, and error semantics.
+
+Acceptance:
+
+- Network and TLS public behavior is stdlib-owned.
+- Runtime substrate is narrow and reusable.
+- No migrated network/TLS operation remains in intrinsic dispatch or preambles.
+
+Validation:
+
+- Focused loopback network tests.
+- TLS fixture tests.
+- Resource certification gate.
+- Retained-glue and migration closure guards.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M11. HTTP Family and Harness Relocation
+
+Migrate HTTP behavior and remove compiler-owned harness injection.
+
+Tasks:
+
+- Implement HTTP behavior in `sifr_stdlib`.
+- Keep HTTP client runtime substrate in `sifr_runtime` only where reusable.
+- Declare HTTP resources, headers, requests, responses, and protocol operations
+  in `stdlib/_sifr/http.sifr`.
+- Move `sifr.http_transport` and related harness behavior into
+  verification-owned fixtures.
+- Delete HTTP prefix dispatch, registry entries, and preambles after migration.
+- Prove header validation, cookie parsing, HTTP/1, HTTP/2, transport, timeout,
+  redirect, body, and error semantics.
+
+Acceptance:
+
+- HTTP behavior is stdlib-owned.
+- Test harness behavior is not emitted as stdlib implementation code.
+- No HTTP prefix intrinsic remains in active dispatch.
+
+Validation:
+
+- Focused HTTP tests.
+- Verification-owned transport fixtures.
+- Generated Cargo dependency snapshots.
+- Retained-glue and migration closure guards.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M12. Callback and Subscription Pilot
+
+Prove callback-shaped interop before Python and signal closure.
+
+Tasks:
+
+- Add or harden callback/subscription declaration support.
+- Prove callback lifetime, cancellation, thread-safety, panic conversion,
+  reentrancy policy, and drop behavior.
+- Update resource and callback certification evidence.
+- Keep pilot evidence separate from Python and signal migration until complete.
+
+Acceptance:
+
+- Callback and subscription resources have checked declaration semantics.
+- Runtime callback substrate is explicitly bounded.
+- Certification evidence blocks unsafe callback migration attempts.
+
+Validation:
+
+- Focused callback lifecycle tests.
+- Rust interop callback certification gate.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M13. Python Interop Adapters
+
+Migrate Python adapter stdlib behavior while preserving Python runtime ownership.
+
+Tasks:
+
+- Move Python object wrapper policy and Sifr-facing adapter behavior into
+  `sifr_stdlib` where it is public stdlib behavior.
+- Keep CPython initialization, GIL/refcount substrate, thread handoff, and raw
+  callback machinery in the Python runtime layer.
+- Declare Python adapter operations in `stdlib/_sifr/python.sifr`.
+- Delete migrated `py_` prefix dispatch and local/threadsafe callback entries.
+- Prove callback, resource, zero-copy, blocking/offload, and error semantics.
+
+Acceptance:
+
+- Python stdlib adapter behavior is source-declared and stdlib-owned.
+- Runtime owns CPython substrate only.
+- No migrated Python adapter operation remains in intrinsic dispatch.
+
+Validation:
+
+- Python interop certification tests.
+- Callback/resource gates.
+- Retained-glue and migration closure guards.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M14. Task, Signal, Runtime Observability, and Test Helpers
+
+Finish the compiler/runtime boundary for surfaces that may stay partly
+compiler-owned.
+
+Tasks:
+
+- Classify task, signal, runtime observability, and test-helper surfaces as
+  migrated, closed, or `retained-by-design`.
+- Move public stdlib wrapper behavior into `sifr_stdlib`.
+- Keep language task machinery, generated test harness mechanics, exact-int
+  conversions, entrypoint wiring, and shared bridge glue compiler-owned.
+- Delete any task/signal/runtime/test intrinsic that is not retained by design.
+- Split or remove remaining preambles so by-design glue is not mixed with
+  stdlib behavior.
+
+Acceptance:
+
+- Retained-by-design entries are precise and stable.
+- Public stdlib behavior is not bundled with compiler harness or bridge glue.
+- Mixed preamble files are gone or contain only retained-by-design language
+  glue.
+
+Validation:
+
+- Focused task/signal/runtime observability tests.
+- Test harness tests.
+- Retained-glue and migration closure guards.
+- `scripts/run_all_tests.sh --profile create-pr`
+
+### M15. Final Closure
+
+Remove the transitional migration machinery.
+
+Tasks:
+
+- Delete remaining stdlib intrinsic dispatch and registry code that no longer
+  represents retained-by-design language glue.
+- Delete fallback intrinsic signature tables for all migrated or closed
+  surfaces.
+- Delete stdlib implementation preambles.
+- Delete handwritten stdlib Rust injection exceptions.
+- Delete direct generated third-party dependency paths for stdlib behavior.
+- Ensure every manifest entry is `migrated`, `closed`, or
+  `retained-by-design`.
+- Convert temporary migration guards into permanent no-regression guards.
+- Update architecture, roadmap, phases, and issue docs with final status and
+  merged PR links.
+
+Acceptance:
+
+- The stdlib implementation boundary matches the final stack exactly.
+- The compiler has no stdlib behavior implementation path.
+- All remaining compiler-owned entries are intentional language, bridge,
+  entrypoint, exact-int, test-harness, or runtime substrate glue.
+- The retained-glue manifest is exhaustive and has no `retained` or `pilot`
+  entries.
+
+Validation:
+
+- `cargo fmt --check`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- `python3 scripts/check_file_size_guardrails.py`
+- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
+- `python3 scripts/check_stdlib_migration_closure.py`
+- `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py`
+- `scripts/run_all_tests.sh --profile create-pr`
+- `scripts/run_all_tests.sh`
+
+## Per-Milestone Closeout Rules
+
+Each milestone must finish with:
+
+- docs updated with status, checklist state, and merged PR links,
+- focused tests for the changed compiler/stdlib/runtime behavior,
+- guardrail updates for any newly closed path,
+- `scripts/run_all_tests.sh --profile create-pr` before PR,
+- review and merge before starting the next milestone.
+
+The final milestone additionally runs the full merge gate with
+`scripts/run_all_tests.sh`.

--- a/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
+++ b/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
@@ -28,6 +28,23 @@ unsupported-by-design decision before any stable release claims that surface.
 - Proc-macro/build-script certification for `serde_derive` and `prost-build`.
 - Locked, offline, and frozen Cargo certification.
 
+## Handoff to Stdlib Native Boundary Completion
+
+The stdlib native boundary completion phase takes ownership of the
+stdlib-blocking certification rows it consumes:
+
+- `opaque_resource_matrix` when the file/resource migration lands.
+- `async_runtime_reqwest` when the async runtime pilot lands.
+- `callback_subscription_matrix` when the signal subscription pilot lands.
+- `callbacks_call_scoped` when the Python adapter migration lands.
+
+When one of those milestones starts, its PR updates the compatibility matrix
+`future_owner`, executable evidence, and milestone evidence table in
+`plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md`. This issue
+continues to own backend, database, messaging, CLI, native-link, proc-macro,
+locked/offline Cargo, and package-ecosystem certification rows that are not
+direct stdlib migration blockers.
+
 ## Required Evidence
 
 Each row must land with:

--- a/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
+++ b/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
@@ -30,20 +30,32 @@ unsupported-by-design decision before any stable release claims that surface.
 
 ## Handoff to Stdlib Native Boundary Completion
 
-The stdlib native boundary completion phase takes ownership of the
-stdlib-blocking certification rows it consumes:
+The stdlib native boundary completion phase takes ownership only of the narrow
+stdlib-blocking certification mechanics it proves. It must split broad matrix
+rows rather than reassigning ecosystem rows wholesale:
 
-- `opaque_resource_matrix` when the file/resource migration lands.
-- `async_runtime_reqwest` when the async runtime pilot lands.
-- `callback_subscription_matrix` when the signal subscription pilot lands.
-- `callbacks_call_scoped` when the Python adapter migration lands.
+- `opaque_resource_matrix` splits into stdlib-owned `opaque_resource_core` and
+  certification-owned `opaque_resource_ecosystem`.
+- `async_runtime_reqwest` splits into stdlib-owned `async_runtime_core` and the
+  certification-owned `async_runtime_reqwest` ecosystem loopback row.
+- `callback_subscription_matrix` splits into stdlib-owned
+  `callback_subscription_core` and certification-owned
+  `callback_subscription_ecosystem`.
+- `callbacks_call_scoped` may split into stdlib-owned
+  `callbacks_call_scoped_core` if the Python adapter migration proves only the
+  core callback lifetime mechanics.
+- `panic_boundary_wrapper_emission` remains certification-owned unless a stdlib
+  milestone needs generated panic-wrapper evidence; in that case the milestone
+  creates a narrow `panic_boundary_stdlib_core` row and leaves package wrapper
+  emission and mapper-panic fallback evidence here.
 
-When one of those milestones starts, its PR updates the compatibility matrix
-`future_owner`, executable evidence, and milestone evidence table in
+When one of those milestones starts, its PR updates the compatibility matrix,
+executable evidence, and milestone evidence table in
 `plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md`. This issue
-continues to own backend, database, messaging, CLI, native-link, proc-macro,
-locked/offline Cargo, and package-ecosystem certification rows that are not
-direct stdlib migration blockers.
+continues to own the ecosystem portions of split rows plus backend, database,
+messaging, CLI, native-link, proc-macro, locked/offline Cargo, and
+package-ecosystem certification rows that are not direct stdlib migration
+blockers.
 
 ## Required Evidence
 


### PR DESCRIPTION
## Summary

- Document the final stdlib boundary as checked Sifr source plus trusted sysroot Rust interop.
- Clarify the planned split from `sifr_stdlib_model` into a manifest/sysroot planning layer and a separate IPC home.
- Add migration-state metadata to the retained compiler-native stdlib glue manifest.
- Add a sequential ad hoc phase for completing the stdlib native boundary migration end to end.

## Impact

This is a planning and architecture update only. It defines the top-down path for removing stdlib behavior from compiler intrinsics, preambles, fallback signature tables, and handwritten Rust injection while keeping compiler-owned language/runtime glue explicit.

## Validation

Not run for this PR per request.