### PR TITLE
Guard closing stdlib fallback signatures

### DIFF
--- a/plans/reviews/active/stdlib-native-boundary-m1d-closing-signature-guard-review-pass1.md
+++ b/plans/reviews/active/stdlib-native-boundary-m1d-closing-signature-guard-review-pass1.md
@@ -1,0 +1,36 @@
+I have enough to render a verdict. Let me summarize the review.
+
+## Review summary
+
+**M1d task**: "Remove fallback intrinsic signature tables for any surface already marked `closing`."
+
+**What the change does**
+- Adds `RETAINED_INTRINSICS_LIB_PATH` and `RETAINED_SIGNATURE_MODULE_RE` (line 25) to scan `crates/sifr_retained_intrinsics/src/lib.rs` for `"_sifr.foo" => Some(...)` match arms.
+- Records those module names as `fallback_signature_modules` in the observed surface (lines 76-80).
+- Introduces `_surface_private_modules()` (lines 167-184) that derives owned private modules from both `surface.id` (stripping any `::leaf` subfamily suffix) and `declaration_files` under `stdlib/_sifr/**.sifr`.
+- Rejects any `state = "closing"` row whose derived module set still intersects the observed fallback module set (lines 134-143).
+- Extends `--self-test` with positive and negative cases (lines 310-328).
+
+**Correctness checks**
+- Regex captures 31 module arms; excludes the `_sifr.not_real` test reference (line 143 in lib.rs) because it isn't a match-arm.
+- `_sifr.http::header_helpers` and similar subfamily ids correctly reduce to `_sifr.http` via `split("::", 1)[0]`.
+- No `closing` rows exist in the current manifest, so the guard is intentionally a forward-only trip wire; existing PASS is unchanged (`fallback_signature_modules=31`).
+- Placement is right: the guard already observes lib.rs-adjacent surfaces (registry_files, preamble_files, exact_intrinsics); adding another observed set alongside them fits. The schema validator has no need to read `sifr_retained_intrinsics/src/lib.rs` and shouldn't own this.
+
+**Non-blocking observations**
+- The regex `_sifr\.[A-Za-z0-9_]+` only captures a single dotted segment, while `_surface_private_modules` can synthesize multi-segment names via `declaration_file.replace("/", ".")`. Today `stdlib/_sifr/` is flat and lib.rs uses only single-segment module names, so no asymmetry surfaces. Not a bug for the current codebase.
+- Self-test exercises only the id-and-declaration-files-aligned case; it does not separately exercise subfamily-id-only derivation or a declaration-files-only derivation. Those code paths are small and self-evident.
+- There is no reverse check that every fallback signature module has an active manifest owner. Out of M1d scope; belongs to a broader closure guard later.
+
+**False positive/negative check**
+- False positive risk: a `closing` subfamily leaf whose parent `_sifr.*` module still has retained peer leaves would be flagged despite the module still being needed. This aligns with the phase invariant that fallback modules must be split when subfamily granularity is used, so this is the intended behavior, not a bug.
+- No false-negative cases identified against the current manifest.
+
+**Validation confirmed**
+- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`: PASS (fallback_signature_modules=31).
+- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py --self-test`: PASS.
+- `python3 scripts/check_stdlib_manifest_schema.py` / `--self-test`: PASS (reported by user).
+
+The change fully covers the "no closing row keeps a fallback signature module" requirement, is placed correctly, and has adequate self-test coverage for M1d's scope.
+
+READY

