### PR TITLE
Add typed async Python declaration wrappers

### DIFF
--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -55,6 +55,8 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
     }
     let uses_task_scope = super::module_uses_task_scope(module);
     let uses_join_set = super::module_uses_join_set(module);
+    let uses_async_python =
+        super::python_interop_common::module_uses_async_python_declaration(module);
     let uses_join_set_spawn_cpu = super::module_uses_join_set_spawn_cpu(module);
     let uses_task_scope_offload = super::module_uses_task_scope_offload(module);
     let uses_task_scope_spawn_cpu = super::module_uses_task_scope_spawn_cpu(module);
@@ -68,8 +70,10 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
     if super::module_uses_async_exit_cause_type(module) {
         emitted_items.extend(super::build_async_exit_cause_type_items());
     }
-    if uses_task_scope || uses_join_set {
+    if uses_task_scope || uses_join_set || uses_async_python {
         emitted_items.extend(super::build_task_cancellation_items());
+    }
+    if uses_task_scope || uses_join_set {
         emitted_items.extend(super::build_task_scope_items());
         emitted_items.extend(super::build_task_supervisor_items());
         emitted_items.extend(super::build_task_context_scope_extension_items(true));

--- a/crates/sifr_codegen/src/function_emitter/generator_bodies.rs
+++ b/crates/sifr_codegen/src/function_emitter/generator_bodies.rs
@@ -3,8 +3,8 @@ use super::{
     python_callback_bounds::python_callback_bound_param_names, HirFunction, HirStmt, OwnershipKind,
     RustEmitter, RustExpr, RustItem, RustLiteral, RustParam, RustStmt, RustType, Type, Visibility,
 };
+use crate::python_interop_common::python_omit_parameter_indices;
 use crate::python_interop_direct::python_interop_function_body;
-use crate::python_interop_direct::python_omit_parameter_indices;
 use crate::rust_interop_direct::rust_interop_function_body;
 use std::collections::HashSet;
 impl RustEmitter {

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -81,6 +81,10 @@ mod operator_protocol_emitters;
 mod output_helpers;
 mod preamble;
 pub use preamble::*;
+mod python_interop_async;
+#[cfg(test)]
+mod python_interop_async_tests;
+mod python_interop_common;
 mod python_interop_direct;
 #[cfg(test)]
 mod python_interop_direct_tests;

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -540,8 +540,12 @@ pub fn generate_rust_with_stdlib_for_module(
             preamble_items.extend(build_file_handle_struct_items());
         }
     }
-    if uses_task_scope || uses_join_set {
+    let uses_async_python =
+        crate::python_interop_common::module_uses_async_python_declaration(module);
+    if uses_task_scope || uses_join_set || uses_async_python {
         preamble_items.extend(build_task_cancellation_items());
+    }
+    if uses_task_scope || uses_join_set {
         preamble_items.extend(build_task_scope_items());
         preamble_items.extend(build_task_supervisor_items());
         preamble_items.extend(build_task_context_scope_extension_items(

--- a/crates/sifr_codegen/src/python_interop_async.rs
+++ b/crates/sifr_codegen/src/python_interop_async.rs
@@ -1,0 +1,826 @@
+use sifr_ir::{
+    HirFunction, PythonInteropDeclaration, PythonInteropDecoratorKind, PythonParameterKind,
+};
+use sifr_type_system::Type;
+use std::collections::HashMap;
+
+use crate::python_interop_direct::{mapped_try, runtime_call};
+use crate::{RustExpr, RustLiteral, RustParam, RustStmt, RustType};
+
+pub(crate) fn async_python_function_body(
+    func: &HirFunction,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<Vec<RustStmt>> {
+    let declaration = func.python_interop.first()?;
+    if declaration.kind != PythonInteropDecoratorKind::Coroutine || !func.is_async {
+        return None;
+    }
+    let Type::Result(ok_type, error_type) = func.return_type.resolve_alias() else {
+        return None;
+    };
+    let target = declaration.target.as_ref()?;
+    if target.segments.len() < 2 || target.segments[0] == "Self" {
+        return None;
+    }
+
+    let mut body = argument_frame(func, declaration, error_type, opaque_classes)?;
+    let request = RustExpr::FnCall {
+        func: Box::new(python_path(&["PythonAsyncRequest", "function"])),
+        args: vec![
+            RustExpr::Vec(
+                target
+                    .segments
+                    .iter()
+                    .map(|value| owned_string(value))
+                    .collect(),
+            ),
+            RustExpr::Ident("__sifr_python_args".to_string()),
+            RustExpr::Ident("__sifr_python_kwargs".to_string()),
+            output_schema(ok_type, opaque_classes)?,
+        ],
+    };
+    body.push(RustStmt::Let {
+        mutable: false,
+        name: "__sifr_python_request".to_string(),
+        ty: None,
+        value: request,
+    });
+    append_submission(&mut body, ok_type, error_type, opaque_classes)?;
+    Some(body)
+}
+
+pub(crate) fn async_python_method_body(
+    func: &HirFunction,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<Vec<RustStmt>> {
+    let declaration = func.python_interop.first()?;
+    if declaration.kind != PythonInteropDecoratorKind::Coroutine || !func.is_async {
+        return None;
+    }
+    let Type::Result(ok_type, error_type) = func.return_type.resolve_alias() else {
+        return None;
+    };
+    let member = declaration.target.as_ref()?.segments.get(1)?.to_string();
+    let mut body = argument_frame(func, declaration, error_type, opaque_classes)?;
+    let receiver = RustExpr::Field {
+        expr: Box::new(RustExpr::Ident("self".to_string())),
+        field: "__sifr_python_object".to_string(),
+    };
+    let constructor = if declaration.consumes_receiver {
+        "owned_method"
+    } else {
+        "borrowed_method"
+    };
+    let receiver = if declaration.consumes_receiver {
+        receiver
+    } else {
+        RustExpr::Ref {
+            mutable: false,
+            expr: Box::new(receiver),
+        }
+    };
+    let request = RustExpr::FnCall {
+        func: Box::new(python_path(&["PythonAsyncRequest", constructor])),
+        args: vec![
+            receiver,
+            owned_string(&member),
+            RustExpr::Ident("__sifr_python_args".to_string()),
+            RustExpr::Ident("__sifr_python_kwargs".to_string()),
+            output_schema(ok_type, opaque_classes)?,
+        ],
+    };
+    body.push(RustStmt::Let {
+        mutable: false,
+        name: "__sifr_python_request".to_string(),
+        ty: None,
+        value: mapped_try(request, error_type),
+    });
+    append_submission(&mut body, ok_type, error_type, opaque_classes)?;
+    Some(body)
+}
+
+fn argument_frame(
+    func: &HirFunction,
+    declaration: &PythonInteropDeclaration,
+    error_type: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<Vec<RustStmt>> {
+    let mut body = vec![
+        vector_let("__sifr_python_args"),
+        vector_let("__sifr_python_kwargs"),
+    ];
+    let mut forward_positional_by_name = false;
+    for (index, (param, shape)) in func.params.iter().zip(&declaration.parameters).enumerate() {
+        let value_name = format!("__sifr_python_arg_{index}");
+        if shape.omit_when_absent {
+            if shape.kind == PythonParameterKind::Positional {
+                forward_positional_by_name = true;
+            }
+            let present_name = format!("__sifr_python_value_{index}");
+            let converted = async_input_conversion(&present_name, &param.ty, opaque_classes)?;
+            body.push(RustStmt::IfLet {
+                pattern: format!("Some({present_name})"),
+                expr: RustExpr::Ident(param.name.clone()),
+                then_body: vec![
+                    mapped_let(&value_name, converted, error_type),
+                    push_keyword(&shape.name, &value_name),
+                ],
+                else_body: None,
+            });
+            continue;
+        }
+        match shape.kind {
+            PythonParameterKind::Positional | PythonParameterKind::KeywordOnly => {
+                body.push(mapped_let(
+                    &value_name,
+                    async_input_conversion(&param.name, &param.ty, opaque_classes)?,
+                    error_type,
+                ));
+                body.push(
+                    if shape.kind == PythonParameterKind::Positional && !forward_positional_by_name
+                    {
+                        push_positional(&value_name)
+                    } else {
+                        push_keyword(&shape.name, &value_name)
+                    },
+                );
+            }
+            PythonParameterKind::PositionalVariadic => {
+                let Type::List(item_type) = param.ty.resolve_alias() else {
+                    return None;
+                };
+                let item_name = format!("__sifr_python_value_{index}");
+                body.push(RustStmt::For {
+                    var: item_name.clone(),
+                    iter: method(RustExpr::Ident(param.name.clone()), "iter", Vec::new()),
+                    body: vec![
+                        mapped_let(
+                            &value_name,
+                            async_input_conversion_borrowed(&item_name, item_type, opaque_classes)?,
+                            error_type,
+                        ),
+                        push_positional(&value_name),
+                    ],
+                });
+            }
+            PythonParameterKind::KeywordVariadic => {
+                let Type::Dict(key_type, value_type) = param.ty.resolve_alias() else {
+                    return None;
+                };
+                if key_type.resolve_alias() != &Type::Str {
+                    return None;
+                }
+                let key_name = format!("__sifr_python_key_{index}");
+                let item_name = format!("__sifr_python_value_{index}");
+                body.push(RustStmt::For {
+                    var: format!("({key_name}, {item_name})"),
+                    iter: method(RustExpr::Ident(param.name.clone()), "iter", Vec::new()),
+                    body: vec![
+                        mapped_let(
+                            &value_name,
+                            async_input_conversion_borrowed(
+                                &item_name,
+                                value_type,
+                                opaque_classes,
+                            )?,
+                            error_type,
+                        ),
+                        push_keyword_expr(
+                            RustExpr::Clone(Box::new(RustExpr::Ident(key_name))),
+                            &value_name,
+                        ),
+                    ],
+                });
+            }
+        }
+    }
+    Some(body)
+}
+
+fn append_submission(
+    body: &mut Vec<RustStmt>,
+    ok_type: &Type,
+    error_type: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<()> {
+    body.push(RustStmt::Let {
+        mutable: false,
+        name: "__sifr_python_cancellation".to_string(),
+        ty: None,
+        value: RustExpr::FnCall {
+            func: Box::new(RustExpr::Ident(
+                "__sifr_current_task_cancellation".to_string(),
+            )),
+            args: Vec::new(),
+        },
+    });
+    let submit = runtime_call(
+        "submit_async_declaration",
+        vec![
+            RustExpr::Ident("__sifr_python_request".to_string()),
+            method(
+                RustExpr::Ident("__sifr_python_cancellation".to_string()),
+                "as_ref",
+                Vec::new(),
+            ),
+        ],
+    );
+    body.push(mapped_let(
+        "__sifr_python_result",
+        RustExpr::Await(Box::new(submit)),
+        error_type,
+    ));
+    let converted =
+        async_output_value("__sifr_python_result", ok_type, error_type, opaque_classes)?;
+    body.push(RustStmt::Return(Some(RustExpr::FnCall {
+        func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
+        args: vec![converted],
+    })));
+    Some(())
+}
+
+fn async_input_conversion(
+    name: &str,
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if let Some(inner) = option_inner(ty) {
+        let receiver = RustExpr::Ident(name.to_string());
+        let borrowed_inner = !matches!(
+            inner.resolve_alias(),
+            Type::None | Type::Bool | Type::Int | Type::Float
+        );
+        let inner_value = method(
+            if borrowed_inner {
+                method(receiver.clone(), "as_ref", Vec::new())
+            } else {
+                receiver.clone()
+            },
+            "unwrap",
+            Vec::new(),
+        );
+        return Some(RustExpr::If {
+            cond: Box::new(method(receiver, "is_some", Vec::new())),
+            then_expr: Box::new(async_input_value(inner_value, inner, opaque_classes)?),
+            else_expr: Some(Box::new(runtime_call("async_from_none", Vec::new()))),
+        });
+    }
+    if is_object(ty) {
+        return Some(runtime_call("async_from_object", vec![reference(name)]));
+    }
+    if matches!(ty.resolve_alias(), Type::Class { name: class_name, .. } if opaque_classes.contains_key(class_name))
+    {
+        return Some(runtime_call(
+            "async_from_object",
+            vec![RustExpr::Ref {
+                mutable: false,
+                expr: Box::new(RustExpr::Field {
+                    expr: Box::new(RustExpr::Ident(name.to_string())),
+                    field: "__sifr_python_object".to_string(),
+                }),
+            }],
+        ));
+    }
+    match ty.resolve_alias() {
+        Type::List(item) => {
+            let converted = mapped_results(
+                method(RustExpr::Ident(name.to_string()), "iter", Vec::new()),
+                "__sifr_python_item",
+                async_input_conversion_borrowed("__sifr_python_item", item, opaque_classes)?,
+            );
+            Some(runtime_call("async_from_list_results", vec![converted]))
+        }
+        Type::Tuple(items) => Some(runtime_call(
+            "async_from_tuple_results",
+            vec![RustExpr::Vec(
+                items
+                    .iter()
+                    .enumerate()
+                    .map(|(index, item)| {
+                        async_input_conversion(&format!("{name}.{index}"), item, opaque_classes)
+                    })
+                    .collect::<Option<Vec<_>>>()?,
+            )],
+        )),
+        Type::Dict(key, value) if key.resolve_alias() == &Type::Str => {
+            let pair = RustExpr::Tuple(vec![
+                RustExpr::Clone(Box::new(RustExpr::Ident("__sifr_python_key".to_string()))),
+                async_input_conversion_borrowed("__sifr_python_value", value, opaque_classes)?,
+            ]);
+            Some(runtime_call(
+                "async_from_dict_results",
+                vec![mapped_results(
+                    method(RustExpr::Ident(name.to_string()), "iter", Vec::new()),
+                    "(__sifr_python_key, __sifr_python_value)",
+                    pair,
+                )],
+            ))
+        }
+        Type::Class {
+            name: class_name,
+            fields,
+            ..
+        } if !fields.is_empty() && !opaque_classes.contains_key(class_name) => Some(runtime_call(
+            "async_from_record_results",
+            vec![RustExpr::Vec(
+                fields
+                    .iter()
+                    .map(|(field, field_type)| {
+                        Some(RustExpr::Tuple(vec![
+                            owned_string(field),
+                            async_input_conversion(
+                                &format!("{name}.{field}"),
+                                field_type,
+                                opaque_classes,
+                            )?,
+                        ]))
+                    })
+                    .collect::<Option<Vec<_>>>()?,
+            )],
+        )),
+        Type::None => Some(runtime_call("async_from_none", Vec::new())),
+        Type::Bool => Some(runtime_call(
+            "async_from_bool",
+            vec![RustExpr::Ident(name.to_string())],
+        )),
+        Type::Int => Some(runtime_call(
+            "async_from_int",
+            vec![RustExpr::Ident(name.to_string())],
+        )),
+        Type::Float => Some(runtime_call(
+            "async_from_float",
+            vec![RustExpr::Ident(name.to_string())],
+        )),
+        Type::Str => Some(runtime_call("async_from_str", vec![reference(name)])),
+        Type::Bytes => Some(runtime_call("async_from_bytes", vec![reference(name)])),
+        _ => None,
+    }
+}
+
+fn async_input_conversion_borrowed(
+    name: &str,
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if matches!(ty.resolve_alias(), Type::Bool | Type::Int | Type::Float) {
+        let function = match ty.resolve_alias() {
+            Type::Bool => "async_from_bool",
+            Type::Int => "async_from_int",
+            Type::Float => "async_from_float",
+            _ => return None,
+        };
+        return Some(runtime_call(
+            function,
+            vec![RustExpr::Deref(Box::new(RustExpr::Ident(name.to_string())))],
+        ));
+    }
+    async_input_conversion(name, ty, opaque_classes)
+}
+
+fn async_input_value(
+    value: RustExpr,
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if matches!(ty.resolve_alias(), Type::Bool | Type::Int | Type::Float) {
+        let function = match ty.resolve_alias() {
+            Type::Bool => "async_from_bool",
+            Type::Int => "async_from_int",
+            Type::Float => "async_from_float",
+            _ => return None,
+        };
+        return Some(runtime_call(function, vec![value]));
+    }
+    Some(RustExpr::Block {
+        stmts: vec![RustStmt::Let {
+            mutable: false,
+            name: "__sifr_python_nested".to_string(),
+            ty: None,
+            value,
+        }],
+        expr: Some(Box::new(async_input_conversion(
+            "__sifr_python_nested",
+            ty,
+            opaque_classes,
+        )?)),
+    })
+}
+
+fn output_schema(
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if let Some(inner) = option_inner(ty) {
+        return Some(schema_variant(
+            "Option",
+            vec![RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec!["Box".to_string(), "new".to_string()])),
+                args: vec![output_schema(inner, opaque_classes)?],
+            }],
+        ));
+    }
+    if is_object(ty) {
+        return Some(schema_variant("Object", Vec::new()));
+    }
+    if let Type::Class { name, .. } = ty.resolve_alias() {
+        if let Some(declaration) = opaque_classes.get(name) {
+            let target = declaration.target.as_ref()?;
+            return Some(schema_variant(
+                "Opaque",
+                vec![RustExpr::Vec(
+                    target
+                        .segments
+                        .iter()
+                        .map(|segment| owned_string(segment))
+                        .collect(),
+                )],
+            ));
+        }
+    }
+    match ty.resolve_alias() {
+        Type::None => Some(schema_variant("None", Vec::new())),
+        Type::Bool => Some(schema_variant("Bool", Vec::new())),
+        Type::Int => Some(schema_variant("Int", Vec::new())),
+        Type::Float => Some(schema_variant("Float", Vec::new())),
+        Type::Str => Some(schema_variant("Str", Vec::new())),
+        Type::Bytes => Some(schema_variant("Bytes", Vec::new())),
+        Type::List(item) => Some(schema_variant(
+            "List",
+            vec![RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec!["Box".to_string(), "new".to_string()])),
+                args: vec![output_schema(item, opaque_classes)?],
+            }],
+        )),
+        Type::Tuple(items) => Some(schema_variant(
+            "Tuple",
+            vec![RustExpr::Vec(
+                items
+                    .iter()
+                    .map(|item| output_schema(item, opaque_classes))
+                    .collect::<Option<Vec<_>>>()?,
+            )],
+        )),
+        Type::Dict(key, value) if key.resolve_alias() == &Type::Str => Some(schema_variant(
+            "Dict",
+            vec![RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec!["Box".to_string(), "new".to_string()])),
+                args: vec![output_schema(value, opaque_classes)?],
+            }],
+        )),
+        Type::Class { fields, .. } if !fields.is_empty() => Some(schema_variant(
+            "Record",
+            vec![RustExpr::Vec(
+                fields
+                    .iter()
+                    .map(|(field, field_type)| {
+                        Some(RustExpr::Tuple(vec![
+                            owned_string(field),
+                            output_schema(field_type, opaque_classes)?,
+                        ]))
+                    })
+                    .collect::<Option<Vec<_>>>()?,
+            )],
+        )),
+        _ => None,
+    }
+}
+
+fn async_output_value(
+    name: &str,
+    ty: &Type,
+    error_type: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if let Some(inner) = option_inner(ty) {
+        return Some(RustExpr::If {
+            cond: Box::new(runtime_call("async_value_is_none", vec![reference(name)])),
+            then_expr: Box::new(RustExpr::Literal(RustLiteral::None)),
+            else_expr: Some(Box::new(RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec!["Some".to_string()])),
+                args: vec![async_output_value(name, inner, error_type, opaque_classes)?],
+            })),
+        });
+    }
+    if is_object(ty) {
+        return Some(mapped_try(
+            runtime_call("async_to_object", vec![RustExpr::Ident(name.to_string())]),
+            error_type,
+        ));
+    }
+    if let Type::Class {
+        name: class_name, ..
+    } = ty.resolve_alias()
+    {
+        if opaque_classes.contains_key(class_name) {
+            return Some(RustExpr::StructInit {
+                name: class_name.clone(),
+                fields: vec![(
+                    "__sifr_python_object".to_string(),
+                    mapped_try(
+                        runtime_call("async_to_object", vec![RustExpr::Ident(name.to_string())]),
+                        error_type,
+                    ),
+                )],
+            });
+        }
+    }
+    match ty.resolve_alias() {
+        Type::List(item) => {
+            let converted =
+                async_output_value("__sifr_python_item", item, error_type, opaque_classes)?;
+            Some(RustExpr::Block {
+                stmts: vec![
+                    mapped_let(
+                        "__sifr_python_items",
+                        runtime_call("async_list_items", vec![RustExpr::Ident(name.to_string())]),
+                        error_type,
+                    ),
+                    vector_let("__sifr_python_values"),
+                    RustStmt::For {
+                        var: "__sifr_python_item".to_string(),
+                        iter: method(
+                            RustExpr::Ident("__sifr_python_items".to_string()),
+                            "into_iter",
+                            Vec::new(),
+                        ),
+                        body: vec![
+                            RustStmt::Let {
+                                mutable: false,
+                                name: "__sifr_python_value".to_string(),
+                                ty: None,
+                                value: converted,
+                            },
+                            push_to("__sifr_python_values", "__sifr_python_value"),
+                        ],
+                    },
+                ],
+                expr: Some(Box::new(RustExpr::Ident(
+                    "__sifr_python_values".to_string(),
+                ))),
+            })
+        }
+        Type::Tuple(items) => {
+            let mut stmts = vec![mapped_mutable_let(
+                "__sifr_python_items",
+                runtime_call("async_tuple_items", vec![RustExpr::Ident(name.to_string())]),
+                error_type,
+            )];
+            let mut values = Vec::with_capacity(items.len());
+            for (index, item) in items.iter().enumerate() {
+                let binding = format!("__sifr_python_tuple_{index}");
+                stmts.push(RustStmt::Let {
+                    mutable: false,
+                    name: binding.clone(),
+                    ty: None,
+                    value: method(
+                        RustExpr::Ident("__sifr_python_items".to_string()),
+                        "remove",
+                        vec![RustExpr::Literal(RustLiteral::Int(0))],
+                    ),
+                });
+                values.push(async_output_value(
+                    &binding,
+                    item,
+                    error_type,
+                    opaque_classes,
+                )?);
+            }
+            Some(RustExpr::Block {
+                stmts,
+                expr: Some(Box::new(RustExpr::Tuple(values))),
+            })
+        }
+        Type::Dict(key, value) if key.resolve_alias() == &Type::Str => {
+            let converted =
+                async_output_value("__sifr_python_item", value, error_type, opaque_classes)?;
+            Some(RustExpr::Block {
+                stmts: vec![
+                    mapped_let(
+                        "__sifr_python_items",
+                        runtime_call("async_dict_items", vec![RustExpr::Ident(name.to_string())]),
+                        error_type,
+                    ),
+                    RustStmt::Let {
+                        mutable: true,
+                        name: "__sifr_python_values".to_string(),
+                        ty: None,
+                        value: RustExpr::FnCall {
+                            func: Box::new(RustExpr::Path(vec![
+                                "Default".to_string(),
+                                "default".to_string(),
+                            ])),
+                            args: Vec::new(),
+                        },
+                    },
+                    RustStmt::For {
+                        var: "(__sifr_python_key, __sifr_python_item)".to_string(),
+                        iter: RustExpr::Ident("__sifr_python_items".to_string()),
+                        body: vec![RustStmt::Expr(method(
+                            RustExpr::Ident("__sifr_python_values".to_string()),
+                            "insert",
+                            vec![RustExpr::Ident("__sifr_python_key".to_string()), converted],
+                        ))],
+                    },
+                ],
+                expr: Some(Box::new(RustExpr::Ident(
+                    "__sifr_python_values".to_string(),
+                ))),
+            })
+        }
+        Type::Class {
+            name: class_name,
+            fields,
+            ..
+        } if !fields.is_empty() => {
+            let mut stmts = vec![RustStmt::Let {
+                mutable: true,
+                name: "__sifr_python_record".to_string(),
+                ty: None,
+                value: RustExpr::Ident(name.to_string()),
+            }];
+            let mut converted = Vec::with_capacity(fields.len());
+            for (field, field_type) in fields {
+                let binding = format!("__sifr_python_field_{field}");
+                stmts.push(mapped_let(
+                    &binding,
+                    runtime_call(
+                        "async_record_field",
+                        vec![
+                            RustExpr::Ref {
+                                mutable: true,
+                                expr: Box::new(RustExpr::Ident("__sifr_python_record".to_string())),
+                            },
+                            RustExpr::Literal(RustLiteral::Str(field.clone())),
+                        ],
+                    ),
+                    error_type,
+                ));
+                converted.push((
+                    field.clone(),
+                    async_output_value(&binding, field_type, error_type, opaque_classes)?,
+                ));
+            }
+            Some(RustExpr::Block {
+                stmts,
+                expr: Some(Box::new(RustExpr::StructInit {
+                    name: class_name.clone(),
+                    fields: converted,
+                })),
+            })
+        }
+        Type::None => primitive_output(name, "async_to_none", error_type),
+        Type::Bool => primitive_output(name, "async_to_bool", error_type),
+        Type::Int => primitive_output(name, "async_to_int", error_type),
+        Type::Float => primitive_output(name, "async_to_float", error_type),
+        Type::Str => primitive_output(name, "async_to_str", error_type),
+        Type::Bytes => primitive_output(name, "async_to_bytes", error_type),
+        _ => None,
+    }
+}
+
+fn primitive_output(name: &str, function: &str, error_type: &Type) -> Option<RustExpr> {
+    Some(mapped_try(
+        runtime_call(function, vec![RustExpr::Ident(name.to_string())]),
+        error_type,
+    ))
+}
+
+fn schema_variant(name: &str, args: Vec<RustExpr>) -> RustExpr {
+    if args.is_empty() {
+        python_path(&["PythonAsyncType", name])
+    } else {
+        RustExpr::FnCall {
+            func: Box::new(python_path(&["PythonAsyncType", name])),
+            args,
+        }
+    }
+}
+
+fn python_path(parts: &[&str]) -> RustExpr {
+    RustExpr::Path(
+        ["sifr_runtime", "python"]
+            .into_iter()
+            .chain(parts.iter().copied())
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
+fn option_inner(ty: &Type) -> Option<&Type> {
+    let Type::Union(variants) = ty.resolve_alias() else {
+        return None;
+    };
+    if variants.len() != 2
+        || !variants
+            .iter()
+            .any(|variant| variant.resolve_alias() == &Type::None)
+    {
+        return None;
+    }
+    variants
+        .iter()
+        .find(|variant| variant.resolve_alias() != &Type::None)
+}
+
+fn is_object(ty: &Type) -> bool {
+    matches!(ty.resolve_alias(), Type::Class { name, .. } if name == "Object")
+}
+
+fn mapped_results(iter: RustExpr, parameter: &str, body: RustExpr) -> RustExpr {
+    method(
+        method(
+            iter,
+            "map",
+            vec![RustExpr::Closure {
+                params: vec![RustParam::Named {
+                    name: parameter.to_string(),
+                    ty: RustType::Named("_".to_string()),
+                }],
+                body: Box::new(body),
+                is_move: false,
+            }],
+        ),
+        "collect",
+        Vec::new(),
+    )
+}
+
+fn mapped_let(name: &str, value: RustExpr, error_type: &Type) -> RustStmt {
+    RustStmt::Let {
+        mutable: false,
+        name: name.to_string(),
+        ty: None,
+        value: mapped_try(value, error_type),
+    }
+}
+
+fn mapped_mutable_let(name: &str, value: RustExpr, error_type: &Type) -> RustStmt {
+    RustStmt::Let {
+        mutable: true,
+        name: name.to_string(),
+        ty: None,
+        value: mapped_try(value, error_type),
+    }
+}
+
+fn vector_let(name: &str) -> RustStmt {
+    RustStmt::Let {
+        mutable: true,
+        name: name.to_string(),
+        ty: None,
+        value: RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec!["Vec".to_string(), "new".to_string()])),
+            args: Vec::new(),
+        },
+    }
+}
+
+fn push_positional(value: &str) -> RustStmt {
+    push_to("__sifr_python_args", value)
+}
+
+fn push_keyword(name: &str, value: &str) -> RustStmt {
+    push_keyword_expr(owned_string(name), value)
+}
+
+fn push_keyword_expr(key: RustExpr, value: &str) -> RustStmt {
+    RustStmt::Expr(method(
+        RustExpr::Ident("__sifr_python_kwargs".to_string()),
+        "push",
+        vec![RustExpr::Tuple(vec![
+            key,
+            RustExpr::Ident(value.to_string()),
+        ])],
+    ))
+}
+
+fn push_to(vector: &str, value: &str) -> RustStmt {
+    RustStmt::Expr(method(
+        RustExpr::Ident(vector.to_string()),
+        "push",
+        vec![RustExpr::Ident(value.to_string())],
+    ))
+}
+
+fn reference(name: &str) -> RustExpr {
+    RustExpr::Ref {
+        mutable: false,
+        expr: Box::new(RustExpr::Ident(name.to_string())),
+    }
+}
+
+fn owned_string(value: &str) -> RustExpr {
+    method(
+        RustExpr::Literal(RustLiteral::Str(value.to_string())),
+        "to_string",
+        Vec::new(),
+    )
+}
+
+fn method(receiver: RustExpr, method: &str, args: Vec<RustExpr>) -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(receiver),
+        method: method.to_string(),
+        args,
+    }
+}

