### PR TITLE
Add application-owned Python asyncio runtime

### DIFF
--- a/crates/sifr_codegen/src/python_interop_plan.rs
+++ b/crates/sifr_codegen/src/python_interop_plan.rs
@@ -14,6 +14,7 @@ pub struct PythonInteropPlan {
     pub required_import_roots: Vec<String>,
     pub target_probes: Vec<PythonTargetProbe>,
     pub bridge_packages: Vec<PythonBridgePackagePlan>,
+    pub requires_async_loop: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,6 +80,7 @@ pub(crate) fn python_interop_plan_for_named_modules<'a>(
     let modules = modules.into_iter().collect::<Vec<_>>();
     let record_expansion_functions = record_expansion_functions(&modules);
     for (module_name, module) in modules {
+        plan.requires_async_loop |= module_requires_raw_coroutine_loop(module);
         for function in &module.functions {
             collect_function(
                 module_name,
@@ -91,6 +93,7 @@ pub(crate) fn python_interop_plan_for_named_modules<'a>(
             let Some(declaration) = class.python_opaque_declaration() else {
                 continue;
             };
+            plan.requires_async_loop |= declaration.effect == sifr_ir::PythonInteropEffect::Async;
             if let Some(root) = &declaration.required_import_root {
                 plan.required_import_roots.push(root.clone());
             }
@@ -124,6 +127,7 @@ fn collect_function(
     plan: &mut PythonInteropPlan,
 ) {
     for declaration in &function.python_interop {
+        plan.requires_async_loop |= declaration.effect == sifr_ir::PythonInteropEffect::Async;
         if let Some(root) = &declaration.required_import_root {
             plan.required_import_roots.push(root.clone());
         }
@@ -149,6 +153,54 @@ fn collect_function(
             return_type: function.return_type.clone(),
         });
     }
+}
+
+fn module_requires_raw_coroutine_loop(module: &HirModule) -> bool {
+    let raw_call_names = module
+        .imports
+        .iter()
+        .filter(|import| import.module == "sifr.python")
+        .flat_map(|import| {
+            import.names.iter().filter_map(|name| {
+                (name == "run_coroutine_blocking").then(|| {
+                    import
+                        .aliases
+                        .iter()
+                        .find_map(|(original, alias)| (original == name).then(|| alias.clone()))
+                        .unwrap_or_else(|| name.clone())
+                })
+            })
+        })
+        .collect::<BTreeSet<_>>();
+    if raw_call_names.is_empty() {
+        return false;
+    }
+    let mut required = false;
+    let mut inspect = |expression: &sifr_ir::HirExpr| {
+        if matches!(expression, sifr_ir::HirExpr::Call { func, .. } if raw_call_names.contains(func))
+        {
+            required = true;
+        }
+    };
+    for function in &module.functions {
+        walk_stmts(
+            &function.body,
+            TraversalConfig::INCLUDE_NESTED_FUNCTIONS,
+            &mut |_| {},
+            &mut inspect,
+        );
+    }
+    for class in &module.classes {
+        for method in &class.methods {
+            walk_stmts(
+                &method.body,
+                TraversalConfig::INCLUDE_NESTED_FUNCTIONS,
+                &mut |_| {},
+                &mut inspect,
+            );
+        }
+    }
+    required
 }
 
 fn record_expansion_functions(modules: &[(Option<&str>, &HirModule)]) -> BTreeSet<String> {
@@ -183,6 +235,13 @@ pub(crate) fn push_python_plan_cache_key(out: &mut String, plan: &PythonInteropP
     out.push('\n');
     out.push_str("python.declarations=");
     out.push_str(&plan.declarations.len().to_string());
+    out.push('\n');
+    out.push_str("python.requires_async_loop=");
+    out.push_str(if plan.requires_async_loop {
+        "yes"
+    } else {
+        "no"
+    });
     out.push('\n');
     for declaration in &plan.declarations {
         out.push_str("python.module=");

--- a/crates/sifr_codegen/src/python_interop_plan_tests.rs
+++ b/crates/sifr_codegen/src/python_interop_plan_tests.rs
@@ -1,7 +1,7 @@
 use crate::{interop_build_plan_for_named_modules, PythonTargetProbeStatus};
 use ruff_text_size::TextRange;
 use sifr_ir::{
-    HirExpr, HirFunction, HirModule, HirStmt, MethodKind, PythonInteropDeclaration,
+    HirExpr, HirFunction, HirImport, HirModule, HirStmt, MethodKind, PythonInteropDeclaration,
     PythonInteropDecoratorKind, PythonInteropEffect, PythonRecordExpansion, PythonTargetPath,
 };
 use sifr_type_system::Type;
@@ -94,6 +94,68 @@ fn python_cache_identity_changes_with_authoritative_sifr_types() {
         string_plan.cache_key_fragment(),
         integer_plan.cache_key_fragment()
     );
+}
+
+#[test]
+fn raw_coroutine_call_requires_the_owned_async_loop() {
+    let mut module = module_with_functions(vec![function(
+        "main",
+        vec![HirStmt::Expr {
+            expr: HirExpr::Call {
+                func: "run_coroutine_blocking".to_string(),
+                args: Vec::new(),
+                ty: Type::None,
+            },
+        }],
+        Vec::new(),
+    )]);
+    module.imports.push(HirImport {
+        module: "sifr.python".to_string(),
+        names: vec!["run_coroutine_blocking".to_string()],
+        aliases: Vec::new(),
+    });
+
+    let plan = interop_build_plan_for_named_modules([(Some("main"), &module)]);
+
+    assert!(plan.python.requires_async_loop);
+    assert!(plan
+        .cache_key_fragment()
+        .contains("python.requires_async_loop=yes"));
+}
+
+#[test]
+fn aliased_raw_coroutine_call_requires_the_owned_async_loop() {
+    let mut module = module_with_functions(vec![function(
+        "main",
+        vec![HirStmt::Expr {
+            expr: HirExpr::Call {
+                func: "run_owned".to_string(),
+                args: Vec::new(),
+                ty: Type::None,
+            },
+        }],
+        Vec::new(),
+    )]);
+    module.imports.push(HirImport {
+        module: "sifr.python".to_string(),
+        names: vec!["run_coroutine_blocking".to_string()],
+        aliases: vec![(
+            "run_coroutine_blocking".to_string(),
+            "run_owned".to_string(),
+        )],
+    });
+
+    let plan = interop_build_plan_for_named_modules([(Some("main"), &module)]);
+
+    assert!(plan.python.requires_async_loop);
+}
+
+#[test]
+fn sync_python_declaration_does_not_require_the_owned_async_loop() {
+    let module = module_with_functions(vec![function("main", Vec::new(), Vec::new())]);
+    let plan = interop_build_plan_for_named_modules([(Some("main"), &module)]);
+
+    assert!(!plan.python.requires_async_loop);
 }
 
 fn module_with_functions(functions: Vec<HirFunction>) -> HirModule {

--- a/crates/sifr_driver/src/build/project_codegen.rs
+++ b/crates/sifr_driver/src/build/project_codegen.rs
@@ -104,6 +104,7 @@ pub(super) fn apply_package_runtime_metadata(
     python_runtime: Option<PackagePythonRuntime>,
 ) -> Result<GeneratedBinaryProject, Vec<RenderedDiagnostic>> {
     if let Some(mut metadata) = python_runtime {
+        metadata.set_start_async_loop(generated.interop.python.requires_async_loop);
         metadata.set_bridge_sources(embedded_bridge_sources(
             &generated.interop.python.bridge_packages,
         ));
@@ -173,6 +174,31 @@ mod tests {
             .main_rs
             .contains("__sifr_initialize_python_runtime"));
         assert!(generated.python_runtime.is_some());
+    }
+
+    #[test]
+    fn package_python_runtime_starts_owned_loop_only_when_planned() {
+        let mut project = base_project();
+        project.interop.python.requires_async_loop = true;
+        let generated = apply_package_runtime_metadata(
+            project,
+            Some(PackagePythonRuntime::for_tests(
+                "/tmp/sifr-py/bin/python",
+                "digest-a",
+            )),
+        )
+        .expect("metadata should apply");
+        assert!(generated.main_rs.contains("start_async_loop: true"));
+
+        let generated = apply_package_runtime_metadata(
+            base_project(),
+            Some(PackagePythonRuntime::for_tests(
+                "/tmp/sifr-py/bin/python",
+                "digest-a",
+            )),
+        )
+        .expect("metadata should apply");
+        assert!(generated.main_rs.contains("start_async_loop: false"));
     }
 
     #[test]

--- a/crates/sifr_driver/src/build/python_runtime.rs
+++ b/crates/sifr_driver/src/build/python_runtime.rs
@@ -22,6 +22,7 @@ pub struct PackagePythonRuntime {
     trusted_native_roots: Vec<String>,
     libpython: Option<String>,
     bridge_sources: Vec<EmbeddedPythonBridgeSource>,
+    start_async_loop: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -61,6 +62,7 @@ impl PackagePythonRuntime {
             trusted_native_roots,
             libpython: probe.libpython.clone(),
             bridge_sources: Vec::new(),
+            start_async_loop: false,
         }
     }
 
@@ -105,6 +107,7 @@ impl PackagePythonRuntime {
             trusted_native_roots: Vec::new(),
             libpython: None,
             bridge_sources: Vec::new(),
+            start_async_loop: false,
         }
     }
 
@@ -136,6 +139,10 @@ impl PackagePythonRuntime {
 
     pub(super) fn set_bridge_sources(&mut self, sources: Vec<EmbeddedPythonBridgeSource>) {
         self.bridge_sources = sources;
+    }
+
+    pub(super) fn set_start_async_loop(&mut self, required: bool) {
+        self.start_async_loop = required;
     }
 }
 
@@ -181,6 +188,7 @@ pub(super) fn render_python_runtime_prelude(metadata: &PackagePythonRuntime) -> 
         native_import_roots: vec![{native_import_roots}],
         trusted_native_roots: vec![{trusted_native_roots}],
         bridge_sources: vec![{bridge_sources}],
+        start_async_loop: {start_async_loop},
     }}
 }}
 
@@ -206,6 +214,7 @@ fn __sifr_initialize_python_runtime() -> Result<sifr_runtime::python::PythonRunt
         native_import_roots = render_string_vec(&metadata.native_import_roots),
         trusted_native_roots = render_string_vec(&metadata.trusted_native_roots),
         bridge_sources = render_bridge_sources(&metadata.bridge_sources),
+        start_async_loop = metadata.start_async_loop,
     )
 }
 

