### PR TITLE
Record sysroot Self diagnostic coverage

### DIFF
--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -91,7 +91,7 @@ merged, and documented before the next milestone starts.
 | --- | --- | --- |
 | M0. Model Split and Raw-Injection Removal | merged | PR #2820 · sha=8f1f44d; PR #2821 · sha=f82cc64; PR #2823 · sha=c0828de; PR #2825 · sha=5e05898; PR #2827 · sha=45b36d1 |
 | M1. Manifest Schema and Normal-Path Guards | merged | PR #2829 · sha=d2b97bb; PR #2831 · sha=05cb817; PR #2833 · sha=af66be2; PR #2835 · sha=7683ff6; PR #2837 · sha=91cae31 |
-| M2. Declaration Infrastructure and Provenance | in progress | PR #2839 · sha=d920e16; PR #2841 · sha=4e5621d; PR #2843 · sha=631b1d8 |
+| M2. Declaration Infrastructure and Provenance | in progress | PR #2839 · sha=d920e16; PR #2841 · sha=4e5621d; PR #2843 · sha=631b1d8; PR #2845 · sha=217e04d |
 | M3. File and Filesystem Migration | planned |  |
 | M4. Random, Time, and Logging | planned |  |
 | M5. Simple Sys and Environment | planned |  |
@@ -445,6 +445,10 @@ milestone is merged:
     methods through the existing opaque `SelfMethod` resolver, while non-sysroot
     opaque `type=` roots still hit the canonical sysroot guard in PR #2843
     (merge sha `631b1d8a22460cabdbe49f2f07685df0be365e30`).
+  - Private sysroot `Self.*` lifecycle targets on non-opaque classes now have
+    regression coverage proving they keep the `@rust.opaque` diagnostic path
+    instead of being caught by the canonical sysroot-crate guard in PR #2845
+    (merge sha `217e04df5730b31fd50f9207f83452985c50edcb`).
 - M2c: structural `StdlibRustSource` provenance with canonical
   sysroot-relative paths, source digests, and raw-string rejection.
 - M2d: permanent side-channel guards for new dispatch entries, preambles,


### PR DESCRIPTION
## Summary
- records PR #2845 in the M2 implementation evidence row
- adds the M2b note for non-opaque sysroot `Self.*` diagnostic coverage

## Validation
- `scripts/run_all_tests.sh --profile create-pr` — pass, wall_time=242.76s, e2e cache_hits=41/41, advisories=none