--- a/crates/sifr_codegen/src/python_interop_async_tests.rs
+++ b/crates/sifr_codegen/src/python_interop_async_tests.rs
@@ -1,0 +1,267 @@
+use crate::python_interop_direct::{python_interop_function_body, python_interop_method_body};
+use crate::{generate_rust, render_stmts};
+use ruff_text_size::TextRange;
+use sifr_ir::{
+    HirFunction, HirModule, HirParam, MethodKind, PythonInteropDeclaration,
+    PythonInteropDecoratorKind, PythonInteropEffect, PythonInteropParameter, PythonParameterKind,
+    PythonTargetPath,
+};
+use sifr_type_system::{ParamConvention, Type};
+use std::collections::HashMap;
+
+#[test]
+fn typed_async_function_emits_owned_frame_schema_cancellation_and_await() {
+    let optional_string = Type::Union(vec![Type::Str, Type::None]);
+    let function = function(
+        "collect",
+        vec![
+            param("value", Type::Int, ParamConvention::own()),
+            param(
+                "rest",
+                Type::List(Box::new(Type::Int)),
+                ParamConvention::borrow(),
+            ),
+            param("label", optional_string, ParamConvention::borrow()),
+            param(
+                "extra",
+                Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+                ParamConvention::borrow(),
+            ),
+        ],
+        Type::Dict(
+            Box::new(Type::Str),
+            Box::new(Type::Tuple(vec![Type::Int, Type::Str])),
+        ),
+        declaration(
+            vec!["pkg", "collect"],
+            vec![
+                shape("value", PythonParameterKind::Positional, false),
+                shape("rest", PythonParameterKind::PositionalVariadic, false),
+                shape("label", PythonParameterKind::KeywordOnly, true),
+                shape("extra", PythonParameterKind::KeywordVariadic, false),
+            ],
+        ),
+    );
+
+    let rendered = render_stmts(
+        &python_interop_function_body(&function, &Default::default())
+            .expect("typed async wrapper should lower"),
+    );
+    assert!(rendered.contains("async_from_int"), "{rendered}");
+    assert!(rendered.contains("for __sifr_python_value_1 in rest.iter()"));
+    assert!(rendered.contains("if let Some(__sifr_python_value_2) = label"));
+    assert!(rendered.contains("for (__sifr_python_key_3, __sifr_python_value_3) in extra.iter()"));
+    assert!(rendered.contains("PythonAsyncRequest::function"));
+    assert!(rendered.contains("PythonAsyncType::Dict"));
+    assert!(rendered.contains("PythonAsyncType::Tuple"));
+    assert!(rendered.contains("__sifr_current_task_cancellation()"));
+    assert!(rendered.contains("submit_async_declaration"));
+    assert!(rendered.contains(".await"));
+    assert!(rendered.contains("async_dict_items"));
+    assert!(rendered.contains("async_tuple_items"));
+    assert!(!rendered.contains("resolve_target"));
+    assert!(!rendered.contains("call_object_owned"));
+}
+
+#[test]
+fn recursive_factory_emits_loop_thread_schema_and_owned_opaque_result() {
+    let payload = Type::Class {
+        name: "Payload".to_string(),
+        fields: vec![
+            ("name".to_string(), Type::Str),
+            ("scores".to_string(), Type::List(Box::new(Type::Int))),
+        ],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let client = Type::Class {
+        name: "Client".to_string(),
+        fields: Vec::new(),
+        methods: Vec::new(),
+        parent_class: Some("NonSend".to_string()),
+    };
+    let mut opaque = HashMap::new();
+    opaque.insert("Client".to_string(), opaque_declaration());
+    let function = function(
+        "make_client",
+        vec![param("payload", payload, ParamConvention::borrow())],
+        client,
+        declaration(
+            vec!["pkg", "make_client"],
+            vec![shape("payload", PythonParameterKind::Positional, false)],
+        ),
+    );
+
+    let rendered = render_stmts(
+        &python_interop_function_body(&function, &opaque).expect("factory should lower"),
+    );
+    assert!(rendered.contains("async_from_record_results"), "{rendered}");
+    assert!(rendered.contains("async_from_list_results"), "{rendered}");
+    assert!(rendered.contains("PythonAsyncType::Opaque"), "{rendered}");
+    assert!(rendered.contains("\"pkg\".to_string()"), "{rendered}");
+    assert!(rendered.contains("\"Client\".to_string()"), "{rendered}");
+    assert!(rendered.contains("async_to_object"), "{rendered}");
+    assert!(rendered.contains("Client { __sifr_python_object:"));
+}
+
+#[test]
+fn borrowed_and_consuming_async_methods_select_distinct_identity_transfers() {
+    let borrowed = method_function(false);
+    let consuming = method_function(true);
+
+    let borrowed = render_stmts(
+        &python_interop_method_body(&borrowed, &Default::default())
+            .expect("borrowed method should lower"),
+    );
+    assert!(borrowed.contains("PythonAsyncRequest::borrowed_method"));
+    assert!(borrowed.contains("&self.__sifr_python_object"));
+
+    let consuming = render_stmts(
+        &python_interop_method_body(&consuming, &Default::default())
+            .expect("consuming method should lower"),
+    );
+    assert!(consuming.contains("PythonAsyncRequest::owned_method"));
+    assert!(consuming.contains("self.__sifr_python_object"));
+    assert!(!consuming.contains("&self.__sifr_python_object"));
+}
+
+#[test]
+fn resolved_bridge_target_stays_structured_in_typed_request() {
+    let function = function(
+        "value",
+        Vec::new(),
+        Type::Int,
+        declaration(
+            vec!["__sifr_bridge__", "p_abc123", "adapter", "value"],
+            Vec::new(),
+        ),
+    );
+    let rendered = render_stmts(
+        &python_interop_function_body(&function, &Default::default())
+            .expect("bridge wrapper should lower"),
+    );
+    for segment in ["__sifr_bridge__", "p_abc123", "adapter", "value"] {
+        assert!(rendered.contains(&format!("\"{segment}\".to_string()")));
+    }
+}
+
+#[test]
+fn standalone_typed_wrapper_emits_cancellation_carrier_preamble() {
+    let wrapper = function(
+        "value",
+        Vec::new(),
+        Type::Int,
+        declaration(vec!["pkg", "value"], Vec::new()),
+    );
+    let module = HirModule {
+        functions: vec![wrapper],
+        classes: Vec::new(),
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: HashMap::new(),
+        type_param_bounds: HashMap::new(),
+    };
+
+    let rendered = generate_rust(&module);
+    assert!(rendered.contains("fn __sifr_current_task_cancellation"));
+    assert!(rendered.contains("submit_async_declaration"));
+}
+
+fn function(
+    name: &str,
+    params: Vec<HirParam>,
+    ok_type: Type,
+    declaration: PythonInteropDeclaration,
+) -> HirFunction {
+    HirFunction {
+        name: name.to_string(),
+        params,
+        return_type: Type::Result(Box::new(ok_type), Box::new(python_error_type())),
+        body: Vec::new(),
+        is_async: true,
+        method_kind: MethodKind::Regular,
+        decorators: Vec::new(),
+        rust_interop: Vec::new(),
+        python_interop: vec![declaration],
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    }
+}
+
+fn method_function(consumes_receiver: bool) -> HirFunction {
+    let mut declaration = declaration(
+        vec!["Self", "work"],
+        vec![shape("amount", PythonParameterKind::Positional, false)],
+    );
+    declaration.consumes_receiver = consumes_receiver;
+    function(
+        "work",
+        vec![param("amount", Type::Int, ParamConvention::own())],
+        Type::Int,
+        declaration,
+    )
+}
+
+fn declaration(
+    target: Vec<&str>,
+    parameters: Vec<PythonInteropParameter>,
+) -> PythonInteropDeclaration {
+    PythonInteropDeclaration {
+        kind: PythonInteropDecoratorKind::Coroutine,
+        target: Some(PythonTargetPath {
+            segments: target.into_iter().map(str::to_string).collect(),
+            span: TextRange::default(),
+        }),
+        span: TextRange::default(),
+        effect: PythonInteropEffect::Async,
+        cleanup: None,
+        consumes_receiver: false,
+        parameters,
+        required_import_root: Some("pkg".to_string()),
+    }
+}
+
+fn opaque_declaration() -> PythonInteropDeclaration {
+    PythonInteropDeclaration {
+        kind: PythonInteropDecoratorKind::Opaque,
+        target: Some(PythonTargetPath {
+            segments: vec!["pkg".to_string(), "Client".to_string()],
+            span: TextRange::default(),
+        }),
+        span: TextRange::default(),
+        effect: PythonInteropEffect::BlockingIo,
+        cleanup: None,
+        consumes_receiver: false,
+        parameters: Vec::new(),
+        required_import_root: Some("pkg".to_string()),
+    }
+}
+
+fn python_error_type() -> Type {
+    Type::Class {
+        name: "PythonError".to_string(),
+        fields: vec![("message".to_string(), Type::Str)],
+        methods: Vec::new(),
+        parent_class: Some("Error".to_string()),
+    }
+}
+
+fn param(name: &str, ty: Type, convention: ParamConvention) -> HirParam {
+    HirParam {
+        name: name.to_string(),
+        ty,
+        default: None,
+        keyword_only: false,
+        convention,
+    }
+}
+
+fn shape(name: &str, kind: PythonParameterKind, omit: bool) -> PythonInteropParameter {
+    PythonInteropParameter {
+        name: name.to_string(),
+        kind,
+        has_default: omit,
+        omit_when_absent: omit,
+        span: TextRange::default(),
+    }
+}

--- a/crates/sifr_codegen/src/python_interop_common.rs
+++ b/crates/sifr_codegen/src/python_interop_common.rs
@@ -1,0 +1,24 @@
+use sifr_ir::{HirModule, PythonInteropDeclaration, PythonInteropEffect};
+
+pub(crate) fn python_omit_parameter_indices(
+    declaration: &PythonInteropDeclaration,
+) -> impl Iterator<Item = usize> + '_ {
+    declaration
+        .parameters
+        .iter()
+        .enumerate()
+        .filter_map(|(index, parameter)| parameter.omit_when_absent.then_some(index))
+}
+
+pub(crate) fn module_uses_async_python_declaration(module: &HirModule) -> bool {
+    module
+        .functions
+        .iter()
+        .chain(module.classes.iter().flat_map(|class| class.methods.iter()))
+        .any(|function| {
+            function
+                .python_interop
+                .iter()
+                .any(|declaration| declaration.effect == PythonInteropEffect::Async)
+        })
+}

