### PR TITLE
Add stdlib bootstrap ordering guard

### DIFF
--- a/crates/sifr_stdlib_manifest/src/sources.rs
+++ b/crates/sifr_stdlib_manifest/src/sources.rs
@@ -1,5 +1,5 @@
 use sifr_sysroot::ResolvedSysroot;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -29,6 +29,12 @@ pub enum LoadedStdlibSourceKind {
 pub struct StdlibSourceInventoryError {
     pub message: String,
     pub path: Option<PathBuf>,
+}
+
+struct BootstrapSource<'a> {
+    module: &'a str,
+    source: &'a str,
+    path: Option<&'a Path>,
 }
 
 impl StdlibSourceInventoryError {
@@ -336,7 +342,7 @@ pub fn load_stdlib_sources_from_sysroot(
     sysroot: &ResolvedSysroot,
 ) -> Result<Vec<LoadedStdlibSource>, StdlibSourceInventoryError> {
     validate_stdlib_source_inventory(sysroot)?;
-    STDLIB_SOURCES
+    let sources = STDLIB_SOURCES
         .iter()
         .map(|source| {
             let path = public_module_path(&sysroot.paths.stdlib_public_sources, source.module);
@@ -353,7 +359,9 @@ pub fn load_stdlib_sources_from_sysroot(
                 kind: LoadedStdlibSourceKind::Public,
             })
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    validate_loaded_public_stdlib_bootstrap_order(&sources)?;
+    Ok(sources)
 }
 
 pub fn load_stdlib_tooling_sources_from_sysroot(
@@ -376,6 +384,7 @@ pub fn load_stdlib_tooling_sources_from_sysroot(
             kind: LoadedStdlibSourceKind::PrivateDeclaration,
         });
     }
+    validate_loaded_private_stdlib_declarations_are_dependency_free(&sources)?;
     sources.extend(load_stdlib_sources_from_sysroot(sysroot)?);
     Ok(sources)
 }
@@ -391,6 +400,7 @@ pub fn validate_stdlib_source_inventory(
         PRIVATE_STDLIB_MODULES.iter().copied(),
         "private stdlib source",
     )?;
+    validate_static_public_stdlib_bootstrap_order()?;
     validate_module_files(
         &sysroot.paths.stdlib_public_sources,
         STDLIB_SOURCES.iter().map(|source| source.module),
@@ -466,6 +476,104 @@ fn validate_module_files<'a>(
     Ok(())
 }
 
