### PR TITLE
Record time migration evidence

### DIFF
--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -93,7 +93,7 @@ merged, and documented before the next milestone starts.
 | M1. Manifest Schema and Normal-Path Guards | merged | PR #2829 · sha=d2b97bb; PR #2831 · sha=05cb817; PR #2833 · sha=af66be2; PR #2835 · sha=7683ff6; PR #2837 · sha=91cae31 |
 | M2. Declaration Infrastructure and Provenance | merged | PR #2839 · sha=d920e16; PR #2841 · sha=4e5621d; PR #2843 · sha=631b1d8; PR #2845 · sha=217e04d; PR #2847 · sha=d75a54e; PR #2849 · sha=dd1fc69 |
 | M3. File and Filesystem Migration | merged | PR #2851 · sha=12b64b4; PR #2852 · sha=72a62f1; PR #2853 · sha=84b0419; PR #2855 · sha=4372f13; PR #2858 · sha=f08fc98 |
-| M4. Random, Time, and Logging | in progress | PR #2860 · sha=5daa4cc · manifest: `_sifr.logging` retained -> closing; PR #2862 · sha=b0d6a29 · manifest: `_sifr.crypto::random` retained -> closing |
+| M4. Random, Time, and Logging | in progress | PR #2860 · sha=5daa4cc · manifest: `_sifr.logging` retained -> closing; PR #2862 · sha=b0d6a29 · manifest: `_sifr.crypto::random` retained -> closing; PR #2864 · sha=9d901ad · manifest: `_sifr.time` exact retained leaves narrowed to `sleep`/`monotonic` |
 | M5. Simple Sys and Environment | planned |  |
 | M6. Async Resource Pilot | planned |  |
 | M7. Process Family | planned |  |
@@ -599,6 +599,20 @@ M4 may land as ordered sub-PRs:
   `5daa4cc7ade7b6a7da4b424ba4778f6cc99b6ce4`; local `create-pr`
   validation passed with wall-time/cache advisories only; reviewer round 3
   READY).
+- M4b migrates random scalar and state leaves behind `_sifr.crypto` private
+  Rust interop declarations and `sifr_stdlib::random`, removes the compiler
+  random registry path, retires the migrated random names from the closure
+  guard, and marks `_sifr.crypto::random` as `closing` in PR #2862 (merge sha
+  `b0d6a29c5`; local `create-pr` validation passed with wall-time/cache
+  advisories only; reviewer round 3 READY).
+- M4c migrates synchronous `_sifr.time` clock, formatting, parsing,
+  perf-counter, and struct-time helper leaves behind private Rust interop
+  declarations and `sifr_stdlib::time`, removes their compiler registry and
+  fallback-signature paths, keeps only `sleep` and `monotonic` retained for the
+  M6 runtime split, and updates generated dependency planning to route time
+  through `sifr_stdlib(time)` instead of direct `chrono` in PR #2864 (merge sha
+  `9d901ad460026b4f70b4281873544f7d6a8cac28`; local `create-pr` validation
+  passed with a warm wall-time advisory only; reviewer round 1 READY).
 
 Acceptance:
 


### PR DESCRIPTION
## Summary
- record M4c time migration evidence in the stdlib native boundary phase ledger
- add PR #2864 merge SHA and retained `_sifr.time` split status

## Validation
- `git diff --check`