--- a/crates/sifr_codegen/src/python_interop_direct.rs
+++ b/crates/sifr_codegen/src/python_interop_direct.rs
@@ -12,6 +12,9 @@ pub(crate) fn python_interop_function_body(
     opaque_classes: &HashMap<String, PythonInteropDeclaration>,
 ) -> Option<Vec<RustStmt>> {
     let declaration = func.python_interop.first()?;
+    if declaration.kind == PythonInteropDecoratorKind::Coroutine {
+        return crate::python_interop_async::async_python_function_body(func, opaque_classes);
+    }
     if declaration.kind != PythonInteropDecoratorKind::Function {
         return None;
     }
@@ -175,6 +178,9 @@ pub(crate) fn python_interop_method_body(
     opaque_classes: &HashMap<String, PythonInteropDeclaration>,
 ) -> Option<Vec<RustStmt>> {
     let declaration = func.python_interop.first()?;
+    if declaration.kind == PythonInteropDecoratorKind::Coroutine {
+        return crate::python_interop_async::async_python_method_body(func, opaque_classes);
+    }
     let Type::Result(ok_type, error_type) = func.return_type.resolve_alias() else {
         return None;
     };
@@ -291,16 +297,6 @@ pub(crate) fn python_interop_method_body(
         args: vec![converted],
     })));
     Some(body)
