### PR TITLE
Close out M7 process migration

### DIFF
--- a/internal_docs/stdlib_retained_compiler_intrinsics.toml
+++ b/internal_docs/stdlib_retained_compiler_intrinsics.toml
@@ -14,6 +14,13 @@
 #
 schema_version = 2
 
+[[closed_surface]]
+id = "_sifr.process"
+previous_state = "closing"
+removed_in_pr = "PR #2884"
+evidence_links = ["stdlib-native-boundary-completion"]
+reason = "All _sifr.process compiler-native registry, preamble, and fallback signature glue was migrated through private declarations and sifr_stdlib.process in PR #2883; closure guards prove the retained process surface is absent."
+
 [[surface]]
 id = "_sifr.sys"
 state = "retained"
@@ -169,17 +176,6 @@ evidence_links = ["stdlib-native-boundary-completion"]
 removal_criteria = ["Delete this closing row after the migrated random registry names are proven absent by closure guards."]
 declaration_files = ["stdlib/_sifr/crypto.sifr"]
 reason = "Random module state and distribution helpers now route through _sifr.crypto private Rust interop declarations and sifr_stdlib.random; this row remains only to record closure of the former compiler intrinsic names."
-
-[[surface]]
-id = "_sifr.process"
-state = "closing"
-owner = "stdlib-native-boundary-completion"
-issue = "stdlib-native-boundary-completion"
-evidence_links = ["stdlib-native-boundary-completion"]
-removal_criteria = ["Delete this closing row after all migrated process registry, preamble, and fallback signature names are proven absent by closure guards."]
-declaration_files = ["stdlib/_sifr/process.sifr"]
-certification_rows = ["async_runtime_reqwest"]
-reason = "Process run/output/shell, child lifecycle, sync pipes, async child lifecycle, and async pipes now route through _sifr.process private Rust interop declarations and sifr_stdlib.process; this row remains only to record closure of the former compiler intrinsic names."
 
 [[surface]]
 id = "_sifr.net"

--- a/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
+++ b/plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md
@@ -96,7 +96,7 @@ merged, and documented before the next milestone starts.
 | M4. Random, Time, and Logging | merged | PR #2860 · sha=5daa4cc · manifest: `_sifr.logging` retained -> closing; PR #2862 · sha=b0d6a29 · manifest: `_sifr.crypto::random` retained -> closing; PR #2864 · sha=9d901ad · manifest: `_sifr.time` exact retained leaves narrowed to `sleep`/`monotonic`; PR #2866 · sha=c241b20 · manifest: mixed preamble now IO/file-handle only |
 | M5. Simple Sys and Environment | merged | PR #2868 · sha=e21e67a · manifest: `_sifr.sys` retained set narrowed to later-slice process/OS helpers; PR #2870 · sha=03d0126 · manifest: `_sifr.sys` retained set narrowed to `run_command`/`chdir`/`stat_size`/`disk_usage`; closeout review READY |
 | M6. Async Resource Pilot | merged | PR #2873 · sha=7b5f634 · manifest: `_sifr.time` retained -> closing for `sleep`/`monotonic`; PR #2875 · sha=f3ce312 · certification: `async_runtime_core` supported and `_sifr.time` -> `async_runtime_core`; closeout review READY |
-| M7. Process Family | in progress | PR #2877 · sha=de07b23 · M7a sync process output migrated through `_sifr.process` and `sifr_stdlib::process`; PR #2879 · sha=0603eec · M7b sync child/pipe leaves migrated through `_sifr.process` and `sifr_stdlib::process`; PR #2881 · sha=beaf17b · M7c async run/output/shell leaves migrated through `_sifr.process` and `sifr_stdlib::process`; M7d async child/pipe lifecycle migration ready for review |
+| M7. Process Family | merged | PR #2877 · sha=de07b23 · M7a sync process output migrated through `_sifr.process` and `sifr_stdlib::process`; PR #2879 · sha=0603eec · M7b sync child/pipe leaves migrated through `_sifr.process` and `sifr_stdlib::process`; PR #2881 · sha=beaf17b · M7c async run/output/shell leaves migrated through `_sifr.process` and `sifr_stdlib::process`; PR #2883 · sha=69fb162 · M7d async child/pipe lifecycle migrated through `_sifr.process` and `sifr_stdlib::process`; manifest: `_sifr.process` retained -> closing |
 | M8. Network and TLS Families | planned |  |
 | M9. HTTP Family | planned |  |
 | M10. Signal Callback and Subscription Pilot | planned |  |
@@ -798,7 +798,8 @@ Tasks:
   child/pipe/scoped E2E fixtures, file-size guardrails, migration closure,
   allowlist, manifest schema, and sysroot resource certification guards passed;
   local `scripts/run_all_tests.sh --profile create-pr` passed; reviewer round
-  1 blocked by local reviewer tool timeout.
+  1 blocked by local reviewer tool timeout (merged in PR #2883, merge commit
+  `69fb162c7127879ada08f402ce05c3d05da4042c`).
 - Implement process behavior and Sifr-facing errors in `sifr_stdlib`.
 - Keep low-level spawn, pipe, timeout, and async substrate in `sifr_runtime`.
 - Declare child handles, pipe handles, async child handles, and operations in


### PR DESCRIPTION
## Summary

- mark M7 Process Family merged with PR #2883 and merge commit `69fb162`
- remove the `_sifr.process` closing row from the retained compiler-native manifest and add a `closed_surface` record
- record that all process compiler-native registry, preamble, and fallback signature glue is gone

## Validation

- `python3 scripts/check_stdlib_manifest_schema.py`
- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
- `python3 scripts/check_stdlib_migration_closure.py`
- `git diff --check`

