### PR TITLE
Lock declaration-first Python interop contract

### DIFF
--- a/crates/sifr_diagnostics/src/codes/registry.rs
+++ b/crates/sifr_diagnostics/src/codes/registry.rs
@@ -444,6 +444,16 @@ pub const DIAGNOSTIC_FAMILIES: &[DiagnosticFamily] = &[
         reserved_base: "SIFR-PYRES-0000",
     },
     DiagnosticFamily {
+        name: "PYASYNC",
+        summary: "Embedded Python loop ownership, awaitable, cancellation, and async-cleanup diagnostics.",
+        reserved_base: "SIFR-PYASYNC-0000",
+    },
+    DiagnosticFamily {
+        name: "PYCTX",
+        summary: "Embedded Python context entry, exit, suppression, and cause-mapping diagnostics.",
+        reserved_base: "SIFR-PYCTX-0000",
+    },
+    DiagnosticFamily {
         name: "PYZC",
         summary:
             "Embedded Python zero-copy buffer, Arrow, DLPack, and array-interface diagnostics.",

--- a/crates/sifr_diagnostics/src/codes/registry/registry_entries/reserved.rs
+++ b/crates/sifr_diagnostics/src/codes/registry/registry_entries/reserved.rs
@@ -14,6 +14,8 @@ pub(super) const ENTRIES: &[DiagnosticRegistryEntry] = &[
     reserved_family_base("SIFR-PYCALL-0000", "PYCALL"),
     reserved_family_base("SIFR-PYCONV-0000", "PYCONV"),
     reserved_family_base("SIFR-PYRES-0000", "PYRES"),
+    reserved_family_base("SIFR-PYASYNC-0000", "PYASYNC"),
+    reserved_family_base("SIFR-PYCTX-0000", "PYCTX"),
     reserved_family_base("SIFR-PYZC-0000", "PYZC"),
     reserved_family_base("SIFR-PYCB-0000", "PYCB"),
     reserved_family_base("SIFR-PYTRUST-0000", "PYTRUST"),
@@ -31,6 +33,51 @@ pub(super) const ENTRIES: &[DiagnosticRegistryEntry] = &[
     reserved_family_base("SIFR-INT-0000", "INT"),
     reserved_family_base("SIFR-IO-0000", "IO"),
     reserved_family_base("SIFR-ENCODING-0000", "ENCODING"),
+    reserved_code(
+            "SIFR-PYIMP-0001",
+            "PYIMP",
+            "Reserved for an unresolved or invalid static Python or bridge target.",
+        ),
+    reserved_code(
+            "SIFR-PYCALL-0001",
+            "PYCALL",
+            "Reserved for an unsupported or incompatible Python callable, attribute, item, or argument shape.",
+        ),
+    reserved_code(
+            "SIFR-PYCONV-0001",
+            "PYCONV",
+            "Reserved for an unsupported Sifr/Python declaration conversion type.",
+        ),
+    reserved_code(
+            "SIFR-PYRES-0001",
+            "PYRES",
+            "Reserved for an invalid Python opaque cleanup or ownership policy.",
+        ),
+    reserved_code(
+            "SIFR-PYRES-0002",
+            "PYRES",
+            "Reserved for recognized declaration-first syntax whose sole production lowering is not active yet.",
+        ),
+    reserved_code(
+            "SIFR-PYASYNC-0001",
+            "PYASYNC",
+            "Reserved for an invalid Python awaitable, cancellation, or loop-ownership declaration.",
+        ),
+    reserved_code(
+            "SIFR-PYCTX-0001",
+            "PYCTX",
+            "Reserved for an invalid Python context-manager entry, exit, or suppression declaration.",
+        ),
+    reserved_code(
+            "SIFR-PYZC-0001",
+            "PYZC",
+            "Reserved for an invalid advanced-data ownership or hidden-copy declaration.",
+        ),
+    reserved_code(
+            "SIFR-PYCB-0001",
+            "PYCB",
+            "Reserved for an invalid callback lifetime, threading, or shutdown declaration.",
+        ),
     reserved_code(
             "SIFR-INT-0002",
             "INT",

--- a/demos/python_interop_contract_demo/README.md
+++ b/demos/python_interop_contract_demo/README.md
@@ -1,0 +1,28 @@
+# Python Interop Declaration Contract Demo
+
+The declaration contract intentionally activates no declaration syntax. It
+locks the complete declaration-first design and makes support claims executable
+policy.
+
+Run the demo through the Python interop scaffold:
+
+```bash
+verification/areas/python_interop/run.sh --group scaffold
+```
+
+The generated report at
+`target/verification/areas/python_interop/latest.json` includes a
+`declaration_capabilities` summary. The scaffold validates the separate
+`verification/areas/python_interop/declaration_capabilities.json` ledger,
+including target classification, implementation status, activation ownership,
+and positive, negative, cleanup, cancellation, and live evidence ownership.
+
+Run the negative policy checks with:
+
+```bash
+verification/areas/python_interop/run.sh --self-test
+```
+
+Those checks prove that duplicate capabilities, passing evidence on reserved
+syntax, incomplete evidence on active syntax, and missing required cleanup
+evidence are rejected.

--- a/docs/errors/diagnostic-codes.md
+++ b/docs/errors/diagnostic-codes.md
@@ -20,6 +20,8 @@ Tooling metadata defaults: `tool_actions` is empty, `fix_all_eligible` is `false
 | `PYCALL` | `SIFR-PYCALL-0000` | Embedded Python callable, attribute, item, and coroutine diagnostics. |
 | `PYCONV` | `SIFR-PYCONV-0000` | Sifr/Python primitive and structured conversion diagnostics. |
 | `PYRES` | `SIFR-PYRES-0000` | Embedded Python resource cleanup and leak diagnostics. |
+| `PYASYNC` | `SIFR-PYASYNC-0000` | Embedded Python loop ownership, awaitable, cancellation, and async-cleanup diagnostics. |
+| `PYCTX` | `SIFR-PYCTX-0000` | Embedded Python context entry, exit, suppression, and cause-mapping diagnostics. |
 | `PYZC` | `SIFR-PYZC-0000` | Embedded Python zero-copy buffer, Arrow, DLPack, and array-interface diagnostics. |
 | `PYCB` | `SIFR-PYCB-0000` | Python-to-Sifr callback lifetime, dispatch, and closure diagnostics. |
 | `PYTRUST` | `SIFR-PYTRUST-0000` | Embedded Python import and native-extension trust diagnostics. |
@@ -267,6 +269,8 @@ Tooling metadata defaults: `tool_actions` is empty, `fix_all_eligible` is `false
 | `SIFR-PYCALL-0000` | `PYCALL` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-PYCONV-0000` | `PYCONV` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-PYRES-0000` | `PYRES` | Reserved family base; not emitted as a diagnostic. |
+| `SIFR-PYASYNC-0000` | `PYASYNC` | Reserved family base; not emitted as a diagnostic. |
+| `SIFR-PYCTX-0000` | `PYCTX` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-PYZC-0000` | `PYZC` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-PYCB-0000` | `PYCB` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-PYTRUST-0000` | `PYTRUST` | Reserved family base; not emitted as a diagnostic. |
@@ -284,6 +288,15 @@ Tooling metadata defaults: `tool_actions` is empty, `fix_all_eligible` is `false
 | `SIFR-INT-0000` | `INT` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-IO-0000` | `IO` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-ENCODING-0000` | `ENCODING` | Reserved family base; not emitted as a diagnostic. |
+| `SIFR-PYIMP-0001` | `PYIMP` | Reserved for an unresolved or invalid static Python or bridge target. |
+| `SIFR-PYCALL-0001` | `PYCALL` | Reserved for an unsupported or incompatible Python callable, attribute, item, or argument shape. |
+| `SIFR-PYCONV-0001` | `PYCONV` | Reserved for an unsupported Sifr/Python declaration conversion type. |
+| `SIFR-PYRES-0001` | `PYRES` | Reserved for an invalid Python opaque cleanup or ownership policy. |
+| `SIFR-PYRES-0002` | `PYRES` | Reserved for recognized declaration-first syntax whose sole production lowering is not active yet. |
+| `SIFR-PYASYNC-0001` | `PYASYNC` | Reserved for an invalid Python awaitable, cancellation, or loop-ownership declaration. |
+| `SIFR-PYCTX-0001` | `PYCTX` | Reserved for an invalid Python context-manager entry, exit, or suppression declaration. |
+| `SIFR-PYZC-0001` | `PYZC` | Reserved for an invalid advanced-data ownership or hidden-copy declaration. |
+| `SIFR-PYCB-0001` | `PYCB` | Reserved for an invalid callback lifetime, threading, or shutdown declaration. |
 | `SIFR-INT-0002` | `INT` | Reserved for implicit narrowing from exact or fixed-width integer sources to narrower fixed-width targets. |
 | `SIFR-INT-0008` | `INT` | Reserved for fixed-width array, tensor, or dataframe arithmetic without an explicit overflow policy. |
 | `SIFR-INT-0009` | `INT` | Reserved for JSON or web-safe integer serialization policy failures. |

--- a/internal_docs/diagnostic_codes.md
+++ b/internal_docs/diagnostic_codes.md
@@ -27,6 +27,8 @@ Tooling metadata defaults: `tool_actions` is empty, `fix_all_eligible` is `false
 | `PYCALL` | `SIFR-PYCALL-0000` | Embedded Python callable, attribute, item, and coroutine diagnostics. |
 | `PYCONV` | `SIFR-PYCONV-0000` | Sifr/Python primitive and structured conversion diagnostics. |
 | `PYRES` | `SIFR-PYRES-0000` | Embedded Python resource cleanup and leak diagnostics. |
+| `PYASYNC` | `SIFR-PYASYNC-0000` | Embedded Python loop ownership, awaitable, cancellation, and async-cleanup diagnostics. |
+| `PYCTX` | `SIFR-PYCTX-0000` | Embedded Python context entry, exit, suppression, and cause-mapping diagnostics. |
 | `PYZC` | `SIFR-PYZC-0000` | Embedded Python zero-copy buffer, Arrow, DLPack, and array-interface diagnostics. |
 | `PYCB` | `SIFR-PYCB-0000` | Python-to-Sifr callback lifetime, dispatch, and closure diagnostics. |
 | `PYTRUST` | `SIFR-PYTRUST-0000` | Embedded Python import and native-extension trust diagnostics. |
@@ -74,6 +76,8 @@ Tooling metadata defaults: `tool_actions` is empty, `fix_all_eligible` is `false
 | `SIFR-PYCALL-0000` | `PYCALL` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-PYCONV-0000` | `PYCONV` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-PYRES-0000` | `PYRES` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYASYNC-0000` | `PYASYNC` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYCTX-0000` | `PYCTX` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-PYZC-0000` | `PYZC` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-PYCB-0000` | `PYCB` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-PYTRUST-0000` | `PYTRUST` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
@@ -91,6 +95,15 @@ Tooling metadata defaults: `tool_actions` is empty, `fix_all_eligible` is `false
 | `SIFR-INT-0000` | `INT` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-IO-0000` | `IO` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-ENCODING-0000` | `ENCODING` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYIMP-0001` | `PYIMP` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYCALL-0001` | `PYCALL` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYCONV-0001` | `PYCONV` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYRES-0001` | `PYRES` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYRES-0002` | `PYRES` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYASYNC-0001` | `PYASYNC` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYCTX-0001` | `PYCTX` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYZC-0001` | `PYZC` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-PYCB-0001` | `PYCB` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-INT-0002` | `INT` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-INT-0008` | `INT` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-INT-0009` | `INT` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |

--- a/internal_docs/python_interop_declaration_architecture.md
+++ b/internal_docs/python_interop_declaration_architecture.md
@@ -71,8 +71,9 @@ from sifr.python import PythonError
 def sqrt(value: float) -> Result[float, PythonError]: ...
 ```
 
-The declared parameter and return types are authoritative. The decorator does
-not repeat them through `returns=`, `copy=`, or per-argument converter fields.
+The declared parameter and return types are authoritative. The Sifr signature
+is the only conversion type contract. The decorator does not repeat types
+through `returns=`, `copy=`, or per-argument converter fields.
 This prevents decorator metadata and Sifr types from drifting apart.
 Ellipsis is public Python interop declaration syntax, not a general Sifr
 function body form.
@@ -552,7 +553,7 @@ failure is statically provable:
 Dynamic Python exceptions, values that violate declared output conversion, and
 runtime resource failures remain structured `PythonError` results.
 
-M0 reserves the first declaration codes with stable meanings:
+The declaration contract reserves the first diagnostic codes with stable meanings:
 
 | Code | Meaning |
 | --- | --- |
@@ -560,6 +561,7 @@ M0 reserves the first declaration codes with stable meanings:
 | `SIFR-PYCALL-0001` | Unsupported or definitively incompatible callable/attribute/item shape. |
 | `SIFR-PYCONV-0001` | Unsupported Sifr/Python declaration conversion type. |
 | `SIFR-PYRES-0001` | Invalid opaque close or ownership policy. |
+| `SIFR-PYRES-0002` | Recognized declaration-first syntax whose sole production lowering is not active yet. |
 | `SIFR-PYZC-0001` | Invalid advanced-data ownership or hidden-copy declaration. |
 | `SIFR-PYCB-0001` | Invalid callback lifetime, threading, or shutdown declaration. |
 | `SIFR-PYASYNC-0001` | Invalid Python awaitable, cancellation, or loop-ownership declaration. |
@@ -567,15 +569,19 @@ M0 reserves the first declaration codes with stable meanings:
 
 ## Verification Contract
 
-The Python interop capability matrix distinguishes:
+The Python interop capability matrix classifies the target contract separately
+from current implementation status. Target states are:
 
-- `supported`;
-- `supported-through-bridge`;
+- `declaration-supported`;
+- `bridge-supported`;
 - `dynamic-only`;
 - `unsupported-by-design`.
 
-No row is supported merely because a package appears in an inventory matrix.
-Supported capability rows require executable positive and negative evidence.
+Implementation status is independently `reserved` or `active`. A reserved row
+is architectural intent and cannot claim passing evidence. No row is active
+merely because a package appears in an inventory matrix. Active capability rows
+require all executable positive, negative, cleanup, cancellation, and live
+evidence marked as required by that row.
 The declaration layer must cover at least:
 
 - direct functions, factories, methods, attributes, and item access;

--- a/internal_docs/python_interop_protocol_architecture.md
+++ b/internal_docs/python_interop_protocol_architecture.md
@@ -4,7 +4,7 @@
 
 This document is part of the proposed declaration-first Python interop contract.
 It defines the complete end state for Python coroutine, context-manager,
-callback, buffer, Arrow, and DLPack integration. Ordered milestones implement
+callback, buffer, Arrow, and DLPack integration. Ordered changes activate
 this one contract without publishing reduced substitutes.
 
 The common rules in

--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -2,11 +2,12 @@
 
 ## Status
 
-Proposed. The phase defines one complete end-state architecture and an ordered
-implementation sequence. Opus High pass 5 approved the complete design; a final
-independent Fable High audit found no blockers and its eight non-blocking
-precision refinements are incorporated. Nothing described here is currently
-implemented.
+In progress. The phase defines one complete end-state architecture and an
+ordered implementation sequence. Opus High pass 5 approved the complete design;
+a final independent Fable High audit found no blockers and its eight
+non-blocking precision refinements are incorporated. M0 is implemented and
+locally validated in [PR #2930](https://github.com/sifr-lang/sifr/pull/2930);
+later milestones are not yet implemented.
 Milestones sequence delivery; they do not create reduced language versions,
 temporary public contracts, dual authorities, or alternate lowering paths.
 
@@ -126,6 +127,27 @@ owner milestone, a form hard-errors with `SIFR-PYRES-0002`; it never uses raw
 objects, alternate semantics, or a compatibility implementation.
 
 ## Milestones
+
+Implementation progress:
+
+- [x] M0 complete contract lock and evidence model — [PR #2930](https://github.com/sifr-lang/sifr/pull/2930)
+- [ ] M1 sealed runtime identity and cleanup
+- [ ] M2 environment and trust authority cutover
+- [ ] M3 synchronous declaration core and complete call shapes
+- [ ] M4 recursive conversion and opaque lifecycle
+- [ ] M5 synchronous Python context managers
+- [ ] M6 hermetic package-local Python bridges
+- [ ] M7 owned asyncio runtime and async declarations
+- [ ] M8 async context managers
+- [ ] M9 typed callback lifetimes and dispatch
+- [ ] M10 typed buffer protocol
+- [ ] M11 Arrow C Data Interface
+- [ ] M12 DLPack one-shot tensor transfer
+- [ ] M13 read-only check and doctor
+- [ ] M14 binding and certification authoring
+- [ ] M15 LSP declaration authoring
+- [ ] M16 raw API ergonomics on shared ownership
+- [ ] M17 ecosystem migration and certification
 
 ### M0. Complete Contract Lock And Evidence Model
 

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m0-review-round1.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m0-review-round1.md
@@ -1,0 +1,66 @@
+Now I have enough context to produce the review. Let me write it up.
+
+---
+
+# M0 Review — Complete Contract Lock And Evidence Model
+
+## Scope and validation
+
+Reviewed the current branch diff (`codex/python-interop-m0-contract-lock`) against `plans/issues/active/ad-hoc-declaration-first-python-interop.md` M0 tasks/acceptance and the two durable architecture documents.
+
+**M0 tasks — coverage confirmed:**
+
+| Task | Evidence in diff |
+| --- | --- |
+| Accept both architecture documents as target contract | `internal_docs/python_interop_declaration_architecture.md`, `internal_docs/python_interop_protocol_architecture.md` both present; declaration doc updated (`Sifr signature is the only conversion type contract`, PYRES-0002 row, target-state/implementation-status split) |
+| Define capability states | `declaration_capabilities.py:11-17` — `CAPABILITY_STATES = {declaration-supported, bridge-supported, dynamic-only, unsupported-by-design}` and `IMPLEMENTATION_STATUSES = {reserved, active}` |
+| Machine-readable ledger separate from package inventory | `verification/areas/python_interop/declaration_capabilities.json` (16 rows); loaded by `run.py:212` and reported at `run.py:242-253` distinct from `matrix_files` / `package_certification` |
+| Positive/negative/cleanup/cancellation/live evidence owners on every decorator+protocol | Every row in `declaration_capabilities.json` lists all five evidence kinds with explicit owner strings; non-required kinds are `not-applicable` with a documented reason |
+| Lock decorator grammar, policy atoms, target namespace, ellipsis body | `python_interop_declaration_architecture.md:62-186` + `python_interop_protocol_architecture.md:31-565` |
+| Lock complete call-shape semantics | `python_interop_declaration_architecture.md:188-225` (positional, keyword-only, `python.omit`, typed `*args`, typed `**kwargs`, explicit `**record`) |
+| Lock 8 diagnostic families + stable first codes | `crates/sifr_diagnostics/src/codes/registry.rs:446-466` adds PYASYNC + PYCTX (six others already registered). `registry/registry_entries/reserved.rs:36-80` adds nine reserved codes (PYIMP-0001, PYCALL-0001, PYCONV-0001, PYRES-0001, PYRES-0002, PYASYNC-0001, PYCTX-0001, PYZC-0001, PYCB-0001) |
+| Reserve `SIFR-PYRES-0002` | `reserved.rs:56-60` + declaration doc row + phase plan reference; documented as staged-activation gate |
+| Lock trust authority / atomic `[python].allow-imports` removal | `python_interop_declaration_architecture.md:423-437` — retained as design contract with `SIFR-PYTRUST-0005` role |
+| Stale-design checks | `declaration_capabilities.py:40-49` `FORBIDDEN_DESIGN_PATTERNS` rejects string decorator targets, `send=`, `converter=`, `copy=` on buffer/arrow/dlpack, and `MVP`/`subset release`/`reduced release` |
+
+**Acceptance criteria — all met:**
+- Every public syntax form maps to one HIR/runtime contract (protocol doc `Design Principles` line 28-29).
+- Every protocol has explicit ownership and shutdown state machines (`### Shutdown State Machine`, cleanup policies table, ExitCause table).
+- No capability is labeled supported from package inventory alone (`README.md:30-38`, `declaration_capabilities.py:112-113` blocks `reserved` + `passing`).
+- No document describes a smaller language version (`FORBIDDEN_DESIGN_PATTERNS` catches `MVP` / `subset release` / `reduced release`).
+
+**Cross-checks:**
+- Runtime module registered in runner (`run.py:13-16`), scaffold path invokes ledger validation (`run.py:212`), self-test path invokes negative fixtures (`run.py:378`).
+- Ledger schema is complete: 16 rows cover sync-declaration, complete-call-shapes, opaque-lifecycle, sync-context, package-bridge, coroutine-declaration, async-context, three callback rows, buffer, Arrow, DLPack, raw-dynamic-object, and two unsupported-by-design rows.
+- Registry tests still pass (`cargo test -p sifr_diagnostics` = 32 pass), the new families satisfy `assert_family_name` / `assert_canonical_code`.
+- Design-fragment strings referenced by `_validate_design_contract` are all present in the two architecture docs (verified line-by-line).
+
+## Findings
+
+### Actionable findings
+
+**None.** The M0 changes match the phase-plan tasks and acceptance criteria; validations named in the prompt already passed locally.
+
+### Non-blocking suggestions
+
+1. **`declaration_capabilities.py:115-125` allows a required-evidence kind to be marked `not-applicable`.** Only the `reserved` + `passing` combination is rejected. A future edit could hide a required capability commitment by flipping `planned` → `not-applicable`. Consider tightening: for kinds in `required_evidence`, require `status in {"planned", "passing"}` (i.e., forbid `not-applicable`). Today the ledger is well-formed, but the validator does not enforce it.
+
+2. **`crates/sifr_diagnostics/src/codes/registry.rs` is 895 / 900 lines** after the two new families. It is under the guardrail but has only ~5 lines of headroom. M2's PYTRUST rebase and each subsequent milestone's active-code activations will need to add rows to `registry.rs` and `reserved.rs`. Consider factoring `DIAGNOSTIC_FAMILIES` into a small sibling file now (mirroring `registry/registry_entries/…`) rather than under milestone pressure.
+
+3. **`demos/python_interop_m0_demo/` contains only a README.** `AGENTS.md` describes `demos/` as "Runnable language-feature demos (*.sifr)". Since M0 activates no syntax, the "demo" is really pointer documentation. The same content could live in `verification/areas/python_interop/README.md` (where the ledger is already documented) or in the M0 review-evidence file. As a demo directory it violates the file-type convention and adds no runnable Sifr surface.
+
+4. **Stale-design sweep is scoped to two documents.** `FORBIDDEN_DESIGN_PATTERNS` runs only against the two architecture markdown files listed in `REQUIRED_DESIGN_FRAGMENTS`. The phase plan file (`plans/issues/active/ad-hoc-declaration-first-python-interop.md`), other internal_docs pages, and future public docs are not covered. Extending the sweep to at least the active phase plan and any `docs/python*` page would harden the rejected-syntax guardrail.
+
+5. **`FORBIDDEN_DESIGN_PATTERNS` string-decorator regex is narrow.** `r"@python(?:\.coroutine)?\(\s*['\"]"` catches `@python("…")` and `@python.coroutine("…")` but not string targets in `@python.opaque(type="…")`, `@python.attr("…")`, `@python.item("…")`, or `@python.dlpack(target="…")`. Those decorators legitimately take target references and are equally prone to a string-target regression. Broaden to `@python(\.\w+)*\(\s*['\"]` (excluding `@python.callback` where the first positional arg is a parameter name — that would need an explicit allowlist).
+
+6. **`_expect_rejection` (declaration_capabilities.py:171-178) uses substring matching.** Fragile against future error-message wording changes; a wrong-cause SystemExit whose message happens to contain the expected substring would silently pass. Anchoring on the concrete `raise SystemExit(...)` prefix (e.g., `"reserved capability"`, `"missing required evidence"`) or introducing a small error-code enum would be more resilient.
+
+7. **`passing` claims are not cross-linked to concrete tests.** `raw-dynamic-object`, `arbitrary-dynamic-attributes`, and `untyped-generation` mark `passing` evidence with human-readable owners like "existing conversion and resource diagnostics." The ledger check accepts these labels without verifying the referenced suites still exist or still pass. This is consistent with M0's contract-lock scope (M17 is the exit gate for evidence-vs-claim reconciliation), but a follow-up milestone should require each `passing` claim to name a fixture-file path or diagnostic-code identifier.
+
+8. **Grammar coverage gap in evidence rows (aggregate rows lump sub-states).** `opaque-lifecycle` bundles `@python.opaque`, `@python.attr`, and `@python.item` under one row with `milestone_owner: M4`, and `arrow-c-data` bundles five capsule return types. The M0 task says "every decorator and protocol state transition"; sub-state transitions (attribute-vs-item failure paths, ArrowArray-vs-ArrowStream vs device variants) are implicit in the evidence owner descriptions rather than distinct rows. Not a defect, but if the ledger is to remain the authoritative evidence contract through M17, splitting these into per-decorator or per-return-type rows would let later milestones tick each transition off explicitly.
+
+## Verdict
+
+**SATISFIED.**
+
+The branch delivers the full M0 contract lock: eight diagnostic families + nine stable first codes reserved (including SIFR-PYRES-0002 for staged-activation guarding), a machine-readable declaration/protocol capability ledger separated from package inventory, evidence ownership for every decorator/protocol row, target-state vs. implementation-status decoupling that structurally prevents inventory-only support claims, a design-fragment presence check plus stale-design pattern sweep, and runner integration with a passing self-test. Architecture docs are complete and consistent with the phase plan. All named local validations passed. No actionable findings; the suggestions above are refinements for later milestones, not M0 blockers.

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m0-review-round2.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m0-review-round2.md
@@ -1,0 +1,53 @@
+I have enough context. Let me finalize the round-2 review.
+
+# M0 Review Round 2 — Complete Contract Lock And Evidence Model
+
+## Scope
+
+Re-reviewed the current branch diff (`codex/python-interop-m0-contract-lock`, all uncommitted) with the three adopted round-1 refinements in focus, and cross-checked them against `declaration_capabilities.json`, both architecture docs, the reserved diagnostic codes/families, and the runner integration.
+
+## Verification of the three adopted refinements
+
+**1. Required evidence may not be `not-applicable` — `verification/areas/python_interop/runner/declaration_capabilities.py:129-137`.**
+The check is stronger than round-1 suggested: it rejects `required + not-applicable` (line 129-133) *and* symmetrically rejects `non-required + status != not-applicable` (line 134-137). All 16 rows in `declaration_capabilities.json` satisfy both directions:
+- Every required kind has status `planned` or `passing`.
+- Every non-required kind carries status `not-applicable` with a documented owner reason.
+
+Negative self-test at line 189-191 mutates `capabilities[0].evidence[0]` (positive/required on `sync-declaration`) to `not-applicable` and asserts the "cannot be not-applicable" rejection fires. Confirmed by simulation.
+
+**2. Design sweep includes the active phase plan — `declaration_capabilities.py:39-42, 151-167`.**
+`DESIGN_SWEEP_PATHS = (*REQUIRED_DESIGN_FRAGMENTS, "plans/issues/active/ad-hoc-declaration-first-python-interop.md")` unpacks the two dict keys plus the phase plan. Line 157-161 explicitly skips the `reduced-version term` pattern for `plans/issues/` so `plans/issues/active/…:751` ("not a reduced release" — the historical review-checklist item) does not trip. Ran the four other patterns manually across all three files: zero hits.
+
+**3. String-target rejection broadened — `declaration_capabilities.py:44-49`.**
+`r"@python(?:\.[a-z_]+)*\(\s*['\"]"` catches `@python(...)`, `@python.coroutine(...)`, `@python.attr/.item/.callback/.buffer/.arrow/.dlpack/.context.enter/.aenter/.exit/.aexit/.dlpack.stream(...)` positional string targets. The `@python.opaque(type="...")` case that the first regex misses (opaque's first arg is `type=`, not the string) is covered by the second regex `r"@python\.opaque\([^\n)]*\btype\s*=\s*['\"]"`. Legitimate non-string callable arguments (`@python.callback(handler, …)`, `parameter(name)` in `stream=`) do not trip because the char after `(\s*` is an identifier, not a quote.
+
+## Cross-checks
+
+- **Fragment presence** — every fragment in `REQUIRED_DESIGN_FRAGMENTS` is present in the target file (verified by search): declaration doc has `is the only conversion type contract.` at line 75, `SIFR-PYRES-0002` at 564; protocol doc has the four headings and the "async Python declaration owns exactly one" phrase.
+- **Diagnostic families/codes** — `registry.rs:446-455` adds `PYASYNC` + `PYCTX`; `reserved.rs:17-18, 36-80` reserves 9 first codes including `SIFR-PYRES-0002` (staged-activation gate). Names/codes match the declaration doc's line 549-568 and phase-plan tasks. Indentation of new `reserved_code(…)` entries matches the pre-existing `SIFR-INT-0002…0010` block.
+- **Runner integration** — `run.py:212` loads the ledger under `scaffold`, `run.py:242-253` reports counts distinct from `matrix_files` / `package_certification`; `run.py:377-378` invokes the four self-tests under `--self-test`.
+- **State-name consistency** — `declaration-supported | bridge-supported | dynamic-only | unsupported-by-design` is consistent across declaration doc (line 575-578), phase plan (line 135-136), README (line 32-33), ledger, and validator constants.
+- **File-size guardrail** — `registry.rs` = 895/900; `declaration_capabilities.py` = 201; `declaration_capabilities.json` = 246. All within cap.
+- **All named validations already passing** per the prompt.
+
+## Findings
+
+### Actionable findings
+
+**None.** The three adopted refinements are correctly implemented, the ledger and validator agree, all fragment/pattern checks are internally consistent, and no regression was introduced against the round-1 baseline.
+
+### Material non-blocking suggestions
+
+1. **`declaration_capabilities.py:120` does not reject `active + planned`.** The validator forbids `reserved + passing`, but there is no complementary check that an `active` row's required evidence is at `passing` (or at least, not `planned`). All three current `active` rows happen to comply, but the design intent per `declaration_capabilities.json:3` ("only active rows with passing required evidence are implemented claims") is not enforced by code. Consider tightening in M2 or later: `if implementation == "active" and kind in required_kinds and status == "planned": reject`.
+
+2. **Self-tests reference `capabilities[0]` by index (`declaration_capabilities.py:177, 190`).** Both `unsupported_claim` and `inapplicable_required` rely on capabilities[0] being reserved *and* its evidence[0] being a required kind — currently `sync-declaration` + `positive` — but nothing anchors that. A JSON reorder in a later milestone could silently make one or both tests no-op (the "invalid" mutation would produce a still-valid matrix). Prefer selecting by attribute (`next(row for row in matrix["capabilities"] if row["implementation_status"] == "reserved" and row["evidence"][0]["kind"] in row["required_evidence"])`) as done for `missing_cleanup` at line 181-186.
+
+3. **`crates/sifr_diagnostics/src/codes/registry.rs` is 895/900 lines** after the two new families (unchanged from round 1). M2's PYTRUST rebase and later milestones' active-code activations will add rows here and in `reserved.rs`. Factoring `DIAGNOSTIC_FAMILIES` into a sibling file now is easier than under M2 pressure.
+
+4. **`demos/python_interop_m0_demo/` still contains only a README** (unchanged from round 1). `AGENTS.md` describes `demos/` as "Runnable language-feature demos (*.sifr)"; a pointer-only directory reads as violating that convention. The same content could live in `verification/areas/python_interop/README.md` or in an M0 exit-evidence note.
+
+## Verdict
+
+**SATISFIED.**
+
+The three adopted refinements land correctly with no regressions: required evidence can no longer be `not-applicable` (validator + negative self-test); the stale-design sweep now covers the active phase plan with a scoped exception for the historically-referenced "reduced release" term; and string-target rejection covers every `@python.*` immediate positional target plus `@python.opaque(type="…")`. Diagnostic families/codes, ledger classifications, architecture-doc fragments, runner integration, state-name usage, and file-size guardrails are all consistent. M0 is ready for PR. The four non-blocking suggestions above are refinements for later milestones, not M0 blockers.

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m0-review-round3.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m0-review-round3.md
@@ -1,0 +1,55 @@
+I've verified the two adopted refinements against the current tree.
+
+# M0 Review Round 3 — Verification of adopted refinements
+
+## Change 1: active rows require passing required evidence
+
+`declaration_capabilities.py:134-141` adds
+
+```
+if (
+    implementation == "active"
+    and item["kind"] in required_kinds
+    and item["status"] != "passing"
+):
+    raise SystemExit(f"active capability {capability_id} requires passing {item['kind']} evidence")
+```
+
+Ledger compliance for all three `active` rows:
+- `raw-dynamic-object` — required = {positive, negative, cleanup}; all three at `passing`; cancellation/live are non-required and at `not-applicable`.
+- `arbitrary-dynamic-attributes` — required = {negative}; `negative: passing`; other four `not-applicable`.
+- `untyped-generation` — required = {negative}; `negative: passing`; other four `not-applicable`.
+
+All 13 `reserved` rows still comply with the pre-existing `reserved + passing` rejection (all required kinds are `planned`, all non-required are `not-applicable`).
+
+New negative self-test `incomplete_active` (lines 221-233): picks an `active` row by property, selects a required evidence item by property, mutates its status to `planned`, and expects `"requires passing"`. Rejection is triggered by the new branch above — verified by simulation on `raw-dynamic-object`.
+
+## Change 2: property-based self-test selection
+
+- `unsupported_claim` (lines 185-196) — now selects the reserved row and required item via `next(...)`.
+- `inapplicable_required` (lines 207-219) — same property-based selection.
+- `missing_cleanup` (lines 198-205) — already property-based (unchanged from round 1).
+- `incomplete_active` (new) — property-based.
+- `duplicate` (line 181) — still uses `capabilities[0]`, correctly, since duplicate-ID detection is orthogonal to row properties (round-2 suggestion #2 explicitly scoped this to the two tests that depended on row content, not to the duplicate test).
+
+Error-string matching is intact: `unsupported_claim → "cannot claim passing evidence"`, `inapplicable_required → "cannot be not-applicable"`, `incomplete_active → "requires passing"`, `missing_cleanup → "missing required evidence"`, `duplicate → "duplicate declaration capability id"`. Order-of-checks is safe: on a reserved row the `reserved + passing` guard (line 120) fires before any second-pass check; on an active row with a required kind set to `not-applicable`, the `not-applicable` guard (line 130) fires before the new `requires passing` guard, and either message would still correctly reject the mutation.
+
+## Cross-checks (unchanged from round 2)
+
+- Nothing else moved: `registry.rs` (895/900), `reserved.rs`, both architecture docs, README, and `run.py` are identical to the round-2 snapshot.
+- Design-sweep + fragment checks still hold; the ledger row order is compatible with `next(...)` selection (first reserved = `sync-declaration`, first active = `raw-dynamic-object`, both have their first `evidence` entry as a required kind, but the property-based selection no longer depends on that anyway).
+
+## Findings
+
+### Actionable findings
+
+**None.**
+
+### Material non-blocking notes
+
+Carried over from round 2 (not regressions, not M0 blockers, called out only so they don't get lost):
+
+1. `crates/sifr_diagnostics/src/codes/registry.rs` still sits at **895/900** lines. Factoring `DIAGNOSTIC_FAMILIES` out before M2's PYTRUST rebase will be easier than under milestone pressure.
+2. `demos/python_interop_m0_demo/` remains README-only. `AGENTS.md` describes `demos/` as runnable `*.sifr` demos; consider moving the M0 exit-evidence content into the area README or a phase-plan note.
+
+SATISFIED

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m0-review-round4.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m0-review-round4.md
@@ -1,0 +1,41 @@
+## M0 Review Round 4 — Post authoritative-gate corrections
+
+### Verification of the five checklisted concerns
+
+**1. Durable activation owners satisfy M0's evidence-owner requirement — PASS**
+
+`verification/areas/python_interop/declaration_capabilities.json` retains, for all 16 rows, per-evidence-kind owner strings across `positive/negative/cleanup/cancellation/live`. Row-level `activation_owner` is a separate, durable kebab-case slug enforced by `declaration_capabilities.py:95` (`re.fullmatch(r"[a-z][a-z0-9-]+", owner)`). No slug encodes delivery order; each names the durable subsystem. The M0 task ("assign … evidence owners to every decorator and protocol state transition") is met by the per-kind owner fields, not by activation_owner — so replacing M-labels with subsystem slugs did not remove any evidence commitment.
+
+**2. Phase-plan sequencing remains unambiguous — PASS**
+
+Distinct activation_owner slugs in the JSON (13 unique: `sync-declarations, opaque-lifecycle, sync-context, package-bridge, async-runtime, async-context, callback-runtime, buffer-protocol, arrow-c-data, dlpack-transfer, raw-api, static-language, binding-authoring`) map 1:1 to the plan's Delivery Rule (`plans/issues/active/…M0.md:117–128`) and its section titles (M3–M12, M14, M16). The plans directory remains the sole sequencing authority (47 `M#` occurrences confined there); no ambiguity introduced.
+
+**3. Taxonomy corrections do not weaken capability/evidence guarantees — PASS**
+
+All prior guards remain in `runner/declaration_capabilities.py`: (a) enum-restricted target/implementation/kind/status sets; (b) reserved-cannot-pass (`:117–118`); (c) active-must-pass (`:131–138`); (d) required-cannot-be-NA (`:127–130`); (e) non-required-must-be-NA (`:139–142`); (f) required-set-must-be-covered (`:120–125`); (g) forbidden-design patterns (string targets, `send=`, `converter=`, hidden `copy=`, reduced-version terms). New guard added on top: activation_owner regex shape (`:95`). Guarantees are strengthened, not weakened. `cargo test -p sifr_diagnostics` = 32/32 pass. Self-tests round-trip clean (verified locally: `rows: 16` reported).
+
+**4. Generated diagnostic docs are correct — PASS**
+
+`crates/sifr_diagnostics/src/codes/registry.rs` now registers `PYASYNC` (`:446–450`) and `PYCTX` (`:451–455`) family bases; `registry_entries/reserved.rs` adds their `-0000` bases (`:17–18`) plus nine stable first codes `SIFR-{PYIMP,PYCALL,PYCONV,PYRES-0001,PYRES-0002,PYASYNC,PYCTX,PYZC,PYCB}-0001` (`:36–80`). Both `docs/errors/diagnostic-codes.md` and `internal_docs/diagnostic_codes.md` list the two new families and all nine reserved rows in the same order with matching descriptions. Registry stays at 895/900 lines; file-size guardrail passes.
+
+**5. No stale delivery labels remain in tracked active roots — PASS (with one local-workspace nit)**
+
+Grep for `\bM[0-9]+\b|milestone` across the six affected files returns zero. Grep for `MVP|subset release|reduced release` across the same set returns zero. `python3 verification/areas/coverage_matrix/checks/verification_taxonomy.py` exits 0. Durable `SIFR-PYRES-0002` doc rows describe activation as "sole production lowering is not active yet" — durable phrasing.
+
+### Findings
+
+**Actionable findings: none.**
+
+**Non-blocking observation** (unchanged from round 3): `crates/sifr_diagnostics/src/codes/registry.rs` sits at 895/900. Factoring `DIAGNOSTIC_FAMILIES` into a sibling file before further family additions remains a good idea, but not an M0 blocker.
+
+**Local-workspace nit (does not ship):** `demos/python_interop_m0_demo/` is an empty directory left over from the round-4 rename to `demos/python_interop_contract_demo/`. Its name contains the token `m0`. It is untracked (git does not track empty dirs), does not appear in the PR diff, and does not trigger `verification_taxonomy.FILENAME_PATTERNS` because no files are walked inside it. However, it is a stale delivery label present in the working tree under an active root; a plain `rmdir demos/python_interop_m0_demo` would remove the last local trace of the pre-rename state. Not a PR-readiness blocker.
+
+### Cross-checks
+
+- `git diff` for the two architecture docs only softens M-number references to durable phrasing ("Ordered changes activate", "declaration contract reserves the first diagnostic codes") — no capability, ownership, or state-machine content is weakened.
+- Verification README's new `declaration_capabilities.json` paragraph and the contract demo README both describe target/implementation/activation ownership and evidence coverage in durable vocabulary.
+- Delivery Rule in the plan (M3→M12 mapping to declaration forms) is preserved and remains authoritative sequencing; the JSON is silent on ordering, as it must be.
+
+### Verdict
+
+**SATISFIED.** M0 is PR-ready.

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m0-review-round5.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m0-review-round5.md
@@ -1,0 +1,28 @@
+## M0 Tracker Review
+
+**Diff scope**: Only `plans/issues/active/ad-hoc-declaration-first-python-interop.md`:
+1. Status: `Proposed` → `In progress`, adding "M0 is implemented and locally validated in [PR #2930]; later milestones are not yet implemented."
+2. New "Implementation progress:" checklist inserted at the top of the `## Milestones` section, with M0 checked and linked to PR #2930; M1–M17 all unchecked.
+
+**Accuracy**
+- PR #2930 is OPEN and its file list confirms the M0 deliverables the tracker attributes to it: the machine-readable capability ledger (`verification/areas/python_interop/declaration_capabilities.{json,py}`), reserved diagnostic entries incl. `SIFR-PYRES-0002` (`crates/sifr_diagnostics/src/codes/registry/registry_entries/reserved.rs`), diagnostic docs refresh, architecture doc updates, and the declaration contract demo. PR body confirms `create-pr` profile passed and Opus rounds 1–4 SATISFIED.
+- The 17 checklist labels match the section headers verbatim (M0…M17 titles preserved).
+
+**Complete-language / no-temporary-contract rule preserved**
+- The paragraph "Milestones sequence delivery; they do not create reduced language versions, temporary public contracts, dual authorities, or alternate lowering paths." is retained.
+- Delivery Rule section, End-State Decisions, and `SIFR-PYRES-0002` staged-activation clause untouched.
+- Status prose still frames the phase as "one complete end-state architecture and an ordered implementation sequence" — reduced-version language does not creep in.
+
+**Overclaim check**
+- Only M0 is `[x]`; every other milestone (M1–M17) is `[ ]`.
+- Status prose explicitly says "later milestones are not yet implemented."
+- No task-list bullets under M0 were flipped to reflect implementation state — appropriate, since the checklist is the tracker, not per-task ticks.
+
+**Ready to add to PR #2930**
+- Minimal, focused edit (~29 lines); no code touched; no unrelated review artifact bundled (the untracked round-5 review file is not staged).
+- Frontmatter and section structure unchanged; markdown link and list formatting match surrounding style.
+- Only unstaged file, so a `git add` of just this path avoids sweeping in the untracked review draft.
+
+No actionable finding.
+
+SATISFIED

--- a/verification/areas/python_interop/README.md
+++ b/verification/areas/python_interop/README.md
@@ -27,6 +27,16 @@ evidence and validates checked-in positive probe fixtures plus concrete negative
 probe/selection cases. The runner must never invoke `uv sync` or install
 packages implicitly.
 
+`declaration_capabilities.json` is the separate declaration/protocol capability
+ledger. Its `target_state` classifies the intended contract as
+`declaration-supported`, `bridge-supported`, `dynamic-only`, or
+`unsupported-by-design`; it does not claim implementation. Current availability
+is recorded independently as `reserved` or `active`, and a reserved row cannot
+claim passing evidence. Each row names its durable activation owner and the status of
+positive, negative, cleanup, cancellation, and live evidence. The scaffold and
+self-test suites reject missing ownership, unsupported states, duplicate rows,
+or a supported claim without the evidence required by that row.
+
 Live dependency examples are intentionally opt-in. The `python-interop-live`
 profile uses selected-areas-only execution and runs both:
 

--- a/verification/areas/python_interop/declaration_capabilities.json
+++ b/verification/areas/python_interop/declaration_capabilities.json
@@ -1,0 +1,246 @@
+{
+  "schema_version": 1,
+  "description": "Target capability classification and evidence ownership for declaration-first Python interop. A target state is architectural intent; only active rows with passing required evidence are implemented claims.",
+  "capabilities": [
+    {
+      "id": "sync-declaration",
+      "surface": "@python(path)",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "sync-declarations",
+      "required_evidence": ["positive", "negative", "cleanup", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "sync wrapper matrix"},
+        {"kind": "negative", "status": "planned", "owner": "target and call-shape diagnostics"},
+        {"kind": "cleanup", "status": "planned", "owner": "wrapper failure reference assertions"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "synchronous boundary"},
+        {"kind": "live", "status": "planned", "owner": "pure-Python and native-extension binaries"}
+      ]
+    },
+    {
+      "id": "complete-call-shapes",
+      "surface": "positional, keyword-only, omit, variadics, kwargs, and closed-record expansion",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "sync-declarations",
+      "required_evidence": ["positive", "negative", "cleanup"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "parser/lowering/codegen call-shape matrix"},
+        {"kind": "negative", "status": "planned", "owner": "duplicate and incompatible-shape fixtures"},
+        {"kind": "cleanup", "status": "planned", "owner": "partial argument-conversion cleanup"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "synchronous call shapes"},
+        {"kind": "live", "status": "not-applicable", "owner": "covered by sync-declaration live evidence"}
+      ]
+    },
+    {
+      "id": "opaque-lifecycle",
+      "surface": "@python.opaque, @python.attr, and @python.item",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "opaque-lifecycle",
+      "required_evidence": ["positive", "negative", "cleanup", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "opaque method/attribute/item matrix"},
+        {"kind": "negative", "status": "planned", "owner": "moved/closed/poison diagnostics"},
+        {"kind": "cleanup", "status": "planned", "owner": "exact-once drop and close fixtures"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "owned async close runtime"},
+        {"kind": "live", "status": "planned", "owner": "biip and schwifty binaries"}
+      ]
+    },
+    {
+      "id": "sync-context",
+      "surface": "@python.context.enter and @python.context.exit",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "sync-context",
+      "required_evidence": ["positive", "negative", "cleanup", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "context outcome and suppression matrix"},
+        {"kind": "negative", "status": "planned", "owner": "escape and incompatible entered-value fixtures"},
+        {"kind": "cleanup", "status": "planned", "owner": "replay-token and exact-once exit fixtures"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "synchronous context boundary"},
+        {"kind": "live", "status": "planned", "owner": "database transaction binary"}
+      ]
+    },
+    {
+      "id": "package-bridge",
+      "surface": "bridge.* target namespace",
+      "target_state": "bridge-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "package-bridge",
+      "required_evidence": ["positive", "negative", "cleanup", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "loader, sibling import, and archive fixtures"},
+        {"kind": "negative", "status": "planned", "owner": "collision and dynamic-import rejection"},
+        {"kind": "cleanup", "status": "planned", "owner": "failed-loader state cleanup"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "bridge loading is synchronous initialization"},
+        {"kind": "live", "status": "planned", "owner": "installed package run without source checkout"}
+      ]
+    },
+    {
+      "id": "coroutine-declaration",
+      "surface": "@python.coroutine(path)",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "async-runtime",
+      "required_evidence": ["positive", "negative", "cleanup", "cancellation", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "async declaration matrix"},
+        {"kind": "negative", "status": "planned", "owner": "sync/async kind mismatch fixtures"},
+        {"kind": "cleanup", "status": "planned", "owner": "loop, task, and async-close shutdown fixtures"},
+        {"kind": "cancellation", "status": "planned", "owner": "bidirectional cancellation matrix"},
+        {"kind": "live", "status": "planned", "owner": "compiled httpx-style client"}
+      ]
+    },
+    {
+      "id": "async-context",
+      "surface": "@python.context.aenter and @python.context.aexit",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "async-context",
+      "required_evidence": ["positive", "negative", "cleanup", "cancellation", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "async context outcome matrix"},
+        {"kind": "negative", "status": "planned", "owner": "escape and unsuppressible-cause fixtures"},
+        {"kind": "cleanup", "status": "planned", "owner": "exact-once async exit fixtures"},
+        {"kind": "cancellation", "status": "planned", "owner": "masked cleanup and resume matrix"},
+        {"kind": "live", "status": "planned", "owner": "compiled async database session"}
+      ]
+    },
+    {
+      "id": "callback-current",
+      "surface": "@python.callback(..., dispatch=current)",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "callback-runtime",
+      "required_evidence": ["positive", "negative", "cleanup", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "current-thread callback matrix"},
+        {"kind": "negative", "status": "planned", "owner": "escape and conversion fixtures"},
+        {"kind": "cleanup", "status": "planned", "owner": "call/result/Self owner shutdown"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "current-thread callable is synchronous"},
+        {"kind": "live", "status": "planned", "owner": "compiled CFFI callback example"}
+      ]
+    },
+    {
+      "id": "callback-foreign",
+      "surface": "@python.callback(..., dispatch=foreign)",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "callback-runtime",
+      "required_evidence": ["positive", "negative", "cleanup", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "foreign serial/parallel matrix"},
+        {"kind": "negative", "status": "planned", "owner": "capture, argument, and reentrancy fixtures"},
+        {"kind": "cleanup", "status": "planned", "owner": "unregister/drain/release shutdown"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "foreign callback is synchronous"},
+        {"kind": "live", "status": "planned", "owner": "compiled Kafka callback example"}
+      ]
+    },
+    {
+      "id": "callback-asyncio",
+      "surface": "@python.callback(..., dispatch=asyncio)",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "callback-runtime",
+      "required_evidence": ["positive", "negative", "cleanup", "cancellation", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "AsyncCallable dispatch matrix"},
+        {"kind": "negative", "status": "planned", "owner": "async result and reentrancy fixtures"},
+        {"kind": "cleanup", "status": "planned", "owner": "asyncio callback owner shutdown"},
+        {"kind": "cancellation", "status": "planned", "owner": "bidirectional callback cancellation"},
+        {"kind": "live", "status": "planned", "owner": "compiled Pub/Sub callback example"}
+      ]
+    },
+    {
+      "id": "buffer-protocol",
+      "surface": "@python.buffer",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "buffer-protocol",
+      "required_evidence": ["positive", "negative", "cleanup", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "format/layout/access matrix"},
+        {"kind": "negative", "status": "planned", "owner": "borrow, move, and metadata failures"},
+        {"kind": "cleanup", "status": "planned", "owner": "exact PyBuffer_Release counters"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "buffer acquisition is synchronous"},
+        {"kind": "live", "status": "planned", "owner": "compiled NumPy buffer example"}
+      ]
+    },
+    {
+      "id": "arrow-c-data",
+      "surface": "@python.arrow",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "arrow-c-data",
+      "required_evidence": ["positive", "negative", "cleanup", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "array/schema/stream transfer matrix"},
+        {"kind": "negative", "status": "planned", "owner": "capsule, copy, and consumption failures"},
+        {"kind": "cleanup", "status": "planned", "owner": "exact release and partial-consumption counters"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "Arrow transfer is synchronous"},
+        {"kind": "live", "status": "planned", "owner": "pandas, PyArrow, and Polars binaries"}
+      ]
+    },
+    {
+      "id": "dlpack-transfer",
+      "surface": "@python.dlpack and @python.dlpack.stream",
+      "target_state": "declaration-supported",
+      "implementation_status": "reserved",
+      "activation_owner": "dlpack-transfer",
+      "required_evidence": ["positive", "negative", "cleanup", "live"],
+      "evidence": [
+        {"kind": "positive", "status": "planned", "owner": "dtype/device/stream transfer matrix"},
+        {"kind": "negative", "status": "planned", "owner": "capsule, copy, device, and double-consume failures"},
+        {"kind": "cleanup", "status": "planned", "owner": "exact deleter and failure-transition counters"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "DLPack transfer is synchronous"},
+        {"kind": "live", "status": "planned", "owner": "PyTorch and TensorFlow binaries"}
+      ]
+    },
+    {
+      "id": "raw-dynamic-object",
+      "surface": "sifr.python.Object",
+      "target_state": "dynamic-only",
+      "implementation_status": "active",
+      "activation_owner": "raw-api",
+      "required_evidence": ["positive", "negative", "cleanup"],
+      "evidence": [
+        {"kind": "positive", "status": "passing", "owner": "existing embedded interop raw-object suites"},
+        {"kind": "negative", "status": "passing", "owner": "existing conversion and resource diagnostics"},
+        {"kind": "cleanup", "status": "passing", "owner": "existing outstanding-object assertions"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "raw coroutine integration owner"},
+        {"kind": "live", "status": "not-applicable", "owner": "inventory is not used as live certification"}
+      ]
+    },
+    {
+      "id": "arbitrary-dynamic-attributes",
+      "surface": "ordinary Sifr dynamic attribute syntax",
+      "target_state": "unsupported-by-design",
+      "implementation_status": "active",
+      "activation_owner": "static-language",
+      "required_evidence": ["negative"],
+      "evidence": [
+        {"kind": "positive", "status": "not-applicable", "owner": "unsupported by design"},
+        {"kind": "negative", "status": "passing", "owner": "existing static member resolution diagnostics"},
+        {"kind": "cleanup", "status": "not-applicable", "owner": "no value is constructed"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "no execution occurs"},
+        {"kind": "live", "status": "not-applicable", "owner": "unsupported by design"}
+      ]
+    },
+    {
+      "id": "untyped-generation",
+      "surface": "Any, bare object, or implicit py.Object generated boundaries",
+      "target_state": "unsupported-by-design",
+      "implementation_status": "active",
+      "activation_owner": "binding-authoring",
+      "required_evidence": ["negative"],
+      "evidence": [
+        {"kind": "positive", "status": "not-applicable", "owner": "unsupported by design"},
+        {"kind": "negative", "status": "passing", "owner": "declaration contract and existing no-Any type system"},
+        {"kind": "cleanup", "status": "not-applicable", "owner": "no value is generated"},
+        {"kind": "cancellation", "status": "not-applicable", "owner": "no execution occurs"},
+        {"kind": "live", "status": "not-applicable", "owner": "unsupported by design"}
+      ]
+    }
+  ]
+}

