### PR TITLE
Add safe Python foreign-object release queue

### DIFF
--- a/crates/sifr_driver/src/build/python_runtime.rs
+++ b/crates/sifr_driver/src/build/python_runtime.rs
@@ -165,8 +165,9 @@ pub(super) fn render_python_runtime_prelude(metadata: &PackagePythonRuntime) -> 
     }}
 }}
 
-fn __sifr_initialize_python_runtime() -> Result<(), sifr_runtime::python::PythonRuntimeError> {{
-    sifr_runtime::python::initialize_runtime(__sifr_python_runtime_config()).map(|_| ())
+fn __sifr_initialize_python_runtime() -> Result<sifr_runtime::python::PythonRuntimeGuard, sifr_runtime::python::PythonRuntimeError> {{
+    sifr_runtime::python::initialize_runtime(__sifr_python_runtime_config())?;
+    sifr_runtime::python::runtime_guard()
 }}
 
 "#,
@@ -198,7 +199,7 @@ pub(super) fn inject_python_runtime_bootstrap(
     let mut with_bootstrap = render_python_runtime_prelude(metadata);
     with_bootstrap.push_str(&main_rs[..insert_at]);
     with_bootstrap.push_str(
-        "\n    if let Err(__sifr_python_runtime_error) = __sifr_initialize_python_runtime() {\n        eprintln!(\"Sifr Python runtime initialization failed: {}\", __sifr_python_runtime_error);\n        std::process::exit(1);\n    }\n",
+        "\n    let __sifr_python_runtime_guard = match __sifr_initialize_python_runtime() {\n        Ok(__sifr_python_runtime_guard) => __sifr_python_runtime_guard,\n        Err(__sifr_python_runtime_error) => {\n            eprintln!(\"Sifr Python runtime initialization failed: {}\", __sifr_python_runtime_error);\n            std::process::exit(1);\n        }\n    };\n",
     );
     with_bootstrap.push_str(&main_rs[insert_at..]);
     Ok(with_bootstrap)
@@ -364,7 +365,9 @@ mod tests {
             inject_python_runtime_bootstrap(&main_rs, &metadata()).expect("main should be patched");
 
         assert!(rendered.starts_with("fn __sifr_python_runtime_config()"));
-        assert!(rendered.contains("fn main() {\n    if let Err(__sifr_python_runtime_error)"));
+        assert!(rendered.contains(
+            "fn main() {\n    let __sifr_python_runtime_guard = match __sifr_initialize_python_runtime()"
+        ));
         assert!(rendered.contains("println!(\"ok\")"));
     }
 
@@ -378,7 +381,7 @@ mod tests {
             inject_python_runtime_bootstrap(&main_rs, &metadata()).expect("main should be patched");
 
         assert!(rendered.contains(
-            "fn main() -> Result<(), PythonError> {\n    if let Err(__sifr_python_runtime_error)"
+            "fn main() -> Result<(), PythonError> {\n    let __sifr_python_runtime_guard = match __sifr_initialize_python_runtime()"
         ));
         assert!(rendered.contains("run_example()?"));
     }
@@ -393,7 +396,7 @@ mod tests {
             inject_python_runtime_bootstrap(&main_rs, &metadata()).expect("main should be patched");
 
         assert!(rendered.contains(
-            "async fn main() -> Result<(), Error> {\n    if let Err(__sifr_python_runtime_error)"
+            "async fn main() -> Result<(), Error> {\n    let __sifr_python_runtime_guard = match __sifr_initialize_python_runtime()"
         ));
         assert!(rendered.contains("run().await"));
     }

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -1,6 +1,6 @@
 #![allow(unsafe_code)]
 
-use pyo3::{ffi, prelude::*, Py, PyAny};
+use pyo3::{ffi, prelude::*};
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::mem::MaybeUninit;
@@ -13,7 +13,10 @@ mod callback_ops;
 mod config_verify;
 mod coroutine_ops;
 mod dlpack_ops;
+mod foreign_object;
 mod object_ops;
+#[cfg(test)]
+mod object_ops_tests;
 mod resource_ops;
 pub use arrow_ops::{
     arrow_array, arrow_schema, arrow_stream, release_arrow, ArrowHandle, PythonArrowCapsuleMetadata,
@@ -29,6 +32,7 @@ pub use callback_ops::{
 use config_verify::verify_interpreter_config;
 pub use coroutine_ops::run_coroutine_blocking;
 pub use dlpack_ops::{dlpack_tensor, release_dlpack, DlpackHandle, PythonDlpackTensorMetadata};
+pub use foreign_object::ForeignObject;
 pub use object_ops::{
     call_attr, call_object, close_object, copy_dict_str_bool, copy_dict_str_bytes,
     copy_dict_str_float, copy_dict_str_i32, copy_dict_str_int, copy_dict_str_str, copy_dict_str_u8,
@@ -67,6 +71,17 @@ pub struct PythonRuntimeConfig {
 pub enum PythonRuntimeInitStatus {
     Initialized,
     AlreadyInitialized,
+}
+
+#[derive(Debug)]
+pub struct PythonRuntimeGuard {
+    _private: (),
+}
+
+impl Drop for PythonRuntimeGuard {
+    fn drop(&mut self) {
+        let _ignored = Python::try_attach(foreign_object::drain_pending_releases);
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -140,50 +155,6 @@ impl fmt::Display for PythonRuntimeError {
 
 impl std::error::Error for PythonRuntimeError {}
 
-#[derive(Debug)]
-pub struct Object {
-    inner: Option<Py<PyAny>>,
-}
-
-impl Object {
-    pub fn new(object: Py<PyAny>) -> Result<Self, PythonRuntimeError> {
-        update_object_count(1)?;
-        Ok(Self {
-            inner: Some(object),
-        })
-    }
-
-    fn clone_ref(&self, py: Python<'_>) -> Result<Py<PyAny>, PythonRuntimeError> {
-        self.inner
-            .as_ref()
-            .map(|object| object.clone_ref(py))
-            .ok_or(PythonRuntimeError::PythonOperationFailed(
-                "Python object handle is closed".to_string(),
-            ))
-    }
-}
-
-impl Drop for Object {
-    fn drop(&mut self) {
-        let Some(object) = self.inner.take() else {
-            return;
-        };
-        let mut pending = Some(object);
-        if Python::try_attach(|_py| {
-            drop(pending.take());
-        })
-        .is_some()
-        {
-            let _ignored = update_object_count(-1);
-            return;
-        }
-        if let Some(leaked) = pending.take() {
-            std::mem::forget(leaked);
-        }
-        let _ignored = record_leaked_object();
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct RuntimeState {
     config: Option<PythonRuntimeConfig>,
@@ -226,12 +197,21 @@ pub fn initialize_runtime(
     Ok(PythonRuntimeInitStatus::Initialized)
 }
 
+pub fn runtime_guard() -> Result<PythonRuntimeGuard, PythonRuntimeError> {
+    ensure_initialized()?;
+    Ok(PythonRuntimeGuard { _private: () })
+}
+
 pub fn attach<F, R>(f: F) -> Result<R, PythonRuntimeError>
 where
     F: for<'py> FnOnce(Python<'py>) -> R,
 {
     ensure_initialized()?;
-    Python::try_attach(f).ok_or(PythonRuntimeError::NotInitialized)
+    Python::try_attach(|py| {
+        foreign_object::drain_pending_releases(py);
+        f(py)
+    })
+    .ok_or(PythonRuntimeError::NotInitialized)
 }
 
 pub fn detach<F, R>(py: Python<'_>, f: F) -> R
@@ -252,6 +232,7 @@ pub fn shutdown_diagnostics() -> Result<PythonRuntimeDiagnostics, PythonRuntimeE
 }
 
 pub fn validate_shutdown() -> Result<(), PythonRuntimeError> {
+    attach(foreign_object::drain_pending_releases)?;
     let diagnostics = shutdown_diagnostics()?;
     if diagnostics.live_objects == 0 && diagnostics.leaked_objects == 0 {
         return Ok(());
@@ -502,13 +483,6 @@ pub(super) fn update_object_count(delta: isize) -> Result<(), PythonRuntimeError
     Ok(())
 }
 
-pub(super) fn record_leaked_object() -> Result<(), PythonRuntimeError> {
-    let mut state = runtime_state()?;
-    state.live_objects = state.live_objects.saturating_sub(1);
-    state.leaked_objects = state.leaked_objects.saturating_add(1);
-    Ok(())
-}
-
 fn py_error(error: &PyErr) -> PythonRuntimeError {
     PythonRuntimeError::PythonOperationFailed(error.to_string())
 }
@@ -517,6 +491,7 @@ fn py_error(error: &PyErr) -> PythonRuntimeError {
 fn reset_runtime_state_for_tests() {
     let mut state = runtime_state().expect("runtime state should be available");
     *state = RuntimeState::new();
+    foreign_object::reset_pending_releases_for_tests();
     object_ops::reset_object_store_for_tests();
 }
 
@@ -669,11 +644,11 @@ mod tests {
     }
 
     #[test]
-    fn owned_object_tracking_is_released_through_gil_bound_drop() {
+    fn owned_object_tracking_is_released_on_next_attach() {
         let _guard = test_guard();
         reset_runtime_state_for_tests();
         initialize_runtime(test_config("object")).expect("init should succeed");
-        let object = attach(|py| Object::new(py.None())).expect("attach should succeed");
+        let object = attach(|py| ForeignObject::new(py.None())).expect("attach should succeed");
         assert!(object.is_ok());
         assert_eq!(
             shutdown_diagnostics().expect("diagnostics should be available"),
@@ -685,7 +660,67 @@ mod tests {
         );
 
         drop(object);
+        attach(|_py| ()).expect("attach should drain the dropped object");
 
+        assert_eq!(
+            shutdown_diagnostics().expect("diagnostics should be available"),
+            PythonRuntimeDiagnostics {
+                initialized: true,
+                live_objects: 0,
+                leaked_objects: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn detached_thread_drop_is_drained_on_next_attach() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("detached-drop")).expect("init should succeed");
+        let object = attach(|py| ForeignObject::new(py.None())).expect("attach should succeed");
+        let object = object.expect("object should be created");
+
+        std::thread::spawn(move || drop(object))
+            .join()
+            .expect("detached drop thread should finish");
+
+        assert_eq!(foreign_object::pending_release_count(), 1);
+        assert_eq!(
+            shutdown_diagnostics().expect("diagnostics should be available"),
+            PythonRuntimeDiagnostics {
+                initialized: true,
+                live_objects: 1,
+                leaked_objects: 0,
+            }
+        );
+        attach(|_py| ()).expect("attach should drain pending releases");
+        assert_eq!(foreign_object::pending_release_count(), 0);
+        assert_eq!(
+            shutdown_diagnostics().expect("diagnostics should be available"),
+            PythonRuntimeDiagnostics {
+                initialized: true,
+                live_objects: 0,
+                leaked_objects: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn runtime_guard_drains_pending_releases_at_epilogue() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("epilogue-drop")).expect("init should succeed");
+        let runtime_guard = runtime_guard().expect("runtime guard should be available");
+        let object = attach(|py| ForeignObject::new(py.None())).expect("attach should succeed");
+        let object = object.expect("object should be created");
+        std::thread::spawn(move || drop(object))
+            .join()
+            .expect("detached drop thread should finish");
+        assert_eq!(foreign_object::pending_release_count(), 1);
+
+        drop(runtime_guard);
+
+        assert_eq!(foreign_object::pending_release_count(), 0);
         assert_eq!(
             shutdown_diagnostics().expect("diagnostics should be available"),
             PythonRuntimeDiagnostics {
@@ -701,7 +736,7 @@ mod tests {
         let _guard = test_guard();
         reset_runtime_state_for_tests();
         initialize_runtime(test_config("shutdown")).expect("init should succeed");
-        let object = attach(|py| Object::new(py.None())).expect("attach should succeed");
+        let object = attach(|py| ForeignObject::new(py.None())).expect("attach should succeed");
         assert!(object.is_ok());
 
         let error = validate_shutdown().expect_err("live object should block shutdown");

--- a/crates/sifr_runtime/src/python/callback_ops.rs
+++ b/crates/sifr_runtime/src/python/callback_ops.rs
@@ -211,7 +211,16 @@ fn invoke_sifr_callback(
             return Err(py_runtime_error(error));
         }
     };
-    let result = clone_handle(py, result_handle).map_err(py_runtime_error)?;
+    let result = match clone_handle(py, result_handle) {
+        Ok(result) => result,
+        Err(error) => {
+            if result_handle != arg_handle {
+                let _ignored = close_object(arg_handle);
+            }
+            let _ignored = close_object(result_handle);
+            return Err(py_runtime_error(error));
+        }
+    };
     if result_handle != arg_handle {
         let _ignored = close_object(arg_handle);
     }
@@ -272,6 +281,10 @@ mod tests {
         call_object, close_object, from_int, initialize_runtime, reset_runtime_state_for_tests,
         resource_diagnostics, test_config, test_guard, to_int, PythonResourceDiagnostics,
     };
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     #[test]
     fn local_callback_allows_same_stack_reentry_and_rejects_escape() {
@@ -330,6 +343,28 @@ mod tests {
             .expect("registered callback call should succeed");
         assert_eq!(to_int(result).expect("result should convert"), 8);
         close_object(result).expect("result should close");
+        close_object(arg).expect("arg should close");
+        close_callback((callback.handle, callback.token)).expect("callback should close");
+    }
+
+    #[test]
+    fn malformed_callback_result_releases_temporary_argument() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("callback-stale-result")).expect("init should succeed");
+        let stale = from_int(99).expect("stale result should store");
+        close_object(stale).expect("stale result should close");
+        let callback = local_callback(move |_arg| Ok(stale)).expect("callback should create");
+        let arg = from_int(7).expect("arg should store");
+        let before = resource_diagnostics().expect("diagnostics should be available");
+
+        call_object((callback.object_handle, callback.object_token), &[arg], &[])
+            .expect_err("stale callback result should fail");
+
+        assert_eq!(
+            resource_diagnostics().expect("diagnostics should be available"),
+            before
+        );
         close_object(arg).expect("arg should close");
         close_callback((callback.handle, callback.token)).expect("callback should close");
     }
@@ -399,6 +434,71 @@ assert result[0] == 19
             .expect_err("calling closed callback object should fail");
         assert_eq!(after_close.kind, "resource");
         close_object(arg).expect("arg should close");
+        assert_eq!(
+            resource_diagnostics().expect("diagnostics should be available"),
+            PythonResourceDiagnostics {
+                initialized: true,
+                live_objects: 0,
+                leaked_objects: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn object_destructor_can_reenter_callback_and_object_stores() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("destructor-reentry")).expect("init should succeed");
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let invocation_counter = Arc::clone(&invocations);
+        let callback = threadsafe_callback(move |arg| {
+            invocation_counter.fetch_add(1, Ordering::SeqCst);
+            close_object(arg)?;
+            super::super::from_none()
+        })
+        .expect("callback should create");
+        let object = super::super::attach(|py| {
+            let callable = super::super::object_ops::clone_handle(
+                py,
+                (callback.object_handle, callback.object_token),
+            )?;
+            let globals = PyDict::new(py);
+            globals
+                .set_item("CALLBACK", callable.bind(py))
+                .map_err(|error| PythonError::from_pyerr(py, error, "callback", "destructor"))?;
+            py.run(
+                cr#"
+class ReentrantDestructor:
+    def __del__(self):
+        CALLBACK(1)
+value = ReentrantDestructor()
+"#,
+                Some(&globals),
+                None,
+            )
+            .map_err(|error| PythonError::from_pyerr(py, error, "callback", "destructor"))?;
+            let value = globals
+                .get_item("value")
+                .map_err(|error| PythonError::from_pyerr(py, error, "callback", "destructor"))?
+                .ok_or_else(|| {
+                    PythonError::runtime(PythonRuntimeError::PythonOperationFailed(
+                        "destructor fixture did not create a value".to_string(),
+                    ))
+                })?;
+            let object = super::super::object_ops::store_object(value.unbind())?;
+            globals
+                .del_item("value")
+                .map_err(|error| PythonError::from_pyerr(py, error, "callback", "destructor"))?;
+            Ok(object)
+        })
+        .map_err(PythonError::runtime)
+        .and_then(|result| result)
+        .expect("destructor object should be stored");
+
+        close_object(object).expect("destructor object should close");
+
+        assert_eq!(invocations.load(Ordering::SeqCst), 1);
+        close_callback((callback.handle, callback.token)).expect("callback should close");
         assert_eq!(
             resource_diagnostics().expect("diagnostics should be available"),
             PythonResourceDiagnostics {

--- a/crates/sifr_runtime/src/python/foreign_object.rs
+++ b/crates/sifr_runtime/src/python/foreign_object.rs
@@ -1,0 +1,80 @@
+use super::{update_object_count, PythonRuntimeError};
+use pyo3::{ffi, prelude::*, Py, PyAny};
+use std::sync::{LazyLock, Mutex};
+
+static PENDING_RELEASES: LazyLock<Mutex<Vec<Py<PyAny>>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+
+/// Compiler-owned Python identity payload.
+///
+/// Public Sifr values never expose this payload or a structural token. Generated
+/// glue carries it inside the sealed interop handle representation.
+#[derive(Debug)]
+pub struct ForeignObject {
+    inner: Option<Py<PyAny>>,
+}
+
+impl ForeignObject {
+    pub(super) fn new(object: Py<PyAny>) -> Result<Self, PythonRuntimeError> {
+        update_object_count(1)?;
+        Ok(Self {
+            inner: Some(object),
+        })
+    }
+
+    pub(super) fn clone_ref(&self, py: Python<'_>) -> Result<Py<PyAny>, PythonRuntimeError> {
+        self.inner
+            .as_ref()
+            .map(|object| object.clone_ref(py))
+            .ok_or(PythonRuntimeError::PythonOperationFailed(
+                "Python object identity is closed".to_string(),
+            ))
+    }
+}
+
+impl Drop for ForeignObject {
+    fn drop(&mut self) {
+        let Some(object) = self.inner.take() else {
+            return;
+        };
+        if unsafe { ffi::PyGILState_Check() } != 0 {
+            drop(object);
+            let _ignored = update_object_count(-1);
+            return;
+        }
+        pending_releases().push(object);
+    }
+}
+
+pub(super) fn drain_pending_releases(_py: Python<'_>) {
+    let pending = {
+        let mut queue = pending_releases();
+        std::mem::take(&mut *queue)
+    };
+    let released = pending.len();
+    drop(pending);
+    if released > 0 {
+        let released = isize::try_from(released).unwrap_or(isize::MAX);
+        let _ignored = update_object_count(-released);
+    }
+}
+
+#[cfg(test)]
+pub(super) fn pending_release_count() -> usize {
+    pending_releases().len()
+}
+
+#[cfg(test)]
+pub(super) fn reset_pending_releases_for_tests() {
+    let pending = {
+        let mut queue = pending_releases();
+        std::mem::take(&mut *queue)
+    };
+    std::mem::forget(pending);
+}
+
+fn pending_releases() -> std::sync::MutexGuard<'static, Vec<Py<PyAny>>> {
+    match PENDING_RELEASES.lock() {
+        Ok(queue) => queue,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}

--- a/crates/sifr_runtime/src/python/object_ops.rs
+++ b/crates/sifr_runtime/src/python/object_ops.rs
@@ -1,4 +1,4 @@
-use super::{runtime_config, Object, PythonRuntimeError};
+use super::{runtime_config, ForeignObject, PythonRuntimeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
 use pyo3::IntoPyObjectExt;
@@ -118,7 +118,7 @@ struct ObjectStore {
 
 struct ObjectEntry {
     token: i64,
-    object: Object,
+    object: ForeignObject,
 }
 
 pub fn import_module(name: &str) -> Result<ObjectHandle, PythonError> {
@@ -225,17 +225,20 @@ pub fn exit_context(object: ObjectHandle) -> Result<(), PythonError> {
 }
 
 pub fn close_object((handle, token): ObjectHandle) -> Result<(), PythonError> {
-    let mut store = object_store()?;
-    if store
-        .objects
-        .get(&handle)
-        .is_some_and(|entry| entry.token == token)
-    {
-        store.objects.remove(&handle);
-        Ok(())
-    } else {
-        Err(PythonError::closed(handle))
-    }
+    let entry = {
+        let mut store = object_store()?;
+        if store
+            .objects
+            .get(&handle)
+            .is_some_and(|entry| entry.token == token)
+        {
+            store.objects.remove(&handle)
+        } else {
+            return Err(PythonError::closed(handle));
+        }
+    };
+    super::attach(|_py| drop(entry)).map_err(PythonError::runtime)?;
+    Ok(())
 }
 
 pub fn from_none() -> Result<ObjectHandle, PythonError> {
@@ -454,7 +457,7 @@ fn contains_root(roots: &[String], root: &str) -> bool {
 }
 
 pub(super) fn store_object(object: Py<PyAny>) -> Result<ObjectHandle, PythonError> {
-    let object = Object::new(object).map_err(PythonError::runtime)?;
+    let object = ForeignObject::new(object).map_err(PythonError::runtime)?;
     let mut store = object_store()?;
     let (handle, token) = reserve_handle(&mut store)?;
     store.objects.insert(handle, ObjectEntry { token, object });
@@ -464,7 +467,7 @@ pub(super) fn store_object(object: Py<PyAny>) -> Result<ObjectHandle, PythonErro
 fn store_objects(objects: Vec<Py<PyAny>>) -> Result<Vec<ObjectHandle>, PythonError> {
     let objects = objects
         .into_iter()
-        .map(Object::new)
+        .map(ForeignObject::new)
         .collect::<Result<Vec<_>, _>>()
         .map_err(PythonError::runtime)?;
     let mut handles = Vec::with_capacity(objects.len());
@@ -776,124 +779,4 @@ fn format_traceback(py: Python<'_>, error: &PyErr) -> String {
 pub(super) fn reset_object_store_for_tests() {
     let mut store = object_store().expect("object store should be available");
     *store = ObjectStore::default();
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::python::{
-        initialize_runtime, reset_runtime_state_for_tests, shutdown_diagnostics, test_config,
-        test_guard, PythonRuntimeDiagnostics,
-    };
-
-    #[test]
-    fn primitive_conversion_round_trips_and_rejects_fixed_width_overflow() {
-        let _guard = test_guard();
-        reset_runtime_state_for_tests();
-        initialize_runtime(test_config("primitive-conversion")).expect("init should succeed");
-
-        let none = from_none().expect("None object should be stored");
-        to_none(none).expect("None should convert to None");
-        close_object(none).expect("None object should close");
-
-        let flag = from_bool(true).expect("bool object should be stored");
-        assert!(to_bool(flag).expect("bool should convert"));
-        close_object(flag).expect("bool object should close");
-
-        let integer = from_int(127).expect("int object should be stored");
-        assert_eq!(to_int(integer).expect("int should convert"), 127);
-        assert_eq!(to_i8(integer).expect("int8 should convert"), 127);
-        assert_eq!(to_u8(integer).expect("uint8 should convert"), 127);
-        close_object(integer).expect("int object should close");
-
-        let too_wide = from_int(256).expect("wide int object should be stored");
-        let overflow = to_u8(too_wide).expect_err("uint8 overflow should fail");
-        assert_eq!(overflow.kind, "conversion");
-        assert!(overflow.context.contains("uint8"));
-        close_object(too_wide).expect("wide int object should close");
-
-        let float = from_float(1.25).expect("float object should be stored");
-        assert_eq!(to_float(float).expect("float should convert"), 1.25);
-        close_object(float).expect("float object should close");
-
-        let text = from_str("sifr").expect("str object should be stored");
-        assert_eq!(to_str(text).expect("str should convert"), "sifr");
-        close_object(text).expect("str object should close");
-
-        let bytes = from_bytes(&[1, 2, 3]).expect("bytes object should be stored");
-        assert_eq!(
-            to_bytes(bytes).expect("bytes should convert"),
-            vec![1, 2, 3]
-        );
-        close_object(bytes).expect("bytes object should close");
-
-        assert_eq!(
-            shutdown_diagnostics().expect("diagnostics should be available"),
-            PythonRuntimeDiagnostics {
-                initialized: true,
-                live_objects: 0,
-                leaked_objects: 0,
-            }
-        );
-    }
-
-    #[test]
-    fn explicit_container_copy_conversions_preserve_nested_paths() {
-        let _guard = test_guard();
-        reset_runtime_state_for_tests();
-        initialize_runtime(test_config("container-conversion")).expect("init should succeed");
-
-        let first = from_int(1).expect("int object should be stored");
-        let second = from_int(2).expect("int object should be stored");
-        let list = from_list(&[first, second]).expect("list should be stored");
-        assert_eq!(copy_list_int(list).expect("list should copy"), vec![1, 2]);
-
-        let tuple = from_tuple(&[first, second]).expect("tuple should be stored");
-        assert_eq!(
-            copy_tuple_i32(tuple).expect("tuple should copy"),
-            vec![1, 2]
-        );
-
-        let too_wide = from_int(256).expect("wide int object should be stored");
-        let bad_list = from_list(&[first, too_wide]).expect("bad list should be stored");
-        let overflow = copy_list_u8(bad_list).expect_err("nested overflow should fail");
-        assert_eq!(overflow.kind, "conversion");
-        assert!(overflow.context.contains("copy_list_u8[1]"));
-        assert!(overflow.context.contains("uint8"));
-
-        let dict =
-            from_dict_str(&[("first", first), ("second", second)]).expect("dict should be stored");
-        let copied = copy_dict_str_int(dict).expect("dict should copy");
-        assert_eq!(copied.get("first"), Some(&1));
-        assert_eq!(copied.get("second"), Some(&2));
-
-        let record = from_record(&[("answer", second)]).expect("record should be stored");
-        let fields = copy_record_fields(record, &["answer"]).expect("record should copy fields");
-        assert_eq!(fields.len(), 1);
-        assert_eq!(fields[0].0, "answer");
-        assert_eq!(to_int(fields[0].1).expect("field should convert"), 2);
-
-        for handle in [
-            first,
-            second,
-            list,
-            tuple,
-            too_wide,
-            bad_list,
-            dict,
-            record,
-            fields[0].1,
-        ] {
-            close_object(handle).expect("object should close");
-        }
-
-        assert_eq!(
-            shutdown_diagnostics().expect("diagnostics should be available"),
-            PythonRuntimeDiagnostics {
-                initialized: true,
-                live_objects: 0,
-                leaked_objects: 0,
-            }
-        );
-    }
 }

--- a/crates/sifr_runtime/src/python/object_ops_tests.rs
+++ b/crates/sifr_runtime/src/python/object_ops_tests.rs
@@ -1,0 +1,116 @@
+use super::object_ops::*;
+use super::{
+    initialize_runtime, reset_runtime_state_for_tests, shutdown_diagnostics, test_config,
+    test_guard, PythonRuntimeDiagnostics,
+};
+
+#[test]
+fn primitive_conversion_round_trips_and_rejects_fixed_width_overflow() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("primitive-conversion")).expect("init should succeed");
+
+    let none = from_none().expect("None object should be stored");
+    to_none(none).expect("None should convert to None");
+    close_object(none).expect("None object should close");
+
+    let flag = from_bool(true).expect("bool object should be stored");
+    assert!(to_bool(flag).expect("bool should convert"));
+    close_object(flag).expect("bool object should close");
+
+    let integer = from_int(127).expect("int object should be stored");
+    assert_eq!(to_int(integer).expect("int should convert"), 127);
+    assert_eq!(to_i8(integer).expect("int8 should convert"), 127);
+    assert_eq!(to_u8(integer).expect("uint8 should convert"), 127);
+    close_object(integer).expect("int object should close");
+
+    let too_wide = from_int(256).expect("wide int object should be stored");
+    let overflow = to_u8(too_wide).expect_err("uint8 overflow should fail");
+    assert_eq!(overflow.kind, "conversion");
+    assert!(overflow.context.contains("uint8"));
+    close_object(too_wide).expect("wide int object should close");
+
+    let float = from_float(1.25).expect("float object should be stored");
+    assert_eq!(to_float(float).expect("float should convert"), 1.25);
+    close_object(float).expect("float object should close");
+
+    let text = from_str("sifr").expect("str object should be stored");
+    assert_eq!(to_str(text).expect("str should convert"), "sifr");
+    close_object(text).expect("str object should close");
+
+    let bytes = from_bytes(&[1, 2, 3]).expect("bytes object should be stored");
+    assert_eq!(
+        to_bytes(bytes).expect("bytes should convert"),
+        vec![1, 2, 3]
+    );
+    close_object(bytes).expect("bytes object should close");
+
+    assert_eq!(
+        shutdown_diagnostics().expect("diagnostics should be available"),
+        PythonRuntimeDiagnostics {
+            initialized: true,
+            live_objects: 0,
+            leaked_objects: 0,
+        }
+    );
+}
+
+#[test]
+fn explicit_container_copy_conversions_preserve_nested_paths() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("container-conversion")).expect("init should succeed");
+
+    let first = from_int(1).expect("int object should be stored");
+    let second = from_int(2).expect("int object should be stored");
+    let list = from_list(&[first, second]).expect("list should be stored");
+    assert_eq!(copy_list_int(list).expect("list should copy"), vec![1, 2]);
+
+    let tuple = from_tuple(&[first, second]).expect("tuple should be stored");
+    assert_eq!(
+        copy_tuple_i32(tuple).expect("tuple should copy"),
+        vec![1, 2]
+    );
+
+    let too_wide = from_int(256).expect("wide int object should be stored");
+    let bad_list = from_list(&[first, too_wide]).expect("bad list should be stored");
+    let overflow = copy_list_u8(bad_list).expect_err("nested overflow should fail");
+    assert_eq!(overflow.kind, "conversion");
+    assert!(overflow.context.contains("copy_list_u8[1]"));
+    assert!(overflow.context.contains("uint8"));
+
+    let dict =
+        from_dict_str(&[("first", first), ("second", second)]).expect("dict should be stored");
+    let copied = copy_dict_str_int(dict).expect("dict should copy");
+    assert_eq!(copied.get("first"), Some(&1));
+    assert_eq!(copied.get("second"), Some(&2));
+
+    let record = from_record(&[("answer", second)]).expect("record should be stored");
+    let fields = copy_record_fields(record, &["answer"]).expect("record should copy fields");
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].0, "answer");
+    assert_eq!(to_int(fields[0].1).expect("field should convert"), 2);
+
+    for handle in [
+        first,
+        second,
+        list,
+        tuple,
+        too_wide,
+        bad_list,
+        dict,
+        record,
+        fields[0].1,
+    ] {
+        close_object(handle).expect("object should close");
+    }
+
+    assert_eq!(
+        shutdown_diagnostics().expect("diagnostics should be available"),
+        PythonRuntimeDiagnostics {
+            initialized: true,
+            live_objects: 0,
+            leaked_objects: 0,
+        }
+    );
+}

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m1-runtime-substrate-review-round1.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m1-runtime-substrate-review-round1.md
@@ -1,0 +1,40 @@
+Review of the M1 runtime substrate diff below. I did not modify any files.
+
+## Intent verification
+
+| Intent | Where | Status |
+|---|---|---|
+| ForeignObject owns Py<PyAny>, queues on unattached drop | `foreign_object.rs:34-46` | ✓ Fast path on `PyGILState_Check`, else push to global queue |
+| Every runtime attach drains pending outside the queue lock | `python.rs:210-213`, `foreign_object.rs:48-59` | ✓ `mem::take` releases guard before `drop(pending)`; count updated after |
+| `close_object` removes before attach/drop | `object_ops.rs:227-242` | ✓ Store guard scoped in inner block, released before `super::attach(drop(entry))` |
+| Poisoned queue mutex recovers without panic | `foreign_object.rs:75-80` | ✓ `Err(poisoned) => poisoned.into_inner()` |
+| Generated PythonRuntimeGuard declared before user main locals; drains on scope exit | `python_runtime.rs:202`, `python.rs:81-85` | ✓ Injected as first `let` in `fn main(` / `async fn main(`; drop uses `Python::try_attach(drain_pending_releases)` |
+| Tests: detached-thread drop | `python.rs:676` | ✓ |
+| Tests: next-attach drain | `python.rs:647` | ✓ |
+| Tests: epilogue drain | `python.rs:709` | ✓ |
+| Tests: `__del__` reentering Sifr callback which reenters object store | `callback_ops.rs:417-479` | ✓ Uses `threadsafe_callback` + `ReentrantDestructor.__del__`; asserts `live_objects: 0` post-run |
+| Object_ops tests moved to sibling | `object_ops_tests.rs` (116L); `object_ops.rs` at 782L | ✓ Under 900-line cap |
+
+## Correctness checks
+
+- **Lock ordering (OBJECT_STORE ↔ GIL):** `close_object` drops store guard before attach; `store_object`/`clone_handle` acquire OBJECT_STORE only inside attach. No thread holds OBJECT_STORE and then requests the GIL, so no AB/BA cycle. Similar clean ordering for `CALLBACK_STORE`.
+- **Nested attach reentry:** `Python::try_attach` handles the nested case; `drain_pending_releases` is idempotent (`mem::take` yields an empty queue on subsequent calls in the same GIL scope).
+- **Closure-drop-on-attach-fail:** If `Python::try_attach` returns `None`, the closure `|_py| drop(entry)` is dropped rather than called; `entry` still drops → `ForeignObject::drop` queues without GIL. State stays consistent, deferred until the next attach.
+- **Object count accounting:** `ForeignObject::new` +1 pairs with either the direct-drop `-1` (GIL fast path) or the drained `update_object_count(-released)`. `create_callback`/`close_callback` also pair a separate ±1 for the callback record. Uses `saturating_add`/`saturating_sub` and `checked_add` — no panic surface.
+- **Generated main forms:** Tests cover `fn main() {}`, `fn main() -> Result<...>`, and `async fn main()`. Guard is the first `let`, dropped last, so user locals that hold ForeignObjects drop → queue → guard drain runs after them.
+- **No user-triggerable panic paths:** No `unwrap`/`expect` on data-dependent values in non-test code; poisoned PENDING_RELEASES mutex recovers.
+
+## Observations (non-blocking)
+
+- **`python.rs` at 885 lines** (`wc -l`) — 15 lines under the 900-line guardrail. Any further growth here should trigger a decomposition pass.
+- **Rare-failure cleanup gaps (not introduced by this diff, but adjacent):**
+  - `callback_ops.rs:107-110` — if `update_object_count(-1)` errored (RUNTIME_STATE poisoned) after callback entry removal, the PyCFunction object is never `close_object`'d. In practice RUNTIME_STATE is only poisoned via panic-in-hold, and no code path panics while holding it, so this is theoretical.
+  - `callback_ops.rs:214` — if `clone_handle(py, result_handle)` fails, both `arg_handle` (if still open) and `result_handle` (if it happens to be open) are leaked before returning `Err`. Only triggerable by a malformed callback returning an unexpected handle.
+- **`initialize_runtime` holds RUNTIME_STATE across `configure_interpreter`'s attach** (`python.rs:180-197`). Safe today (no `super::attach`, no callbacks registered yet, no pending releases), but the invariant "don't call attach while holding RUNTIME_STATE" is worth preserving if init grows.
+- **Guard type is Send+Sync** (`PythonRuntimeGuard { _private: () }`), so it survives await points in async main correctly. If it later gains a non-Send field, that assumption breaks.
+
+None of these are actionable for closing this sub-wave.
+
+## Verdict
+
+**SATISFIED** — the sealed runtime substrate implements every intent item, all four required tests are present and correct, the diff respects the 900-line guardrail, and lock/GIL ordering, count accounting, and error-path drops hold up across attached, unattached, nested, poisoned, and shutdown scenarios. Safe to proceed to the sealed stdlib identity cutover.

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m1-runtime-substrate-review-round2.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m1-runtime-substrate-review-round2.md
@@ -1,0 +1,36 @@
+## Re-review of round-2 fix — callback_ops.rs invoke_sifr_callback
+
+**Fix location:** `crates/sifr_runtime/src/python/callback_ops.rs:214-223`
+
+### Scenario walk-through
+
+| Scenario | Behavior | Verdict |
+|---|---|---|
+| `result_handle == arg_handle`, clone succeeds | skips arg-close (`if result_handle != arg_handle` false), then closes `result_handle` once → aliased handle released exactly once | ✓ no double-free |
+| `result_handle == arg_handle`, clone fails | skips arg-close in error branch, closes `result_handle` once (ignored if closed) → same aliased handle released at most once | ✓ no double-free |
+| stale `result_handle` (malformed callback) | closes `arg_handle` (removed from store → -1), attempts `close_object(result_handle)` which returns `closed_error` (swallowed by `_ignored`) → arg released, stale is a no-op | ✓ balanced |
+| user callback closed `arg_handle` before returning new result | outer `close_object(arg_handle)` fails silently (ignored), `close_object(result_handle)` succeeds → net one release each | ✓ balanced |
+
+### Nested attach/close under GIL
+
+`invoke_sifr_callback` runs inside `PyCFunction`, so GIL is held. Every cleanup path goes through `close_object` (object_ops.rs:227), which:
+1. acquires OBJECT_STORE, removes entry, drops the guard (scoped block ends at line 239);
+2. calls `super::attach(|_py| drop(entry))` — since GIL is already held, PyO3 treats this as a no-op nested attach and runs the drop inline.
+
+Guard is released before attach, so the ordering (GIL → OBJECT_STORE) matches every other call site — no AB/BA cycle. The store lookup keying on `(handle, token)` with monotonic `next_handle` also rules out ABA even if handles are reused.
+
+### Original error preservation
+
+Both cleanup calls use `let _ignored = …`; the returned value is `Err(py_runtime_error(error))` where `error` is the `clone_handle` failure. Cleanup errors cannot shadow it (callback_ops.rs:220-221). ✓
+
+### Regression test
+
+`malformed_callback_result_releases_temporary_argument` (callback_ops.rs:351-370) copies a pre-closed `stale` handle (Copy on `(i64,i64)`), snapshots `resource_diagnostics()` before invoking, and asserts the snapshot is unchanged after the expected `Err`. This is exactly the leak the fix closes: `-1` for `arg_handle` cancels the `+1` from the internal `store_object(arg)` inside `invoke_sifr_callback`. Test aligns with fix.
+
+### Rest of substrate diff
+
+Line counts and non-callback files unchanged from round 1 (`python.rs` 885L, `object_ops.rs` 782L, `object_ops_tests.rs` 116L, `foreign_object.rs` 80L; guardrail respected). Round 1's other non-blocking observations still stand and are still non-actionable.
+
+## Verdict
+
+**SATISFIED** — the clone_handle failure path now releases both `arg_handle` (when distinct) and `result_handle`, handles the alias `result_handle == arg_handle` without double-close, correctly swallows the expected `closed_error` when the returned handle is stale, preserves the original clone error, and respects the GIL/OBJECT_STORE ordering already established elsewhere. The regression test exercises the specific fix path. No remaining actionable issues in the substrate diff.


### PR DESCRIPTION
## Summary
- add a compiler-owned Python foreign-object payload with attached and deferred release paths
- drain deferred decrefs at every runtime attach and through a generated main-scope epilogue guard
- detach object-store entries before decref so reentrant destructors and callbacks never run under the store lock
- add detached-thread, epilogue, reentrant-destructor, and malformed-callback cleanup coverage
- split object operation tests by responsibility to retain the file-size guardrail

This is the runtime substrate sub-wave for declaration-first Python interop M1; it does not mark M1 complete or expose new public syntax.

## Validation
- `scripts/run_all_tests.sh --profile create-pr` (pass; 130/130 E2E; warm wall-time advisory only)
- `cargo test -p sifr_runtime --features python python:: -- --test-threads=1` (39 pass)
- `cargo test -p sifr_driver build::python_runtime::tests -- --test-threads=1` (9 pass)
- Claude Opus substrate reviews rounds 1-2: SATISFIED