### PR TITLE
Record M7 owned asyncio runtime wave

### DIFF
--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -6,8 +6,9 @@ In progress. The phase defines one complete end-state architecture and an
 ordered implementation sequence. Opus High pass 5 approved the complete design;
 a final independent Fable High audit found no blockers and its eight
 non-blocking precision refinements are incorporated. M0 through M6 are
-implemented, locally validated, and linked below; M7 and later milestones are
-not yet implemented.
+implemented, locally validated, and linked below; M7 is in progress with its
+frontend-contract and owned-loop waves merged, while later milestones are not
+yet implemented.
 Milestones sequence delivery; they do not create reduced language versions,
 temporary public contracts, dual authorities, or alternate lowering paths.
 
@@ -517,7 +518,8 @@ Implementation waves (one locally validated and reviewed PR per wave):
   - Prepare stable diagnostics for sync/async decorator substitution, borrowed
     async results, non-consuming close, and unsupported cleanup shapes. Keep
     `cleanup=async_close` gated until its runtime lifecycle is complete.
-- [ ] Add the application-owned asyncio runtime and raw submission path:
+- [x] Add the application-owned asyncio runtime and raw submission path —
+  [PR #2958](https://github.com/sifr-lang/sifr/pull/2958):
   - Start one loop on one named OS thread after CPython and bridge-loader setup;
     publish a thread-safe submission handle only after loop readiness.
   - Maintain an explicit accepting/running/stopping/stopped state machine and a

--- a/plans/reviews/active/ad-hoc-python-interop-m7-wave2-tracker-pr-2959-review-round1.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-wave2-tracker-pr-2959-review-round1.md
@@ -1,0 +1,19 @@
+I've reviewed PR #2959 against the criteria. Verification results:
+
+**Content verification:**
+- **Phase status**: Updated text at lines 8–11 reads "M0 through M6 are implemented, locally validated, and linked below; M7 is in progress with its frontend-contract and owned-loop waves merged, while later milestones are not yet implemented." ✓ Accurate.
+- **M7 Wave 2 checkbox and PR link**: Line 521 flips Wave 2 ("Add the application-owned asyncio runtime and raw submission path") to `[x]` linked to PR #2958. Confirmed via `gh` that PR #2958 is merged (state=MERGED, mergedAt=2026-07-13T04:29:44Z). ✓
+- **Wave 3 and later**: Lines 533, 546, 556, 567, 574 remain `[ ]` (cooperative-cancellation carrier, supervisor/shutdown substrate, typed async wrappers, async-close lifecycle, activation-and-close). ✓
+- **M7 top-level milestone**: Line 141 keeps `[ ] M7 owned asyncio runtime and async declarations` unchecked, correctly reflecting that M7 overall is still in progress. ✓
+- **Contract wording preserved**: Complete-design language ("Opus High pass 5 approved the complete design"), Non-Goals, Delivery Rule (lines 116–128), and Milestones section headings are untouched. The "In progress" preamble was refined without weakening any contract. ✓
+- **Prior Wave 1 entry**: Line 507 already carried `[x]` with PR #2956 from the earlier tracker commit — this PR does not re-touch it, avoiding churn. ✓
+
+**PR shape:**
+- Diff limited to a single file (`plans/issues/active/ad-hoc-declaration-first-python-interop.md`), +5/-3. Docs-only, focused. ✓
+- PR title and summary accurately describe the change (record Wave 2 merge, correct phase status). ✓
+
+**Minor observation (non-blocking):** The PR is currently in `DRAFT` state on GitHub. Content is ready for merge; only workflow state distinguishes it from mergeable. Not a defect in the change itself — flagging so the author can flip it to "Ready for review" when they intend to land it.
+
+No actionable findings against the content or contract preservation.
+
+VERDICT: SATISFIED


### PR DESCRIPTION
## Summary

- record merged M7 Wave 2 implementation PR #2958
- mark the application-owned asyncio runtime/raw submission wave complete
- correct the phase status to show M7 is in progress with its first two waves merged

## Validation

- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`