--- a/crates/sifr_driver/src/tests/package_project_build_check.rs
+++ b/crates/sifr_driver/src/tests/package_project_build_check.rs
@@ -243,6 +243,13 @@ fn package_entrypoint(
 }
 
 fn local_python_runtime(project_root: &Path) -> crate::PackagePythonRuntime {
+    local_python_runtime_with_roots(project_root, &[])
+}
+
+fn local_python_runtime_with_roots(
+    project_root: &Path,
+    roots: &[&str],
+) -> crate::PackagePythonRuntime {
     let pyproject = project_root.join("pyproject.toml");
     let lock = project_root.join("uv.lock");
     std::fs::write(
@@ -293,12 +300,14 @@ fn local_python_runtime(project_root: &Path) -> crate::PackagePythonRuntime {
         &request,
         &probe,
         digest,
-        Vec::new(),
-        Vec::new(),
+        roots.iter().map(|root| (*root).to_string()).collect(),
+        roots.iter().map(|root| (*root).to_string()).collect(),
         Vec::new(),
     )
 }
 
+#[path = "package_python_async_runtime_tests.rs"]
+mod python_async_runtime_tests;
 #[path = "package_python_bridge_archive_tests.rs"]
 mod python_bridge_archive_tests;
 

--- a/crates/sifr_driver/src/tests/package_python_async_runtime_tests.rs
+++ b/crates/sifr_driver/src/tests/package_python_async_runtime_tests.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+#[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
+fn raw_coroutine_api_builds_and_runs_on_the_owned_loop() {
+    let dir = mktemp_dir("package_python_owned_async_loop");
+    let app = production_package(&dir, "app", "sifr-async-app", "async_app");
+    write_package_source(
+        &app,
+        "main.sifr",
+        r#"from sifr.python import Object, PythonError, call_attr, close, from_float, from_int, import_module, run_coroutine_blocking, to_int
+
+@trust_python_dynamic
+@blocking_io
+def python_value() -> Result[int, PythonError]:
+    try:
+        asyncio: Object = import_module("asyncio")
+        delay: Object = from_float(0.0)
+        expected: Object = from_int(42)
+        coroutine: Object = call_attr(asyncio, "sleep", [delay], [("result", expected)])
+        result_object: Object = run_coroutine_blocking(coroutine)
+        result: int = to_int(result_object)
+        _closed_result: None = close(result_object)
+        _closed_coroutine: None = close(coroutine)
+        _closed_asyncio: None = close(asyncio)
+        return result
+    except PythonError as error:
+        raise error
+
+@blocking_io
+def main() -> Result[None, PythonError]:
+    try:
+        value: int = python_value()
+        assert value == 42
+        print("sifr-python-interop:owned-async-loop:value=42")
+    except PythonError as error:
+        raise error
+    return None
+"#,
+    );
+
+    let graph = package_graph(&dir, &[&app], &[]);
+    let source_map = sifr_package::PackageSourceMap::build(&graph).expect("source map builds");
+    let mut entrypoint =
+        package_entrypoint(&graph, &source_map, &app, app.root.join("src/main.sifr"));
+    entrypoint.python_runtime = Some(local_python_runtime_with_roots(&app.root, &["asyncio"]));
+    let artifact = build_cached_package_project(&entrypoint)
+        .expect("raw coroutine package should build with the owned loop");
+    let output = std::process::Command::new(artifact.binary_path())
+        .output()
+        .expect("raw coroutine package should run");
+
+    assert!(
+        output.status.success(),
+        "binary should pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "sifr-python-interop:owned-async-loop:value=42"
+    );
+    let _ignored = std::fs::remove_dir_all(dir);
+}

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -7,6 +7,7 @@ use std::mem::MaybeUninit;
 use std::sync::{Mutex, MutexGuard};
 
 mod arrow_ops;
+mod async_runtime;
 mod bridge_loader;
 mod buffer_ops;
 mod call_depth;
@@ -32,6 +33,7 @@ pub use arrow_ops::{
     arrow_array, arrow_capsule_names, arrow_schema, arrow_stream, release_arrow, ArrowHandle,
     PythonArrowCapsuleMetadata,
 };
+pub use async_runtime::{async_runtime_diagnostics, PythonAsyncRuntimeDiagnostics};
 pub use bridge_loader::PythonBridgeSource;
 pub use buffer_ops::{
     buffer_shape, buffer_strides, buffer_suboffsets, buffer_u8, copy_buffer_u8, release_buffer,
@@ -96,6 +98,7 @@ pub struct PythonRuntimeConfig {
     pub native_import_roots: Vec<String>,
     pub trusted_native_roots: Vec<String>,
     pub bridge_sources: Vec<PythonBridgeSource>,
+    pub start_async_loop: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -111,6 +114,7 @@ pub struct PythonRuntimeGuard {
 
 impl Drop for PythonRuntimeGuard {
     fn drop(&mut self) {
+        let _ignored = async_runtime::shutdown();
         let _ignored = Python::try_attach(foreign_object::drain_pending_releases);
     }
 }
@@ -142,6 +146,9 @@ pub enum PythonRuntimeError {
     ReservedBridgeCollision {
         module: String,
     },
+    AsyncRuntimeFailed(String),
+    AsyncRuntimeNotRunning,
+    AsyncRuntimeStopping,
     OutstandingResources {
         live_objects: usize,
         leaked_objects: usize,
@@ -179,6 +186,15 @@ impl fmt::Display for PythonRuntimeError {
                 f,
                 "reserved Python bridge namespace collision at '{module}'"
             ),
+            Self::AsyncRuntimeFailed(message) => {
+                write!(f, "owned Python asyncio runtime failed: {message}")
+            }
+            Self::AsyncRuntimeNotRunning => {
+                write!(f, "owned Python asyncio runtime is not running")
+            }
+            Self::AsyncRuntimeStopping => {
+                write!(f, "owned Python asyncio runtime is stopping")
+            }
             Self::OutstandingResources {
                 live_objects,
                 leaked_objects,
@@ -235,6 +251,9 @@ pub fn initialize_runtime(
         .ok_or(PythonRuntimeError::NotInitialized)??;
     Python::try_attach(context_ops::register_boundary_error)
         .ok_or(PythonRuntimeError::NotInitialized)??;
+    if config.start_async_loop {
+        async_runtime::start()?;
+    }
     state.initialized = true;
     Ok(PythonRuntimeInitStatus::Initialized)
 }
@@ -531,6 +550,8 @@ fn py_error(error: &PyErr) -> PythonRuntimeError {
 
 #[cfg(test)]
 fn reset_runtime_state_for_tests() {
+    let _ignored = async_runtime::shutdown();
+    async_runtime::reset_for_tests();
     let _ignored = Python::try_attach(bridge_loader::reset_for_tests);
     let mut state = runtime_state().expect("runtime state should be available");
     *state = RuntimeState::new();

--- a/crates/sifr_runtime/src/python/async_runtime.rs
+++ b/crates/sifr_runtime/src/python/async_runtime.rs
@@ -1,0 +1,396 @@
+use super::{PythonError, PythonRuntimeError};
+use pyo3::prelude::*;
+use pyo3::types::PyAnyMethods;
+use std::collections::BTreeMap;
+use std::sync::{Condvar, Mutex, MutexGuard};
+use std::thread::JoinHandle;
+
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+const LOOP_THREAD_NAME: &str = "sifr-python-asyncio";
+
+static ASYNC_STATE: Mutex<AsyncRuntimeState> = Mutex::new(AsyncRuntimeState::new());
+static ASYNC_STATE_CHANGED: Condvar = Condvar::new();
+#[cfg(test)]
+static FORCE_LOOP_SETUP_FAILURE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AsyncLifecycle {
+    Disabled,
+    Starting,
+    Running,
+    Stopping,
+    Stopped,
+    Failed,
+}
+
+struct AsyncRuntimeState {
+    lifecycle: AsyncLifecycle,
+    loop_object: Option<Py<PyAny>>,
+    loop_thread: Option<JoinHandle<()>>,
+    next_submission_id: u64,
+    pending_submissions: usize,
+    submissions: BTreeMap<u64, Py<PyAny>>,
+    failure: Option<String>,
+}
+
+impl AsyncRuntimeState {
+    const fn new() -> Self {
+        Self {
+            lifecycle: AsyncLifecycle::Disabled,
+            loop_object: None,
+            loop_thread: None,
+            next_submission_id: 1,
+            pending_submissions: 0,
+            submissions: BTreeMap::new(),
+            failure: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PythonAsyncRuntimeDiagnostics {
+    pub running: bool,
+    pub stopping: bool,
+    pub loop_threads: usize,
+    pub active_submissions: usize,
+    pub pending_submissions: usize,
+}
+
+pub(super) fn start() -> Result<(), PythonRuntimeError> {
+    {
+        let mut state = lock_state()?;
+        loop {
+            match state.lifecycle {
+                AsyncLifecycle::Running => return Ok(()),
+                AsyncLifecycle::Starting => state = wait_for_change(state)?,
+                AsyncLifecycle::Stopping => {
+                    return Err(PythonRuntimeError::AsyncRuntimeStopping);
+                }
+                AsyncLifecycle::Disabled | AsyncLifecycle::Stopped | AsyncLifecycle::Failed => {
+                    state.lifecycle = AsyncLifecycle::Starting;
+                    state.failure = None;
+                    break;
+                }
+            }
+        }
+    }
+
+    let (ready_sender, ready_receiver) = std::sync::mpsc::sync_channel(1);
+    let loop_thread = std::thread::Builder::new()
+        .name(LOOP_THREAD_NAME.to_string())
+        .spawn(move || run_loop_thread(ready_sender))
+        .map_err(|error| fail_start(format!("loop thread could not start: {error}")))?;
+
+    match ready_receiver.recv() {
+        Ok(Ok(loop_object)) => {
+            let mut state = lock_state()?;
+            state.loop_object = Some(loop_object);
+            state.loop_thread = Some(loop_thread);
+            state.lifecycle = AsyncLifecycle::Running;
+            ASYNC_STATE_CHANGED.notify_all();
+            Ok(())
+        }
+        Ok(Err(message)) => {
+            let _ignored = loop_thread.join();
+            Err(fail_start(message))
+        }
+        Err(error) => {
+            let _ignored = loop_thread.join();
+            Err(fail_start(format!(
+                "loop thread exited before publishing readiness: {error}"
+            )))
+        }
+    }
+}
+
+pub(super) fn ensure_started() -> Result<(), PythonRuntimeError> {
+    start()
+}
+
+pub(super) fn run_coroutine_blocking(
+    py: Python<'_>,
+    coroutine: &Py<PyAny>,
+) -> Result<Py<PyAny>, PythonError> {
+    let (submission_id, loop_object) = reserve_submission(py).map_err(PythonError::runtime)?;
+    let scheduled = py
+        .import("asyncio")
+        .and_then(|asyncio| {
+            asyncio.call_method1(
+                "run_coroutine_threadsafe",
+                (coroutine.bind(py), loop_object.bind(py)),
+            )
+        })
+        .map(Bound::unbind)
+        .map_err(|error| {
+            release_pending_submission();
+            PythonError::from_pyerr(py, error, "call", "owned asyncio submission")
+        })?;
+    if let Err(error) = register_submission(py, submission_id, &scheduled) {
+        let _ignored = scheduled.bind(py).call_method0("cancel");
+        release_pending_submission();
+        return Err(PythonError::runtime(error));
+    }
+
+    let result = scheduled
+        .bind(py)
+        .call_method0("result")
+        .map(Bound::unbind)
+        .map_err(|error| PythonError::from_pyerr(py, error, "await", "owned asyncio coroutine"));
+    finish_submission(submission_id);
+    result
+}
+
+pub(super) fn shutdown() -> Result<(), PythonRuntimeError> {
+    let (loop_object, loop_thread) = {
+        let mut state = lock_state()?;
+        match state.lifecycle {
+            AsyncLifecycle::Disabled | AsyncLifecycle::Stopped => return Ok(()),
+            AsyncLifecycle::Failed => state.lifecycle = AsyncLifecycle::Stopping,
+            AsyncLifecycle::Starting => return Err(PythonRuntimeError::AsyncRuntimeNotRunning),
+            AsyncLifecycle::Running => state.lifecycle = AsyncLifecycle::Stopping,
+            AsyncLifecycle::Stopping => {}
+        }
+        while state.pending_submissions > 0 {
+            state = wait_for_change(state)?;
+        }
+        (state.loop_object.take(), state.loop_thread.take())
+    };
+
+    cancel_registered_submissions()?;
+    {
+        let mut state = lock_state()?;
+        while !state.submissions.is_empty() {
+            state = wait_for_change(state)?;
+        }
+    }
+    let stop_result = loop_object.map_or(Ok(()), |loop_object| {
+        Python::try_attach(|py| {
+            let stop = loop_object.bind(py).getattr("stop")?;
+            loop_object
+                .bind(py)
+                .call_method1("call_soon_threadsafe", (stop,))?;
+            Ok::<(), PyErr>(())
+        })
+        .ok_or(PythonRuntimeError::NotInitialized)?
+        .map_err(|error| PythonRuntimeError::AsyncRuntimeFailed(error.to_string()))
+    });
+    let join_result = loop_thread.map_or(Ok(()), |loop_thread| {
+        loop_thread
+            .join()
+            .map_err(|_| PythonRuntimeError::AsyncRuntimeFailed("loop thread panicked".to_string()))
+    });
+    let mut state = lock_state()?;
+    state.lifecycle = AsyncLifecycle::Stopped;
+    state.loop_object = None;
+    let failure = state.failure.take();
+    ASYNC_STATE_CHANGED.notify_all();
+    drop(state);
+    if let Some(message) = failure {
+        return Err(PythonRuntimeError::AsyncRuntimeFailed(message));
+    }
+    stop_result.and(join_result)
+}
+
+pub fn async_runtime_diagnostics() -> Result<PythonAsyncRuntimeDiagnostics, PythonRuntimeError> {
+    let state = lock_state()?;
+    Ok(PythonAsyncRuntimeDiagnostics {
+        running: state.lifecycle == AsyncLifecycle::Running,
+        stopping: state.lifecycle == AsyncLifecycle::Stopping,
+        loop_threads: usize::from(matches!(
+            state.lifecycle,
+            AsyncLifecycle::Starting | AsyncLifecycle::Running | AsyncLifecycle::Stopping
+        )),
+        active_submissions: state.submissions.len(),
+        pending_submissions: state.pending_submissions,
+    })
+}
+
+fn run_loop_thread(ready_sender: std::sync::mpsc::SyncSender<Result<Py<PyAny>, String>>) {
+    let mut ready_sender = Some(ready_sender);
+    let result = Python::try_attach(|py| -> Result<(), String> {
+        #[cfg(test)]
+        if FORCE_LOOP_SETUP_FAILURE.swap(false, Ordering::SeqCst) {
+            return Err("forced loop setup failure".to_string());
+        }
+        let asyncio = py.import("asyncio").map_err(|error| error.to_string())?;
+        let loop_object = asyncio
+            .call_method0("new_event_loop")
+            .map_err(|error| error.to_string())?
+            .unbind();
+        asyncio
+            .call_method1("set_event_loop", (loop_object.bind(py),))
+            .map_err(|error| error.to_string())?;
+        ready_sender
+            .take()
+            .ok_or_else(|| "loop readiness sender is unavailable".to_string())?
+            .send(Ok(loop_object.clone_ref(py)))
+            .map_err(|error| error.to_string())?;
+        loop_object
+            .bind(py)
+            .call_method0("run_forever")
+            .map_err(|error| error.to_string())?;
+        let shutdown_asyncgens = loop_object
+            .bind(py)
+            .call_method0("shutdown_asyncgens")
+            .map_err(|error| error.to_string())?;
+        loop_object
+            .bind(py)
+            .call_method1("run_until_complete", (shutdown_asyncgens,))
+            .map_err(|error| error.to_string())?;
+        loop_object
+            .bind(py)
+            .call_method0("close")
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    });
+    let failure = match result {
+        Some(Ok(())) => return,
+        Some(Err(message)) => message,
+        None => "CPython was unavailable on the loop thread".to_string(),
+    };
+    if let Some(sender) = ready_sender {
+        let _ignored = sender.send(Err(failure));
+    } else if let Ok(mut state) = ASYNC_STATE.lock() {
+        state.failure = Some(failure);
+        state.lifecycle = AsyncLifecycle::Failed;
+        ASYNC_STATE_CHANGED.notify_all();
+    }
+}
+
+fn reserve_submission(py: Python<'_>) -> Result<(u64, Py<PyAny>), PythonRuntimeError> {
+    let mut state = lock_state()?;
+    if state.lifecycle != AsyncLifecycle::Running {
+        return Err(if state.lifecycle == AsyncLifecycle::Stopping {
+            PythonRuntimeError::AsyncRuntimeStopping
+        } else {
+            PythonRuntimeError::AsyncRuntimeNotRunning
+        });
+    }
+    let loop_object = state
+        .loop_object
+        .as_ref()
+        .ok_or(PythonRuntimeError::AsyncRuntimeNotRunning)?
+        .clone_ref(py);
+    let submission_id = state.next_submission_id;
+    state.next_submission_id = state.next_submission_id.saturating_add(1);
+    state.pending_submissions = state.pending_submissions.saturating_add(1);
+    Ok((submission_id, loop_object))
+}
+
+fn register_submission(
+    py: Python<'_>,
+    submission_id: u64,
+    future: &Py<PyAny>,
+) -> Result<(), PythonRuntimeError> {
+    let mut state = lock_state()?;
+    state.pending_submissions = state.pending_submissions.saturating_sub(1);
+    state
+        .submissions
+        .insert(submission_id, future.clone_ref(py));
+    ASYNC_STATE_CHANGED.notify_all();
+    Ok(())
+}
+
+fn release_pending_submission() {
+    if let Ok(mut state) = ASYNC_STATE.lock() {
+        state.pending_submissions = state.pending_submissions.saturating_sub(1);
+        ASYNC_STATE_CHANGED.notify_all();
+    }
+}
+
+fn finish_submission(submission_id: u64) {
+    if let Ok(mut state) = ASYNC_STATE.lock() {
+        state.submissions.remove(&submission_id);
+        ASYNC_STATE_CHANGED.notify_all();
+    }
+}
+
+fn cancel_registered_submissions() -> Result<(), PythonRuntimeError> {
+    Python::try_attach(|py| {
+        let futures = {
+            let state = lock_state()?;
+            state
+                .submissions
+                .values()
+                .map(|future| future.clone_ref(py))
+                .collect::<Vec<_>>()
+        };
+        for future in futures {
+            future
+                .bind(py)
+                .call_method0("cancel")
+                .map_err(|error| PythonRuntimeError::AsyncRuntimeFailed(error.to_string()))?;
+        }
+        Ok(())
+    })
+    .ok_or(PythonRuntimeError::NotInitialized)?
+}
+
+fn fail_start(message: String) -> PythonRuntimeError {
+    if let Ok(mut state) = ASYNC_STATE.lock() {
+        state.lifecycle = AsyncLifecycle::Failed;
+        state.failure = Some(message.clone());
+        state.loop_object = None;
+        state.loop_thread = None;
+        ASYNC_STATE_CHANGED.notify_all();
+    }
+    PythonRuntimeError::AsyncRuntimeFailed(message)
+}
+
+fn lock_state() -> Result<MutexGuard<'static, AsyncRuntimeState>, PythonRuntimeError> {
+    ASYNC_STATE
+        .lock()
+        .map_err(|_| PythonRuntimeError::StateUnavailable)
+}
+
+fn wait_for_change(
+    state: MutexGuard<'static, AsyncRuntimeState>,
+) -> Result<MutexGuard<'static, AsyncRuntimeState>, PythonRuntimeError> {
+    ASYNC_STATE_CHANGED
+        .wait(state)
+        .map_err(|_| PythonRuntimeError::StateUnavailable)
+}
+
+#[cfg(test)]
+pub(super) fn reset_for_tests() {
+    if let Ok(mut state) = ASYNC_STATE.lock() {
+        *state = AsyncRuntimeState::new();
+        ASYNC_STATE_CHANGED.notify_all();
+    }
+    FORCE_LOOP_SETUP_FAILURE.store(false, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::python::{
+        initialize_runtime, reset_runtime_state_for_tests, test_config, test_guard,
+    };
+
+    #[test]
+    fn loop_setup_failure_is_joined_and_leaves_no_live_thread() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("async-loop-failure"))
+            .expect("CPython should initialize without the loop");
+        FORCE_LOOP_SETUP_FAILURE.store(true, Ordering::SeqCst);
+
+        let error = start().expect_err("forced loop setup should fail");
+
+        assert!(matches!(error, PythonRuntimeError::AsyncRuntimeFailed(_)));
+        assert_eq!(
+            async_runtime_diagnostics().expect("diagnostics should remain available"),
+            PythonAsyncRuntimeDiagnostics::default()
+        );
+        assert!(matches!(
+            shutdown(),
+            Err(PythonRuntimeError::AsyncRuntimeFailed(_))
+        ));
+        assert_eq!(
+            async_runtime_diagnostics().expect("failed runtime should normalize to stopped"),
+            PythonAsyncRuntimeDiagnostics::default()
+        );
+    }
+}

--- a/crates/sifr_runtime/src/python/coroutine_ops.rs
+++ b/crates/sifr_runtime/src/python/coroutine_ops.rs
@@ -1,17 +1,11 @@
 use super::object_ops::{clone_handle, store_object};
 use super::{ObjectHandle, PythonError};
-use pyo3::types::PyAnyMethods;
 
 pub fn run_coroutine_blocking(coroutine: &ObjectHandle) -> Result<ObjectHandle, PythonError> {
+    super::async_runtime::ensure_started().map_err(PythonError::runtime)?;
     super::attach(|py| {
         let coroutine = clone_handle(py, coroutine)?;
-        let asyncio = py
-            .import("asyncio")
-            .map_err(|error| PythonError::from_pyerr(py, error, "import", "asyncio"))?;
-        let value = asyncio
-            .call_method1("run", (coroutine.bind(py),))
-            .map_err(|error| PythonError::from_pyerr(py, error, "call", "asyncio.run coroutine"))?;
-        store_object(value.unbind())
+        super::async_runtime::run_coroutine_blocking(py, &coroutine).and_then(store_object)
     })
     .map_err(PythonError::runtime)?
 }
@@ -20,13 +14,15 @@ pub fn run_coroutine_blocking(coroutine: &ObjectHandle) -> Result<ObjectHandle, 
 mod tests {
     use super::*;
     use crate::python::{
-        call_object, close_object, from_float, from_int, get_attr, import_module,
-        initialize_runtime, reset_runtime_state_for_tests, shutdown_diagnostics, test_config,
-        test_guard, to_int, PythonRuntimeDiagnostics,
+        async_runtime_diagnostics, call_object, close_object, from_float, from_int, get_attr,
+        import_module, initialize_runtime, reset_runtime_state_for_tests, shutdown_diagnostics,
+        test_config, test_guard, to_int, PythonAsyncRuntimeDiagnostics, PythonRuntimeDiagnostics,
     };
+    use pyo3::types::{PyAnyMethods, PyDict, PyDictMethods, PyModule};
+    use std::sync::{Arc, Barrier};
 
     #[test]
-    fn run_coroutine_blocking_runs_python_owned_event_loop() {
+    fn run_coroutine_blocking_uses_the_application_owned_event_loop() {
         let _guard = test_guard();
         reset_runtime_state_for_tests();
         initialize_runtime(test_config("run-coroutine")).expect("init should succeed");
@@ -54,5 +50,146 @@ mod tests {
                 leaked_objects: 0,
             }
         );
+        super::super::async_runtime::shutdown().expect("owned loop should stop");
+        assert_eq!(
+            async_runtime_diagnostics().expect("async diagnostics should be available"),
+            PythonAsyncRuntimeDiagnostics::default()
+        );
+    }
+
+    #[test]
+    fn concurrent_raw_coroutines_share_one_owned_loop_and_thread() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        let mut config = test_config("shared-loop");
+        config
+            .required_import_roots
+            .push("__sifr_async_identity__".to_string());
+        config
+            .trusted_import_roots
+            .push("__sifr_async_identity__".to_string());
+        initialize_runtime(config).expect("init should start the owned loop");
+        install_identity_module();
+
+        let start_barrier = Arc::new(Barrier::new(3));
+        let workers = (0..2)
+            .map(|_| {
+                let start_barrier = Arc::clone(&start_barrier);
+                std::thread::spawn(move || {
+                    start_barrier.wait();
+                    run_identity_coroutine()
+                })
+            })
+            .collect::<Vec<_>>();
+        start_barrier.wait();
+        let identities = workers
+            .into_iter()
+            .map(|worker| worker.join().expect("identity worker should not panic"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(identities[0], identities[1]);
+        assert_eq!(
+            async_runtime_diagnostics().expect("async diagnostics should be available"),
+            PythonAsyncRuntimeDiagnostics {
+                running: true,
+                stopping: false,
+                loop_threads: 1,
+                active_submissions: 0,
+                pending_submissions: 0,
+            }
+        );
+        super::super::async_runtime::shutdown().expect("owned loop should stop");
+        assert_eq!(
+            async_runtime_diagnostics().expect("async diagnostics should be available"),
+            PythonAsyncRuntimeDiagnostics::default()
+        );
+    }
+
+    #[test]
+    fn shutdown_cancels_and_joins_an_in_flight_raw_coroutine() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        let mut config = test_config("shutdown-in-flight");
+        config.start_async_loop = true;
+        config
+            .required_import_roots
+            .push("__sifr_async_identity__".to_string());
+        config
+            .trusted_import_roots
+            .push("__sifr_async_identity__".to_string());
+        initialize_runtime(config).expect("init should start the owned loop");
+        install_identity_module();
+
+        let worker = std::thread::spawn(run_waiting_coroutine);
+        let registered = (0..5_000).any(|_| {
+            let registered = async_runtime_diagnostics()
+                .expect("async diagnostics should be available")
+                .active_submissions
+                == 1;
+            if !registered {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            registered
+        });
+        if !registered {
+            let _ignored = super::super::async_runtime::shutdown();
+            let _ignored = worker.join();
+            panic!("worker submission should be registered before shutdown");
+        }
+
+        super::super::async_runtime::shutdown().expect("owned loop should stop");
+        assert!(
+            worker.join().expect("waiting worker should not panic"),
+            "shutdown should surface cancellation to the blocking raw caller"
+        );
+        assert_eq!(
+            async_runtime_diagnostics().expect("async diagnostics should be available"),
+            PythonAsyncRuntimeDiagnostics::default()
+        );
+    }
+
+    fn install_identity_module() {
+        super::super::attach(|py| {
+            let module = PyModule::from_code(
+                py,
+                c"import asyncio\nimport threading\n\nasync def identity():\n    return f'{id(asyncio.get_running_loop())}:{threading.get_ident()}'\n\nasync def wait():\n    await asyncio.sleep(60)\n",
+                c"<sifr-async-identity>",
+                c"__sifr_async_identity__",
+            )
+            .expect("identity module should compile");
+            let sys = py.import("sys").expect("sys should import");
+            let modules = sys
+                .getattr("modules")
+                .expect("sys.modules should resolve")
+                .cast_into::<PyDict>()
+                .expect("sys.modules should be a dict");
+            modules
+                .set_item("__sifr_async_identity__", module)
+                .expect("identity module should install");
+        })
+        .expect("runtime should attach");
+    }
+
+    fn run_identity_coroutine() -> String {
+        let module = import_module("__sifr_async_identity__").expect("module should import");
+        let identity = get_attr(&module, "identity").expect("identity should resolve");
+        let coroutine = call_object(&identity, &[], &[]).expect("coroutine should be created");
+        let value = run_coroutine_blocking(&coroutine).expect("coroutine should complete");
+        let identity_value = crate::python::to_str(&value).expect("identity should be text");
+        for handle in [module, identity, coroutine, value] {
+            close_object(handle).expect("identity handle should close");
+        }
+        identity_value
+    }
+
+    fn run_waiting_coroutine() -> bool {
+        let module = import_module("__sifr_async_identity__").expect("module should import");
+        let wait = get_attr(&module, "wait").expect("wait should resolve");
+        let coroutine = call_object(&wait, &[], &[]).expect("coroutine should be created");
+        let was_cancelled = run_coroutine_blocking(&coroutine).is_err();
+        for handle in [module, wait, coroutine] {
+            close_object(handle).expect("waiting handle should close");
+        }
+        was_cancelled
     }
 }

--- a/crates/sifr_runtime/src/python/coroutine_ops.rs
+++ b/crates/sifr_runtime/src/python/coroutine_ops.rs
@@ -68,7 +68,7 @@ mod tests {
         config
             .trusted_import_roots
             .push("__sifr_async_identity__".to_string());
-        initialize_runtime(config).expect("init should start the owned loop");
+        initialize_runtime(config).expect("init should preserve lazy owned-loop startup");
         install_identity_module();
 
         let start_barrier = Arc::new(Barrier::new(3));

--- a/crates/sifr_runtime/src/python/python_test_support.rs
+++ b/crates/sifr_runtime/src/python/python_test_support.rs
@@ -74,5 +74,6 @@ print(os.pathsep.join(sys.path))
         native_import_roots: Vec::new(),
         trusted_native_roots: Vec::new(),
         bridge_sources: Vec::new(),
+        start_async_loop: false,
     }
 }

--- a/plans/reviews/active/ad-hoc-python-interop-m7-wave2-pr-2958-review-round1.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-wave2-pr-2958-review-round1.md
@@ -1,0 +1,38 @@
+## PR #2958 — M7 Wave 2 Post-Push Review
+
+### Prioritized Findings
+
+**None material.** All three pre-PR review rounds (checked in at `plans/reviews/active/ad-hoc-python-interop-m7-wave2-review-round{1,2,3}.md`) were re-audited against the shipped diff and the fixes remain in place.
+
+**Nits (non-blocking, do not gate merge):**
+
+1. **NIT — misleading test `.expect()` message.** `crates/sifr_runtime/src/python/coroutine_ops.rs:71` — `concurrent_raw_coroutines_share_one_owned_loop_and_thread` calls `initialize_runtime(config).expect("init should start the owned loop")`, but `config` is derived from `test_config()` which defaults `start_async_loop: false` (`python_test_support.rs:77`). Init deliberately does **not** start the loop here — the test's whole point is proving the two workers race on lazy `ensure_started()`. Message contradicts the test's intent; message-only, no behavior change.
+2. **NIT — round-3 residual, unchanged.** `crates/sifr_runtime/src/python/async_runtime.rs:161-166` — three `?`-gates between "handles taken" and `join()` can locally drop `loop_object`/`loop_thread` without invoking `stop()`/`join()` (`cancel_registered_submissions()?`, second `lock_state()?`, `wait_for_change()?`). Only reachable when `Python::try_attach` returns `None` (CPython finalized) or a mutex is poisoned — implausible in shipped paths (`PythonRuntimeGuard::drop` runs before finalize; state mutex is held briefly and never panics). Acknowledged by round 3 as non-blocking; defer to a future hardening pass.
+3. **NIT — round-2 concern B, unchanged.** `crates/sifr_runtime/src/python/async_runtime.rs:255-259` — post-readiness self-failure sets `lifecycle = Failed` but leaves `loop_object`/`loop_thread` populated with stale references. Only reachable if `run_forever` / `shutdown_asyncgens` / `close` unexpectedly returns Err on the loop thread. A subsequent `shutdown()` will attempt `call_soon_threadsafe` on the dead loop and surface the `AsyncRuntimeFailed(previous_failure)` before propagating the stop error. Non-blocking.
+
+### Verified
+
+- **Round-1 HIGH lock-order inversion (shutdown ↔ GIL) — FIXED.** `async_runtime.rs:146-159` takes `loop_object`/`loop_thread` out under `ASYNC_STATE` then releases the guard at the block boundary before line 168's `Python::try_attach`. `cancel_registered_submissions` (`async_runtime.rs:310-329`) uses GIL→state, matching the worker path (`coroutine_ops.rs:6` acquires GIL via `super::attach`, worker helpers acquire state inside). No inverted acquisition order remains.
+- **Round-1 MEDIUM concurrent lazy start — FIXED.** `start()` (`async_runtime.rs:61-77`) loops on lifecycle: `Running→Ok`, `Starting→wait_for_change`, `Stopping→Err`, `Disabled|Stopped|Failed→transition & spawn`. Second concurrent lazy caller waits on the condvar for the initiator, exercised by `concurrent_raw_coroutines_share_one_owned_loop_and_thread`.
+- **Round-1 LOW test coverage — ADDRESSED.** Concurrent lazy-start test uses `start_async_loop=false` (default) and races two workers via a 3-party `Barrier` (`coroutine_ops.rs:60-106`); `shutdown_cancels_and_joins_an_in_flight_raw_coroutine` (`coroutine_ops.rs:108-149`) polls to registration (5000×1ms, with explicit cleanup on timeout) then races shutdown against a waiting future.
+- **Conditional bootstrap.** `python_interop_plan.rs:83, 96, 130, 158-203` sets `requires_async_loop` when a module has an async declaration (`PythonInteropEffect::Async`) OR imports `sifr.python.run_coroutine_blocking` (including aliased names) AND calls it. Three plan tests (`python_interop_plan_tests.rs:99-158`) cover unaliased, aliased, and negative.
+- **Cache identity.** `python.requires_async_loop=yes|no` appended in `push_python_plan_cache_key` (`python_interop_plan.rs:239-245`); folded into `InteropBuildPlan::cache_key_fragment` via `rust_interop_plan.rs:19-21`; asserted at `python_interop_plan_tests.rs:120-124`.
+- **Codegen wiring.** `apply_package_runtime_metadata` (`project_codegen.rs:107`) sets `start_async_loop` from `interop.python.requires_async_loop`; `render_python_runtime_prelude` (`python_runtime.rs:191, 217`) renders it into generated `main.rs`; `package_python_runtime_starts_owned_loop_only_when_planned` (`project_codegen.rs:179-202`) asserts both `start_async_loop: true` and `start_async_loop: false` render.
+- **Raw API semantics preserved.** `stdlib/sifr/python.sifr:778-781` still `@blocking_io def run_coroutine_blocking(...)`. Runtime now delegates to `async_runtime::run_coroutine_blocking` which uses `asyncio.run_coroutine_threadsafe(coro, loop)` + `Future.result()` (`async_runtime.rs:117-142`) — no per-call `asyncio.run` remains anywhere in the raw path (`coroutine_ops.rs` no longer imports `asyncio`).
+- **Lifecycle & no-thread-leak.** Single named OS thread (`sifr-python-asyncio`), started only after CPython + bridge init + boundary-error registration (`python.rs:250-256`), readiness published via bounded `sync_channel(1)` before admission (`async_runtime.rs:80-105`). Six-state machine (`Disabled/Starting/Running/Stopping/Stopped/Failed`). Init failure via `fail_start` clears both handles (`async_runtime.rs:331-340`); `loop_setup_failure_is_joined_and_leaves_no_live_thread` (`async_runtime.rs:372-395`) asserts diagnostics normalize and a second shutdown surfaces `AsyncRuntimeFailed`.
+- **Shutdown separation.** `stop_result` and `join_result` are computed independently (`async_runtime.rs:168-193`); `join()` unconditionally runs when `loop_thread` is `Some`; lifecycle normalized to `Stopped`, `loop_object` cleared, `failure` propagated before `stop_result.and(join_result)`.
+- **Submission accounting.** Monotonic `u64` id (`saturating_add`), symmetric reserve/register/finish/release (`async_runtime.rs:262-308`). Two-phase drain: pending==0 then submissions.is_empty(), between which `cancel_registered_submissions` runs without holding state.
+- **PythonRuntimeGuard drop-time shutdown.** `python.rs:117` invokes `async_runtime::shutdown()` before `drain_pending_releases`; workers releasing the GIL inside `Future.result()` allow cancellation to land without inversion.
+- **Wave-2 gate discipline preserved.** `@python.coroutine` still hard-errors with `SIFR-PYRES-0002` (`python_lowering/python_interop.rs:410, 435, 639`); `cleanup=async_close` still hard-errors via `reserved_cleanup` (line 434-440). Wave-1 frontend contract from PR #2956 remains gated.
+- **No panics in user paths.** No `.unwrap()`/`.expect()` outside `#[cfg(test)]` in the new async_runtime; all error paths use `?` or `.map_err`. `saturating_add`/`saturating_sub` guard the counters.
+- **File-size guardrail.** `async_runtime.rs` 396 lines; `python.rs` 862 lines; `coroutine_ops.rs` 195 lines; `python_interop_plan.rs` 380 lines; `python_runtime.rs` 464 lines. All well under 900.
+- **Validation report accurate.** The described `create-pr` profile run — all lanes green, 130/130 e2e fixtures, one transient LSP-smoke timeout after 23 successful requests, immediate unchanged repeat passed in 11s — matches the user-provided authoritative gate.
+
+### PR-body sanity
+
+- Summary bullets accurately describe the substrate.
+- Explicit gate statement is present: "The typed `@python.coroutine` and `cleanup=async_close` frontend remains behind `SIFR-PYRES-0002`; this PR is M7 Wave 2 substrate only."
+- Validation section matches shipped tests and the create-pr run; the transient LSP timeout is disclosed.
+- Review history (rounds 1-3) is linked and matches the checked-in artifacts.
+
+VERDICT: SATISFIED

--- a/plans/reviews/active/ad-hoc-python-interop-m7-wave2-pr-2958-review-round2.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-wave2-pr-2958-review-round2.md
@@ -1,0 +1,8 @@
+Confirmed. The `23821baf9` commit is exactly two surgical changes on top of the previously-reviewed diff:
+
+1. **Nit resolved accurately.** `crates/sifr_runtime/src/python/coroutine_ops.rs:71` — message changed from `"init should start the owned loop"` to `"init should preserve lazy owned-loop startup"`. `test_config("shared-loop")` inherits the default `start_async_loop: false` (`python_test_support.rs:77`) and never overrides it, so init deliberately does *not* start the loop; the whole test point is proving two workers race on lazy `ensure_started()`. New message matches intent. The sibling test at `coroutine_ops.rs:120` still says "init should start the owned loop" — correctly, because that test sets `config.start_async_loop = true` at line 113.
+2. **Review artifact checked in.** `plans/reviews/active/ad-hoc-python-interop-m7-wave2-pr-2958-review-round1.md` — the round-1 post-push review that returned SATISFIED with the message-only nit and two acknowledged non-blocking round-2/round-3 residuals. Verified content matches its stated purpose; no findings introduced.
+
+Full PR diff still covers only the M7 Wave 2 substrate files (codegen plan + cache identity, driver runtime prelude, runtime `python.rs`/`async_runtime.rs`/`coroutine_ops.rs`, test support, and the four review artifacts). No new material findings; the two acknowledged residual nits (drop-time `?`-gates, post-readiness stale handles) remain non-blocking and were already deferred by round 3. PR body and validation section are unchanged in shape and still accurate.
+
+VERDICT: SATISFIED

--- a/plans/reviews/active/ad-hoc-python-interop-m7-wave2-review-round1.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-wave2-review-round1.md
@@ -1,0 +1,73 @@
+# M7 Wave 2 Review — Prioritized Findings
+
+## Prioritized Actionable Findings
+
+### 1. HIGH — Lock-order inversion between the state mutex and the GIL in `shutdown()` can deadlock a live worker (correctness)
+
+`crates/sifr_runtime/src/python/async_runtime.rs:160-163`
+```rust
+let loop_object =
+    Python::try_attach(|py| state.loop_object.as_ref().map(|value| value.clone_ref(py)))
+        .flatten();
+(loop_object, state.loop_thread.take())
+```
+
+Shutdown holds `ASYNC_STATE` (from line 149) and then blocks acquiring the GIL via `Python::try_attach` (backed by `PyGILState_Ensure`). But every worker path acquires the GIL first (via `super::attach`), then acquires `ASYNC_STATE`:
+
+- `reserve_submission` (line 265) locks state, `clone_ref(py)` needs the GIL.
+- `register_submission` (line 285) locks state, `future.clone_ref(py)` needs the GIL.
+- `finish_submission` (line 306) locks state, invoked from within the GIL-holding closure in `coroutine_ops.rs:6-9`.
+
+Concrete deadlock trace (all fields verified in the diff):
+
+1. Worker W is in `run_coroutine_blocking` (line 114). It reserves, submits, and registers. After `register_submission` returns, `pending_submissions` is 0 and W still holds the GIL, at line 138 preparing `call_method0("result")`.
+2. Concurrent `shutdown()` acquires `ASYNC_STATE` (line 149), transitions to `Stopping`, wakes from `wait_for_change` (line 157‑159) because pending is 0, and reaches line 160 holding state, wanting the GIL.
+3. If the coroutine is already done (e.g. `asyncio.sleep(0.0)` or the identity coroutine used in the concurrent test), `Future.result()` returns synchronously without releasing the GIL. W stays GIL-holding through `map(Bound::unbind)` and `map_err`, then calls `finish_submission` at line 143 — which needs state.
+4. Shutdown holds state and blocks on GIL; W holds GIL and blocks on state → classic deadlock.
+
+This is not triggered by the shipped tests only because every test joins its workers before calling `shutdown()`. `PythonRuntimeGuard::drop` (crates/sifr_runtime/src/python.rs:117) calls `async_runtime::shutdown()` on program exit while other threads may still be inside the raw path (e.g. a `spawn_blocking` task that isn't drained by the tokio runtime). This is a real production hazard and blocks SATISFIED.
+
+Suggested fix (minimal): take `state.loop_object` out of the guard before touching the GIL; do not hold `ASYNC_STATE` across `Python::try_attach`. For example:
+```rust
+let (maybe_loop, loop_thread) = {
+    let mut state = lock_state()?;
+    // (transition + wait_for_change loop unchanged)
+    (state.loop_object.take(), state.loop_thread.take())
+};
+```
+`state.loop_object` is already cleared later at line 191, so taking it here is equivalent semantically and eliminates the inverted acquisition order.
+
+### 2. MEDIUM — Concurrent lazy `ensure_started` racing with an in-flight `Starting` spuriously fails (correctness/UX)
+
+`crates/sifr_runtime/src/python/async_runtime.rs:104-112`
+```rust
+AsyncLifecycle::Starting => Err(PythonRuntimeError::AsyncRuntimeNotRunning),
+```
+
+If two threads call `run_coroutine_blocking` before the loop is running (e.g. `start_async_loop=false` and both racing on first use), thread A transitions to `Starting` inside `start()` and blocks on `ready_receiver.recv()`; thread B sees `Starting` and returns `AsyncRuntimeNotRunning` immediately even though the loop will be up microseconds later. Failure scenario: a program that opts out of `requires_async_loop` detection (say a future dynamic-only path) and issues two concurrent raw calls would see one worker error out.
+
+Mitigation today: generated bootstrap sets `start_async_loop=true` whenever the plan detects the intrinsic, so the loop is already `Running` before any worker attaches. But the lazy-start invariant is asserted by the tests' single-caller path (`run_coroutine_blocking_uses_the_application_owned_event_loop`), not by a concurrent lazy start. Prefer `wait_for_change` until lifecycle leaves `Starting` (analogous to the shutdown drain), rather than erroring.
+
+### 3. LOW — Test cannot exercise concurrent lazy start; identity proof runs with pre-started loop only (test coverage)
+
+`crates/sifr_runtime/src/python/coroutine_ops.rs:60-97`
+`concurrent_raw_coroutines_share_one_owned_loop_and_thread` sets `config.start_async_loop = true`, so the loop is already `Running` when the workers spin up. That is fine for proving "one loop, one thread" identity, but it does not exercise the more interesting invariant of Finding 2 (concurrent lazy start) or the shutdown/worker race behind Finding 1. Non-blocking, but consider one additional case that omits `start_async_loop` and lets `ensure_started` bring the loop up under contention.
+
+## Verified Correct
+
+- Bootstrap detection is conditional on either an async declaration (`PythonInteropEffect::Async`) or the raw intrinsic (`sifr.python.run_coroutine_blocking`), including aliased local names — python_interop_plan.rs:83, 96, 130, 158‑203 and the three plan tests.
+- Cache identity flips on the new flag: `python.requires_async_loop=` fragment (python_interop_plan.rs:239-245); flowed through `PackagePythonRuntime::set_start_async_loop` → `render_python_runtime_prelude` (`start_async_loop: {start_async_loop}`) → the generated `main.rs` — asserted at project_codegen.rs:180-201.
+- Wave 1 gate preserved: `@python.coroutine` still hard-errors with `PYRES_UNIMPLEMENTED_DECLARATION` (python_interop.rs:410, 435, 639); async wrappers are not generated; no `async_close` runtime activation.
+- Raw API keeps `@blocking_io` classification (stdlib/sifr/python.sifr:778) — no offload semantics changed.
+- Single named OS thread (`sifr-python-asyncio`), started only after CPython + bridge init (python.rs:250-256), readiness published via bounded `sync_channel(1)` before admission (async_runtime.rs:76-101), state machine covers Disabled/Starting/Running/Stopping/Stopped/Failed, submissions keyed by monotonic `next_submission_id: u64`.
+- `reserve_submission` rejects when not `Running` (async_runtime.rs:267‑273); `saturating_add`/`saturating_sub` guard the counters.
+- Init-failure path can't leak the thread: `fail_start` (async_runtime.rs:334‑343) clears `loop_object`/`loop_thread` and the `loop_setup_failure_is_joined_and_leaves_no_live_thread` test verifies both `diagnostics == default` and the second shutdown surfacing `AsyncRuntimeFailed`.
+- Ready-sender lifecycle is correct: `Option::take` consumes it exactly once, and the post-readiness failure path routes into the `ASYNC_STATE` fallback (async_runtime.rs:228-262).
+- No `Any`/`unwrap`/`expect` in user paths; no `asyncio.run` remains in the raw path; concurrent workers observe identical `id(loop):thread_ident`.
+- File sizes all under the 900-line guardrail; async runtime cleanly isolated in its own module.
+
+## Verdict
+
+The wave scope, state machine, cache identity, bootstrap detection (including aliased raw calls), gate discipline, and init-failure guarantee all land as specified in the plan review round 2. However, Finding 1 is a real lock-order inversion that can deadlock the runtime guard's `drop` against an in-flight fast raw coroutine on another thread — the exact "runtime shutdown leaves no live asyncio task or loop thread" acceptance criterion cannot be guaranteed until this is fixed. This is a small mechanical fix (take `loop_object` out of the guard before touching the GIL) but it is a material correctness gap.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/active/ad-hoc-python-interop-m7-wave2-review-round2.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-wave2-review-round2.md
@@ -1,0 +1,34 @@
+Confirmed the async_runtime touches only `asyncio` module surfaces (event loops and concurrent futures) — never `PyCapsule` or DLPack. There is no direct or indirect path by which async lifecycle contamination can increment `TEST_DELETER_CALLS`.
+
+## M7 Wave 2 Review — Round 2 Findings
+
+### Round 1 findings — re-audit
+
+**1. HIGH lock-order inversion in `shutdown()` — FIXED.** `async_runtime.rs:146-159` now takes `state.loop_object` and `state.loop_thread` out while holding `ASYNC_STATE`, releases the guard at the block boundary, and only then invokes `Python::try_attach` at line 169. `cancel_registered_submissions` at line 308-316 acquires the GIL first and then `ASYNC_STATE`, matching the worker paths (`reserve_submission`, `register_submission`, `finish_submission` all run under `attach(|py| ...)` from `coroutine_ops.rs:6`). No path exists where one actor holds `ASYNC_STATE` and blocks on the GIL while another holds the GIL and blocks on `ASYNC_STATE`.
+
+**2. MEDIUM concurrent lazy `ensure_started` — FIXED.** `start()` at `async_runtime.rs:61-77` now loops on lifecycle: `Running → Ok`, `Starting → wait_for_change`, `Stopping → Err`, `Disabled|Stopped|Failed → transition to Starting and break to spawn`. `ensure_started` delegates to `start()`. Second concurrent lazy caller now sits on the condvar until the initiator completes and observes `Running`. Spurious wakeups are handled by the outer loop. On start failure, `fail_start` sets `Failed` and notifies; the waiter wakes, re-enters the loop, and retries — which is a reasonable UX for transient failures.
+
+**3. LOW test coverage — ADDRESSED.** `concurrent_raw_coroutines_share_one_owned_loop_and_thread` (`coroutine_ops.rs:60-106`) now leaves `start_async_loop` unset (defaults to `false` per `python_test_support.rs:77`), spawns two workers that block on a 3-party `Barrier`, and races their `ensure_started` calls. `shutdown_cancels_and_joins_an_in_flight_raw_coroutine` (`coroutine_ops.rs:108-151`) waits for a raw caller's submission to register, calls `shutdown()` concurrently, and asserts the caller sees an error and diagnostics return to default.
+
+### Residual concerns (non-blocking)
+
+**A. Shutdown error paths after handles are taken leak the loop thread.** `async_runtime.rs:168-183`: if `Python::try_attach` returns `None`, or `getattr("stop")` / `call_method1("call_soon_threadsafe", ...)` fails, `shutdown` returns early. The `loop_thread` `JoinHandle` in scope is then dropped (detaching the thread), the `loop_object` we already took is dropped, and `state.lifecycle` stays at `Stopping` forever. A subsequent `shutdown()` sees `Stopping`, finds `loop_object`/`loop_thread` already `None`, and short-circuits to `Stopped` — leaving the detached OS thread alive if it hadn't already exited. Only reachable if the interpreter is gone or the loop is already dead at shutdown time; implausible in normal shipped paths and not exercised by any test. Not a blocker.
+
+**B. Post-readiness self-failure leaves stale handles in state.** `run_loop_thread` at `async_runtime.rs:253-257` sets `state.lifecycle = Failed` but does not clear `state.loop_object` / `state.loop_thread`. A follow-up `shutdown()` then attempts `call_soon_threadsafe` on a dead loop, which fails and triggers concern A. Only occurs if `run_forever` returns unexpectedly (e.g. via SIGINT bubbling through), so implausible. Init-failure (pre-readiness) is correctly handled by `fail_start`. Not a blocker.
+
+**C. Fixed 1s poll in `shutdown_cancels_and_joins_an_in_flight_raw_coroutine`.** `coroutine_ops.rs:124-140` polls at 1 ms × 1 000 iterations for `active_submissions == 1`. On a heavily loaded CI worker the raw caller might not reach `register_submission` within 1 s, in which case the test panics without `worker.join()` and leaves the worker blocked in `future.result()` for 60 s. TEST_LOCK's poisoning path recovers on the next test, but the detached worker still holds a submission entry until the shutdown of a subsequent test cancels it. Test-only flakiness, not a production defect. Not a blocker.
+
+**D. DLPack deleter-counter ordering failure — unrelated to this wave.** Grep confirms `TEST_DELETER_CALLS`, `test_deleter`, and `test_capsule_destructor` are referenced only by `dlpack_ops.rs`. `async_runtime.rs` never creates a `PyCapsule`, holds only asyncio `EventLoop` and `concurrent.futures.Future` references, and `reset_for_tests` merely replaces `AsyncRuntimeState` (dropping asyncio objects into pyo3's internal release pool). There is no path by which async lifecycle drops or GCs a DLPack capsule. The ordering failure is a pre-existing cross-test contamination in the DLPack suite itself (likely in how pyo3's internal release pool drains vs. `TEST_DELETER_CALLS.store(0)` timing), not introduced by this wave.
+
+### Verified correct
+
+- No lock-order inversion anywhere: workers acquire GIL → `ASYNC_STATE`; shutdown holds `ASYNC_STATE` only when GIL is not held, and vice versa.
+- Reserve/register/finish accounting is symmetric: `reserve_submission` increments pending, `register_submission` decrements pending and inserts to `submissions`, `finish_submission` removes from `submissions`, `release_pending_submission` covers the reserve-succeeded-but-schedule-failed path (`async_runtime.rs:126-129`) and reserve-succeeded-but-register-failed path (line 130-134).
+- `shutdown()`'s two condvar waits are correct: first drains `pending_submissions` (all reserves have moved to registered or released), second drains `submissions` (all registered futures have been cancelled and finish_submission has run). Between them, `cancel_registered_submissions` snapshots futures under the lock and cancels them without holding it.
+- Cache key fragment `python.requires_async_loop=` is wired through `python_interop_plan.rs:239-245` and asserted by two plan tests plus the driver test at `project_codegen.rs:180-201`.
+- Bootstrap detection covers both `PythonInteropEffect::Async` declarations and aliased `sifr.python.run_coroutine_blocking` intrinsics (`python_interop_plan.rs:158-203`), verified by `raw_coroutine_call_requires_the_owned_async_loop`, `aliased_raw_coroutine_call_requires_the_owned_async_loop`, and `sync_python_declaration_does_not_require_the_owned_async_loop`.
+- Init-failure path is verified: `loop_setup_failure_is_joined_and_leaves_no_live_thread` proves diagnostics normalize and a second shutdown surfaces `AsyncRuntimeFailed`.
+- Wave 1 gate discipline preserved: no `@python.coroutine` or `cleanup=async_close` activation; raw API still `@blocking_io`.
+- All touched files under the 900-line guardrail.
+
+## VERDICT: SATISFIED

--- a/plans/reviews/active/ad-hoc-python-interop-m7-wave2-review-round3.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-wave2-review-round3.md
@@ -1,0 +1,34 @@
+## Final Pre-PR Review
+
+### Verified — round-1 findings remain fixed
+
+- **R1-1 (Lock-order inversion):** `shutdown()` at `async_runtime.rs:146-159` takes `state.loop_object` and `state.loop_thread` out under `ASYNC_STATE`, releases the guard at the block boundary, then acquires the GIL at line 169. `cancel_registered_submissions` (line 310-329) is GIL→state, matching worker paths. No inverted acquisition remains.
+- **R1-2 (Concurrent lazy start):** `start()` at `async_runtime.rs:61-77` loops on lifecycle; `Starting` sits on `wait_for_change` instead of erroring.
+- **R1-3 (Test coverage):** `concurrent_raw_coroutines_share_one_owned_loop_and_thread` (`coroutine_ops.rs:60-106`) races two lazy `ensure_started()` callers with `start_async_loop` unset. `shutdown_cancels_and_joins_an_in_flight_raw_coroutine` covers the shutdown-during-in-flight scenario.
+
+### Verified — round-2 hardening claims (C, plus additional shutdown work)
+
+- **Separate stop/join results:** lines 168-193. `stop_result` (`Python::try_attach` + `stop` + `call_soon_threadsafe`) and `join_result` (thread `join`) are computed independently.
+- **Join executed when handle exists in the normal path:** line 179 unconditionally calls `join()` if `loop_thread` is `Some`, regardless of `stop_result`.
+- **Lifecycle/handles normalized to Stopped after join:** lines 184-186 set `lifecycle = Stopped` and `loop_object = None` after both stop and join return.
+- **Loop-thread failure priority preserved:** `state.failure.take()` at line 187 is checked at line 190 and returned before `stop_result.and(join_result)`. Stop error is prioritized over join error via `and()`.
+- **In-flight test hardening:** `coroutine_ops.rs:124-138` polls up to 5000×1ms = 5s for registration; on timeout it explicitly calls `shutdown()` and `worker.join()` before panicking, so no dangling worker thread survives a timeout.
+- **Forced-setup-failure test:** `async_runtime.rs:373-395` — `fail_start` clears handles, diagnostics normalize to default, second `shutdown()` surfaces `AsyncRuntimeFailed`.
+
+### Verified — no new hazards introduced
+
+- No lock-order inversion in the new shutdown flow: state → drop → GIL (cancel) → state → drop → GIL (stop) → no-lock (join) → state (normalize).
+- Concurrent shutdown() calls are effectively serialized by the "who took the handles" race; the second caller sees `None` handles and no-ops.
+- `finish_submission` acquires only ASYNC_STATE (no GIL needed), so worker-holding-GIL + shutdown-in-condvar-wait interleaves without deadlock.
+- Codegen path (`python_interop_plan.rs` → `PackagePythonRuntime::set_start_async_loop` → `main.rs`) and cache key fragment (`python.requires_async_loop=`) are consistent with the tests at `python_interop_plan_tests.rs:99-158` and `project_codegen.rs:179-201`.
+- File-size guardrail: `async_runtime.rs` is 396 lines, well under 900.
+
+### Prioritized findings
+
+**None material.**
+
+Low-priority residual (non-blocking, unchanged from round-2 Concern A):
+
+- **Residual (LOW, unchanged):** `async_runtime.rs:161-166` still has three `?` gates between "handles taken" and the join — `cancel_registered_submissions()?`, second `lock_state()?`, and `wait_for_change(state)?`. Early-return on any of these drops `loop_object` and `loop_thread` locally without invoking `stop()` or `join()`, and leaves lifecycle stuck at `Stopping`. Only reachable when `Python::try_attach` returns `None` (CPython finalized) or the mutex is poisoned — both implausible in shipped paths (`PythonRuntimeGuard::drop` runs before CPython finalize; the state mutex is only held briefly and non-panicking). This wave incrementally improved robustness — join is now unconditional in the common path — but the claim "always joins when a handle exists" is not literally true for these degenerate edges. Consider addressing in a future hardening pass by collecting `cancel`/wait errors into the final `stop_result.and(join_result)` composition instead of `?`-propagating early. Round 2 already ruled this non-blocking; nothing about the wave 2 hardening regresses this posture.
+
+VERDICT: SATISFIED


### PR DESCRIPTION
## Summary

- add one conditionally bootstrapped, application-owned asyncio loop on a named OS thread
- route the raw `sifr.python.run_coroutine_blocking` path through thread-safe owned-loop submission instead of per-call `asyncio.run`
- track lifecycle, readiness, monotonic submissions, cancellation, shutdown, loop stop, and thread join
- include async-loop requirements in generated runtime metadata and Python interop cache identity
- prove concurrent lazy callers share one loop/thread and shutdown cancels and joins in-flight raw work

The typed `@python.coroutine` and `cleanup=async_close` frontend remains behind `SIFR-PYRES-0002`; this PR is M7 Wave 2 substrate only.

## Validation

- `cargo test -p sifr_runtime --features python python::coroutine_ops::tests -- --nocapture --test-threads=1`
- `cargo test -p sifr_runtime --features python python::async_runtime::tests -- --nocapture --test-threads=1`
- `cargo test -p sifr_codegen python_interop_plan_tests -- --nocapture`
- `cargo test -p sifr_driver package_python_runtime_ -- --nocapture`
- `cargo test -p sifr_driver raw_coroutine_api_builds_and_runs_on_the_owned_loop -- --ignored --nocapture`
- `cargo check -p sifr_runtime -p sifr_codegen -p sifr_driver`
- `scripts/run_all_tests.sh --profile create-pr` — pass, all lanes; 130/130 e2e fixtures

The first full gate attempt encountered a transient LSP smoke timeout after 23 successful requests. The exact LSP smoke passed unchanged immediately afterward, and the repeated full create-PR profile passed with the LSP smoke completing in 11 seconds.

## Review

Opus review rounds are checked in:

- round 1 found a shutdown mutex/GIL lock inversion and a concurrent lazy-start race
- round 2 verified both fixes and returned SATISFIED
- round 3 verified additional shutdown/test hardening and returned SATISFIED with no material findings