### PR TITLE
Record M1a merge evidence

### DIFF
--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -327,7 +327,10 @@ M1 may land as ordered sub-PRs:
 
 - M1a: harden retained-glue manifest schema, remove manifest prefix concepts,
   exact-enumerate current prefix-dispatched retained surfaces, and route
-  certification gating through manifest `certification_rows` (PR #2829).
+  certification gating through manifest `certification_rows` (merged in PR
+  #2829, merge commit `d2b97bb796908e787202ed123b9ea889e8c7e2c3`;
+  local `create-pr` validation passed with no advisories; reviewer pass 2
+  READY).
 
 Acceptance:
 


### PR DESCRIPTION
## Summary

Records M1a merge evidence in the active stdlib native boundary completion plan.

## Validation

Doc-only ledger update after M1a PR #2829 merged. M1a validation was `scripts/run_all_tests.sh --profile create-pr` (168.06s, advisories=none).