--- a/verification/areas/python_interop/runner/declaration_capabilities.py
+++ b/verification/areas/python_interop/runner/declaration_capabilities.py
@@ -1,0 +1,235 @@
+"""Validate declaration-first Python interop capability and design contracts."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+CAPABILITY_MATRIX = "declaration_capabilities.json"
+CAPABILITY_STATES = {
+    "declaration-supported",
+    "bridge-supported",
+    "dynamic-only",
+    "unsupported-by-design",
+}
+IMPLEMENTATION_STATUSES = {"reserved", "active"}
+EVIDENCE_KINDS = {"positive", "negative", "cleanup", "cancellation", "live"}
+EVIDENCE_STATUSES = {"planned", "passing", "not-applicable"}
+
+REQUIRED_DESIGN_FRAGMENTS = {
+    "internal_docs/python_interop_declaration_architecture.md": (
+        "is the only conversion type contract.",
+        "structured dotted paths, never strings",
+        "`python.omit`",
+        "typed `*args: T`",
+        "typed `**kwargs: T`",
+        "explicit `**record`",
+        "`SIFR-PYRES-0002`",
+    ),
+    "internal_docs/python_interop_protocol_architecture.md": (
+        "async Python declaration owns exactly one",
+        "### Shutdown State Machine",
+        "## Buffer Protocol",
+        "## Arrow C Data Interface",
+        "## DLPack",
+    ),
+}
+DESIGN_SWEEP_PATHS = tuple(REQUIRED_DESIGN_FRAGMENTS)
+
+FORBIDDEN_DESIGN_PATTERNS = (
+    (re.compile(r"@python(?:\.[a-z_]+)*\(\s*['\"]"), "string decorator target"),
+    (
+        re.compile(r"@python\.opaque\([^\n)]*\btype\s*=\s*['\"]"),
+        "string opaque type target",
+    ),
+    (re.compile(r"@python\.opaque\([^\n)]*\bsend\s*="), "configurable opaque send policy"),
+    (re.compile(r"@python[^\n]*\bconverter\s*="), "decorator converter type"),
+    (
+        re.compile(r"@python\.(?:buffer|arrow|dlpack)\([^\n)]*\bcopy\s*="),
+        "advanced-data copy policy",
+    ),
+    (re.compile(r"\b(?:MVP|subset release|reduced release)\b", re.IGNORECASE), "reduced-version term"),
+)
+
+
+def load_and_validate_capabilities(area_root: Path, repo_root: Path) -> dict[str, Any]:
+    matrix_path = area_root / CAPABILITY_MATRIX
+    if not matrix_path.is_file():
+        raise SystemExit(f"missing declaration capability matrix: {matrix_path}")
+    try:
+        matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"invalid declaration capability matrix JSON: {error}") from error
+    _validate_matrix(matrix)
+    _validate_design_contract(repo_root)
+    return matrix
+
+
+def _validate_matrix(matrix: dict[str, Any]) -> None:
+    if matrix.get("schema_version") != 1:
+        raise SystemExit("declaration capability matrix schema_version must be 1")
+    rows = matrix.get("capabilities")
+    if not isinstance(rows, list) or not rows:
+        raise SystemExit("declaration capability matrix must contain capabilities")
+
+    seen: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            raise SystemExit("declaration capability rows must be objects")
+        capability_id = row.get("id")
+        if not isinstance(capability_id, str) or not capability_id:
+            raise SystemExit("declaration capability id is required")
+        if capability_id in seen:
+            raise SystemExit(f"duplicate declaration capability id: {capability_id}")
+        seen.add(capability_id)
+
+        state = row.get("target_state")
+        if state not in CAPABILITY_STATES:
+            raise SystemExit(f"unknown target state for {capability_id}: {state}")
+        implementation = row.get("implementation_status")
+        if implementation not in IMPLEMENTATION_STATUSES:
+            raise SystemExit(f"unknown implementation status for {capability_id}: {implementation}")
+        owner = row.get("activation_owner")
+        if not isinstance(owner, str) or not re.fullmatch(r"[a-z][a-z0-9-]+", owner):
+            raise SystemExit(f"invalid activation owner for {capability_id}: {owner}")
+
+        evidence = row.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            raise SystemExit(f"missing evidence ownership for {capability_id}")
+        kinds: set[str] = set()
+        for item in evidence:
+            if not isinstance(item, dict):
+                raise SystemExit(f"evidence entries for {capability_id} must be objects")
+            kind = item.get("kind")
+            status = item.get("status")
+            evidence_owner = item.get("owner")
+            if kind not in EVIDENCE_KINDS:
+                raise SystemExit(f"unknown evidence kind for {capability_id}: {kind}")
+            if kind in kinds:
+                raise SystemExit(f"duplicate {kind} evidence for {capability_id}")
+            kinds.add(kind)
+            if status not in EVIDENCE_STATUSES:
+                raise SystemExit(f"unknown {kind} evidence status for {capability_id}: {status}")
+            if not isinstance(evidence_owner, str) or not evidence_owner:
+                raise SystemExit(f"missing {kind} evidence owner for {capability_id}")
+            if implementation == "reserved" and status == "passing":
+                raise SystemExit(f"reserved capability {capability_id} cannot claim passing evidence")
+
+        required_kinds = set(row.get("required_evidence", []))
+        if not required_kinds or not required_kinds.issubset(EVIDENCE_KINDS):
+            raise SystemExit(f"invalid required evidence set for {capability_id}")
+        missing = sorted(required_kinds.difference(kinds))
+        if missing:
+            raise SystemExit(f"missing required evidence for {capability_id}: {', '.join(missing)}")
+        for item in evidence:
+            if item["kind"] in required_kinds and item["status"] == "not-applicable":
+                raise SystemExit(
+                    f"required {item['kind']} evidence for {capability_id} cannot be not-applicable"
+                )
+            if (
+                implementation == "active"
+                and item["kind"] in required_kinds
+                and item["status"] != "passing"
+            ):
+                raise SystemExit(
+                    f"active capability {capability_id} requires passing {item['kind']} evidence"
+                )
+            if item["kind"] not in required_kinds and item["status"] != "not-applicable":
+                raise SystemExit(
+                    f"non-required {item['kind']} evidence for {capability_id} must be not-applicable"
+                )
+
+
+def _validate_design_contract(repo_root: Path) -> None:
+    for relative_path, fragments in REQUIRED_DESIGN_FRAGMENTS.items():
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise SystemExit(f"missing declaration-first architecture document: {relative_path}")
+        text = path.read_text(encoding="utf-8")
+        missing = [fragment for fragment in fragments if fragment not in text]
+        if missing:
+            raise SystemExit(
+                f"declaration-first design contract drift in {relative_path}: missing {missing!r}"
+            )
+    for relative_path in DESIGN_SWEEP_PATHS:
+        path = repo_root / relative_path
+        if not path.is_file():
+            raise SystemExit(f"missing declaration-first design input: {relative_path}")
+        text = path.read_text(encoding="utf-8")
+        for pattern, label in FORBIDDEN_DESIGN_PATTERNS:
+            match = pattern.search(text)
+            if match is not None:
+                line = text.count("\n", 0, match.start()) + 1
+                raise SystemExit(
+                    f"stale declaration-first design in {path.relative_to(repo_root)}:{line}: {label}"
+                )
+
+
+def run_declaration_capability_self_tests(area_root: Path, repo_root: Path) -> None:
+    matrix = load_and_validate_capabilities(area_root, repo_root)
+    duplicate = json.loads(json.dumps(matrix))
+    duplicate["capabilities"].append(duplicate["capabilities"][0])
+    _expect_rejection(duplicate, "duplicate declaration capability id")
+
+    unsupported_claim = json.loads(json.dumps(matrix))
+    reserved_row = next(
+        row
+        for row in unsupported_claim["capabilities"]
+        if row["implementation_status"] == "reserved"
+    )
+    required_item = next(
+        item
+        for item in reserved_row["evidence"]
+        if item["kind"] in reserved_row["required_evidence"]
+    )
+    required_item["status"] = "passing"
+    _expect_rejection(unsupported_claim, "cannot claim passing evidence")
+
+    missing_cleanup = json.loads(json.dumps(matrix))
+    row = next(
+        candidate
+        for candidate in missing_cleanup["capabilities"]
+        if "cleanup" in candidate["required_evidence"]
+    )
+    row["evidence"] = [item for item in row["evidence"] if item["kind"] != "cleanup"]
+    _expect_rejection(missing_cleanup, "missing required evidence")
+
+    inapplicable_required = json.loads(json.dumps(matrix))
+    reserved_row = next(
+        row
+        for row in inapplicable_required["capabilities"]
+        if row["implementation_status"] == "reserved"
+    )
+    required_item = next(
+        item
+        for item in reserved_row["evidence"]
+        if item["kind"] in reserved_row["required_evidence"]
+    )
+    required_item["status"] = "not-applicable"
+    _expect_rejection(inapplicable_required, "cannot be not-applicable")
+
+    incomplete_active = json.loads(json.dumps(matrix))
+    active_row = next(
+        row
+        for row in incomplete_active["capabilities"]
+        if row["implementation_status"] == "active"
+    )
+    required_item = next(
+        item
+        for item in active_row["evidence"]
+        if item["kind"] in active_row["required_evidence"]
+    )
+    required_item["status"] = "planned"
+    _expect_rejection(incomplete_active, "requires passing")
+
+
+def _expect_rejection(matrix: dict[str, Any], expected: str) -> None:
+    try:
+        _validate_matrix(matrix)
+    except SystemExit as error:
+        if expected not in str(error):
+            raise SystemExit(f"capability self-test expected {expected!r}, got {error!r}") from error
+    else:
+        raise SystemExit(f"capability self-test failed: accepted invalid matrix ({expected})")

--- a/verification/areas/python_interop/runner/run.py
+++ b/verification/areas/python_interop/runner/run.py
@@ -10,6 +10,10 @@ if __package__ in {None, ""}:
 
 from certification_matrix import build_certification_report, validate_certification_policy
 from dataframe_examples import build_dataframe_examples_report, run_dataframe_examples_self_tests
+from declaration_capabilities import (
+    load_and_validate_capabilities,
+    run_declaration_capability_self_tests,
+)
 from env import discover_paths
 from env_probe import run_env_probe
 from import_matrix import PackageEntry, load_matrix
@@ -205,6 +209,7 @@ def main(argv: list[str] | None = None) -> int:
     matrices = load_matrices(paths.packages_root)
     validate_matrix_entries(matrices)
     validate_certification_policy(matrices)
+    declaration_capabilities = load_and_validate_capabilities(paths.area_root, paths.repo_root)
     validate_fixtures(paths.fixtures_root)
     validate_fixture_files(paths.fixtures_root)
 
@@ -234,6 +239,18 @@ def main(argv: list[str] | None = None) -> int:
         "packages": sorted({entry.name for entry in selected}),
         "matrix_files": list(MATRIX_FILES),
         "matrix_entries": len(matrices),
+        "declaration_capabilities": {
+            "file": "declaration_capabilities.json",
+            "rows": len(declaration_capabilities["capabilities"]),
+            "active": sum(
+                row["implementation_status"] == "active"
+                for row in declaration_capabilities["capabilities"]
+            ),
+            "reserved": sum(
+                row["implementation_status"] == "reserved"
+                for row in declaration_capabilities["capabilities"]
+            ),
+        },
         "fixture_directories": list(REQUIRED_FIXTURES),
         "fixture_files": list(REQUIRED_FIXTURE_FILES),
         "source_fixtures": list(REQUIRED_SOURCE_FIXTURES),
@@ -357,6 +374,8 @@ def run_self_tests(area_root: Path) -> None:
     entries = load_matrices(area_root / "packages")
     validate_matrix_entries(entries)
     validate_certification_policy(entries)
+    repo_root = area_root.parents[2]
+    run_declaration_capability_self_tests(area_root, repo_root)
     validate_fixture_files(area_root / "fixtures")
     run_env_probe(area_root)
     try:


### PR DESCRIPTION
## Summary
- add a machine-readable declaration/protocol capability ledger with durable activation and evidence ownership
- reserve declaration-first diagnostic families and stable first codes, including the staged activation guard
- enforce stale-design, evidence-state, and activation-owner invariants in the Python interop verification area
- refresh diagnostic references and add the declaration contract demo

## Validation
- `scripts/run_all_tests.sh --profile create-pr` (pass; 130/130 E2E; warm wall-time advisory only)
- `verification/areas/python_interop/run.sh --group scaffold`
- `verification/areas/python_interop/run.sh --self-test`
- `cargo test -p sifr_diagnostics`
- Claude Opus review rounds 1-4: SATISFIED