### PR TITLE
Certify stdlib async runtime core

### DIFF
--- a/crates/sifr_driver/src/build/rust_interop_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_contract_tests.rs
@@ -405,6 +405,75 @@ fn package_rust_interop_opaque_close_policy_requires_close_method_contract() {
         .contains("requires `close` cleanup method"));
 }
 
+#[test]
+fn package_rust_interop_opaque_async_close_policy_accepts_async_aclose_contract() {
+    let generated = base_project_with_contracts(
+        vec![
+            opaque_class_declaration_entry(vec![
+                target_argument("type", "bridge.resources.Connection"),
+                symbol_argument("close", "async_close"),
+            ]),
+            tokenizer_method_declaration_entry("aclose", RustInteropDecoratorKind::Async),
+        ],
+        Vec::new(),
+    );
+    let mut context = package_context(TrustPolicy::default(), Vec::new());
+    set_bridge_roots(&mut context, vec![PathBuf::from("src/bridges")]);
+
+    apply_package_rust_interop_metadata(generated, Some(context))
+        .expect("async aclose should satisfy async_close policy");
+}
+
+#[test]
+fn package_rust_interop_opaque_async_close_policy_requires_async_aclose_contract() {
+    let generated = base_project_with_contracts(
+        vec![
+            opaque_class_declaration_entry(vec![
+                target_argument("type", "bridge.resources.Connection"),
+                symbol_argument("close", "async_close"),
+            ]),
+            tokenizer_method_declaration_entry("aclose", RustInteropDecoratorKind::Function),
+        ],
+        Vec::new(),
+    );
+    let mut context = package_context(TrustPolicy::default(), Vec::new());
+    set_bridge_roots(&mut context, vec![PathBuf::from("src/bridges")]);
+
+    let diagnostics = interop_errors(generated, Some(context), "sync aclose must fail");
+
+    assert_eq!(diagnostics[0].code, "SIFR-RUST-HANDLE-0001");
+    assert!(diagnostics[0]
+        .message
+        .contains("requires `aclose` cleanup method"));
+}
+
+#[test]
+fn package_rust_interop_opaque_async_close_policy_rejects_sync_close_only_contract() {
+    let generated = base_project_with_contracts(
+        vec![
+            opaque_class_declaration_entry(vec![
+                target_argument("type", "bridge.resources.Connection"),
+                symbol_argument("close", "async_close"),
+            ]),
+            tokenizer_method_declaration_entry("close", RustInteropDecoratorKind::Function),
+        ],
+        Vec::new(),
+    );
+    let mut context = package_context(TrustPolicy::default(), Vec::new());
+    set_bridge_roots(&mut context, vec![PathBuf::from("src/bridges")]);
+
+    let diagnostics = interop_errors(
+        generated,
+        Some(context),
+        "sync close must not satisfy aclose",
+    );
+
+    assert_eq!(diagnostics[0].code, "SIFR-RUST-HANDLE-0001");
+    assert!(diagnostics[0]
+        .message
+        .contains("requires `aclose` cleanup method"));
+}
+
 pub(super) fn base_project_with_contracts(
     declarations: Vec<RustInteropPlanDeclaration>,
     signatures: Vec<RustBridgeSignatureContract>,
@@ -570,6 +639,33 @@ fn opaque_class_declaration_entry(
                 opaque_handle: true,
                 ..RustInteropAbiRequirements::default()
             },
+        },
+    }
+}
+
+fn tokenizer_method_declaration_entry(
+    name: &str,
+    kind: RustInteropDecoratorKind,
+) -> RustInteropPlanDeclaration {
+    RustInteropPlanDeclaration {
+        module_name: Some("app".to_string()),
+        owner: RustInteropOwner::Method {
+            class_name: "Tokenizer".to_string(),
+            name: name.to_string(),
+        },
+        declaration: RustInteropDeclaration {
+            kind,
+            target: Some(RustTargetPath {
+                segments: ["bridge", "resources", name]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect(),
+                span: span(),
+            }),
+            arguments: Vec::new(),
+            span: span(),
+            effect: effect_for_kind(kind),
+            abi_requirements: abi_for_kind(kind),
         },
     }
 }

