### PR TITLE
Record M6 Python bridge closure

### DIFF
--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -136,7 +136,7 @@ Implementation progress:
 - [x] M3 synchronous declaration core and complete call shapes — [PR #2934](https://github.com/sifr-lang/sifr/pull/2934)
 - [x] M4 recursive conversion and opaque lifecycle — [PR #2935](https://github.com/sifr-lang/sifr/pull/2935)
 - [x] M5 synchronous Python context managers — [PR #2942](https://github.com/sifr-lang/sifr/pull/2942)
-- [x] M6 hermetic package-local Python bridges
+- [x] M6 hermetic package-local Python bridges — [PR #2953](https://github.com/sifr-lang/sifr/pull/2953)
 - [ ] M7 owned asyncio runtime and async declarations
 - [ ] M8 async context managers
 - [ ] M9 typed callback lifetimes and dispatch
@@ -419,7 +419,7 @@ Implementation waves:
     inputs in package, driver, and generated-artifact caches.
   - Prove archive unpack/install/build/run uses only archived bridge inputs and
     the generated binary uses no writable extraction directory.
-- [x] Complete bridge evidence and milestone closure:
+- [x] Complete bridge evidence and milestone closure — [PR #2953](https://github.com/sifr-lang/sifr/pull/2953):
   - Cover loader-before-main ordering, first-position and post-mutation reserved
     resolution, collision rejection, sibling import rewriting, deterministic
     traceback filenames, cache invalidation, invalid syntax, rejected dynamic

--- a/plans/reviews/active/ad-hoc-python-interop-m6-pr-2953-review-round1.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m6-pr-2953-review-round1.md
@@ -1,0 +1,1 @@
+SATISFIED

--- a/plans/reviews/active/ad-hoc-python-interop-m6-tracker-pr-2954-review-round1.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m6-tracker-pr-2954-review-round1.md
@@ -1,0 +1,18 @@
+Review complete. Findings summary:
+
+**Verification results:**
+
+1. **Phase links** — Both additions accurate:
+   - Line 139: M6 milestone box → PR #2953 ✓ (PR title "Complete hermetic package-owned Python bridge milestone", merged 2026-07-13, closes M6)
+   - Line 422: "Complete bridge evidence and milestone closure" wave → PR #2953 ✓ (matches PR #2953 body: "close the M6 package-owned Python bridge milestone…")
+   - Prior wave links (PRs #2945, #2947, #2949, #2951) unchanged and still consistent
+
+2. **Checklist honesty** — Both boxes were already `[x]` before this PR; PR only adds the backlink text. PR #2953 is genuinely MERGED (verified via `gh pr view 2953`), so `[x]` is truthful. No premature checks introduced; no other M6 wave items left unlinked. Global "Review Checklist" (lines 847–864) remains unchecked but that matches the established cross-milestone pattern (M0–M5 line items there also stayed unchecked at their closures).
+
+3. **Preserved actual-PR review artifact** — `plans/reviews/active/ad-hoc-python-interop-m6-pr-2953-review-round1.md` is a new file with the single word `SATISFIED`. Terser than the M5 equivalent (`ad-hoc-python-interop-m5-closure-pr2942-review-round1.md`, 27 lines with VERDICT prefix and evidence pointers), but matches the minimalist precedent already accepted in-tree for `ad-hoc-python-interop-m6-wave2-pr2947-review-round1.md` (one line, "VERDICT: SATISFIED"). Not a blocking inconsistency.
+
+4. **Scope** — PR is genuinely documentation-only (2 files, +3/-2). No code churn, no unrelated tracker items touched.
+
+No actionable findings.
+
+SATISFIED


### PR DESCRIPTION
## Summary
- add merged PR #2953 to the M6 implementation and closure-wave tracker entries
- preserve the SATISFIED actual-PR Opus review artifact

## Validation
- documentation-only follow-up to validated and merged PR #2953