### PR TITLE
Implement recursive Python conversion and opaque lifecycle

### DIFF
--- a/crates/sifr_codegen/src/class_emitter.rs
+++ b/crates/sifr_codegen/src/class_emitter.rs
@@ -136,6 +136,12 @@ impl RustEmitter {
         class: &HirClass,
         module_public: bool,
     ) -> Vec<(String, RustType)> {
+        if class.python_opaque_declaration().is_some() {
+            return vec![(
+                "__sifr_python_object".to_string(),
+                RustType::Named("sifr_runtime::python::ObjectHandle".to_string()),
+            )];
+        }
         let mut fields = Vec::new();
         if let Some(parent) = &class.parent_class {
             if parent != "NonSend" {
@@ -389,6 +395,7 @@ impl RustEmitter {
             return;
         }
 
+        let is_python_opaque = class.python_opaque_declaration().is_some();
         let has_custom_eq = class
             .operator_impls
             .iter()
@@ -410,7 +417,7 @@ impl RustEmitter {
         });
         let has_auto_display =
             !class.fields.is_empty() && class.fields.iter().all(|(_, ty)| is_auto_display_type(ty));
-        let derives = if self.is_current_process_resource_class(&class.name) {
+        let derives = if is_python_opaque || self.is_current_process_resource_class(&class.name) {
             vec!["Debug".to_string()]
         } else if has_callable_field || has_affine_field {
             Vec::new()
@@ -444,7 +451,8 @@ impl RustEmitter {
         self.current_class_name = Some(class.name.clone());
         let mut impl_items = Vec::new();
         let has_constructor = class.methods.iter().any(|method| method.name == "new");
-        if !has_constructor
+        if !is_python_opaque
+            && !has_constructor
             && class
                 .parent_class
                 .as_deref()

--- a/crates/sifr_codegen/src/class_method_emitter.rs
+++ b/crates/sifr_codegen/src/class_method_emitter.rs
@@ -2,6 +2,7 @@ use crate::{
     function_emitter::{is_result_int_type, result_int_return_type_to_sifr_int, result_method_key},
     helpers::{body_contains_field_assign_codegen, collect_mutated_vars_with_sigs},
     hir_analysis::traversal::{self, TraversalConfig},
+    python_interop_direct::python_interop_method_body,
     rust_interop_direct::rust_interop_method_body,
     RustEmitter, RustExpr, RustItem, RustParam, RustStmt, RustType, RustTypeParam, Visibility,
 };
@@ -640,9 +641,17 @@ impl RustEmitter {
         let mut params = Vec::new();
         match method.method_kind {
             MethodKind::Regular if method.name != "new" => {
-                params.push(RustParam::SelfParam {
-                    mutable: self.class_method_requires_mutable_self(class, method),
-                });
+                if method
+                    .python_interop
+                    .first()
+                    .is_some_and(|declaration| declaration.consumes_receiver)
+                {
+                    params.push(RustParam::SelfValue);
+                } else {
+                    params.push(RustParam::SelfParam {
+                        mutable: self.class_method_requires_mutable_self(class, method),
+                    });
+                }
             }
             _ => {}
         }
@@ -669,7 +678,11 @@ impl RustEmitter {
             );
         }
 
-        let mut body = if let Some(interop_body) = rust_interop_method_body(method) {
+        let mut body = if let Some(interop_body) =
+            python_interop_method_body(method, &self.python_opaque_classes)
+        {
+            interop_body
+        } else if let Some(interop_body) = rust_interop_method_body(method) {
             interop_body
         } else if method.method_kind == MethodKind::Regular && method.name == "new" {
             self.lower_constructor_body(method, class)

--- a/crates/sifr_codegen/src/function_emitter/generator_bodies.rs
+++ b/crates/sifr_codegen/src/function_emitter/generator_bodies.rs
@@ -339,8 +339,8 @@ impl RustEmitter {
             })
             .collect::<Vec<_>>();
 
-        let interop_body =
-            python_interop_function_body(func).or_else(|| rust_interop_function_body(func));
+        let interop_body = python_interop_function_body(func, &self.python_opaque_classes)
+            .or_else(|| rust_interop_function_body(func));
         let interop_body_supplied = interop_body.is_some();
         let mut lowered_body = if let Some(interop_body) = interop_body {
             interop_body

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -64,6 +64,8 @@ pub struct RustEmitter {
     pub(crate) generic_class_params: HashMap<String, Vec<String>>,
     /// Map of generic class name -> original HIR class template.
     pub(crate) generic_class_templates: HashMap<String, sifr_ir::HirClass>,
+    /// Opaque Python class declarations available to direct wrapper lowering.
+    pub(crate) python_opaque_classes: HashMap<String, sifr_ir::PythonInteropDeclaration>,
     /// Set of parameter names that are borrowed (&T) in the current function.
     /// Used to emit dereference (*name) in comparisons where &String != String.
     pub(crate) borrowed_params: HashSet<String>,
@@ -210,6 +212,7 @@ impl RustEmitter {
             generic_classes: HashSet::new(),
             generic_class_params: HashMap::new(),
             generic_class_templates: HashMap::new(),
+            python_opaque_classes: HashMap::new(),
             borrowed_params: HashSet::new(),
             mut_borrowed_params: HashSet::new(),
             generator_functions: HashSet::new(),

--- a/crates/sifr_codegen/src/module_body.rs
+++ b/crates/sifr_codegen/src/module_body.rs
@@ -8,6 +8,16 @@ impl RustEmitter {
         module_public: bool,
         test_mode: bool,
     ) {
+        self.python_opaque_classes = module
+            .classes
+            .iter()
+            .filter_map(|class| {
+                class
+                    .python_opaque_declaration()
+                    .cloned()
+                    .map(|declaration| (class.name.clone(), declaration))
+            })
+            .collect();
         self.emit_module_classes(module, module_public);
         self.emit_module_functions(module, module_public, test_mode);
     }

--- a/crates/sifr_codegen/src/python_interop_direct.rs
+++ b/crates/sifr_codegen/src/python_interop_direct.rs
@@ -2,11 +2,15 @@ use sifr_ir::{
     HirFunction, PythonInteropDeclaration, PythonInteropDecoratorKind, PythonParameterKind,
 };
 use sifr_type_system::Type;
+use std::collections::HashMap;
 
 use crate::rust_interop_error_mapping::bridge_error_expr;
 use crate::{RustExpr, RustLiteral, RustParam, RustStmt, RustType};
 
-pub(crate) fn python_interop_function_body(func: &HirFunction) -> Option<Vec<RustStmt>> {
+pub(crate) fn python_interop_function_body(
+    func: &HirFunction,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<Vec<RustStmt>> {
     let declaration = func.python_interop.first()?;
     if declaration.kind != PythonInteropDecoratorKind::Function {
         return None;
@@ -50,7 +54,7 @@ pub(crate) fn python_interop_function_body(func: &HirFunction) -> Option<Vec<Rus
             let value_name = format!("__sifr_python_value_{index}");
             let mut present = vec![mapped_let(
                 &handle_name,
-                input_conversion(&value_name, &param.ty)?,
+                input_conversion(&value_name, &param.ty, opaque_classes)?,
                 error_type,
             )];
             present.push(match shape.kind {
@@ -74,7 +78,7 @@ pub(crate) fn python_interop_function_body(func: &HirFunction) -> Option<Vec<Rus
                 let conversion = if is_python_object(&param.ty) {
                     runtime_call("temporary_argument_handle", vec![reference(&param.name)])
                 } else {
-                    input_conversion(&param.name, &param.ty)?
+                    input_conversion(&param.name, &param.ty, opaque_classes)?
                 };
                 body.push(mapped_let(&handle_name, conversion, error_type));
                 body.push(
@@ -101,7 +105,7 @@ pub(crate) fn python_interop_function_body(func: &HirFunction) -> Option<Vec<Rus
                     body: vec![
                         mapped_let(
                             &loop_handle,
-                            input_conversion_borrowed(&value_name, element_type)?,
+                            input_conversion_borrowed(&value_name, element_type, opaque_classes)?,
                             error_type,
                         ),
                         push_positional(&loop_handle),
@@ -129,6 +133,7 @@ pub(crate) fn python_interop_function_body(func: &HirFunction) -> Option<Vec<Rus
                             input_conversion_borrowed(
                                 &format!("__sifr_python_value_{index}"),
                                 value_type,
+                                opaque_classes,
                             )?,
                             error_type,
                         ),
@@ -157,14 +162,130 @@ pub(crate) fn python_interop_function_body(func: &HirFunction) -> Option<Vec<Rus
         error_type,
     ));
 
-    let converted = if is_python_object(ok_type) {
-        RustExpr::Ident("__sifr_python_result".to_string())
-    } else {
-        mapped_try(
-            output_conversion("__sifr_python_result", ok_type)?,
-            error_type,
-        )
+    let converted = output_value_expr("__sifr_python_result", ok_type, error_type, opaque_classes)?;
+    body.push(RustStmt::Return(Some(RustExpr::FnCall {
+        func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
+        args: vec![converted],
+    })));
+    Some(body)
+}
+
+pub(crate) fn python_interop_method_body(
+    func: &HirFunction,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<Vec<RustStmt>> {
+    let declaration = func.python_interop.first()?;
+    let Type::Result(ok_type, error_type) = func.return_type.resolve_alias() else {
+        return None;
     };
+    let mut body = Vec::new();
+    if declaration.kind != PythonInteropDecoratorKind::Attribute && !declaration.consumes_receiver {
+        body.push(vector_let("__sifr_python_args"));
+        body.push(vector_let("__sifr_python_kwargs"));
+    }
+    for (index, (param, shape)) in func.params.iter().zip(&declaration.parameters).enumerate() {
+        let handle = format!("__sifr_python_arg_{index}");
+        body.push(mapped_let(
+            &handle,
+            input_conversion(&param.name, &param.ty, opaque_classes)?,
+            error_type,
+        ));
+        body.push(push_for_shape(shape.kind, &shape.name, &handle)?);
+    }
+    let member = declaration
+        .target
+        .as_ref()
+        .and_then(|target| target.segments.get(1))
+        .map(String::as_str);
+    if declaration.consumes_receiver {
+        if declaration.kind != PythonInteropDecoratorKind::Function
+            || ok_type.resolve_alias() != &Type::None
+            || !func.params.is_empty()
+        {
+            return None;
+        }
+        let closed = mapped_try(
+            runtime_call(
+                "semantic_close",
+                vec![
+                    RustExpr::Field {
+                        expr: Box::new(RustExpr::Ident("self".to_string())),
+                        field: "__sifr_python_object".to_string(),
+                    },
+                    RustExpr::Literal(RustLiteral::Str(member?.to_string())),
+                ],
+            ),
+            error_type,
+        );
+        body.push(RustStmt::Return(Some(RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
+            args: vec![closed],
+        })));
+        return Some(body);
+    }
+    let receiver = RustExpr::Ref {
+        mutable: false,
+        expr: Box::new(RustExpr::Field {
+            expr: Box::new(RustExpr::Ident("self".to_string())),
+            field: "__sifr_python_object".to_string(),
+        }),
+    };
+    let operation = match declaration.kind {
+        PythonInteropDecoratorKind::Attribute => runtime_call(
+            "get_attr",
+            vec![
+                receiver,
+                RustExpr::Literal(RustLiteral::Str(member?.to_string())),
+            ],
+        ),
+        PythonInteropDecoratorKind::Item => {
+            let item_callable = "__sifr_python_item_callable";
+            body.push(mapped_let(
+                item_callable,
+                runtime_call(
+                    "get_attr",
+                    vec![
+                        receiver.clone(),
+                        RustExpr::Literal(RustLiteral::Str("__getitem__".to_string())),
+                    ],
+                ),
+                error_type,
+            ));
+            runtime_call(
+                "call_object_owned",
+                vec![
+                    reference(item_callable),
+                    reference("__sifr_python_args"),
+                    reference("__sifr_python_kwargs"),
+                ],
+            )
+        }
+        PythonInteropDecoratorKind::Function => {
+            let callable = "__sifr_python_method_callable";
+            body.push(mapped_let(
+                callable,
+                runtime_call(
+                    "get_attr",
+                    vec![
+                        receiver,
+                        RustExpr::Literal(RustLiteral::Str(member?.to_string())),
+                    ],
+                ),
+                error_type,
+            ));
+            runtime_call(
+                "call_object_owned",
+                vec![
+                    reference(callable),
+                    reference("__sifr_python_args"),
+                    reference("__sifr_python_kwargs"),
+                ],
+            )
+        }
+        _ => return None,
+    };
+    body.push(mapped_let("__sifr_python_result", operation, error_type));
+    let converted = output_value_expr("__sifr_python_result", ok_type, error_type, opaque_classes)?;
     body.push(RustStmt::Return(Some(RustExpr::FnCall {
         func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
         args: vec![converted],
@@ -182,11 +303,17 @@ pub(crate) fn python_omit_parameter_indices(
         .filter_map(|(index, parameter)| parameter.omit_when_absent.then_some(index))
 }
 
-fn input_conversion(name: &str, ty: &Type) -> Option<RustExpr> {
+pub(crate) fn input_conversion(
+    name: &str,
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
     if let Some(inner) = option_inner(ty) {
         let receiver = RustExpr::Ident(name.to_string());
-        let borrowed_inner =
-            matches!(inner.resolve_alias(), Type::Str | Type::Bytes) || is_python_object(inner);
+        let borrowed_inner = !matches!(
+            inner.resolve_alias(),
+            Type::None | Type::Bool | Type::Int | Type::Float
+        );
         let inner_value = RustExpr::MethodCall {
             receiver: Box::new(if borrowed_inner {
                 RustExpr::MethodCall {
@@ -206,9 +333,84 @@ fn input_conversion(name: &str, ty: &Type) -> Option<RustExpr> {
                 method: "is_some".to_string(),
                 args: Vec::new(),
             }),
-            then_expr: Box::new(input_conversion_value(inner_value, inner)?),
+            then_expr: Box::new(input_conversion_value(inner_value, inner, opaque_classes)?),
             else_expr: Some(Box::new(runtime_call("from_none", Vec::new()))),
         });
+    }
+    if matches!(ty.resolve_alias(), Type::Class { name: class_name, .. } if opaque_classes.contains_key(class_name))
+    {
+        return Some(runtime_call(
+            "temporary_argument_handle",
+            vec![RustExpr::Ref {
+                mutable: false,
+                expr: Box::new(RustExpr::Field {
+                    expr: Box::new(RustExpr::Ident(name.to_string())),
+                    field: "__sifr_python_object".to_string(),
+                }),
+            }],
+        ));
+    }
+    match ty.resolve_alias() {
+        Type::List(item) => {
+            let iter = RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident(name.to_string())),
+                method: "iter".to_string(),
+                args: Vec::new(),
+            };
+            let converted = mapped_collection_results(
+                iter,
+                "__sifr_python_item",
+                input_conversion_borrowed("__sifr_python_item", item, opaque_classes)?,
+            );
+            return Some(runtime_call("from_list_results", vec![converted]));
+        }
+        Type::Tuple(items) => {
+            let values = items
+                .iter()
+                .enumerate()
+                .map(|(index, item)| {
+                    input_conversion(&format!("{name}.{index}"), item, opaque_classes)
+                })
+                .collect::<Option<Vec<_>>>()?;
+            return Some(runtime_call(
+                "from_tuple_results",
+                vec![RustExpr::Vec(values)],
+            ));
+        }
+        Type::Dict(key, value) if key.resolve_alias() == &Type::Str => {
+            let iter = RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident(name.to_string())),
+                method: "iter".to_string(),
+                args: Vec::new(),
+            };
+            let pair = RustExpr::Tuple(vec![
+                RustExpr::Clone(Box::new(RustExpr::Ident("__sifr_python_key".to_string()))),
+                input_conversion_borrowed("__sifr_python_value", value, opaque_classes)?,
+            ]);
+            let converted =
+                mapped_collection_results(iter, "(__sifr_python_key, __sifr_python_value)", pair);
+            return Some(runtime_call("from_dict_results", vec![converted]));
+        }
+        Type::Class {
+            name: class_name,
+            fields,
+            ..
+        } if !fields.is_empty() && !opaque_classes.contains_key(class_name) => {
+            let values = fields
+                .iter()
+                .map(|(field, field_type)| {
+                    Some(RustExpr::Tuple(vec![
+                        RustExpr::Literal(RustLiteral::Str(field.clone())),
+                        input_conversion(&format!("{name}.{field}"), field_type, opaque_classes)?,
+                    ]))
+                })
+                .collect::<Option<Vec<_>>>()?;
+            return Some(runtime_call(
+                "from_record_results",
+                vec![RustExpr::Vec(values)],
+            ));
+        }
+        _ => {}
     }
     let ident = RustExpr::Ident(name.to_string());
     let (function, value) = match ty.resolve_alias() {
@@ -223,9 +425,260 @@ fn input_conversion(name: &str, ty: &Type) -> Option<RustExpr> {
     Some(runtime_call(function, value.into_iter().collect()))
 }
 
-fn input_conversion_value(value: RustExpr, ty: &Type) -> Option<RustExpr> {
+pub(crate) fn output_value_expr(
+    value_name: &str,
+    ty: &Type,
+    error_type: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if let Some(inner) = option_inner(ty) {
+        let is_none = mapped_try(
+            runtime_call("object_is_none", vec![reference(value_name)]),
+            error_type,
+        );
+        return Some(RustExpr::Block {
+            stmts: vec![RustStmt::Let {
+                mutable: false,
+                name: "__sifr_python_is_none".to_string(),
+                ty: None,
+                value: is_none,
+            }],
+            expr: Some(Box::new(RustExpr::If {
+                cond: Box::new(RustExpr::Ident("__sifr_python_is_none".to_string())),
+                then_expr: Box::new(RustExpr::Literal(RustLiteral::None)),
+                else_expr: Some(Box::new(RustExpr::FnCall {
+                    func: Box::new(RustExpr::Path(vec!["Some".to_string()])),
+                    args: vec![output_value_expr(
+                        value_name,
+                        inner,
+                        error_type,
+                        opaque_classes,
+                    )?],
+                })),
+            })),
+        });
+    }
+    if is_python_object(ty) {
+        return Some(RustExpr::Ident(value_name.to_string()));
+    }
+    if let Type::Class { name, .. } = ty.resolve_alias() {
+        if let Some(opaque) = opaque_classes.get(name) {
+            let target = opaque.target.as_ref()?;
+            let checked = mapped_try(
+                runtime_call(
+                    "expect_instance",
+                    vec![
+                        RustExpr::Ident(value_name.to_string()),
+                        RustExpr::Ref {
+                            mutable: false,
+                            expr: Box::new(RustExpr::Array(
+                                target
+                                    .segments
+                                    .iter()
+                                    .map(|segment| {
+                                        RustExpr::Literal(RustLiteral::Str(segment.clone()))
+                                    })
+                                    .collect(),
+                            )),
+                        },
+                    ],
+                ),
+                error_type,
+            );
+            return Some(RustExpr::StructInit {
+                name: name.clone(),
+                fields: vec![("__sifr_python_object".to_string(), checked)],
+            });
+        }
+    }
+    match ty.resolve_alias() {
+        Type::List(item) => {
+            let mut body = vec![RustStmt::Let {
+                mutable: false,
+                name: "__sifr_python_value".to_string(),
+                ty: None,
+                value: output_value_expr("__sifr_python_item", item, error_type, opaque_classes)?,
+            }];
+            body.push(push_to("__sifr_python_values", "__sifr_python_value"));
+            return Some(RustExpr::Block {
+                stmts: vec![
+                    mapped_let(
+                        "__sifr_python_items",
+                        runtime_call("list_items", vec![reference(value_name)]),
+                        error_type,
+                    ),
+                    vector_let("__sifr_python_values"),
+                    RustStmt::For {
+                        var: "__sifr_python_item".to_string(),
+                        iter: RustExpr::MethodCall {
+                            receiver: Box::new(RustExpr::Ident("__sifr_python_items".to_string())),
+                            method: "into_iter".to_string(),
+                            args: Vec::new(),
+                        },
+                        body,
+                    },
+                ],
+                expr: Some(Box::new(RustExpr::Ident(
+                    "__sifr_python_values".to_string(),
+                ))),
+            });
+        }
+        Type::Tuple(items) => {
+            let mut statements = vec![mapped_let(
+                "__sifr_python_items",
+                runtime_call("tuple_items", vec![reference(value_name)]),
+                error_type,
+            )];
+            let mut values = Vec::with_capacity(items.len());
+            for (index, item) in items.iter().enumerate() {
+                let binding = format!("__sifr_python_tuple_{index}");
+                statements.push(RustStmt::Let {
+                    mutable: false,
+                    name: binding.clone(),
+                    ty: None,
+                    value: RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident("__sifr_python_items".to_string())),
+                        method: "remove".to_string(),
+                        args: vec![RustExpr::Literal(RustLiteral::Int(0))],
+                    },
+                });
+                values.push(output_value_expr(
+                    &binding,
+                    item,
+                    error_type,
+                    opaque_classes,
+                )?);
+            }
+            statements.insert(
+                0,
+                RustStmt::Let {
+                    mutable: true,
+                    name: "__sifr_python_items".to_string(),
+                    ty: None,
+                    value: mapped_try(
+                        runtime_call("tuple_items", vec![reference(value_name)]),
+                        error_type,
+                    ),
+                },
+            );
+            statements.remove(1);
+            return Some(RustExpr::Block {
+                stmts: statements,
+                expr: Some(Box::new(RustExpr::Tuple(values))),
+            });
+        }
+        Type::Dict(key, value) if key.resolve_alias() == &Type::Str => {
+            let converted =
+                output_value_expr("__sifr_python_item", value, error_type, opaque_classes)?;
+            return Some(RustExpr::Block {
+                stmts: vec![
+                    mapped_let(
+                        "__sifr_python_items",
+                        runtime_call("dict_str_items", vec![reference(value_name)]),
+                        error_type,
+                    ),
+                    RustStmt::Let {
+                        mutable: true,
+                        name: "__sifr_python_values".to_string(),
+                        ty: None,
+                        value: RustExpr::FnCall {
+                            func: Box::new(RustExpr::Path(vec![
+                                "Default".to_string(),
+                                "default".to_string(),
+                            ])),
+                            args: Vec::new(),
+                        },
+                    },
+                    RustStmt::For {
+                        var: "(__sifr_python_key, __sifr_python_item)".to_string(),
+                        iter: RustExpr::MethodCall {
+                            receiver: Box::new(RustExpr::Ident("__sifr_python_items".to_string())),
+                            method: "into_iter".to_string(),
+                            args: Vec::new(),
+                        },
+                        body: vec![RustStmt::Expr(RustExpr::MethodCall {
+                            receiver: Box::new(RustExpr::Ident("__sifr_python_values".to_string())),
+                            method: "insert".to_string(),
+                            args: vec![RustExpr::Ident("__sifr_python_key".to_string()), converted],
+                        })],
+                    },
+                ],
+                expr: Some(Box::new(RustExpr::Ident(
+                    "__sifr_python_values".to_string(),
+                ))),
+            });
+        }
+        Type::Class { name, fields, .. } if !fields.is_empty() => {
+            let mut statements = Vec::new();
+            let mut converted_fields = Vec::new();
+            for (field, field_type) in fields {
+                let handle = format!("__sifr_python_field_{field}");
+                statements.push(mapped_let(
+                    &handle,
+                    runtime_call(
+                        "record_field",
+                        vec![
+                            reference(value_name),
+                            RustExpr::Literal(RustLiteral::Str(field.clone())),
+                        ],
+                    ),
+                    error_type,
+                ));
+                converted_fields.push((
+                    field.clone(),
+                    output_value_expr(&handle, field_type, error_type, opaque_classes)?,
+                ));
+            }
+            return Some(RustExpr::Block {
+                stmts: statements,
+                expr: Some(Box::new(RustExpr::StructInit {
+                    name: name.clone(),
+                    fields: converted_fields,
+                })),
+            });
+        }
+        _ => {}
+    }
+    Some(mapped_try(output_conversion(value_name, ty)?, error_type))
+}
+
+fn input_conversion_value(
+    value: RustExpr,
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
     if is_python_object(ty) {
         return Some(runtime_call("temporary_argument_handle", vec![value]));
+    }
+    if matches!(ty.resolve_alias(), Type::Class { name, .. } if opaque_classes.contains_key(name)) {
+        return Some(runtime_call(
+            "temporary_argument_handle",
+            vec![RustExpr::Ref {
+                mutable: false,
+                expr: Box::new(RustExpr::Field {
+                    expr: Box::new(value),
+                    field: "__sifr_python_object".to_string(),
+                }),
+            }],
+        ));
+    }
+    if matches!(
+        ty.resolve_alias(),
+        Type::List(_) | Type::Tuple(_) | Type::Dict(_, _) | Type::Class { .. }
+    ) {
+        return Some(RustExpr::Block {
+            stmts: vec![RustStmt::Let {
+                mutable: false,
+                name: "__sifr_python_nested".to_string(),
+                ty: None,
+                value,
+            }],
+            expr: Some(Box::new(input_conversion(
+                "__sifr_python_nested",
+                ty,
+                opaque_classes,
+            )?)),
+        });
     }
     let function = match ty.resolve_alias() {
         Type::Bool => "from_bool",
@@ -254,7 +707,22 @@ fn option_inner(ty: &Type) -> Option<&Type> {
         .find(|variant| variant.resolve_alias() != &Type::None)
 }
 
-fn input_conversion_borrowed(name: &str, ty: &Type) -> Option<RustExpr> {
+fn input_conversion_borrowed(
+    name: &str,
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if option_inner(ty).is_some() {
+        return input_conversion(name, ty, opaque_classes);
+    }
+    if matches!(
+        ty.resolve_alias(),
+        Type::List(_) | Type::Tuple(_) | Type::Dict(_, _) | Type::Class { .. }
+    ) && !is_python_object(ty)
+        && !matches!(ty.resolve_alias(), Type::Class { name, .. } if opaque_classes.contains_key(name))
+    {
+        return input_conversion(name, ty, opaque_classes);
+    }
     let value = match ty.resolve_alias() {
         Type::Bool | Type::Int | Type::Float => {
             RustExpr::Deref(Box::new(RustExpr::Ident(name.to_string())))
@@ -264,6 +732,20 @@ fn input_conversion_borrowed(name: &str, ty: &Type) -> Option<RustExpr> {
             return Some(runtime_call(
                 "temporary_argument_handle",
                 vec![RustExpr::Ident(name.to_string())],
+            ));
+        }
+        Type::Class {
+            name: class_name, ..
+        } if opaque_classes.contains_key(class_name) => {
+            return Some(runtime_call(
+                "temporary_argument_handle",
+                vec![RustExpr::Ref {
+                    mutable: false,
+                    expr: Box::new(RustExpr::Field {
+                        expr: Box::new(RustExpr::Ident(name.to_string())),
+                        field: "__sifr_python_object".to_string(),
+                    }),
+                }],
             ));
         }
         _ => return None,
@@ -277,6 +759,26 @@ fn input_conversion_borrowed(name: &str, ty: &Type) -> Option<RustExpr> {
         _ => return None,
     };
     Some(runtime_call(function, vec![value]))
+}
+
+fn mapped_collection_results(iter: RustExpr, parameter: &str, body: RustExpr) -> RustExpr {
+    let mapped = RustExpr::MethodCall {
+        receiver: Box::new(iter),
+        method: "map".to_string(),
+        args: vec![RustExpr::Closure {
+            params: vec![RustParam::Named {
+                name: parameter.to_string(),
+                ty: RustType::Named("_".to_string()),
+            }],
+            body: Box::new(body),
+            is_move: false,
+        }],
+    };
+    RustExpr::MethodCall {
+        receiver: Box::new(mapped),
+        method: "collect".to_string(),
+        args: Vec::new(),
+    }
 }
 
 fn output_conversion(name: &str, ty: &Type) -> Option<RustExpr> {
@@ -374,6 +876,14 @@ fn push_positional(handle: &str) -> RustStmt {
         receiver: Box::new(RustExpr::Ident("__sifr_python_args".to_string())),
         method: "push".to_string(),
         args: vec![RustExpr::Ident(handle.to_string())],
+    })
+}
+
+fn push_to(vector: &str, value: &str) -> RustStmt {
+    RustStmt::Expr(RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::Ident(vector.to_string())),
+        method: "push".to_string(),
+        args: vec![RustExpr::Ident(value.to_string())],
     })
 }
 

--- a/crates/sifr_codegen/src/python_interop_direct_tests.rs
+++ b/crates/sifr_codegen/src/python_interop_direct_tests.rs
@@ -1,4 +1,6 @@
-use crate::python_interop_direct::python_interop_function_body;
+use crate::python_interop_direct::{
+    input_conversion, output_value_expr, python_interop_function_body, python_interop_method_body,
+};
 use crate::render_stmts;
 use ruff_text_size::TextRange;
 use sifr_ir::{
@@ -50,7 +52,8 @@ fn sync_wrapper_emits_complete_owned_argument_frame() {
         type_params: Vec::new(),
     };
 
-    let body = python_interop_function_body(&function).expect("wrapper should lower");
+    let body =
+        python_interop_function_body(&function, &Default::default()).expect("wrapper should lower");
     let rendered = render_stmts(&body);
     assert!(rendered.contains("sifr_runtime::python::resolve_target"));
     assert!(rendered.contains("for __sifr_python_value_1 in rest.iter()"));
@@ -94,7 +97,9 @@ fn omittable_positional_parameters_are_forwarded_by_name_without_shifting() {
         type_params: Vec::new(),
     };
 
-    let rendered = render_stmts(&python_interop_function_body(&function).expect("wrapper"));
+    let rendered = render_stmts(
+        &python_interop_function_body(&function, &Default::default()).expect("wrapper"),
+    );
     assert!(rendered.contains("__sifr_python_args.push(__sifr_python_arg_0)"));
     assert!(
         rendered.contains("(\"b\".to_string(), __sifr_python_arg_1)"),
@@ -104,6 +109,95 @@ fn omittable_positional_parameters_are_forwarded_by_name_without_shifting() {
         rendered.contains("(\"c\".to_string(), __sifr_python_arg_2)"),
         "{rendered}"
     );
+}
+
+#[test]
+fn recursive_wrapper_emits_list_dict_tuple_and_record_conversions() {
+    let error_type = python_error_type();
+    let record = Type::Class {
+        name: "Payload".to_string(),
+        fields: vec![
+            ("name".to_string(), Type::Str),
+            ("scores".to_string(), Type::List(Box::new(Type::Int))),
+        ],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let mut declaration = declaration();
+    declaration.parameters = vec![shape("payload", PythonParameterKind::Positional, false)];
+    assert!(
+        input_conversion("payload", &record, &Default::default()).is_some(),
+        "recursive input should lower"
+    );
+    let output_type = Type::Dict(
+        Box::new(Type::Str),
+        Box::new(Type::Tuple(vec![Type::Int, record.clone()])),
+    );
+    assert!(
+        output_value_expr("value", &output_type, &error_type, &Default::default()).is_some(),
+        "recursive output should lower"
+    );
+    let function = HirFunction {
+        name: "round_trip".to_string(),
+        params: vec![param("payload", record.clone(), ParamConvention::borrow())],
+        return_type: Type::Result(Box::new(output_type), Box::new(error_type)),
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        decorators: Vec::new(),
+        rust_interop: Vec::new(),
+        python_interop: vec![declaration],
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    };
+    let rendered = render_stmts(
+        &python_interop_function_body(&function, &Default::default())
+            .expect("recursive wrapper should lower"),
+    );
+    assert!(rendered.contains("from_record_results"), "{rendered}");
+    assert!(rendered.contains("from_list_results"), "{rendered}");
+    assert!(rendered.contains("dict_str_items"), "{rendered}");
+    assert!(rendered.contains("tuple_items"), "{rendered}");
+    assert!(rendered.contains("record_field"), "{rendered}");
+}
+
+#[test]
+fn consuming_opaque_close_emits_semantic_close_operation() {
+    let error_type = python_error_type();
+    let mut declaration = declaration();
+    declaration.target = Some(PythonTargetPath {
+        segments: vec!["Self".to_string(), "close".to_string()],
+        span: TextRange::default(),
+    });
+    declaration.parameters.clear();
+    declaration.consumes_receiver = true;
+    let method = HirFunction {
+        name: "close".to_string(),
+        params: Vec::new(),
+        return_type: Type::Result(Box::new(Type::None), Box::new(error_type)),
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        decorators: Vec::new(),
+        rust_interop: Vec::new(),
+        python_interop: vec![declaration],
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    };
+    let rendered = render_stmts(
+        &python_interop_method_body(&method, &Default::default())
+            .expect("consuming close should lower"),
+    );
+    assert!(rendered.contains("semantic_close(self.__sifr_python_object"));
+}
+
+fn python_error_type() -> Type {
+    Type::Class {
+        name: "PythonError".to_string(),
+        fields: vec![("message".to_string(), Type::Str)],
+        methods: Vec::new(),
+        parent_class: Some("Error".to_string()),
+    }
 }
 
 fn param(name: &str, ty: Type, convention: ParamConvention) -> HirParam {
@@ -125,6 +219,8 @@ fn declaration() -> PythonInteropDeclaration {
         }),
         span: TextRange::default(),
         effect: PythonInteropEffect::BlockingIo,
+        cleanup: None,
+        consumes_receiver: false,
         parameters: vec![
             shape("value", PythonParameterKind::Positional, false),
             shape("rest", PythonParameterKind::PositionalVariadic, false),

--- a/crates/sifr_codegen/src/python_interop_plan.rs
+++ b/crates/sifr_codegen/src/python_interop_plan.rs
@@ -26,6 +26,7 @@ pub struct PythonTargetProbe {
     pub import_root: Option<String>,
     pub target_path: String,
     pub requires_inspectable_signature: bool,
+    pub expects_type: bool,
     pub status: PythonTargetProbeStatus,
 }
 
@@ -51,6 +52,30 @@ pub(crate) fn python_interop_plan_for_named_modules<'a>(
                 &mut plan,
             );
         }
+        for class in &module.classes {
+            let Some(declaration) = class.python_opaque_declaration() else {
+                continue;
+            };
+            if let Some(root) = &declaration.required_import_root {
+                plan.required_import_roots.push(root.clone());
+            }
+            if let Some(target) = &declaration.target {
+                plan.target_probes.push(PythonTargetProbe {
+                    import_root: declaration.required_import_root.clone(),
+                    target_path: target.dotted(),
+                    requires_inspectable_signature: false,
+                    expects_type: true,
+                    status: PythonTargetProbeStatus::Planned,
+                });
+                plan.declarations.push(PythonInteropPlanDeclaration {
+                    module_name: module_name.map(str::to_string),
+                    function_name: class.name.clone(),
+                    declaration: declaration.clone(),
+                    parameter_types: Vec::new(),
+                    return_type: Type::None,
+                });
+            }
+        }
     }
     plan.required_import_roots.sort();
     plan.required_import_roots.dedup();
@@ -74,6 +99,7 @@ fn collect_function(
             import_root: declaration.required_import_root.clone(),
             target_path: target.dotted(),
             requires_inspectable_signature: record_expansion_functions.contains(&function.name),
+            expects_type: false,
             status: PythonTargetProbeStatus::Planned,
         });
         plan.declarations.push(PythonInteropPlanDeclaration {
@@ -159,6 +185,12 @@ pub(crate) fn push_python_plan_cache_key(out: &mut String, plan: &PythonInteropP
             "inspectable"
         } else {
             "runtime-checkable"
+        });
+        out.push(':');
+        out.push_str(if probe.expects_type {
+            "type"
+        } else {
+            "callable"
         });
         out.push(':');
         out.push_str(match probe.status {

--- a/crates/sifr_codegen/src/python_interop_plan_tests.rs
+++ b/crates/sifr_codegen/src/python_interop_plan_tests.rs
@@ -16,6 +16,8 @@ fn plan_retains_deferred_probe_requirements_record_constraint_and_cache_identity
         }),
         span: TextRange::default(),
         effect: PythonInteropEffect::BlockingIo,
+        cleanup: None,
+        consumes_receiver: false,
         parameters: Vec::new(),
         required_import_root: Some("json".to_string()),
     };
@@ -58,7 +60,7 @@ fn plan_retains_deferred_probe_requirements_record_constraint_and_cache_identity
     let cache_key = plan.cache_key_fragment();
     assert!(cache_key.contains("python.target=json.dumps"));
     assert!(cache_key.contains("python.required_import=json"));
-    assert!(cache_key.contains("python.probe=json.dumps:inspectable:planned"));
+    assert!(cache_key.contains("python.probe=json.dumps:inspectable:callable:planned"));
 }
 
 fn function(

--- a/crates/sifr_driver/src/build/python_interop.rs
+++ b/crates/sifr_driver/src/build/python_interop.rs
@@ -42,13 +42,15 @@ if is_callable:
         ]
     except (TypeError, ValueError):
         pass
-print(json.dumps({"ok": True, "callable": is_callable, "inspectable": inspectable, "parameters": parameters, "error": None}))
+print(json.dumps({"ok": True, "callable": is_callable, "is_type": isinstance(value, type), "inspectable": inspectable, "parameters": parameters, "error": None}))
 "#;
 
 #[derive(Deserialize)]
 struct ProbeOutput {
     ok: bool,
     callable: bool,
+    #[serde(default)]
+    is_type: bool,
     inspectable: bool,
     #[serde(default)]
     parameters: Vec<ProbeParameter>,
@@ -96,6 +98,15 @@ pub(super) fn apply_python_interop_metadata(
                 ),
                 DiagnosticCode::PYCALL_INVALID_SHAPE,
             )),
+            Ok(output) if probe.expects_type && !output.is_type => {
+                diagnostics.push(diagnostic_with_code(
+                    format!(
+                        "invalid Python opaque declaration: target '{}' is not a Python type",
+                        probe.target_path
+                    ),
+                    DiagnosticCode::PYCALL_INVALID_SHAPE,
+                ))
+            }
             Ok(output) if !output.inspectable && probe.requires_inspectable_signature => {
                 diagnostics.push(diagnostic_with_code(
                     format!(
@@ -113,11 +124,13 @@ pub(super) fn apply_python_interop_metadata(
                         .declarations
                         .iter()
                         .filter(|declaration| {
-                            declaration
-                                .declaration
-                                .target
-                                .as_ref()
-                                .is_some_and(|target| target.dotted() == probe.target_path)
+                            declaration.declaration.kind
+                                == sifr_ir::PythonInteropDecoratorKind::Function
+                                && declaration
+                                    .declaration
+                                    .target
+                                    .as_ref()
+                                    .is_some_and(|target| target.dotted() == probe.target_path)
                         })
                         .find_map(|declaration| validate_signature(declaration, &output.parameters))
                     {
@@ -327,6 +340,26 @@ mod tests {
     }
 
     #[test]
+    fn opaque_probe_requires_a_python_type() {
+        let runtime = PackagePythonRuntime::for_tests(python(), "probe");
+        let mut generated = project("math.sqrt");
+        generated.interop.python.target_probes[0].expects_type = true;
+        generated.interop.python.declarations[0].declaration.kind =
+            sifr_ir::PythonInteropDecoratorKind::Opaque;
+        let Err(diagnostics) = apply_python_interop_metadata(generated, Some(&runtime)) else {
+            panic!("opaque target must be a Python type");
+        };
+        assert_eq!(diagnostics[0].code, "SIFR-PYCALL-0001");
+
+        let mut generated = project("builtins.str");
+        generated.interop.python.target_probes[0].expects_type = true;
+        generated.interop.python.declarations[0].declaration.kind =
+            sifr_ir::PythonInteropDecoratorKind::Opaque;
+        apply_python_interop_metadata(generated, Some(&runtime))
+            .expect("Python class target should verify");
+    }
+
+    #[test]
     fn uninspectable_callable_is_runtime_checked() {
         let runtime = PackagePythonRuntime::for_tests(python(), "probe");
         let generated = apply_python_interop_metadata(project("builtins.dir"), Some(&runtime))
@@ -432,6 +465,8 @@ mod tests {
             }),
             span: ruff_text_size::TextRange::default(),
             effect: sifr_ir::PythonInteropEffect::BlockingIo,
+            cleanup: None,
+            consumes_receiver: false,
             parameters: if target == "math.sqrt" {
                 vec![sifr_ir::PythonInteropParameter {
                     name: "value".to_string(),
@@ -450,6 +485,7 @@ mod tests {
             import_root: Some(root),
             target_path: target.to_string(),
             requires_inspectable_signature: false,
+            expects_type: false,
             status: PythonTargetProbeStatus::Planned,
         });
         python

--- a/crates/sifr_ir/src/hir_nodes.rs
+++ b/crates/sifr_ir/src/hir_nodes.rs
@@ -36,6 +36,7 @@ pub enum HirClassKind {
     Regular,
     Protocol,
     Enum,
+    PythonOpaque(PythonInteropDeclaration),
 }
 
 /// A class definition with resolved types.
@@ -77,6 +78,13 @@ impl HirClass {
 
     pub fn is_enum(&self) -> bool {
         matches!(self.kind, HirClassKind::Enum)
+    }
+
+    pub fn python_opaque_declaration(&self) -> Option<&PythonInteropDeclaration> {
+        match &self.kind {
+            HirClassKind::PythonOpaque(declaration) => Some(declaration),
+            HirClassKind::Regular | HirClassKind::Protocol | HirClassKind::Enum => None,
+        }
     }
 }
 

--- a/crates/sifr_ir/src/python_interop.rs
+++ b/crates/sifr_ir/src/python_interop.rs
@@ -46,6 +46,16 @@ pub enum PythonInteropEffect {
     Async,
 }
 
+/// Semantic cleanup obligation attached to an opaque Python class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PythonCleanupPolicy {
+    Drop,
+    Close,
+    AsyncClose,
+    Context,
+    AsyncContext,
+}
+
 /// How a declared Sifr parameter contributes to the Python call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PythonParameterKind {
@@ -72,6 +82,9 @@ pub struct PythonInteropDeclaration {
     pub target: Option<PythonTargetPath>,
     pub span: TextRange,
     pub effect: PythonInteropEffect,
+    pub cleanup: Option<PythonCleanupPolicy>,
+    /// Whether an opaque instance method consumes its receiver (`own self`).
+    pub consumes_receiver: bool,
     pub parameters: Vec<PythonInteropParameter>,
     /// The non-reserved import root contributed by this declaration.
     pub required_import_root: Option<String>,

--- a/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
@@ -5,10 +5,15 @@ use super::{
     HirClassKind, HirExpr, HirFunction, HirParam, HirPattern, HirStmt, HirTupleTargetBinding,
     LowerCtx, MethodKind, ParamConvention, Ranged, Stmt, StmtClassDef, Type,
 };
+use crate::lower::python_interop::{
+    classify_python_interop_stub_body, collect_python_method_declarations,
+    has_python_interop_decorator_syntax, validate_python_interop_signature,
+};
 use crate::lower::rust_interop::{
     classify_rust_interop_stub_body, collect_rust_interop_declarations,
     has_rust_interop_decorator_syntax, RustInteropOwner,
 };
+use crate::lower::typing_and_functions::ast_convention_to_param;
 /// Second pass: lower class method bodies into `HirClass`.
 pub(in crate::lower) fn lower_class(
     class_def: &StmtClassDef,
@@ -16,6 +21,7 @@ pub(in crate::lower) fn lower_class(
 ) -> Option<HirClass> {
     let class_name = class_def.name.to_string();
     let class_ty = ctx.class_types.get(&class_name)?.clone();
+    let is_python_opaque = ctx.python_opaque_classes.contains_key(&class_name);
     let is_protocol = is_protocol_class(class_def);
     let newtype_inner = get_newtype_inner(class_def);
 
@@ -399,12 +405,17 @@ pub(in crate::lower) fn lower_class(
                     Type::Any
                 };
                 ctx.scope.define(param_name.clone(), param_ty.clone());
+                let convention = if ctx.must_use_obligation_for_type(&param_ty).is_some() {
+                    ast_convention_to_param(param.parameter.convention, &param_ty)
+                } else {
+                    ParamConvention::default()
+                };
                 params.push(HirParam {
                     name: param_name,
                     ty: param_ty,
                     default: None,
                     keyword_only: false,
-                    convention: ParamConvention::default(),
+                    convention,
                 });
             }
 
@@ -433,11 +444,44 @@ pub(in crate::lower) fn lower_class(
                 has_decorator(func, "cpu_heavy"),
                 func.is_async,
             );
-            let stub_body = classify_rust_interop_stub_body(
-                &func.body,
-                has_rust_interop_decorator_syntax(&func.decorator_list),
+            let has_python_interop = has_python_interop_decorator_syntax(&func.decorator_list);
+            let python_interop = collect_python_method_declarations(
+                &func.decorator_list,
+                &func.parameters,
+                func.is_async,
                 ctx,
             );
+            if !python_interop.is_empty() && !is_python_opaque {
+                ctx.error_with_code_at(
+                    sifr_diagnostics::DiagnosticCode::PYIMP_INVALID_TARGET,
+                    "`Self` Python declarations require an enclosing `@python.opaque` class"
+                        .to_string(),
+                    func.name.range(),
+                );
+            }
+            if python_interop.first().is_some_and(|declaration| {
+                declaration.kind == sifr_ir::PythonInteropDecoratorKind::Item
+            }) && params.len() != 1
+            {
+                ctx.error_with_code_at(
+                    sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
+                    "`@python.item` requires exactly one key parameter after the receiver"
+                        .to_string(),
+                    func.name.range(),
+                );
+            }
+            validate_python_interop_signature(&python_interop, &params, &return_ty, ctx);
+            let skips_normal_body_lowering = if has_python_interop {
+                classify_python_interop_stub_body(&func.body, true, ctx)
+                    .skips_normal_body_lowering()
+            } else {
+                classify_rust_interop_stub_body(
+                    &func.body,
+                    has_rust_interop_decorator_syntax(&func.decorator_list),
+                    ctx,
+                )
+                .skips_normal_body_lowering()
+            };
 
             // Lower method body
             let previous_owner = ctx.current_owner.replace(class_name.clone());
@@ -449,11 +493,36 @@ pub(in crate::lower) fn lower_class(
             ctx.current_function_is_async = func.is_async;
             ctx.current_function_is_async_generator =
                 func.is_async && function_body_contains_yield(&func.body);
-            let body = if stub_body.skips_normal_body_lowering() {
+            let previous_must_use_bindings = std::mem::take(&mut ctx.live_must_use_bindings);
+            for param in &params {
+                if param.convention.is_owned() {
+                    ctx.record_must_use_binding(&param.name, &param.ty);
+                }
+            }
+            let body = if skips_normal_body_lowering {
                 Vec::new()
             } else {
                 lower_stmts(&func.body, &method_ft, ctx)
             };
+            let mut live_must_use = ctx
+                .live_must_use_bindings
+                .iter()
+                .filter(|(name, _)| {
+                    ctx.scope.lookup(name.as_str()).is_some() && !ctx.scope.is_moved(name)
+                })
+                .map(|(name, obligation)| (name.clone(), obligation.clone()))
+                .collect::<Vec<_>>();
+            live_must_use.sort();
+            for (name, obligation) in live_must_use {
+                ctx.error_with_code_at(
+                    sifr_diagnostics::DiagnosticCode::OWN_USE_AFTER_MOVE,
+                    format!(
+                        "must-use binding '{name}' owns {obligation} and must be closed or transferred before method exit"
+                    ),
+                    func.name.range(),
+                );
+            }
+            ctx.live_must_use_bindings = previous_must_use_bindings;
             ctx.current_function_is_async = previous_async;
             ctx.current_function_is_async_generator = previous_async_generator;
             ctx.current_function_trusts_dynamic_python = previous_dynamic_python;
@@ -497,7 +566,7 @@ pub(in crate::lower) fn lower_class(
                 method_kind,
                 decorators: method_decorators,
                 rust_interop,
-                python_interop: Vec::new(),
+                python_interop,
                 compiler_intrinsic: None,
                 type_params: Vec::new(),
             };
@@ -509,6 +578,51 @@ pub(in crate::lower) fn lower_class(
                 hir_methods.push(hir_func);
             }
         }
+    }
+
+    let semantic_close_methods = hir_methods
+        .iter()
+        .filter(|method| {
+            method.python_interop.first().is_some_and(|declaration| {
+                declaration.consumes_receiver
+                    && declaration.kind == sifr_ir::PythonInteropDecoratorKind::Function
+                    && declaration
+                        .target
+                        .as_ref()
+                        .is_some_and(|target| target.segments.as_slice() == ["Self", "close"])
+                    && method.params.is_empty()
+                    && matches!(
+                        method.return_type.resolve_alias(),
+                        Type::Result(ok, _) if ok.resolve_alias() == &Type::None
+                    )
+            })
+        })
+        .count();
+    let cleanup = ctx
+        .python_opaque_classes
+        .get(&class_name)
+        .and_then(|declaration| declaration.cleanup);
+    if cleanup == Some(sifr_ir::PythonCleanupPolicy::Close) && semantic_close_methods != 1 {
+        ctx.error_with_code_at(
+            sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
+            "`cleanup=close` requires exactly one `@python(Self.close)` method declared as `def close(own self) -> Result[None, PythonError]`".to_string(),
+            class_def.range,
+        );
+    }
+    if cleanup != Some(sifr_ir::PythonCleanupPolicy::Close)
+        && hir_methods.iter().any(|method| {
+            method
+                .python_interop
+                .first()
+                .is_some_and(|declaration| declaration.consumes_receiver)
+        })
+    {
+        ctx.error_with_code_at(
+            sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
+            "a consuming Python method is reserved for the declared semantic cleanup operation"
+                .to_string(),
+            class_def.range,
+        );
     }
 
     let is_error = ctx.error_types.contains(&class_name);
@@ -547,13 +661,23 @@ pub(in crate::lower) fn lower_class(
         Vec::new()
     };
 
+    let python_opaque = ctx.python_opaque_classes.get(&class_name).cloned();
+    if python_opaque.is_some() && !own_fields.is_empty() {
+        ctx.error_with_code_at(
+            sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
+            "opaque Python classes cannot declare structural fields".to_string(),
+            class_def.range,
+        );
+    }
+    let kind = python_opaque.map_or(HirClassKind::Regular, HirClassKind::PythonOpaque);
+
     Some(HirClass {
         name: class_name,
         fields: own_fields,
         methods: hir_methods,
         is_hashable,
         is_error_type: is_error,
-        kind: HirClassKind::Regular,
+        kind,
         operator_impls,
         newtype_inner: None,
         implements_protocols,

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -690,15 +690,22 @@ pub(in crate::lower) fn collect_class_type(
         );
     }
 
+    let is_python_opaque = ctx.python_opaque_classes.contains_key(&class_name);
     let class_ty = Type::Class {
         name: class_name.clone(),
         fields: fields.clone(),
         methods: methods.clone(),
-        parent_class: parent_class_chain.clone(),
+        parent_class: if is_python_opaque {
+            Some("NonSend".to_string())
+        } else {
+            parent_class_chain.clone()
+        },
     };
 
     // Update the constructor function to return the class type
-    if let Some(ft) = ctx.functions.get_mut(&class_name) {
+    if is_python_opaque {
+        ctx.functions.remove(&class_name);
+    } else if let Some(ft) = ctx.functions.get_mut(&class_name) {
         *ft.return_type = class_ty.clone();
     } else {
         // No __init__ defined -- create a default constructor from fields

--- a/crates/sifr_lowering/src/lower/expressions/methods_lambdas_and_comprehensions.rs
+++ b/crates/sifr_lowering/src/lower/expressions/methods_lambdas_and_comprehensions.rs
@@ -254,6 +254,18 @@ pub(in crate::lower) fn lower_method_call(
         });
     }
 
+    if let Type::Class {
+        name: class_name, ..
+    } = object_ty.resolve_alias()
+    {
+        let qualified = format!("{class_name}.{method_name}");
+        if ctx.python_consuming_methods.contains(&qualified) {
+            if let HirExpr::Name { name, .. } = &object {
+                ctx.mark_moved_with_flow(name);
+            }
+        }
+    }
+
     Some(HirExpr::MethodCall {
         object: Box::new(object),
         method: method_name,

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -82,6 +82,7 @@ mod min_max_validation;
 mod mod_impl;
 mod module_constants_lowering;
 mod module_function_registry;
+mod must_use_obligations;
 mod mutating_methods;
 mod name_diagnostics;
 #[cfg(test)]

--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -34,6 +34,12 @@ pub(in crate::lower) struct LowerCtx {
     pub(in crate::lower) function_defaults: HashMap<String, Vec<(usize, HirExpr)>>,
     /// Class type definitions (name -> `Type::Class`)
     pub(in crate::lower) class_types: HashMap<String, Type>,
+    /// Class name -> declaration metadata for sealed Python-backed identities.
+    pub(in crate::lower) python_opaque_classes: HashMap<String, sifr_ir::PythonInteropDeclaration>,
+    /// General affine must-use obligations keyed by their current owning binding.
+    pub(in crate::lower) live_must_use_bindings: HashMap<String, String>,
+    /// Qualified opaque methods whose source receiver is declared `own self`.
+    pub(in crate::lower) python_consuming_methods: HashSet<String>,
     /// Current scope for name resolution
     pub(in crate::lower) scope: Scope,
     /// First non-Never child error type observed for each in-scope `TaskGroup` binding.
@@ -141,6 +147,9 @@ impl LowerCtx {
             function_workload_annotations: HashMap::new(),
             function_defaults: HashMap::new(),
             class_types: HashMap::new(),
+            python_opaque_classes: HashMap::new(),
+            live_must_use_bindings: HashMap::new(),
+            python_consuming_methods: HashSet::new(),
             scope: Scope::new(),
             task_group_error_types: HashMap::new(),
             task_handle_group_owners: HashMap::new(),
@@ -202,6 +211,35 @@ impl LowerCtx {
 
     pub(in crate::lower) fn is_stdlib_lowering(&self) -> bool {
         self.source_origin.is_sysroot_source()
+    }
+
+    pub(in crate::lower) fn must_use_obligation_for_type(&self, ty: &Type) -> Option<String> {
+        match ty.resolve_alias() {
+            Type::Class { name, .. } => self
+                .python_opaque_classes
+                .get(name)
+                .and_then(|declaration| declaration.cleanup)
+                .filter(|cleanup| *cleanup != sifr_ir::PythonCleanupPolicy::Drop)
+                .map(|cleanup| format!("Python opaque {name} ({cleanup:?})")),
+            Type::List(item) => self.must_use_obligation_for_type(item),
+            Type::Tuple(items) | Type::Union(items) => items
+                .iter()
+                .find_map(|item| self.must_use_obligation_for_type(item)),
+            Type::Dict(key, value) => self
+                .must_use_obligation_for_type(key)
+                .or_else(|| self.must_use_obligation_for_type(value)),
+            Type::Result(ok, _) => self.must_use_obligation_for_type(ok),
+            _ => None,
+        }
+    }
+
+    pub(in crate::lower) fn record_must_use_binding(&mut self, name: &str, ty: &Type) {
+        if let Some(obligation) = self.must_use_obligation_for_type(ty) {
+            self.live_must_use_bindings
+                .insert(name.to_string(), obligation);
+        } else {
+            self.live_must_use_bindings.remove(name);
+        }
     }
 
     pub(in crate::lower) fn is_sysroot_private_declaration(&self) -> bool {

--- a/crates/sifr_lowering/src/lower/mod_impl.rs
+++ b/crates/sifr_lowering/src/lower/mod_impl.rs
@@ -67,6 +67,30 @@ pub(in crate::lower) fn lower_module_impl(
     // This must happen before function signature extraction so that imported error classes
     // (e.g., StatisticsError from sifr.statistics) can be used in Result[T, E] annotations.
     resolve_imports_early(stmts, externals, &mut ctx);
+    // Opaque identity metadata participates in signature validation, so collect it before
+    // function signatures regardless of declaration order.
+    for stmt in stmts {
+        if let Stmt::ClassDef(class_def) = stmt {
+            if let Some(declaration) = python_interop::collect_python_opaque_declaration(
+                &class_def.decorator_list,
+                &mut ctx,
+            ) {
+                ctx.python_opaque_classes
+                    .insert(class_def.name.to_string(), declaration);
+                for body_stmt in &class_def.body {
+                    if let Stmt::FunctionDef(method) = body_stmt {
+                        if python_interop::method_consumes_receiver(
+                            &method.decorator_list,
+                            &method.parameters,
+                        ) {
+                            ctx.python_consuming_methods
+                                .insert(format!("{}.{}", class_def.name, method.name));
+                        }
+                    }
+                }
+            }
+        }
+    }
     let alias_decls = collect_type_alias_decls(stmts, &mut ctx);
     predeclare_type_aliases(&alias_decls, &mut ctx);
     // First class pass materializes full class shapes before alias resolution so aliases like

--- a/crates/sifr_lowering/src/lower/must_use_obligations.rs
+++ b/crates/sifr_lowering/src/lower/must_use_obligations.rs
@@ -1,0 +1,48 @@
+use super::LowerCtx;
+use crate::scope::MovedSnapshot;
+use ruff_text_size::TextRange;
+use sifr_diagnostics::DiagnosticCode;
+
+pub(in crate::lower) fn validate_branch_join(
+    ctx: &mut LowerCtx,
+    branch_moved_states: &[MovedSnapshot],
+    branch_exits: &[bool],
+    saved_moved: &MovedSnapshot,
+    has_else: bool,
+    range: TextRange,
+) {
+    let mut ownership_branches = branch_moved_states
+        .iter()
+        .zip(branch_exits)
+        .map(|(moved, exits)| (moved, *exits))
+        .collect::<Vec<_>>();
+    if !has_else {
+        ownership_branches.push((saved_moved, false));
+    }
+    let names = ctx
+        .live_must_use_bindings
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    for name in names {
+        let continuing = ownership_branches
+            .iter()
+            .filter(|(_, exits)| !exits)
+            .map(|(state, _)| {
+                state
+                    .iter()
+                    .find(|(binding, _)| binding == &name)
+                    .is_some_and(|(_, moved)| *moved)
+            })
+            .collect::<Vec<_>>();
+        if continuing.iter().any(|moved| *moved) && continuing.iter().any(|moved| !*moved) {
+            ctx.error_with_code_at(
+                DiagnosticCode::OWN_USE_AFTER_MOVE,
+                format!(
+                    "must-use binding '{name}' is consumed on only some continuing control-flow branches"
+                ),
+                range,
+            );
+        }
+    }
+}

--- a/crates/sifr_lowering/src/lower/python_interop.rs
+++ b/crates/sifr_lowering/src/lower/python_interop.rs
@@ -2,10 +2,10 @@ use super::LowerCtx;
 use ruff_text_size::{Ranged, TextRange};
 use sifr_diagnostics::DiagnosticCode;
 use sifr_ir::{
-    HirParam, PythonInteropDeclaration, PythonInteropDecoratorKind, PythonInteropEffect,
-    PythonInteropParameter, PythonParameterKind, PythonTargetPath,
+    HirParam, PythonCleanupPolicy, PythonInteropDeclaration, PythonInteropDecoratorKind,
+    PythonInteropEffect, PythonInteropParameter, PythonParameterKind, PythonTargetPath,
 };
-use sifr_python_ast::{Decorator, Expr, ExprCall, Parameters, Stmt};
+use sifr_python_ast::{AstParamOwnership, Decorator, Expr, ExprCall, Parameters, Stmt};
 use sifr_type_system::Type;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -119,6 +119,299 @@ pub(in crate::lower) fn collect_python_interop_declarations(
     declarations
 }
 
+pub(in crate::lower) fn collect_python_method_declarations(
+    decorators: &[Decorator],
+    parameters: &Parameters,
+    is_async_decl: bool,
+    ctx: &mut LowerCtx,
+) -> Vec<PythonInteropDeclaration> {
+    let mut declarations = Vec::new();
+    for decorator in decorators {
+        if decorator_path(&decorator.expression)
+            .is_some_and(|path| path.as_slice() == ["python", "item"])
+        {
+            declarations.push(PythonInteropDeclaration {
+                kind: PythonInteropDecoratorKind::Item,
+                target: None,
+                span: decorator.expression.range(),
+                effect: PythonInteropEffect::BlockingIo,
+                cleanup: None,
+                consumes_receiver: receiver_is_owned(parameters),
+                parameters: parameter_metadata(parameters).into_iter().skip(1).collect(),
+                required_import_root: None,
+            });
+            continue;
+        }
+        let Some((kind, call, span)) = classify_decorator(&decorator.expression, ctx) else {
+            continue;
+        };
+        if is_async_decl {
+            invalid_shape(
+                ctx,
+                "opaque Python methods must use synchronous `def`",
+                span,
+            );
+            continue;
+        }
+        let declaration = match kind {
+            PythonInteropDecoratorKind::Function => parse_sync_method(call, parameters, ctx),
+            PythonInteropDecoratorKind::Attribute => parse_attribute_method(call, parameters, ctx),
+            PythonInteropDecoratorKind::Item => {
+                invalid_shape(ctx, "`@python.item` does not take arguments", span);
+                None
+            }
+            _ => {
+                ctx.error_with_code_at(
+                    DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION,
+                    format!(
+                        "Python declaration lowering is not active yet: `{}` belongs to a later phase",
+                        decorator_label(kind)
+                    ),
+                    span,
+                );
+                None
+            }
+        };
+        if let Some(declaration) = declaration {
+            declarations.push(declaration);
+        }
+    }
+    if declarations.len() > 1 {
+        invalid_shape(
+            ctx,
+            "a method may have only one Python implementation declaration",
+            declarations[1].span,
+        );
+        declarations.truncate(1);
+    }
+    declarations
+}
+
+fn parse_sync_method(
+    call: &ExprCall,
+    parameters: &Parameters,
+    ctx: &mut LowerCtx,
+) -> Option<PythonInteropDeclaration> {
+    if call.arguments.args.len() != 1 || !call.arguments.keywords.is_empty() {
+        invalid_shape(
+            ctx,
+            "`@python(Self.method)` requires one target",
+            call.range,
+        );
+        return None;
+    }
+    let target = parse_method_target_path(&call.arguments.args[0], ctx)?;
+    Some(PythonInteropDeclaration {
+        kind: PythonInteropDecoratorKind::Function,
+        target: Some(target),
+        span: call.range,
+        effect: PythonInteropEffect::BlockingIo,
+        cleanup: None,
+        consumes_receiver: receiver_is_owned(parameters),
+        parameters: parameter_metadata(parameters).into_iter().skip(1).collect(),
+        required_import_root: None,
+    })
+}
+
+fn parse_attribute_method(
+    call: &ExprCall,
+    parameters: &Parameters,
+    ctx: &mut LowerCtx,
+) -> Option<PythonInteropDeclaration> {
+    if call.arguments.args.len() != 1 || !call.arguments.keywords.is_empty() {
+        invalid_shape(
+            ctx,
+            "`@python.attr(Self.name)` requires one target",
+            call.range,
+        );
+        return None;
+    }
+    let target = parse_method_target_path(&call.arguments.args[0], ctx)?;
+    let consumes_receiver = receiver_is_owned(parameters);
+    let parameters = parameter_metadata(parameters)
+        .into_iter()
+        .skip(1)
+        .collect::<Vec<_>>();
+    if !parameters.is_empty() {
+        invalid_shape(
+            ctx,
+            "a Python attribute declaration takes no parameters",
+            call.range,
+        );
+        return None;
+    }
+    Some(PythonInteropDeclaration {
+        kind: PythonInteropDecoratorKind::Attribute,
+        target: Some(target),
+        span: call.range,
+        effect: PythonInteropEffect::BlockingIo,
+        cleanup: None,
+        consumes_receiver,
+        parameters,
+        required_import_root: None,
+    })
+}
+
+fn parse_method_target_path(expr: &Expr, ctx: &mut LowerCtx) -> Option<PythonTargetPath> {
+    let segments = decorator_path(expr)?;
+    if segments.len() != 2 || segments[0] != "Self" {
+        invalid_target(
+            ctx,
+            "opaque method targets must be `Self.name`",
+            expr.range(),
+        );
+        return None;
+    }
+    Some(PythonTargetPath {
+        segments,
+        span: expr.range(),
+    })
+}
+
+pub(in crate::lower) fn collect_python_opaque_declaration(
+    decorators: &[Decorator],
+    ctx: &mut LowerCtx,
+) -> Option<PythonInteropDeclaration> {
+    let mut result = None;
+    for decorator in decorators {
+        let Expr::Call(call) = &decorator.expression else {
+            continue;
+        };
+        if !decorator_path(&call.func).is_some_and(|path| path.as_slice() == ["python", "opaque"]) {
+            continue;
+        }
+        if result.is_some() {
+            invalid_shape(
+                ctx,
+                "a class may have only one `@python.opaque` declaration",
+                call.range,
+            );
+            continue;
+        }
+        result = parse_opaque_class(call, ctx);
+    }
+    result
+}
+
+fn parse_opaque_class(call: &ExprCall, ctx: &mut LowerCtx) -> Option<PythonInteropDeclaration> {
+    if !call.arguments.args.is_empty() {
+        invalid_shape(
+            ctx,
+            "`@python.opaque` accepts only `type=` and `cleanup=` keyword arguments",
+            call.arguments.args[0].range(),
+        );
+        return None;
+    }
+    let mut target = None;
+    let mut cleanup = None;
+    let mut reserved_cleanup_seen = false;
+    for keyword in &call.arguments.keywords {
+        let Some(name) = keyword.arg.as_ref() else {
+            invalid_shape(
+                ctx,
+                "`@python.opaque` does not accept `**kwargs`",
+                keyword.range(),
+            );
+            return None;
+        };
+        match name.as_str() {
+            "type" if target.is_none() => target = parse_target_path(&keyword.value, ctx),
+            "cleanup" if cleanup.is_none() => {
+                let Some(path) = decorator_path(&keyword.value) else {
+                    invalid_shape(
+                        ctx,
+                        "opaque cleanup must be a closed policy atom",
+                        keyword.value.range(),
+                    );
+                    return None;
+                };
+                cleanup = match path.as_slice() {
+                    [name] if name == "drop" => Some(PythonCleanupPolicy::Drop),
+                    [name] if name == "close" => Some(PythonCleanupPolicy::Close),
+                    [name] if name == "async_close" => {
+                        reserved_cleanup(ctx, "async_close", keyword.value.range());
+                        reserved_cleanup_seen = true;
+                        None
+                    }
+                    [name] if name == "context" => {
+                        reserved_cleanup(ctx, "context", keyword.value.range());
+                        reserved_cleanup_seen = true;
+                        None
+                    }
+                    [name] if name == "async_context" => {
+                        reserved_cleanup(ctx, "async_context", keyword.value.range());
+                        reserved_cleanup_seen = true;
+                        None
+                    }
+                    _ => {
+                        invalid_shape(ctx, "unknown opaque cleanup policy", keyword.value.range());
+                        None
+                    }
+                };
+            }
+            "type" | "cleanup" => {
+                invalid_shape(
+                    ctx,
+                    &format!("duplicate `@python.opaque` argument `{name}`"),
+                    keyword.range(),
+                );
+                return None;
+            }
+            _ => {
+                invalid_shape(
+                    ctx,
+                    &format!("unknown `@python.opaque` argument `{name}`"),
+                    keyword.range(),
+                );
+                return None;
+            }
+        }
+    }
+    let Some(target) = target else {
+        invalid_shape(ctx, "`@python.opaque` requires `type=`", call.range);
+        return None;
+    };
+    let Some(cleanup) = cleanup else {
+        if !reserved_cleanup_seen {
+            invalid_shape(ctx, "`@python.opaque` requires `cleanup=`", call.range);
+        }
+        return None;
+    };
+    if matches!(target.root(), Some("Self" | "bridge")) {
+        let code = if target.root() == Some("bridge") {
+            DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION
+        } else {
+            DiagnosticCode::PYIMP_INVALID_TARGET
+        };
+        ctx.error_with_code_at(
+            code,
+            "invalid Python opaque type target: expected an import-rooted dotted path".to_string(),
+            target.span,
+        );
+        return None;
+    }
+    Some(PythonInteropDeclaration {
+        kind: PythonInteropDecoratorKind::Opaque,
+        required_import_root: target.root().map(str::to_string),
+        target: Some(target),
+        span: call.range,
+        effect: PythonInteropEffect::BlockingIo,
+        cleanup: Some(cleanup),
+        consumes_receiver: false,
+        parameters: Vec::new(),
+    })
+}
+
+fn reserved_cleanup(ctx: &mut LowerCtx, name: &str, span: TextRange) {
+    ctx.error_with_code_at(
+        DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION,
+        format!(
+            "Python declaration lowering is not active yet: cleanup policy `{name}` is reserved"
+        ),
+        span,
+    );
+}
+
 pub(in crate::lower) fn validate_python_interop_signature(
     declarations: &[PythonInteropDeclaration],
     params: &[HirParam],
@@ -143,7 +436,7 @@ pub(in crate::lower) fn validate_python_interop_signature(
             declaration.span,
         );
     }
-    if !is_direct_type(ok_type, false) {
+    if !is_direct_type(ok_type, true, ctx) {
         unsupported_conversion(
             ctx,
             &format!(
@@ -167,13 +460,13 @@ pub(in crate::lower) fn validate_python_interop_signature(
         }
         let supported = match shape.kind {
             PythonParameterKind::Positional | PythonParameterKind::KeywordOnly => {
-                is_direct_type(&param.ty, true)
+                is_direct_type(&param.ty, true, ctx)
             }
             PythonParameterKind::PositionalVariadic => {
-                matches!(param.ty.resolve_alias(), Type::List(element) if is_direct_type(element, false))
+                matches!(param.ty.resolve_alias(), Type::List(element) if is_direct_type(element, false, ctx))
             }
             PythonParameterKind::KeywordVariadic => {
-                matches!(param.ty.resolve_alias(), Type::Dict(key, value) if key.resolve_alias() == &Type::Str && is_direct_type(value, false))
+                matches!(param.ty.resolve_alias(), Type::Dict(key, value) if key.resolve_alias() == &Type::Str && is_direct_type(value, false, ctx))
             }
         };
         if !supported {
@@ -191,16 +484,29 @@ pub(in crate::lower) fn validate_python_interop_signature(
     }
 }
 
-fn is_direct_type(ty: &Type, allow_option: bool) -> bool {
+fn is_direct_type(ty: &Type, allow_option: bool, ctx: &LowerCtx) -> bool {
     match ty.resolve_alias() {
         Type::None | Type::Bool | Type::Int | Type::Float | Type::Str | Type::Bytes => true,
         Type::Class { name, .. } if name == "Object" => true,
+        Type::Class { name, .. } if ctx.python_opaque_classes.contains_key(name) => true,
+        Type::Class { name, fields, .. } => {
+            !ctx.error_types.contains(name)
+                && !fields.is_empty()
+                && fields
+                    .iter()
+                    .all(|(_, field)| is_direct_type(field, true, ctx))
+        }
+        Type::List(item) => is_direct_type(item, true, ctx),
+        Type::Tuple(items) => items.iter().all(|item| is_direct_type(item, true, ctx)),
+        Type::Dict(key, value) => {
+            key.resolve_alias() == &Type::Str && is_direct_type(value, true, ctx)
+        }
         Type::Union(variants) if allow_option && variants.len() == 2 => {
             variants
                 .iter()
                 .any(|variant| variant.resolve_alias() == &Type::None)
                 && variants.iter().all(|variant| {
-                    variant.resolve_alias() == &Type::None || is_direct_type(variant, false)
+                    variant.resolve_alias() == &Type::None || is_direct_type(variant, false, ctx)
                 })
         }
         _ => false,
@@ -247,6 +553,8 @@ fn parse_sync_function(
         target: Some(target),
         span: call.range,
         effect: PythonInteropEffect::BlockingIo,
+        cleanup: None,
+        consumes_receiver: false,
         parameters: parameter_metadata(parameters),
         required_import_root,
     })
@@ -291,6 +599,29 @@ fn parameter_metadata(parameters: &Parameters) -> Vec<PythonInteropParameter> {
         });
     }
     result
+}
+
+fn receiver_is_owned(parameters: &Parameters) -> bool {
+    parameters
+        .args
+        .first()
+        .is_some_and(|parameter| parameter.parameter.convention.ownership == AstParamOwnership::Own)
+}
+
+pub(in crate::lower) fn method_consumes_receiver(
+    decorators: &[Decorator],
+    parameters: &Parameters,
+) -> bool {
+    receiver_is_owned(parameters)
+        && decorators.iter().any(|decorator| {
+            let Expr::Call(call) = &decorator.expression else {
+                return false;
+            };
+            decorator_path(&call.func).is_some_and(|path| path.as_slice() == ["python"])
+                && call.arguments.args.first().is_some_and(|target| {
+                    decorator_path(target).is_some_and(|path| path.as_slice() == ["Self", "close"])
+                })
+        })
 }
 
 fn parse_target_path(expr: &Expr, ctx: &mut LowerCtx) -> Option<PythonTargetPath> {

--- a/crates/sifr_lowering/src/lower/python_interop_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_interop_tests.rs
@@ -1,6 +1,6 @@
 use crate::{lower_module, HirDiagnostic, HirExpr, HirModule, HirStmt};
 use sifr_diagnostics::DiagnosticCode;
-use sifr_ir::{PythonInteropEffect, PythonParameterKind};
+use sifr_ir::{HirClassKind, PythonCleanupPolicy, PythonInteropEffect, PythonParameterKind};
 use sifr_python_parser::parse_module;
 
 fn lower_ok(source: &str) -> HirModule {
@@ -96,7 +96,7 @@ class PythonError(Error):
     message: str
 
 @python(pkg.compute)
-def compute(values: list[int]) -> Result[int, PythonError]: ...
+def compute(values: set[int]) -> Result[int, PythonError]: ...
 ",
     );
     assert!(errors
@@ -150,6 +150,160 @@ def compute(value: int = python.omit, *rest: int) -> Result[int, PythonError]: .
     assert!(errors
         .iter()
         .any(|error| error.code == Some(DiagnosticCode::PYCALL_INVALID_SHAPE)));
+}
+
+#[test]
+fn opaque_class_retains_type_and_cleanup_policy() {
+    let module = lower_ok(
+        r"
+@python.opaque(type=pkg.Token, cleanup=drop)
+class Token:
+    pass
+",
+    );
+    let HirClassKind::PythonOpaque(declaration) = &module.classes[0].kind else {
+        panic!("class should be Python opaque");
+    };
+    assert_eq!(declaration.cleanup, Some(PythonCleanupPolicy::Drop));
+    assert_eq!(
+        declaration.target.as_ref().expect("target").dotted(),
+        "pkg.Token"
+    );
+    assert_eq!(declaration.required_import_root.as_deref(), Some("pkg"));
+}
+
+#[test]
+fn opaque_methods_retain_self_attribute_and_item_declarations() {
+    let module = lower_ok(
+        r#"
+class PythonError(Error):
+    message: str
+
+@python.opaque(type=pkg.Token, cleanup=drop)
+class Token:
+    @python.attr(Self.name)
+    def name(self) -> Result[str, PythonError]: ...
+
+    @python.item
+    def get(self, key: str) -> Result[int, PythonError]: ...
+
+    @python(Self.refresh)
+    def refresh(self, force: bool) -> Result[None, PythonError]: ...
+"#,
+    );
+    let methods = &module.classes[1].methods;
+    assert_eq!(methods.len(), 3);
+    assert_eq!(
+        methods[0].python_interop[0].kind,
+        sifr_ir::PythonInteropDecoratorKind::Attribute
+    );
+    assert_eq!(
+        methods[1].python_interop[0].kind,
+        sifr_ir::PythonInteropDecoratorKind::Item
+    );
+    assert_eq!(
+        methods[2].python_interop[0]
+            .target
+            .as_ref()
+            .expect("target")
+            .dotted(),
+        "Self.refresh"
+    );
+}
+
+const CLOSE_OPAQUE_PREFIX: &str = r#"
+class PythonError(Error):
+    message: str
+
+@python.opaque(type=pkg.Client, cleanup=close)
+class Client:
+    @python(Self.close)
+    def close(own self) -> Result[None, PythonError]: ...
+
+@python(pkg.Client)
+def make_client() -> Result[Client, PythonError]: ...
+"#;
+
+#[test]
+fn close_opaque_obligation_is_discharged_by_consuming_close() {
+    lower_ok(&format!(
+        "{CLOSE_OPAQUE_PREFIX}\ndef use_client() -> Result[None, PythonError]:\n    try:\n        client: Client = make_client()\n        _closed: None = client.close()\n        return None\n    except PythonError as error:\n        raise error\n"
+    ));
+}
+
+#[test]
+fn close_opaque_obligation_rejects_abandonment() {
+    let errors = lower_errors(&format!(
+        "{CLOSE_OPAQUE_PREFIX}\ndef abandon_client() -> Result[None, PythonError]:\n    try:\n        client: Client = make_client()\n        return None\n    except PythonError as error:\n        raise error\n"
+    ));
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::OWN_USE_AFTER_MOVE)
+            && error.message.contains("must-use binding 'client'")
+    }));
+}
+
+#[test]
+fn close_opaque_obligation_transfers_through_return() {
+    lower_ok(&format!(
+        "{CLOSE_OPAQUE_PREFIX}\ndef forward_client() -> Result[Client, PythonError]:\n    try:\n        client: Client = make_client()\n        return client\n    except PythonError as error:\n        raise error\n"
+    ));
+}
+
+#[test]
+fn close_opaque_obligation_rejects_partial_branch_consumption() {
+    let errors = lower_errors(&format!(
+        "{CLOSE_OPAQUE_PREFIX}\ndef partial(flag: bool) -> Result[None, PythonError]:\n    try:\n        client: Client = make_client()\n        if flag:\n            _closed: None = client.close()\n        return None\n    except PythonError as error:\n        raise error\n"
+    ));
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::OWN_USE_AFTER_MOVE)
+            && error
+                .message
+                .contains("only some continuing control-flow branches")
+    }));
+}
+
+#[test]
+fn close_opaque_obligation_transfers_through_owned_aggregate_return() {
+    lower_ok(&format!(
+        "{CLOSE_OPAQUE_PREFIX}\ndef forward_many() -> Result[list[Client], PythonError]:\n    try:\n        client: Client = make_client()\n        return [client]\n    except PythonError as error:\n        raise error\n"
+    ));
+}
+
+#[test]
+fn consuming_close_rejects_double_close_and_use_after_close() {
+    let errors = lower_errors(&format!(
+        "{CLOSE_OPAQUE_PREFIX}\ndef double_close() -> Result[None, PythonError]:\n    try:\n        client: Client = make_client()\n        _first: None = client.close()\n        _second: None = client.close()\n        return None\n    except PythonError as error:\n        raise error\n"
+    ));
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::OWN_USE_AFTER_MOVE) && error.message.contains("client")
+    }));
+}
+
+#[test]
+fn close_opaque_obligation_rejects_live_reassignment() {
+    let errors = lower_errors(&format!(
+        "{CLOSE_OPAQUE_PREFIX}\ndef replace_client() -> Result[None, PythonError]:\n    try:\n        client: Client = make_client()\n        client = make_client()\n        return None\n    except PythonError as error:\n        raise error\n"
+    ));
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::OWN_USE_AFTER_MOVE)
+            && error
+                .message
+                .contains("cannot reassign must-use binding 'client'")
+    }));
+}
+
+#[test]
+fn close_opaque_obligation_transfers_through_comprehension_return() {
+    lower_ok(&format!(
+        "{CLOSE_OPAQUE_PREFIX}\ndef forward_comprehension(own clients: list[Client]) -> list[Client]:\n    return [client for client in clients]\n"
+    ));
+}
+
+#[test]
+fn method_exit_ignores_consumed_obligations_from_popped_nested_scopes() {
+    lower_ok(&format!(
+        "{CLOSE_OPAQUE_PREFIX}\nclass Owner:\n    def use_nested(self) -> Result[None, PythonError]:\n        try:\n            if True:\n                client: Client = make_client()\n                _closed: None = client.close()\n            return None\n        except PythonError as error:\n            raise error\n"
+    ));
 }
 
 #[test]

--- a/crates/sifr_lowering/src/lower/return_lowering.rs
+++ b/crates/sifr_lowering/src/lower/return_lowering.rs
@@ -64,6 +64,10 @@ pub(in crate::lower) fn lower_return(
             if ctx.borrowed_params.contains(name.as_str()) && ty.ownership() == OwnershipKind::Move
             {
                 ownership_diagnostics::borrowed_parameter_return_escape(ctx, name, val.range());
+            } else if ty.ownership() == OwnershipKind::Move
+                && ctx.live_must_use_bindings.contains_key(name)
+            {
+                ctx.mark_moved_with_flow(name);
             }
         }
         if !ctx.is_stdlib_lowering() {
@@ -71,6 +75,7 @@ pub(in crate::lower) fn lower_return(
                 ownership_diagnostics::sync_guard_return_escape(ctx, label, val.range());
             }
         }
+        transfer_return_ownership(&expr, ctx);
 
         if let Type::Result(ref ok_ty, _) = *func_type.return_type {
             if expr_ty.is_assignable_to(ok_ty) && !matches!(expr_ty, Type::Result(_, _)) {
@@ -120,4 +125,88 @@ pub(in crate::lower) fn lower_return(
     };
 
     HirStmt::Return { value }
+}
+
+fn transfer_return_ownership(expr: &HirExpr, ctx: &mut LowerCtx) {
+    match expr {
+        HirExpr::Name { name, ty }
+            if ty.ownership() == OwnershipKind::Move
+                && ctx.live_must_use_bindings.contains_key(name) =>
+        {
+            ctx.mark_moved_with_flow(name);
+        }
+        HirExpr::ListLiteral { elements, .. }
+        | HirExpr::SetLiteral { elements, .. }
+        | HirExpr::TupleLiteral { elements, .. } => {
+            for element in elements {
+                transfer_return_ownership(element, ctx);
+            }
+        }
+        HirExpr::DictLiteral { keys, values, .. } => {
+            for element in keys.iter().chain(values) {
+                transfer_return_ownership(element, ctx);
+            }
+        }
+        HirExpr::ConstructorCall { args, .. } => {
+            for argument in args {
+                transfer_return_ownership(argument, ctx);
+            }
+        }
+        HirExpr::IteratorCall { args, .. } => {
+            for argument in args {
+                transfer_return_ownership(argument, ctx);
+            }
+        }
+        HirExpr::OkWrap { value, .. } => transfer_return_ownership(value, ctx),
+        HirExpr::QuestionMark { expr, .. } | HirExpr::ErrWrap { value: expr, .. } => {
+            transfer_return_ownership(expr, ctx);
+        }
+        HirExpr::IfExpr {
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            transfer_return_ownership(then_expr, ctx);
+            transfer_return_ownership(else_expr, ctx);
+        }
+        HirExpr::ListComp {
+            expr, generators, ..
+        }
+        | HirExpr::SetComp {
+            expr, generators, ..
+        } => {
+            transfer_return_ownership(expr, ctx);
+            for (_, iter, filter) in generators {
+                transfer_return_ownership(iter, ctx);
+                if let Some(filter) = filter {
+                    transfer_return_ownership(filter, ctx);
+                }
+            }
+        }
+        HirExpr::DictComp {
+            key_expr,
+            val_expr,
+            generators,
+            ..
+        } => {
+            transfer_return_ownership(key_expr, ctx);
+            transfer_return_ownership(val_expr, ctx);
+            for (_, iter, filter) in generators {
+                transfer_return_ownership(iter, ctx);
+                if let Some(filter) = filter {
+                    transfer_return_ownership(filter, ctx);
+                }
+            }
+        }
+        HirExpr::GeneratorExpr {
+            expr, iter, filter, ..
+        } => {
+            transfer_return_ownership(expr, ctx);
+            transfer_return_ownership(iter, ctx);
+            if let Some(filter) = filter {
+                transfer_return_ownership(filter, ctx);
+            }
+        }
+        _ => {}
+    }
 }

--- a/crates/sifr_lowering/src/lower/statements/control_flow.rs
+++ b/crates/sifr_lowering/src/lower/statements/control_flow.rs
@@ -20,6 +20,7 @@ use super::{
     NarrowingCondition, Ranged, StmtAssign, StmtAugAssign, StmtFor, StmtIf, StmtWhile, TextRange,
     Type,
 };
+use crate::lower::must_use_obligations;
 use crate::lower::task_join_set_calls::record_join_set_terminal_awaitable;
 pub(in crate::lower) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<HirStmt> {
     if assign.targets.len() != 1 {
@@ -255,6 +256,13 @@ pub(in crate::lower) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) ->
     if name == "_" {
         let value = lower_expr(&assign.value, ctx)?;
         let value_ty = value.ty().clone();
+        if let Some(obligation) = ctx.must_use_obligation_for_type(&value_ty) {
+            ctx.error_with_code_at(
+                DiagnosticCode::OWN_USE_AFTER_MOVE,
+                format!("cannot discard must-use resource `{obligation}`; transfer or close it"),
+                assign.range(),
+            );
+        }
         finish_async_generator_advance_for_expr(ctx, &value);
         return Some(HirStmt::Let {
             name: "_".to_string(),
@@ -333,8 +341,20 @@ pub(in crate::lower) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) ->
                 name_range,
             );
         }
+        if let Some(obligation) = ctx.live_must_use_bindings.get(&name).cloned() {
+            if !ctx.scope.is_moved(&name) {
+                ctx.error_with_code_at(
+                    DiagnosticCode::OWN_USE_AFTER_MOVE,
+                    format!(
+                        "cannot reassign must-use binding '{name}' owning {obligation} before closing or transferring it"
+                    ),
+                    name_range,
+                );
+            }
+        }
         // Reset moved state on reassignment
         ctx.reset_moved_with_flow(&name);
+        ctx.record_must_use_binding(&name, &value_ty);
         ctx.task_handle_group_owners.remove(&name);
         ctx.live_join_set_bindings.remove(&name);
         record_join_set_terminal_awaitable(&name, &value, ctx);
@@ -371,6 +391,7 @@ pub(in crate::lower) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) ->
             .cloned()
             .unwrap_or_else(|| value_ty.clone());
         ctx.scope.define(name.clone(), binding_ty.clone());
+        ctx.record_must_use_binding(&name, &binding_ty);
         if matches!(value.ty(), Type::Int | Type::LiteralInt(_))
             && value.ty().is_assignable_to(&binding_ty)
         {
@@ -561,6 +582,19 @@ pub(in crate::lower) fn lower_if(
     );
     ctx.restore_sequence_guards(&saved_sequence_guards);
     ctx.restore_proven_nonzero_integer_bindings(&saved_nonzero_integer_bindings);
+
+    let branch_exits = branch_const_integer_states
+        .iter()
+        .map(|(_, exits)| *exits)
+        .collect::<Vec<_>>();
+    must_use_obligations::validate_branch_join(
+        ctx,
+        &branch_moved_states,
+        &branch_exits,
+        &saved_moved,
+        else_body.is_some(),
+        if_stmt.range(),
+    );
 
     for branch_state in &branch_moved_states {
         for (name, was_moved) in branch_state {

--- a/crates/sifr_lowering/src/lower/statements/patterns_and_assignments.rs
+++ b/crates/sifr_lowering/src/lower/statements/patterns_and_assignments.rs
@@ -418,6 +418,7 @@ pub(in crate::lower) fn lower_ann_assign(
     ctx.pending_container_specialization_patches.remove(&name);
     ctx.scope
         .define_explicit_local(name.clone(), declared_type.clone());
+    ctx.record_must_use_binding(&name, &declared_type);
     if matches!(value.ty(), Type::Int | Type::LiteralInt(_))
         && value.ty().is_assignable_to(&declared_type)
     {

--- a/crates/sifr_lowering/src/lower/typing_and_functions/annotations_and_function_lowering.rs
+++ b/crates/sifr_lowering/src/lower/typing_and_functions/annotations_and_function_lowering.rs
@@ -670,18 +670,26 @@ pub(in crate::lower) fn lower_function(
         .current_function_return_type
         .replace(ft.return_type.as_ref().clone());
     let previous_live_join_sets = std::mem::take(&mut ctx.live_join_set_bindings);
+    let previous_must_use_bindings = std::mem::take(&mut ctx.live_must_use_bindings);
     let previous_join_set_terminal_awaitables =
         std::mem::take(&mut ctx.join_set_terminal_awaitables);
     ctx.current_function_is_async = effective_is_async;
     ctx.current_function_is_async_generator = is_async_generator;
     ctx.current_function_trusts_dynamic_python = has_decorator(func, "trust_python_dynamic");
+    for param in &params {
+        if param.convention.is_owned() {
+            ctx.record_must_use_binding(&param.name, &param.ty);
+        }
+    }
     let body = if skips_normal_body_lowering {
         Vec::new()
     } else {
         lower_stmts(&func.body, &ft, ctx)
     };
     reject_live_join_sets_at_function_exit(func, ctx);
+    reject_live_must_use_bindings_at_function_exit(func, ctx);
     ctx.live_join_set_bindings = previous_live_join_sets;
+    ctx.live_must_use_bindings = previous_must_use_bindings;
     ctx.join_set_terminal_awaitables = previous_join_set_terminal_awaitables;
     ctx.current_function_is_async = previous_async;
     ctx.current_function_is_async_generator = previous_async_generator;
@@ -808,6 +816,26 @@ fn reject_live_join_sets_at_function_exit(func: &StmtFunctionDef, ctx: &mut Lowe
     }
     ctx.live_join_set_bindings.clear();
     ctx.join_set_terminal_awaitables.clear();
+}
+
+fn reject_live_must_use_bindings_at_function_exit(func: &StmtFunctionDef, ctx: &mut LowerCtx) {
+    let mut live = ctx
+        .live_must_use_bindings
+        .iter()
+        .filter(|(name, _)| ctx.scope.lookup(name.as_str()).is_some() && !ctx.scope.is_moved(name))
+        .map(|(name, obligation)| (name.clone(), obligation.clone()))
+        .collect::<Vec<_>>();
+    live.sort();
+    for (name, obligation) in live {
+        ctx.error_with_code_at(
+            DiagnosticCode::OWN_USE_AFTER_MOVE,
+            format!(
+                "must-use binding '{name}' owns {obligation} and must be closed or transferred before function exit"
+            ),
+            func.name.range(),
+        );
+    }
+    ctx.live_must_use_bindings.clear();
 }
 
 pub(super) fn requires_exhaustive_return_annotation(

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -17,6 +17,8 @@ mod foreign_object;
 mod object_ops;
 #[cfg(test)]
 mod object_ops_tests;
+mod opaque_ops;
+mod recursive_ops;
 mod resource_identity;
 mod resource_ops;
 pub use arrow_ops::{
@@ -45,11 +47,16 @@ pub use object_ops::{
     copy_dict_str_int, copy_dict_str_str, copy_dict_str_u8, copy_list_bool, copy_list_bytes,
     copy_list_float, copy_list_i32, copy_list_int, copy_list_str, copy_list_u8, copy_record_fields,
     copy_tuple_bool, copy_tuple_bytes, copy_tuple_float, copy_tuple_i32, copy_tuple_int,
-    copy_tuple_str, copy_tuple_u8, enter_context, exit_context, from_bool, from_bytes,
-    from_dict_str, from_float, from_int, from_list, from_none, from_record, from_str, from_tuple,
-    get_attr, get_item_str, import_module, resolve_target, temporary_argument_handle, to_bool,
-    to_bytes, to_float, to_i16, to_i32, to_i64, to_i8, to_int, to_isize, to_none, to_str, to_u16,
-    to_u32, to_u64, to_u8, to_usize, ObjectHandle, PythonError,
+    copy_tuple_str, copy_tuple_u8, enter_context, exit_context, expect_instance, from_bool,
+    from_bytes, from_dict_str, from_float, from_int, from_list, from_none, from_record, from_str,
+    from_tuple, get_attr, get_item_str, import_module, resolve_target, temporary_argument_handle,
+    to_bool, to_bytes, to_float, to_i16, to_i32, to_i64, to_i8, to_int, to_isize, to_none, to_str,
+    to_u16, to_u32, to_u64, to_u8, to_usize, ObjectHandle, PythonError,
+};
+pub use opaque_ops::semantic_close;
+pub use recursive_ops::{
+    at_path, dict_str_items, from_dict_results, from_list_results, from_record_results,
+    from_tuple_results, list_items, object_is_none, record_field, tuple_items,
 };
 pub use resource_identity::PythonResourceIdentity;
 pub use resource_ops::{exit_context_with_error, resource_diagnostics, PythonResourceDiagnostics};

--- a/crates/sifr_runtime/src/python/foreign_object.rs
+++ b/crates/sifr_runtime/src/python/foreign_object.rs
@@ -11,11 +11,19 @@ static PENDING_RELEASES: LazyLock<Mutex<Vec<Py<PyAny>>>> = LazyLock::new(|| Mute
 #[derive(Clone, Debug)]
 pub struct ForeignObject {
     inner: Arc<ForeignObjectInner>,
+    boundary_path: String,
 }
 
 #[derive(Debug)]
 struct ForeignObjectInner {
-    object: Option<Py<PyAny>>,
+    state: Mutex<ForeignObjectState>,
+}
+
+#[derive(Debug)]
+enum ForeignObjectState {
+    Open(Py<PyAny>),
+    Poisoned(Py<PyAny>),
+    Closed,
 }
 
 impl ForeignObject {
@@ -23,37 +31,87 @@ impl ForeignObject {
         update_object_count(1)?;
         Ok(Self {
             inner: Arc::new(ForeignObjectInner {
-                object: Some(object),
+                state: Mutex::new(ForeignObjectState::Open(object)),
             }),
+            boundary_path: String::new(),
         })
     }
 
     pub(super) fn clone_ref(&self, py: Python<'_>) -> Result<Py<PyAny>, PythonRuntimeError> {
-        self.inner
-            .object
-            .as_ref()
-            .map(|object| object.clone_ref(py))
-            .ok_or(PythonRuntimeError::PythonOperationFailed(
+        match &*lock_state(&self.inner.state) {
+            ForeignObjectState::Open(object) => Ok(object.clone_ref(py)),
+            ForeignObjectState::Poisoned(_) => Err(PythonRuntimeError::PythonOperationFailed(
+                "Python object identity is poisoned after failed semantic cleanup".to_string(),
+            )),
+            ForeignObjectState::Closed => Err(PythonRuntimeError::PythonOperationFailed(
                 "Python object identity is closed".to_string(),
-            ))
+            )),
+        }
+    }
+
+    pub(super) fn poison(&self) {
+        let mut state = lock_state(&self.inner.state);
+        if let ForeignObjectState::Open(object) =
+            std::mem::replace(&mut *state, ForeignObjectState::Closed)
+        {
+            *state = ForeignObjectState::Poisoned(object);
+        }
+    }
+
+    pub(super) fn close(&self) {
+        let object = {
+            let mut state = lock_state(&self.inner.state);
+            match std::mem::replace(&mut *state, ForeignObjectState::Closed) {
+                ForeignObjectState::Open(object) | ForeignObjectState::Poisoned(object) => {
+                    Some(object)
+                }
+                ForeignObjectState::Closed => None,
+            }
+        };
+        if let Some(object) = object {
+            release_object(object);
+        }
     }
 
     pub(super) fn ptr_eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.inner, &other.inner)
     }
+
+    pub(super) fn with_child_path(mut self, child: impl AsRef<str>) -> Self {
+        self.boundary_path.push_str(child.as_ref());
+        self
+    }
+
+    pub(super) fn boundary_path(&self) -> &str {
+        &self.boundary_path
+    }
 }
 
 impl Drop for ForeignObjectInner {
     fn drop(&mut self) {
-        let Some(object) = self.object.take() else {
-            return;
+        let state = match self.state.get_mut() {
+            Ok(state) => std::mem::replace(state, ForeignObjectState::Closed),
+            Err(poisoned) => std::mem::replace(poisoned.into_inner(), ForeignObjectState::Closed),
         };
-        if unsafe { ffi::PyGILState_Check() } != 0 {
-            drop(object);
-            let _ignored = update_object_count(-1);
-            return;
+        if let ForeignObjectState::Open(object) | ForeignObjectState::Poisoned(object) = state {
+            release_object(object);
         }
+    }
+}
+
+fn release_object(object: Py<PyAny>) {
+    if unsafe { ffi::PyGILState_Check() } != 0 {
+        drop(object);
+        let _ignored = update_object_count(-1);
+    } else {
         pending_releases().push(object);
+    }
+}
+
+fn lock_state(state: &Mutex<ForeignObjectState>) -> std::sync::MutexGuard<'_, ForeignObjectState> {
+    match state.lock() {
+        Ok(state) => state,
+        Err(poisoned) => poisoned.into_inner(),
     }
 }
 

--- a/crates/sifr_runtime/src/python/object_ops.rs
+++ b/crates/sifr_runtime/src/python/object_ops.rs
@@ -163,13 +163,53 @@ pub fn resolve_target(segments: &[String]) -> Result<ObjectHandle, PythonError> 
     .map_err(PythonError::runtime)?
 }
 
-pub fn get_attr(object: &ObjectHandle, name: &str) -> Result<ObjectHandle, PythonError> {
+pub fn expect_instance(
+    object: ObjectHandle,
+    expected_segments: &[String],
+) -> Result<ObjectHandle, PythonError> {
+    let boundary_path = object.boundary_path().to_string();
+    let expected = resolve_target(expected_segments)?;
+    let matches = super::attach(|py| {
+        let object_ref = clone_handle(py, &object)?;
+        let expected_ref = clone_handle(py, &expected)?;
+        let matches = object_ref
+            .bind(py)
+            .is_instance(expected_ref.bind(py))
+            .map_err(|error| {
+                PythonError::from_pyerr(py, error, "conversion", expected_segments.join("."))
+            })?;
+        expected.close();
+        if !matches {
+            object.close();
+        }
+        Ok(matches)
+    })
+    .map_err(PythonError::runtime)??;
+    if matches {
+        Ok(object)
+    } else {
+        Err(conversion_error(
+            format!(
+                "expected Python instance of '{}'",
+                expected_segments.join(".")
+            ),
+            if boundary_path.is_empty() {
+                "opaque factory result".to_string()
+            } else {
+                boundary_path
+            },
+        ))
+    }
+}
+
+pub fn get_attr(object: &ObjectHandle, name: impl AsRef<str>) -> Result<ObjectHandle, PythonError> {
+    let name = name.as_ref().to_string();
     super::attach(|py| {
         let object = clone_handle(py, object)?;
         object
             .bind(py)
-            .getattr(name)
-            .map_err(|error| PythonError::from_pyerr(py, error, "attribute", name))
+            .getattr(name.as_str())
+            .map_err(|error| PythonError::from_pyerr(py, error, "attribute", &name))
             .and_then(|value| store_object(value.unbind()))
     })
     .map_err(PythonError::runtime)?
@@ -388,12 +428,20 @@ pub fn from_record(values: &[(&str, ObjectHandle)]) -> Result<ObjectHandle, Pyth
 }
 
 pub fn to_none(object: &ObjectHandle) -> Result<(), PythonError> {
+    let boundary_path = object.boundary_path().to_string();
     super::attach(|py| {
         let object = clone_handle(py, object)?;
         if object.bind(py).is_none() {
             Ok(())
         } else {
-            Err(conversion_error("expected Python None", "to_none"))
+            Err(conversion_error(
+                "expected Python None",
+                if boundary_path.is_empty() {
+                    "to_none".to_string()
+                } else {
+                    boundary_path.clone()
+                },
+            ))
         }
     })
     .map_err(PythonError::runtime)?
@@ -553,7 +601,7 @@ pub(super) fn store_object(object: Py<PyAny>) -> Result<ObjectHandle, PythonErro
     ForeignObject::new(object).map_err(PythonError::runtime)
 }
 
-fn store_objects(objects: Vec<Py<PyAny>>) -> Result<Vec<ObjectHandle>, PythonError> {
+pub(super) fn store_objects(objects: Vec<Py<PyAny>>) -> Result<Vec<ObjectHandle>, PythonError> {
     objects
         .into_iter()
         .map(ForeignObject::new)
@@ -604,11 +652,16 @@ fn extract_handle<T>(
 where
     for<'py> T: FromPyObject<'py, 'py>,
 {
+    let boundary_path = object.boundary_path().to_string();
     super::attach(|py| {
         let object = clone_handle(py, object)?;
         object.bind(py).extract::<T>().map_err(|error| {
             let mut converted = PythonError::from_pyerr(py, error.into(), "conversion", context);
-            converted.context = format!("{context}: expected {expected}");
+            converted.context = if boundary_path.is_empty() {
+                format!("{context}: expected {expected}")
+            } else {
+                format!("{boundary_path}: expected {expected}")
+            };
             converted
         })
     })

--- a/crates/sifr_runtime/src/python/object_ops_tests.rs
+++ b/crates/sifr_runtime/src/python/object_ops_tests.rs
@@ -1,7 +1,7 @@
 use super::object_ops::*;
 use super::{
-    initialize_runtime, reset_runtime_state_for_tests, shutdown_diagnostics, test_config,
-    test_guard, PythonRuntimeDiagnostics,
+    initialize_runtime, list_items, record_field, reset_runtime_state_for_tests, semantic_close,
+    shutdown_diagnostics, test_config, test_guard, PythonRuntimeDiagnostics,
 };
 
 #[test]
@@ -155,6 +155,95 @@ fn declaration_wrapper_failure_points_release_every_temporary_handle() {
     }
     assert_eq!(
         shutdown_diagnostics().expect("diagnostics should be available"),
+        PythonRuntimeDiagnostics {
+            initialized: true,
+            live_objects: 0,
+            leaked_objects: 0,
+        }
+    );
+}
+
+#[test]
+fn recursive_handles_report_exact_nested_paths_and_required_record_fields() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("recursive-paths")).expect("init should succeed");
+
+    let bad = from_str("not-an-int").expect("value should be stored");
+    let inner = from_list(std::slice::from_ref(&bad)).expect("inner list should be stored");
+    let outer = from_list(std::slice::from_ref(&inner)).expect("outer list should be stored");
+    let outer_item = list_items(&outer)
+        .expect("outer list should extract")
+        .into_iter()
+        .next()
+        .expect("outer item");
+    let inner_item = list_items(&outer_item)
+        .expect("inner list should extract")
+        .into_iter()
+        .next()
+        .expect("inner item");
+    let error = to_int(&inner_item).expect_err("nested conversion should fail");
+    assert!(error.context.contains("[0][0]"), "{error:?}");
+
+    let record = from_record(&[("present", bad.clone()), ("extra", bad.clone())])
+        .expect("record should be stored");
+    let present = record_field(&record, "present").expect("required field should extract");
+    let missing = record_field(&record, "missing").expect_err("missing field should fail");
+    assert!(missing.context.contains("missing"));
+
+    for handle in [bad, inner, outer, outer_item, inner_item, record, present] {
+        close_object(handle).expect("object should close");
+    }
+    assert_eq!(
+        shutdown_diagnostics().expect("diagnostics"),
+        PythonRuntimeDiagnostics {
+            initialized: true,
+            live_objects: 0,
+            leaked_objects: 0,
+        }
+    );
+}
+
+#[test]
+fn semantic_close_consumes_identity_and_poison_failure_releases_it() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("semantic-close")).expect("init should succeed");
+
+    let target = resolve_target(&["contextlib".to_string(), "ExitStack".to_string()])
+        .expect("ExitStack should resolve");
+    let stack = call_object_owned(&target, &[], &[]).expect("ExitStack should construct");
+    semantic_close(stack, "close").expect("semantic close should succeed");
+
+    let invalid = from_int(1).expect("invalid receiver should be stored");
+    let error = semantic_close(invalid, "close").expect_err("missing close should fail");
+    assert_eq!(error.kind, "cleanup");
+
+    close_object(target).expect("target should close");
+    assert_eq!(
+        shutdown_diagnostics().expect("diagnostics"),
+        PythonRuntimeDiagnostics {
+            initialized: true,
+            live_objects: 0,
+            leaked_objects: 0,
+        }
+    );
+}
+
+#[test]
+fn opaque_factory_instance_mismatch_releases_the_rejected_identity() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("opaque-instance-mismatch")).expect("init should succeed");
+
+    let integer = from_int(7).expect("integer should be stored");
+    let error = expect_instance(integer, &["builtins".to_string(), "str".to_string()])
+        .expect_err("wrong factory identity should fail");
+    assert_eq!(error.kind, "conversion");
+    assert!(error.message.contains("builtins.str"));
+
+    assert_eq!(
+        shutdown_diagnostics().expect("diagnostics"),
         PythonRuntimeDiagnostics {
             initialized: true,
             live_objects: 0,

--- a/crates/sifr_runtime/src/python/opaque_ops.rs
+++ b/crates/sifr_runtime/src/python/opaque_ops.rs
@@ -1,0 +1,28 @@
+use super::{ForeignObject, PythonError};
+use pyo3::prelude::*;
+
+/// Invoke the declared semantic close operation and consume the sealed identity.
+/// A Python exception poisons the identity before ownership is released.
+pub fn semantic_close(object: ForeignObject, method: impl AsRef<str>) -> Result<(), PythonError> {
+    let method = method.as_ref().to_string();
+    let outcome = super::attach(|py| {
+        let receiver = object.clone_ref(py).map_err(PythonError::runtime)?;
+        let _call_depth = super::enter_python_call();
+        receiver
+            .bind(py)
+            .call_method0(method.as_str())
+            .map(|_| ())
+            .map_err(|error| PythonError::from_pyerr(py, error, "cleanup", &method))
+    })
+    .map_err(PythonError::runtime)?;
+    match outcome {
+        Ok(()) => {
+            object.close();
+            Ok(())
+        }
+        Err(error) => {
+            object.poison();
+            Err(error)
+        }
+    }
+}

--- a/crates/sifr_runtime/src/python/recursive_ops.rs
+++ b/crates/sifr_runtime/src/python/recursive_ops.rs
@@ -1,0 +1,182 @@
+use super::object_ops::{clone_handle, store_object, store_objects};
+use super::{ObjectHandle, PythonError};
+use pyo3::exceptions::PyAttributeError;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyTuple};
+
+pub fn from_list_results(
+    values: Vec<Result<ObjectHandle, PythonError>>,
+) -> Result<ObjectHandle, PythonError> {
+    let values = values
+        .into_iter()
+        .enumerate()
+        .map(|(index, value)| at_path(value, format!("[{index}]")))
+        .collect::<Result<Vec<_>, _>>()?;
+    super::object_ops::from_list(&values)
+}
+
+pub fn from_tuple_results(
+    values: Vec<Result<ObjectHandle, PythonError>>,
+) -> Result<ObjectHandle, PythonError> {
+    let values = values
+        .into_iter()
+        .enumerate()
+        .map(|(index, value)| at_path(value, format!("[{index}]")))
+        .collect::<Result<Vec<_>, _>>()?;
+    super::object_ops::from_tuple(&values)
+}
+
+pub fn from_dict_results(
+    values: Vec<(String, Result<ObjectHandle, PythonError>)>,
+) -> Result<ObjectHandle, PythonError> {
+    let values = values
+        .into_iter()
+        .map(|(key, value)| {
+            let value = at_path(value, format!("[{key:?}]"))?;
+            Ok((key, value))
+        })
+        .collect::<Result<Vec<_>, PythonError>>()?;
+    let borrowed = values
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.clone()))
+        .collect::<Vec<_>>();
+    super::object_ops::from_dict_str(&borrowed)
+}
+
+pub fn from_record_results(
+    values: Vec<(String, Result<ObjectHandle, PythonError>)>,
+) -> Result<ObjectHandle, PythonError> {
+    let values = values
+        .into_iter()
+        .map(|(field, value)| {
+            let value = at_path(value, format!(".{field}"))?;
+            Ok((field, value))
+        })
+        .collect::<Result<Vec<_>, PythonError>>()?;
+    let borrowed = values
+        .iter()
+        .map(|(field, value)| (field.as_str(), value.clone()))
+        .collect::<Vec<_>>();
+    super::object_ops::from_record(&borrowed)
+}
+
+pub fn list_items(object: &ObjectHandle) -> Result<Vec<ObjectHandle>, PythonError> {
+    let parent_path = object.boundary_path().to_string();
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let list = object
+            .bind(py)
+            .cast::<PyList>()
+            .map_err(|_| conversion_error("expected Python list", "list"))?;
+        store_objects(list.iter().map(Bound::unbind).collect()).map(|items| {
+            items
+                .into_iter()
+                .enumerate()
+                .map(|(index, item)| item.with_child_path(format!("{parent_path}[{index}]")))
+                .collect()
+        })
+    })
+    .map_err(PythonError::runtime)?
+}
+
+pub fn tuple_items(object: &ObjectHandle) -> Result<Vec<ObjectHandle>, PythonError> {
+    let parent_path = object.boundary_path().to_string();
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let tuple = object
+            .bind(py)
+            .cast::<PyTuple>()
+            .map_err(|_| conversion_error("expected Python tuple", "tuple"))?;
+        store_objects(tuple.iter().map(Bound::unbind).collect()).map(|items| {
+            items
+                .into_iter()
+                .enumerate()
+                .map(|(index, item)| item.with_child_path(format!("{parent_path}[{index}]")))
+                .collect()
+        })
+    })
+    .map_err(PythonError::runtime)?
+}
+
+pub fn dict_str_items(object: &ObjectHandle) -> Result<Vec<(String, ObjectHandle)>, PythonError> {
+    let parent_path = object.boundary_path().to_string();
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let dict = object
+            .bind(py)
+            .cast::<PyDict>()
+            .map_err(|_| conversion_error("expected Python dict", "dict"))?;
+        let mut names = Vec::with_capacity(dict.len());
+        let mut objects = Vec::with_capacity(dict.len());
+        for (key, value) in dict.iter() {
+            names.push(
+                key.extract::<String>()
+                    .map_err(|_| conversion_error("expected string dictionary key", "dict key"))?,
+            );
+            objects.push(value.unbind());
+        }
+        let handles = store_objects(objects)?;
+        Ok(names
+            .into_iter()
+            .zip(handles)
+            .map(|(name, value)| {
+                let value = value.with_child_path(format!("{parent_path}[{name:?}]"));
+                (name, value)
+            })
+            .collect())
+    })
+    .map_err(PythonError::runtime)?
+}
+
+pub fn record_field(
+    object: &ObjectHandle,
+    field: impl AsRef<str>,
+) -> Result<ObjectHandle, PythonError> {
+    let field = field.as_ref().to_string();
+    let path = format!("{}.{field}", object.boundary_path());
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let object = object.bind(py);
+        let value = match object.getattr(field.as_str()) {
+            Ok(value) => value,
+            Err(error) if error.is_instance_of::<PyAttributeError>(py) => {
+                object.get_item(field.as_str()).map_err(|_| {
+                    conversion_error(format!("missing required record field '{field}'"), &path)
+                })?
+            }
+            Err(error) => {
+                return Err(PythonError::from_pyerr(py, error, "attribute", &path));
+            }
+        };
+        store_object(value.unbind()).map(|value| value.with_child_path(path))
+    })
+    .map_err(PythonError::runtime)?
+}
+
+pub fn object_is_none(object: &ObjectHandle) -> Result<bool, PythonError> {
+    super::attach(|py| Ok(clone_handle(py, object)?.bind(py).is_none()))
+        .map_err(PythonError::runtime)?
+}
+
+pub fn at_path<T>(result: Result<T, PythonError>, path: String) -> Result<T, PythonError> {
+    result.map_err(|mut error| {
+        error.context = if error.context.is_empty() {
+            path
+        } else if error.context.starts_with('[') || error.context.starts_with('.') {
+            format!("{path}{}", error.context)
+        } else {
+            format!("{path}.{}", error.context)
+        };
+        error
+    })
+}
+
+fn conversion_error(message: impl Into<String>, context: impl Into<String>) -> PythonError {
+    PythonError {
+        kind: "conversion".to_string(),
+        exception_type: "TypeError".to_string(),
+        message: message.into(),
+        traceback: String::new(),
+        context: context.into(),
+    }
+}

--- a/demos/m4_demo/README.md
+++ b/demos/m4_demo/README.md
@@ -1,0 +1,30 @@
+# M4 Recursive Conversion And Opaque Lifecycle Demo
+
+M4's runnable demo is the dependency-pinned biip/schwifty program at
+[`verification/areas/python_interop/fixtures/simple_import/biip_schwifty_full_example.sifr`](../../verification/areas/python_interop/fixtures/simple_import/biip_schwifty_full_example.sifr).
+It stays in the Python interop verification project so its real Python
+dependencies and lockfile remain authoritative.
+
+The program demonstrates the milestone in four sections:
+
+1. Closed `Summary` records cross the Python boundary recursively inside a
+   list, option, and tuple.
+2. `@python.opaque` declarations seal biip and schwifty identities without
+   exposing structural handle fields.
+3. `@python.attr(Self.*)` methods read typed attributes through fallible
+   `Result` boundaries.
+4. Factories validate Python types, and the compiled program checks the nested
+   values returned by biip, schwifty, and `builtins.tuple`.
+
+Run the demo and its dependency/trust/probe checks with:
+
+```bash
+bash demos/m4_demo/run.sh
+```
+
+The command must finish with the biip/schwifty example marked `passed` and the
+compiled program marker:
+
+```text
+sifr-python-interop:biip-schwifty:gtin=7032069804988:bic=DEUTDEFF
+```

--- a/demos/m4_demo/run.sh
+++ b/demos/m4_demo/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AREA_ROOT="${REPO_ROOT}/verification/areas/python_interop"
+RUNNER_ROOT="${AREA_ROOT}/runner"
+
+# Run only M4's canonical case. The other library examples belong to later
+# declaration-first milestones and intentionally are not part of this demo.
+uv run --project "${AREA_ROOT}" --locked python - "${RUNNER_ROOT}" <<'PY'
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+runner_root = Path(sys.argv[1])
+sys.path.insert(0, str(runner_root))
+
+from env import discover_paths
+from example_packages import _run_case, prepare_example_package
+from library_examples import LIBRARY_EXAMPLE_CASES
+
+paths = discover_paths()
+case = LIBRARY_EXAMPLE_CASES["biip-schwifty"]
+package_root = prepare_example_package(paths, "library", case)
+result = _run_case(paths, package_root, case)
+
+if result["status"] != "example-passed":
+    print(result.get("stdout", ""), end="")
+    print(result.get("stderr", ""), file=sys.stderr, end="")
+    raise SystemExit("M4 biip/schwifty demo failed")
+
+print(result["stdout"], end="")
+PY

--- a/internal_docs/stdlib_retained_compiler_intrinsics.toml
+++ b/internal_docs/stdlib_retained_compiler_intrinsics.toml
@@ -195,3 +195,12 @@ issue = "stdlib-native-boundary-completion"
 evidence_links = ["stdlib-native-boundary-completion"]
 reason = "Historical mixed preamble now contains only retained-by-design IOError and generated file-handle bridge glue used by builtin open; logging and random behavior have migrated to sifr_stdlib."
 preamble_files = ["io_file_handles.rs"]
+
+[[surface]]
+id = "declaration-first-python-runtime-glue"
+state = "retained-by-design"
+owner = "python-runtime-boundary"
+issue = "python-runtime-boundary"
+evidence_links = ["declaration-first-python-runtime"]
+reason = "Generated declaration-first Python wrappers are compiler-owned boundary glue that must call the sealed sifr_runtime::python identity, conversion, invocation, and lifecycle substrate directly."
+direct_runtime_roots = ["sifr_runtime::python"]

--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -138,7 +138,7 @@ Implementation progress:
 - [x] M1 sealed runtime identity and cleanup — [PR #2932](https://github.com/sifr-lang/sifr/pull/2932)
 - [x] M2 environment and trust authority cutover — [PR #2933](https://github.com/sifr-lang/sifr/pull/2933)
 - [x] M3 synchronous declaration core and complete call shapes — [PR #2934](https://github.com/sifr-lang/sifr/pull/2934)
-- [ ] M4 recursive conversion and opaque lifecycle
+- [x] M4 recursive conversion and opaque lifecycle — [PR #2935](https://github.com/sifr-lang/sifr/pull/2935)
 - [ ] M5 synchronous Python context managers
 - [ ] M6 hermetic package-local Python bridges
 - [ ] M7 owned asyncio runtime and async declarations

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m4-opus-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m4-opus-review-pass-1.md
@@ -1,0 +1,9 @@
+## Summary
+
+The M4 milestone is largely wired up correctly — sealed identities, semantic close consuming the receiver, target probes, cache-key fingerprints, `record_field` attribute-then-item, `expect_instance` factory rejection, must-use side table with control-flow-join checks, and a live biip/schwifty declaration-first binary. The runtime unit tests exercise semantic close, poison-on-failure, recursive nested-path errors, and factory mismatches with exact-once release assertions, all of which pass.
+
+However, the codegen for compound return types has two runtime-panic bugs (Tuple containing a Record / Option), the class-method must-use exit check drifts from the top-level one and can false-positive on bindings that were consumed inside popped nested scopes, reassignment silently abandons a live `cleanup=close` obligation, and the aggregate-transfer helper doesn't cover comprehensions/match. The declaration-first tests only substring-check rendered Rust and never build the wrapper, so the tuple/record and Option-in-tuple panics ship undetected. Findings #1–#4 must be fixed before this milestone can meet the M4 acceptance criteria; #5–#7 are ordering-safe but should follow.
+
+**Gate decision:** the top four findings each break an explicit M4 acceptance clause (no data-dependent panics in generated code, cleanup exact-once, must-use transfer through moves/returns/aggregates), and they are direct code defects rather than doc gaps.
+
+NOT SATISFIED

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m4-opus-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m4-opus-review-pass-2.md
@@ -1,0 +1,3 @@
+**Gate decision:** All six pass-1 blockers are correctly root-fixed, and the runtime tests exercise the exact-release path — but `crates/sifr_lowering/src/lower/statements/control_flow.rs` is 913 lines, which fails the 900-line file-size guardrail (`scripts/check_file_size_guardrails.py`) that the merge-gate profile runs. CLAUDE.md/AGENTS.md flag this as a hard requirement to satisfy before considering work complete, so the milestone cannot ship on this branch until the file is decomposed by responsibility.
+
+NOT SATISFIED

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m4-opus-review-pass-3.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m4-opus-review-pass-3.md
@@ -1,0 +1,24 @@
+Pass 2 flagged only the 900-line guardrail on `control_flow.rs`. Verifying the fix:
+
+**Extraction correctness (`crates/sifr_lowering/src/lower/must_use_obligations.rs:6-48`)**
+- Signature takes `branch_moved_states`, `branch_exits`, `saved_moved`, `has_else`, `range` and mutates `ctx`.
+- Logic preserved verbatim: zips branch state with exit flags, adds `(saved_moved, false)` when `!has_else` (fall-through), iterates `live_must_use_bindings`, and emits `OWN_USE_AFTER_MOVE` when a binding is consumed on some but not all continuing branches. Same message text.
+- Caller at `control_flow.rs:590-597` passes `else_body.is_some()` and the same `branch_exits` derived from `branch_const_integer_states`, matching pre-extraction inputs.
+- `mod must_use_obligations;` registered at `mod.rs:85`; visibility `pub(in crate::lower)` matches other lowering helpers.
+- Only caller: `lower_if`. No other join point relied on the inline logic, so the extraction is complete.
+
+**Guardrails**
+- `scripts/check_file_size_guardrails.py`: PASS (2501 files, limit 900) — `control_flow.rs` at 892.
+- `scripts/check_hir_maintainability_guardrails.py`: PASS.
+- `close_opaque_obligation_rejects_partial_branch_consumption` (regression for the extraction): PASS.
+
+**Adjacent code untouched**
+- Assign-site checks (`control_flow.rs:255-261`, `344-357`, `394`) and record-must-use bindings unchanged.
+- Function-exit rejection (`annotations_and_function_lowering.rs:673-692, 821-838`) and class-body wiring (`class_body_lowering.rs:492-521`) still route through the same `ctx.live_must_use_bindings` surface.
+- No new call sites needed; nothing else changed beyond the module move.
+
+No semantic drift. No new actionable blockers.
+
+Gate reason: Pass 2's only blocker (900-line guardrail) is resolved by a responsibility-based extraction that preserves inputs, outputs, error code, and message; guardrails and the extraction's regression test pass; no other code paths were altered.
+
+SATISFIED

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m4-opus-review-pass-4.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m4-opus-review-pass-4.md
@@ -1,0 +1,36 @@
+I've reviewed the narrow M4 correction in `crates/sifr_lowering/src/lower/classes/class_body_lowering.rs` and traced its interactions with the ownership/convention/must-use paths.
+
+**What the correction actually does**
+
+```rust
+let convention = if ctx.must_use_obligation_for_type(&param_ty).is_some() {
+    ast_convention_to_param(param.parameter.convention, &param_ty)
+} else {
+    ParamConvention::default()
+};
+```
+
+- `ParamConvention::default()` = `{ Borrow, Immutable }` (types/definitions.rs:311–315). This is exactly the value used in the pre‑M4 line `convention: ParamConvention::default()`, so ordinary class method params round‑trip to the same ABI they had before M4.
+- `must_use_obligation_for_type` (mod_context.rs:216–234) only returns `Some` for opaque Python classes with `cleanup ∈ {close, async_close, context, async_context}` and their container wrappers. Every non‑opaque Move/Copy type falls to the `default()` branch.
+
+**M4 opaque cleanup=close guarantees still hold**
+
+- Opaque `own`‑annotated params: the must‑use branch runs `ast_convention_to_param`, producing `Own`. The subsequent block at 496–501 then calls `record_must_use_binding`, so the exit check at 507–524 will flag any owned opaque param that isn't moved/closed. Unchanged behavior.
+- Opaque `borrow` (implicit) params: `ast_convention_to_param(borrow, Move)` = `Borrow`; `is_owned() == false`; not tracked. Correct — a borrowed opaque doesn't take on the must‑use obligation.
+- Consuming `Self.close` receiver: `receiver_is_owned` (python_interop.rs:604–609) is derived directly from AST `own self` before `params` is populated, so `HirParam.convention` for the receiver was never involved. The `semantic_close_methods` counter (583–599) and the "consuming method is reserved for cleanup=close" guard (601–614) both key off `python_interop.consumes_receiver`, which is untouched by this correction.
+- Container types (`Result[None, PythonError]`, `list[Opaque]`, `dict[str, Opaque]`, unions/tuples containing opaque) still flow through `must_use_obligation_for_type` recursively (mod_context.rs:224–231), so nested obligations propagate.
+
+**Ordinary class method ABI is restored**
+
+- `class_method_emitter::lower_class_method_param_type` (crates/sifr_codegen/src/class_method_emitter.rs:311–320) emits `&T` only when `param_ty.ownership() != Copy && convention.is_borrowed()`. Restoring `ParamConvention::default() = Borrow` for non‑opaque types keeps Copy types (like `i64`) as owned in the emitted Rust signature — the send‑call regression's precondition is removed at the source.
+- The FunctionType stored by `class_type_collection.rs` still routes params through `FunctionType::new` (Own for Copy/TypeVar, Borrow for Move), which is what channel/callable type inference reads. Both sides now agree again.
+- Free functions still apply `ast_convention_to_param` unconditionally (annotations_and_function_lowering.rs:465, 493, 514, 541). The asymmetry between class methods (narrow, opaque‑only) and free functions (full AST) is intentional pre‑M4 compatibility, not a regression.
+
+**Validation cross‑checked**
+
+- The correction's `if is_owned() { record_must_use_binding }` block (497–501) is the sole gate for HirParam‑derived must‑use bookkeeping, and it's driven by the corrected convention — so narrowing convention to must‑use types is exactly what the tracker consumes.
+- The runtime reports `cargo test -p sifr_lowering python_interop --lib` = 22 passed and `run_e2e_pass.sh --profile create-pr` = 130 passed / 0 failed, which is the merge‑gate profile.
+
+No actionable blocker found. The correction is a minimal restoration of pre‑M4 convention for non‑opaque types that leaves every must‑use/opaque cleanup enforcement path — recording, exit rejection, semantic‑close counting, consuming‑receiver guard — intact.
+
+SATISFIED

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m4-opus-review-pass-5.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m4-opus-review-pass-5.md
@@ -1,0 +1,31 @@
+I've completed a thorough independent audit. Based on my investigation, here is my final review.
+
+## Review Summary
+
+**IR & HIR contracts** — `PythonInteropDeclaration` gains `cleanup: Option<PythonCleanupPolicy>` and `consumes_receiver: bool`; `HirClassKind::PythonOpaque(...)` stores the declaration on the class. `HirClass::python_opaque_declaration()` gives codegen a single source of truth. Only `Drop` and `Close` policies parse; `async_close`, `context`, and `async_context` explicitly hard-error via `PYRES_UNIMPLEMENTED_DECLARATION` (crates/sifr_lowering/src/lower/python_interop.rs:270–301). No later-milestone syntax is activated.
+
+**Lowering** — Opaque metadata is collected in a pre-pass in `mod_impl.rs` so signature validation sees it regardless of declaration order. `is_direct_type` recursively accepts nested lists, tuples, dicts, closed records, and opaque classes. Non-send is enforced via `parent_class: Some("NonSend")` and constructor removal in `class_type_collection.rs:695–708`, wiring into the existing `NonSend` marker check used by task-scope and IPC-payload lowering. Opaque classes with structural fields are rejected at `class_body_lowering.rs:670–676`.
+
+**Must-use side table** — `ctx.live_must_use_bindings` is recorded on `ann_assign`, `assign` (including first-assignment specialization), reset on reassignment (`control_flow.rs:344–357`), rejected on `_` discard (`control_flow.rs:259–265`), and transferred on return through `Name`, `ListLiteral`/`SetLiteral`/`TupleLiteral`/`DictLiteral`, `ConstructorCall`, `IteratorCall`, comprehensions, `OkWrap`/`QuestionMark`/`ErrWrap`, and `IfExpr` (`return_lowering.rs:130–212`). Control-flow join validation lives in the extracted `must_use_obligations::validate_branch_join` (`must_use_obligations.rs:6-48`) and is invoked from `lower_if` after `saved_moved`/`branch_moved_states` are restored. Function-exit rejection sorts alphabetically before diagnosing, so ordering is stable. `python_consuming_methods` is filled from the pre-pass so `mark_moved_with_flow` fires at the call site (`methods_lambdas_and_comprehensions.rs:257-266`). Class-method must-use narrows `ast_convention_to_param` to must-use types only (pass 4 correction), preserving ordinary class ABI.
+
+**Codegen** — `python_interop_direct.rs` recursively lowers inputs (`from_list_results`/`from_tuple_results`/`from_dict_results`/`from_record_results`) and outputs (`list_items`/`tuple_items`/`dict_str_items`/`record_field`). `expect_instance` gates opaque factory returns and releases the rejected identity on mismatch (`object_ops.rs:181-196`). `semantic_close` consumes the receiver, poisons on Python failure, and closes on success (`opaque_ops.rs:5–28`). `RustParam::SelfValue` is emitted only for `consumes_receiver` methods and the opaque class derives only `Debug`. `python_opaque_classes` is populated from `emit_module_body` and threaded into method-body lowering.
+
+**Driver & plan** — `PythonTargetProbe.expects_type` propagates through the plan into `apply_python_interop_metadata`; the runtime probe reports `is_type` via `isinstance(value, type)` and rejects opaque targets that resolve to a non-type; the signature validation is scoped to `PythonInteropDecoratorKind::Function` so opaque callables aren't re-validated as callables. Cache key gains `:callable|type:` axis.
+
+**Runtime** — `ForeignObject` now holds a `Mutex<ForeignObjectState>` with `Open`/`Poisoned`/`Closed`. `poison()` transitions Open→Poisoned; both `Poisoned` and `Open` drop paths release via `release_object`, so the poisoned identity still decrefs when the last `Arc` drops. Boundary paths are attached via `with_child_path` and propagated through `list_items`/`tuple_items`/`dict_str_items`/`record_field`. `expect_instance` releases the resolved factory and, on mismatch, the rejected value before returning `Err`, closing the leak seen in earlier passes.
+
+**Non-send identity** — `parent_class = "NonSend"` for opaque classes trips the existing NonSend enforcement in `task_scope_calls`/`ipc_payload_calls`; no `send=` grammar exists.
+
+**Demo & fixture** — `demos/m4_demo/run.sh` invokes the biip/schwifty case through the Python interop runner and checks the biip/schwifty stdout marker; `builtins` is added to `import_roots` so `builtins.tuple` is authorized.
+
+**Guardrails** — `check_file_size_guardrails.py` PASSES (touched files: python_interop_direct.rs 899, control_flow.rs 892, class_body_lowering.rs 788, python_interop.rs 758 — all under 900). HIR maintainability guardrails pass.
+
+**Phase tracker** — `plans/issues/active/ad-hoc-declaration-first-python-interop.md` now marks M4 checked and links PR #2935.
+
+## Verdict
+
+Every M4 acceptance clause (recursive conversion, boundary-path errors with exact-once release, opaque lifecycle with distinct drop/close/poison, non-send identity, ordinary class ABI unchanged, no later-milestone activation) has a corresponding implementation and evidence path. Pass 1's four correctness gaps (compound-return panic patterns, popped-scope must-use, reassignment abandonment, aggregate/comprehension transfer) are fixed and covered by unit tests. Pass 2's file-size regression on `control_flow.rs` is resolved by the responsibility-based extraction in `must_use_obligations.rs`. Pass 3 verified the extraction; pass 4 verified the narrow must-use convention restoration; the authoritative gate then passed. The current implementation adds no new regressions on top of that.
+
+No actionable blocker.
+
+SATISFIED

--- a/verification/areas/python_interop/declaration_capabilities.json
+++ b/verification/areas/python_interop/declaration_capabilities.json
@@ -36,15 +36,15 @@
       "id": "opaque-lifecycle",
       "surface": "@python.opaque, @python.attr, and @python.item",
       "target_state": "declaration-supported",
-      "implementation_status": "reserved",
+      "implementation_status": "active",
       "activation_owner": "opaque-lifecycle",
       "required_evidence": ["positive", "negative", "cleanup", "live"],
       "evidence": [
-        {"kind": "positive", "status": "planned", "owner": "opaque method/attribute/item matrix"},
-        {"kind": "negative", "status": "planned", "owner": "moved/closed/poison diagnostics"},
-        {"kind": "cleanup", "status": "planned", "owner": "exact-once drop and close fixtures"},
+        {"kind": "positive", "status": "passing", "owner": "opaque factory, method, attribute, item, and recursive conversion matrices"},
+        {"kind": "negative", "status": "passing", "owner": "factory type, abandonment, partial-branch, moved, and poison diagnostics"},
+        {"kind": "cleanup", "status": "passing", "owner": "runtime nested partial-failure and semantic-close exact-release assertions"},
         {"kind": "cancellation", "status": "not-applicable", "owner": "owned async close runtime"},
-        {"kind": "live", "status": "planned", "owner": "biip and schwifty binaries"}
+        {"kind": "live", "status": "passing", "owner": "simple_import/biip_schwifty_full_example.sifr declaration-first binary"}
       ]
     },
     {

--- a/verification/areas/python_interop/fixtures/simple_import/biip_schwifty_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/simple_import/biip_schwifty_full_example.sifr
@@ -1,68 +1,90 @@
-from sifr.python import (
-    Object,
-    PythonError,
-    call,
-    call_attr,
-    close,
-    from_str,
-    get_attr,
-    import_module,
-    to_int,
-    to_str,
-)
+from sifr.python import PythonError
+
+
+class Summary:
+    label: str
+    scores: list[int]
+
+
+@python.opaque(type=biip.gtin.GtinFormat, cleanup=drop)
+class GtinFormat:
+    @python.attr(Self.value)
+    def value(self) -> Result[int, PythonError]: ...
+
+
+@python.opaque(type=biip.gtin.Gtin, cleanup=drop)
+class Gtin:
+    @python.attr(Self.value)
+    def value(self) -> Result[str, PythonError]: ...
+
+    @python.attr(Self.format)
+    def format(self) -> Result[GtinFormat, PythonError]: ...
+
+    @python.attr(Self.check_digit)
+    def check_digit(self) -> Result[int, PythonError]: ...
+
+
+@python.opaque(type=biip._parser.ParseResult, cleanup=drop)
+class ParseResult:
+    @python.attr(Self.gtin)
+    def gtin(self) -> Result[Gtin, PythonError]: ...
+
+
+@python.opaque(type=schwifty.BIC, cleanup=drop)
+class Bic:
+    @python.attr(Self.country_code)
+    def country_code(self) -> Result[str, PythonError]: ...
+
+    @python.attr(Self.bank_code)
+    def bank_code(self) -> Result[str, PythonError]: ...
+
+
+@python(biip.parse)
+def parse_identifier(text: str) -> Result[ParseResult, PythonError]: ...
+
+
+@python(schwifty.BIC)
+def bic(text: str) -> Result[Bic, PythonError]: ...
+
+
+@python(builtins.tuple)
+def tuple_copy(values: list[Summary]) -> Result[tuple[Summary | None, Summary], PythonError]: ...
 
 
 @blocking_io
 def main() -> Result[None, PythonError]:
     try:
-        biip: Object = import_module("biip")
-        schwifty: Object = import_module("schwifty")
+        parsed: ParseResult = parse_identifier("7032069804988")
+        gtin: Gtin = parsed.gtin()
+        gtin_value: str = gtin.value()
+        gtin_format: GtinFormat = gtin.format()
+        gtin_format_value: int = gtin_format.value()
+        check_digit: int = gtin.check_digit()
 
-        gtin_text: Object = from_str("7032069804988")
-        parsed: Object = call_attr(biip, "parse", [gtin_text], [])
-        gtin: Object = get_attr(parsed, "gtin")
-        gtin_value_obj: Object = get_attr(gtin, "value")
-        gtin_value: str = to_str(gtin_value_obj)
-        gtin_format_obj: Object = get_attr(gtin, "format")
-        gtin_format_value_obj: Object = get_attr(gtin_format_obj, "value")
-        gtin_format: int = to_int(gtin_format_value_obj)
-        check_digit_obj: Object = get_attr(gtin, "check_digit")
-        check_digit: int = to_int(check_digit_obj)
+        bank_id: Bic = bic("DEUTDEFF")
+        bic_country: str = bank_id.country_code()
+        bic_bank: str = bank_id.bank_code()
 
-        bic_class: Object = get_attr(schwifty, "BIC")
-        bic_text: Object = from_str("DEUTDEFF")
-        bic: Object = call(bic_class, [bic_text], [])
-        bic_country_obj: Object = get_attr(bic, "country_code")
-        bic_country: str = to_str(bic_country_obj)
-        bic_bank_obj: Object = get_attr(bic, "bank_code")
-        bic_bank: str = to_str(bic_bank_obj)
+        first_summary: Summary = Summary("first", [1])
+        second_summary: Summary = Summary("typed", [7, 8])
+        copied: tuple[Summary | None, Summary] = tuple_copy([first_summary, second_summary])
+        maybe_first: Summary | None = copied[0]
+        copied_summary: Summary = copied[1]
 
         passed: bool = (
             gtin_value == "7032069804988"
-            and gtin_format == 13
+            and gtin_format_value == 13
             and check_digit == 8
             and bic_country == "DE"
             and bic_bank == "DEUT"
+            and maybe_first is not None
+            and copied_summary.label == "typed"
+            and copied_summary.scores == [7, 8]
         )
-
-        closed_bic_bank_obj: None = close(bic_bank_obj)
-        closed_bic_country_obj: None = close(bic_country_obj)
-        closed_bic: None = close(bic)
-        closed_bic_text: None = close(bic_text)
-        closed_bic_class: None = close(bic_class)
-        closed_check_digit_obj: None = close(check_digit_obj)
-        closed_gtin_format_value_obj: None = close(gtin_format_value_obj)
-        closed_gtin_format_obj: None = close(gtin_format_obj)
-        closed_gtin_value_obj: None = close(gtin_value_obj)
-        closed_gtin: None = close(gtin)
-        closed_parsed: None = close(parsed)
-        closed_gtin_text: None = close(gtin_text)
-        closed_schwifty: None = close(schwifty)
-        closed_biip: None = close(biip)
         if passed:
             print("sifr-python-interop:biip-schwifty:gtin=7032069804988:bic=DEUTDEFF")
         else:
-            raise PythonError("biip/schwifty full example did not validate expected identifiers")
-    except PythonError as e:
-        raise e
+            raise PythonError("biip/schwifty declarations returned unexpected identifiers")
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/runner/library_examples.py
+++ b/verification/areas/python_interop/runner/library_examples.py
@@ -11,7 +11,7 @@ LIBRARY_EXAMPLE_CASES = {
         case_id="biip-schwifty",
         relative_source="simple_import/biip_schwifty_full_example.sifr",
         stdout_marker="sifr-python-interop:biip-schwifty:gtin=7032069804988:bic=DEUTDEFF",
-        import_roots=("biip", "schwifty"),
+        import_roots=("biip", "builtins", "schwifty"),
         native_roots=(),
     ),
     "pyarrow": ExampleCase(


### PR DESCRIPTION
## What changed

- adds recursive typed Python boundary conversion for options, lists, tuples, string-key dictionaries, closed records, and opaque identities with precise nested error paths
- adds sealed `@python.opaque` classes, factories, `Self` methods, attributes, item access, exact type checks, and automatic-vs-semantic cleanup
- adds general must-use ownership obligations for `cleanup=close`, including move/return/aggregate/control-flow transfer checks
- extends runtime object state with open/poisoned/closed behavior and exact-once semantic close
- wires opaque targets into Python requirement, trust, probe, and cache authority
- activates M4 verification evidence and a runnable biip/schwifty milestone demo

## Why

M4 activates the declaration-first opaque lifecycle and recursive conversion contract. Typed Python objects can now cross the boundary without exposing raw handles, while close-required resources cannot be abandoned or reused after consumption.

## Validation

- `scripts/run_all_tests.sh --profile create-pr` — passed
- `cargo test -p sifr_lowering python_interop --lib` — 22 passed
- `verification/runner/e2e/run_e2e_pass.sh --profile create-pr` — 130 passed
- `bash demos/m4_demo/run.sh` — passed
- Claude Opus review rounds 1–4 — final result SATISFIED
