### PR TITLE
Record stdlib Rust provenance milestone

### DIFF
--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -91,7 +91,7 @@ merged, and documented before the next milestone starts.
 | --- | --- | --- |
 | M0. Model Split and Raw-Injection Removal | merged | PR #2820 · sha=8f1f44d; PR #2821 · sha=f82cc64; PR #2823 · sha=c0828de; PR #2825 · sha=5e05898; PR #2827 · sha=45b36d1 |
 | M1. Manifest Schema and Normal-Path Guards | merged | PR #2829 · sha=d2b97bb; PR #2831 · sha=05cb817; PR #2833 · sha=af66be2; PR #2835 · sha=7683ff6; PR #2837 · sha=91cae31 |
-| M2. Declaration Infrastructure and Provenance | in progress | PR #2839 · sha=d920e16; PR #2841 · sha=4e5621d; PR #2843 · sha=631b1d8; PR #2845 · sha=217e04d |
+| M2. Declaration Infrastructure and Provenance | in progress | PR #2839 · sha=d920e16; PR #2841 · sha=4e5621d; PR #2843 · sha=631b1d8; PR #2845 · sha=217e04d; PR #2847 · sha=d75a54e |
 | M3. File and Filesystem Migration | planned |  |
 | M4. Random, Time, and Logging | planned |  |
 | M5. Simple Sys and Environment | planned |  |
@@ -451,6 +451,10 @@ milestone is merged:
     (merge sha `217e04df5730b31fd50f9207f83452985c50edcb`).
 - M2c: structural `StdlibRustSource` provenance with canonical
   sysroot-relative paths, source digests, and raw-string rejection.
+  - Compiled stdlib Rust is now transported as `StdlibRustSource` with module,
+    canonical `stdlib/...` source path, source SHA-256 computed from checked
+    source content, and the generated Rust payload in PR #2847 (merge sha
+    `d75a54e4ee3cc6d026606410d390ff828b0513e4`).
 - M2d: permanent side-channel guards for new dispatch entries, preambles,
   direct dependencies, fallback registries, private target escapes, and direct
   stdlib-behavior `sifr_runtime::*` calls.


### PR DESCRIPTION
## Summary
- records PR #2847 in the M2 implementation status evidence row
- documents the M2c `StdlibRustSource` provenance slice with the full merge SHA

## Validation
- `git diff --check`
- `scripts/run_all_tests.sh --profile create-pr` (pass, wall_time=262.71s, e2e cache_hits=41/41, budget_ok=yes, advisories=none)
