### PR TITLE
docs(plan): mark bridge inventory wave complete

### DIFF
--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -376,7 +376,7 @@ Depends on M1 sealed identities and M4 conversion.
 
 Implementation waves:
 
-- [ ] Package bridge source and inventory substrate:
+- [x] Package bridge source and inventory substrate — [PR #2945](https://github.com/sifr-lang/sifr/pull/2945):
   - Discover only package-root `src/python_bridges/**/*.py`, independent of
     custom Sifr source roots; reject misplaced bridge roots, invalid module
     paths, duplicate modules, invalid Python syntax, and dynamic import calls as


### PR DESCRIPTION
## Summary
- mark the first M6 implementation wave complete
- link the merged, fully validated and Opus-reviewed implementation PR #2945
- leave the M6 milestone open for its remaining four waves

## Review
- verified the diff changes only the intended wave checkbox and merged PR link
- `git diff --check`