--- a/crates/sifr_runtime/src/interop.rs
+++ b/crates/sifr_runtime/src/interop.rs
@@ -456,4 +456,27 @@ mod tests {
 
         assert!(matches!(handle.inner_ref(), Err(HandleStateError::Closed)));
     }
+
+    #[cfg(feature = "net")]
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_handle_close_and_cancel_join_are_deterministic() {
+        async fn close_after_yield(handle: &mut Handle<i64>) {
+            tokio::task::yield_now().await;
+            handle.mark_closed(super::__generated_glue::token());
+        }
+
+        let mut handle = Handle::new(1_i64);
+        close_after_yield(&mut handle).await;
+        handle.mark_closed(super::__generated_glue::token());
+        assert!(matches!(handle.inner_ref(), Err(HandleStateError::Closed)));
+
+        let task = tokio::spawn(async {
+            std::future::pending::<()>().await;
+        });
+        task.abort();
+        let join_error = task
+            .await
+            .expect_err("aborted task should not join successfully");
+        assert!(join_error.is_cancelled());
+    }
 }

--- a/internal_docs/stdlib_retained_compiler_intrinsics.toml
+++ b/internal_docs/stdlib_retained_compiler_intrinsics.toml
@@ -157,8 +157,8 @@ issue = "stdlib-native-boundary-completion"
 evidence_links = ["stdlib-native-boundary-completion"]
 removal_criteria = ["Delete this closing row after migrated time registry names are proven absent by closure guards."]
 declaration_files = ["stdlib/_sifr/time.sifr"]
-certification_rows = ["async_runtime_reqwest"]
-reason = "Sleep and monotonic now route through _sifr.time private Rust interop declarations and sifr_stdlib.time; this row remains only to record closure of the former compiler intrinsic names."
+certification_rows = ["async_runtime_core"]
+reason = "Sleep and monotonic now route through _sifr.time private Rust interop declarations and sifr_stdlib.time using the stdlib-owned async runtime core evidence; this row remains only to record closure of the former compiler intrinsic names."
 
 [[surface]]
 id = "_sifr.crypto::random"

--- a/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
+++ b/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
@@ -36,8 +36,12 @@ rows rather than reassigning ecosystem rows wholesale:
 
 - `opaque_resource_matrix` splits into stdlib-owned `opaque_resource_core` and
   certification-owned `opaque_resource_ecosystem`.
-- `async_runtime_reqwest` splits into stdlib-owned `async_runtime_core` and the
-  certification-owned `async_runtime_reqwest` ecosystem loopback row.
+- `async_runtime_reqwest` split in M6 into stdlib-owned `async_runtime_core`
+  and the certification-owned `async_runtime_reqwest` ecosystem loopback row.
+  The core row covers async declaration contracts, async-close lifecycle
+  validation, current-thread affinity, cancellation/drop task semantics, panic
+  conversion through declared stdlib error surfaces, and hidden-blocking
+  rejection. This issue still owns `tokio`/`reqwest` loopback behavior evidence.
 - `callback_subscription_matrix` splits into stdlib-owned
   `callback_subscription_core` and certification-owned
   `callback_subscription_ecosystem`.

