### PR TITLE
docs(plan): close Python interop M7

### DIFF
--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -5,12 +5,10 @@
 In progress. The phase defines one complete end-state architecture and an
 ordered implementation sequence. Opus High pass 5 approved the complete design;
 a final independent Fable High audit found no blockers and its eight
-non-blocking precision refinements are incorporated. M0 through M6 are
-implemented, locally validated, and linked below; M7 is in progress with its
-frontend-contract, owned-loop, cooperative-cancellation-carrier,
-cancellation-aware-supervisor/ordered-shutdown, typed-async-wrapper, and
-consuming-async-close-lifecycle waves merged, while later milestones are not
-yet implemented.
+non-blocking precision refinements are incorporated. M0 through M7 are
+implemented, locally validated, and linked below; typed async declarations,
+owned-loop cancellation, and consuming async close are active on one production
+path, while later milestones are not yet implemented.
 Milestones sequence delivery; they do not create reduced language versions,
 temporary public contracts, dual authorities, or alternate lowering paths.
 
@@ -140,7 +138,7 @@ Implementation progress:
 - [x] M4 recursive conversion and opaque lifecycle — [PR #2935](https://github.com/sifr-lang/sifr/pull/2935)
 - [x] M5 synchronous Python context managers — [PR #2942](https://github.com/sifr-lang/sifr/pull/2942)
 - [x] M6 hermetic package-local Python bridges — [PR #2953](https://github.com/sifr-lang/sifr/pull/2953)
-- [ ] M7 owned asyncio runtime and async declarations
+- [x] M7 owned asyncio runtime and async declarations — [PR #2968](https://github.com/sifr-lang/sifr/pull/2968)
 - [ ] M8 async context managers
 - [ ] M9 typed callback lifetimes and dispatch
 - [ ] M10 typed buffer protocol
@@ -577,7 +575,8 @@ Implementation waves (one locally validated and reviewed PR per wave):
   - Poison on cleanup failure and reject reuse, duplicate close, or abandonment
     of an `async_close` obligation. Cover success, failure, poison,
     use-after-close, cancellation, and shutdown interaction.
-- [ ] Atomically activate async declarations and close M7 evidence:
+- [x] Atomically activate async declarations and close M7 evidence —
+  [PR #2968](https://github.com/sifr-lang/sifr/pull/2968):
   - Lift the `@python.coroutine` and `cleanup=async_close` gates only after the
     owned loop, typed wrappers, cooperative cancellation, terminal shutdown,
     and consuming lifecycle are present in the same production path.

--- a/plans/reviews/active/ad-hoc-python-interop-m7-wave7-tracker-pr2969-review-round1.md
+++ b/plans/reviews/active/ad-hoc-python-interop-m7-wave7-tracker-pr2969-review-round1.md
@@ -1,0 +1,25 @@
+I've cross-checked the PR diff against the merged state and the tracker context. Here's the review.
+
+## PR #2969 review — docs(plan): close Python interop M7
+
+**Scope check:** Single file changed — `plans/issues/active/ad-hoc-declaration-first-python-interop.md` (+7/-8). Documentation-only, no code.
+
+**Cross-checks against requirements:**
+
+1. **PR #2968 merged?** Yes — `state: MERGED`, `mergedAt: 2026-07-13T11:40:13Z`, commit `b7a978a4d`, title "feat(python-interop): activate typed async declarations". Matches the reference used throughout.
+
+2. **M7 milestone marked complete with link:** ✓ `plans/issues/active/ad-hoc-declaration-first-python-interop.md:141` — `[x] M7 owned asyncio runtime and async declarations — [PR #2968]`.
+
+3. **Final activation wave marked complete with link:** ✓ line 578 — `[x] Atomically activate async declarations and close M7 evidence — [PR #2968]`. All six prior M7 waves already `[x]` with their own PR links (2956, 2958, 2960, 2962, 2964, 2966).
+
+4. **"M0 through M7" complete claim:** ✓ line 8 — `M0 through M7 are implemented, locally validated, and linked below`. Milestone list confirms M0–M7 all `[x]` with PR links.
+
+5. **Overall phase still in progress:** ✓ line 5 — `In progress. The phase defines one complete end-state architecture...`.
+
+6. **M8–M17 left unchecked:** ✓ lines 142–151 — all ten remain `[ ]` with no PR links.
+
+7. **Status wording doesn't overclaim later families:** ✓ Lines 9–11 name only "typed async declarations, owned-loop cancellation, and consuming async close" — all three within M7's declared scope (owned asyncio loop, `@python.coroutine`, bidirectional cancellation with `CancelledError` mapping, `cleanup=async_close`). No async context managers (M8), callbacks (M9), buffers/Arrow/DLPack (M10–M12), or later families are claimed active. The "one production path" phrasing matches M7's Delivery Rule for the atomic activation wave.
+
+No mismatches found. The doc updates are internally consistent, accurately reflect merged PR #2968, and preserve the ordered-implementation invariant for M8+.
+
+VERDICT: SATISFIED


### PR DESCRIPTION
## Summary

- mark M7 and its activation wave complete
- link merged implementation PR #2968
- advance the phase status to M0 through M7 complete

## Validation

- `git diff --check`
- implementation PR #2968 merged after two satisfied Opus reviews and the authoritative create-PR gate