### PR TITLE
Harden retained stdlib manifest schema

### DIFF
--- a/internal_docs/stdlib_retained_compiler_intrinsics.toml
+++ b/internal_docs/stdlib_retained_compiler_intrinsics.toml
@@ -12,15 +12,15 @@
 # - retained-by-design: permanently compiler-owned language, bridge, entrypoint,
 #   exact-int, test-harness, or runtime substrate glue.
 #
-# `prefix_intrinsics` is a temporary compatibility field for the current
-# prefix-shaped dispatcher. The stdlib native boundary completion phase
-# exact-enumerates those dispatchers and removes this field from the final
-# manifest schema.
-schema_version = 1
+schema_version = 2
 
 [[surface]]
 id = "_sifr.sys"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/sys.sifr"]
 certification_rows = ["opaque_resource_matrix"]
 reason = "Process environment, argv, platform constants, and process-exit semantics remain compiler/runtime-owned pending the final retained-glue decision."
@@ -52,6 +52,10 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.fs"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/fs.sifr"]
 certification_rows = ["opaque_resource_matrix"]
 reason = "Filesystem paths, open handles, and IOError shaping remain compiler/runtime-owned until file-handle lifecycle certification is complete."
@@ -101,6 +105,9 @@ exact_intrinsics = [
 [[surface]]
 id = "generated-test-glue"
 state = "retained-by-design"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
 reason = "Sifr test assertions are generated harness glue, not public stdlib-native behavior."
 registry_files = ["test.rs"]
 exact_intrinsics = [
@@ -116,6 +123,9 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.collections::counter_defaultdict"
 state = "retained-by-design"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
 declaration_files = ["stdlib/_sifr/collections.sifr"]
 reason = "Counter/defaultdict semantics and core collection behavior remain language-owned after helper-leaf migration."
 registry_files = [
@@ -137,6 +147,10 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.http::header_helpers"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/http.sifr"]
 certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
 reason = "HTTP protocol and header helper shims still route through generated glue while the HTTP stdlib migration is pending."
@@ -148,12 +162,17 @@ exact_intrinsics = [
   "http_parse_cookie_header",
   "http_validate_header_name",
   "http_validate_header_value",
+  "http_validate_method",
+  "http_validate_status",
+  "http_validate_version",
 ]
-prefix_intrinsics = ["http_"]
 
 [[surface]]
 id = "_sifr.encoding::utf8_bytes_string_glue"
 state = "retained-by-design"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
 declaration_files = ["stdlib/_sifr/encoding.sifr"]
 reason = "UTF-8 encode/decode result glue is tied to first-class bytes/string wrapper behavior and shared runtime error shaping."
 registry_files = ["encoding.rs"]
@@ -167,6 +186,9 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.bytes::first_class_constructors"
 state = "retained-by-design"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
 declaration_files = ["stdlib/_sifr/bytes.sifr"]
 reason = "First-class bytes constructors, strict hex parsing/formatting, and method glue remain compiler-language behavior."
 registry_files = ["bytes.rs"]
@@ -180,6 +202,10 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.time"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/time.sifr"]
 certification_rows = ["async_runtime_reqwest"]
 reason = "Clock, sleep, and struct_time compatibility glue remains runtime-sensitive until async/runtime certification closes."
@@ -204,6 +230,10 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.crypto::random"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/crypto.sifr"]
 certification_rows = ["opaque_resource_matrix"]
 reason = "Random module state and random distribution helpers remain compiler/runtime-owned until resource/state semantics are certified."
@@ -226,6 +256,10 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.process"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/process.sifr"]
 certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
 reason = "Process children, pipes, shell execution, async process handles, and timeout behavior remain resource/runtime-owned pending certification."
@@ -287,6 +321,10 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.net"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/net.sifr"]
 certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
 reason = "Network handles and split stream lifecycle behavior remain resource/runtime-owned pending certification."
@@ -318,16 +356,50 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.tls"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/tls.sifr"]
 certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
 reason = "TLS configuration, handshakes, stream handles, and certificate state remain resource/runtime-owned pending certification."
 registry_files = ["tls.rs"]
 preamble_files = ["tls_runtime.rs"]
-prefix_intrinsics = ["tls_"]
+exact_intrinsics = [
+  "tls_accept",
+  "tls_client_config_close",
+  "tls_client_config_platform",
+  "tls_client_config_with_roots",
+  "tls_client_config_with_roots_and_client_auth",
+  "tls_connect",
+  "tls_read_half_close",
+  "tls_read_half_read_chunk",
+  "tls_server_config",
+  "tls_server_config_close",
+  "tls_server_config_require_client_auth",
+  "tls_stream_alpn_protocol",
+  "tls_stream_close",
+  "tls_stream_close_notify",
+  "tls_stream_flush",
+  "tls_stream_protocol_version",
+  "tls_stream_read_chunk",
+  "tls_stream_split",
+  "tls_stream_write",
+  "tls_stream_write_all",
+  "tls_write_half_close",
+  "tls_write_half_close_notify",
+  "tls_write_half_flush",
+  "tls_write_half_write",
+  "tls_write_half_write_all",
+]
 
 [[surface]]
 id = "_sifr.signal"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/signal.sifr"]
 certification_rows = ["callback_subscription_matrix"]
 reason = "Signal streams and shutdown coordination remain runtime-sensitive pending callback/resource certification."