--- a/plans/reviews/active/m6b-async-runtime-core-opus-round6.md
+++ b/plans/reviews/active/m6b-async-runtime-core-opus-round6.md
@@ -1,0 +1,17 @@
+Working only from the patch summary as instructed (no file inspection), so these are reasoning-level flags, not confirmed defects.
+
+## Risk flags to self-check before merge
+
+1. **Evidence-id ↔ claim coupling (overclaim risk).** `async_runtime_core` is marked *supported* on the strength of exactly two evidence ids: `stdlib_async_resource_lifecycle` and `stdlib_async_hidden_blocking_rejected`. Those cover (a) resource lifecycle and (b) rejection of hidden blocking. Confirm the matrix row's *claimed capabilities* are limited to exactly those two axes. If the row also implies e.g. cancellation/join determinism as a *supported* guarantee, the driving evidence for that is the new `sifr_runtime` tokio test (`async_handle_close_and_cancel_join_are_deterministic`) — make sure that test is actually referenced as evidence for the row, otherwise cancel/join is an overclaim with no cited evidence.
+
+2. **`_sifr.time` certification_rows repoint.** Changing the retained manifest from `async_runtime_reqwest` → `async_runtime_core` is only sound if `_sifr.time` genuinely needs *no* reqwest/loopback-level guarantee. Since `async_runtime_reqwest` is deliberately left `future-owned`, any `_sifr.time` leaf that still depends on network-async semantics would now be certified against a row that doesn't cover it. Verify no time leaf pulls in the reqwest path.
+
+3. **Gate allowlist scope (gate-bug risk).** The sysroot gate now "allows supported core rows {opaque_resource_core, async_runtime_core}." Confirm this is an *allowlist that still rejects* any other row (notably `async_runtime_reqwest`) being marked supported at the core level — i.e., the change tightened, not loosened, the gate. A set-membership check that only *adds* async_runtime_core without keeping the "reject everything else" branch would silently let future overclaims through.
+
+4. **Self-test "select rows by id" fix.** Good direction (positional selection is fragile). Just confirm the ids used in the self-test are asserted to *exist* — if `.get(id)` returns None-equivalent and the assertion is "not rejected," a typo�'d id would pass vacuously.
+
+5. **Sync-vs-async close matrix.** Driver tests accept async `aclose` for `close=async_close` and reject sync `aclose`; the runtime test covers close+cancel/join. Confirm there's negative coverage that a `close=async_close` resource is *rejected* if it only exposes sync `close` — otherwise "hidden blocking rejected" is asserted one-directionally.
+
+None of these are confirmed blocking from the summary alone — each is a "verify this holds" item. If items 1–3 check out (evidence ids match the exact claimed capabilities, no time leaf needs reqwest, and the gate still rejects non-allowlisted supported rows), then:
+
+**READY** — subject to confirming flags 1–3, which I could not verify without inspecting files.

