### PR TITLE
Prepare gated Python coroutine frontend contracts

### DIFF
--- a/crates/sifr_lowering/src/lower/async_effects.rs
+++ b/crates/sifr_lowering/src/lower/async_effects.rs
@@ -21,9 +21,21 @@ pub(in crate::lower) fn collect_async_suspension_summaries(
     stmts: &[Stmt],
 ) -> HashMap<String, AsyncSuspensionSummary> {
     let async_functions = collect_top_level_async_functions(stmts);
-    let mut summaries = async_functions
+    let mut summaries = stmts
         .iter()
-        .map(|name| (name.clone(), AsyncSuspensionSummary::NoSuspend))
+        .filter_map(|stmt| {
+            let Stmt::FunctionDef(func) = stmt else {
+                return None;
+            };
+            func.is_async.then(|| {
+                let summary = if super::python_interop::is_bodyless_python_coroutine(func) {
+                    AsyncSuspensionSummary::Suspends
+                } else {
+                    AsyncSuspensionSummary::NoSuspend
+                };
+                (func.name.to_string(), summary)
+            })
+        })
         .collect::<HashMap<_, _>>();
 
     let mut changed = true;
@@ -35,6 +47,9 @@ pub(in crate::lower) fn collect_async_suspension_summaries(
             };
             let name = func.name.to_string();
             if !async_functions.contains(&name) {
+                continue;
+            }
+            if super::python_interop::is_bodyless_python_coroutine(func) {
                 continue;
             }
             let next = summarize_stmts(&func.body, &async_functions, &summaries);
@@ -418,6 +433,20 @@ async def values() -> AsyncGenerator[int, GeneratorCloseError]:
         );
         assert_eq!(
             summaries.get("values"),
+            Some(&AsyncSuspensionSummary::Suspends)
+        );
+    }
+
+    #[test]
+    fn marks_bodyless_python_coroutine_stub_as_suspending() {
+        let summaries = summaries(
+            r"
+@python.coroutine(pkg.compute)
+async def compute(value: int) -> int: ...
+",
+        );
+        assert_eq!(
+            summaries.get("compute"),
             Some(&AsyncSuspensionSummary::Suspends)
         );
     }

--- a/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
@@ -611,26 +611,59 @@ pub(in crate::lower) fn lower_class(
             class_def.range,
         );
     }
