### PR TITLE
Guard stdlib side-channel boundaries

### DIFF
--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -889,8 +889,9 @@ resource migration cannot advance a resource-shaped surface ahead of the
 runtime evidence recorded by the Rust interop matrix.
 The stdlib native intrinsic allowlist guard is also part of core validation:
 it freezes every retained compiler intrinsic name, prefix dispatcher, registry
-file, and preamble file until that entry is closing, deleted, or explicitly kept
-as compiler-language glue.
+file, preamble file, retained direct dependency package, and direct
+`sifr_runtime::<root>` generated-code reference until that entry is closing,
+deleted, or explicitly kept as compiler-language glue.
 
 Private stdlib Rust interop uses the normal Rust interop contract plus a
 compiler-owned sysroot trust policy. A canonical private `_sifr.*` declaration

--- a/internal_docs/stdlib_retained_compiler_intrinsics.toml
+++ b/internal_docs/stdlib_retained_compiler_intrinsics.toml
@@ -330,6 +330,8 @@ certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
 reason = "Network handles and split stream lifecycle behavior remain resource/runtime-owned pending certification."
 registry_files = ["net.rs"]
 preamble_files = ["net_runtime.rs"]
+retained_direct_dependency_packages = ["tokio", "tracing"]
+direct_runtime_roots = ["sifr_runtime::net"]
 exact_intrinsics = [
   "net_connect_tcp",
   "net_listen_tcp",
@@ -365,6 +367,15 @@ certification_rows = ["opaque_resource_matrix", "async_runtime_reqwest"]
 reason = "TLS configuration, handshakes, stream handles, and certificate state remain resource/runtime-owned pending certification."
 registry_files = ["tls.rs"]
 preamble_files = ["tls_runtime.rs"]
+retained_direct_dependency_packages = [
+  "rustls",
+  "rustls-pemfile",
+  "rustls-platform-verifier",
+  "tokio",
+  "tokio-rustls",
+  "tracing",
+]
+direct_runtime_roots = ["sifr_runtime::tls"]
 exact_intrinsics = [
   "tls_accept",
   "tls_client_config_close",
@@ -436,6 +447,7 @@ certification_rows = [
 ]
 reason = "Python object handles, callback adapters, and runtime initialization remain behind Python resource/callback certification."
 registry_files = ["python.rs"]
+direct_runtime_roots = ["sifr_runtime::python"]
 exact_intrinsics = [
   "local_callback",
   "py_arrow_array",
@@ -550,8 +562,54 @@ state = "retained-by-design"
 owner = "stdlib-native-boundary-completion"
 issue = "stdlib-native-boundary-completion"
 evidence_links = ["stdlib-native-boundary-completion"]
-reason = "Additional feature planning is compiler-owned glue that selects retained runtime/sysroot dependencies for generated projects."
+reason = "Additional feature planning is compiler-owned glue that selects retained runtime/sysroot dependencies for generated projects and freezes the transitional direct dependency package namespace."
 registry_files = ["requirements.rs"]
+retained_direct_dependency_packages = [
+  "bigdecimal",
+  "blake2",
+  "bytes",
+  "chrono",
+  "flate2",
+  "h2",
+  "http",
+  "http-body",
+  "http-body-util",
+  "hyper",
+  "hyper-util",
+  "icu_collator",
+  "icu_datetime",
+  "icu_decimal",
+  "icu_locale",
+  "icu_plurals",
+  "md5",
+  "metrics",
+  "num-bigint",
+  "num-traits",
+  "percent-encoding",
+  "postcard",
+  "rand",
+  "rand_distr",
+  "rayon",
+  "regex",
+  "rust_decimal",
+  "rustls",
+  "rustls-pemfile",
+  "rustls-platform-verifier",
+  "serde",
+  "serde_json",
+  "sha1",
+  "sha2",
+  "tokio",
+  "tokio-rustls",
+  "tower-service",
+  "tracing",
+  "unicode-normalization",
+  "unicode-segmentation",
+  "unicode_names2",
+  "url",
+  "uuid",
+  "zip",
+]
 
 [[surface]]
 id = "shared-language-preamble"
@@ -561,6 +619,10 @@ issue = "stdlib-native-boundary-completion"
 evidence_links = ["stdlib-native-boundary-completion"]
 reason = "Generated Rust type conversion and error wrapper helpers are shared language/runtime glue."
 preamble_files = ["types_and_errors.rs"]
+direct_runtime_roots = [
+  "sifr_runtime::DEFAULT_MAX_INTEGER_DIGITS",
+  "sifr_runtime::interop",
+]
 
 [[surface]]
 id = "mixed-io-logging-random-preamble"

--- a/plans/reviews/active/m2d-side-channel-guards-opus-pass1.md
+++ b/plans/reviews/active/m2d-side-channel-guards-opus-pass1.md
@@ -1,0 +1,11 @@
+READY
+
+Findings (none blocking):
+
+- **Non-unique dedup fall-through is correct but leaves `owners` pointing at the last surface for `retained_direct_dependency_packages`.** Since duplicates are not failed and `allowed[key]` is a set, this is harmless — just noting the diagnostic (if ever surfaced elsewhere) would show the most-recent owner rather than the first.
+- **`GENERATED_DEPENDENCY_PACKAGE_RE` assumes `features.rs` writes dep names as `package: "<name>"` literals.** If a dep is ever emitted via `const` or `format!(…)`, it will be silently missed from `observed`. Not a bug in this diff — worth flagging as an assumption baked into the guard.
+- **`DIRECT_RUNTIME_ROOT_RE` only matches when the first path segment after `sifr_runtime::` is a bare identifier.** Any dynamic construction (`format!("sifr_runtime::{}::…")`) would evade observation. Again an assumption, not a correctness bug against the current codegen.
+- The `interop`/`DEFAULT_MAX_INTEGER_DIGITS` entries under `shared-language-preamble` and the per-surface `net`/`tls`/`python` roots line up with the `direct_runtime_roots` unique-owner rule — no cross-surface ownership conflicts visible in the manifest.
+- Manifest schema updates and the `has_owned_surface` extension correctly permit surfaces (e.g. `additional-feature-planning`) that only own dependency packages without registry files.
+
+No concrete correctness bugs in gating behavior for the new fields.

--- a/scripts/check_stdlib_manifest_schema.py
+++ b/scripts/check_stdlib_manifest_schema.py
@@ -37,6 +37,8 @@ ALLOWED_SURFACE_FIELDS = {
     "registry_files",
     "preamble_files",
     "exact_intrinsics",
+    "retained_direct_dependency_packages",
+    "direct_runtime_roots",
 }
 VALID_STATES = {"retained", "pilot", "closing", "retained-by-design"}
 ALLOWED_STATE_TRANSITIONS = {
@@ -128,6 +130,8 @@ def _validate(manifest: dict[str, Any]) -> list[str]:
             "registry_files",
             "preamble_files",
             "exact_intrinsics",
+            "retained_direct_dependency_packages",
+            "direct_runtime_roots",
         ):
             _optional_string_list(failures, surface, key, context)
 
@@ -142,7 +146,13 @@ def _validate(manifest: dict[str, Any]) -> list[str]:
 
         has_owned_surface = any(
             surface.get(key)
-            for key in ("registry_files", "preamble_files", "exact_intrinsics")
+            for key in (
+                "registry_files",
+                "preamble_files",
+                "exact_intrinsics",
+                "retained_direct_dependency_packages",
+                "direct_runtime_roots",
+            )
         )
         if not has_owned_surface:
             failures.append(f"{context}: must own registry_files, preamble_files, or exact_intrinsics")

--- a/scripts/check_stdlib_native_intrinsic_allowlist.py
+++ b/scripts/check_stdlib_native_intrinsic_allowlist.py
@@ -18,11 +18,15 @@ REGISTRY_DISPATCH_PATH = (
 )
 PREAMBLE_ROOT = REPO_ROOT / "crates" / "sifr_codegen" / "src" / "preamble"
 RETAINED_INTRINSICS_LIB_PATH = REPO_ROOT / "crates" / "sifr_retained_intrinsics" / "src" / "lib.rs"
+FEATURES_RS_PATH = REPO_ROOT / "crates" / "sifr_stdlib_manifest" / "src" / "features.rs"
+CODEGEN_ROOT = REPO_ROOT / "crates" / "sifr_codegen" / "src"
 
 EXACT_INTRINSIC_RE = re.compile(r'"([A-Za-z0-9_]+)"\s*(?=\||=>)')
 LOWERER_MATCH_INTRINSIC_RE = re.compile(r'"([A-Za-z0-9_]+)"\s*(?=\||=>)')
 PREFIX_INTRINSIC_RE = re.compile(r'starts_with\("([A-Za-z0-9_]+)"\)')
 RETAINED_SIGNATURE_MODULE_RE = re.compile(r'"(_sifr\.[A-Za-z0-9_]+)"\s*=>\s*Some\(')
+GENERATED_DEPENDENCY_PACKAGE_RE = re.compile(r'package:\s*"([^"]+)"')
+DIRECT_RUNTIME_ROOT_RE = re.compile(r"\bsifr_runtime::([A-Za-z_][A-Za-z0-9_]*)")
 EXPECTED_PREFIX_DISPATCHERS = {"http_", "py_", "tls_"}
 PREFIX_DISPATCH_LOWERERS = (
     REGISTRY_ROOT / "tls.rs",
@@ -50,7 +54,10 @@ def _run(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> int:
         f"(exact_intrinsics={len(observed['exact_intrinsics'])}, "
         f"registry_files={len(observed['registry_files'])}, "
         f"preamble_files={len(observed['preamble_files'])}, "
-        f"fallback_signature_modules={len(observed['fallback_signature_modules'])})"
+        f"fallback_signature_modules={len(observed['fallback_signature_modules'])}, "
+        "retained_direct_dependency_packages="
+        f"{len(observed['retained_direct_dependency_packages'])}, "
+        f"direct_runtime_roots={len(observed['direct_runtime_roots'])})"
     )
     return 0
 
@@ -78,6 +85,14 @@ def _observed_surface() -> dict[str, set[str]]:
                 RETAINED_INTRINSICS_LIB_PATH.read_text(encoding="utf-8")
             )
         ),
+        "retained_direct_dependency_packages": {
+            package
+            for package in GENERATED_DEPENDENCY_PACKAGE_RE.findall(
+                FEATURES_RS_PATH.read_text(encoding="utf-8")
+            )
+            if package != "sifr_runtime"
+        },
+        "direct_runtime_roots": _direct_runtime_roots(),
     }
 
 
@@ -87,8 +102,11 @@ def _validate(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> list[
         "exact_intrinsics": set[str](),
         "registry_files": set[str](),
         "preamble_files": set[str](),
+        "retained_direct_dependency_packages": set[str](),
+        "direct_runtime_roots": set[str](),
     }
     owners: dict[tuple[str, str], str] = {}
+    unique_owner_keys = {"exact_intrinsics", "registry_files", "preamble_files", "direct_runtime_roots"}
 
     surfaces = allowlist.get("surface", [])
     if not isinstance(surfaces, list) or not surfaces:
@@ -118,11 +136,12 @@ def _validate(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> list[
                 owner_key = (key, value)
                 previous_owner = owners.get(owner_key)
                 if previous_owner is not None:
-                    failures.append(
-                        f"{key} entry {value!r} is duplicated by {surface_id} "
-                        f"and {previous_owner}"
-                    )
-                    continue
+                    if key in unique_owner_keys:
+                        failures.append(
+                            f"{key} entry {value!r} is duplicated by {surface_id} "
+                            f"and {previous_owner}"
+                        )
+                        continue
                 owners[owner_key] = surface_id
                 allowed[key].add(value)
 
@@ -162,6 +181,24 @@ def _validate(observed: dict[str, set[str]], allowlist: dict[str, Any]) -> list[
         _compare_sets(failures, key, observed_values, allowed[key])
 
     return failures
+
+
+def _direct_runtime_roots() -> set[str]:
+    roots: set[str] = set()
+    for path in CODEGEN_ROOT.rglob("*.rs"):
+        relative = path.relative_to(CODEGEN_ROOT).as_posix()
+        if _is_test_source(relative):
+            continue
+        text = path.read_text(encoding="utf-8")
+        roots.update(
+            f"sifr_runtime::{root}" for root in DIRECT_RUNTIME_ROOT_RE.findall(text)
+        )
+    return roots
+
+
+def _is_test_source(relative_path: str) -> bool:
+    name = relative_path.rsplit("/", 1)[-1]
+    return name.endswith("_tests.rs") or "/tests/" in f"/{relative_path}/"
 
 
 def _surface_private_modules(surface: dict[str, Any]) -> set[str]:
@@ -238,6 +275,8 @@ def _self_test() -> int:
         "registry_files": {"alpha.rs"},
         "preamble_files": {"runtime.rs"},
         "fallback_signature_modules": {"_sifr.alpha"},
+        "retained_direct_dependency_packages": {"alpha-dep"},
+        "direct_runtime_roots": {"sifr_runtime::alpha"},
     }
     allowlist = {
         "surface": [
@@ -249,6 +288,8 @@ def _self_test() -> int:
                 "exact_intrinsics": ["alpha"],
                 "registry_files": ["alpha.rs"],
                 "preamble_files": ["runtime.rs"],
+                "retained_direct_dependency_packages": ["alpha-dep"],
+                "direct_runtime_roots": ["sifr_runtime::alpha"],
             }
         ]
     }
@@ -272,6 +313,24 @@ def _self_test() -> int:
         for failure in _validate(observed, stale)
     ):
         print("self-test stale registry file was not rejected", file=sys.stderr)
+        return 1
+
+    missing_dependency = json.loads(json.dumps(allowlist))
+    missing_dependency["surface"][0]["retained_direct_dependency_packages"] = []
+    if not any(
+        "retained_direct_dependency_packages missing allowlist entries: alpha-dep" in failure
+        for failure in _validate(observed, missing_dependency)
+    ):
+        print("self-test missing retained direct dependency was not rejected", file=sys.stderr)
+        return 1
+
+    missing_runtime_root = json.loads(json.dumps(allowlist))
+    missing_runtime_root["surface"][0]["direct_runtime_roots"] = []
+    if not any(
+        "direct_runtime_roots missing allowlist entries: sifr_runtime::alpha" in failure
+        for failure in _validate(observed, missing_runtime_root)
+    ):
+        print("self-test missing direct runtime root was not rejected", file=sys.stderr)
         return 1
 
     duplicate = json.loads(json.dumps(allowlist))


### PR DESCRIPTION
## Summary
- extends the retained stdlib manifest schema with `retained_direct_dependency_packages` and `direct_runtime_roots` ownership fields
- teaches the native allowlist guard to freeze retained direct dependency package names and direct `sifr_runtime::<root>` generated-code references
- records the current retained dependency/runtime-root surfaces in the manifest and updates sysroot architecture docs

## Review
- `plans/reviews/active/m2d-side-channel-guards-opus-pass1.md` - READY

## Validation
- `python3 scripts/check_stdlib_manifest_schema.py`
- `python3 scripts/check_stdlib_manifest_schema.py --self-test`
- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py --self-test`
- `python3 scripts/check_file_size_guardrails.py`
- `git diff --check`
- `scripts/run_all_tests.sh --profile create-pr` (pass, wall_time=200.94s, e2e cache_hits=40/41, budget_ok=yes, advisories=none)