--- a/plans/reviews/active/m6b-async-runtime-core-opus-round7.md
+++ b/plans/reviews/active/m6b-async-runtime-core-opus-round7.md
@@ -1,0 +1,17 @@
+I've verified all the key logic. Let me confirm my read of the three flags:
+
+**Flag 3 (gate allowlist tightening) — holds.** `_is_supported_stdlib_core` (gate:87-94) requires `row_id ∈ {async_runtime_core, opaque_resource_core}` **and** `category==supported` **and** both evidences `passing` **and** no `future_owner`. Anything else that is `supported` but not `FUTURE_OWNED` fails at line 66-70. So marking `async_runtime_reqwest` supported would still be rejected — the change tightened, not loosened. Self-test still exercises the rejection path via `opaque_resource_matrix` (a non-allowlisted supported row) and the failing-evidence path on an allowlisted row.
+
+**Flag 4 (id-based self-test selection) — holds.** `_self_test_row` raises `AssertionError` if the id is absent (line 273), so a typo'd id fails loudly rather than vacuously passing.
+
+**Flag 5 (sync-close-only rejection) — genuinely covered.** Traced through `validate_opaque_close_contracts` + `close_method_kind_matches`: `close=async_close` → required method `aclose`. The new `rejects_sync_close_only` test supplies only a method named `close`, so `name == method_name` fails → `SIFR-RUST-HANDLE-0001` fires. The `requires_async_aclose` test supplies `aclose` with `Function` kind → `close_method_kind_matches("aclose", Function)` is false → rejected. `accepts_async_aclose` supplies `aclose`/`Async` → matches. Class names (`Tokenizer`) align between opaque class and method owner, so the matcher's `owner_class == class_name` guard is actually exercised. All three are meaningful.
+
+**Flag 2 (`_sifr.time` repoint) — sound.** Time leaves (sleep/monotonic) route through tokio time, which `async_runtime_core` covers (current-thread affinity, async lifecycle); none need reqwest/network semantics. Repoint from `async_runtime_reqwest` → `async_runtime_core` is correct.
+
+One **non-blocking observation** (residual flag 1):
+
+The `async_runtime_core` compatibility-matrix `notes` claim "**task cancellation/drop semantics**" as part of the supported capability, but neither cited evidence fixture exercises cancellation — the positive fixture only covers async-close lifecycle + current-thread affinity + observe, and the negative covers hidden-blocking rejection. The cancel/join determinism guarantee rests solely on the `sifr_runtime` unit test `async_handle_close_and_cancel_join_are_deterministic`, which is not referenced as matrix evidence. This isn't a correctness defect (the behavior *is* tested via cargo), but the certification-evidence coupling is looser than the notes imply. If you want the matrix to be strictly self-documenting, either trim "task cancellation/drop semantics" from the notes or add a fixture/evidence pointer for it. Not blocking.
+
+Everything else — evidence-id consistency between the two matrices, the `check_fixture_matrix` required-fixtures addition, fixture files present, and the reqwest-stays-future-owned handoff — checks out. The `_is_supported_stdlib_core` guard and the future-owned backstop remain intact.
+
+READY

--- a/scripts/check_sysroot_stdlib_resource_certification_gate.py
+++ b/scripts/check_sysroot_stdlib_resource_certification_gate.py
@@ -22,7 +22,7 @@ MANIFEST_PATH = REPO_ROOT / "internal_docs" / "stdlib_retained_compiler_intrinsi
 CERTIFICATION_ISSUE = "plans/issues/active/rust-interop-runtime-ecosystem-certification.md"
 FUTURE_OWNED = "future-owned-by-separate-phase"
 SUPPORTED = "supported"
-SUPPORTED_STDLIB_CORE_ROWS = frozenset({"opaque_resource_core"})
+SUPPORTED_STDLIB_CORE_ROWS = frozenset({"async_runtime_core", "opaque_resource_core"})
 
 
 def main() -> int:
@@ -161,7 +161,11 @@ def _rows_by_id(failures: list[str], matrix: dict[str, Any]) -> dict[str, dict[s
 def _self_test() -> int:
     surface_rows = {
         "_sifr.example": ("opaque_resource_core", "opaque_resource_matrix"),
-        "_sifr.example_async": ("async_runtime_reqwest", "callback_subscription_matrix"),
+        "_sifr.example_async": (
+            "async_runtime_core",
+            "async_runtime_reqwest",
+            "callback_subscription_matrix",
+        ),
     }
     base_manifest = {
         "surface": [
@@ -173,6 +177,12 @@ def _self_test() -> int:
         "rows": [
             {
                 "id": "opaque_resource_core",
+                "category": SUPPORTED,
+                "positive_evidence": {"status": "passing"},
+                "negative_evidence": {"status": "passing"},
+            },
+            {
+                "id": "async_runtime_core",
                 "category": SUPPORTED,
                 "positive_evidence": {"status": "passing"},
                 "negative_evidence": {"status": "passing"},
@@ -210,8 +220,9 @@ def _self_test() -> int:
         return 1
 
     certified_matrix = json.loads(json.dumps(base_matrix))
-    certified_matrix["rows"][1]["category"] = SUPPORTED
-    certified_matrix["rows"][1].pop("future_owner", None)
+    certified_resource_row = _self_test_row(certified_matrix, "opaque_resource_matrix")
+    certified_resource_row["category"] = SUPPORTED
+    certified_resource_row.pop("future_owner", None)
     if not any(
         "supported stdlib resource rows must be explicitly allowed core rows with passing evidence"
         in failure
@@ -221,7 +232,9 @@ def _self_test() -> int:
         return 1
 
     wrong_owner_matrix = json.loads(json.dumps(base_matrix))
-    wrong_owner_matrix["rows"][1]["future_owner"] = "plans/issues/active/other.md"
+    _self_test_row(wrong_owner_matrix, "opaque_resource_matrix")["future_owner"] = (
+        "plans/issues/active/other.md"
+    )
     if not any(
         "future_owner must remain" in failure
         for failure in _validate(wrong_owner_matrix, base_manifest)
@@ -251,6 +264,13 @@ def _self_test() -> int:
 
     print("sysroot stdlib resource certification gate self-test: PASS")
     return 0
+
+
+def _self_test_row(matrix: dict[str, Any], row_id: str) -> dict[str, Any]:
+    for row in matrix["rows"]:
+        if row["id"] == row_id:
+            return row
+    raise AssertionError(f"missing self-test row {row_id}")
 
 
 if __name__ == "__main__":

--- a/verification/areas/rust_interop/checks/check_fixture_matrix.py
+++ b/verification/areas/rust_interop/checks/check_fixture_matrix.py
@@ -22,6 +22,7 @@ REQUIRED_FIXTURES = {
     "advanced_data_matrix",
     "arrow_record_batch",
     "async_ecosystem_matrix",
+    "async_runtime_core",
     "async_runtime_reqwest",
     "blocking_diagnostics",
     "bridge_type_matrix",

--- a/verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json
+++ b/verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json
@@ -218,6 +218,18 @@
       "notes": "Async contract validation is implemented, but loopback reqwest runtime behavior is pending."
     },
     {
+      "id": "async_runtime_core",
+      "fixture": "async_runtime_core",
+      "category": "supported",
+      "tier": 2,
+      "capability": "stdlib-owned async runtime and async resource lifecycle core",
+      "execution_kind": "runtime-observed",
+      "required_crates": [],
+      "positive_evidence": {"id": "stdlib_async_resource_lifecycle", "status": "passing"},
+      "negative_evidence": {"id": "stdlib_async_hidden_blocking_rejected", "status": "passing"},
+      "notes": "Stdlib-owned async resources may use async declarations, async-close lifecycle contracts, current-thread affinity, and hidden-blocking rejection; runtime task cancellation/drop coverage is kept in executable Rust tests, and reqwest loopback runtime evidence remains future-owned."
+    },
+    {
       "id": "async_ecosystem_matrix",
       "fixture": "async_ecosystem_matrix",
       "category": "supported",

--- a/verification/areas/rust_interop/data/rust_interop_fixture_matrix.json
+++ b/verification/areas/rust_interop/data/rust_interop_fixture_matrix.json
@@ -177,6 +177,15 @@
       "negative_evidence": {"id": "hidden_block_on_rejected", "status": "planned"}
     },
     {
+      "id": "async_runtime_core",
+      "tier": 2,
+      "capability": "stdlib-owned async runtime and async resource lifecycle core",
+      "required_crates": [],
+      "execution_kind": "runtime-observed",
+      "positive_evidence": {"id": "stdlib_async_resource_lifecycle", "status": "passing"},
+      "negative_evidence": {"id": "stdlib_async_hidden_blocking_rejected", "status": "passing"}
+    },
+    {
       "id": "async_ecosystem_matrix",
       "tier": 2,
       "capability": "async ecosystem signature probing",

--- a/verification/areas/rust_interop/fixtures/async_runtime_core/README.md
+++ b/verification/areas/rust_interop/fixtures/async_runtime_core/README.md
@@ -1,0 +1,32 @@
+# async_runtime_core
+
+Runtime-observed fixture family for the stdlib-owned async runtime core needed
+by native stdlib resource migrations.
+
+- Positive evidence: `stdlib_async_resource_lifecycle` is represented by
+  executable async declaration and lifecycle tests:
+  `rust_interop_async_contract_tests::package_rust_interop_direct_probe_accepts_async_signature`,
+  `rust_interop_async_contract_tests::package_rust_interop_async_current_thread_allows_non_send_future`,
+  `rust_interop_async_contract_tests::package_rust_interop_opaque_current_thread_clears_async_method_send_probe`,
+  `rust_interop_contract_tests::package_rust_interop_opaque_async_close_policy_accepts_async_aclose_contract`,
+  `rust_interop_contract_tests::package_rust_interop_opaque_async_close_policy_requires_async_aclose_contract`,
+  `rust_interop_contract_tests::package_rust_interop_opaque_async_close_policy_rejects_sync_close_only_contract`,
+  `async_task_runtime_codegen_tests::test_task_handle_join_lowers_to_task_result_observation`,
+  `async_task_runtime_codegen_tests::test_await_task_handle_desugars_to_join_observation`,
+  `async_task_runtime_codegen_tests::test_task_handle_cancel_borrows_handle_and_aborts_child`,
+  `async_task_runtime_codegen_tests::test_task_timeout_handle_lowers_to_private_timeout_result`,
+  and `sifr_runtime::interop::tests::async_handle_close_and_cancel_join_are_deterministic`.
+- Negative evidence: `stdlib_async_hidden_blocking_rejected` is represented by
+  `rust_interop_async_contract_tests::package_rust_interop_async_rejects_unsupported_thread_affinity`,
+  `rust_interop_async_contract_tests::package_rust_interop_async_requires_send_future_by_default`,
+  and `blocking_diagnostics` evidence that rejects hidden blocking/CPU-heavy
+  effects on async Rust interop declarations.
+- Panic and poisoning evidence is represented by
+  `sifr_runtime::interop::tests::handle_poison_guard_marks_open_handle_when_rust_call_unwinds`,
+  `sifr_runtime::interop::tests::poisoned_state_wins_over_closed_state`, and
+  `sifr_runtime::interop::tests::catch_rust_panic_redacts_payload_details`.
+- Scope note: this row certifies only stdlib-owned async declarations,
+  async-close lifecycle contracts, cancellation/drop task semantics, panic
+  conversion through declared `RustPanicError` surfaces, and hidden-blocking
+  rejection. Loopback `tokio`/`reqwest` behavior remains tracked by
+  `async_runtime_reqwest`.

--- a/verification/areas/rust_interop/fixtures/async_runtime_core/fixture.json
+++ b/verification/areas/rust_interop/fixtures/async_runtime_core/fixture.json
@@ -1,0 +1,26 @@
+{
+  "capability": "stdlib-owned async runtime and async resource lifecycle core",
+  "diagnostic_family": "SIFR-RUST-ASYNC-0001",
+  "evidence": {
+    "negative": {
+      "expected_diagnostic": "SIFR-RUST-ASYNC-0001",
+      "expected_result": "diagnostic",
+      "id": "stdlib_async_hidden_blocking_rejected",
+      "path": "negative/stdlib_async_hidden_blocking_rejected.sifr",
+      "status": "passing"
+    },
+    "positive": {
+      "expected_result": "pass",
+      "id": "stdlib_async_resource_lifecycle",
+      "path": "positive/stdlib_async_resource_lifecycle.sifr",
+      "status": "passing"
+    }
+  },
+  "execution_kind": "runtime-observed",
+  "features": {},
+  "id": "async_runtime_core",
+  "package_examples": {},
+  "required_crates": [],
+  "schema_version": 1,
+  "tier": 2
+}

--- a/verification/areas/rust_interop/fixtures/async_runtime_core/negative/stdlib_async_hidden_blocking_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/async_runtime_core/negative/stdlib_async_hidden_blocking_rejected.sifr
@@ -1,0 +1,22 @@
+# fixture: async_runtime_core
+# evidence: negative/stdlib_async_hidden_blocking_rejected
+# evidence-status: passing
+# execution-kind: runtime-observed
+# expected-result: diagnostic
+# expected-diagnostic: SIFR-RUST-ASYNC-0001
+class AsyncResourceError(Error):
+    message: str
+
+@rust.opaque(type=sifr_stdlib.async_core.Resource, send=True, sync=False, clone=none, close=async_close)
+class AsyncResource:
+    @rust(Self.aclose, panic=trusted_no_panic)
+    def aclose(self) -> None: ...
+
+@blocking_io
+@rust(sifr_stdlib.async_core.hidden_blocking_wait, panic=trusted_no_panic)
+async def hidden_blocking_wait(resource: AsyncResource) -> None: ...
+
+async def verify_stdlib_async_hidden_blocking_rejected(resource: AsyncResource) -> None:
+    resource.aclose()
+    waited: None = await hidden_blocking_wait(resource)
+    return waited

--- a/verification/areas/rust_interop/fixtures/async_runtime_core/positive/stdlib_async_resource_lifecycle.sifr
+++ b/verification/areas/rust_interop/fixtures/async_runtime_core/positive/stdlib_async_resource_lifecycle.sifr
@@ -1,0 +1,20 @@
+# fixture: async_runtime_core
+# evidence: positive/stdlib_async_resource_lifecycle
+# evidence-status: passing
+# execution-kind: runtime-observed
+# expected-result: pass
+class AsyncResourceError(Error):
+    message: str
+
+@rust.opaque(type=sifr_stdlib.async_core.Resource, send=True, sync=False, clone=none, close=async_close, thread_affinity=tokio_current_thread)
+class AsyncResource:
+    @rust(Self.aclose, panic=map_error(sifr_stdlib.async_core.map_panic))
+    async def aclose(self) -> Result[None, AsyncResourceError | RustPanicError]: ...
+
+    @rust(Self.observe, panic=map_error(sifr_stdlib.async_core.map_panic))
+    async def observe(self) -> Result[int, AsyncResourceError | RustPanicError]: ...
+
+async def verify_stdlib_async_resource_lifecycle(resource: AsyncResource) -> Result[int, AsyncResourceError | RustPanicError]:
+    observed: Result[int, AsyncResourceError | RustPanicError] = await resource.observe()
+    closed: Result[None, AsyncResourceError | RustPanicError] = await resource.aclose()
+    return observed


### PR DESCRIPTION
## Summary
- Add async_runtime_core as the stdlib-owned async runtime certification row and fixture.
- Cover async-close contracts with accept/reject driver tests, including sync-close-only rejection for close=async_close.
- Add runtime Handle async close/double-close plus cancelled join determinism coverage.
- Repoint _sifr.time certification from future-owned reqwest runtime evidence to async_runtime_core, while keeping reqwest loopback future-owned by the ecosystem certification issue.

## Validation
- cargo fmt --check
- python3 verification/areas/rust_interop/checks/check_fixture_matrix.py
- python3 verification/areas/rust_interop/checks/check_compatibility_matrix.py
- python3 scripts/check_sysroot_stdlib_resource_certification_gate.py --self-test
- python3 scripts/check_sysroot_stdlib_resource_certification_gate.py
- cargo test -p sifr_driver package_rust_interop_opaque_async_close_policy -- --nocapture
- cargo test -p sifr_runtime --features net async_handle_close_and_cancel_join_are_deterministic -- --nocapture
- cargo test -p sifr_driver package_rust_interop_async -- --nocapture
- cargo test -p sifr_codegen async_task_runtime_codegen_tests -- --nocapture
- scripts/run_all_tests.sh --profile create-pr (129/129 E2E, no advisories, wall_time=281.16s)

## Reviewer
- Opus round6: conditional READY with async-close sync-only negative requested.
- Opus round7: READY after adding the negative case and tightening the compatibility note.