--- a/plans/reviews/active/stdlib-native-boundary-m1d-closing-signature-guard-review-pass2.md
+++ b/plans/reviews/active/stdlib-native-boundary-m1d-closing-signature-guard-review-pass2.md
@@ -1,0 +1,9 @@
+Pass1's verdict holds. Verified independently:
+
+- **Guard integration** — `verification/runner/sifr_verify/profile_runner.py:353-354` invokes both the main check and `--self-test`, and it's declared in `verification/policy/guardrails.json:55`. Pass1 didn't call this out explicitly; it is present and exercised by the reported `create-pr` run.
+- **Regex correctness** — Independently reproduced 31 captured fallback modules from `crates/sifr_retained_intrinsics/src/lib.rs`; the `_sifr.not_real` test string on line 143 is correctly excluded because it isn't a `=> Some(` arm.
+- **No closing rows today** — Grep across the manifest shows only `retained` / `retained-by-design` states, so the guard is a forward-only trip wire as documented.
+- **Self-test adequacy** — Positive and negative closing-row cases are covered (lines 310-328); the `--self-test` exits 0.
+- **Subfamily false-positive scan** — `_surface_private_modules` strips any `::leaf` suffix via `split("::", 1)[0]`, so a closing subfamily leaf trips the guard while the parent fallback module still exists — that matches the phase invariant.
+
+READY

--- a/scripts/check_stdlib_native_intrinsic_allowlist.py
+++ b/scripts/check_stdlib_native_intrinsic_allowlist.py
@@ -17,10 +17,12 @@ REGISTRY_DISPATCH_PATH = (
     REPO_ROOT / "crates" / "sifr_codegen" / "src" / "intrinsics" / "registry.rs"
 )
 PREAMBLE_ROOT = REPO_ROOT / "crates" / "sifr_codegen" / "src" / "preamble"
+RETAINED_INTRINSICS_LIB_PATH = REPO_ROOT / "crates" / "sifr_retained_intrinsics" / "src" / "lib.rs"
 
 EXACT_INTRINSIC_RE = re.compile(r'"([A-Za-z0-9_]+)"\s*(?=\||=>)')
 LOWERER_MATCH_INTRINSIC_RE = re.compile(r'"([A-Za-z0-9_]+)"\s*(?=\||=>)')
 PREFIX_INTRINSIC_RE = re.compile(r'starts_with\("([A-Za-z0-9_]+)"\)')
+RETAINED_SIGNATURE_MODULE_RE = re.compile(r'"(_sifr\.[A-Za-z0-9_]+)"\s*=>\s*Some\(')
 EXPECTED_PREFIX_DISPATCHERS = {"http_", "py_", "tls_"}
 PREFIX_DISPATCH_LOWERERS = (
     REGISTRY_ROOT / "tls.rs",
@@ -47,7 +49,8 @@ def _run(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> int:
         "stdlib native intrinsic allowlist guard: PASS "
         f"(exact_intrinsics={len(observed['exact_intrinsics'])}, "
         f"registry_files={len(observed['registry_files'])}, "
-        f"preamble_files={len(observed['preamble_files'])})"
+        f"preamble_files={len(observed['preamble_files'])}, "
+        f"fallback_signature_modules={len(observed['fallback_signature_modules'])})"
     )
     return 0
 
@@ -70,6 +73,11 @@ def _observed_surface() -> dict[str, set[str]]:
             path.relative_to(PREAMBLE_ROOT).as_posix()
             for path in PREAMBLE_ROOT.rglob("*.rs")
         },
+        "fallback_signature_modules": set(
+            RETAINED_SIGNATURE_MODULE_RE.findall(
+                RETAINED_INTRINSICS_LIB_PATH.read_text(encoding="utf-8")
+            )
+        ),
     }
 
 
