### PR TITLE
[codex] Route sysroot dependency identity through plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,6 +3126,7 @@ dependencies = [
  "sifr_lint",
  "sifr_lsp",
  "sifr_package",
+ "sifr_stdlib_manifest",
  "sifr_syntax",
  "sifr_sysroot",
 ]

--- a/crates/sifr/Cargo.toml
+++ b/crates/sifr/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = { workspace = true }
 [dev-dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+sifr_stdlib_manifest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/sifr/src/build_output.rs
+++ b/crates/sifr/src/build_output.rs
@@ -138,16 +138,16 @@ mod tests {
     use sifr_driver::{
         BuildCompilationMode, BuildReportInput, BuildStageReport, BuildSysrootReport,
     };
+    use sifr_stdlib_manifest::{
+        CargoVendorMode, StdlibFeature, SysrootCrate, SysrootCrateDependency, SysrootDependencyPlan,
+    };
+    use std::collections::BTreeSet;
 
     fn report(cache_hit: bool) -> BuildReport {
         BuildReport::new(BuildReportInput {
             entrypoint_path: Path::new("demo main.sifr").to_path_buf(),
             mode: BuildCompilationMode::Project,
-            sysroot: BuildSysrootReport::new(
-                Path::new("/opt/sifr").to_path_buf(),
-                "0.1.0-test-x86_64-test",
-                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-            ),
+            sysroot: BuildSysrootReport::from_dependency_plan(&sysroot_dependency_plan()),
             binary_path: Path::new("./sifr_output/target/release/sifr_output").to_path_buf(),
             total_elapsed: Duration::from_millis(54),
             stages: vec![
@@ -164,6 +164,27 @@ mod tests {
             frontend_diagnostics: Vec::new(),
             cache_hit,
         })
+    }
+
+    fn sysroot_dependency_plan() -> SysrootDependencyPlan {
+        SysrootDependencyPlan {
+            stdlib_modules: BTreeSet::from(["sifr.json".to_string()]),
+            required_features: BTreeSet::from([StdlibFeature::SerdeJson]),
+            sysroot_root: Path::new("/opt/sifr").to_path_buf(),
+            toolchain_id: "0.1.0-test-x86_64-test".to_string(),
+            sysroot_content_sha256:
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+            cargo_config: Path::new("/opt/sifr/.cargo/config.toml").to_path_buf(),
+            vendor_dir: Path::new("/opt/sifr/vendor").to_path_buf(),
+            crates: vec![SysrootCrateDependency {
+                krate: SysrootCrate::SifrStdlib,
+                path: Path::new("/opt/sifr/crates/sifr_stdlib").to_path_buf(),
+                features: BTreeSet::from(["json".to_string()]),
+            }],
+            retained_direct_dependencies: Vec::new(),
+            cargo_vendor_mode: CargoVendorMode::SysrootOnly,
+            cache_fingerprint: "fingerprint-a".to_string(),
+        }
     }
 
     #[test]
@@ -221,5 +242,16 @@ mod tests {
         );
 
         assert!(rendered.starts_with("Finished release build in 54 ms (cached)\n"));
+    }
+
+    #[test]
+    fn build_sysroot_report_carries_dependency_plan_identity() {
+        let report = report(false);
+
+        assert_eq!(
+            report.sysroot().dependency_inputs(),
+            "[stdlib]\nsifr.json\n[features]\nserde_json\n"
+        );
+        assert_eq!(report.sysroot().dependency_fingerprint(), "fingerprint-a");
     }
 }

--- a/crates/sifr_driver/src/build/cargo_manifest.rs
+++ b/crates/sifr_driver/src/build/cargo_manifest.rs
@@ -454,6 +454,8 @@ serde_json = { version = "1.0.149", features = ["preserve_order"] }
         vendor_dir: PathBuf,
     ) -> SysrootDependencyPlan {
         SysrootDependencyPlan {
+            stdlib_modules: BTreeSet::new(),
+            required_features: BTreeSet::new(),
             sysroot_root: PathBuf::from("/opt/sifr"),
             toolchain_id: "0.0.0-test-x86_64-test".to_string(),
             sysroot_content_sha256: "content".to_string(),

--- a/crates/sifr_driver/src/build/materialize.rs
+++ b/crates/sifr_driver/src/build/materialize.rs
@@ -10,7 +10,7 @@ use crate::diagnostics::RenderedDiagnostic;
 use crate::project::{namespace_module_files, rust_module_file_path};
 use sifr_codegen::RustInteropTrustRequirementKind;
 use sifr_diagnostics::DiagnosticCode;
-use sifr_stdlib_manifest::{CargoVendorMode, StdlibFeature, SysrootCrate, SysrootDependencyPlan};
+use sifr_stdlib_manifest::{CargoVendorMode, SysrootCrate, SysrootDependencyPlan};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -156,11 +156,7 @@ fn materialize_binary_project_at_path(
 }
 
 fn sysroot_report(dependency_plan: &SysrootDependencyPlan) -> BuildSysrootReport {
-    BuildSysrootReport::new(
-        dependency_plan.sysroot_root.clone(),
-        dependency_plan.toolchain_id.clone(),
-        dependency_plan.sysroot_content_sha256.clone(),
-    )
+    BuildSysrootReport::from_dependency_plan(dependency_plan)
 }
 
 fn materialize_binary_project_files(
@@ -421,8 +417,6 @@ fn binary_project_cache_key(
     generated_project: &GeneratedBinaryProject,
     dependency_plan: &SysrootDependencyPlan,
 ) -> String {
-    let stdlib_modules = sorted_lines(&generated_project.used_stdlib_modules);
-    let required_features = sorted_feature_lines(&generated_project.required_features);
     let support_modules = generated_project
         .support_modules
         .iter()
@@ -430,7 +424,7 @@ fn binary_project_cache_key(
         .collect::<Vec<_>>()
         .join("\n===\n");
     format!(
-        "project_name={project_name}\n[Cargo.toml]\n{}\n[main.rs]\n{}\n[support]\n{}\n[stdlib]\n{}\n[crates]\n{}\n[interop]\n{}\n[cache-key-fragment]\n{}\n[sysroot-dependency-plan]\n{}",
+        "project_name={project_name}\n[Cargo.toml]\n{}\n[main.rs]\n{}\n[support]\n{}\n[sysroot-dependency-inputs]\n{}[interop]\n{}\n[cache-key-fragment]\n{}\n[sysroot-dependency-plan]\n{}",
         generate_dependency_cargo_toml_for_cache_key(
             project_name,
             dependency_plan,
@@ -438,28 +432,11 @@ fn binary_project_cache_key(
         ),
         generated_project.main_rs,
         support_modules,
-        stdlib_modules.join("\n"),
-        required_features.join("\n"),
+        dependency_plan.dependency_input_fingerprint(),
         generated_project.interop.cache_key_fragment(),
         generated_project.cache_key_fragment.as_deref().unwrap_or(""),
         dependency_plan.cache_fingerprint
     )
-}
-
-fn sorted_lines(values: &std::collections::HashSet<String>) -> Vec<String> {
-    let mut ordered: BTreeSet<&str> = BTreeSet::new();
-    for value in values {
-        ordered.insert(value.as_str());
-    }
-    ordered.into_iter().map(str::to_string).collect()
-}
-
-fn sorted_feature_lines(values: &std::collections::HashSet<StdlibFeature>) -> Vec<String> {
-    let mut ordered: BTreeSet<&str> = BTreeSet::new();
-    for value in values {
-        ordered.insert(value.id());
-    }
-    ordered.into_iter().map(str::to_string).collect()
 }
 
 #[cfg(test)]
@@ -479,7 +456,7 @@ mod tests {
         RustInteropAbiRequirements, RustInteropDeclaration, RustInteropDecoratorKind,
         RustInteropEffect, RustTargetPath,
     };
-    use sifr_stdlib_manifest::{CargoVendorMode, SysrootDependencyPlan};
+    use sifr_stdlib_manifest::{CargoVendorMode, StdlibFeature, SysrootDependencyPlan};
     use std::collections::{BTreeMap, BTreeSet, HashSet};
 
     #[test]
@@ -546,6 +523,20 @@ mod tests {
             binary_project_cache_key("sifr_output", &base, &test_dependency_plan("fingerprint-a")),
             binary_project_cache_key("sifr_output", &base, &test_dependency_plan("fingerprint-b"))
         );
+    }
+
+    #[test]
+    fn binary_project_cache_key_uses_sysroot_dependency_plan_inputs() {
+        let base = base_project();
+        let mut dependency_plan = test_dependency_plan("fingerprint-a");
+        dependency_plan.stdlib_modules = BTreeSet::from(["sifr.json".to_string()]);
+        dependency_plan.required_features = BTreeSet::from([StdlibFeature::SerdeJson]);
+
+        let cache_key = binary_project_cache_key("sifr_output", &base, &dependency_plan);
+
+        assert!(cache_key.contains(
+            "[sysroot-dependency-inputs]\n[stdlib]\nsifr.json\n[features]\nserde_json\n"
+        ));
     }
 
     #[test]
@@ -673,6 +664,8 @@ mod tests {
 
     fn test_dependency_plan(cache_fingerprint: &str) -> SysrootDependencyPlan {
         SysrootDependencyPlan {
+            stdlib_modules: BTreeSet::new(),
+            required_features: BTreeSet::new(),
             sysroot_root: "/sysroot".into(),
             toolchain_id: "0.1.0-test-aarch64-test".to_string(),
             sysroot_content_sha256: "0".repeat(64),

--- a/crates/sifr_driver/src/build/report.rs
+++ b/crates/sifr_driver/src/build/report.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::diagnostics::RenderedDiagnostic;
+use sifr_stdlib_manifest::SysrootDependencyPlan;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BuildCompilationMode {
@@ -48,18 +49,18 @@ pub struct BuildSysrootReport {
     root: PathBuf,
     toolchain_id: String,
     content_sha256: String,
+    dependency_inputs: String,
+    dependency_fingerprint: String,
 }
 
 impl BuildSysrootReport {
-    pub fn new(
-        root: PathBuf,
-        toolchain_id: impl Into<String>,
-        content_sha256: impl Into<String>,
-    ) -> Self {
+    pub fn from_dependency_plan(dependency_plan: &SysrootDependencyPlan) -> Self {
         Self {
-            root,
-            toolchain_id: toolchain_id.into(),
-            content_sha256: content_sha256.into(),
+            root: dependency_plan.sysroot_root.clone(),
+            toolchain_id: dependency_plan.toolchain_id.clone(),
+            content_sha256: dependency_plan.sysroot_content_sha256.clone(),
+            dependency_inputs: dependency_plan.dependency_input_fingerprint(),
+            dependency_fingerprint: dependency_plan.cache_fingerprint.clone(),
         }
     }
 
@@ -73,6 +74,14 @@ impl BuildSysrootReport {
 
     pub fn content_sha256(&self) -> &str {
         &self.content_sha256
+    }
+
+    pub fn dependency_inputs(&self) -> &str {
+        &self.dependency_inputs
+    }
+
+    pub fn dependency_fingerprint(&self) -> &str {
+        &self.dependency_fingerprint
     }
 }
 

--- a/crates/sifr_driver/src/test_runner/execution.rs
+++ b/crates/sifr_driver/src/test_runner/execution.rs
@@ -6,6 +6,7 @@ use crate::build::{
 use crate::diagnostics::{write_stderr, write_stderr_line, RenderedDiagnostic};
 use crate::project::{namespace_module_files, rust_module_file_path};
 use sifr_diagnostics::DiagnosticCode;
+use sifr_stdlib_manifest::SysrootDependencyPlan;
 use std::path::Path;
 
 pub(crate) struct TestRunnerExecutionOutcome {
@@ -35,7 +36,7 @@ pub(crate) fn execute_test_runner_project(
         generated_project,
         &cargo_plan.cargo_toml,
         &test_lib,
-        &cargo_plan.dependency_plan.cache_fingerprint,
+        &cargo_plan.dependency_plan,
     );
     let required_paths = [
         Path::new("Cargo.toml"),
@@ -170,7 +171,7 @@ fn test_runner_cache_key(
     generated_project: &GeneratedTestRunnerProject,
     cargo_toml: &str,
     test_lib: &str,
-    dependency_plan_fingerprint: &str,
+    dependency_plan: &SysrootDependencyPlan,
 ) -> String {
     let mut support_modules: Vec<(&str, &str)> = generated_project
         .support_rust_files
@@ -183,22 +184,62 @@ fn test_runner_cache_key(
         .map(|(name, code)| format!("{name}\n{code}"))
         .collect::<Vec<_>>()
         .join("\n===\n");
-    let mut stdlib_modules: Vec<&str> = generated_project
-        .all_stdlib_modules
-        .iter()
-        .map(String::as_str)
-        .collect();
-    stdlib_modules.sort_unstable();
-    let mut required_features: Vec<&str> = generated_project
-        .all_required_features
-        .iter()
-        .map(|feature| feature.id())
-        .collect();
-    required_features.sort_unstable();
     format!(
-        "[scope]\n{}\n[Cargo.toml]\n{cargo_toml}\n[src/lib.rs]\n{test_lib}\n[support]\n{support_modules}\n[stdlib]\n{}\n[crates]\n{}\n[sysroot-dependency-plan]\n{dependency_plan_fingerprint}",
+        "[scope]\n{}\n[Cargo.toml]\n{cargo_toml}\n[src/lib.rs]\n{test_lib}\n[support]\n{support_modules}\n[sysroot-dependency-inputs]\n{}[sysroot-dependency-plan]\n{}",
         generated_project.cache_scope.display(),
-        stdlib_modules.join("\n"),
-        required_features.join("\n")
+        dependency_plan.dependency_input_fingerprint(),
+        dependency_plan.cache_fingerprint
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_runner_cache_key;
+    use crate::test_runner::orchestrator::GeneratedTestRunnerProject;
+    use sifr_stdlib_manifest::{
+        CargoVendorMode, StdlibFeature, SysrootCrate, SysrootCrateDependency, SysrootDependencyPlan,
+    };
+    use std::collections::{BTreeSet, HashMap, HashSet};
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_runner_cache_key_uses_sysroot_dependency_plan_inputs() {
+        let generated_project = GeneratedTestRunnerProject {
+            cache_scope: PathBuf::from("/tmp/sifr-tests"),
+            support_module_names: Vec::new(),
+            support_rust_files: HashMap::new(),
+            all_rust_code: "#[test]\nfn test_case() {}\n".to_string(),
+            all_stdlib_modules: HashSet::from(["sifr.json".to_string()]),
+            all_required_features: HashSet::from([StdlibFeature::SerdeJson]),
+        };
+        let dependency_plan = SysrootDependencyPlan {
+            stdlib_modules: BTreeSet::from(["sifr.json".to_string()]),
+            required_features: BTreeSet::from([StdlibFeature::SerdeJson]),
+            sysroot_root: "/sysroot".into(),
+            toolchain_id: "0.1.0-test-aarch64-test".to_string(),
+            sysroot_content_sha256: "0".repeat(64),
+            cargo_config: "/sysroot/.cargo/config.toml".into(),
+            vendor_dir: "/sysroot/vendor".into(),
+            crates: vec![SysrootCrateDependency {
+                krate: SysrootCrate::SifrStdlib,
+                path: "/sysroot/crates/sifr_stdlib".into(),
+                features: BTreeSet::from(["json".to_string()]),
+            }],
+            retained_direct_dependencies: Vec::new(),
+            cargo_vendor_mode: CargoVendorMode::SysrootOnly,
+            cache_fingerprint: "fingerprint-a".to_string(),
+        };
+
+        let cache_key = test_runner_cache_key(
+            &generated_project,
+            "[package]\nname = \"sifr_tests\"\n",
+            "#[test]\nfn test_case() {}\n",
+            &dependency_plan,
+        );
+
+        assert!(cache_key.contains(
+            "[sysroot-dependency-inputs]\n[stdlib]\nsifr.json\n[features]\nserde_json\n"
+        ));
+        assert!(cache_key.contains("[sysroot-dependency-plan]\nfingerprint-a"));
+    }
 }

--- a/crates/sifr_stdlib_manifest/src/features/dependency_plan.rs
+++ b/crates/sifr_stdlib_manifest/src/features/dependency_plan.rs
@@ -87,6 +87,8 @@ impl SysrootCrateDependency {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SysrootDependencyPlan {
+    pub stdlib_modules: BTreeSet<String>,
+    pub required_features: BTreeSet<StdlibFeature>,
     pub sysroot_root: PathBuf,
     pub toolchain_id: String,
     pub sysroot_content_sha256: String,
@@ -106,6 +108,21 @@ impl SysrootDependencyPlan {
             .map(SysrootCrateDependency::cargo_line)
             .chain(self.retained_direct_dependencies.iter().cloned())
             .collect()
+    }
+
+    #[must_use]
+    pub fn dependency_input_fingerprint(&self) -> String {
+        let mut fingerprint = String::from("[stdlib]\n");
+        for module in &self.stdlib_modules {
+            fingerprint.push_str(module);
+            fingerprint.push('\n');
+        }
+        fingerprint.push_str("[features]\n");
+        for feature in &self.required_features {
+            fingerprint.push_str(feature.id());
+            fingerprint.push('\n');
+        }
+        fingerprint
     }
 }
 
@@ -130,6 +147,8 @@ pub fn sysroot_dependency_plan_with_sysroot(
     sysroot: &ResolvedSysroot,
     cargo_vendor_mode: CargoVendorMode,
 ) -> SysrootDependencyPlan {
+    let stdlib_module_inputs = stdlib_modules.iter().cloned().collect::<BTreeSet<_>>();
+    let required_feature_inputs = required_features.iter().copied().collect::<BTreeSet<_>>();
     let runtime_features = RuntimeFeatures::from_requirements(stdlib_modules, required_features);
     let stdlib_features = planned_sifr_stdlib_features(stdlib_modules, required_features)
         .into_iter()
@@ -148,6 +167,8 @@ pub fn sysroot_dependency_plan_with_sysroot(
         cache_fingerprint(sysroot, &crates, &direct_dependencies, cargo_vendor_mode);
 
     SysrootDependencyPlan {
+        stdlib_modules: stdlib_module_inputs,
+        required_features: required_feature_inputs,
         sysroot_root: sysroot.root.clone(),
         toolchain_id: sysroot.toolchain_id(),
         sysroot_content_sha256: sysroot.manifest.sysroot_content_sha256.clone(),

--- a/crates/sifr_stdlib_manifest/src/features_tests.rs
+++ b/crates/sifr_stdlib_manifest/src/features_tests.rs
@@ -308,12 +308,24 @@ fn planned_sysroot_stdlib_features_include_codegen_requirements_without_umbrella
 fn sysroot_dependency_plan_captures_identity_features_and_vendor_mode() {
     let plan = try_sysroot_dependency_plan(
         &HashSet::from(["sifr.json".to_string()]),
-        &HashSet::new(),
+        &HashSet::from([StdlibFeature::SerdeJson]),
         CargoVendorMode::SysrootOnly,
     )
     .expect("source-tree sysroot should resolve");
 
     assert_eq!(plan.cargo_vendor_mode, CargoVendorMode::SysrootOnly);
+    assert_eq!(
+        plan.stdlib_modules,
+        ["sifr.json".to_string()].into_iter().collect()
+    );
+    assert_eq!(
+        plan.required_features,
+        [StdlibFeature::SerdeJson].into_iter().collect()
+    );
+    assert_eq!(
+        plan.dependency_input_fingerprint(),
+        "[stdlib]\nsifr.json\n[features]\nserde_json\n"
+    );
     assert_eq!(plan.sysroot_content_sha256.len(), 64);
     assert!(plan.cargo_config.ends_with(".cargo/config.toml"));
     assert!(plan.vendor_dir.ends_with("vendor"));

--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -348,6 +348,12 @@ M1 may land as ordered sub-PRs:
   in PR #2835, merge commit `7683ff65f1517b42639d8834f73a71d98eae1a16`;
   local `create-pr` validation passed in 168.61s with no advisories; reviewer
   pass 2 READY).
+- M1e: route sysroot dependency input identity through
+  `SysrootDependencyPlan` for binary cache keys, test-runner cache keys, and
+  build sysroot reports, so downstream consumers do not re-sort raw codegen
+  stdlib module and native feature sets (implementation PR pending; focused
+  local validation passed; local `create-pr` validation passed in 536.17s
+  with advisory: warm wall-time budget exceeded; reviewer pass 2 READY).
 
 Acceptance:
 

--- a/plans/reviews/active/m1e-sysroot-dependency-plan-opus-pass1.md
+++ b/plans/reviews/active/m1e-sysroot-dependency-plan-opus-pass1.md
@@ -1,0 +1,23 @@
+# M1e Sysroot Dependency Plan - Opus Review Pass 1
+
+Command:
+
+```bash
+claude --dangerously-skip-permissions --setting-sources project --model claude-opus-4-7 --effort xhigh -p "Review the current uncommitted changes for milestone M1e of plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md. Scope: SysrootDependencyPlan now owns the sorted dependency inputs; binary build cache keys, test runner cache keys, and build sysroot reports should consume the plan object instead of recomputing sysroot feature/module identity from raw codegen sets. Please inspect the diff and relevant call paths. Pay special attention to: (1) any stale recomputation of sysroot stdlib modules/features downstream of try_generate_sysroot_dependency_plan, (2) whether the cache key changes preserve invalidation specificity, (3) whether BuildSysrootReport now represents the dependency plan accurately without output churn, (4) tests and edge cases. Focused validation already run: cargo fmt --check; cargo test -p sifr_stdlib_manifest sysroot_dependency_plan_captures_identity_features_and_vendor_mode; cargo test -p sifr_driver binary_project_cache_key; cargo test -p sifr_driver test_runner_cache_key_uses_sysroot_dependency_plan_inputs; git diff --check; python3 scripts/check_file_size_guardrails.py. Return findings with severity and concrete file/line references. End with one of READY or BLOCKED."
+```
+
+Verdict: READY, with recommendations addressed before PR.
+
+Notes:
+
+- Non-blocking: feature ordering in dependency input fingerprints is now
+  `StdlibFeature` enum order rather than prior lexicographic id order. This is
+  deterministic and specificity-preserving, but it can flush existing caches.
+- Recommendation: avoid leaving `BuildSysrootReport::new()` as a path that
+  produces empty dependency identity. Addressed by removing `new()` and making
+  the CLI build-output test construct reports via `from_dependency_plan`.
+- Recommendation: make the new report dependency identity accessors consumed.
+  Addressed by asserting `dependency_inputs()` and `dependency_fingerprint()`
+  in `crates/sifr/src/build_output.rs`.
+- Recommendation: add an M1e phase-doc bullet before PR. Addressed in
+  `plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md`.

--- a/plans/reviews/active/m1e-sysroot-dependency-plan-opus-pass2.md
+++ b/plans/reviews/active/m1e-sysroot-dependency-plan-opus-pass2.md
@@ -1,0 +1,21 @@
+# M1e Sysroot Dependency Plan - Opus Review Pass 2
+
+Command:
+
+```bash
+claude --dangerously-skip-permissions --setting-sources project --model claude-opus-4-7 --effort xhigh -p "Review pass 2 for M1e of plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md. The previous READY review recommended removing the empty-identity BuildSysrootReport::new path, adding a consumer/assertion for report dependency identity, and updating the phase doc. Those changes are now included: BuildSysrootReport only has from_dependency_plan; crates/sifr build-output tests construct a stub SysrootDependencyPlan and assert dependency_inputs/dependency_fingerprint; crates/sifr has a dev-dependency on sifr_stdlib_manifest and Cargo.lock only adds that dependency edge; the phase doc has an M1e bullet; pass1 notes are saved under plans/reviews/active. Please inspect the current uncommitted diff and relevant call paths. Check for: (1) any remaining stale downstream recomputation of sysroot stdlib modules/features after a SysrootDependencyPlan exists, (2) cache-key invalidation specificity for binary and test-runner projects, (3) correctness/appropriateness of the BuildSysrootReport API and test dependency, (4) doc/review artifact issues. Validation since changes: cargo fmt --check; cargo test -p sifr_stdlib_manifest sysroot_dependency_plan_captures_identity_features_and_vendor_mode; cargo test -p sifr_driver binary_project_cache_key; cargo test -p sifr_driver test_runner_cache_key_uses_sysroot_dependency_plan_inputs; cargo test -p sifr_driver cargo_manifest; cargo test -p sifr build_sysroot_report_carries_dependency_plan_identity; git diff --check; python3 scripts/check_file_size_guardrails.py. Return findings with severity and concrete file/line references. End with one of READY or BLOCKED."
+```
+
+Verdict: READY.
+
+Findings:
+
+- No blocking or non-blocking findings survived verification.
+- Binary and test-runner cache keys consume
+  `dependency_plan.dependency_input_fingerprint()` and retain
+  `dependency_plan.cache_fingerprint`.
+- `BuildSysrootReport` exposes only `from_dependency_plan` for construction,
+  and the CLI build-output tests consume and assert report dependency identity.
+- The `sifr` dev-dependency on `sifr_stdlib_manifest` and `Cargo.lock` change
+  are limited to the direct test dependency edge.
+- The M1e phase-doc bullet and pass-1 review artifact are present.


### PR DESCRIPTION
## Summary

- Add raw stdlib module and required native feature identity to `SysrootDependencyPlan`, with a stable `dependency_input_fingerprint()`.
- Route binary build cache keys, test-runner cache keys, and build sysroot reports through the dependency plan instead of re-sorting raw codegen sets downstream.
- Remove the empty-identity `BuildSysrootReport::new()` path; report construction now uses `BuildSysrootReport::from_dependency_plan()` and tests assert the dependency identity is carried.
- Record M1e status and Opus review artifacts for the active phase.

## Impact

This keeps sysroot dependency identity centralized in the manifest-owned plan while preserving cache invalidation specificity: cache keys include both the raw dependency inputs and the resolved sysroot dependency fingerprint. The feature ordering in the input fingerprint is now deterministic `StdlibFeature` enum order rather than the old downstream lexicographic string order, which may cause a one-time local artifact cache miss but does not reduce specificity.

## Validation

- `cargo fmt --check`
- `cargo test -p sifr_stdlib_manifest sysroot_dependency_plan_captures_identity_features_and_vendor_mode`
- `cargo test -p sifr_driver binary_project_cache_key`
- `cargo test -p sifr_driver test_runner_cache_key_uses_sysroot_dependency_plan_inputs`
- `cargo test -p sifr_driver cargo_manifest`
- `cargo test -p sifr build_sysroot_report_carries_dependency_plan_identity`
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`
- `scripts/run_all_tests.sh --profile create-pr` passed in 536.17s; advisory: warm wall-time budget exceeded

## Reviews

- Opus pass 1: READY, recommendations addressed before PR
- Opus pass 2: READY, no findings