-}
-
-pub(crate) fn python_omit_parameter_indices(
-    declaration: &PythonInteropDeclaration,
-) -> impl Iterator<Item = usize> + '_ {
-    declaration
-        .parameters
-        .iter()
-        .enumerate()
-        .filter_map(|(index, parameter)| parameter.omit_when_absent.then_some(index))
 }
 
 pub(crate) fn input_conversion(

--- a/crates/sifr_codegen/src/python_interop_plan.rs
+++ b/crates/sifr_codegen/src/python_interop_plan.rs
@@ -90,6 +90,12 @@ pub(crate) fn python_interop_plan_for_named_modules<'a>(
             );
         }
         for class in &module.classes {
+            plan.requires_async_loop |= class.methods.iter().any(|method| {
+                method
+                    .python_interop
+                    .iter()
+                    .any(|declaration| declaration.effect == sifr_ir::PythonInteropEffect::Async)
+            });
             let Some(declaration) = class.python_opaque_declaration() else {
                 continue;
             };

--- a/crates/sifr_codegen/src/python_interop_plan_tests.rs
+++ b/crates/sifr_codegen/src/python_interop_plan_tests.rs
@@ -1,8 +1,9 @@
 use crate::{interop_build_plan_for_named_modules, PythonTargetProbeStatus};
 use ruff_text_size::TextRange;
 use sifr_ir::{
-    HirExpr, HirFunction, HirImport, HirModule, HirStmt, MethodKind, PythonInteropDeclaration,
-    PythonInteropDecoratorKind, PythonInteropEffect, PythonRecordExpansion, PythonTargetPath,
+    HirClass, HirClassKind, HirExpr, HirFunction, HirImport, HirModule, HirStmt, MethodKind,
+    PythonInteropDeclaration, PythonInteropDecoratorKind, PythonInteropEffect,
+    PythonRecordExpansion, PythonTargetPath,
 };
 use sifr_type_system::Type;
 
@@ -156,6 +157,45 @@ fn sync_python_declaration_does_not_require_the_owned_async_loop() {
     let plan = interop_build_plan_for_named_modules([(Some("main"), &module)]);
 
     assert!(!plan.python.requires_async_loop);
+}
+
+#[test]
+fn method_only_async_python_declaration_requires_owned_loop() {
+    let mut method = function("work", Vec::new(), Vec::new());
+    method.is_async = true;
+    method.python_interop.push(PythonInteropDeclaration {
+        kind: PythonInteropDecoratorKind::Coroutine,
+        target: Some(PythonTargetPath {
+            segments: vec!["Self".to_string(), "work".to_string()],
+            span: TextRange::default(),
+        }),
+        span: TextRange::default(),
+        effect: PythonInteropEffect::Async,
+        cleanup: None,
+        consumes_receiver: false,
+        parameters: Vec::new(),
+        required_import_root: None,
+    });
+    let mut module = module_with_functions(Vec::new());
+    module.classes.push(HirClass {
+        name: "Client".to_string(),
+        fields: Vec::new(),
+        methods: vec![method],
+        is_hashable: false,
+        is_error_type: false,
+        kind: HirClassKind::Regular,
+        operator_impls: Vec::new(),
+        newtype_inner: None,
+        implements_protocols: Vec::new(),
+        parent_class: Some("NonSend".to_string()),
+        type_params: Vec::new(),
+        enum_variants: Vec::new(),
+        rust_interop: Vec::new(),
+    });
+
+    let plan = interop_build_plan_for_named_modules([(Some("main"), &module)]);
+
+    assert!(plan.python.requires_async_loop);
 }
 
 fn module_with_functions(functions: Vec<HirFunction>) -> HirModule {

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -7,8 +7,12 @@ use std::mem::MaybeUninit;
 use std::sync::{Mutex, MutexGuard};
 
 mod arrow_ops;
+mod async_declaration;
+#[cfg(test)]
+mod async_declaration_tests;
 mod async_runtime;
 mod async_terminal;
+mod async_value;
 mod bridge_loader;
 mod buffer_ops;
 mod call_depth;
@@ -35,7 +39,18 @@ pub use arrow_ops::{
     arrow_array, arrow_capsule_names, arrow_schema, arrow_stream, release_arrow, ArrowHandle,
     PythonArrowCapsuleMetadata,
 };
+#[doc(hidden)]
+pub use async_declaration::submit_async_declaration;
 pub use async_runtime::{async_runtime_diagnostics, PythonAsyncRuntimeDiagnostics};
+#[doc(hidden)]
+pub use async_value::{
+    async_dict_items, async_from_bool, async_from_bytes, async_from_dict_results, async_from_float,
+    async_from_int, async_from_list_results, async_from_none, async_from_object,
+    async_from_owned_object, async_from_record_results, async_from_str, async_from_tuple_results,
+    async_list_items, async_record_field, async_to_bool, async_to_bytes, async_to_float,
+    async_to_int, async_to_none, async_to_object, async_to_str, async_tuple_items,
+    async_value_is_none, PythonAsyncRequest, PythonAsyncType, PythonAsyncValue,
+};
 pub use bridge_loader::PythonBridgeSource;
 pub use buffer_ops::{
     buffer_shape, buffer_strides, buffer_suboffsets, buffer_u8, copy_buffer_u8, release_buffer,

--- a/crates/sifr_runtime/src/python/async_declaration.rs
+++ b/crates/sifr_runtime/src/python/async_declaration.rs
@@ -1,0 +1,305 @@
+use super::async_runtime::{
+    finish_submission, register_submission, release_pending_submission, reserve_submission,
+    terminal_for_submission, SubmissionCancellationBridge,
+};
+use super::async_terminal::{
+    PythonTerminal, PythonTerminalError, PythonTerminalOutcome, PythonTerminalValue,
+};
+use super::async_value::{materialize, PythonAsyncRequest, PythonAsyncTarget, PythonAsyncValue};
+use super::object_ops::clone_handle;
+use super::{PythonError, PythonRuntimeError};
+use crate::cancellation::CancellationCarrier;
+use pyo3::prelude::*;
+use pyo3::types::{PyCFunction, PyDict, PyTuple};
+use std::collections::HashSet;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::Arc;
+
+/// Submit one generated typed declaration operation to the application-owned
+/// asyncio loop. This API is compiler glue, not a user-visible interop surface.
+#[doc(hidden)]
+pub async fn submit_async_declaration(
+    request: PythonAsyncRequest,
+    carrier: Option<&CancellationCarrier>,
+) -> Result<PythonAsyncValue, PythonError> {
+    super::async_runtime::ensure_started().map_err(PythonError::runtime)?;
+    validate_keywords(&request)?;
+    let terminal =
+        super::attach(|py| submit_typed(py, request, carrier)).map_err(PythonError::runtime)??;
+    match terminal.await {
+        Ok(PythonTerminalValue::Typed(value)) => Ok(value),
+        Ok(PythonTerminalValue::Raw(_)) => Err(PythonError::runtime(
+            PythonRuntimeError::AsyncRuntimeFailed(
+                "typed asyncio submission produced a raw terminal value".to_string(),
+            ),
+        )),
+        Err(PythonTerminalError::Mapped(error)) => Err(*error),
+        Err(PythonTerminalError::Runtime(error)) => Err(PythonError::runtime(error)),
+        Err(PythonTerminalError::Python(error)) => Python::try_attach(|py| {
+            Err(PythonError::from_pyerr(
+                py,
+                error,
+                "await",
+                "typed Python declaration",
+            ))
+        })
+        .unwrap_or_else(|| Err(PythonError::runtime(PythonRuntimeError::NotInitialized))),
+    }
+}
+
+fn submit_typed(
+    py: Python<'_>,
+    request: PythonAsyncRequest,
+    carrier: Option<&CancellationCarrier>,
+) -> Result<PythonTerminal, PythonError> {
+    let (terminal, cancellation) = terminal_for_submission(carrier)?;
+    let (submission_id, loop_object) =
+        reserve_submission(py, &terminal).map_err(PythonError::runtime)?;
+    let context = request_context(&request);
+    let request = Arc::new(request);
+    let done_callback = build_done_callback(
+        py,
+        submission_id,
+        Arc::clone(&request),
+        context.clone(),
+        &terminal,
+    )
+    .map_err(|error| {
+        release_pending_submission(submission_id);
+        PythonError::from_pyerr(py, error, "call", "typed asyncio completion callback")
+    })?;
+    let setup_callback = build_setup_callback(
+        py,
+        submission_id,
+        request,
+        &loop_object,
+        &done_callback,
+        &terminal,
+        &cancellation,
+        context,
+    )
+    .map_err(|error| {
+        release_pending_submission(submission_id);
+        PythonError::from_pyerr(py, error, "call", "typed asyncio setup callback")
+    })?;
+    loop_object
+        .bind(py)
+        .call_method1("call_soon_threadsafe", (setup_callback,))
+        .map_err(|error| {
+            release_pending_submission(submission_id);
+            PythonError::from_pyerr(py, error, "call", "typed asyncio submission")
+        })?;
+    Ok(terminal)
+}
+
+fn build_done_callback(
+    py: Python<'_>,
+    submission_id: u64,
+    request: Arc<PythonAsyncRequest>,
+    context: String,
+    terminal: &PythonTerminal,
+) -> PyResult<Py<PyAny>> {
+    let terminal = terminal.clone();
+    PyCFunction::new_closure(
+        py,
+        Some(c"__sifr_python_typed_task_done"),
+        None,
+        move |args: &Bound<'_, PyTuple>, _kwargs: Option<&Bound<'_, PyDict>>| -> PyResult<()> {
+            let py = args.py();
+            let outcome = catch_unwind(AssertUnwindSafe(|| -> PythonTerminalOutcome {
+                let task = args.get_item(0).map_err(|error| {
+                    mapped_error(PythonError::from_pyerr(py, error, "await", &context))
+                })?;
+                let value = task.call_method0("result").map_err(|error| {
+                    mapped_error(PythonError::from_pyerr(py, error, "await", &context))
+                })?;
+                super::async_value::convert_output(py, &value, &request.output, &context)
+                    .map(PythonTerminalValue::Typed)
+                    .map_err(mapped_error)
+            }))
+            .unwrap_or_else(|_| {
+                Err(PythonTerminalError::Runtime(
+                    PythonRuntimeError::AsyncRuntimeFailed(
+                        "typed asyncio terminal callback panicked".to_string(),
+                    ),
+                ))
+            });
+            let outcome = match finish_submission(submission_id) {
+                Ok(()) => outcome,
+                Err(error) => Err(PythonTerminalError::Runtime(error)),
+            };
+            let _completed = terminal.complete(outcome);
+            Ok(())
+        },
+    )
+    .map(|callback| callback.into_any().unbind())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_setup_callback(
+    py: Python<'_>,
+    submission_id: u64,
+    request: Arc<PythonAsyncRequest>,
+    loop_object: &Py<PyAny>,
+    done_callback: &Py<PyAny>,
+    terminal: &PythonTerminal,
+    cancellation: &Arc<SubmissionCancellationBridge>,
+    context: String,
+) -> PyResult<Py<PyAny>> {
+    let loop_object = loop_object.clone_ref(py);
+    let done_callback = done_callback.clone_ref(py);
+    let terminal = terminal.clone();
+    let cancellation = Arc::clone(cancellation);
+    PyCFunction::new_closure(
+        py,
+        Some(c"__sifr_python_typed_task_setup"),
+        None,
+        move |args: &Bound<'_, PyTuple>, _kwargs: Option<&Bound<'_, PyDict>>| -> PyResult<()> {
+            let py = args.py();
+            let mut registered = false;
+            let mut exact_task: Option<Py<PyAny>> = None;
+            let setup = catch_unwind(AssertUnwindSafe(|| -> Result<(), PythonTerminalError> {
+                let callable =
+                    resolve_callable(py, &request.target, &context).map_err(mapped_error)?;
+                let positional = request
+                    .args
+                    .iter()
+                    .enumerate()
+                    .map(|(index, value)| {
+                        materialize(py, value, &format!("{context}.arg[{index}]"))
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(mapped_error)?;
+                let positional = PyTuple::new(py, positional.iter())
+                    .map_err(|error| mapped_pyerr(py, error, "conversion", &context))?;
+                let keywords = PyDict::new(py);
+                for (name, value) in &request.kwargs {
+                    let value = materialize(py, value, &format!("{context}.{name}"))
+                        .map_err(mapped_error)?;
+                    keywords
+                        .set_item(name, value.bind(py))
+                        .map_err(|error| mapped_pyerr(py, error, "conversion", &context))?;
+                }
+                let _call_depth = super::enter_python_call();
+                let awaitable = callable
+                    .bind(py)
+                    .call(positional, Some(&keywords))
+                    .map_err(|error| mapped_pyerr(py, error, "call", &context))?;
+                let inspect = py
+                    .import("inspect")
+                    .map_err(|error| mapped_pyerr(py, error, "import", &context))?;
+                let is_awaitable = inspect
+                    .call_method1("isawaitable", (&awaitable,))
+                    .and_then(|value| value.extract::<bool>())
+                    .map_err(|error| mapped_pyerr(py, error, "call", &context))?;
+                if !is_awaitable {
+                    return Err(mapped_error(PythonError::without_replay(
+                        "call",
+                        "TypeError",
+                        "Python coroutine declaration returned a non-awaitable value",
+                        String::new(),
+                        context.clone(),
+                    )));
+                }
+                let asyncio = py
+                    .import("asyncio")
+                    .map_err(|error| mapped_pyerr(py, error, "import", &context))?;
+                let ensure_kwargs = PyDict::new(py);
+                ensure_kwargs
+                    .set_item("loop", loop_object.bind(py))
+                    .map_err(|error| mapped_pyerr(py, error, "call", &context))?;
+                let task = asyncio
+                    .getattr("ensure_future")
+                    .and_then(|ensure| ensure.call((awaitable,), Some(&ensure_kwargs)))
+                    .map_err(|error| mapped_pyerr(py, error, "call", &context))?;
+                exact_task = Some(task.clone().unbind());
+                task.call_method1("add_done_callback", (done_callback.bind(py),))
+                    .map_err(|error| mapped_pyerr(py, error, "call", &context))?;
+                register_submission(py, submission_id, &loop_object, &task.clone().unbind())
+                    .map_err(PythonTerminalError::Runtime)?;
+                registered = true;
+                if cancellation.publish(submission_id) {
+                    task.call_method0("cancel")
+                        .map_err(|error| mapped_pyerr(py, error, "call", &context))?;
+                }
+                Ok(())
+            }))
+            .unwrap_or_else(|_| {
+                Err(PythonTerminalError::Runtime(
+                    PythonRuntimeError::AsyncRuntimeFailed(
+                        "typed asyncio setup callback panicked".to_string(),
+                    ),
+                ))
+            });
+
+            if let Err(error) = setup {
+                if registered {
+                    let _ignored = finish_submission(submission_id);
+                } else {
+                    release_pending_submission(submission_id);
+                }
+                if let Some(task) = exact_task {
+                    let _ignored = task.bind(py).call_method0("cancel");
+                }
+                let _completed = terminal.complete(Err(error));
+            }
+            Ok(())
+        },
+    )
+    .map(|callback| callback.into_any().unbind())
+}
+
+fn resolve_callable(
+    py: Python<'_>,
+    target: &PythonAsyncTarget,
+    context: &str,
+) -> Result<Py<PyAny>, PythonError> {
+    match target {
+        PythonAsyncTarget::Function(path) => {
+            let target = super::object_ops::resolve_target(path)?;
+            clone_handle(py, &target)
+        }
+        PythonAsyncTarget::Method { receiver, member } => receiver
+            .clone_ref(py)?
+            .bind(py)
+            .getattr(member.as_str())
+            .map(Bound::unbind)
+            .map_err(|error| PythonError::from_pyerr(py, error, "attribute", context)),
+    }
+}
+
+fn validate_keywords(request: &PythonAsyncRequest) -> Result<(), PythonError> {
+    let mut names = HashSet::with_capacity(request.kwargs.len());
+    for (name, _) in &request.kwargs {
+        if !names.insert(name.as_str()) {
+            return Err(PythonError::without_replay(
+                "call",
+                "TypeError",
+                format!("multiple values for keyword argument '{name}'"),
+                String::new(),
+                request_context(request),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn request_context(request: &PythonAsyncRequest) -> String {
+    match &request.target {
+        PythonAsyncTarget::Function(path) => path.join("."),
+        PythonAsyncTarget::Method { member, .. } => format!("Self.{member}"),
+    }
+}
+
+fn mapped_pyerr(
+    py: Python<'_>,
+    error: PyErr,
+    kind: &'static str,
+    context: &str,
+) -> PythonTerminalError {
+    mapped_error(PythonError::from_pyerr(py, error, kind, context))
+}
+
+fn mapped_error(error: PythonError) -> PythonTerminalError {
+    PythonTerminalError::Mapped(Box::new(error))
+}

--- a/crates/sifr_runtime/src/python/async_declaration_tests.rs
+++ b/crates/sifr_runtime/src/python/async_declaration_tests.rs
@@ -1,0 +1,283 @@
+use super::*;
+use pyo3::types::{PyDict, PyModule};
+use std::future::Future;
+use std::pin::pin;
+use std::sync::Arc;
+use std::task::{Context, Poll, Wake, Waker};
+
+const MODULE: &str = "__sifr_typed_async__";
+
+#[test]
+fn typed_function_converts_complete_frames_and_recursive_results_on_owned_loop() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_typed_runtime("typed-frame");
+
+    let request = PythonAsyncRequest::function(
+        vec![MODULE.to_string(), "collect".to_string()],
+        vec![
+            async_from_int(3).expect("int transport"),
+            async_from_int(4).expect("variadic transport"),
+            async_from_int(5).expect("variadic transport"),
+        ],
+        vec![
+            (
+                "label".to_string(),
+                async_from_str("ready").expect("label transport"),
+            ),
+            (
+                "bonus".to_string(),
+                async_from_int(6).expect("keyword variadic transport"),
+            ),
+        ],
+        PythonAsyncType::Record(vec![
+            ("total".to_string(), PythonAsyncType::Int),
+            ("label".to_string(), PythonAsyncType::Str),
+            (
+                "nested".to_string(),
+                PythonAsyncType::List(Box::new(PythonAsyncType::Int)),
+            ),
+            ("identity".to_string(), PythonAsyncType::Str),
+        ]),
+    );
+    let mut result = block_on(submit_async_declaration(request, None))
+        .expect("typed declaration should complete");
+
+    assert_eq!(
+        async_to_int(async_record_field(&mut result, "total").expect("total field"))
+            .expect("total int"),
+        18
+    );
+    assert_eq!(
+        async_to_str(async_record_field(&mut result, "label").expect("label field"))
+            .expect("label str"),
+        "ready"
+    );
+    let nested = async_list_items(async_record_field(&mut result, "nested").expect("nested field"))
+        .expect("nested list")
+        .into_iter()
+        .map(async_to_int)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("nested ints");
+    assert_eq!(nested, vec![3, 4, 5, 6]);
+    let identity =
+        async_to_str(async_record_field(&mut result, "identity").expect("identity field"))
+            .expect("identity str");
+    assert!(identity.contains(':'));
+
+    shutdown_typed_runtime();
+}
+
+#[test]
+fn typed_factory_and_borrowed_method_preserve_sealed_identity_across_await() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_typed_runtime("typed-method");
+
+    let factory = PythonAsyncRequest::function(
+        vec![MODULE.to_string(), "make_client".to_string()],
+        vec![async_from_int(41).expect("factory input")],
+        Vec::new(),
+        PythonAsyncType::Opaque(vec![MODULE.to_string(), "Client".to_string()]),
+    );
+    let client = async_to_object(
+        block_on(submit_async_declaration(factory, None)).expect("factory should complete"),
+    )
+    .expect("factory should produce an owned identity");
+    let request = PythonAsyncRequest::borrowed_method(
+        &client,
+        "increment".to_string(),
+        vec![async_from_int(1).expect("method input")],
+        Vec::new(),
+        PythonAsyncType::Int,
+    )
+    .expect("borrowed receiver should freeze");
+
+    // Runtime cleanup may mark the public handle closed, but the compiler-private
+    // lease pins the exact identity until the in-flight request reaches terminal.
+    close_object(client).expect("public identity should close");
+    let value =
+        block_on(submit_async_declaration(request, None)).expect("leased method should complete");
+    assert_eq!(async_to_int(value).expect("method result"), 42);
+
+    shutdown_typed_runtime();
+}
+
+#[test]
+fn typed_failures_and_concurrent_calls_use_one_terminal_registry_and_loop() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_typed_runtime("typed-failures");
+
+    let identity_request = || {
+        PythonAsyncRequest::function(
+            vec![MODULE.to_string(), "identity".to_string()],
+            Vec::new(),
+            Vec::new(),
+            PythonAsyncType::Str,
+        )
+    };
+    let first =
+        std::thread::spawn(move || block_on(submit_async_declaration(identity_request(), None)));
+    let second =
+        std::thread::spawn(move || block_on(submit_async_declaration(identity_request(), None)));
+    let first = first.join().expect("first worker should not panic");
+    let second = second.join().expect("second worker should not panic");
+    assert_eq!(
+        async_to_str(first.expect("first identity")).expect("first str"),
+        async_to_str(second.expect("second identity")).expect("second str")
+    );
+    assert_eq!(
+        async_runtime_diagnostics().expect("async diagnostics"),
+        PythonAsyncRuntimeDiagnostics {
+            running: true,
+            stopping: false,
+            loop_threads: 1,
+            active_submissions: 0,
+            pending_submissions: 0,
+        }
+    );
+
+    let non_awaitable = PythonAsyncRequest::function(
+        vec![MODULE.to_string(), "not_awaitable".to_string()],
+        Vec::new(),
+        Vec::new(),
+        PythonAsyncType::Int,
+    );
+    let error = block_on(submit_async_declaration(non_awaitable, None))
+        .expect_err("non-awaitable should fail");
+    assert!(error.message.contains("non-awaitable"));
+
+    let python_failure = PythonAsyncRequest::function(
+        vec![MODULE.to_string(), "fails".to_string()],
+        Vec::new(),
+        Vec::new(),
+        PythonAsyncType::Int,
+    );
+    let error = block_on(submit_async_declaration(python_failure, None))
+        .expect_err("Python exception should fail");
+    assert_eq!(error.exception_type, "ValueError");
+
+    let conversion_failure = PythonAsyncRequest::function(
+        vec![MODULE.to_string(), "identity".to_string()],
+        Vec::new(),
+        Vec::new(),
+        PythonAsyncType::Int,
+    );
+    let error = block_on(submit_async_declaration(conversion_failure, None))
+        .expect_err("conversion should fail");
+    assert_eq!(error.kind, "conversion");
+
+    shutdown_typed_runtime();
+}
+
+#[test]
+fn typed_bridge_target_resolves_inside_owned_loop() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    let mut config = test_config("typed-bridge");
+    config.start_async_loop = true;
+    config.bridge_sources.extend([
+        PythonBridgeSource {
+            module: "__sifr_bridge__".to_string(),
+            source: String::new(),
+            filename: "<typed-bridge-root>".to_string(),
+            is_package: true,
+            package_prefix: "__sifr_bridge__".to_string(),
+        },
+        PythonBridgeSource {
+            module: "__sifr_bridge__.p_typed".to_string(),
+            source: String::new(),
+            filename: "<typed-bridge-package>".to_string(),
+            is_package: true,
+            package_prefix: "__sifr_bridge__.p_typed".to_string(),
+        },
+        PythonBridgeSource {
+            module: "__sifr_bridge__.p_typed.adapter".to_string(),
+            source: "async def value():\n    return {'answer': 73}\n".to_string(),
+            filename: "<typed-bridge>".to_string(),
+            is_package: false,
+            package_prefix: "__sifr_bridge__.p_typed".to_string(),
+        },
+    ]);
+    initialize_runtime(config).expect("bridge runtime should initialize");
+
+    let request = PythonAsyncRequest::function(
+        vec![
+            "__sifr_bridge__".to_string(),
+            "p_typed".to_string(),
+            "adapter".to_string(),
+            "value".to_string(),
+        ],
+        Vec::new(),
+        Vec::new(),
+        PythonAsyncType::Dict(Box::new(PythonAsyncType::Int)),
+    );
+    let result = block_on(submit_async_declaration(request, None))
+        .expect("bridge declaration should complete");
+    let items = async_dict_items(result).expect("bridge dict");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].0, "answer");
+
+    shutdown_typed_runtime();
+}
+
+fn initialize_typed_runtime(label: &str) {
+    let mut config = test_config(label);
+    config.start_async_loop = true;
+    config.required_import_roots.push(MODULE.to_string());
+    config.trusted_import_roots.push(MODULE.to_string());
+    initialize_runtime(config).expect("typed runtime should initialize");
+    install_module();
+}
+
+fn install_module() {
+    attach(|py| {
+        let module = PyModule::from_code(
+            py,
+            c"import asyncio\nimport threading\n\nasync def collect(a, *rest, label=None, **extra):\n    await asyncio.sleep(0)\n    values = [a, *rest, *extra.values()]\n    return {'total': sum(values), 'label': label, 'nested': values, 'identity': f'{id(asyncio.get_running_loop())}:{threading.get_ident()}'}\n\nasync def identity():\n    await asyncio.sleep(0)\n    return f'{id(asyncio.get_running_loop())}:{threading.get_ident()}'\n\ndef not_awaitable():\n    return 1\n\nasync def fails():\n    raise ValueError('typed boom')\n\nclass Client:\n    def __init__(self, value):\n        self.value = value\n\n    async def increment(self, amount):\n        await asyncio.sleep(0)\n        return self.value + amount\n\nasync def make_client(value):\n    await asyncio.sleep(0)\n    return Client(value)\n",
+            c"<sifr-typed-async>",
+            c"__sifr_typed_async__",
+        )
+        .expect("typed module should compile");
+        let modules = py
+            .import("sys")
+            .expect("sys should import")
+            .getattr("modules")
+            .expect("sys.modules should resolve")
+            .cast_into::<PyDict>()
+            .expect("sys.modules should be a dict");
+        modules
+            .set_item(MODULE, module)
+            .expect("typed module should install");
+    })
+    .expect("runtime should attach");
+}
+
+fn shutdown_typed_runtime() {
+    super::async_runtime::shutdown().expect("owned loop should stop");
+    assert_eq!(
+        async_runtime_diagnostics().expect("async diagnostics"),
+        PythonAsyncRuntimeDiagnostics::default()
+    );
+}
+
+fn block_on<T>(future: impl Future<Output = T>) -> T {
+    struct ThreadWake(std::thread::Thread);
+
+    impl Wake for ThreadWake {
+        fn wake(self: Arc<Self>) {
+            self.0.unpark();
+        }
+    }
+
+    let waker = Waker::from(Arc::new(ThreadWake(std::thread::current())));
+    let mut context = Context::from_waker(&waker);
+    let mut future = pin!(future);
+    loop {
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(value) => return value,
+            Poll::Pending => std::thread::park(),
+        }
+    }
+}

--- a/crates/sifr_runtime/src/python/async_runtime.rs
+++ b/crates/sifr_runtime/src/python/async_runtime.rs
@@ -1,5 +1,6 @@
 use super::async_terminal::{
     terminal_error_to_python, PythonTerminal, PythonTerminalError, PythonTerminalOutcome,
+    PythonTerminalValue,
 };
 use super::{PythonError, PythonRuntimeError};
 use crate::cancellation::{CancellationCarrier, CancellationClaimError, CancellationHook};
@@ -61,7 +62,7 @@ struct SubmissionCancellationState {
 }
 
 #[derive(Default)]
-struct SubmissionCancellationBridge {
+pub(super) struct SubmissionCancellationBridge {
     state: Mutex<SubmissionCancellationState>,
 }
 
@@ -80,7 +81,7 @@ impl AsyncRuntimeState {
 }
 
 impl SubmissionCancellationBridge {
-    fn publish(&self, submission_id: u64) -> bool {
+    pub(super) fn publish(&self, submission_id: u64) -> bool {
         let Ok(mut state) = self.state.lock() else {
             return true;
         };
@@ -173,7 +174,14 @@ pub(super) fn run_coroutine_blocking(
     // `run_coroutine_blocking` is classified as blocking_io and must be explicitly
     // offloaded by async Sifr code. Releasing the GIL here lets the loop thread run.
     let outcome = super::detach(py, || terminal.wait());
-    outcome.map_err(|error| terminal_error_to_python(py, error, "owned asyncio coroutine"))
+    match outcome.map_err(|error| terminal_error_to_python(py, error, "owned asyncio coroutine"))? {
+        PythonTerminalValue::Raw(value) => Ok(value),
+        PythonTerminalValue::Typed(_) => Err(PythonError::runtime(
+            PythonRuntimeError::AsyncRuntimeFailed(
+                "raw asyncio submission produced a typed terminal value".to_string(),
+            ),
+        )),
+    }
 }
 
 pub(super) fn submit_coroutine(
@@ -181,29 +189,7 @@ pub(super) fn submit_coroutine(
     coroutine: &Py<PyAny>,
     carrier: Option<&CancellationCarrier>,
 ) -> Result<PythonTerminal, PythonError> {
-    let cancellation = Arc::new(SubmissionCancellationBridge::default());
-    let cancellation_claim = if let Some(carrier) = carrier {
-        match carrier.claim(cancellation_hook(&cancellation)) {
-            Ok(claim) => Some(claim),
-            Err(CancellationClaimError::CancelledBeforeClaim) => {
-                return Err(PythonError::runtime(
-                    PythonRuntimeError::AsyncSubmissionCancelled,
-                ));
-            }
-            Err(CancellationClaimError::AlreadyClaimed) => {
-                return Err(PythonError::runtime(
-                    PythonRuntimeError::AsyncCancellationAlreadyClaimed,
-                ));
-            }
-            Err(CancellationClaimError::StateUnavailable) => {
-                return Err(PythonError::runtime(PythonRuntimeError::StateUnavailable));
-            }
-        }
-    } else {
-        None
-    };
-
-    let terminal = PythonTerminal::with_cancellation_claim(cancellation_claim);
+    let (terminal, cancellation) = terminal_for_submission(carrier)?;
     let (submission_id, loop_object) =
         reserve_submission(py, &terminal).map_err(PythonError::runtime)?;
     let done_callback = build_done_callback(py, submission_id, &terminal).map_err(|error| {
@@ -242,6 +228,37 @@ pub(super) fn submit_coroutine(
     Ok(terminal)
 }
 
+pub(super) fn terminal_for_submission(
+    carrier: Option<&CancellationCarrier>,
+) -> Result<(PythonTerminal, Arc<SubmissionCancellationBridge>), PythonError> {
+    let cancellation = Arc::new(SubmissionCancellationBridge::default());
+    let cancellation_claim = if let Some(carrier) = carrier {
+        match carrier.claim(cancellation_hook(&cancellation)) {
+            Ok(claim) => Some(claim),
+            Err(CancellationClaimError::CancelledBeforeClaim) => {
+                return Err(PythonError::runtime(
+                    PythonRuntimeError::AsyncSubmissionCancelled,
+                ));
+            }
+            Err(CancellationClaimError::AlreadyClaimed) => {
+                return Err(PythonError::runtime(
+                    PythonRuntimeError::AsyncCancellationAlreadyClaimed,
+                ));
+            }
+            Err(CancellationClaimError::StateUnavailable) => {
+                return Err(PythonError::runtime(PythonRuntimeError::StateUnavailable));
+            }
+        }
+    } else {
+        None
+    };
+
+    Ok((
+        PythonTerminal::with_cancellation_claim(cancellation_claim),
+        cancellation,
+    ))
+}
+
 fn build_done_callback(
     py: Python<'_>,
     submission_id: u64,
@@ -261,7 +278,7 @@ fn build_done_callback(
                 );
                 let task = args.get_item(0).map_err(PythonTerminalError::Python)?;
                 task.call_method0("result")
-                    .map(Bound::unbind)
+                    .map(|value| PythonTerminalValue::Raw(value.unbind()))
                     .map_err(PythonTerminalError::Python)
             }))
             .unwrap_or_else(|_| {
@@ -536,7 +553,7 @@ fn run_loop_thread(ready_sender: std::sync::mpsc::SyncSender<Result<Py<PyAny>, S
     }
 }
 
-fn reserve_submission(
+pub(super) fn reserve_submission(
     py: Python<'_>,
     terminal: &PythonTerminal,
 ) -> Result<(u64, Py<PyAny>), PythonRuntimeError> {
@@ -561,7 +578,7 @@ fn reserve_submission(
     Ok((submission_id, loop_object))
 }
 
-fn register_submission(
+pub(super) fn register_submission(
     py: Python<'_>,
     submission_id: u64,
     loop_object: &Py<PyAny>,
@@ -588,7 +605,7 @@ fn register_submission(
     Ok(())
 }
 
-fn release_pending_submission(submission_id: u64) {
+pub(super) fn release_pending_submission(submission_id: u64) {
     let terminal = {
         let Ok(mut state) = ASYNC_STATE.lock() else {
             return;
@@ -600,7 +617,7 @@ fn release_pending_submission(submission_id: u64) {
     drop(terminal);
 }
 
-fn finish_submission(submission_id: u64) -> Result<(), PythonRuntimeError> {
+pub(super) fn finish_submission(submission_id: u64) -> Result<(), PythonRuntimeError> {
     let removed = {
         let mut state = lock_state()?;
         let removed = state.submissions.remove(&submission_id);

--- a/crates/sifr_runtime/src/python/async_runtime_tests.rs
+++ b/crates/sifr_runtime/src/python/async_runtime_tests.rs
@@ -150,6 +150,9 @@ fn cancellation_suppression_result_wins_after_terminal_wait() {
     super::super::attach(|py| {
         let value = super::super::detach(py, || terminal.wait())
             .expect("suppressed cancellation should return normally");
+        let PythonTerminalValue::Raw(value) = value else {
+            panic!("raw submission should return a raw terminal value");
+        };
         assert_eq!(
             value
                 .bind(py)
@@ -560,8 +563,12 @@ fn wait_for_submission_count(expected: usize) {
 
 fn wait_terminal_int(terminal: PythonTerminal) -> i64 {
     super::super::attach(|py| {
-        super::super::detach(py, || terminal.wait())
-            .expect("terminal should contain a value")
+        let value =
+            super::super::detach(py, || terminal.wait()).expect("terminal should contain a value");
+        let PythonTerminalValue::Raw(value) = value else {
+            panic!("raw submission should return a raw terminal value");
+        };
+        value
             .bind(py)
             .extract::<i64>()
             .expect("terminal value should be an integer")

--- a/crates/sifr_runtime/src/python/async_terminal.rs
+++ b/crates/sifr_runtime/src/python/async_terminal.rs
@@ -1,3 +1,4 @@
+use super::async_value::PythonAsyncValue;
 use super::{PythonError, PythonRuntimeError};
 use crate::cancellation::CancellationClaimLease;
 use pyo3::prelude::*;
@@ -6,11 +7,17 @@ use std::pin::Pin;
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::task::{Context, Poll, Waker};
 
-pub(super) type PythonTerminalOutcome = Result<Py<PyAny>, PythonTerminalError>;
+pub(super) type PythonTerminalOutcome = Result<PythonTerminalValue, PythonTerminalError>;
+
+pub(super) enum PythonTerminalValue {
+    Raw(Py<PyAny>),
+    Typed(PythonAsyncValue),
+}
 
 #[derive(Debug)]
 pub(super) enum PythonTerminalError {
     Python(PyErr),
+    Mapped(Box<PythonError>),
     Runtime(PythonRuntimeError),
 }
 
@@ -119,6 +126,7 @@ pub(super) fn terminal_error_to_python(
         PythonTerminalError::Python(error) => {
             PythonError::from_pyerr(py, error, "await", operation)
         }
+        PythonTerminalError::Mapped(error) => *error,
         PythonTerminalError::Runtime(error) => PythonError::runtime(error),
     }
 }

--- a/crates/sifr_runtime/src/python/async_value.rs
+++ b/crates/sifr_runtime/src/python/async_value.rs
@@ -1,0 +1,558 @@
+use super::foreign_object::ForeignObjectLease;
+use super::object_ops::{clone_handle, store_object};
+use super::{ObjectHandle, PythonError};
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
+use pyo3::IntoPyObjectExt;
+
+/// Compiler-private owned value transported to and from the asyncio loop.
+///
+/// Generated glue is the only intended consumer. Python objects are represented
+/// by pinned sealed identities and are resolved only by the loop thread.
+#[doc(hidden)]
+#[derive(Debug)]
+pub enum PythonAsyncValue {
+    None,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Str(String),
+    Bytes(Vec<u8>),
+    List(Vec<Self>),
+    Tuple(Vec<Self>),
+    Dict(Vec<(String, Self)>),
+    Record(Vec<(String, Self)>),
+    Object(PythonAsyncObject),
+}
+
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub enum PythonAsyncType {
+    None,
+    Bool,
+    Int,
+    Float,
+    Str,
+    Bytes,
+    Option(Box<Self>),
+    List(Box<Self>),
+    Tuple(Vec<Self>),
+    Dict(Box<Self>),
+    Record(Vec<(String, Self)>),
+    Object,
+    Opaque(Vec<String>),
+}
+
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct PythonAsyncRequest {
+    pub(super) target: PythonAsyncTarget,
+    pub(super) args: Vec<PythonAsyncValue>,
+    pub(super) kwargs: Vec<(String, PythonAsyncValue)>,
+    pub(super) output: PythonAsyncType,
+}
+
+#[derive(Debug)]
+pub(super) enum PythonAsyncTarget {
+    Function(Vec<String>),
+    Method {
+        receiver: PythonAsyncObject,
+        member: String,
+    },
+}
+
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct PythonAsyncObject {
+    lease: ForeignObjectLease,
+    owner: Option<ObjectHandle>,
+}
+
+impl PythonAsyncRequest {
+    #[doc(hidden)]
+    #[must_use]
+    pub fn function(
+        target: Vec<String>,
+        args: Vec<PythonAsyncValue>,
+        kwargs: Vec<(String, PythonAsyncValue)>,
+        output: PythonAsyncType,
+    ) -> Self {
+        Self {
+            target: PythonAsyncTarget::Function(target),
+            args,
+            kwargs,
+            output,
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn borrowed_method(
+        receiver: &ObjectHandle,
+        member: String,
+        args: Vec<PythonAsyncValue>,
+        kwargs: Vec<(String, PythonAsyncValue)>,
+        output: PythonAsyncType,
+    ) -> Result<Self, PythonError> {
+        Ok(Self {
+            target: PythonAsyncTarget::Method {
+                receiver: PythonAsyncObject::borrowed(receiver)?,
+                member,
+            },
+            args,
+            kwargs,
+            output,
+        })
+    }
+
+    #[doc(hidden)]
+    pub fn owned_method(
+        receiver: ObjectHandle,
+        member: String,
+        args: Vec<PythonAsyncValue>,
+        kwargs: Vec<(String, PythonAsyncValue)>,
+        output: PythonAsyncType,
+    ) -> Result<Self, PythonError> {
+        Ok(Self {
+            target: PythonAsyncTarget::Method {
+                receiver: PythonAsyncObject::owned(receiver)?,
+                member,
+            },
+            args,
+            kwargs,
+            output,
+        })
+    }
+}
+
+impl PythonAsyncObject {
+    fn borrowed(object: &ObjectHandle) -> Result<Self, PythonError> {
+        Ok(Self {
+            lease: object.lease().map_err(PythonError::runtime)?,
+            owner: None,
+        })
+    }
+
+    fn owned(object: ObjectHandle) -> Result<Self, PythonError> {
+        let lease = object.lease().map_err(PythonError::runtime)?;
+        Ok(Self {
+            lease,
+            owner: Some(object),
+        })
+    }
+
+    pub(super) fn clone_ref(&self, py: Python<'_>) -> Result<Py<PyAny>, PythonError> {
+        self.lease.clone_ref(py).map_err(PythonError::runtime)
+    }
+
+    fn into_owner(self) -> Result<ObjectHandle, PythonError> {
+        self.owner.ok_or_else(|| {
+            conversion_error(
+                "borrowed Python identity cannot be used as an owned async result",
+                self.lease.boundary_path(),
+            )
+        })
+    }
+}
+
+macro_rules! primitive_constructor {
+    ($name:ident, $variant:ident, $ty:ty) => {
+        #[doc(hidden)]
+        pub fn $name(value: $ty) -> Result<PythonAsyncValue, PythonError> {
+            Ok(PythonAsyncValue::$variant(value))
+        }
+    };
+}
+
+#[doc(hidden)]
+pub fn async_from_none() -> Result<PythonAsyncValue, PythonError> {
+    Ok(PythonAsyncValue::None)
+}
+
+primitive_constructor!(async_from_bool, Bool, bool);
+primitive_constructor!(async_from_int, Int, i64);
+primitive_constructor!(async_from_float, Float, f64);
+
+#[doc(hidden)]
+pub fn async_from_str(value: &str) -> Result<PythonAsyncValue, PythonError> {
+    Ok(PythonAsyncValue::Str(value.to_string()))
+}
+
+#[doc(hidden)]
+pub fn async_from_bytes(value: &[u8]) -> Result<PythonAsyncValue, PythonError> {
+    Ok(PythonAsyncValue::Bytes(value.to_vec()))
+}
+
+#[doc(hidden)]
+pub fn async_from_object(value: &ObjectHandle) -> Result<PythonAsyncValue, PythonError> {
+    PythonAsyncObject::borrowed(value).map(PythonAsyncValue::Object)
+}
+
+#[doc(hidden)]
+pub fn async_from_owned_object(value: ObjectHandle) -> Result<PythonAsyncValue, PythonError> {
+    PythonAsyncObject::owned(value).map(PythonAsyncValue::Object)
+}
+
+#[doc(hidden)]
+pub fn async_from_list_results(
+    values: Vec<Result<PythonAsyncValue, PythonError>>,
+) -> Result<PythonAsyncValue, PythonError> {
+    collect_values(values, "list").map(PythonAsyncValue::List)
+}
+
+#[doc(hidden)]
+pub fn async_from_tuple_results(
+    values: Vec<Result<PythonAsyncValue, PythonError>>,
+) -> Result<PythonAsyncValue, PythonError> {
+    collect_values(values, "tuple").map(PythonAsyncValue::Tuple)
+}
+
+#[doc(hidden)]
+pub fn async_from_dict_results(
+    values: Vec<(String, Result<PythonAsyncValue, PythonError>)>,
+) -> Result<PythonAsyncValue, PythonError> {
+    collect_named_values(values, "dict").map(PythonAsyncValue::Dict)
+}
+
+#[doc(hidden)]
+pub fn async_from_record_results(
+    values: Vec<(String, Result<PythonAsyncValue, PythonError>)>,
+) -> Result<PythonAsyncValue, PythonError> {
+    collect_named_values(values, "record").map(PythonAsyncValue::Record)
+}
+
+#[doc(hidden)]
+pub fn async_value_is_none(value: &PythonAsyncValue) -> bool {
+    matches!(value, PythonAsyncValue::None)
+}
+
+macro_rules! primitive_extractor {
+    ($name:ident, $variant:ident, $ty:ty, $expected:literal) => {
+        #[doc(hidden)]
+        pub fn $name(value: PythonAsyncValue) -> Result<$ty, PythonError> {
+            match value {
+                PythonAsyncValue::$variant(value) => Ok(value),
+                _ => Err(conversion_error(
+                    concat!("expected converted ", $expected),
+                    stringify!($name),
+                )),
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+pub fn async_to_none(value: PythonAsyncValue) -> Result<(), PythonError> {
+    match value {
+        PythonAsyncValue::None => Ok(()),
+        _ => Err(conversion_error("expected converted None", "async_to_none")),
+    }
+}
+
+primitive_extractor!(async_to_bool, Bool, bool, "bool");
+primitive_extractor!(async_to_int, Int, i64, "int");
+primitive_extractor!(async_to_float, Float, f64, "float");
+primitive_extractor!(async_to_str, Str, String, "str");
+primitive_extractor!(async_to_bytes, Bytes, Vec<u8>, "bytes");
+
+#[doc(hidden)]
+pub fn async_list_items(value: PythonAsyncValue) -> Result<Vec<PythonAsyncValue>, PythonError> {
+    match value {
+        PythonAsyncValue::List(values) => Ok(values),
+        _ => Err(conversion_error(
+            "expected converted list",
+            "async_list_items",
+        )),
+    }
+}
+
+#[doc(hidden)]
+pub fn async_tuple_items(value: PythonAsyncValue) -> Result<Vec<PythonAsyncValue>, PythonError> {
+    match value {
+        PythonAsyncValue::Tuple(values) => Ok(values),
+        _ => Err(conversion_error(
+            "expected converted tuple",
+            "async_tuple_items",
+        )),
+    }
+}
+
+#[doc(hidden)]
+pub fn async_dict_items(
+    value: PythonAsyncValue,
+) -> Result<Vec<(String, PythonAsyncValue)>, PythonError> {
+    match value {
+        PythonAsyncValue::Dict(values) => Ok(values),
+        _ => Err(conversion_error(
+            "expected converted dict",
+            "async_dict_items",
+        )),
+    }
+}
+
+#[doc(hidden)]
+pub fn async_record_field(
+    value: &mut PythonAsyncValue,
+    field: &str,
+) -> Result<PythonAsyncValue, PythonError> {
+    let PythonAsyncValue::Record(values) = value else {
+        return Err(conversion_error(
+            "expected converted record",
+            "async_record_field",
+        ));
+    };
+    let Some(index) = values.iter().position(|(name, _)| name == field) else {
+        return Err(conversion_error(
+            format!("missing converted record field '{field}'"),
+            format!(".{field}"),
+        ));
+    };
+    Ok(values.remove(index).1)
+}
+
+#[doc(hidden)]
+pub fn async_to_object(value: PythonAsyncValue) -> Result<ObjectHandle, PythonError> {
+    match value {
+        PythonAsyncValue::Object(object) => object.into_owner(),
+        _ => Err(conversion_error(
+            "expected converted Python object",
+            "async_to_object",
+        )),
+    }
+}
+
+pub(super) fn materialize(
+    py: Python<'_>,
+    value: &PythonAsyncValue,
+    context: &str,
+) -> Result<Py<PyAny>, PythonError> {
+    match value {
+        PythonAsyncValue::None => Ok(py.None()),
+        PythonAsyncValue::Bool(value) => into_python(py, *value, context),
+        PythonAsyncValue::Int(value) => into_python(py, *value, context),
+        PythonAsyncValue::Float(value) => into_python(py, *value, context),
+        PythonAsyncValue::Str(value) => into_python(py, value.as_str(), context),
+        PythonAsyncValue::Bytes(value) => Ok(PyBytes::new(py, value).into_any().unbind()),
+        PythonAsyncValue::List(values) => {
+            let values = materialize_values(py, values, context)?;
+            PyList::new(py, values.iter())
+                .map(|value| value.into_any().unbind())
+                .map_err(|error| PythonError::from_pyerr(py, error, "conversion", context))
+        }
+        PythonAsyncValue::Tuple(values) => {
+            let values = materialize_values(py, values, context)?;
+            PyTuple::new(py, values.iter())
+                .map(|value| value.into_any().unbind())
+                .map_err(|error| PythonError::from_pyerr(py, error, "conversion", context))
+        }
+        PythonAsyncValue::Dict(values) | PythonAsyncValue::Record(values) => {
+            let dict = PyDict::new(py);
+            for (name, value) in values {
+                let value = materialize(py, value, &format!("{context}[{name:?}]"))?;
+                dict.set_item(name, value.bind(py))
+                    .map_err(|error| PythonError::from_pyerr(py, error, "conversion", context))?;
+            }
+            Ok(dict.into_any().unbind())
+        }
+        PythonAsyncValue::Object(object) => object.clone_ref(py),
+    }
+}
+
+pub(super) fn convert_output(
+    py: Python<'_>,
+    value: &Bound<'_, PyAny>,
+    schema: &PythonAsyncType,
+    context: &str,
+) -> Result<PythonAsyncValue, PythonError> {
+    match schema {
+        PythonAsyncType::None => {
+            if value.is_none() {
+                Ok(PythonAsyncValue::None)
+            } else {
+                Err(conversion_error("expected Python None", context))
+            }
+        }
+        PythonAsyncType::Bool => extract(py, value, context).map(PythonAsyncValue::Bool),
+        PythonAsyncType::Int => extract(py, value, context).map(PythonAsyncValue::Int),
+        PythonAsyncType::Float => extract(py, value, context).map(PythonAsyncValue::Float),
+        PythonAsyncType::Str => extract(py, value, context).map(PythonAsyncValue::Str),
+        PythonAsyncType::Bytes => value
+            .cast::<PyBytes>()
+            .map(|value| PythonAsyncValue::Bytes(value.as_bytes().to_vec()))
+            .map_err(|_| conversion_error("expected Python bytes", context)),
+        PythonAsyncType::Option(inner) => {
+            if value.is_none() {
+                Ok(PythonAsyncValue::None)
+            } else {
+                convert_output(py, value, inner, context)
+            }
+        }
+        PythonAsyncType::List(inner) => {
+            let list = value
+                .cast::<PyList>()
+                .map_err(|_| conversion_error("expected Python list", context))?;
+            let mut converted = Vec::with_capacity(list.len());
+            for (index, item) in list.iter().enumerate() {
+                converted.push(convert_output(
+                    py,
+                    &item,
+                    inner,
+                    &format!("{context}[{index}]"),
+                )?);
+            }
+            Ok(PythonAsyncValue::List(converted))
+        }
+        PythonAsyncType::Tuple(items) => {
+            let tuple = value
+                .cast::<PyTuple>()
+                .map_err(|_| conversion_error("expected Python tuple", context))?;
+            if tuple.len() != items.len() {
+                return Err(conversion_error(
+                    format!("expected Python tuple of length {}", items.len()),
+                    context,
+                ));
+            }
+            let mut converted = Vec::with_capacity(items.len());
+            for (index, schema) in items.iter().enumerate() {
+                let item = tuple
+                    .get_item(index)
+                    .map_err(|error| PythonError::from_pyerr(py, error, "conversion", context))?;
+                converted.push(convert_output(
+                    py,
+                    &item,
+                    schema,
+                    &format!("{context}[{index}]"),
+                )?);
+            }
+            Ok(PythonAsyncValue::Tuple(converted))
+        }
+        PythonAsyncType::Dict(inner) => {
+            let dict = value
+                .cast::<PyDict>()
+                .map_err(|_| conversion_error("expected Python dict", context))?;
+            let mut converted = Vec::with_capacity(dict.len());
+            for (key, item) in dict.iter() {
+                let key = extract::<String>(py, &key, &format!("{context}.<key>"))?;
+                let item = convert_output(py, &item, inner, &format!("{context}[{key:?}]"))?;
+                converted.push((key, item));
+            }
+            Ok(PythonAsyncValue::Dict(converted))
+        }
+        PythonAsyncType::Record(fields) => {
+            let mut converted = Vec::with_capacity(fields.len());
+            for (field, schema) in fields {
+                let item = value
+                    .getattr(field.as_str())
+                    .or_else(|_| value.get_item(field.as_str()))
+                    .map_err(|_| {
+                        conversion_error(
+                            format!("missing required record field '{field}'"),
+                            format!("{context}.{field}"),
+                        )
+                    })?;
+                converted.push((
+                    field.clone(),
+                    convert_output(py, &item, schema, &format!("{context}.{field}"))?,
+                ));
+            }
+            Ok(PythonAsyncValue::Record(converted))
+        }
+        PythonAsyncType::Object => stored_object(value.clone().unbind()),
+        PythonAsyncType::Opaque(expected) => {
+            let expected_handle = super::object_ops::resolve_target(expected)?;
+            let expected_type = clone_handle(py, &expected_handle)?;
+            let matches = value
+                .is_instance(expected_type.bind(py))
+                .map_err(|error| PythonError::from_pyerr(py, error, "conversion", context))?;
+            if !matches {
+                return Err(conversion_error(
+                    format!("expected Python instance of {}", expected.join(".")),
+                    context,
+                ));
+            }
+            stored_object(value.clone().unbind())
+        }
+    }
+}
+
+fn stored_object(object: Py<PyAny>) -> Result<PythonAsyncValue, PythonError> {
+    let object = store_object(object)?;
+    PythonAsyncObject::owned(object).map(PythonAsyncValue::Object)
+}
+
+fn collect_values(
+    values: Vec<Result<PythonAsyncValue, PythonError>>,
+    context: &str,
+) -> Result<Vec<PythonAsyncValue>, PythonError> {
+    values
+        .into_iter()
+        .enumerate()
+        .map(|(index, value)| value.map_err(|error| at_path(error, format!("{context}[{index}]"))))
+        .collect()
+}
+
+fn collect_named_values(
+    values: Vec<(String, Result<PythonAsyncValue, PythonError>)>,
+    context: &str,
+) -> Result<Vec<(String, PythonAsyncValue)>, PythonError> {
+    values
+        .into_iter()
+        .map(|(name, value)| {
+            value
+                .map(|value| (name.clone(), value))
+                .map_err(|error| at_path(error, format!("{context}[{name:?}]")))
+        })
+        .collect()
+}
+
+fn materialize_values(
+    py: Python<'_>,
+    values: &[PythonAsyncValue],
+    context: &str,
+) -> Result<Vec<Py<PyAny>>, PythonError> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(index, value)| materialize(py, value, &format!("{context}[{index}]")))
+        .collect()
+}
+
+fn into_python<'py, T>(py: Python<'py>, value: T, context: &str) -> Result<Py<PyAny>, PythonError>
+where
+    T: IntoPyObjectExt<'py>,
+{
+    value
+        .into_py_any(py)
+        .map_err(|error| PythonError::from_pyerr(py, error, "conversion", context))
+}
+
+fn extract<'a, 'py, T>(
+    py: Python<'py>,
+    value: &'a Bound<'py, PyAny>,
+    context: &str,
+) -> Result<T, PythonError>
+where
+    T: FromPyObject<'a, 'py>,
+{
+    value
+        .extract::<T>()
+        .map_err(|error| PythonError::from_pyerr(py, error.into(), "conversion", context))
+}
+
+fn at_path(mut error: PythonError, path: String) -> PythonError {
+    error.context = if error.context.is_empty() {
+        path
+    } else {
+        format!("{path}.{}", error.context)
+    };
+    error
+}
+
+fn conversion_error(message: impl Into<String>, context: impl Into<String>) -> PythonError {
+    PythonError::without_replay(
+        "conversion",
+        "SifrPythonTypeConversionError",
+        message,
+        String::new(),
+        context,
+    )
+}

--- a/crates/sifr_runtime/src/python/foreign_object.rs
+++ b/crates/sifr_runtime/src/python/foreign_object.rs
@@ -14,15 +14,33 @@ pub struct ForeignObject {
     boundary_path: String,
 }
 
+/// Runtime-private pin for an identity used by an in-flight async declaration.
+///
+/// The pin is deliberately not exposed through the Sifr type model. It keeps the
+/// exact identity resolvable on the owned asyncio thread even if runtime cleanup
+/// concurrently marks the public handle closed.
+#[derive(Debug)]
+pub(super) struct ForeignObjectLease {
+    inner: Arc<ForeignObjectInner>,
+    boundary_path: String,
+}
+
 #[derive(Debug)]
 struct ForeignObjectInner {
     state: Mutex<ForeignObjectState>,
 }
 
 #[derive(Debug)]
-enum ForeignObjectState {
-    Open(Py<PyAny>),
-    Poisoned(Py<PyAny>),
+struct ForeignObjectState {
+    status: ForeignObjectStatus,
+    object: Option<Py<PyAny>>,
+    active_leases: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ForeignObjectStatus {
+    Open,
+    Poisoned,
     Closed,
 }
 
@@ -31,41 +49,65 @@ impl ForeignObject {
         update_object_count(1)?;
         Ok(Self {
             inner: Arc::new(ForeignObjectInner {
-                state: Mutex::new(ForeignObjectState::Open(object)),
+                state: Mutex::new(ForeignObjectState {
+                    status: ForeignObjectStatus::Open,
+                    object: Some(object),
+                    active_leases: 0,
+                }),
             }),
             boundary_path: String::new(),
         })
     }
 
     pub(super) fn clone_ref(&self, py: Python<'_>) -> Result<Py<PyAny>, PythonRuntimeError> {
-        match &*lock_state(&self.inner.state) {
-            ForeignObjectState::Open(object) => Ok(object.clone_ref(py)),
-            ForeignObjectState::Poisoned(_) => Err(PythonRuntimeError::PythonOperationFailed(
+        let state = lock_state(&self.inner.state);
+        match state.status {
+            ForeignObjectStatus::Open => state.object.as_ref().map_or_else(
+                || {
+                    Err(PythonRuntimeError::PythonOperationFailed(
+                        "Python object identity is unavailable".to_string(),
+                    ))
+                },
+                |object| Ok(object.clone_ref(py)),
+            ),
+            ForeignObjectStatus::Poisoned => Err(PythonRuntimeError::PythonOperationFailed(
                 "Python object identity is poisoned after failed semantic cleanup".to_string(),
             )),
-            ForeignObjectState::Closed => Err(PythonRuntimeError::PythonOperationFailed(
+            ForeignObjectStatus::Closed => Err(PythonRuntimeError::PythonOperationFailed(
                 "Python object identity is closed".to_string(),
             )),
         }
     }
 
+    pub(super) fn lease(&self) -> Result<ForeignObjectLease, PythonRuntimeError> {
+        let mut state = lock_state(&self.inner.state);
+        if state.status != ForeignObjectStatus::Open || state.object.is_none() {
+            return Err(PythonRuntimeError::PythonOperationFailed(
+                "Python object identity is closed".to_string(),
+            ));
+        }
+        state.active_leases = state.active_leases.saturating_add(1);
+        Ok(ForeignObjectLease {
+            inner: Arc::clone(&self.inner),
+            boundary_path: self.boundary_path.clone(),
+        })
+    }
+
     pub(super) fn poison(&self) {
         let mut state = lock_state(&self.inner.state);
-        if let ForeignObjectState::Open(object) =
-            std::mem::replace(&mut *state, ForeignObjectState::Closed)
-        {
-            *state = ForeignObjectState::Poisoned(object);
+        if state.status == ForeignObjectStatus::Open {
+            state.status = ForeignObjectStatus::Poisoned;
         }
     }
 
     pub(super) fn close(&self) {
         let object = {
             let mut state = lock_state(&self.inner.state);
-            match std::mem::replace(&mut *state, ForeignObjectState::Closed) {
-                ForeignObjectState::Open(object) | ForeignObjectState::Poisoned(object) => {
-                    Some(object)
-                }
-                ForeignObjectState::Closed => None,
+            state.status = ForeignObjectStatus::Closed;
+            if state.active_leases == 0 {
+                state.object.take()
+            } else {
+                None
             }
         };
         if let Some(object) = object {
@@ -90,10 +132,45 @@ impl ForeignObject {
 impl Drop for ForeignObjectInner {
     fn drop(&mut self) {
         let state = match self.state.get_mut() {
-            Ok(state) => std::mem::replace(state, ForeignObjectState::Closed),
-            Err(poisoned) => std::mem::replace(poisoned.into_inner(), ForeignObjectState::Closed),
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
         };
-        if let ForeignObjectState::Open(object) | ForeignObjectState::Poisoned(object) = state {
+        if let Some(object) = state.object.take() {
+            release_object(object);
+        }
+    }
+}
+
+impl ForeignObjectLease {
+    pub(super) fn clone_ref(&self, py: Python<'_>) -> Result<Py<PyAny>, PythonRuntimeError> {
+        let state = lock_state(&self.inner.state);
+        state.object.as_ref().map_or_else(
+            || {
+                Err(PythonRuntimeError::PythonOperationFailed(
+                    "leased Python object identity is unavailable".to_string(),
+                ))
+            },
+            |object| Ok(object.clone_ref(py)),
+        )
+    }
+
+    pub(super) fn boundary_path(&self) -> &str {
+        &self.boundary_path
+    }
+}
+
+impl Drop for ForeignObjectLease {
+    fn drop(&mut self) {
+        let object = {
+            let mut state = lock_state(&self.inner.state);
+            state.active_leases = state.active_leases.saturating_sub(1);
+            if state.active_leases == 0 && state.status == ForeignObjectStatus::Closed {
+                state.object.take()
+            } else {
+                None
+            }
+        };
+        if let Some(object) = object {
             release_object(object);
         }
     }

--- a/plans/reviews/active/python-interop-m7-wave5-typed-wrappers-design-review-round1.md
+++ b/plans/reviews/active/python-interop-m7-wave5-typed-wrappers-design-review-round1.md
@@ -1,0 +1,39 @@
+I've read the phase plan, the runtime async_runtime/async_terminal/foreign_object/object_ops/recursive_ops modules, the codegen direct wrapper, and the lowering gate. Here is the design review.
+
+## What Wave 5 requires vs. what the design delivers
+
+| Requirement | Design coverage |
+|-------------|----------------|
+| Gate remains SIFR-PYRES-0002 | ✔ Design keeps `reserved_declaration` on `Coroutine`; wrapper is exercised only by unit + runtime tests, no lowering escape hatch |
+| Compiler-private owned inputs/identity cross to owned loop | ✔ `PythonAsyncValue` transport is Rust-owned; opaque/Object inputs carry a sealed identity lease (Arc over `ForeignObject`), not a `Py<PyAny>` |
+| All Python work on loop thread | ✔ Setup callback resolves target/receiver, materializes args, invokes, calls `loop.create_task` (awaitability check), registers exact task; done callback extracts `task.result`, applies schema conversion, converts PyErr — all under the loop-thread GIL |
+| Functions / factories / borrowed & consuming methods | ✔ Codegen branches on `PythonInteropDecoratorKind`; consuming non-cleanup methods transfer the owned handle by move (distinct from sync semantic-close, which the current `python_interop_direct.rs` already rejects for non-Function/non-`()`/non-empty-args, so the async path adds the case rather than colliding with it) |
+| Positional / keyword-only / variadic / omit / recursive values / opaque results / bridges / failures | ✔ Reuses existing per-parameter shape logic; bridge targets are already rewritten in `parse_function` before the declaration is packed into HIR; opaque result path performs `isinstance` + `store_object` on the loop thread |
+| Non-send public opaque, receiver frozen across await | ✔ Wrapper is `async fn(&self, …)`; the source `&self` borrow lives for the entire `.await`, and the lease adds defense-in-depth over `ForeignObject::close`. No raw `Py<PyAny>` moves — only the Arc-wrapped `ForeignObject` and Rust-owned transport values |
+| No alternate coroutine execution path | ✔ Raw `run_coroutine_blocking` and typed wrappers both go through the one `PythonTerminal` + `reserve/register/finish_submission` + cancellation-carrier machinery; only the setup/done callbacks and terminal payload variant differ |
+| No test-only bypass | ✔ Design explicitly forbids env flag / private lowering escape hatch |
+
+## Root-cause correctness
+
+- `submit_typed(..., __sifr_current_task_cancellation().as_ref()).await` composes cleanly with the existing `Option<&CancellationCarrier>` claim path from Wave 3; `CancelledBeforeClaim`, `AlreadyClaimed`, and `StateUnavailable` map to the same runtime errors as the raw path.
+- Duplicate-kwarg validation on the caller side (before queueing) mirrors the sync `call_object_owned` check and does not require GIL; correct.
+- Shutdown handles the typed variant by construction — `drain_outstanding_submissions` and `cancel_registered_submissions` operate on `RegisteredSubmission` identity, not payload shape.
+
+## Concurrency/identity safety
+
+- The transport is `Send` because `ForeignObject` (Arc<Mutex<Py<PyAny>>>) is `Send`, but no bare `Py<PyAny>` escapes the sealed wrapper. The `Py<PyAny>` is only materialized under the GIL on the loop thread, matching the phase contract.
+- The lease/freeze prevents `close()` from racing a live request; combined with the source `&self` borrow this is belt-and-braces. The mechanism is under-specified (blocking behavior vs. error on close-with-live-lease) but this is a Wave 5 implementation choice rather than a design defect — Sifr's borrow checker already precludes the practical race for borrowed receivers, and consuming methods move the handle in exclusively.
+- `PyCFunction::new_closure` requires `Send + 'static`; all transport variants (`PythonAsyncValue`, output schema, `PythonError`) are `Send`.
+
+## Practical / non-blocking observations (not verdict-changing)
+
+1. **File-size guardrail pressure.** `crates/sifr_codegen/src/python_interop_direct.rs` is 899 lines. Adding a Coroutine branch plus construction/extraction helpers pushes it over 900 unless the emitter is split (sync/async or by helper family). The design mentions "a focused runtime module" for the runtime side but does not call out the codegen split.
+2. **Terminal payload generalization is glossed.** Moving `PythonTerminalOutcome` from `Result<Py<PyAny>, …>` to a `Raw|Typed` payload enum touches all raw-path tests. The design should name whether it is one enum with two success variants or parameterizes `PythonTerminal` — either works, but the raw callsites in `async_runtime.rs`/`coroutine_ops.rs` need a small refactor.
+3. **Consuming non-close method surface.** Design correctly covers this, but note that today `python_interop_method_body` bails out on any consuming non-close case (`declaration.consumes_receiver` branch demands `Function` + `None` return + no params). The async emitter must not reuse that branch — it needs its own consuming-async path that transfers `self.__sifr_python_object` into the descriptor and then returns the schema-destructured result.
+4. **Every typed wrapper re-resolves the target on the loop thread.** Not a correctness bug — matches the "loop-thread-only" contract — but is worth a per-declaration cache in a later wave if it shows up in profiles.
+
+## Blocking findings
+
+None. The design does not create a second execution path, does not weaken the SIFR-PYRES-0002 gate, does not leak `Py<PyAny>` across threads, does not introduce a test-only compiler bypass, and covers every listed Wave 5 shape and failure mode by extending the single existing terminal/registry.
+
+VERDICT: SATISFIED

--- a/plans/reviews/active/python-interop-m7-wave5-typed-wrappers-implementation-review-round1.md
+++ b/plans/reviews/active/python-interop-m7-wave5-typed-wrappers-implementation-review-round1.md
@@ -1,0 +1,50 @@
+I've completed the review of the Wave 5 typed async Python declaration wrappers implementation. Here is my assessment.
+
+## Review Summary
+
+**Files reviewed:**
+- Codegen: `python_interop_async.rs` (new, 826 lines), `python_interop_common.rs` (new), `python_interop_direct.rs` (895 lines), `python_interop_plan.rs`, `entrypoints.rs`, `lib.rs`, `lib_modules_and_codegen.rs`, `generator_bodies.rs`
+- Runtime: `async_declaration.rs` (new, 305 lines), `async_value.rs` (new, 558 lines), `foreign_object.rs`, `async_runtime.rs`, `async_terminal.rs`, `python.rs`
+- Tests: `python_interop_async_tests.rs`, `python_interop_plan_tests.rs`, `async_declaration_tests.rs`, `async_runtime_tests.rs`
+- Lowering gate: `sifr_lowering/src/lower/python_interop.rs`
+
+## Blocking findings
+
+**None.**
+
+## Verified correctness properties
+
+1. **Single terminal/registry.** Both raw `submit_coroutine` and typed `submit_async_declaration` use the same `terminal_for_submission`/`reserve_submission`/`register_submission`/`finish_submission` and shared `PythonTerminal` machinery. `PythonTerminalOutcome` now carries `PythonTerminalValue::{Raw,Typed}` and the raw path rejects `Typed` (async_runtime.rs:177–184), the typed path rejects `Raw` (async_declaration.rs:29–37).
+
+2. **All Python work on the loop thread.** In `submit_typed`, `call_soon_threadsafe(setup)` queues resolve_callable → materialize args → call → `inspect.isawaitable` → `asyncio.ensure_future(..., loop=...)` → `add_done_callback` → `register_submission` → `publish` on the loop thread; the done_callback runs `task.result()` + `convert_output` + `resolve_target` for `Opaque` + `isinstance` + `store_object` under the same GIL.
+
+3. **No Py<PyAny> across threads.** Public `PythonAsyncValue::Object` wraps `PythonAsyncObject`, whose fields (`lease`, `owner`) are `pub(super)`. `PythonAsyncObject` itself is not re-exported. The `Py<PyAny>` is only materialized via `ForeignObjectLease::clone_ref(py)` on the loop thread. `PythonAsyncRequest`, `PythonAsyncValue`, and their transitive contents are `Send + Sync` because they hold `Arc<Mutex<...>>`-wrapped state, never a bare `Py<PyAny>` in a public position.
+
+4. **ForeignObjectLease correctness.** `ForeignObject::lease()` rejects `Closed`/`Poisoned` or missing object (foreign_object.rs:82–94); `close()` sets `Closed` but defers releasing the `Py<PyAny>` when `active_leases > 0` (foreign_object.rs:103–116); lease `Drop` re-checks `Closed + last lease` before taking the object (foreign_object.rs:162–177). `lease.clone_ref` reads `state.object` regardless of status so in-flight requests survive concurrent close.
+
+5. **Receiver freeze across await.** Generated borrowed methods take `&self`; the code builds `PythonAsyncRequest::borrowed_method(&self.__sifr_python_object, ...)` before the `.await`, and the lease pins the identity for the full duration. Consuming methods use `RustParam::SelfValue` (class_method_emitter.rs:664) and `PythonAsyncRequest::owned_method(self.__sifr_python_object, ...)`, transferring ownership without touching raw pointers.
+
+6. **SIFR-PYRES-0002 preserved.** Both `Coroutine + async def` function and method lowering call `reserved_declaration(...)` (python_interop.rs:60–63, 122–126) which emits `PYRES_UNIMPLEMENTED_DECLARATION` at `Severity::Error`, blocking user compilation. Codegen tests exercise the wrapper via HIR fixtures, and runtime tests call `submit_async_declaration` directly; no `#[cfg(test)]` or feature-gated compiler bypass exists.
+
+7. **Cancellation carrier.** `submit_typed` calls `terminal_for_submission(carrier)` (shared with raw) which either claims the exact hook or returns `CancelledBeforeClaim`/`AlreadyClaimed`/`StateUnavailable`. The setup callback atomically `publish`es the submission_id after `register_submission`, and either the carrier's late `request()` finds the id and issues `cancel_submission`, or `publish` observes `requested=true` and cancels inline. Race paths verified from the shared `SubmissionCancellationBridge` implementation.
+
+8. **Panic safety.** `catch_unwind(AssertUnwindSafe(…))` wraps the setup and done bodies (async_declaration.rs:109, 161); panics degrade to `AsyncRuntimeFailed` and complete the terminal.
+
+9. **Method-only async loop plan.** `python_interop_plan.rs` now ORs `class.methods` async effect into `plan.requires_async_loop` (line 93–98), with dedicated test coverage (`method_only_async_python_declaration_requires_owned_loop`).
+
+10. **Codegen preamble.** `module_uses_async_python_declaration` triggers `build_task_cancellation_items()` for modules that use only async python declarations, without dragging in task_scope/join_set (lib_modules_and_codegen.rs:540–553, entrypoints.rs:56–79).
+
+11. **Shape coverage in codegen.** Positional/keyword-only/positional-variadic/keyword-variadic/`python.omit` and recursive list/tuple/dict/record/`Option`/opaque/`Object` all lower in `argument_frame`, `async_input_conversion`, `output_schema`, and `async_output_value`. Bridge targets pass structured segments through verbatim (verified by `resolved_bridge_target_stays_structured_in_typed_request`).
+
+12. **File-size guardrail.** All touched/added files remain under 900 lines: `python_interop_direct.rs` 895, `python_interop_async.rs` 826, `async_runtime.rs` 812, `async_value.rs` 558. The design review's flagged pressure was resolved by extracting `python_interop_async.rs` and the shared `python_interop_common.rs`.
+
+13. **Runtime acceptance.** Runtime tests exercise recursive frames, opaque factory + borrowed method with lease-across-await, concurrent one-loop identity, non-awaitable/Python/conversion failures, and bridge target resolution on the owned loop.
+
+## Non-blocking observations (not verdict-changing)
+
+- `async_from_owned_object` is exported but unused by current codegen (reserved for future owned-parameter transfer).
+- The `close_object(client)` call in `typed_factory_and_borrowed_method_preserve_sealed_identity_across_await` proves the lease keeps the identity alive after the public wrapper is dropped; the comment's "public identity should close" phrasing is slightly aspirational because `close_object` drops the wrapper rather than calling `ForeignObject::close()`, but the lease-across-cleanup invariant it tests is a strict superset (it also holds against explicit `.close()` since the lease branch of `close()` leaves `state.object` intact).
+- No runtime test exercises consuming async methods or omitted-argument runtime materialization; both are exercised at codegen and are consistent with Wave 5's gating (cancellation and consuming close activate in Waves 6–7).
+- Every typed wrapper re-resolves opaque `expected` types on the loop thread; matches the design's stated "loop-thread-only" contract with a note for later profile-driven caching.
+
+VERDICT: SATISFIED

--- a/plans/reviews/active/python-interop-m7-wave5-typed-wrappers-implementation-review-round2.md
+++ b/plans/reviews/active/python-interop-m7-wave5-typed-wrappers-implementation-review-round2.md
@@ -1,0 +1,39 @@
+Based on my review of the entire diff, planning artifacts, and prior review artifacts, here is my final assessment.
+
+## What I verified
+
+**File sizes (all under 900):**
+- `python_interop_async.rs` 826, `python_interop_direct.rs` 895, `async_runtime.rs` 812, `async_value.rs` 558, `async_declaration.rs` 305, `python_interop_async_tests.rs` 267, `async_declaration_tests.rs` 283, `python_interop_common.rs` 24, `foreign_object.rs` 227, `async_terminal.rs` 218, `python.rs` 887, `python_interop_plan.rs` 388, `lib_modules_and_codegen.rs` 771.
+
+**Owned‑loop thread confinement:** `submit_typed` (`async_declaration.rs:50‑93`) queues one setup on `call_soon_threadsafe`; the setup resolves the callable (`async_declaration.rs:252‑269`), materializes args (`async_value.rs:323‑358`), calls, `inspect.isawaitable`, `asyncio.ensure_future(..., loop=…)`, `add_done_callback`, `register_submission`, and `publish`/cancel — all under the same GIL on the loop thread. The done callback runs `task.result()` and `convert_output` (`async_value.rs:360‑475`) including `resolve_target`/`is_instance`/`store_object` for `Opaque` on the same thread.
+
+**Send Future, no Py/Bound in the public surface:** The awaited value is `PythonTerminal`, which becomes `PythonAsyncValue`. `PythonAsyncValue::Object` wraps `PythonAsyncObject` whose `lease`/`owner` are private (`async_value.rs:66‑69`); `Py<PyAny>` is only materialized via `ForeignObjectLease::clone_ref(py)` under the loop‑thread GIL (`foreign_object.rs:144‑155`). `PythonAsyncRequest`/`PythonAsyncValue` are `Send` because their identity path is `Arc<Mutex<…>>`, never a bare `Py<PyAny>` in a public position.
+
+**Lease/close correctness:** `ForeignObject::lease()` rejects Closed/Poisoned/None (`foreign_object.rs:82‑94`); `close()` sets Closed but defers releasing the Py when `active_leases > 0` (`foreign_object.rs:103‑116`); `Drop for ForeignObjectLease` releases when `Closed && last lease` (`foreign_object.rs:162‑177`); `Drop for ForeignObjectInner` releases any remaining object. `update_object_count` is symmetric.
+
+**One cancellation/registry/terminal path:** `submit_coroutine` and `submit_typed` both use `terminal_for_submission` (now shared, `async_runtime.rs:231‑260`), `reserve_submission`, `register_submission`, `finish_submission`, and share `PythonTerminal`/`SubmissionCancellationBridge`. `PythonTerminalOutcome` is `Result<PythonTerminalValue, …>`; the raw path rejects `Typed` (`async_runtime.rs:177‑184`), the typed path rejects `Raw` (`async_declaration.rs:29‑37`).
+
+**Call‑shape coverage:** `argument_frame` (`python_interop_async.rs:102‑198`) handles positional, keyword‑only, positional‑variadic (list), keyword‑variadic (`dict[str, T]`), and `python.omit`; forwards positional‑by‑name once any positional gets omitted (matches sync path). `async_input_conversion` (`python_interop_async.rs:242‑358`) covers primitives, `Object`, opaque, `Option`, `List`, `Tuple`, `Dict[str, T]`, and records; `output_schema`/`async_output_value` are recursive symmetrically. Bridge segments pass through verbatim (verified by `resolved_bridge_target_stays_structured_in_typed_request`). Consuming methods emit `PythonAsyncRequest::owned_method` and move `self.__sifr_python_object`, which composes with `RustParam::SelfValue` selected in `class_method_emitter.rs:660‑671`.
+
+**Panic/unwrap safety:** No `.unwrap()`/`.expect()`/`panic!`/`assert!` in the new runtime/codegen sources. Setup and done bodies are inside `catch_unwind(AssertUnwindSafe(...))` and degrade to `AsyncRuntimeFailed` (`async_declaration.rs:109/161`). The single emitted `.unwrap()` in the codegen (`python_interop_async.rs:259`) generates unwrap on generated code guarded by `.is_some()` in the same block — matches the sync idiom in `python_interop_direct.rs`.
+
+**Gate closed:** `reserved_declaration` still fires `PYRES_UNIMPLEMENTED_DECLARATION` at Severity::Error on Coroutine function and method paths (`sifr_lowering/src/lower/python_interop.rs:60‑62, 122‑126, 637‑646`). The wrappers are exercised only through unit tests and runtime tests; no `#[cfg(test)]` compiler bypass exists.
+
+**Method‑only async loop plan:** `python_interop_plan.rs:93‑98` ORs class method async effect into `requires_async_loop`; `method_only_async_python_declaration_requires_owned_loop` covers it. Codegen preamble additions (`entrypoints.rs:58‑79`, `lib_modules_and_codegen.rs:540‑553`) emit `build_task_cancellation_items` without pulling in `task_scope`/`join_set` for modules that only use async python declarations. `standalone_typed_wrapper_emits_cancellation_carrier_preamble` proves it.
+
+**Namespace rename:** `p_wave` → `p_typed`. `grep -r "p_wave"` finds no remaining reference; `p_typed` appears only in `async_declaration_tests.rs:189/193/196/200/208` where it is a taxonomy‑only bridge name. No behavior change.
+
+**Test coverage:** recursive frames/opaque factory + borrowed method with lease across `close_object` + concurrent one‑loop identity + non‑awaitable/Python/conversion failures + bridge target under owned loop + typed emitter shape unit tests + preamble unit test + method‑only plan test.
+
+## Findings
+
+None.
+
+## Non-blocking observations (already flagged in round 1, not verdict-changing)
+
+- `async_from_owned_object` (`async_value.rs:191‑193`) is publicly exported but not yet used by codegen — reserved for future owned‑parameter transfer.
+- No runtime test exercises consuming async methods or omitted‑argument runtime materialization; consumption/cleanup activate in Waves 6–7 and both are covered at codegen level.
+- Every typed wrapper re‑resolves opaque `expected` types on the loop thread — matches design; per‑declaration caching is a later profile‑driven concern.
+- The comment in `typed_factory_and_borrowed_method_preserve_sealed_identity_across_await` (`async_declaration_tests.rs:96‑98`) still says the public identity "should close", but `close_object(client)` just drops the `ObjectHandle`; the lease‑over‑cleanup invariant it actually tests is a strict superset of an explicit `.close()` (both keep `state.object` intact while leases exist).
+
+VERDICT: SATISFIED


### PR DESCRIPTION
## What changed\n\n- add compiler-private owned async transport values and recursive output schemas\n- generate typed async Python function, factory, borrowed-method, and consuming-method wrappers\n- keep all CPython work on the owned loop thread while the public future remains Send\n- preserve opaque object identity through full-await leases and deferred close\n- unify typed and raw submissions on the existing cancellation, registry, and terminal path\n- add runtime and codegen coverage for call shapes, recursive values, bridges, concurrency, and failures\n\n## Why\n\nWave 5 of M7 requires declaration-first typed async wrappers to be complete behind the public lowering gate before cancellation and cleanup semantics are finalized in the next waves.\n\n## Validation\n\n- focused sifr_runtime, sifr_codegen, and sifr_lowering tests\n- python3 scripts/check_hir_maintainability_guardrails.py\n- file-size guardrail\n- scripts/run_all_tests.sh --profile create-pr\n- two implementation reviews by Claude Opus 4.7, final verdict SATISFIED\n\nThe public async declaration lowering gate intentionally remains closed until Waves 6 and 7.