### PR TITLE
Close M5 stdlib sys environment milestone

### DIFF
--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -94,7 +94,7 @@ merged, and documented before the next milestone starts.
 | M2. Declaration Infrastructure and Provenance | merged | PR #2839 · sha=d920e16; PR #2841 · sha=4e5621d; PR #2843 · sha=631b1d8; PR #2845 · sha=217e04d; PR #2847 · sha=d75a54e; PR #2849 · sha=dd1fc69 |
 | M3. File and Filesystem Migration | merged | PR #2851 · sha=12b64b4; PR #2852 · sha=72a62f1; PR #2853 · sha=84b0419; PR #2855 · sha=4372f13; PR #2858 · sha=f08fc98 |
 | M4. Random, Time, and Logging | merged | PR #2860 · sha=5daa4cc · manifest: `_sifr.logging` retained -> closing; PR #2862 · sha=b0d6a29 · manifest: `_sifr.crypto::random` retained -> closing; PR #2864 · sha=9d901ad · manifest: `_sifr.time` exact retained leaves narrowed to `sleep`/`monotonic`; PR #2866 · sha=c241b20 · manifest: mixed preamble now IO/file-handle only |
-| M5. Simple Sys and Environment | in progress | PR #2868 · sha=e21e67a · manifest: `_sifr.sys` retained set narrowed to later-slice process/OS helpers; PR #2870 · sha=03d0126 · manifest: `_sifr.sys` retained set narrowed to `run_command`/`chdir`/`stat_size`/`disk_usage` |
+| M5. Simple Sys and Environment | merged | PR #2868 · sha=e21e67a · manifest: `_sifr.sys` retained set narrowed to later-slice process/OS helpers; PR #2870 · sha=03d0126 · manifest: `_sifr.sys` retained set narrowed to `run_command`/`chdir`/`stat_size`/`disk_usage`; closeout review READY |
 | M6. Async Resource Pilot | planned |  |
 | M7. Process Family | planned |  |
 | M8. Network and TLS Families | planned |  |
@@ -678,6 +678,11 @@ with later process/OS helper slices:
   registry file (merged in PR #2870, merge commit
   `03d012674ed6b6da43190ae4b52ea397d2fc374e`; local `create-pr` validation
   passed with wall-time/cache advisories only; reviewer round 1 READY).
+- M5 closeout: milestone-level review confirmed the 17 simple env/sys/helper
+  leaves are declaration-backed by `sifr_stdlib::sys`, `sifr.os`/`sifr.sys`/
+  `sifr.shutil` consumers are rewired, and only `run_command`, `chdir`,
+  `stat_size`, and `disk_usage` remain in compiler dispatch with documented
+  later-slice reasons (reviewer round 1 READY).
 
 Acceptance:
 

--- a/plans/reviews/active/m5-simple-sys-env-closeout-opus-round1.md
+++ b/plans/reviews/active/m5-simple-sys-env-closeout-opus-round1.md
@@ -1,0 +1,15 @@
+Verification complete. I checked the actual repo state against every claim rather than the summary.
+
+Confirmed on `main` (`e0ea3b8e1`):
+
+- 17 migrated symbols are all declared in `stdlib/_sifr/sys.sifr` with `@rust(sifr_stdlib.sys.*)` and each has a matching backing helper in `crates/sifr_stdlib/src/sys.rs`: env_get/set/unset/keys/values/items, get_args, sys_exit/version/platform/maxsize, getpid, cpu_count, which, os_sep/linesep/name. Declarations and helpers are 1:1, no gaps.
+- Consumers are rewired: `stdlib/sifr/os.sifr`, `stdlib/sifr/sys.sifr`, and `stdlib/sifr/shutil.sifr` import the migrated names from `_sifr.sys`.
+- The retained set is exactly the 4 deferred helpers: `run_command`, `chdir`, `stat_size`, and `disk_usage` still carry compiler signatures in `crates/sifr_retained_intrinsics/src/sys_fs.rs` and lowerers in `crates/sifr_codegen/src/intrinsics/registry/os.rs`, wired from `registry.rs`. Their deferral reasons, command execution, cwd mutation, file-stat, and disk-usage, are legitimately outside simple sys not requiring process resource handles.
+- No leakage: none of the migrated symbols retain lowerers in `registry/os.rs`; the migrated names appearing in `registry_core_tests.rs` are test references only, not live registry entries.
+- Platform module is already on `_sifr.platform`.
+
+The migrated/retained split is coherent and matches the stated M5 goal, and both slice reviewer verdicts were READY with `create-pr` passing.
+
+One caveat from the reviewer: `gh pr view` for #2868/#2870 was denied in that reviewer context, so it verified migrations landed in the working tree on `main` but did not read GitHub's merge flag directly. The main-agent workflow independently confirmed both PRs are merged.
+
+READY


### PR DESCRIPTION
## Summary
- mark M5 Simple Sys and Environment as merged
- record the M5 milestone closeout review
- document that only run_command, chdir, stat_size, and disk_usage remain deferred for later process/filesystem slices

## Validation
- docs/review-only update; implementation validation recorded from PR #2868 and PR #2870