+fn validate_static_public_stdlib_bootstrap_order() -> Result<(), StdlibSourceInventoryError> {
+    validate_public_stdlib_bootstrap_order(STDLIB_SOURCES.iter().map(|source| BootstrapSource {
+        module: source.module,
+        source: source.source,
+        path: None,
+    }))
+}
+
+fn validate_loaded_public_stdlib_bootstrap_order(
+    sources: &[LoadedStdlibSource],
+) -> Result<(), StdlibSourceInventoryError> {
+    validate_public_stdlib_bootstrap_order(sources.iter().map(|source| BootstrapSource {
+        module: &source.module,
+        source: &source.source,
+        path: Some(source.path.as_path()),
+    }))
+}
+
+fn validate_public_stdlib_bootstrap_order<'a>(
+    sources: impl IntoIterator<Item = BootstrapSource<'a>>,
+) -> Result<(), StdlibSourceInventoryError> {
+    let sources = sources.into_iter().collect::<Vec<_>>();
+    let module_indices = sources
+        .iter()
+        .enumerate()
+        .map(|(index, source)| (source.module, index))
+        .collect::<BTreeMap<_, _>>();
+    for (index, source) in sources.iter().enumerate() {
+        for imported_module in stdlib_imports(source.source, "sifr.") {
+            let Some(imported_index) = module_indices.get(imported_module) else {
+                return Err(StdlibSourceInventoryError::new(
+                    format!(
+                        "public stdlib module {} imports unknown stdlib module {imported_module}",
+                        source.module
+                    ),
+                    source.path.map(Path::to_path_buf),
+                ));
+            };
+            if *imported_index > index {
+                return Err(StdlibSourceInventoryError::new(
+                    format!(
+                        "public stdlib module {} imports {imported_module} before it is available in bootstrap order",
+                        source.module
+                    ),
+                    source.path.map(Path::to_path_buf),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_loaded_private_stdlib_declarations_are_dependency_free(
+    sources: &[LoadedStdlibSource],
+) -> Result<(), StdlibSourceInventoryError> {
+    for source in sources {
+        if let Some(imported_module) = stdlib_imports(&source.source, "_sifr.")
+            .into_iter()
+            .chain(stdlib_imports(&source.source, "sifr."))
+            .next()
+        {
+            return Err(StdlibSourceInventoryError::new(
+                format!(
+                    "private stdlib declaration {} imports {imported_module}; private declarations must be dependency-free",
+                    source.module
+                ),
+                Some(source.path.clone()),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn stdlib_imports<'a>(source: &'a str, prefix: &str) -> BTreeSet<&'a str> {
+    let mut imports = BTreeSet::new();
+    for line in source.lines() {
+        let line = line.split('#').next().unwrap_or("").trim();
+        if let Some(module) = line
+            .strip_prefix("from ")
+            .and_then(|rest| rest.split_once(" import ").map(|(module, _)| module))
+        {
+            if module.starts_with(prefix) {
+                imports.insert(module);
+            }
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("import ") {
+            for item in rest.split(',') {
+                let module = item.split_whitespace().next().unwrap_or("");
+                if module.starts_with(prefix) {
+                    imports.insert(module);
+                }
+            }
+        }
+    }
+    imports
+}
+
 fn public_module_path(root: &Path, module: &str) -> PathBuf {
     module_path(root, module, "sifr")
 }
@@ -485,8 +593,8 @@ fn module_path(root: &Path, module: &str, prefix: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        load_stdlib_sources_from_sysroot, validate_stdlib_source_inventory, PRIVATE_STDLIB_MODULES,
-        STDLIB_SOURCES,
+        load_stdlib_sources_from_sysroot, load_stdlib_tooling_sources_from_sysroot,
+        validate_stdlib_source_inventory, PRIVATE_STDLIB_MODULES, STDLIB_SOURCES,
     };
     use sifr_sysroot::{ResolvedSysroot, SysrootManifest, SysrootPaths};
     use std::fs;
@@ -592,6 +700,92 @@ mod tests {
             .message
             .contains("stale stdlib source module _sifr.stale"));
         assert_eq!(error.path, Some(root.path.join("stdlib/_sifr/stale.sifr")));
+    }
+
+    #[test]
+    fn load_stdlib_sources_rejects_forward_public_bootstrap_imports() {
+        let root = complete_source_tree("forward_public_import");
+        let sysroot = resolved_sysroot(&root.path);
+        let test_path = root.path.join("stdlib/sifr/test.sifr");
+        fs::write(&test_path, "from sifr.json import JsonValue\n")
+            .expect("write forward import source");
+
+        let error = load_stdlib_sources_from_sysroot(&sysroot)
+            .expect_err("forward public stdlib import should fail");
+
+        assert!(error
+            .message
+            .contains("public stdlib module sifr.test imports sifr.json before it is available"));
+        assert_eq!(error.path, Some(test_path));
+    }
+
+    #[test]
+    fn load_stdlib_sources_rejects_unknown_public_bootstrap_imports() {
+        let root = complete_source_tree("unknown_public_import");
+        let sysroot = resolved_sysroot(&root.path);
+        let test_path = root.path.join("stdlib/sifr/test.sifr");
+        fs::write(&test_path, "from sifr.missing import Missing\n")
+            .expect("write unknown import source");
+
+        let error = load_stdlib_sources_from_sysroot(&sysroot)
+            .expect_err("unknown public stdlib import should fail");
+
+        assert!(error
+            .message
+            .contains("public stdlib module sifr.test imports unknown stdlib module sifr.missing"));
+        assert_eq!(error.path, Some(test_path));
+    }
+
+    #[test]
+    fn load_stdlib_sources_rejects_public_import_cycles() {
+        let root = complete_source_tree("cycle_public_import");
+        let sysroot = resolved_sysroot(&root.path);
+        let bytes_path = root.path.join("stdlib/sifr/bytes.sifr");
+        let encoding_path = root.path.join("stdlib/sifr/encoding.sifr");
+        fs::write(&bytes_path, "from sifr.encoding import Encoding\n")
+            .expect("write forward half of cycle");
+        fs::write(&encoding_path, "from sifr.bytes import Bytes\n")
+            .expect("write backward half of cycle");
+
+        let error = load_stdlib_sources_from_sysroot(&sysroot)
+            .expect_err("public stdlib import cycle should fail");
+
+        assert!(error.message.contains(
+            "public stdlib module sifr.bytes imports sifr.encoding before it is available"
+        ));
+        assert_eq!(error.path, Some(bytes_path));
+    }
+
+    #[test]
+    fn load_stdlib_tooling_sources_rejects_private_declaration_imports() {
+        let root = complete_source_tree("private_declaration_import");
+        let sysroot = resolved_sysroot(&root.path);
+        let bytes_path = root.path.join("stdlib/_sifr/bytes.sifr");
+        fs::write(&bytes_path, "from _sifr.fs import open\n").expect("write private import");
+
+        let error = load_stdlib_tooling_sources_from_sysroot(&sysroot)
+            .expect_err("private stdlib declaration import should fail");
+
+        assert!(error
+            .message
+            .contains("private stdlib declaration _sifr.bytes imports _sifr.fs"));
+        assert_eq!(error.path, Some(bytes_path));
+    }
+
+    #[test]
+    fn load_stdlib_tooling_sources_rejects_private_declaration_public_imports() {
+        let root = complete_source_tree("private_declaration_public_import");
+        let sysroot = resolved_sysroot(&root.path);
+        let bytes_path = root.path.join("stdlib/_sifr/bytes.sifr");
+        fs::write(&bytes_path, "from sifr.bytes import Bytes\n").expect("write public import");
+
+        let error = load_stdlib_tooling_sources_from_sysroot(&sysroot)
+            .expect_err("private stdlib declaration public import should fail");
+
+        assert!(error
+            .message
+            .contains("private stdlib declaration _sifr.bytes imports sifr.bytes"));
+        assert_eq!(error.path, Some(bytes_path));
     }
 
     fn complete_source_tree(label: &str) -> TempRoot {

--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -90,7 +90,7 @@ merged, and documented before the next milestone starts.
 | Milestone | Status | Evidence |
 | --- | --- | --- |
 | M0. Model Split and Raw-Injection Removal | merged | PR #2820 · sha=8f1f44d; PR #2821 · sha=f82cc64; PR #2823 · sha=c0828de; PR #2825 · sha=5e05898; PR #2827 · sha=45b36d1 |
-| M1. Manifest Schema and Normal-Path Guards | planned |  |
+| M1. Manifest Schema and Normal-Path Guards | in progress | PR #2829 · sha=d2b97bb; PR #2831 open |
 | M2. Declaration Infrastructure and Provenance | planned |  |
 | M3. File and Filesystem Migration | planned |  |
 | M4. Random, Time, and Logging | planned |  |
@@ -331,6 +331,10 @@ M1 may land as ordered sub-PRs:
   #2829, merge commit `d2b97bb796908e787202ed123b9ea889e8c7e2c3`;
   local `create-pr` validation passed with no advisories; reviewer pass 2
   READY).
+- M1b: validate deterministic stdlib bootstrap ordering, reject public forward
+  imports and private declaration dependencies, and wire a standalone bootstrap
+  ordering guard into local validation (open in PR #2831; local `create-pr`
+  validation passed in 180.50s with no advisories; reviewer pass 2 READY).
 
 Acceptance:
 

--- a/plans/reviews/active/stdlib-native-boundary-m1b-bootstrap-ordering-review-pass2.md
+++ b/plans/reviews/active/stdlib-native-boundary-m1b-bootstrap-ordering-review-pass2.md
@@ -1,0 +1,30 @@
+## Review of M1b stdlib native-boundary bootstrap ordering
+
+### Requirements coverage
+
+- Deterministic public bootstrap order enforced via strict `>` index check in `validate_public_stdlib_bootstrap_order` (`sources.rs:497-529`).
+- Forward and cyclic public imports rejected — a cycle necessarily contains at least one forward reference in the linear STDLIB_SOURCES order, so the index check catches both; the Python script additionally has an explicit `_first_cycle` graph walk (`scripts/check_stdlib_bootstrap_ordering.py:149-175`).
+- Private declarations enforced dependency-free by `validate_loaded_private_stdlib_declarations_are_dependency_free` — rejects any `_sifr.*` or `sifr.*` import from a private declaration (`sources.rs:531-550`).
+- Static (compile-time) STDLIB_SOURCES ordering is checked via `validate_static_public_stdlib_bootstrap_order` inside `validate_stdlib_source_inventory` (`sources.rs:403`).
+- Standalone guard wired into `verification/policy/guardrails.json:67-73` and `profile_runner.py:360-362` with both live check and `--self-test`; both consistent with sibling guards.
+- Pass-1 advisory (duplicate detection coverage) addressed in `check_stdlib_bootstrap_ordering.py:256-262` with a `["sifr.a", "sifr.a"]` self-test entry.
+
+### Consistency between Rust and Python enforcement
+
+Rust `stdlib_imports` (`sources.rs:552-575`) and Python `_imports_with_prefix` (`scripts/check_stdlib_bootstrap_ordering.py:132-146`) apply the same strategy: strip inline `#` comments, trim, then match `from X import ...` or `import a, b, c` with `starts_with` prefix. Both handle `import ... as ...` and comma-separated imports; both correctly skip bare `import sifr` (no dot) and `_sifr.*` when scanning `sifr.` prefix (and vice versa). The tests exercise both forward and unknown-import failures on the load path and the equivalent conditions in the Python self-test.
+
+### Test coverage
+
+- New Rust tests cover forward public import, unknown public import, cycle (as forward reference on the earlier arm), private-→private import, and private-→public import (`sources.rs:706-789`). All error paths assert both message and path.
+- Python `_self_test` covers forward, comma-form, unknown, cycle, private-→private, private-→public, unsorted-private and duplicate-public (`scripts/check_stdlib_bootstrap_ordering.py:183-265`).
+
+### Non-blocking observations
+
+- Backslash line-continuation and single-line compound statements (`if TYPE_CHECKING: from sifr.x import y`) aren't recognized by either parser. Grep of the stdlib confirms no such usage exists, so this is a documented parser limitation, not a real gap.
+- Self-imports (`imported_index == index`) would pass both parsers because comparison is strict `>`. No stdlib module does this and the case is degenerate; not worth adding a check.
+- `validate_stdlib_source_inventory` runs twice in `load_stdlib_tooling_sources_from_sysroot` (direct call at `sources.rs:370`, then again through `load_stdlib_sources_from_sysroot` at `sources.rs:388`). Harmless duplication.
+- `plans/reviews/active/stdlib-native-boundary-m1b-bootstrap-ordering-review-pass1.md` and `-pass2.md` are both empty files. They appear to be untracked review scaffolding — worth confirming intent (populate with reviewer notes or delete before commit); doesn't affect implementation correctness.
+
+### Verdict
+
+READY

--- a/scripts/check_stdlib_bootstrap_ordering.py
+++ b/scripts/check_stdlib_bootstrap_ordering.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Validate deterministic sysroot stdlib bootstrap ordering."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCES_RS = REPO_ROOT / "crates" / "sifr_stdlib_manifest" / "src" / "sources.rs"
+PUBLIC_ROOT = REPO_ROOT / "stdlib" / "sifr"
+PRIVATE_ROOT = REPO_ROOT / "stdlib" / "_sifr"
+
+PRIVATE_LIST_RE = re.compile(
+    r"PRIVATE_STDLIB_MODULES:\s*&\[&str\]\s*=\s*&\[(.*?)\];",
+    re.DOTALL,
+)
+PUBLIC_MODULE_RE = re.compile(r'module:\s*"((?:sifr)\.[A-Za-z0-9_]+)"')
+STRING_RE = re.compile(r'"([^"]+)"')
+def main() -> int:
+    sources_text = SOURCES_RS.read_text(encoding="utf-8")
+    private_modules = _private_modules(sources_text)
+    public_modules = _public_modules(sources_text)
+    public_sources = {
+        module: _module_path(PUBLIC_ROOT, module, "sifr").read_text(encoding="utf-8")
+        for module in public_modules
+    }
+    private_sources = {
+        module: _module_path(PRIVATE_ROOT, module, "_sifr").read_text(encoding="utf-8")
+        for module in private_modules
+    }
+    failures = _validate(private_modules, public_modules, private_sources, public_sources)
+    if failures:
+        print("stdlib bootstrap ordering: FAIL")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    public_set = set(public_modules)
+    edge_count = sum(
+        len(_public_imports(source) & public_set) for source in public_sources.values()
+    )
+    print(
+        "stdlib bootstrap ordering: PASS "
+        f"(private={len(private_modules)}, public={len(public_modules)}, public_edges={edge_count})"
+    )
+    return 0
+
+
+def _private_modules(sources_text: str) -> list[str]:
+    match = PRIVATE_LIST_RE.search(sources_text)
+    if match is None:
+        return []
+    return STRING_RE.findall(match.group(1))
+
+
+def _public_modules(sources_text: str) -> list[str]:
+    return PUBLIC_MODULE_RE.findall(sources_text)
+
+
+def _validate(
+    private_modules: list[str],
+    public_modules: list[str],
+    private_sources: dict[str, str],
+    public_sources: dict[str, str],
+) -> list[str]:
+    failures: list[str] = []
+    _validate_unique(failures, private_modules, "private stdlib module")
+    _validate_unique(failures, public_modules, "public stdlib module")
+
+    if private_modules != sorted(private_modules):
+        failures.append("private stdlib modules must be sorted lexicographically")
+
+    private_set = set(private_modules)
+    for module, source in private_sources.items():
+        imported_private = sorted(_private_imports(source, private_set))
+        if imported_private:
+            failures.append(
+                f"{module}: private declaration source imports private declarations: "
+                + ", ".join(imported_private)
+            )
+        imported_public = sorted(_public_imports(source))
+        if imported_public:
+            failures.append(
+                f"{module}: private declaration source imports public stdlib modules: "
+                + ", ".join(imported_public)
+            )
+
+    public_set = set(public_modules)
+    public_index = {module: index for index, module in enumerate(public_modules)}
+    graph: dict[str, set[str]] = {}
+    for module in public_modules:
+        deps = _public_imports(public_sources.get(module, ""))
+        unknown_deps = sorted(deps - public_set)
+        for dep in unknown_deps:
+            failures.append(f"{module}: imports unknown public stdlib module {dep}")
+        graph[module] = deps & public_set
+        for dep in sorted(graph[module]):
+            if public_index[dep] > public_index[module]:
+                failures.append(
+                    f"{module}: imports {dep}, but {dep} appears later in STDLIB_SOURCES"
+                )
+
+    cycle = _first_cycle(graph)
+    if cycle:
+        failures.append("public stdlib import cycle: " + " -> ".join(cycle))
+
+    return failures
+
+
+def _validate_unique(failures: list[str], modules: list[str], label: str) -> None:
+    seen: set[str] = set()
+    for module in modules:
+        if module in seen:
+            failures.append(f"duplicate {label}: {module}")
+        seen.add(module)
+
+
+def _public_imports(source: str) -> set[str]:
+    return _imports_with_prefix(source, "sifr.")
+
+
+def _private_imports(source: str, private_modules: set[str]) -> set[str]:
+    return {
+        module
+        for module in _imports_with_prefix(source, "_sifr.")
+        if module in private_modules
+    }
+
+
+def _imports_with_prefix(source: str, prefix: str) -> set[str]:
+    imports: set[str] = set()
+    for raw_line in source.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if line.startswith("from "):
+            module = line.removeprefix("from ").split(" import ", 1)[0].strip()
+            if module.startswith(prefix):
+                imports.add(module)
+            continue
+        if line.startswith("import "):
+            for item in line.removeprefix("import ").split(","):
+                module = item.strip().split()[0] if item.strip() else ""
+                if module.startswith(prefix):
+                    imports.add(module)
+    return imports
+
+
+def _first_cycle(graph: dict[str, set[str]]) -> list[str]:
+    visiting: set[str] = set()
+    visited: set[str] = set()
+    stack: list[str] = []
+
+    def visit(module: str) -> list[str]:
+        if module in visited:
+            return []
+        if module in visiting:
+            start = stack.index(module)
+            return stack[start:] + [module]
+        visiting.add(module)
+        stack.append(module)
+        for dep in sorted(graph.get(module, ())):
+            cycle = visit(dep)
+            if cycle:
+                return cycle
+        stack.pop()
+        visiting.remove(module)
+        visited.add(module)
+        return []
+
+    for module in sorted(graph):
+        cycle = visit(module)
+        if cycle:
+            return cycle
+    return []
+
+
+def _module_path(root: Path, module: str, prefix: str) -> Path:
+    tail = module.removeprefix(prefix).removeprefix(".")
+    return root / f"{tail}.sifr"
+
+
+def _self_test() -> int:
+    private = ["_sifr.a", "_sifr.b"]
+    public = ["sifr.a", "sifr.b"]
+    private_sources = {"_sifr.a": "", "_sifr.b": ""}
+    public_sources = {"sifr.a": "", "sifr.b": "from sifr.a import value\n"}
+    if _validate(private, public, private_sources, public_sources):
+        print("self-test seed should pass", file=sys.stderr)
+        return 1
+
+    forward = {"sifr.a": "from sifr.b import value\n", "sifr.b": ""}
+    if not any(
+        "appears later" in failure
+        for failure in _validate(private, public, private_sources, forward)
+    ):
+        print("self-test public forward import was not rejected", file=sys.stderr)
+        return 1
+
+    comma_import = {"sifr.a": "import sifr.b, sifr.a\n", "sifr.b": ""}
+    if not any(
+        "appears later" in failure
+        for failure in _validate(private, public, private_sources, comma_import)
+    ):
+        print("self-test comma public import was not rejected", file=sys.stderr)
+        return 1
+
+    unknown = {"sifr.a": "from sifr.missing import value\n", "sifr.b": ""}
+    if not any(
+        "unknown public stdlib module" in failure
+        for failure in _validate(private, public, private_sources, unknown)
+    ):
+        print("self-test unknown public import was not rejected", file=sys.stderr)
+        return 1
+
+    cycle = {
+        "sifr.a": "from sifr.b import value\n",
+        "sifr.b": "from sifr.a import value\n",
+    }
+    if not any(
+        "import cycle" in failure
+        for failure in _validate(private, public, private_sources, cycle)
+    ):
+        print("self-test public import cycle was not rejected", file=sys.stderr)
+        return 1
+
+    private_bad = {"_sifr.a": "from _sifr.b import value\n", "_sifr.b": ""}
+    if not any(
+        "imports private declarations" in failure
+        for failure in _validate(private, public, private_bad, public_sources)
+    ):
+        print("self-test private import was not rejected", file=sys.stderr)
+        return 1
+
+    private_public_bad = {"_sifr.a": "from sifr.a import value\n", "_sifr.b": ""}
+    if not any(
+        "imports public stdlib modules" in failure
+        for failure in _validate(private, public, private_public_bad, public_sources)
+    ):
+        print("self-test private public import was not rejected", file=sys.stderr)
+        return 1
+
+    unsorted_private = ["_sifr.b", "_sifr.a"]
+    if not any(
+        "sorted lexicographically" in failure
+        for failure in _validate(
+            unsorted_private,
+            public,
+            private_sources,
+            public_sources,
+        )
+    ):
+        print("self-test private sort order was not rejected", file=sys.stderr)
+        return 1
+
+    duplicate_public = ["sifr.a", "sifr.a"]
+    if not any(
+        "duplicate public stdlib module: sifr.a" in failure
+        for failure in _validate(private, duplicate_public, private_sources, public_sources)
+    ):
+        print("self-test duplicate public module was not rejected", file=sys.stderr)
+        return 1
+
+    print("stdlib bootstrap ordering self-test: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--self-test"]:
+        raise SystemExit(_self_test())
+    raise SystemExit(main())

--- a/verification/policy/guardrails.json
+++ b/verification/policy/guardrails.json
@@ -65,6 +65,13 @@
       "report": "stdout"
     },
     {
+      "name": "stdlib-bootstrap-ordering",
+      "entrypoint": "scripts/check_stdlib_bootstrap_ordering.py",
+      "args": [],
+      "timeout_seconds": 60,
+      "report": "stdout"
+    },
+    {
       "name": "stdlib-migration-closure",
       "entrypoint": "scripts/check_stdlib_migration_closure.py",
       "args": [],

--- a/verification/runner/sifr_verify/profile_runner.py
+++ b/verification/runner/sifr_verify/profile_runner.py
@@ -357,6 +357,10 @@ class ProfileRunner:
         run_python("scripts/check_stdlib_manifest_schema.py")
         run_python("scripts/check_stdlib_manifest_schema.py", "--self-test")
 
+        print("Running stdlib bootstrap ordering guard")
+        run_python("scripts/check_stdlib_bootstrap_ordering.py")
+        run_python("scripts/check_stdlib_bootstrap_ordering.py", "--self-test")
+
         print("Running stdlib migration closure guard")
         run_python("scripts/check_stdlib_migration_closure.py")
         run_python("scripts/check_stdlib_migration_closure.py", "--self-test")


### PR DESCRIPTION
## Summary
- enforce deterministic public stdlib bootstrap ordering at manifest load time
- reject private declaration imports before public sources are appended
- add a standalone bootstrap ordering guard and wire it into create-pr guardrails
- include Claude Opus READY review artifact for M1b

## Validation
- python3 scripts/check_stdlib_bootstrap_ordering.py
- python3 scripts/check_stdlib_bootstrap_ordering.py --self-test
- cargo fmt --check
- git diff --check
- PYTHONPATH=verification/runner python3 verification/areas/coverage_matrix/checks/verification_taxonomy.py
- python3 scripts/check_file_size_guardrails.py
- scripts/run_all_tests.sh --profile create-pr (180.50s, advisories=none)

## Review
- plans/reviews/active/stdlib-native-boundary-m1b-bootstrap-ordering-review-pass2.md: READY
