### PR TITLE
Migrate Python call helpers to stdlib

### DIFF
--- a/crates/sifr_codegen/src/intrinsics/registry/python.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/python.rs
@@ -2,8 +2,6 @@ use crate::{render_expr, RustExpr};
 
 pub(crate) fn lower_python_intrinsic(name: &str, args: &[RustExpr]) -> Option<RustExpr> {
     match name {
-        "py_call" => lower_py_call(args),
-        "py_call_attr" => lower_py_call_attr(args),
         "py_buffer_u8" => lower_py_buffer_u8(args),
         "py_copy_buffer_u8" => lower_py_copy_buffer_u8(args),
         "py_release_buffer" => lower_py_release_buffer(args),
@@ -78,53 +76,6 @@ fn lower_handle_conversion(args: &[RustExpr], function: &str) -> Option<RustExpr
     Some(map_python_error(format!(
         "sifr_runtime::python::{function}({})",
         object_expr(&handle, &token)
-    )))
-}
-
-pub(crate) fn lower_py_call(args: &[RustExpr]) -> Option<RustExpr> {
-    if args.len() != 4 {
-        return None;
-    }
-    let handle = render_expr(&args[0]);
-    let token = render_expr(&args[1]);
-    let positional = render_expr(&args[2]);
-    let keyword = render_expr(&args[3]);
-    Some(map_python_error(format!(
-        r#"{{
-            let __sifr_python_args = ({positional})
-                .iter()
-                .map(|__sifr_python_arg| (__sifr_python_arg.0, __sifr_python_arg.1))
-                .collect::<Vec<(i64, i64)>>();
-            let __sifr_python_kwargs = ({keyword})
-                .iter()
-                .map(|__sifr_python_kwarg| (__sifr_python_kwarg.0.as_str(), (__sifr_python_kwarg.1.0, __sifr_python_kwarg.1.1)))
-                .collect::<Vec<(&str, (i64, i64))>>();
-            sifr_runtime::python::call_object(({handle}, {token}), &__sifr_python_args, &__sifr_python_kwargs)
-        }}"#
-    )))
-}
-
-pub(crate) fn lower_py_call_attr(args: &[RustExpr]) -> Option<RustExpr> {
-    if args.len() != 5 {
-        return None;
-    }
-    let handle = render_expr(&args[0]);
-    let token = render_expr(&args[1]);
-    let name = render_expr(&args[2]);
-    let positional = render_expr(&args[3]);
-    let keyword = render_expr(&args[4]);
-    Some(map_python_error(format!(
-        r#"{{
-            let __sifr_python_args = ({positional})
-                .iter()
-                .map(|__sifr_python_arg| (__sifr_python_arg.0, __sifr_python_arg.1))
-                .collect::<Vec<(i64, i64)>>();
-            let __sifr_python_kwargs = ({keyword})
-                .iter()
-                .map(|__sifr_python_kwarg| (__sifr_python_kwarg.0.as_str(), (__sifr_python_kwarg.1.0, __sifr_python_kwarg.1.1)))
-                .collect::<Vec<(&str, (i64, i64))>>();
-            sifr_runtime::python::call_attr(({handle}, {token}), ({name}).as_str(), &__sifr_python_args, &__sifr_python_kwargs)
-        }}"#
     )))
 }
 

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -17,27 +17,6 @@ pub(crate) fn legacy_subprocess_intrinsics_are_not_lowered() {
 
 #[test]
 pub(crate) fn lowers_python_intrinsics_with_runtime_feature_metadata() {
-    let call = lower_intrinsic(
-        "py_call",
-        &[
-            "callable_handle".to_string(),
-            "callable_token".to_string(),
-            "args".to_string(),
-            "kwargs".to_string(),
-        ],
-    )
-    .expect("py_call should lower");
-    assert_eq!(
-        call.required_feature,
-        Some(sifr_stdlib_manifest::StdlibFeature::PythonRuntime)
-    );
-    let call_rendered = render_expr(&call.expr);
-    assert!(call_rendered.contains("sifr_runtime::python::call_object"));
-    assert!(call_rendered.contains("(callable_handle, callable_token)"));
-    assert!(call_rendered.contains("__sifr_python_args"));
-    assert!(call_rendered.contains("__sifr_python_kwargs"));
-    assert!(call_rendered.contains("PythonError"));
-
     let copy_list_u8 = lower_intrinsic(
         "py_copy_list_u8",
         &["object_handle".to_string(), "object_token".to_string()],
@@ -248,6 +227,38 @@ pub(crate) fn python_collection_constructors_are_owned_by_compiled_stdlib_declar
     ] {
         assert!(
             lower_intrinsic(removed, &["values".to_string()]).is_none(),
+            "{removed} must lower through _sifr.python private Rust interop declarations"
+        );
+    }
+}
+
+#[test]
+pub(crate) fn python_call_helpers_are_owned_by_compiled_stdlib_declarations() {
+    for (removed, args) in [
+        (
+            "py_call",
+            vec![
+                "callable_handle".to_string(),
+                "callable_token".to_string(),
+                "args".to_string(),
+                "kwargs_keys".to_string(),
+                "kwargs_values".to_string(),
+            ],
+        ),
+        (
+            "py_call_attr",
+            vec![
+                "object_handle".to_string(),
+                "object_token".to_string(),
+                "name".to_string(),
+                "args".to_string(),
+                "kwargs_keys".to_string(),
+                "kwargs_values".to_string(),
+            ],
+        ),
+    ] {
+        assert!(
+            lower_intrinsic(removed, &args).is_none(),
             "{removed} must lower through _sifr.python private Rust interop declarations"
         );
     }

--- a/crates/sifr_driver/src/stdlib/stateless_python_codegen_tests.rs
+++ b/crates/sifr_driver/src/stdlib/stateless_python_codegen_tests.rs
@@ -213,6 +213,37 @@ fn python_collection_constructors_codegen_through_sifr_stdlib() {
     }
 }
 
+#[test]
+fn python_call_helpers_codegen_through_sifr_stdlib() {
+    let compiled = compile_stdlib_uncached().expect("stdlib should compile");
+    let private_code = compiled
+        .code
+        .module_rust_code
+        .get("_sifr.python")
+        .expect("_sifr.python should generate private Rust code");
+    for name in ["py_call", "py_call_attr"] {
+        assert!(
+            private_code
+                .rust
+                .contains(&format!("sifr_stdlib::python::{name}(")),
+            "{name} should lower through _sifr.python private Rust interop declarations"
+        );
+    }
+    assert!(private_code.rust.contains("kwargs_keys"));
+    assert!(private_code.rust.contains("kwargs_values"));
+    let private_intrinsics = compiled
+        .code
+        .intrinsic_names
+        .get("_sifr.python")
+        .expect("_sifr.python intrinsic names should be tracked");
+    for name in ["py_call", "py_call_attr"] {
+        assert!(
+            !private_intrinsics.contains(name),
+            "{name} should not remain a compiler-retained _sifr.python intrinsic"
+        );
+    }
+}
+
 fn sha256_hex(source: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(source.as_bytes());

--- a/crates/sifr_retained_intrinsics/src/python.rs
+++ b/crates/sifr_retained_intrinsics/src/python.rs
@@ -14,37 +14,6 @@ fn object_handle() -> Type {
 pub(super) fn intrinsic_python() -> IntrinsicModule {
     let mut functions = HashMap::new();
     functions.insert(
-        "py_call".to_string(),
-        FunctionType::all_borrow(
-            vec![
-                ("handle".to_string(), Type::Int),
-                ("token".to_string(), Type::Int),
-                ("args".to_string(), Type::List(Box::new(object_handle()))),
-                (
-                    "kwargs".to_string(),
-                    Type::List(Box::new(Type::Tuple(vec![Type::Str, object_handle()]))),
-                ),
-            ],
-            python_error_result(object_handle()),
-        ),
-    );
-    functions.insert(
-        "py_call_attr".to_string(),
-        FunctionType::all_borrow(
-            vec![
-                ("handle".to_string(), Type::Int),
-                ("token".to_string(), Type::Int),
-                ("name".to_string(), Type::Str),
-                ("args".to_string(), Type::List(Box::new(object_handle()))),
-                (
-                    "kwargs".to_string(),
-                    Type::List(Box::new(Type::Tuple(vec![Type::Str, object_handle()]))),
-                ),
-            ],
-            python_error_result(object_handle()),
-        ),
-    );
-    functions.insert(
         "py_buffer_u8".to_string(),
         FunctionType::all_borrow(
             vec![

--- a/crates/sifr_stdlib/src/python.rs
+++ b/crates/sifr_stdlib/src/python.rs
@@ -144,6 +144,37 @@ pub fn py_get_item_str(
     python::get_item_str(object_handle(handle, token), key).map(object_raw)
 }
 
+pub fn py_call(
+    handle: SifrIntBridge,
+    token: SifrIntBridge,
+    args: &[ObjectRaw],
+    kwargs_keys: &[String],
+    kwargs_values: &[ObjectRaw],
+) -> Result<ObjectRaw, python::PythonError> {
+    let kwargs = keyed_object_handles(
+        kwargs_keys,
+        kwargs_values,
+        "Python call received mismatched keyword key/value counts",
+    )?;
+    python::call_object(object_handle(handle, token), args, &kwargs).map(object_raw)
+}
+
+pub fn py_call_attr(
+    handle: SifrIntBridge,
+    token: SifrIntBridge,
+    name: &str,
+    args: &[ObjectRaw],
+    kwargs_keys: &[String],
+    kwargs_values: &[ObjectRaw],
+) -> Result<ObjectRaw, python::PythonError> {
+    let kwargs = keyed_object_handles(
+        kwargs_keys,
+        kwargs_values,
+        "Python attribute call received mismatched keyword key/value counts",
+    )?;
+    python::call_attr(object_handle(handle, token), name, args, &kwargs).map(object_raw)
+}
+
 pub fn py_close(handle: SifrIntBridge, token: SifrIntBridge) -> Result<(), python::PythonError> {
     python::close_object(object_handle(handle, token))
 }
@@ -170,7 +201,11 @@ pub fn py_from_dict_str(
     keys: &[String],
     values: &[ObjectRaw],
 ) -> Result<ObjectRaw, python::PythonError> {
-    let keyed = keyed_object_handles(keys, values)?;
+    let keyed = keyed_object_handles(
+        keys,
+        values,
+        "Python keyed object constructor received mismatched key/value counts",
+    )?;
     python::from_dict_str(&keyed).map(object_raw)
 }
 
@@ -178,18 +213,22 @@ pub fn py_from_record(
     keys: &[String],
     values: &[ObjectRaw],
 ) -> Result<ObjectRaw, python::PythonError> {
-    let keyed = keyed_object_handles(keys, values)?;
+    let keyed = keyed_object_handles(
+        keys,
+        values,
+        "Python keyed object constructor received mismatched key/value counts",
+    )?;
     python::from_record(&keyed).map(object_raw)
 }
 
 fn keyed_object_handles<'a>(
     keys: &'a [String],
     values: &[ObjectRaw],
+    mismatch_message: &str,
 ) -> Result<Vec<(&'a str, ObjectRaw)>, python::PythonError> {
     if keys.len() != values.len() {
         return Err(python::PythonError {
-            message: "Python keyed object constructor received mismatched key/value counts"
-                .to_string(),
+            message: mismatch_message.to_string(),
             kind: "invalid_argument".to_string(),
             exception_type: String::new(),
             traceback: String::new(),

--- a/internal_docs/stdlib_retained_compiler_intrinsics.toml
+++ b/internal_docs/stdlib_retained_compiler_intrinsics.toml
@@ -230,8 +230,6 @@ exact_intrinsics = [
   "py_arrow_schema",
   "py_arrow_stream",
   "py_buffer_u8",
-  "py_call",
-  "py_call_attr",
   "py_close_callback",
   "py_copy_buffer_u8",
   "py_copy_dict_str_bool",

--- a/plans/reviews/active/m11e-python-call-helpers-opus-round1.md
+++ b/plans/reviews/active/m11e-python-call-helpers-opus-round1.md
@@ -1,0 +1,115 @@
+# M11e Python Call Helper Migration - Opus Review, Round 1
+
+## Scope
+
+Migrate `_sifr.python.py_call` and `_sifr.python.py_call_attr` from
+compiler-retained intrinsic lowering (`sifr_codegen::intrinsics::registry::python`
++ `sifr_retained_intrinsics::python`) into compiled stdlib declarations backed
+by `sifr_stdlib::python::py_call` / `py_call_attr`. Kwargs are split into
+`kwargs_keys: list[str]` and `kwargs_values: list[tuple[int, int]]` because
+direct Rust interop cannot round-trip `list[tuple[str, tuple[int, int]]]`.
+Runtime CPython substrate (`sifr_runtime::python::call_object` /
+`call_attr`) is unchanged; the stdlib shim delegates.
+
+## Verification of intent
+
+- Intrinsic dispatch removed:
+  - `crates/sifr_codegen/src/intrinsics/registry/python.rs` drops `py_call` /
+    `py_call_attr` match arms and the two `lower_py_call*` helpers.
+  - `crates/sifr_retained_intrinsics/src/python.rs` drops the retained signature
+    rows.
+  - `internal_docs/stdlib_retained_compiler_intrinsics.toml` allowlist entries
+    removed.
+  - `scripts/check_stdlib_migration_closure.py` adds both names to
+    `RETIRED_INTRINSICS`.
+- No compiler-side call site still lowers to `sifr_runtime::python::call_object`
+  / `call_attr`; `rg -n 'sifr_runtime::python::call_object|call_attr' crates/`
+  turns up only the runtime module itself, callback/coroutine internals, and
+  the stdlib shim - no codegen path.
+- Public `sifr.python.call` / `call_attr` signatures unchanged
+  (`list[Object]`, `list[tuple[str, Object]]`); only the internal marshaling
+  differs. The keys/values split follows the M11d pattern already accepted for
+  `py_from_dict_str` / `py_from_record`.
+- Runtime call semantics preserved: `sifr_stdlib::python::py_call` recombines
+  keys+values into `Vec<(&str, ObjectRaw)>` and forwards to
+  `python::call_object`; `py_call_attr` forwards similarly, preserving the
+  runtime's callable-open / call / close sequence in `object_ops::call_attr`.
+- No fallback path introduced.
+- Both new tests (`python_call_helpers_are_owned_by_compiled_stdlib_declarations`,
+  `python_call_helpers_codegen_through_sifr_stdlib`) assert intrinsic removal
+  and that `_sifr.python`'s emitted Rust contains
+  `sifr_stdlib::python::py_call(` / `py_call_attr(` plus the `kwargs_keys` /
+  `kwargs_values` tokens.
+
+## Findings
+
+### 1. `keyed_object_handles` mismatch message threading is fine but slightly noisy - Nit
+
+`crates/sifr_stdlib/src/python.rs:224` now takes a `mismatch_message: &str`
+so `py_call` / `py_call_attr` can attribute the error to the call surface
+rather than to a "keyed object constructor". Correct - but the two constructor
+call sites (`py_from_dict_str`, `py_from_record`) now duplicate the same
+literal. A `const CONSTRUCTOR_MISMATCH: &str = "..."` or letting the helper
+take an `enum { Call, CallAttr, Constructor }` would remove the duplication.
+Non-blocking.
+
+### 2. Two-pass kwargs marshaling at the sifr level - Nit / consistency
+
+`stdlib/sifr/python.sifr:293-294` and `316-317` walk `kwargs` twice:
+`_keys_from_keyed_objects` then `_handles_from_keyed_objects`. The removed
+`_keyed_handles_from_objects` did it in a single pass. This is intentionally
+symmetric with the M11d constructors (`from_dict_str`, `from_record` at
+`stdlib/sifr/python.sifr:667-668` / `678-679`) and consistent with the
+now-required split shape at the Rust interop boundary, so the extra pass is
+paid for uniformly. Acceptable; keep the pattern consistent within this
+module. Non-blocking.
+
+### 3. Defensive length check in `keyed_object_handles` is unreachable from
+sifr callers - Info
+
+Both `kwargs_keys` and `kwargs_values` are built by iterating the same
+`kwargs: list[tuple[str, Object]]` in order, so their lengths are equal by
+construction. The `if keys.len() != values.len()` guard therefore only fires
+against direct Rust callers. This mirrors what M11d already accepted; keep it
+as defense-in-depth. No action.
+
+### 4. `stdlib/sifr/python.sifr` at 886 lines - Watch
+
+The file is 14 lines under the 900-line guardrail. Not a violation today, but
+any further Python surface migration (e.g. remaining collection extractors,
+Arrow / DLPack helpers) will hit the cap. Worth flagging on the phase doc so
+the next slice budgets a responsibility-based split (e.g. carve keyed-object
+marshaling helpers into a separate module) rather than growing this file.
+Non-blocking for this PR.
+
+### 5. Empty round-1 review file was pre-created - Info
+
+`plans/reviews/active/m11e-python-call-helpers-opus-round1.md` existed as an
+empty file when the review started; this pass fills it. No action.
+
+## Confidence checks
+
+- Correctness: kwargs key/value correspondence preserved by index in both
+  languages; lengths equal by construction on the sifr side and re-checked on
+  the Rust side. Positional args untouched.
+- Coverage: closure script + registry-absence test + codegen-emission test
+  triangulate the migration. `cargo test -p sifr_codegen`, `-p sifr_driver`,
+  `-p sifr_retained_intrinsics`, `-p sifr_stdlib --features python`, and the
+  four migration/allowlist/manifest/resource guards were all run per the task
+  brief.
+- Behavior: single-file `check`/`emit` of
+  `verification/areas/python_interop/fixtures/primitive_conversion/primitive_roundtrip.sifr`
+  showed only `sifr_stdlib::python::py_call` / `py_call_attr` and the
+  underlying `sifr_runtime::python::call_object` / `call_attr` in the emitted
+  Rust - no orphaned intrinsic path. The `numpy_full_example.sifr`
+  SIFR-PYTRUST-0002 result is single-file-trust-mode noise and not a slice
+  regression.
+
+## Verdict
+
+**PR-ready.** All five findings are non-blocking (three nits, two info). The
+migration is symmetric with M11a-d, removes both compiler-retained rows, keeps
+public `sifr.python.call` / `call_attr` behavior intact, and adds guardrails
+in the intrinsic-registry and codegen-emission test layers. File-size
+headroom on `stdlib/sifr/python.sifr` should be tracked in the phase doc for
+the next Python slice.

--- a/scripts/check_stdlib_migration_closure.py
+++ b/scripts/check_stdlib_migration_closure.py
@@ -177,6 +177,8 @@ RETIRED_INTRINSICS = frozenset(
         "platform_system",
         "platform_version",
         "pow_val",
+        "py_call",
+        "py_call_attr",
         "py_from_bool",
         "py_from_bytes",
         "py_from_float",

--- a/stdlib/_sifr/python.sifr
+++ b/stdlib/_sifr/python.sifr
@@ -123,6 +123,27 @@ def py_get_attr(handle: int, token: int, name: str) -> Result[tuple[int, int], P
 def py_get_item_str(handle: int, token: int, key: str) -> Result[tuple[int, int], PythonError]: ...
 
 
+@rust(sifr_stdlib.python.py_call)
+def py_call(
+    handle: int,
+    token: int,
+    args: list[tuple[int, int]],
+    kwargs_keys: list[str],
+    kwargs_values: list[tuple[int, int]],
+) -> Result[tuple[int, int], PythonError]: ...
+
+
+@rust(sifr_stdlib.python.py_call_attr)
+def py_call_attr(
+    handle: int,
+    token: int,
+    name: str,
+    args: list[tuple[int, int]],
+    kwargs_keys: list[str],
+    kwargs_values: list[tuple[int, int]],
+) -> Result[tuple[int, int], PythonError]: ...
+
+
 @rust(sifr_stdlib.python.py_close)
 def py_close(handle: int, token: int) -> Result[None, PythonError]: ...
 

--- a/stdlib/sifr/python.sifr
+++ b/stdlib/sifr/python.sifr
@@ -241,13 +241,6 @@ def _handles_from_objects(values: list[Object]) -> list[tuple[int, int]]:
     return raw_values
 
 
-def _keyed_handles_from_objects(values: list[tuple[str, Object]]) -> list[tuple[str, tuple[int, int]]]:
-    raw_values: list[tuple[str, tuple[int, int]]] = []
-    for value in values:
-        raw_values.append((value[0], (value[1]._handle, value[1]._token)))
-    return raw_values
-
-
 def _keys_from_keyed_objects(values: list[tuple[str, Object]]) -> list[str]:
     keys: list[str] = []
     for value in values:
@@ -297,8 +290,15 @@ def call(
 ) -> Result[Object, PythonError]:
     try:
         raw_args: list[tuple[int, int]] = _handles_from_objects(args)
-        raw_kwargs: list[tuple[str, tuple[int, int]]] = _keyed_handles_from_objects(kwargs)
-        raw: tuple[int, int] = py_call(callable_obj._handle, callable_obj._token, raw_args, raw_kwargs)
+        kwargs_keys: list[str] = _keys_from_keyed_objects(kwargs)
+        kwargs_values: list[tuple[int, int]] = _handles_from_keyed_objects(kwargs)
+        raw: tuple[int, int] = py_call(
+            callable_obj._handle,
+            callable_obj._token,
+            raw_args,
+            kwargs_keys,
+            kwargs_values,
+        )
         return _object_from_handle(raw)
     except PythonError as e:
         raise e
@@ -313,8 +313,16 @@ def call_attr(
 ) -> Result[Object, PythonError]:
     try:
         raw_args: list[tuple[int, int]] = _handles_from_objects(args)
-        raw_kwargs: list[tuple[str, tuple[int, int]]] = _keyed_handles_from_objects(kwargs)
-        raw: tuple[int, int] = py_call_attr(obj._handle, obj._token, name, raw_args, raw_kwargs)
+        kwargs_keys: list[str] = _keys_from_keyed_objects(kwargs)
+        kwargs_values: list[tuple[int, int]] = _handles_from_keyed_objects(kwargs)
+        raw: tuple[int, int] = py_call_attr(
+            obj._handle,
+            obj._token,
+            name,
+            raw_args,
+            kwargs_keys,
+            kwargs_values,
+        )
         return _object_from_handle(raw)
     except PythonError as e:
         raise e


### PR DESCRIPTION
## Summary
- migrate `py_call` and `py_call_attr` to `_sifr.python` private Rust interop declarations backed by `sifr_stdlib::python`
- split internal kwargs marshaling into key/value lists so direct Rust interop avoids the unsupported nested tuple bridge shape
- remove the call helpers from compiler-retained Python intrinsic lowering, retained signatures, and the retained allowlist
- add codegen and retained-registry coverage proving the call helpers are stdlib-owned

## Review
- Opus round 1: PR-ready, no blockers (`plans/reviews/active/m11e-python-call-helpers-opus-round1.md`)

## Validation
- `cargo fmt`
- `git diff --check`
- `cargo test -p sifr_codegen python_call_helpers_are_owned_by_compiled_stdlib_declarations -- --nocapture`
- `cargo test -p sifr_driver python_call_helpers_codegen_through_sifr_stdlib -- --nocapture`
- `cargo test -p sifr_retained_intrinsics -- --nocapture`
- `cargo test -p sifr_stdlib --features python -- --nocapture`
- `cargo test -p sifr_codegen lowers_python_intrinsics_with_runtime_feature_metadata -- --nocapture`
- `python3 scripts/check_stdlib_migration_closure.py`
- `python3 scripts/check_stdlib_native_intrinsic_allowlist.py`
- `python3 scripts/check_stdlib_manifest_schema.py`
- `python3 scripts/check_sysroot_stdlib_resource_certification_gate.py`
- `cargo run -q -p sifr -- check verification/areas/python_interop/fixtures/primitive_conversion/primitive_roundtrip.sifr`
- `cargo run -q -p sifr -- emit verification/areas/python_interop/fixtures/primitive_conversion/primitive_roundtrip.sifr | rg "sifr_stdlib::python::py_call|sifr_stdlib::python::py_call_attr|sifr_runtime::python::call_object|sifr_runtime::python::call_attr"`
- `python3 scripts/check_file_size_guardrails.py`
- `scripts/run_all_tests.sh --profile create-pr` (pass; advisory: warm wall-time budget exceeded)

Note: a single-file check/emit attempt against `verification/areas/python_interop/fixtures/numpy_buffer/numpy_full_example.sifr` returned `SIFR-PYTRUST-0002` because `numpy` is not allowed in that single-file trust mode; it was replaced by the trusted primitive roundtrip fixture.