### PR TITLE
Harden retained design classification for runtime task and tests

### DIFF
--- a/crates/sifr_codegen/src/intrinsics/registry_core_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_core_tests.rs
@@ -168,6 +168,18 @@ pub(crate) fn runtime_module_dependency_metadata_includes_observability_facades(
 }
 
 #[test]
+pub(crate) fn lowers_task_current_context_as_language_runtime_glue() {
+    let lowered =
+        lower_intrinsic("task_current_context", &[]).expect("task_current_context should lower");
+
+    assert_eq!(
+        lowered.required_feature,
+        Some(sifr_stdlib_manifest::StdlibFeature::Tokio)
+    );
+    assert_eq!(render_expr(&lowered.expr), "__sifr_task_current_context()");
+}
+
+#[test]
 pub(crate) fn unicode_intrinsics_are_owned_by_compiled_stdlib_declarations() {
     for name in [
         "unicode_data_version",

--- a/plans/reviews/active/m12a-retained-design-classification-opus-round1.md
+++ b/plans/reviews/active/m12a-retained-design-classification-opus-round1.md
@@ -1,0 +1,21 @@
+Reviewed the diff and cross-checked against the retained manifest, the `sifr_retained_intrinsics` fallback source, the intrinsic registry, and the M12/M13 plan sections.
+
+## Verdict: READY
+
+## Findings (ordered by severity)
+
+None blocking. No correctness or brittleness issues that would justify holding the M12a PR.
+
+## Notes on the review focal points
+
+1. **Required-state guard scope** - Correctly narrow. `REQUIRED_SURFACE_STATES` pins exactly the three surface IDs M12a is hardening (`_sifr.runtime::observability_glue`, `_sifr.task::language_runtime_glue`, `generated-test-glue`) - all already `retained-by-design` in `internal_docs/stdlib_retained_compiler_intrinsics.toml:63,201,227`. Not too brittle for M13: the plan (`plans/issues/active/ad-hoc-stdlib-native-boundary-completion.md:1092`) explicitly calls for "Convert temporary migration guards into permanent no-regression guards" at final closure, and widening this dict is a trivial follow-up. The guard composes cleanly with the existing `_validate_transitions` "new manifest rows must be retained-by-design" invariant - no overlap, no ordering hazard.
+
+2. **Comment updates accuracy** - Accurate. The fallback signatures for `runtime_emit_diagnostic` and `task_current_context` live in `crates/sifr_retained_intrinsics/src/runtime.rs:6` and `crates/sifr_retained_intrinsics/src/task.rs:6`, not in the `.sifr` private-module files. The prior "Concrete Rust interop declarations migrate here in later milestones" comment was stale - nothing is scheduled to migrate into these two `.sifr` files, matching M12 acceptance criterion "Retained-by-design entries are precise and stable."
+
+3. **Task codegen test coverage** - Focused, not overfit. Asserts (a) `task_current_context` with no args lowers, (b) `required_feature = Tokio` (matches `registry.rs:97`), (c) rendered ident is `__sifr_task_current_context()` (matches `registry/task.rs:7`). No implementation details beyond the public dispatch contract are locked in.
+
+## Non-blocking suggestions
+
+- The runtime intrinsic has a companion arity-rejection test (`runtime_diagnostic_intrinsic_rejects_wrong_arity`, `registry_core_tests.rs:139`); an equivalent `task_current_context` negative test would close the symmetry (`task::lower_task_current_context` returns `None` on non-empty args). Cheap to add, but not required for M12a.
+- The failure message `"{surface_id}: required retained manifest surface is missing"` doesn't include the expected state. Minor - the message phrasing implies retained-by-design, and the dict is one screen up in the file.
+- `_validate_required_surface_states` is invoked in `main()` but not from `_self_test`'s existing manifest-level fixtures; it is only exercised through the three dedicated fixtures. Fine; the intent (unit-scope the new function) is clear.

--- a/scripts/check_stdlib_manifest_schema.py
+++ b/scripts/check_stdlib_manifest_schema.py
@@ -48,12 +48,18 @@ ALLOWED_STATE_TRANSITIONS = {
     ("pilot", "closing"),
     ("pilot", "retained-by-design"),
 }
+REQUIRED_SURFACE_STATES = {
+    "_sifr.runtime::observability_glue": "retained-by-design",
+    "_sifr.task::language_runtime_glue": "retained-by-design",
+    "generated-test-glue": "retained-by-design",
+}
 DEFAULT_BASE_REF = "origin/main"
 
 
 def main() -> int:
     manifest = tomllib.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     failures = _validate(manifest)
+    failures.extend(_validate_required_surface_states(manifest, REQUIRED_SURFACE_STATES))
     base_manifest, base_error = _base_manifest()
     if base_manifest is None:
         base_ref = os.environ.get("SIFR_STDLIB_MANIFEST_BASE_REF", DEFAULT_BASE_REF)
@@ -243,6 +249,26 @@ def _validate_transitions(
             + ", ".join(active_closed)
         )
 
+    return failures
+
+
+def _validate_required_surface_states(
+    manifest: dict[str, Any],
+    required_states: dict[str, str],
+) -> list[str]:
+    failures: list[str] = []
+    current_states = _surface_states(manifest)
+    for surface_id, required_state in sorted(required_states.items()):
+        current_state = current_states.get(surface_id)
+        if current_state is None:
+            failures.append(
+                f"{surface_id}: required retained manifest surface is missing"
+            )
+            continue
+        if current_state != required_state:
+            failures.append(
+                f"{surface_id}: state must remain {required_state}, got {current_state}"
+            )
     return failures
 
 
@@ -594,6 +620,66 @@ def _self_test() -> int:
     ]
     if _validate(pr_url_closure):
         print("self-test PR URL closure record failed", file=sys.stderr)
+        return 1
+
+    required_state_manifest = json.loads(json.dumps(manifest))
+    required_state_manifest["surface"] = [
+        {
+            "id": "_sifr.runtime::observability_glue",
+            "state": "retained-by-design",
+            "owner": "stdlib-native-boundary-completion",
+            "issue": "stdlib-native-boundary-completion",
+            "evidence_links": ["stdlib-native-boundary-completion"],
+            "reason": "test fixture",
+            "registry_files": ["runtime.rs"],
+        },
+        {
+            "id": "_sifr.task::language_runtime_glue",
+            "state": "retained-by-design",
+            "owner": "stdlib-native-boundary-completion",
+            "issue": "stdlib-native-boundary-completion",
+            "evidence_links": ["stdlib-native-boundary-completion"],
+            "reason": "test fixture",
+            "registry_files": ["task.rs"],
+        },
+        {
+            "id": "generated-test-glue",
+            "state": "retained-by-design",
+            "owner": "stdlib-native-boundary-completion",
+            "issue": "stdlib-native-boundary-completion",
+            "evidence_links": ["stdlib-native-boundary-completion"],
+            "reason": "test fixture",
+            "registry_files": ["test.rs"],
+        },
+    ]
+    if _validate_required_surface_states(
+        required_state_manifest, REQUIRED_SURFACE_STATES
+    ):
+        print("self-test required retained-by-design states failed", file=sys.stderr)
+        return 1
+
+    required_state_bad = json.loads(json.dumps(required_state_manifest))
+    required_state_bad["surface"][1]["state"] = "retained"
+    if not any(
+        "_sifr.task::language_runtime_glue: state must remain retained-by-design"
+        in failure
+        for failure in _validate_required_surface_states(
+            required_state_bad, REQUIRED_SURFACE_STATES
+        )
+    ):
+        print("self-test required retained-by-design drift was not rejected", file=sys.stderr)
+        return 1
+
+    required_state_missing = json.loads(json.dumps(required_state_manifest))
+    required_state_missing["surface"] = required_state_missing["surface"][:-1]
+    if not any(
+        "generated-test-glue: required retained manifest surface is missing"
+        in failure
+        for failure in _validate_required_surface_states(
+            required_state_missing, REQUIRED_SURFACE_STATES
+        )
+    ):
+        print("self-test missing required retained-by-design row was not rejected", file=sys.stderr)
         return 1
 
     print("stdlib retained manifest schema self-test: PASS")

--- a/stdlib/_sifr/runtime.sifr
+++ b/stdlib/_sifr/runtime.sifr
@@ -1,2 +1,2 @@
 # Private _sifr.runtime native declaration module.
-# Concrete Rust interop declarations migrate here in later milestones.
+# Runtime observability signatures remain retained compiler/runtime glue.

--- a/stdlib/_sifr/task.sifr
+++ b/stdlib/_sifr/task.sifr
@@ -1,2 +1,2 @@
 # Private _sifr.task native declaration module.
-# Concrete Rust interop declarations migrate here in later milestones.
+# Task context signatures remain retained language/runtime glue.


### PR DESCRIPTION
## Summary
- require M12 retained-by-design manifest states for runtime observability glue, task language/runtime glue, and generated test glue
- add schema guard self-tests for required-state success, drift, and missing-row failures
- update stale `_sifr.runtime` and `_sifr.task` comments to reflect retained compiler/runtime and language/runtime glue
- add focused task_current_context codegen coverage

## Review
- Opus round 1: READY, no blockers

## Validation
- cargo fmt --check
- python3 scripts/check_stdlib_manifest_schema.py --self-test
- python3 scripts/check_stdlib_manifest_schema.py
- python3 scripts/check_stdlib_native_intrinsic_allowlist.py
- python3 scripts/check_stdlib_migration_closure.py
- cargo test -p sifr_codegen lowers_task_current_context_as_language_runtime_glue -- --nocapture
- cargo test -p sifr_codegen lowers_runtime_diagnostic_intrinsic_with_observability_metadata -- --nocapture
- cargo test -p sifr_codegen lowers_test_intrinsics_via_registry -- --nocapture
- cargo test -p sifr_retained_intrinsics -- --nocapture
- python3 scripts/check_file_size_guardrails.py
- git diff --check