### PR TITLE
Plan owned asyncio Python interop milestone

### DIFF
--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -501,6 +501,88 @@ Validation:
 - Concurrent coroutine target tests proving one loop identity.
 - Compiled httpx-style async client example.
 
+Implementation waves (one locally validated and reviewed PR per wave):
+
+- [ ] Prepare coroutine and async-close frontend contracts behind the existing
+  `SIFR-PYRES-0002` gate:
+  - Parse and validate the internal contract for bodyless
+    `@python.coroutine(path)` `async def` functions, factories, and methods;
+    retain `PythonInteropEffect::Async`, call-shape metadata, package/bridge
+    target authority, and the ordinary declaration conversion contract without
+    making the syntax publicly executable yet.
+  - Mark bodyless async interop declarations as `Suspends` in the existing
+    suspension summary so they bypass normal body lowering and the `NoSuspend`
+    fake-async diagnostic without adding a summary variant or removing their
+    ordinary async function identity.
+  - Prepare stable diagnostics for sync/async decorator substitution, borrowed
+    async results, non-consuming close, and unsupported cleanup shapes. Keep
+    `cleanup=async_close` gated until its runtime lifecycle is complete.
+- [ ] Add the application-owned asyncio runtime and raw submission path:
+  - Start one loop on one named OS thread after CPython and bridge-loader setup;
+    publish a thread-safe submission handle only after loop readiness.
+  - Maintain an explicit accepting/running/stopping/stopped state machine and a
+    registry keyed by monotonically assigned submission ids. Reject work once
+    shutdown starts, and prove initialization failure cannot leave a thread.
+  - Wire loop bootstrap only when the resolved target uses an async Python
+    declaration or the raw coroutine intrinsic. Replace raw `asyncio.run` with
+    owned-loop submission while preserving the raw API's synchronous
+    `blocking_io` classification and explicit-offload requirement.
+  - Prove repeated and concurrent raw calls use one loop/thread identity.
+- [ ] Land the cooperative cancellation carrier and direct task paths:
+  - Replace the direct generated-task abort handle with a cancellation carrier
+    for `task.cancel`, cancel-and-join, and timeout. At Python-await entry the
+    submission atomically claims that carrier and registers its exact-task
+    cancellation hook.
+  - A claimed cancellation signals the exact asyncio task and makes the Sifr
+    supervisor await the child and Python terminal latch; an unclaimed
+    cancellation keeps the existing Tokio-abort behavior. A cancellation racing
+    registration either aborts before Python submission or is observed by the
+    newly registered submission, never leaving untracked Python work.
+  - Prove cancellation-before-registration, claimed terminal waiting,
+    unclaimed fallback abort, and timeout without changing the behavior of
+    tasks that never enter a Python await.
+- [ ] Complete cancellation-aware supervisors and ordered shutdown substrate:
+  - Route scope/group fail-fast, race/select losers, and join-set cancellation
+    through the same carrier, preserving current abort behavior for unclaimed
+    ordinary Sifr tasks while terminally waiting for claimed Python work.
+  - Add fail-fast sibling, race/select loser, join-set, cancellation suppression,
+    and terminal-latch ordering tests before typed wrappers depend on them.
+  - Define shutdown phases now: stop external admissions; invoke the M9 callback
+    shutdown hook (a no-op ordered slot until M9); run registered async cleanup
+    while the loop is live; cancel and terminally drain remaining submissions;
+    stop the loop; join its thread.
+- [ ] Generate typed async declaration wrappers behind the public gate:
+  - Submit compiler-private owned inputs and object-store identities; resolve
+    targets, convert arguments, invoke, require an awaitable, await, and convert
+    the owned result on the loop thread.
+  - Cover functions, opaque factories, borrowed methods, consuming methods,
+    positional/keyword/variadic/omitted arguments, recursive values, opaque
+    results, package bridges, and Python/conversion/awaitable-shape failures.
+  - Keep opaque values non-send in Sifr and freeze borrowed receivers for the
+    full await without moving raw Python pointers across threads.
+  - Prove two concurrent typed wrappers observe the same loop/thread identity,
+    while the syntax remains gated until cancellation and cleanup are complete.
+- [ ] Complete consuming async-close lifecycle behind the public gate:
+  - Require a consuming `@python.coroutine(Self.<member>)` close declaration for
+    `cleanup=async_close`; transfer exclusive ownership before submission and
+    close exactly once.
+  - Poison on cleanup failure and reject reuse, duplicate close, or abandonment
+    of an `async_close` obligation. Cover success, failure, poison,
+    use-after-close, cancellation, and shutdown interaction.
+- [ ] Atomically activate async declarations and close M7 evidence:
+  - Lift the `@python.coroutine` and `cleanup=async_close` gates only after the
+    owned loop, typed wrappers, cooperative cancellation, terminal shutdown,
+    and consuming lifecycle are present in the same production path.
+  - Map `CancelledError` to the active Sifr cancellation cause and prove that
+    cancellation waits Python `finally`; if Python suppresses cancellation, its
+    later return or exception wins normally.
+  - Add the full success/failure/conversion/cancellation/suppression/shutdown and
+    async-close matrices, a compiled httpx-style client fixture, concurrent
+    one-loop identity proof, and `demos/m7_demo` using real binary output.
+  - Activate coroutine and async-close capability evidence; update user and
+    architecture docs, exit evidence, roadmap, review records, milestone
+    checkboxes, and merged PR links.
+
 ### M8. Async Context Managers
 
 Depends on M5 context semantics and M7 loop ownership.