@@ -123,6 +131,17 @@ def _validate(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> list[
         if not has_items:
             failures.append(f"{surface_id}: allowlist entry has no retained files or intrinsics")
 
+        if surface.get("state") == "closing":
+            fallback_modules = sorted(
+                _surface_private_modules(surface) & observed["fallback_signature_modules"]
+            )
+            if fallback_modules:
+                failures.append(
+                    f"{surface_id}: closing rows must remove fallback signature modules "
+                    "before deletion: "
+                    + ", ".join(fallback_modules)
+                )
+
     prefix_dispatchers = observed.get("prefix_dispatchers", set())
     unexpected_prefixes = sorted(prefix_dispatchers - EXPECTED_PREFIX_DISPATCHERS)
     stale_prefixes = sorted(EXPECTED_PREFIX_DISPATCHERS - prefix_dispatchers)
@@ -143,6 +162,26 @@ def _validate(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> list[
         _compare_sets(failures, key, observed_values, allowed[key])
 
     return failures
+
+
+def _surface_private_modules(surface: dict[str, Any]) -> set[str]:
+    modules: set[str] = set()
+    surface_id = surface.get("id")
+    if isinstance(surface_id, str) and surface_id.startswith("_sifr."):
+        modules.add(surface_id.split("::", 1)[0])
+
+    declaration_files = surface.get("declaration_files", [])
+    if not isinstance(declaration_files, list):
+        return modules
+    for declaration_file in declaration_files:
+        if not isinstance(declaration_file, str):
+            continue
+        prefix = "stdlib/_sifr/"
+        suffix = ".sifr"
+        if declaration_file.startswith(prefix) and declaration_file.endswith(suffix):
+            module_stem = declaration_file.removeprefix(prefix).removesuffix(suffix)
+            modules.add("_sifr." + module_stem.replace("/", "."))
+    return modules
 
 
 def _required_text(
@@ -198,12 +237,15 @@ def _self_test() -> int:
         "prefix_dispatchers": EXPECTED_PREFIX_DISPATCHERS,
         "registry_files": {"alpha.rs"},
         "preamble_files": {"runtime.rs"},
+        "fallback_signature_modules": {"_sifr.alpha"},
     }
     allowlist = {
         "surface": [
             {
-                "id": "test-retained-glue",
+                "id": "_sifr.alpha",
+                "state": "retained",
                 "reason": "language-owned test fixture",
+                "declaration_files": ["stdlib/_sifr/alpha.sifr"],
                 "exact_intrinsics": ["alpha"],
                 "registry_files": ["alpha.rs"],
                 "preamble_files": ["runtime.rs"],
@@ -263,6 +305,26 @@ def _self_test() -> int:
         for failure in _validate(observed, missing_reason)
     ):
         print("self-test missing reason was not rejected", file=sys.stderr)
+        return 1
+
+    closing_with_signature = json.loads(json.dumps(allowlist))
+    closing_with_signature["surface"][0]["state"] = "closing"
+    if not any(
+        "closing rows must remove fallback signature modules" in failure
+        for failure in _validate(observed, closing_with_signature)
+    ):
+        print("self-test closing fallback signature module was not rejected", file=sys.stderr)
+        return 1
+
+    closing_without_signature_observed = json.loads(
+        json.dumps({key: sorted(value) for key, value in observed.items()})
+    )
+    closing_without_signature_observed["fallback_signature_modules"] = []
+    closing_without_signature_observed = {
+        key: set(value) for key, value in closing_without_signature_observed.items()
+    }
+    if _validate(closing_without_signature_observed, closing_with_signature):
+        print("self-test closing row without fallback signature module failed", file=sys.stderr)
         return 1
 
     print("stdlib native intrinsic allowlist guard self-test: PASS")


### PR DESCRIPTION
## Summary
- observes retained fallback signature modules from sifr_retained_intrinsics in the native intrinsic allowlist guard
- rejects any retained manifest row marked closing while its _sifr module still has fallback signature tables
- adds self-test coverage for closing rows with and without fallback signature modules

## Validation
- python3 scripts/check_stdlib_native_intrinsic_allowlist.py
- python3 scripts/check_stdlib_native_intrinsic_allowlist.py --self-test
- python3 scripts/check_stdlib_manifest_schema.py
- python3 scripts/check_stdlib_manifest_schema.py --self-test
- git diff --check
- wc -l scripts/check_stdlib_native_intrinsic_allowlist.py (337 lines)
- scripts/run_all_tests.sh --profile create-pr (wall_time=168.61s, advisories=none)

## Review
- plans/reviews/active/stdlib-native-boundary-m1d-closing-signature-guard-review-pass1.md: READY
- plans/reviews/active/stdlib-native-boundary-m1d-closing-signature-guard-review-pass2.md: READY