-    let has_unmatched_consuming_method = hir_methods.iter().any(|method| {
-        method.python_interop.first().is_some_and(|declaration| {
-            if !declaration.consumes_receiver {
-                return false;
-            }
-            match cleanup {
-                Some(sifr_ir::PythonCleanupPolicy::Close) => {
-                    declaration.kind != sifr_ir::PythonInteropDecoratorKind::Function
-                        || declaration
-                            .target
-                            .as_ref()
-                            .is_none_or(|target| target.segments.as_slice() != ["Self", "close"])
-                }
-                Some(sifr_ir::PythonCleanupPolicy::Context) => {
-                    declaration.kind != sifr_ir::PythonInteropDecoratorKind::ContextExit
-                }
-                _ => true,
-            }
+    let semantic_async_close_methods = hir_methods
+        .iter()
+        .filter(|method| {
+            method.python_interop.first().is_some_and(|declaration| {
+                declaration.consumes_receiver
+                    && declaration.kind == sifr_ir::PythonInteropDecoratorKind::Coroutine
+                    && declaration
+                        .target
+                        .as_ref()
+                        .is_some_and(|target| target.segments.as_slice() == ["Self", "aclose"])
+                    && method.params.is_empty()
+                    && matches!(
+                        method.return_type.resolve_alias(),
+                        Type::Result(ok, _) if ok.resolve_alias() == &Type::None
+                    )
+            })
         })
-    });
+        .count();
+    if cleanup == Some(sifr_ir::PythonCleanupPolicy::AsyncClose)
+        && semantic_async_close_methods != 1
+    {
+        ctx.error_with_code_at(
+            sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
+            "`cleanup=async_close` requires exactly one `@python.coroutine(Self.aclose)` method declared as `async def aclose(own self) -> Result[None, PythonError]`".to_string(),
+            class_def.range,
+        );
+    }
+    let has_unmatched_consuming_method =
+        hir_methods.iter().any(|method| {
+            method.python_interop.first().is_some_and(|declaration| {
+                if !declaration.consumes_receiver {
+                    return false;
+                }
+                match cleanup {
+                    Some(sifr_ir::PythonCleanupPolicy::Close) => {
+                        declaration.kind != sifr_ir::PythonInteropDecoratorKind::Function
+                            || declaration.target.as_ref().is_none_or(|target| {
+                                target.segments.as_slice() != ["Self", "close"]
+                            })
+                    }
+                    Some(sifr_ir::PythonCleanupPolicy::AsyncClose) => {
+                        declaration.kind != sifr_ir::PythonInteropDecoratorKind::Coroutine
+                            || declaration.target.as_ref().is_none_or(|target| {
+                                target.segments.as_slice() != ["Self", "aclose"]
+                            })
+                    }
+                    Some(sifr_ir::PythonCleanupPolicy::Context) => {
+                        declaration.kind != sifr_ir::PythonInteropDecoratorKind::ContextExit
+                    }
+                    _ => true,
+                }
+            })
+        });
     if has_unmatched_consuming_method {
         ctx.error_with_code_at(
             sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -109,6 +109,8 @@ mod python_async_tests;
 mod python_bridge_tests;
 #[cfg(test)]
 mod python_context_expression_tests;
+#[cfg(test)]
+mod python_coroutine_contract_tests;
 mod python_interop;
 #[cfg(test)]
 mod python_interop_tests;

--- a/crates/sifr_lowering/src/lower/mod_impl.rs
+++ b/crates/sifr_lowering/src/lower/mod_impl.rs
@@ -223,7 +223,9 @@ pub(in crate::lower) fn lower_module_impl(
             {
                 ctx.function_workload_annotations
                     .insert(function_name.clone(), workload);
-            } else if python_interop::has_python_interop_decorator_syntax(&func.decorator_list) {
+            } else if !func.is_async
+                && python_interop::has_python_interop_decorator_syntax(&func.decorator_list)
+            {
                 ctx.function_workload_annotations.insert(
                     function_name.clone(),
                     workload_annotations::WorkloadKind::BlockingIo,

--- a/crates/sifr_lowering/src/lower/python_coroutine_contract_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_coroutine_contract_tests.rs
@@ -1,0 +1,109 @@
+use crate::{lower_module, HirDiagnostic};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_parser::parse_module;
+
+fn lower_errors(source: &str) -> Vec<HirDiagnostic> {
+    let parsed = parse_module(source).expect("source should parse");
+    match lower_module(parsed.suite()) {
+        Ok(_) => panic!("reserved async Python syntax must stay gated"),
+        Err(errors) => errors,
+    }
+}
+
+fn has_code(errors: &[HirDiagnostic], code: DiagnosticCode) -> bool {
+    errors.iter().any(|error| error.code == Some(code))
+}
+
+const PYTHON_ERROR: &str = r"
+class PythonError(Error):
+    message: str
+";
+
+#[test]
+fn valid_coroutine_contract_is_parsed_but_remains_reserved() {
+    let errors = lower_errors(&format!(
+        "{PYTHON_ERROR}\n@python.coroutine(pkg.compute)\nasync def compute(value: int) -> Result[int, PythonError]: ...\n"
+    ));
+    assert!(has_code(
+        &errors,
+        DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION
+    ));
+    assert!(!has_code(&errors, DiagnosticCode::PYCALL_INVALID_SHAPE));
+    assert!(!has_code(
+        &errors,
+        DiagnosticCode::PYCONV_UNSUPPORTED_DECLARATION_TYPE
+    ));
+}
+
+#[test]
+fn coroutine_contract_validates_async_shape_and_conversion_while_gated() {
+    let sync_errors = lower_errors(&format!(
+        "{PYTHON_ERROR}\n@python.coroutine(pkg.compute)\ndef compute(value: int) -> Result[int, PythonError]: ...\n"
+    ));
+    assert!(has_code(&sync_errors, DiagnosticCode::PYCALL_INVALID_SHAPE));
+
+    let conversion_errors = lower_errors(&format!(
+        "{PYTHON_ERROR}\n@python.coroutine(pkg.compute)\nasync def compute(values: set[int]) -> Result[int, PythonError]: ...\n"
+    ));
+    assert!(has_code(
+        &conversion_errors,
+        DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION
+    ));
+    assert!(has_code(
+        &conversion_errors,
+        DiagnosticCode::PYCONV_UNSUPPORTED_DECLARATION_TYPE
+    ));
+}
+
+#[test]
+fn synchronous_python_decorator_is_rejected_on_async_def() {
+    let errors = lower_errors(&format!(
+        "{PYTHON_ERROR}\n@python(pkg.compute)\nasync def compute(value: int) -> Result[int, PythonError]: ...\n"
+    ));
+    assert!(has_code(&errors, DiagnosticCode::PYCALL_INVALID_SHAPE));
+}
+
+#[test]
+fn active_sync_method_decorator_reports_shape_not_reserved_on_async_def() {
+    let errors = lower_errors(&format!(
+        "{PYTHON_ERROR}\n@python.opaque(type=pkg.Client, cleanup=drop)\nclass Client:\n    @python.attr(Self.name)\n    async def name(self) -> Result[str, PythonError]: ...\n"
+    ));
+    assert!(has_code(&errors, DiagnosticCode::PYCALL_INVALID_SHAPE));
+    assert!(!has_code(
+        &errors,
+        DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION
+    ));
+}
+
+#[test]
+fn valid_async_close_contract_is_checked_but_remains_reserved() {
+    let errors = lower_errors(&format!(
+        "{PYTHON_ERROR}\n@python.opaque(type=pkg.Client, cleanup=async_close)\nclass Client:\n    @python.coroutine(Self.aclose)\n    async def aclose(own self) -> Result[None, PythonError]: ...\n"
+    ));
+    assert!(has_code(
+        &errors,
+        DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION
+    ));
+    assert!(!errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::PYCALL_INVALID_SHAPE)
+            && error.message.contains("cleanup=async_close")
+    }));
+}
+
+#[test]
+fn async_close_requires_one_consuming_aclose_coroutine() {
+    for source in [
+        format!(
+            "{PYTHON_ERROR}\n@python.opaque(type=pkg.Client, cleanup=async_close)\nclass Client:\n    @python.coroutine(Self.aclose)\n    async def aclose(self) -> Result[None, PythonError]: ...\n"
+        ),
+        format!(
+            "{PYTHON_ERROR}\n@python.opaque(type=pkg.Client, cleanup=async_close)\nclass Client:\n    @python.coroutine(Self.shutdown)\n    async def shutdown(own self) -> Result[None, PythonError]: ...\n"
+        ),
+    ] {
+        let errors = lower_errors(&source);
+        assert!(errors.iter().any(|error| {
+            error.code == Some(DiagnosticCode::PYCALL_INVALID_SHAPE)
+                && error.message.contains("cleanup=async_close")
+        }));
+    }
+}

--- a/crates/sifr_lowering/src/lower/python_interop.rs
+++ b/crates/sifr_lowering/src/lower/python_interop.rs
@@ -9,32 +9,17 @@ use sifr_python_ast::{AstParamOwnership, Decorator, Expr, ExprCall, Parameters, 
 use sifr_type_system::Type;
 
 mod context;
+mod stub_syntax;
 
 pub(in crate::lower) use context::{
     lower_python_context_owned_expr, python_context_borrow_in_owned_expr, python_context_item_kind,
     reject_python_context_borrow_created_value, reject_python_context_borrow_discard,
     reject_python_context_borrow_storage, validate_context_class_methods,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::lower) enum PythonInteropStubBody {
-    Bodyless,
-    Invalid,
-    Normal,
-}
-
-impl PythonInteropStubBody {
-    pub(in crate::lower) const fn skips_normal_body_lowering(self) -> bool {
-        matches!(self, Self::Bodyless | Self::Invalid)
-    }
-}
-
-pub(in crate::lower) fn has_python_interop_decorator_syntax(decorators: &[Decorator]) -> bool {
-    decorators.iter().any(|decorator| {
-        decorator_path(&decorator.expression).is_some_and(|path| path[0] == "python")
-            || matches!(&decorator.expression, Expr::Call(call) if decorator_path(&call.func).is_some_and(|path| path[0] == "python"))
-    })
-}
+pub(in crate::lower) use stub_syntax::{
+    classify_python_interop_stub_body, has_python_interop_decorator_syntax,
+    is_bodyless_python_coroutine,
+};
 
 pub(in crate::lower) fn is_python_omit(expr: &Expr) -> bool {
     decorator_path(expr).is_some_and(|path| path == ["python", "omit"])
@@ -49,39 +34,6 @@ pub(in crate::lower) fn python_parameter_kinds(
         .collect()
 }
 
-pub(in crate::lower) fn classify_python_interop_stub_body(
-    body: &[Stmt],
-    has_python_decorator: bool,
-    ctx: &mut LowerCtx,
-) -> PythonInteropStubBody {
-    let exact = matches!(body, [stmt] if is_ellipsis_stmt(stmt));
-    let contains = body.iter().any(is_ellipsis_stmt);
-    if exact {
-        if has_python_decorator {
-            return PythonInteropStubBody::Bodyless;
-        }
-        ctx.error_with_code_at(
-            DiagnosticCode::TYPE_UNSUPPORTED_EXPRESSION_FORM,
-            "ellipsis is only supported as the complete body of an interop declaration".to_string(),
-            body[0].range(),
-        );
-        return PythonInteropStubBody::Invalid;
-    }
-    if contains && has_python_decorator {
-        let span = body
-            .iter()
-            .find(|stmt| is_ellipsis_stmt(stmt))
-            .map_or_else(TextRange::default, Ranged::range);
-        invalid_shape(
-            ctx,
-            "declaration stubs must contain exactly one ellipsis statement and no other statements",
-            span,
-        );
-        return PythonInteropStubBody::Invalid;
-    }
-    PythonInteropStubBody::Normal
-}
-
 pub(in crate::lower) fn collect_python_interop_declarations(
     decorators: &[Decorator],
     parameters: &Parameters,
@@ -93,26 +45,32 @@ pub(in crate::lower) fn collect_python_interop_declarations(
         let Some((kind, call, span)) = classify_decorator(&decorator.expression, ctx) else {
             continue;
         };
-        if kind != PythonInteropDecoratorKind::Function {
-            ctx.error_with_code_at(
-                DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION,
-                format!(
-                    "Python declaration lowering is not active yet: `{}` belongs to a later phase",
-                    decorator_label(kind)
-                ),
-                span,
-            );
-            continue;
-        }
-        if is_async_decl {
-            invalid_shape(
-                ctx,
-                "`@python(path)` requires `def`; use `@python.coroutine(path)` for `async def`",
-                span,
-            );
-            continue;
-        }
-        if let Some(declaration) = parse_sync_function(call, parameters, ctx) {
+        let declaration = match (kind, is_async_decl) {
+            (PythonInteropDecoratorKind::Function, false) => {
+                parse_function(call, parameters, kind, PythonInteropEffect::BlockingIo, ctx)
+            }
+            (PythonInteropDecoratorKind::Function, true) => {
+                invalid_shape(
+                    ctx,
+                    "`@python(path)` requires `def`; use `@python.coroutine(path)` for `async def`",
+                    span,
+                );
+                None
+            }
+            (PythonInteropDecoratorKind::Coroutine, true) => {
+                reserved_declaration(ctx, kind, span);
+                parse_function(call, parameters, kind, PythonInteropEffect::Async, ctx)
+            }
+            (PythonInteropDecoratorKind::Coroutine, false) => {
+                invalid_shape(ctx, "`@python.coroutine(path)` requires `async def`", span);
+                None
+            }
+            _ => {
+                reserved_declaration(ctx, kind, span);
+                None
+            }
+        };
+        if let Some(declaration) = declaration {
             declarations.push(declaration);
         }
     }
@@ -138,6 +96,14 @@ pub(in crate::lower) fn collect_python_method_declarations(
         if decorator_path(&decorator.expression)
             .is_some_and(|path| path.as_slice() == ["python", "item"])
         {
+            if is_async_decl {
+                invalid_shape(
+                    ctx,
+                    "`@python.item` requires synchronous `def`",
+                    decorator.expression.range(),
+                );
+                continue;
+            }
             declarations.push(PythonInteropDeclaration {
                 kind: PythonInteropDecoratorKind::Item,
                 target: None,
@@ -153,33 +119,57 @@ pub(in crate::lower) fn collect_python_method_declarations(
         let Some((kind, call, span)) = classify_decorator(&decorator.expression, ctx) else {
             continue;
         };
-        if is_async_decl {
-            invalid_shape(
-                ctx,
-                "opaque Python methods must use synchronous `def`",
-                span,
-            );
-            continue;
-        }
-        let declaration = match kind {
-            PythonInteropDecoratorKind::Function => parse_sync_method(call, parameters, ctx),
-            PythonInteropDecoratorKind::Attribute => parse_attribute_method(call, parameters, ctx),
-            PythonInteropDecoratorKind::ContextEnter | PythonInteropDecoratorKind::ContextExit => {
-                context::parse_context_method(kind, call, parameters, ctx)
+        let declaration = match (kind, is_async_decl) {
+            (PythonInteropDecoratorKind::Coroutine, true) => {
+                reserved_declaration(ctx, kind, span);
+                parse_method(call, parameters, kind, PythonInteropEffect::Async, ctx)
             }
-            PythonInteropDecoratorKind::Item => {
+            (PythonInteropDecoratorKind::Coroutine, false) => {
+                invalid_shape(
+                    ctx,
+                    "`@python.coroutine(Self.method)` requires `async def`",
+                    span,
+                );
+                None
+            }
+            (PythonInteropDecoratorKind::Function, true) => {
+                invalid_shape(
+                    ctx,
+                    "`@python(Self.method)` requires `def`; use `@python.coroutine(Self.method)` for `async def`",
+                    span,
+                );
+                None
+            }
+            (PythonInteropDecoratorKind::Function, false) => {
+                parse_method(call, parameters, kind, PythonInteropEffect::BlockingIo, ctx)
+            }
+            (PythonInteropDecoratorKind::Attribute, false) => {
+                parse_attribute_method(call, parameters, ctx)
+            }
+            (
+                PythonInteropDecoratorKind::ContextEnter | PythonInteropDecoratorKind::ContextExit,
+                false,
+            ) => context::parse_context_method(kind, call, parameters, ctx),
+            (PythonInteropDecoratorKind::Item, false) => {
                 invalid_shape(ctx, "`@python.item` does not take arguments", span);
                 None
             }
-            _ => {
-                ctx.error_with_code_at(
-                    DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION,
-                    format!(
-                        "Python declaration lowering is not active yet: `{}` belongs to a later phase",
-                        decorator_label(kind)
-                    ),
+            (
+                PythonInteropDecoratorKind::Attribute
+                | PythonInteropDecoratorKind::ContextEnter
+                | PythonInteropDecoratorKind::ContextExit
+                | PythonInteropDecoratorKind::Item,
+                true,
+            ) => {
+                invalid_shape(
+                    ctx,
+                    "opaque Python methods must use synchronous `def`",
                     span,
                 );
+                None
+            }
+            _ => {
+                reserved_declaration(ctx, kind, span);
                 None
             }
         };
@@ -198,9 +188,11 @@ pub(in crate::lower) fn collect_python_method_declarations(
     declarations
 }
 
-fn parse_sync_method(
+fn parse_method(
     call: &ExprCall,
     parameters: &Parameters,
+    kind: PythonInteropDecoratorKind,
+    effect: PythonInteropEffect,
     ctx: &mut LowerCtx,
 ) -> Option<PythonInteropDeclaration> {
     if call.arguments.args.len() != 1 || !call.arguments.keywords.is_empty() {
@@ -213,10 +205,10 @@ fn parse_sync_method(
     }
     let target = parse_method_target_path(&call.arguments.args[0], ctx)?;
     Some(PythonInteropDeclaration {
-        kind: PythonInteropDecoratorKind::Function,
+        kind,
         target: Some(target),
         span: call.range,
-        effect: PythonInteropEffect::BlockingIo,
+        effect,
         cleanup: None,
         consumes_receiver: receiver_is_owned(parameters),
         parameters: parameter_metadata(parameters).into_iter().skip(1).collect(),
@@ -371,8 +363,7 @@ fn parse_opaque_class(call: &ExprCall, ctx: &mut LowerCtx) -> Option<PythonInter
                     [name] if name == "close" => Some(PythonCleanupPolicy::Close),
                     [name] if name == "async_close" => {
                         reserved_cleanup(ctx, "async_close", keyword.value.range());
-                        reserved_cleanup_seen = true;
-                        None
+                        Some(PythonCleanupPolicy::AsyncClose)
                     }
                     [name] if name == "context" => Some(PythonCleanupPolicy::Context),
                     [name] if name == "async_context" => {
@@ -466,9 +457,14 @@ pub(in crate::lower) fn validate_python_interop_signature(
         return;
     }
     let Type::Result(ok_type, error_type) = return_type.resolve_alias() else {
+        let declaration_kind = if declaration.effect == PythonInteropEffect::Async {
+            "an asynchronous"
+        } else {
+            "a synchronous"
+        };
         unsupported_conversion(
             ctx,
-            "a synchronous declaration must return `Result[T, PythonError]`",
+            &format!("{declaration_kind} declaration must return `Result[T, PythonError]`"),
             declaration.span,
         );
         return;
@@ -481,10 +477,15 @@ pub(in crate::lower) fn validate_python_interop_signature(
         );
     }
     if !is_direct_type(ok_type, true, ctx) {
+        let declaration_kind = if declaration.effect == PythonInteropEffect::Async {
+            "asynchronous"
+        } else {
+            "synchronous"
+        };
         unsupported_conversion(
             ctx,
             &format!(
-                "return type `{}` is not in the synchronous direct-conversion set",
+                "return type `{}` is not in the {declaration_kind} direct-conversion set",
                 ok_type.display_name()
             ),
             declaration.span,
@@ -565,9 +566,11 @@ fn unsupported_conversion(ctx: &mut LowerCtx, reason: &str, span: TextRange) {
     );
 }
 
-fn parse_sync_function(
+fn parse_function(
     call: &ExprCall,
     parameters: &Parameters,
+    kind: PythonInteropDecoratorKind,
+    effect: PythonInteropEffect,
     ctx: &mut LowerCtx,
 ) -> Option<PythonInteropDeclaration> {
     if call.arguments.args.len() != 1 || !call.arguments.keywords.is_empty() {
@@ -620,15 +623,26 @@ fn parse_sync_function(
         .filter(|root| !matches!(*root, "Self" | "__sifr_bridge__"))
         .map(str::to_string);
     Some(PythonInteropDeclaration {
-        kind: PythonInteropDecoratorKind::Function,
+        kind,
         target: Some(target),
         span: call.range,
-        effect: PythonInteropEffect::BlockingIo,
+        effect,
         cleanup: None,
         consumes_receiver: false,
         parameters: parameter_metadata(parameters),
         required_import_root,
     })
+}
+
+fn reserved_declaration(ctx: &mut LowerCtx, kind: PythonInteropDecoratorKind, span: TextRange) {
+    ctx.error_with_code_at(
+        DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION,
+        format!(
+            "Python declaration lowering is not active yet: `{}` belongs to a later phase",
+            decorator_label(kind)
+        ),
+        span,
+    );
 }
 
 pub(super) fn parameter_metadata(parameters: &Parameters) -> Vec<PythonInteropParameter> {

--- a/crates/sifr_lowering/src/lower/python_interop/stub_syntax.rs
+++ b/crates/sifr_lowering/src/lower/python_interop/stub_syntax.rs
@@ -1,0 +1,66 @@
+use super::{decorator_path, invalid_shape, is_ellipsis_stmt};
+use crate::lower::LowerCtx;
+use ruff_text_size::{Ranged, TextRange};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_ast::{Decorator, Expr, Stmt, StmtFunctionDef};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::lower) enum PythonInteropStubBody {
+    Bodyless,
+    Invalid,
+    Normal,
+}
+
+impl PythonInteropStubBody {
+    pub(in crate::lower) const fn skips_normal_body_lowering(self) -> bool {
+        matches!(self, Self::Bodyless | Self::Invalid)
+    }
+}
+
+pub(in crate::lower) fn has_python_interop_decorator_syntax(decorators: &[Decorator]) -> bool {
+    decorators.iter().any(|decorator| {
+        decorator_path(&decorator.expression).is_some_and(|path| path[0] == "python")
+            || matches!(&decorator.expression, Expr::Call(call) if decorator_path(&call.func).is_some_and(|path| path[0] == "python"))
+    })
+}
+
+pub(in crate::lower) fn is_bodyless_python_coroutine(func: &StmtFunctionDef) -> bool {
+    func.is_async
+        && matches!(func.body.as_slice(), [stmt] if is_ellipsis_stmt(stmt))
+        && func.decorator_list.iter().any(|decorator| {
+            matches!(&decorator.expression, Expr::Call(call) if decorator_path(&call.func).is_some_and(|path| path == ["python", "coroutine"]))
+        })
+}
+
+pub(in crate::lower) fn classify_python_interop_stub_body(
+    body: &[Stmt],
+    has_python_decorator: bool,
+    ctx: &mut LowerCtx,
+) -> PythonInteropStubBody {
+    let exact = matches!(body, [stmt] if is_ellipsis_stmt(stmt));
+    let contains = body.iter().any(is_ellipsis_stmt);
+    if exact {
+        if has_python_decorator {
+            return PythonInteropStubBody::Bodyless;
+        }
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_UNSUPPORTED_EXPRESSION_FORM,
+            "ellipsis is only supported as the complete body of an interop declaration".to_string(),
+            body[0].range(),
+        );
+        return PythonInteropStubBody::Invalid;
+    }
+    if contains && has_python_decorator {
+        let span = body
+            .iter()
+            .find(|stmt| is_ellipsis_stmt(stmt))
+            .map_or_else(TextRange::default, Ranged::range);
+        invalid_shape(
+            ctx,
+            "declaration stubs must contain exactly one ellipsis statement and no other statements",
+            span,
+        );
+        return PythonInteropStubBody::Invalid;
+    }
+    PythonInteropStubBody::Normal
+}

--- a/plans/reviews/active/ad-hoc-python-interop-m7-wave1-pr-2956-review-round1.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-wave1-pr-2956-review-round1.md
@@ -1,0 +1,35 @@
+## Review: PR #2956 — Gated Python coroutine + async-close frontend contracts
+
+Direct verification of the diff against the working tree at `codex/python-interop-m7-wave1-frontend`.
+
+**Reserved gate — every valid new form fails with SIFR-PYRES-0002 ✓**
+- Function coroutine: `python_interop.rs:60-63` — `(Coroutine, true)` runs `reserved_declaration(...)` (emits `PYRES_UNIMPLEMENTED_DECLARATION`) before parsing.
+- Method coroutine: `python_interop.rs:123-126` — same pattern.
+- `cleanup=async_close`: `python_interop.rs:364-367` — emits `PYRES_UNIMPLEMENTED_DECLARATION` and now returns `Some(PythonCleanupPolicy::AsyncClose)` so the class body semantic check has metadata to operate on.
+
+**No codegen/runtime/public activation leaked ✓**
+- Repo-wide grep for `PythonInteropEffect::Async`, `PythonCleanupPolicy::AsyncClose`, and `PythonInteropDecoratorKind::Coroutine` outside `sifr_lowering`: only test fixtures in `sifr_codegen` reference `AsyncClose` inside a `Close | AsyncClose => CloseLike` obligation branch (`mod_context.rs:243`); no emitter or driver ever consumes `Async` effect or `Coroutine` kind.
+- `python_interop_direct.rs:15` bounces any non-`Function` kind with `return None`; the receiver-consuming path also guards `kind != Function || ok_type != None || !params.is_empty()` (`python_interop_direct.rs:201`). Defense-in-depth is intact.
+
+**Bodyless suspension + workload ✓**
+- `stub_syntax.rs:24-29` — `is_bodyless_python_coroutine` requires `is_async && [ellipsis] && call decorator ["python","coroutine"]`.
+- `async_effects.rs:23-39` seeds bodyless coroutine stubs as `Suspends`; `:52-54` short-circuits the fix-point loop so recomputation cannot downgrade them to `NoSuspend`. Non-bodyless async funcs still summarize normally.
+- `mod_impl.rs:226-232` — the `BlockingIo` workload fallback now guards on `!func.is_async`, so `@python.coroutine` stubs never get stamped.
+
+**async-close exactly-one Self.aclose ✓**
+- `class_body_lowering.rs:614-640` counts `Coroutine + target=[Self, aclose] + own self + Result[None, _]` and requires exactly one. Verified with the exploration agent that `method.params` has `self` stripped at `class_body_lowering.rs:389-401`, so `.is_empty()` correctly means "no params beyond self". The `parse_method` interop-metadata side uses `parameter_metadata(...).skip(1)`; `receiver_is_owned` gates the entire predicate, so the `skip(1)` cannot silently misfire on a mis-decorated static method.
+- `has_unmatched_consuming_method` at `:641-666` includes an explicit `AsyncClose` arm parallel to `Close`.
+
+**Sync interop preserved ✓** — `parse_function`/`parse_method` are parametrized shells; the `(Function, false)` and `(Coroutine, true)` arms hit the same code with `PythonInteropEffect::BlockingIo` and produce byte-equivalent `PythonInteropDeclaration` shapes (same `kind`, `consumes_receiver`, `cleanup`, `parameters`, `required_import_root`). Diagnostic phrasing in `validate_python_interop_signature:459-491` picks "synchronous"/"asynchronous" from `declaration.effect`, so sync messages are unchanged.
+
+**Diagnostics — method arm resolution ✓** — The round-1 fix at `python_interop.rs:157-170` adds an explicit `(Attribute|ContextEnter|ContextExit|Item, true)` arm above the `_ => reserved_declaration(...)` wildcard, restoring the "opaque Python methods must use synchronous `def`" message for M4/M5-active decorators on `async def`. Trailing wildcard only catches genuinely-reserved kinds (Callback/Buffer/Arrow/Dlpack/Context{Async}Enter/Exit).
+
+**Tests + decomposition ✓** — 6 contract tests in `python_coroutine_contract_tests.rs` cover: gated valid coroutine, coroutine on sync `def`, sync decorator on `async def`, active sync method decorator on async, valid async-close, and async-close negatives (missing `own`, wrong target). The suspension summary has a dedicated test at `async_effects.rs:441-449`. `stub_syntax.rs` extraction brings `python_interop.rs` under the 900-line cap.
+
+**Observations that do not block this PR**
+- `parse_opaque_class` now returns `Some(AsyncClose)` (vs. the prior `None`), which registers the class in `ctx.python_opaque_classes`. On an empty `cleanup=async_close` class this fires *both* `PYRES_UNIMPLEMENTED_DECLARATION` (cleanup gate) and `PYCALL_INVALID_SHAPE` "cleanup=async_close requires exactly one…" — asymmetric with `async_context`, which drops the entry entirely. Also causes `must_use_obligation_for_type` (`mod_context.rs:236-246`) to emit `CloseLike` obligations for the class. Compilation still fails at PYRES so no runtime behavior leaks; diagnostic surface just gets noisier. No test covers the empty-class case, but the existing `close` path has the same shape.
+- `method_consumes_receiver` (`python_interop.rs:696-714`) does not yet recognize `@python.coroutine(Self.aclose)` as consuming, so `python_consuming_methods` won't mark aclose calls as receiver-moves. Irrelevant while gated (compile always fails at PYRES), and a natural to pick up in the wave that activates the coroutine path.
+
+Neither observation is a correctness bug in the current gated state.
+
+SATISFIED

--- a/plans/reviews/active/ad-hoc-python-interop-m7-wave1-review-round1.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-wave1-review-round1.md
@@ -1,0 +1,22 @@
+I've reviewed the working-tree implementation across all five modified files, the new contract test module, and the surrounding lowering paths (validation, class body, async effects, workload annotations, bridge authority, and consuming-receiver bookkeeping).
+
+## Verification results
+
+- **HIR metadata for valid coroutines** — `parse_function`/`parse_method` are now shared between sync/async, so a valid `@python.coroutine(...)` on `async def` (function, factory, or method) constructs `PythonInteropDeclaration { kind: Coroutine, effect: Async, ... }` with parameter shapes and required import root. `validate_python_interop_signature` runs target/call-shape/conversion validation via the shared path and emits async-flavored messages when `declaration.effect == Async` (python_interop.rs:504-536). Reserved gate at python_interop.rs:118-121 and 181-184 always fires before parse, so compilation cannot succeed. ✓
+- **Sync/async substitution diagnostics** — `(Function, true)` and `(Coroutine, false)` at python_interop.rs:110-125 (functions) and 181-200 (methods) hard-error with `PYCALL_INVALID_SHAPE` and the correct suggestion. Covered by the new tests. ✓
+- **Bodyless coroutine summaries** — `is_bodyless_python_coroutine` (python_interop.rs:41-47) requires `is_async` + single-ellipsis body + `@python.coroutine(...)` call decorator. `collect_async_suspension_summaries` seeds those as `Suspends` and the fix-point loop skips them, preserving normal async identity for everything else (async_effects.rs:24-59). ✓
+- **No blocking_io stamp on async** — mod_impl.rs:226-232 now gates the `BlockingIo` fallback on `!func.is_async`, so `@python.coroutine` async defs are not stamped. ✓
+- **AsyncClose metadata + reserved gate** — `parse_opaque_class` returns `Some(PythonCleanupPolicy::AsyncClose)` after emitting `PYRES_UNIMPLEMENTED_DECLARATION` (python_interop.rs:408-411), so the class carries the metadata for downstream checks and cannot compile. ✓
+- **Exactly one consuming async `Self.aclose`** — class_body_lowering.rs:614-640 counts methods matching `Coroutine + ["Self","aclose"] + own self + Result[None, _]` and requires exactly one; `has_unmatched_consuming_method` (654-659) rejects any other consuming coroutine when cleanup is `AsyncClose`. Both negative test cases (`self` without `own`, wrong name `shutdown`) trigger the diagnostic. ✓
+- **No public syntax / codegen activation leaked** — Diff touches only lowering + new lowering tests + one review artifact. No changes in `sifr_codegen`, `sifr_driver`, `sifr_runtime`, `sifr_package`, or grammar. ✓
+- **Package bridge authority preserved** — `parse_function` still resolves `bridge.*` via `ctx.python_bridge_authorities` and rewrites into `runtime_package` (python_interop.rs:629-664), shared between sync and async. ✓
+- **Existing synchronous behavior** — Functional behavior for sync `@python(...)`, `@python.attr`, `@python.context.enter/exit`, `@python.item`, `@python.opaque` is byte-equivalent to prior code paths; only the message emitted for async-misuse changed (see finding 1 below). ✓ functional, ⚠ diagnostic
+- **Files maintainable** — python_interop.rs is 897/900, class_body_lowering.rs 836/900, async_effects.rs 453/900. Under the cap but tight (finding 2). ✓
+
+## Findings
+
+**1 — Low severity, non-blocking (diagnostic regression).** In `collect_python_method_declarations`, the wildcard arm at python_interop.rs:215-218 sends `(Attribute, true)`, `(ContextEnter | ContextExit, true)`, and `(Item, true)` (when spelled `@python.item(...)` with parens) through `reserved_declaration`, producing e.g. `"Python declaration lowering is not active yet: 'python.attr' belongs to a later phase"`. But `python.attr` and `python.context.enter/exit` are active (M4, M5) — the prior single async-guard emitted the accurate `PYCALL_INVALID_SHAPE "opaque Python methods must use synchronous 'def'"`. Compilation still fails correctly; the error message is misleading. Fix: add explicit `(Attribute | ContextEnter | ContextExit | Item, true) => { invalid_shape(ctx, "opaque Python methods must use synchronous 'def'", span); None }` above the wildcard.
+
+**2 — Very low severity, non-blocking (headroom).** `crates/sifr_lowering/src/lower/python_interop.rs` is at 897 lines against the 900-line cap. Later M7 waves (typed async wrappers, async-close lifecycle) will need to land helpers here; refactor headroom is effectively gone.
+
+SATISFIED

--- a/plans/reviews/active/ad-hoc-python-interop-m7-wave1-review-round2.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-wave1-review-round2.md
@@ -1,0 +1,23 @@
+I've re-reviewed the complete M7 Wave 1 diff and the round-1 remediation.
+
+## Verification of round-1 remediation
+
+**Finding 1 (misleading diagnostic) — RESOLVED.** `collect_python_method_declarations` now has an explicit `(Attribute | ContextEnter | ContextExit | Item, true)` arm at python_interop.rs:157-170 that emits `PYCALL_INVALID_SHAPE "opaque Python methods must use synchronous 'def'"` above the `_ => reserved_declaration(...)` wildcard. Bare `@python.item` async is still caught earlier at 96-105 with the item-specific message, and Coroutine/Function async substitutions retain their own targeted messages. Coverage: `active_sync_method_decorator_reports_shape_not_reserved_on_async_def` in python_coroutine_contract_tests.rs:66-76 asserts PYCALL_INVALID_SHAPE fires and PYRES_UNIMPLEMENTED_DECLARATION does not.
+
+**Finding 2 (headroom) — RESOLVED.** `PythonInteropStubBody`, `skips_normal_body_lowering`, `has_python_interop_decorator_syntax`, `classify_python_interop_stub_body`, and the new `is_bodyless_python_coroutine` moved to `python_interop/stub_syntax.rs` (66 lines) with `pub(in crate::lower) use` re-exports at python_interop.rs:19-22. `python_interop.rs` now 853 lines (47-line headroom).
+
+## Fresh correctness sweep
+
+- **Bodyless coroutine suspension** — `is_bodyless_python_coroutine` requires `is_async && [ellipsis] && call decorator with path == ["python", "coroutine"]`; seeded as `Suspends` at async_effects.rs:31-35 and skipped in the fix-point loop (52-54) so it can't be overwritten. Non-bodyless async funcs correctly recompute via `summarize_stmts`. New test at async_effects.rs:441-449 covers the stub-suspension path.
+- **AsyncClose class contract** — python_interop.rs:364-367 emits `PYRES_UNIMPLEMENTED_DECLARATION` and returns `Some(AsyncClose)`, so `ctx.python_opaque_classes` retains cleanup metadata. class_body_lowering.rs:614-640 counts methods matching `Coroutine + Self.aclose + own self + Result[None, _]` and requires exactly one; 654-658 rejects any other consuming coroutine when cleanup is AsyncClose. `async_close_requires_one_consuming_aclose_coroutine` covers both `self` (missing `own`) and `Self.shutdown` (wrong name) negatives.
+- **Sync/async substitution errors** — `(Function, true)`/`(Coroutine, false)` for both functions (48-72) and methods (122-145) hard-error with `PYCALL_INVALID_SHAPE` and the right suggestion. Coroutine on `async def` still runs `parse_function`/`parse_method` after `reserved_declaration` so shape/conversion checks fire while the reserved gate blocks compile.
+- **BlockingIo workload stamp** — `mod_impl.rs:226-232` gates on `!func.is_async`, so `@python.coroutine` async defs are not stamped as blocking. Sync interop functions still get the fallback.
+- **Async-flavored diagnostics** — `validate_python_interop_signature` picks "an asynchronous"/"a synchronous" phrasing from `declaration.effect` for both Result-shape and direct-conversion messages (python_interop.rs:459-492), matching the coroutine contract tests' expectations.
+- **Bridge authority preserved** — `parse_function` unchanged in bridge-target rewriting logic; sync callers still resolve `bridge.*` via `ctx.python_bridge_authorities`.
+- **No public syntax / codegen surface** — diff limited to lowering + new lowering tests + review artifacts. `sifr_codegen`, `sifr_driver`, `sifr_runtime`, `sifr_package`, grammar unchanged.
+- **File sizes** — python_interop.rs 853, class_body_lowering.rs 836, async_effects.rs 453, stub_syntax.rs 66, python_coroutine_contract_tests.rs 109. All under the 900-line cap.
+- **Wildcard reachability** — after the explicit `(Attribute|ContextEnter|ContextExit|Item, true)` arm, the trailing `_ => reserved_declaration(...)` only catches Opaque/Callback/Buffer/Arrow/Dlpack/ContextAsyncEnter/ContextAsyncExit, which are genuinely reserved for later waves.
+
+No new findings surfaced.
+
+SATISFIED


### PR DESCRIPTION
## Summary
- construct and validate internal `@python.coroutine` HIR with async effect while retaining `SIFR-PYRES-0002`
- retain gated `cleanup=async_close` metadata and validate exactly one consuming `Self.aclose` coroutine
- classify bodyless coroutine stubs as suspending and stop marking async Python declarations as blocking work
- split stub syntax classification into a focused submodule and add contract regressions

## Validation
- `scripts/run_all_tests.sh --profile create-pr` (all lanes; 130/130 E2E)
- `cargo test -p sifr_lowering`
- focused 6 coroutine/async-close contract tests and suspension test
- `cargo clippy -p sifr_lowering --lib -- -D warnings`
- lowering and file-size guardrails
- Opus pre-PR review round 2: SATISFIED