--- a/plans/reviews/active/ad-hoc-python-interop-m7-plan-pr-2955-review-round1.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-plan-pr-2955-review-round1.md
@@ -1,0 +1,25 @@
+I've reviewed the PR contents against each of the concerns you listed. Here is my assessment.
+
+## Review of PR #2955 — Seven-wave M7 plan
+
+**Public gating** — Wave 1 explicitly prepares frontend contracts "behind the existing `SIFR-PYRES-0002` gate" and keeps `cleanup=async_close` gated. Waves 5 and 6 land typed wrappers and consuming lifecycle "behind the public gate." Wave 7 is the sole atomic activation, lifting both gates only after all substrate (owned loop, wrappers, cancellation, terminal shutdown, consuming lifecycle) is present in one production path. Matches the Phase Delivery Rule.
+
+**Cooperative cancellation / abort fallback semantics** — Wave 3 specifies the exact carrier claim mechanic: "at Python-await entry the submission atomically claims that carrier and registers its exact-task cancellation hook"; claimed → signal exact asyncio task + await child + terminal latch; unclaimed → retain Tokio abort; registration race is closed ("aborts before Python submission or is observed by the newly registered submission, never leaving untracked Python work"). Concrete and unambiguous.
+
+**Supervisor coverage** — Split correctly. Wave 3 covers direct task paths (`task.cancel`, cancel-and-join, timeout). Wave 4 covers scope/group fail-fast, race/select losers, and join-set through the same carrier, preserving unclaimed abort behavior. Fail-fast sibling, race/select loser, join-set, suppression, and terminal-latch ordering tests land before typed wrappers depend on them.
+
+**Loop lifecycle** — Wave 2 conditionally wires bootstrap only when async decls / raw intrinsic are present; adds accepting/running/stopping/stopped state machine + submission-id registry; rejects post-shutdown admissions; proves initialization failure cannot leave a thread. Wave 4 defines complete phased shutdown with the M9 callback hook as a no-op ordered slot in the correct position so M9 will not reshape ordering.
+
+**Bodyless suspension** — Wave 1 names the mechanism explicitly (option ii from round-1 §5): mark bodyless async interop declarations as `Suspends` in the existing suspension summary, bypassing `NoSuspend` without adding a variant or losing async identity.
+
+**Async-close sequencing** — Wave 1 keeps `cleanup=async_close` gated; Wave 6 completes the full consuming runtime lifecycle (transfer-before-submission, close-once, poison-on-failure, reject reuse/duplicate/abandonment, cancellation + shutdown interaction) behind the gate; Wave 7 activates atomically with `@python.coroutine`. Runtime completion strictly precedes activation.
+
+**Final evidence** — Wave 7 delivers the full success/failure/conversion/cancellation/suppression/shutdown and async-close matrices, the compiled httpx-style client fixture, concurrent one-loop identity proof, `demos/m7_demo` with real binary output, `CancelledError` mapping, `finally`-waiting proof and suppression semantics, plus capability activation + all doc/roadmap/review/checkbox/PR-link updates.
+
+**Independent reviewability** — Each wave stands alone: Wave 1 is a frontend-only diff that keeps grammar gated; Wave 2 lands runtime substrate with its own raw-path identity proof; Waves 3 and 4 cover direct-path then structured-path cancellation with their own tests; Wave 5 adds typed wrappers with a two-wrapper concurrent one-loop identity assertion (round-1 §6 gap closed); Wave 6 completes async-close lifecycle; Wave 7 activates and closes evidence. Because the syntax remains gated through Waves 1–6, no wave depends on a symbol the next wave has not yet added.
+
+Round-1 blocking findings §1/§2/§3 and refinements §4–§8 are all addressed in the diff text — the round-2 verification artifact in the PR is accurate.
+
+No actionable defects remain.
+
+SATISFIED