@@ -341,6 +413,9 @@ exact_intrinsics = [
 [[surface]]
 id = "_sifr.runtime::observability_glue"
 state = "retained-by-design"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
 declaration_files = ["stdlib/_sifr/runtime.sifr"]
 reason = "Runtime diagnostics and observability metadata are retained compiler/runtime glue rather than stdlib leaf behavior."
 registry_files = ["runtime.rs"]
@@ -349,6 +424,10 @@ exact_intrinsics = ["runtime_emit_diagnostic"]
 [[surface]]
 id = "_sifr.python"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/python.sifr"]
 certification_rows = [
   "opaque_resource_matrix",
@@ -357,12 +436,88 @@ certification_rows = [
 ]
 reason = "Python object handles, callback adapters, and runtime initialization remain behind Python resource/callback certification."
 registry_files = ["python.rs"]
-exact_intrinsics = ["local_callback", "threadsafe_callback"]
-prefix_intrinsics = ["py_"]
+exact_intrinsics = [
+  "local_callback",
+  "py_arrow_array",
+  "py_arrow_schema",
+  "py_arrow_stream",
+  "py_buffer_u8",
+  "py_call",
+  "py_call_attr",
+  "py_close",
+  "py_close_callback",
+  "py_copy_buffer_u8",
+  "py_copy_dict_str_bool",
+  "py_copy_dict_str_bytes",
+  "py_copy_dict_str_float",
+  "py_copy_dict_str_i32",
+  "py_copy_dict_str_int",
+  "py_copy_dict_str_str",
+  "py_copy_dict_str_u8",
+  "py_copy_list_bool",
+  "py_copy_list_bytes",
+  "py_copy_list_float",
+  "py_copy_list_i32",
+  "py_copy_list_int",
+  "py_copy_list_str",
+  "py_copy_list_u8",
+  "py_copy_record_fields",
+  "py_copy_tuple_bool",
+  "py_copy_tuple_bytes",
+  "py_copy_tuple_float",
+  "py_copy_tuple_i32",
+  "py_copy_tuple_int",
+  "py_copy_tuple_str",
+  "py_copy_tuple_u8",
+  "py_dlpack_tensor",
+  "py_enter_context",
+  "py_exit_context",
+  "py_exit_context_with_error",
+  "py_from_bool",
+  "py_from_bytes",
+  "py_from_dict_str",
+  "py_from_float",
+  "py_from_int",
+  "py_from_list",
+  "py_from_none",
+  "py_from_record",
+  "py_from_str",
+  "py_from_tuple",
+  "py_get_attr",
+  "py_get_item_str",
+  "py_import_module",
+  "py_local_callback_echo",
+  "py_release_arrow",
+  "py_release_buffer",
+  "py_release_dlpack",
+  "py_resource_diagnostics",
+  "py_run_coroutine_blocking",
+  "py_threadsafe_callback_echo",
+  "py_to_bool",
+  "py_to_bytes",
+  "py_to_float",
+  "py_to_i16",
+  "py_to_i32",
+  "py_to_i64",
+  "py_to_i8",
+  "py_to_int",
+  "py_to_isize",
+  "py_to_none",
+  "py_to_str",
+  "py_to_u16",
+  "py_to_u32",
+  "py_to_u64",
+  "py_to_u8",
+  "py_to_usize",
+  "threadsafe_callback",
+]
 
 [[surface]]
 id = "_sifr.task::language_runtime_glue"
 state = "retained-by-design"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
 declaration_files = ["stdlib/_sifr/task.sifr"]
 reason = "Task, cancellation, offload, join-set, and context propagation semantics are language/runtime glue."
 registry_files = ["task.rs"]
@@ -379,6 +534,10 @@ exact_intrinsics = ["task_current_context"]
 [[surface]]
 id = "_sifr.logging"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 declaration_files = ["stdlib/_sifr/logging.sifr"]
 certification_rows = ["callback_subscription_matrix"]
 reason = "Global logging level state remains compiler/runtime glue until final observability ownership is settled."
@@ -388,17 +547,27 @@ exact_intrinsics = ["get_global_level", "set_global_level"]
 [[surface]]
 id = "generated-feature-planning-glue"
 state = "retained-by-design"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
 reason = "Additional feature planning is compiler-owned glue that selects retained runtime/sysroot dependencies for generated projects."
 registry_files = ["requirements.rs"]
 
 [[surface]]
 id = "shared-language-preamble"
 state = "retained-by-design"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
 reason = "Generated Rust type conversion and error wrapper helpers are shared language/runtime glue."
 preamble_files = ["types_and_errors.rs"]
 
 [[surface]]
 id = "mixed-io-logging-random-preamble"
 state = "retained"
+owner = "stdlib-native-boundary-completion"
+issue = "stdlib-native-boundary-completion"
+evidence_links = ["stdlib-native-boundary-completion"]
+removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]
 reason = "Legacy generated preamble file contains mixed IOError, file-handle, logging, and random module state glue pending final decomposition."
 preamble_files = ["io_logging_random.rs"]

--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -323,6 +323,12 @@ Tasks:
 - Ensure codegen, driver, LSP traces, build reports, and cache keys consume one
   `SysrootDependencyPlan` rather than recomputing sysroot features.
 
+M1 may land as ordered sub-PRs:
+
+- M1a: harden retained-glue manifest schema, remove manifest prefix concepts,
+  exact-enumerate current prefix-dispatched retained surfaces, and route
+  certification gating through manifest `certification_rows` (PR #2829).
+
 Acceptance:
 
 - A reviewer can identify the owner and migration state for every retained

--- a/plans/reviews/active/stdlib-native-boundary-m1a-manifest-schema-review-pass1.md
+++ b/plans/reviews/active/stdlib-native-boundary-m1a-manifest-schema-review-pass1.md
@@ -1,0 +1,46 @@
+## Review findings
+
+### Blockers
+
+**1. `evidence_links` is not actually required by the schema validator, contrary to the stated intent** (`require owner/issue/reason/evidence`)
+- File: `scripts/check_stdlib_manifest_schema.py:87-98`
+- The `owner`, `issue`, `reason` fields are enforced via `_required_text`, but `evidence_links` is only run through `_optional_string_list` (line 90-98), which returns silently when the key is absent AND accepts an empty list.
+- Failure scenario I reproduced: a manifest surface entry with `owner`, `issue`, `reason`, `removal_criteria`, `registry_files` but **no** `evidence_links` (or `evidence_links = []`) passes `_validate`. So a new retained row can land with zero provenance and the guard says PASS.
+- Fix: add `evidence_links` to the required set, and enforce non-empty (either by a `_required_string_list` helper or by requiring the key + rejecting empty).
+
+**2. New guard script not registered in `verification/policy/guardrails.json`**
+- File: `verification/policy/guardrails.json:52-66`
+- Precedent from `c5e15e074` (stdlib native intrinsic allowlist) and `ed8b7f0ae` (stdlib migration closure) is that new stdlib guards land in both `profile_runner.py` and this policy inventory. `check_stdlib_manifest_schema.py` is only wired into `profile_runner.py:356-358`; the policy inventory is now out of sync.
+- Failure scenario: an operator consulting the policy manifest as the canonical guardrail list misses the new schema gate, and any tooling that snapshots/publishes this inventory loses coverage.
+- Fix: append a `{"name": "stdlib-manifest-schema", "entrypoint": "scripts/check_stdlib_manifest_schema.py", ...}` entry.
+
+### Non-blocking findings
+
+**3. Removing `PREFIX_INTRINSIC_RE` also removed the guard against *new* `starts_with("...")` dispatchers appearing in `registry.rs`**
+- File: `scripts/check_stdlib_native_intrinsic_allowlist.py:22-27`, cross-ref `crates/sifr_codegen/src/intrinsics/registry.rs:401-425`
+- Observation now consists of (a) exact-arm regex in `registry.rs` plus (b) exact match arms inside three hardcoded lowerer files. If a future PR adds e.g. `name if name.starts_with("s3_") => s3::lower_s3_intrinsic(...)` with a new lowerer module, the guard is silent — none of the new intrinsic names are observed and no allowlist entry is required.
+- Suggested defensive fix (does not need to block M1a but should be tracked): assert in the guard that the only `starts_with("<x>_")` occurrences in `registry.rs` are the three known ones (`tls_`, `http_`, `py_`), and hard-fail on any new prefix. This keeps the "no new native surface without allowlisting" invariant even if a subsequent lowerer is prefix-shaped.
+
+**4. `LOWERER_MATCH_INTRINSIC_RE` does not handle pipe-chained match arms**
+- File: `scripts/check_stdlib_native_intrinsic_allowlist.py:22`
+- The regex `r'"([A-Za-z0-9_]+)"\s*=>'` catches only the last name in an arm like `"tls_a" | "tls_b" => lower_x(args)`. No such arms exist today in `tls.rs` / `url_http.rs` / `python.rs`, but if someone consolidates arms (mirroring the `"local_callback" | "threadsafe_callback"` shape already used in `registry.rs:426`), the leading names silently drop out of the observed set.
+- Suggested fix: use the same lookahead as `EXACT_INTRINSIC_RE`, i.e. `r'"([A-Za-z0-9_]+)"\s*(?=\||=>)'`.
+
+**5. `removal_criteria` is uniformly boilerplate on every retained row**
+- File: `internal_docs/stdlib_retained_compiler_intrinsics.toml`
+- Every non-`retained-by-design` row currently uses the identical string `"Migrate or classify this retained compiler-native surface before M13 final closure."`, and every row uses the identical `owner` and `evidence_links`. The schema landing is fine, but the metadata carries no per-row signal today. Subsequent milestones should populate row-specific criteria. Not blocking M1a since the field is now required by schema, but worth noting in the follow-up plan so the fields don't stay as decorative constants.
+
+### Positive observations
+
+- Schema self-test verifies rejection of `prefix_intrinsics`, missing `removal_criteria`, and invalid `state` values (`scripts/check_stdlib_manifest_schema.py:178-193`). Good.
+- Exact enumeration of `tls_*`, `http_*`, `py_*` was cross-verified: manifest counts (25 tls / 8 http / 73 python) match the match arms in `tls.rs:298-330`, `url_http.rs:69-80`, and `python.rs:3-84`.
+- Guard `PASS` output shows 276 exact intrinsics and 20 surfaces, confirming end-to-end wiring.
+- Profile-runner placement (`verification/runner/sifr_verify/profile_runner.py:356-358`) is sensible — schema runs between allowlist and migration closure, matching the logical dependency.
+
+### Untested before PR
+
+- `scripts/run_all_tests.sh --profile create-pr` has not been run yet on this branch per the summary. That is the authoritative gate and must pass before merge.
+
+---
+
+NEEDS_CHANGES — concrete blockers: (1) enforce `evidence_links` in `scripts/check_stdlib_manifest_schema.py` (add to required fields and reject empty), and (2) register `check_stdlib_manifest_schema.py` in `verification/policy/guardrails.json`. Also run the full `scripts/run_all_tests.sh --profile create-pr` before opening the PR.

--- a/plans/reviews/active/stdlib-native-boundary-m1a-manifest-schema-review-pass2.md
+++ b/plans/reviews/active/stdlib-native-boundary-m1a-manifest-schema-review-pass2.md
@@ -1,0 +1,38 @@
+## Findings
+
+I reviewed the working-tree diff against `main` and the pass‑1 review artifact against the current state.
+
+**Blocker 1 — `evidence_links` required non-empty: FIXED**
+- `scripts/check_stdlib_manifest_schema.py:90` now uses `_required_string_list`, which rejects both missing key and empty list (helper at `:148-158` — the `not isinstance(value, list) or not value` guard covers both).
+- Self-test coverage added at `:198-205` (pops `evidence_links` and asserts the "must be a non-empty list" failure).
+- Manifest content is consistent: every one of the 20 surfaces carries `evidence_links = ["stdlib-native-boundary-completion"]`, including all `retained-by-design` entries.
+
+**Blocker 2 — guardrails.json registration: FIXED**
+- `verification/policy/guardrails.json:60-66` registers `stdlib-manifest-schema` with the correct entrypoint, mirroring `stdlib-native-intrinsic-allowlist` (no `--self-test` in the policy inventory; self-test runs from `profile_runner.py:357`, matching precedent).
+
+**Defensive 3 — pipe-chained lowerer match arms: FIXED**
+- `scripts/check_stdlib_native_intrinsic_allowlist.py:22` uses the lookahead `(?=\||=>)`, matching `EXACT_INTRINSIC_RE`. Consolidated arms `"a" | "b" =>` in `tls.rs` / `url_http.rs` / `python.rs` will now yield both names.
+
+**Defensive 4 — untracked prefix dispatchers rejected: FIXED**
+- `scripts/check_stdlib_native_intrinsic_allowlist.py:24` pins `EXPECTED_PREFIX_DISPATCHERS = {"http_", "py_", "tls_"}`; validation flags both unexpected and stale prefixes at `:126-138`.
+- `registry.rs:401,405,422` still shows exactly those three `starts_with` arms — invariant preserved.
+- Self-test at `:247-257` confirms an added `s3_` is rejected.
+
+**Create-pr taxonomy — FIXED**
+- Manifest self-test at `scripts/check_stdlib_manifest_schema.py:172-190` uses the stable id `stdlib-native-boundary-completion` and neutral removal wording (`"migration lands"`), no active-plan paths or delivery-plan terms.
+
+**Live guard runs (spot-checked in this session):**
+- `check_stdlib_manifest_schema.py` main + `--self-test`: PASS (20 surfaces, schema_version=2).
+- `check_stdlib_native_intrinsic_allowlist.py` main + `--self-test`: PASS (276 exact intrinsics, 28 registry files, 16 preamble files).
+- `check_sysroot_stdlib_resource_certification_gate.py` main + `--self-test`: PASS (11 surfaces, 11 future_runtime_rows).
+
+**Scope note (non-blocking) — certification gate refactor is in-diff but not in the summary**
+- `scripts/check_sysroot_stdlib_resource_certification_gate.py:20-33` removes the hardcoded `SURFACE_CERTIFICATION_ROWS` constant and derives surface→row mappings from the retained manifest (`_surface_certification_rows` at `:82-116`). Not mentioned in the pass‑2 summary, but it is a reasonable direct consumer-of-manifest change within the M1a wave.
+- Row-ID coverage is equivalent to the prior constants (`opaque_resource_matrix`, `async_runtime_reqwest`, `callback_subscription_matrix`, `callbacks_call_scoped` all still assert), and the manifest carries the same 11 surfaces that map to those rows. Self-test coverage added at `:184-190` for a malformed manifest. No regression identified.
+
+**Observations that are not blockers but flagged for later milestones (from pass‑1 finding 5, still present)**
+- `internal_docs/stdlib_retained_compiler_intrinsics.toml`: every retained (non-by-design) row uses the identical `removal_criteria = ["Migrate or classify this retained compiler-native entry before final audit."]`, and every row uses the identical `owner`, `issue`, and `evidence_links = ["stdlib-native-boundary-completion"]`. Schema landing is fine; per-row signal should be populated by subsequent M1 sub-waves.
+
+## Verdict
+
+**READY** — all pass‑1 blockers and defensive suggestions are addressed, create-pr taxonomy is green, and no new blockers surfaced in pass‑2. M1a stands as a self-contained schema/allowlist sub-wave; the certification-gate manifest-derivation is a natural consumer update that does not require additional M1 work.

--- a/scripts/check_stdlib_manifest_schema.py
+++ b/scripts/check_stdlib_manifest_schema.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Validate the retained compiler-native stdlib glue manifest schema."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "internal_docs" / "stdlib_retained_compiler_intrinsics.toml"
+
+EXPECTED_SCHEMA_VERSION = 2
+ALLOWED_TOP_LEVEL_FIELDS = {"schema_version", "surface"}
+ALLOWED_SURFACE_FIELDS = {
+    "id",
+    "state",
+    "owner",
+    "issue",
+    "removal_criteria",
+    "evidence_links",
+    "declaration_files",
+    "certification_rows",
+    "reason",
+    "registry_files",
+    "preamble_files",
+    "exact_intrinsics",
+}
+VALID_STATES = {"retained", "pilot", "closing", "retained-by-design"}
+
+
+def main() -> int:
+    manifest = tomllib.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    failures = _validate(manifest)
+    if failures:
+        print("stdlib retained manifest schema: FAIL")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print(
+        "stdlib retained manifest schema: PASS "
+        f"(surfaces={len(manifest.get('surface', []))}, schema_version={EXPECTED_SCHEMA_VERSION})"
+    )
+    return 0
+
+
+def _validate(manifest: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+
+    unknown_top_level = sorted(set(manifest) - ALLOWED_TOP_LEVEL_FIELDS)
+    if unknown_top_level:
+        failures.append(f"unknown top-level fields: {', '.join(unknown_top_level)}")
+
+    if manifest.get("schema_version") != EXPECTED_SCHEMA_VERSION:
+        failures.append(f"schema_version must be {EXPECTED_SCHEMA_VERSION}")
+
+    surfaces = manifest.get("surface")
+    if not isinstance(surfaces, list) or not surfaces:
+        failures.append("surface must contain at least one [[surface]] table")
+        return failures
+
+    ids: set[str] = set()
+    for index, surface in enumerate(surfaces):
+        context = f"surface entry {index}"
+        if not isinstance(surface, dict):
+            failures.append(f"{context}: must be a table")
+            continue
+
+        unknown_fields = sorted(set(surface) - ALLOWED_SURFACE_FIELDS)
+        if unknown_fields:
+            failures.append(f"{context}: unknown fields: {', '.join(unknown_fields)}")
+
+        surface_id = _required_text(failures, surface, "id", context)
+        if surface_id:
+            context = surface_id
+            if surface_id in ids:
+                failures.append(f"{context}: duplicate surface id")
+            ids.add(surface_id)
+
+        state = _required_text(failures, surface, "state", context)
+        if state and state not in VALID_STATES:
+            failures.append(f"{context}: state must be one of {', '.join(sorted(VALID_STATES))}")
+
+        for key in ("owner", "issue", "reason"):
+            _required_text(failures, surface, key, context)
+
+        _required_string_list(failures, surface, "evidence_links", context)
+
+        for key in (
+            "declaration_files",
+            "certification_rows",
+            "registry_files",
+            "preamble_files",
+            "exact_intrinsics",
+        ):
+            _optional_string_list(failures, surface, key, context)
+
+        removal_criteria = surface.get("removal_criteria")
+        if state != "retained-by-design":
+            if not isinstance(removal_criteria, list) or not removal_criteria:
+                failures.append(f"{context}: removal_criteria is required for state {state}")
+            else:
+                _string_list_entries(failures, removal_criteria, "removal_criteria", context)
+        elif removal_criteria is not None:
+            _optional_string_list(failures, surface, "removal_criteria", context)
+
+        has_owned_surface = any(
+            surface.get(key)
+            for key in ("registry_files", "preamble_files", "exact_intrinsics")
+        )
+        if not has_owned_surface:
+            failures.append(f"{context}: must own registry_files, preamble_files, or exact_intrinsics")
+
+    return failures
+
+
+def _required_text(
+    failures: list[str],
+    table: dict[str, Any],
+    key: str,
+    context: str,
+) -> str:
+    value = table.get(key)
+    if not isinstance(value, str) or not value.strip():
+        failures.append(f"{context}: {key} must be a non-empty string")
+        return ""
+    return value.strip()
+
+
+def _optional_string_list(
+    failures: list[str],
+    table: dict[str, Any],
+    key: str,
+    context: str,
+) -> None:
+    if key not in table:
+        return
+    value = table[key]
+    if not isinstance(value, list):
+        failures.append(f"{context}: {key} must be a list")
+        return
+    _string_list_entries(failures, value, key, context)
+
+
+def _required_string_list(
+    failures: list[str],
+    table: dict[str, Any],
+    key: str,
+    context: str,
+) -> None:
+    value = table.get(key)
+    if not isinstance(value, list) or not value:
+        failures.append(f"{context}: {key} must be a non-empty list")
+        return
+    _string_list_entries(failures, value, key, context)
+
+
+def _string_list_entries(
+    failures: list[str],
+    value: list[Any],
+    key: str,
+    context: str,
+) -> None:
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            failures.append(f"{context}: {key} entries must be non-empty strings")
+
+
+def _self_test() -> int:
+    manifest = {
+        "schema_version": EXPECTED_SCHEMA_VERSION,
+        "surface": [
+            {
+                "id": "_sifr.example",
+                "state": "retained",
+                "owner": "stdlib-native-boundary-completion",
+                "issue": "stdlib-native-boundary-completion",
+                "removal_criteria": ["migration lands"],
+                "evidence_links": ["stdlib-native-boundary-completion"],
+                "reason": "test fixture",
+                "registry_files": ["example.rs"],
+            }
+        ],
+    }
+    if _validate(manifest):
+        print("self-test seed should pass", file=sys.stderr)
+        return 1
+
+    unknown = json.loads(json.dumps(manifest))
+    unknown["surface"][0]["prefix_intrinsics"] = ["example_"]
+    if not any("unknown fields: prefix_intrinsics" in failure for failure in _validate(unknown)):
+        print("self-test unknown surface field was not rejected", file=sys.stderr)
+        return 1
+
+    missing_evidence = json.loads(json.dumps(manifest))
+    missing_evidence["surface"][0].pop("evidence_links")
+    if not any(
+        "evidence_links must be a non-empty list" in failure
+        for failure in _validate(missing_evidence)
+    ):
+        print("self-test missing evidence links were not rejected", file=sys.stderr)
+        return 1
+
+    missing_removal = json.loads(json.dumps(manifest))
+    missing_removal["surface"][0].pop("removal_criteria")
+    if not any("removal_criteria is required" in failure for failure in _validate(missing_removal)):
+        print("self-test missing removal criteria was not rejected", file=sys.stderr)
+        return 1
+
+    bad_state = json.loads(json.dumps(manifest))
+    bad_state["surface"][0]["state"] = "done"
+    if not any("state must be one of" in failure for failure in _validate(bad_state)):
+        print("self-test bad state was not rejected", file=sys.stderr)
+        return 1
+
+    print("stdlib retained manifest schema self-test: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--self-test"]:
+        raise SystemExit(_self_test())
+    raise SystemExit(main())

--- a/scripts/check_stdlib_native_intrinsic_allowlist.py
+++ b/scripts/check_stdlib_native_intrinsic_allowlist.py
@@ -19,7 +19,14 @@ REGISTRY_DISPATCH_PATH = (
 PREAMBLE_ROOT = REPO_ROOT / "crates" / "sifr_codegen" / "src" / "preamble"
 
 EXACT_INTRINSIC_RE = re.compile(r'"([A-Za-z0-9_]+)"\s*(?=\||=>)')
+LOWERER_MATCH_INTRINSIC_RE = re.compile(r'"([A-Za-z0-9_]+)"\s*(?=\||=>)')
 PREFIX_INTRINSIC_RE = re.compile(r'starts_with\("([A-Za-z0-9_]+)"\)')
+EXPECTED_PREFIX_DISPATCHERS = {"http_", "py_", "tls_"}
+PREFIX_DISPATCH_LOWERERS = (
+    REGISTRY_ROOT / "tls.rs",
+    REGISTRY_ROOT / "url_http.rs",
+    REGISTRY_ROOT / "python.rs",
+)
 
 
 def main() -> int:
@@ -39,7 +46,6 @@ def _run(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> int:
     print(
         "stdlib native intrinsic allowlist guard: PASS "
         f"(exact_intrinsics={len(observed['exact_intrinsics'])}, "
-        f"prefix_intrinsics={len(observed['prefix_intrinsics'])}, "
         f"registry_files={len(observed['registry_files'])}, "
         f"preamble_files={len(observed['preamble_files'])})"
     )
@@ -48,9 +54,14 @@ def _run(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> int:
 
 def _observed_surface() -> dict[str, set[str]]:
     registry_text = REGISTRY_DISPATCH_PATH.read_text(encoding="utf-8")
+    exact_intrinsics = set(EXACT_INTRINSIC_RE.findall(registry_text))
+    for lowerer_path in PREFIX_DISPATCH_LOWERERS:
+        exact_intrinsics.update(
+            LOWERER_MATCH_INTRINSIC_RE.findall(lowerer_path.read_text(encoding="utf-8"))
+        )
     return {
-        "exact_intrinsics": set(EXACT_INTRINSIC_RE.findall(registry_text)),
-        "prefix_intrinsics": set(PREFIX_INTRINSIC_RE.findall(registry_text)),
+        "exact_intrinsics": exact_intrinsics,
+        "prefix_dispatchers": set(PREFIX_INTRINSIC_RE.findall(registry_text)),
         "registry_files": {
             path.relative_to(REGISTRY_ROOT).as_posix()
             for path in REGISTRY_ROOT.rglob("*.rs")
@@ -66,7 +77,6 @@ def _validate(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> list[
     failures: list[str] = []
     allowed = {
         "exact_intrinsics": set[str](),
-        "prefix_intrinsics": set[str](),
         "registry_files": set[str](),
         "preamble_files": set[str](),
     }
@@ -113,7 +123,23 @@ def _validate(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> list[
         if not has_items:
             failures.append(f"{surface_id}: allowlist entry has no retained files or intrinsics")
 
+    prefix_dispatchers = observed.get("prefix_dispatchers", set())
+    unexpected_prefixes = sorted(prefix_dispatchers - EXPECTED_PREFIX_DISPATCHERS)
+    stale_prefixes = sorted(EXPECTED_PREFIX_DISPATCHERS - prefix_dispatchers)
+    if unexpected_prefixes:
+        failures.append(
+            "registry.rs contains untracked prefix dispatchers: "
+            + ", ".join(unexpected_prefixes)
+        )
+    if stale_prefixes:
+        failures.append(
+            "expected prefix dispatchers are missing from registry.rs: "
+            + ", ".join(stale_prefixes)
+        )
+
     for key, observed_values in observed.items():
+        if key not in allowed:
+            continue
         _compare_sets(failures, key, observed_values, allowed[key])
 
     return failures
@@ -169,7 +195,7 @@ def _compare_sets(
 def _self_test() -> int:
     observed = {
         "exact_intrinsics": {"alpha"},
-        "prefix_intrinsics": {"beta_"},
+        "prefix_dispatchers": EXPECTED_PREFIX_DISPATCHERS,
         "registry_files": {"alpha.rs"},
         "preamble_files": {"runtime.rs"},
     }
@@ -179,7 +205,6 @@ def _self_test() -> int:
                 "id": "test-retained-glue",
                 "reason": "language-owned test fixture",
                 "exact_intrinsics": ["alpha"],
-                "prefix_intrinsics": ["beta_"],
                 "registry_files": ["alpha.rs"],
                 "preamble_files": ["runtime.rs"],
             }
@@ -199,12 +224,12 @@ def _self_test() -> int:
         return 1
 
     stale = json.loads(json.dumps(allowlist))
-    stale["surface"][0]["prefix_intrinsics"].append("stale_")
+    stale["surface"][0]["registry_files"].append("stale.rs")
     if not any(
-        "prefix_intrinsics has stale allowlist entries: stale_" in failure
+        "registry_files has stale allowlist entries: stale.rs" in failure
         for failure in _validate(observed, stale)
     ):
-        print("self-test stale prefix intrinsic was not rejected", file=sys.stderr)
+        print("self-test stale registry file was not rejected", file=sys.stderr)
         return 1
 
     duplicate = json.loads(json.dumps(allowlist))
@@ -217,6 +242,18 @@ def _self_test() -> int:
     )
     if not any("is duplicated" in failure for failure in _validate(observed, duplicate)):
         print("self-test duplicate allowlist entry was not rejected", file=sys.stderr)
+        return 1
+
+    new_prefix_observed = json.loads(
+        json.dumps({key: sorted(value) for key, value in observed.items()})
+    )
+    new_prefix_observed["prefix_dispatchers"].append("s3_")
+    new_prefix_observed = {key: set(value) for key, value in new_prefix_observed.items()}
+    if not any(
+        "untracked prefix dispatchers: s3_" in failure
+        for failure in _validate(new_prefix_observed, allowlist)
+    ):
+        print("self-test untracked prefix dispatcher was not rejected", file=sys.stderr)
         return 1
 
     missing_reason = json.loads(json.dumps(allowlist))

--- a/scripts/check_sysroot_stdlib_resource_certification_gate.py
+++ b/scripts/check_sysroot_stdlib_resource_certification_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -17,35 +18,19 @@ MATRIX_PATH = (
     / "data"
     / "rust_interop_compatibility_matrix.json"
 )
+MANIFEST_PATH = REPO_ROOT / "internal_docs" / "stdlib_retained_compiler_intrinsics.toml"
 CERTIFICATION_ISSUE = "plans/issues/active/rust-interop-runtime-ecosystem-certification.md"
 FUTURE_OWNED = "future-owned-by-separate-phase"
-
-SURFACE_CERTIFICATION_ROWS: dict[str, tuple[str, ...]] = {
-    "_sifr.crypto": ("opaque_resource_matrix",),
-    "_sifr.time": ("async_runtime_reqwest",),
-    "_sifr.logging": ("callback_subscription_matrix",),
-    "_sifr.fs": ("opaque_resource_matrix",),
-    "_sifr.process": ("opaque_resource_matrix", "async_runtime_reqwest"),
-    "_sifr.sys": ("opaque_resource_matrix",),
-    "_sifr.signal": ("callback_subscription_matrix",),
-    "_sifr.net": ("opaque_resource_matrix", "async_runtime_reqwest"),
-    "_sifr.tls": ("opaque_resource_matrix", "async_runtime_reqwest"),
-    "_sifr.http": ("opaque_resource_matrix", "async_runtime_reqwest"),
-    "_sifr.python": (
-        "opaque_resource_matrix",
-        "callbacks_call_scoped",
-        "callback_subscription_matrix",
-    ),
-}
 
 
 def main() -> int:
     matrix = json.loads(MATRIX_PATH.read_text(encoding="utf-8"))
-    return _run(matrix)
+    manifest = tomllib.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return _run(matrix, manifest)
 
 
-def _run(matrix: dict[str, Any]) -> int:
-    failures = _validate(matrix)
+def _run(matrix: dict[str, Any], manifest: dict[str, Any]) -> int:
+    failures = _validate(matrix, manifest)
 
     if failures:
         for failure in failures:
@@ -53,18 +38,20 @@ def _run(matrix: dict[str, Any]) -> int:
         return 1
 
     future_runtime_rows = _future_runtime_rows(matrix)
+    surface_rows = _surface_certification_rows([], manifest)
     print(
         "sysroot stdlib resource certification gate: PASS "
-        f"(surfaces={len(SURFACE_CERTIFICATION_ROWS)}, future_runtime_rows={len(future_runtime_rows)})"
+        f"(surfaces={len(surface_rows)}, future_runtime_rows={len(future_runtime_rows)})"
     )
     return 0
 
 
-def _validate(matrix: dict[str, Any]) -> list[str]:
+def _validate(matrix: dict[str, Any], manifest: dict[str, Any]) -> list[str]:
     failures: list[str] = []
     rows_by_id = _rows_by_id(failures, matrix)
+    surface_rows = _surface_certification_rows(failures, manifest)
 
-    for surface_id, required_rows in SURFACE_CERTIFICATION_ROWS.items():
+    for surface_id, required_rows in surface_rows.items():
         for row_id in required_rows:
             row = rows_by_id.get(row_id)
             if row is None:
@@ -92,6 +79,41 @@ def _validate(matrix: dict[str, Any]) -> list[str]:
     return failures
 
 
+def _surface_certification_rows(
+    failures: list[str],
+    manifest: dict[str, Any],
+) -> dict[str, tuple[str, ...]]:
+    surface_rows: dict[str, tuple[str, ...]] = {}
+    surfaces = manifest.get("surface")
+    if not isinstance(surfaces, list):
+        failures.append("retained manifest must contain [[surface]] tables")
+        return surface_rows
+
+    for index, surface in enumerate(surfaces):
+        if not isinstance(surface, dict):
+            failures.append(f"retained manifest surface entry {index} must be a table")
+            continue
+        surface_id = surface.get("id")
+        if not isinstance(surface_id, str) or not surface_id:
+            failures.append(f"retained manifest surface entry {index} is missing id")
+            continue
+        row_ids = surface.get("certification_rows", [])
+        if row_ids is None:
+            continue
+        if not isinstance(row_ids, list):
+            failures.append(f"{surface_id}: certification_rows must be a list")
+            continue
+        parsed_rows: list[str] = []
+        for row_id in row_ids:
+            if not isinstance(row_id, str) or not row_id:
+                failures.append(f"{surface_id}: certification_rows entries must be non-empty strings")
+                continue
+            parsed_rows.append(row_id)
+        if parsed_rows:
+            surface_rows[surface_id] = tuple(parsed_rows)
+    return surface_rows
+
+
 def _future_runtime_rows(matrix: dict[str, Any]) -> list[str]:
     return [
         row_id
@@ -115,26 +137,42 @@ def _rows_by_id(failures: list[str], matrix: dict[str, Any]) -> dict[str, dict[s
 
 
 def _self_test() -> int:
+    surface_rows = {
+        "_sifr.example": ("opaque_resource_matrix",),
+        "_sifr.example_async": ("async_runtime_reqwest", "callback_subscription_matrix"),
+    }
+    base_manifest = {
+        "surface": [
+            {"id": surface_id, "certification_rows": list(row_ids)}
+            for surface_id, row_ids in surface_rows.items()
+        ]
+    }
     base_matrix = {
         "rows": [
             {"id": row_id, "category": FUTURE_OWNED, "future_owner": CERTIFICATION_ISSUE}
-            for row_id in sorted({row for rows in SURFACE_CERTIFICATION_ROWS.values() for row in rows})
+            for row_id in sorted({row for rows in surface_rows.values() for row in rows})
         ]
     }
 
-    if _validate(base_matrix):
+    if _validate(base_matrix, base_manifest):
         print("self-test seed should pass", file=sys.stderr)
         return 1
 
     certified_matrix = json.loads(json.dumps(base_matrix))
     certified_matrix["rows"][0]["category"] = "supported"
-    if not any("update this gate when resource certification lands" in failure for failure in _validate(certified_matrix)):
+    if not any(
+        "update this gate when resource certification lands" in failure
+        for failure in _validate(certified_matrix, base_manifest)
+    ):
         print("self-test supported resource row was not rejected", file=sys.stderr)
         return 1
 
     wrong_owner_matrix = json.loads(json.dumps(base_matrix))
     wrong_owner_matrix["rows"][0]["future_owner"] = "plans/issues/active/other.md"
-    if not any("future_owner must remain" in failure for failure in _validate(wrong_owner_matrix)):
+    if not any(
+        "future_owner must remain" in failure
+        for failure in _validate(wrong_owner_matrix, base_manifest)
+    ):
         print("self-test wrong future owner was not rejected", file=sys.stderr)
         return 1
 
@@ -143,9 +181,18 @@ def _self_test() -> int:
         row["category"] = "supported"
     if not any(
         "expected at least one runtime/resource compatibility row" in failure
-        for failure in _validate(completed_matrix)
+        for failure in _validate(completed_matrix, base_manifest)
     ):
         print("self-test missing future-owned backstop was not rejected", file=sys.stderr)
+        return 1
+
+    bad_manifest = json.loads(json.dumps(base_manifest))
+    bad_manifest["surface"][0]["certification_rows"] = "opaque_resource_matrix"
+    if not any(
+        "certification_rows must be a list" in failure
+        for failure in _validate(base_matrix, bad_manifest)
+    ):
+        print("self-test malformed manifest rows were not rejected", file=sys.stderr)
         return 1
 
     print("sysroot stdlib resource certification gate self-test: PASS")

--- a/verification/policy/guardrails.json
+++ b/verification/policy/guardrails.json
@@ -58,6 +58,13 @@
       "report": "stdout"
     },
     {
+      "name": "stdlib-manifest-schema",
+      "entrypoint": "scripts/check_stdlib_manifest_schema.py",
+      "args": [],
+      "timeout_seconds": 60,
+      "report": "stdout"
+    },
+    {
       "name": "stdlib-migration-closure",
       "entrypoint": "scripts/check_stdlib_migration_closure.py",
       "args": [],

--- a/verification/runner/sifr_verify/profile_runner.py
+++ b/verification/runner/sifr_verify/profile_runner.py
@@ -353,6 +353,10 @@ class ProfileRunner:
         run_python("scripts/check_stdlib_native_intrinsic_allowlist.py")
         run_python("scripts/check_stdlib_native_intrinsic_allowlist.py", "--self-test")
 
+        print("Running stdlib retained manifest schema guard")
+        run_python("scripts/check_stdlib_manifest_schema.py")
+        run_python("scripts/check_stdlib_manifest_schema.py", "--self-test")
+
         print("Running stdlib migration closure guard")
         run_python("scripts/check_stdlib_migration_closure.py")
         run_python("scripts/check_stdlib_migration_closure.py", "--self-test")


### PR DESCRIPTION
## Summary

Starts M1 with a focused retained-glue manifest schema and guard hardening wave.

- Bumps `internal_docs/stdlib_retained_compiler_intrinsics.toml` to schema v2 with per-entry owner, issue, evidence, and removal metadata.
- Removes manifest `prefix_intrinsics`; the current `http_`, `tls_`, and `py_` prefix-dispatched code paths are exact-enumerated from lowerer match arms.
- Adds `scripts/check_stdlib_manifest_schema.py` and wires it into core create-pr guardrails and policy inventory.
- Hardens the native intrinsic allowlist guard against untracked new prefix dispatchers and pipe-chained lowerer match arms.
- Makes the sysroot stdlib resource certification gate consume `certification_rows` from the retained manifest instead of a hardcoded surface table.

## Validation

- `cargo fmt --check`
- `python3 scripts/check_stdlib_manifest_schema.py`
- `python3 scripts/check_stdlib_manifest_schema.py --self-test`
- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py --self-test`
- `python3 scripts/check_stdlib_migration_closure.py --self-test`
- `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py`
- `python3 scripts/check_file_size_guardrails.py`
- `PYTHONPATH=verification/runner python3 verification/areas/coverage_matrix/checks/verification_taxonomy.py`
- `git diff --check`
- `scripts/run_all_tests.sh --profile create-pr` (168.06s, advisories=none)

## Review

- `plans/reviews/active/stdlib-native-boundary-m1a-manifest-schema-review-pass1.md`
- `plans/reviews/active/stdlib-native-boundary-m1a-manifest-schema-review-pass2.md` (READY)
