### PR TITLE
Diagnose unsupported private stdlib constants

### DIFF
--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -198,6 +198,13 @@ impl LowerCtx {
         self.source_origin.is_sysroot_source()
     }
 
+    pub(in crate::lower) fn is_sysroot_private_declaration(&self) -> bool {
+        matches!(
+            self.source_origin,
+            LoweringSourceOrigin::SysrootPrivateDeclaration
+        )
+    }
+
     pub(in crate::lower) fn can_import_private_stdlib_declarations(&self) -> bool {
         self.source_origin.can_import_private_stdlib_declarations()
     }

--- a/crates/sifr_lowering/src/lower/module_constants_lowering.rs
+++ b/crates/sifr_lowering/src/lower/module_constants_lowering.rs
@@ -1,6 +1,7 @@
 use crate::HirExpr;
 use num_bigint::BigInt;
 use ruff_text_size::Ranged;
+use sifr_diagnostics::DiagnosticCode;
 use sifr_python_ast::{Expr, Stmt, UnaryOp};
 use sifr_type_system::Type;
 
@@ -92,7 +93,12 @@ fn lower_annotated_module_constant_expr(
     if let Some(folded_value) = folded_value {
         return Some(folded_value);
     }
-    is_supported_annotated_module_constant_expr(&hir_value).then_some(hir_value)
+    if is_supported_annotated_module_constant_expr(&hir_value) {
+        Some(hir_value)
+    } else {
+        reject_unsupported_private_declaration_constant(ctx, var_name, value_expr);
+        None
+    }
 }
 
 fn is_supported_annotated_module_constant_expr(value: &HirExpr) -> bool {
@@ -130,6 +136,23 @@ fn is_supported_annotated_module_constant_expr(value: &HirExpr) -> bool {
             .all(is_supported_annotated_module_constant_expr),
         _ => false,
     }
+}
+
+fn reject_unsupported_private_declaration_constant(
+    ctx: &mut LowerCtx,
+    var_name: &str,
+    value_expr: &Expr,
+) {
+    if !ctx.is_sysroot_private_declaration() {
+        return;
+    }
+    ctx.error_with_code_at(
+        DiagnosticCode::TYPE_UNSUPPORTED_EXPRESSION_FORM,
+        format!(
+            "unsupported private declaration constant '{var_name}': initializer must be a literal, supported constant expression, or constructor call"
+        ),
+        value_expr.range(),
+    );
 }
 
 fn collect_bare_constant(
@@ -283,15 +306,21 @@ mod tests {
     }
 
     #[test]
-    fn annotated_scalar_module_constant_name_alias_is_not_collected() {
-        let constants = lower_private_declaration_constants("pi: float = 3.0\nalias: float = pi\n");
+    fn private_declaration_scalar_module_constant_alias_is_diagnostic() {
+        let parsed =
+            parse_module("pi: float = 3.0\nalias: float = pi\n").expect("source should parse");
+        let errors = match lower_module_sysroot_private_declaration_with_externals(
+            parsed.suite(),
+            &ExternalDefs::default(),
+        ) {
+            Ok(_) => panic!("unsupported private declaration constant should fail"),
+            Err(errors) => errors,
+        };
 
-        assert!(constants
-            .iter()
-            .any(|(name, ty, _)| name == "pi" && ty == &Type::Float));
-        assert!(
-            constants.iter().all(|(name, _, _)| name != "alias"),
-            "non-integer scalar aliases should not lower to lowercase Rust identifiers"
-        );
+        assert!(errors.iter().any(|error| {
+            error.code == Some(DiagnosticCode::TYPE_UNSUPPORTED_EXPRESSION_FORM)
+                && error.message
+                    == "unsupported private declaration constant 'alias': initializer must be a literal, supported constant expression, or constructor call"
+        }));
     }
 }

--- a/plans/reviews/active/m2a-private-constant-diagnostics-opus-pass1.md
+++ b/plans/reviews/active/m2a-private-constant-diagnostics-opus-pass1.md
@@ -1,0 +1,29 @@
+## Review: M2a private declaration diagnostics slice
+
+**Scope and correctness**
+
+- `is_sysroot_private_declaration()` (mod_context.rs:201) is a clean accessor gated on the enum variant. It sits parallel to `is_stdlib_lowering()` without conflating public/private stdlib — appropriate, since M2a only wants to tighten the private declaration surface.
+- `reject_unsupported_private_declaration_constant` (module_constants_lowering.rs:141) early-returns for anything that isn't `SysrootPrivateDeclaration`. `User` and `SysrootPublicStdlib` origins keep their existing silent-drop behavior — matches the "normal user behavior unchanged" requirement.
+- The diagnostic is only reached after `validate_annotated_constant_initializer` has settled: the code checks `error_count()` first and returns None if new errors landed, and returns early with any `folded_value`. So no double-report on genuine type mismatch, and no misfire on a folded literal.
+- The integer-constant alias fast path (`lower_module_integer_const_expr` at module_constants_lowering.rs:56) is untouched, so `const_integer_values` compile-time integer facts continue to work.
+- Diagnostic code `SIFR-TYPE-0012` (`TYPE_UNSUPPORTED_EXPRESSION_FORM`) is already registered (registry.rs:51, 683). Reusing it is consistent with other "declaration form isn't supported here" sites.
+- The unchanged `stdlib/_sifr/math.sifr` only contains literals and `1.0/0.0` binops, and `stdlib/sifr/math.sifr` uses `from _sifr.math import …` rather than local scalar aliases — so nothing in the current sysroot regresses.
+
+**Tests**
+
+- `private_declaration_scalar_module_constant_alias_is_diagnostic` (module_constants_lowering.rs:308) asserts the diagnostic's code and message text — good.
+- `private_declarations_collect_annotated_scalar_module_constants` (line 275) confirms literal and BinOp initializers still lower cleanly.
+- The existing `annotated_scalar_module_constant_type_mismatch_is_diagnostic` (line 291) still passes through the same lowering path with `TYPE_MISMATCH` semantics, so the ordering (mismatch first, then unsupported form) is exercised implicitly.
+- Gaps worth noting (not blockers): no explicit negative test that a user module (`lower_module`) with `alias: float = pi` still drops silently — the guard is very small, but a one-line positive test would lock the "user behavior unchanged" invariant. Also no test for a private declaration constructor-call initializer (that path is listed as supported in the message and in `is_supported_annotated_module_constant_expr`).
+
+**Housekeeping**
+
+- File sizes noted (326 / 563 lines) — both well under the 900-line cap.
+- The change adds ~30 net lines of straightforward logic and one test; no responsibility-boundary changes that would nudge maintainability guardrails.
+- Comment-free code is fine here — the intent is clear from names.
+
+**Merge safety**
+
+This is a well-scoped M2a sub-PR: it closes the "silently dropped private-declaration alias" gap with a structured diagnostic while preserving user, public-stdlib, and integer-facts paths verbatim. Recommended follow-up (not blocking): add a user-mode negative test and a constructor-call positive test in a later slice.
+
+READY


### PR DESCRIPTION
## Summary
- Adds a private-declaration origin check for lowering diagnostics
- Reports unsupported private stdlib annotated scalar constants instead of silently dropping them
- Updates the private constant regression test and includes Opus READY review evidence

## Review
- Opus review artifact: plans/reviews/active/m2a-private-constant-diagnostics-opus-pass1.md
- Status: READY

## Validation
- cargo test -p sifr_lowering module_constants_lowering -- --nocapture
- cargo test -p sifr_lowering name_import_diagnostics_tests -- --nocapture
- cargo test -p sifr_driver math_private_declarations_codegen_through_sifr_stdlib -- --nocapture
- cargo test -p sifr_codegen test_render_expr_lowering -- --nocapture
- python3 scripts/check_hir_maintainability_guardrails.py
- scripts/run_all_tests.sh --profile create-pr (pass, wall_time=270.30s, advisories=none)