--- a/plans/reviews/active/ad-hoc-python-interop-m7-plan-review-round1.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-plan-review-round1.md
@@ -1,0 +1,297 @@
+# M7 Owned Asyncio Runtime And Async Declarations — Plan Review, Round 1
+
+## Scope
+
+Review of the proposed five-wave implementation plan for milestone M7 added
+to `plans/issues/active/ad-hoc-declaration-first-python-interop.md`. The
+review compares each wave against M7's task list, acceptance criteria, and
+validation matrix, against the durable contracts in
+`internal_docs/python_interop_declaration_architecture.md` and
+`internal_docs/python_interop_protocol_architecture.md`, and against the
+current implementation surfaces the waves must touch. It is a plan review
+only; no source files were modified.
+
+## Reference Points Used
+
+- Phase Delivery Rule
+  (`plans/issues/active/ad-hoc-declaration-first-python-interop.md` around
+  lines 114–128): "Internal substrate may land before its public syntax, but
+  no PR may expose a temporary public grammar or a second runtime
+  representation. Each milestone ends with one production path for the
+  behavior it activates. When a milestone replaces an existing authority or
+  representation, it updates every consumer, fixture, diagnostic, and
+  document in the same merge unit."
+- M6's own wave sequence (same file, lines 375–432) as the accepted pattern:
+  substrate + gating first (Waves 1–2, syntax kept behind
+  `SIFR-PYRES-0002`), atomic activation and target rewrite in one merge
+  unit (Wave 3), deployment/evidence closure after.
+- Async architecture: `internal_docs/python_interop_protocol_architecture.md`
+  §"Async Python Calls", §"Cancellation And Shutdown", §"Cleanup Policies";
+  `internal_docs/python_interop_declaration_architecture.md` §"Blocking And
+  Async".
+- Async concurrency contract: `internal_docs/async_concurrency_model.md`
+  §"Cancellation Vocabulary" (lines 160–182).
+- HIR/lowering surfaces:
+  - `crates/sifr_ir/src/python_interop.rs` — `PythonInteropEffect::{BlockingIo,
+    Async}` already exists but no code path constructs `Async`.
+  - `crates/sifr_lowering/src/lower/python_interop.rs` —
+    `PythonInteropStubBody::Bodyless` exists; every current declaration
+    hard-codes `effect: PythonInteropEffect::BlockingIo`; `Coroutine` still
+    routes through `SIFR-PYRES-0002`; `parse_opaque_class` gates
+    `async_close`/`async_context` behind `SIFR-PYRES-0002`.
+  - `crates/sifr_lowering/src/lower/async_await.rs:44-58` and
+    `crates/sifr_lowering/src/lower/async_effects.rs:20-48` — the
+    `NoSuspend` gate keyed off `collect_async_suspension_summaries` and
+    `ctx.async_functions`.
+  - `crates/sifr_lowering/src/lower/mod_impl.rs:216-231` — inserts every
+    `async def` into `ctx.async_functions` and stamps `WorkloadKind::BlockingIo`
+    on any function carrying a Python interop decorator (this stamps
+    coroutines as `BlockingIo` today).
+- Runtime surfaces:
+  - `crates/sifr_runtime/src/python/coroutine_ops.rs` — the current
+    `run_coroutine_blocking` calls `asyncio.run(...)` per invocation.
+  - `crates/sifr_runtime/src/python.rs` — initialization, guard drop,
+    `validate_shutdown`; no loop thread or submission registry yet.
+- Task supervisor codegen (e2e cache group
+  `crates/sifr/target/sifr_e2e_cache/groups/faf476fa59c49b20/src/main.rs`,
+  lines ~393–658, representative of generated code today) — `Task::cancel`,
+  `Task::cancel_and_join`, `Task::__sifr_timeout`, and
+  `TaskScope::__sifr_join_all` implement cancellation exclusively via Tokio
+  `abort_handle.abort()`. `abort()` drops the child future, so the child
+  cannot itself `await` a Python task's terminal state before the parent
+  scope proceeds. `crates/sifr_runtime/src/interop.rs:504` and
+  `crates/sifr_runtime/src/http.rs:{227,271}` show the same abort-only
+  pattern in runtime-owned tasks.
+
+## Blocking Findings
+
+### 1. Wave ordering conflicts with the phase Delivery Rule.
+
+Wave 1 is written as an activation wave:
+
+> "Activate `@python.coroutine(path)` only on bodyless `async def`
+> functions… preserve `PythonInteropEffect::Async`… Route ellipsis through
+> the interop `Bodyless` path before normal async body lowering and
+> `NoSuspend` checking. Reject sync/async decorator substitution, borrowed
+> async results, non-consuming async close, and unsupported cleanup shapes
+> with stable diagnostics. Activate `cleanup=async_close` only when a
+> consuming `@python.coroutine(Self.<member>)` close declaration satisfies
+> the sealed opaque lifecycle contract."
+
+Yet the runtime pieces that make that grammar executable land later: the
+owned loop and submission API in Wave 2, the generated async wrappers in
+Wave 3, structured cancellation in Wave 4, and consuming-ownership transfer
+plus poison-on-cleanup-failure in Wave 5. Between Wave 1 and Wave 5, a user
+`@python.coroutine` declaration or `cleanup=async_close` opaque would parse
+and lower but would have no end-to-end production path. That is exactly the
+"temporary public grammar" the phase Delivery Rule forbids. M6's own wave
+plan (same phase file) demonstrates the correct pattern: Waves 1–2 land
+substrate while keeping `bridge.*` behind `SIFR-PYRES-0002`; Wave 3
+atomically rewrites targets and lifts the gate in one merge unit.
+
+Failure scenario: a PR at the Wave-1 boundary is merged in isolation.
+`@python.coroutine(module.func)` on `async def` compiles through
+`collect_python_interop_declarations` (Coroutine no longer hits
+`PYRES_UNIMPLEMENTED_DECLARATION`), reaches codegen with
+`PythonInteropEffect::Async`, and either produces no wrapper (there is no
+async wrapper emitter yet in `sifr_codegen`) or emits code calling
+symbols that Wave 2 has not yet added, breaking `cargo build`. Either way
+Wave 1 fails the "one production path" invariant on its own.
+
+Suggested resolution: keep `Coroutine` and the `async_close`/`async_context`
+cleanup atoms behind `SIFR-PYRES-0002` through Waves 1–4 and lift the gate
+atomically in the same merge unit as the wave that first produces working
+generated wrappers (or fold Waves 1 + 2 + 3 into a single activation merge
+unit, mirroring M6 Wave 3). The Wave-1 language of "activate" should be
+replaced with "prepare frontend contracts and diagnostics behind the
+existing PYRES-0002 gate".
+
+### 2. Cancellation carrier vs. the current Tokio-abort task supervisor is
+under-specified and may exceed one wave.
+
+Wave 4 says:
+
+> "Introduce a cancellation carrier understood by generated Sifr task
+> supervisors and Python submissions; do not treat Tokio task abortion as
+> a completed Python cancellation. Cancellation-before-start and
+> cancellation-in-flight must request cancellation of the exact asyncio
+> task and await its terminal state."
+
+The current implementation of every Sifr cancellation site is Tokio
+`abort_handle.abort()` (`Task::cancel`, `Task::cancel_and_join`,
+`Task::__sifr_timeout`, `TaskScope::__sifr_join_all` fail-fast path, plus
+runtime-owned tasks in `sifr_runtime/src/http.rs` and
+`sifr_runtime/src/interop.rs`). `abort()` drops the child future
+synchronously; the child cannot `await` for the Python task's terminal
+state before the parent scope proceeds. Meeting the M7 acceptance criterion
+"Sifr cancellation does not complete before Python `finally` cleanup" for
+cancellation-in-flight during ordinary program flow (not only at process
+shutdown) therefore requires either:
+
+- (a) rewriting Sifr's task supervisor codegen so tasks holding Python
+  coroutine futures use a cooperative cancellation token rather than
+  `abort()`. That touches `task.spawn`, `task.spawn_blocking`,
+  `task_scope`/`task_group` fail-fast, `task.timeout`, `task.race`,
+  `task.select`, and every runtime-owned `.abort()` site above. It also
+  interacts with the `async_concurrency_model.md` split between "active
+  cancellation signal" and "materialized cancellation evidence", which the
+  current codegen has not yet implemented.
+- (b) redefining "await terminal state" to happen only in the shutdown
+  registry, so at the awaiting Sifr task's completion point the Python
+  task's terminal state has not necessarily been reached — which violates
+  the M7 acceptance criterion outside shutdown.
+- (c) some hybrid where the wrapper's `Drop` schedules
+  `loop.call_soon_threadsafe(task.cancel)` and hands the future off to a
+  runtime-owned pending set that shutdown drains, accepting (b) at the
+  caller and (a) at shutdown.
+
+Wave 4 does not identify which option is chosen. Option (a) is likely
+larger than one wave and would benefit from being decomposed or paired with
+an earlier substrate wave that lands the cancellation-carrier primitives in
+the concurrency runtime before M7's wrappers depend on them. Options (b)
+and (c) are consistent with a single M7 wave but weaken the acceptance
+criterion and should be documented as the accepted semantics if chosen.
+
+Failure scenario without resolution: the Wave-4 PR either lands (b)/(c)
+silently — presenting to reviewers as "terminal-state waiting" while in
+practice cancellation-in-flight can still return `TaskResult::Cancelled`
+before Python `finally` runs — or attempts (a) and grows into a
+cross-cutting task-supervisor rewrite whose Rust diff dwarfs the M7
+substrate diff, violating the "small, reviewable" workflow rule and
+`AGENTS.md` "keep changes focused on the requested milestone/issue".
+
+### 3. `cleanup=async_close` behavior is split across Waves 1 and 5.
+
+Wave 1 activates `cleanup=async_close` at the frontend as soon as the
+opaque class declares a consuming `@python.coroutine(Self.<member>)` close.
+Wave 5 completes the runtime contract: "Transfer consuming ownership
+before submission; close exactly once, poison on cleanup failure, and
+reject reuse, duplicate close, or abandonment of an `async_close`
+obligation." Between Wave 1 and Wave 5, `cleanup=async_close` is either
+non-executable (finding 1) or partially enforced: the linear must-use
+obligation from M4 exists at the frontend but the runtime does not poison
+on failure or reject double close. Because the whole reason to introduce
+async declarations is to make `async_close` sound, the plan should either
+fold Wave 1's `cleanup=async_close` activation into the same merge unit as
+Wave 5's completion (preferred), or explicitly document that Wave 1 lands
+`cleanup=async_close` behind `SIFR-PYRES-0002` and that Wave 5 lifts the
+gate. The current wording of Wave 1 ("Activate `cleanup=async_close` only
+when …") reads as public activation.
+
+Failure scenario: a user program with `cleanup=async_close` compiles after
+Wave 1 lands but before Wave 5, calls the declared `aclose()`, encounters a
+Python exception, and either continues to use the handle (no poison) or
+suffers a runtime panic where the ownership contract expected but the
+runtime did not enforce the closed/poisoned transition.
+
+## Non-Blocking Suggestions
+
+### 4. Conditional loop startup vs. sync-only applications.
+
+`internal_docs/python_interop_protocol_architecture.md` line 59: "A
+generated application containing any async Python declaration owns
+exactly one CPython asyncio loop on one dedicated OS thread." Wave 2
+states "Start one loop on one named OS thread after CPython and
+bridge-loader setup" with no gating on the target's declaration graph.
+`crates/sifr_driver/src/build/python_interop.rs` currently constructs a
+single `PythonInteropPlan` and does not distinguish async-bearing targets.
+Wave 2 (or Wave 3) should explicitly state that the driver only wires the
+loop bootstrap when the resolved package graph contains at least one
+`PythonInteropEffect::Async` declaration (function, method, factory, or
+async context enter/exit), so sync-only apps do not pay the OS-thread
+cost.
+
+### 5. `NoSuspend` bypass mechanism is implicit.
+
+`collect_async_suspension_summaries`
+(`crates/sifr_lowering/src/lower/async_effects.rs:20-48`) walks every
+async top-level function collected by `mod_impl.rs:216-220` and would
+classify a `@python.coroutine async def` with an ellipsis body as
+`NoSuspend`, triggering `ASYNC_AWAIT_NO_SUSPEND` on any awaiting caller
+via `lower_await` (`async_await.rs:44-58`). Wave 1 says "Route ellipsis
+through the interop `Bodyless` path before normal async body lowering and
+`NoSuspend` checking" but does not name the mechanism. Options: (i)
+exclude Bodyless-stub coroutine functions from `ctx.async_functions`; (ii)
+teach the summarizer to treat Bodyless async stubs as `Suspends`; (iii)
+suppress the `NoSuspend` diagnostic for functions with a
+`PythonInteropEffect::Async` declaration. Wave 1 should pick one and
+name it, so reviewers can check the correct site.
+
+### 6. Concurrent one-loop identity proof for typed wrappers is deferred to
+Wave 5.
+
+Wave 2 proves "repeated and concurrent raw calls use one loop/thread
+identity" for the raw submission path. Wave 3 activates typed wrappers but
+does not repeat the identity check. Wave 5 collects a "concurrent one-loop
+identity proof". This is acceptable but Wave 3 should include a small
+end-to-end identity assertion (two typed `@python.coroutine` calls
+concurrently observing the same loop id) so that the Wave-3 PR itself does
+not require the reviewer to trust the raw-path proof.
+
+### 7. Callback-shutdown insertion point in Wave 4.
+
+M7's phase-intro task list requires the loop to "stop it after registered
+async cleanup and callback shutdown." Callbacks are M9; Wave 4 defines the
+M7 shutdown as "stops admission, cancels all registered work, awaits
+Python `finally` and registered async cleanup, stops the loop, and joins
+the OS thread." Wave 4 should explicitly note where callback shutdown
+(M9) will insert in this sequence so that M9 does not have to reshape the
+shutdown ordering later.
+
+### 8. Raw-API `blocking_io` semantics after Wave 2 rewiring.
+
+`stdlib/_sifr/python.sifr:380` and `stdlib/sifr/python.sifr:779` expose
+`py_run_coroutine_blocking` as `blocking_io`. Wave 2 replaces the current
+`asyncio.run` implementation with owned-loop submission. The `blocking_io`
+classification remains correct — the sync caller still waits for a Python
+future's terminal state — but Wave 2 should state that the classification
+is preserved and that async Sifr code continues to require explicit
+offload (per the M3 acceptance criterion "Sync declarations cannot be
+called directly from async code without explicit Sifr offload"). This is
+mostly a doc/diagnostic note but avoids ambiguity when the intrinsic is
+rewired.
+
+## Coverage Cross-Check
+
+| M7 Task / Acceptance / Validation                                            | Wave                             | Status                                   |
+| ---------------------------------------------------------------------------- | -------------------------------- | ---------------------------------------- |
+| One generated-application-owned loop on a dedicated OS thread                | Wave 2                           | Covered; conditional startup gap (§4)    |
+| Start after CPython/bridge init; stop after async cleanup + callback shutdown | Wave 2 (start), Wave 4 (stop)    | Covered; callback ordering hook (§7)     |
+| `@python.coroutine(path)` on async def for functions/factories/methods       | Wave 1 (frontend), Wave 3 (codegen) | Covered; ordering finding (§1)          |
+| Convert inputs, invoke, await, convert outputs on loop thread                | Wave 3                           | Covered                                  |
+| Structured bidirectional cancellation; terminal-state waiting; `CancelledError` mapping; suppression | Wave 4 | Under-specified vs. Tokio abort (§2) |
+| Bodyless routing before body lowering / `NoSuspend`                          | Wave 1                           | Covered but mechanism implicit (§5)      |
+| Raw coroutine API on owned loop; remove per-call `asyncio.run`               | Wave 2                           | Covered; classification note (§8)        |
+| Opaque results non-send                                                      | Wave 3                           | Covered                                  |
+| Consuming `cleanup=async_close`; poison-on-cleanup-failure                   | Wave 1 (frontend), Wave 5 (runtime) | Split across waves — activation split (§3) |
+| Sync/async substitution rejected                                             | Wave 1                           | Covered                                  |
+| Async success / Python failure / conversion failure matrices                 | Wave 5                           | Covered                                  |
+| Cancellation-before-start / in-flight / suppression matrices                 | Wave 5                           | Covered (semantics depend on §2)         |
+| Shutdown matrices                                                            | Wave 4 (diagnostics), Wave 5 (matrix) | Covered                              |
+| Async-close success/failure/poison/use-after-close                           | Wave 5                           | Covered                                  |
+| Reject abandonment of `cleanup=async_close`                                  | Wave 5                           | Covered                                  |
+| Concurrent one-loop identity                                                 | Wave 2 (raw), Wave 5 (typed)     | Wave 3 identity assertion missing (§6)   |
+| Compiled httpx-style example + demos/m7_demo                                 | Wave 5                           | Covered                                  |
+| Doc/roadmap/review/checkbox/PR-link updates                                  | Wave 5                           | Covered                                  |
+
+## Verdict
+
+The five-wave decomposition covers every task, acceptance criterion, and
+validation item in the M7 spec at the level of stated intent. However
+findings §1, §2, and §3 above are actionable plan-level defects that
+should be resolved before the plan is executed:
+
+- §1: reorder or reword so no wave lands public activation of
+  `@python.coroutine`/`cleanup=async_close` ahead of the substrate that
+  makes those forms end-to-end executable, matching M6's substrate-first
+  pattern and the phase Delivery Rule.
+- §2: specify the reconciliation between the M7 cancellation carrier and
+  the current `abort()`-based task supervisor, or decompose Wave 4 to land
+  the required supervisor primitives explicitly.
+- §3: fold `cleanup=async_close` activation into the same merge unit as
+  its runtime completion, or state clearly that Wave 1 leaves it gated
+  behind `SIFR-PYRES-0002`.
+
+Findings §4–§8 are non-blocking refinements.
+
+NOT SATISFIED

--- a/plans/reviews/active/ad-hoc-python-interop-m7-plan-review-round2.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-plan-review-round2.md
@@ -1,0 +1,25 @@
+## Round 2 Verification
+
+Checked the revised M7 wave plan (7 waves) against every Round 1 blocking finding and every prior refinement listed by the user.
+
+### Blocking findings — status
+
+**§1 wave ordering vs. Delivery Rule.** Wave 1 is reworded from "activate" to "Prepare coroutine and async-close frontend contracts behind the existing `SIFR-PYRES-0002` gate"; Waves 5–6 explicitly state "behind the public gate"; Wave 7 is the single atomic activation ("Lift the `@python.coroutine` and `cleanup=async_close` gates only after the owned loop, typed wrappers, cooperative cancellation, terminal shutdown, and consuming lifecycle are present in the same production path"). This now mirrors M6 Wave 3's substrate-first + atomic-activation pattern. Resolved.
+
+**§2 cancellation carrier vs. Tokio-abort supervisor.** A concrete task-local carrier/claim design is chosen: at Python-await entry the submission atomically claims the carrier and registers its exact-task hook; a claimed cancellation signals the exact asyncio task and terminally waits on the child + Python terminal latch; an unclaimed cancellation retains Tokio abort; the registration race is explicitly closed ("aborts before Python submission or is observed by the newly registered submission, never leaving untracked Python work"). The supervisor cutover is split as requested: Wave 3 covers direct task paths (`task.cancel`, cancel-and-join, timeout); Wave 4 covers scope/group fail-fast, race/select losers, and join-set. Resolved.
+
+**§3 async-close split.** Wave 1 explicitly keeps `cleanup=async_close` gated ("Keep `cleanup=async_close` gated until its runtime lifecycle is complete"); Wave 6 completes the consuming runtime lifecycle (transfer, close-once, poison, reject reuse/duplicate/abandonment, cancellation, shutdown interaction) behind the gate; Wave 7 lifts the gate atomically alongside `@python.coroutine`. Runtime completion precedes activation. Resolved.
+
+### Prior refinements — status
+
+- **§4 Conditional loop bootstrap** — Wave 2: "Wire loop bootstrap only when the resolved target uses an async Python declaration or the raw coroutine intrinsic." Addressed.
+- **§5 Explicit Bodyless-as-Suspends mechanism** — Wave 1 names option (ii): "Mark bodyless async interop declarations as `Suspends` in the existing suspension summary so they bypass normal body lowering and the `NoSuspend` fake-async diagnostic without adding a summary variant or removing their ordinary async function identity." Addressed.
+- **§6 Typed-wrapper loop identity proof** — Wave 5: "Prove two concurrent typed wrappers observe the same loop/thread identity, while the syntax remains gated until cancellation and cleanup are complete." Addressed.
+- **§7 M9 no-op shutdown slot** — Wave 4: "stop external admissions; invoke the M9 callback shutdown hook (a no-op ordered slot until M9); run registered async cleanup while the loop is live; cancel and terminally drain remaining submissions; stop the loop; join its thread." Ordering fixed now so M9 does not later reshape it. Addressed.
+- **§8 Preserved `blocking_io` raw API** — Wave 2: "Replace raw `asyncio.run` with owned-loop submission while preserving the raw API's synchronous `blocking_io` classification and explicit-offload requirement." Addressed.
+
+### Remaining actionable defects
+
+None found. The plan is internally consistent, the seven-wave decomposition matches the Delivery Rule, the cancellation design is concrete, and the runtime substrate for both coroutines and `async_close` lands before the single activation wave.
+
+SATISFIED


### PR DESCRIPTION
## Summary
- decompose M7 into seven substrate-first, locally validated, reviewed PR waves
- keep coroutine and async-close syntax gated until one atomic activation wave
- specify a task-local cooperative cancellation claim with abort fallback and terminal waiting
- lock conditional loop startup, Bodyless suspension semantics, shutdown ordering, and evidence closure

## Review
- Opus plan review round 1: NOT SATISFIED; premature activation and cancellation/async-close sequencing corrected
- Opus plan review round 2: SATISFIED

## Validation
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`