### PR TITLE
fix: restore merge-gate Python and cancellation contracts

### DIFF
--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -71,7 +71,7 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
         emitted_items.extend(super::build_async_exit_cause_type_items());
     }
     if uses_task_scope || uses_join_set || uses_async_python {
-        emitted_items.extend(super::build_task_cancellation_items());
+        emitted_items.extend(super::build_task_cancellation_items(uses_async_python));
     }
     if uses_task_scope || uses_join_set {
         emitted_items.extend(super::build_task_scope_items());

--- a/crates/sifr_codegen/src/lib_codegen_tests/async_task_runtime_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/async_task_runtime_codegen_tests.rs
@@ -333,7 +333,7 @@ fn test_task_handle_cancel_uses_cooperative_carrier_with_abort_fallback() {
     assert!(result
         .rust_source
         .contains("static __SIFR_TASK_CANCELLATION:"));
-    assert!(result
+    assert!(!result
         .rust_source
         .contains("fn __sifr_current_task_cancellation"));
     assert!(result

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -547,7 +547,7 @@ pub fn generate_rust_with_stdlib_for_module(
         }
     }
     if uses_task_scope || uses_join_set || uses_async_python {
-        preamble_items.extend(build_task_cancellation_items());
+        preamble_items.extend(build_task_cancellation_items(uses_async_python));
     }
     if uses_task_scope || uses_join_set {
         preamble_items.extend(build_task_scope_items());

--- a/crates/sifr_codegen/src/preamble/task_cancellation_runtime.rs
+++ b/crates/sifr_codegen/src/preamble/task_cancellation_runtime.rs
@@ -1,8 +1,7 @@
 use super::RustItem;
 
-pub fn build_task_cancellation_items() -> Vec<RustItem> {
-    vec![RustItem::Attr(
-        r#"tokio::task_local! {
+pub fn build_task_cancellation_items(include_current_accessor: bool) -> Vec<RustItem> {
+    let mut source = r#"tokio::task_local! {
     static __SIFR_TASK_CANCELLATION: sifr_runtime::cancellation::CancellationCarrier;
 }
 
@@ -25,14 +24,20 @@ impl __SifrCancellationCarrier {
         self.inner.request_cancel()
     }
 }
+"#
+    .to_string();
 
-#[allow(dead_code)]
+    if include_current_accessor {
+        source.push_str(
+            r#"
 fn __sifr_current_task_cancellation(
 ) -> Option<sifr_runtime::cancellation::CancellationCarrier> {
     __SIFR_TASK_CANCELLATION
         .try_with(Clone::clone)
         .ok()
-}"#
-        .to_string(),
-    )]
+}"#,
+        );
+    }
+
+    vec![RustItem::Attr(source)]
 }

--- a/crates/sifr_driver/src/stdlib/bootstrap_tests.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap_tests.rs
@@ -131,6 +131,35 @@ fn python_core_re_exports_preserve_callable_metadata() {
 }
 
 #[test]
+fn python_call_helpers_borrow_argument_collections() {
+    let compiled = compile_stdlib_uncached().expect("stdlib should compile");
+    let functions = compiled
+        .defs
+        .functions
+        .get("sifr.python")
+        .expect("sifr.python functions should be exported");
+
+    for function_name in ["call", "call_attr"] {
+        let function = functions
+            .get(function_name)
+            .unwrap_or_else(|| panic!("sifr.python.{function_name} should be exported"));
+        for parameter_name in ["args", "kwargs"] {
+            let convention = function
+                .params
+                .iter()
+                .find_map(|(name, _, convention)| (name == parameter_name).then_some(*convention))
+                .unwrap_or_else(|| {
+                    panic!("sifr.python.{function_name} should export {parameter_name}")
+                });
+            assert!(
+                convention.is_shared_borrow(),
+                "sifr.python.{function_name} must borrow {parameter_name} so temporary argument lists clone their handles"
+            );
+        }
+    }
+}
+
+#[test]
 fn retained_public_declarations_export_typed_compiler_identity() {
     let compiled = compile_stdlib_uncached().expect("stdlib should compile");
     assert_eq!(

--- a/stdlib/sifr/python.sifr
+++ b/stdlib/sifr/python.sifr
@@ -208,8 +208,8 @@ def get_item(obj: Object, key: str) -> Result[Object, PythonError]:
 @blocking_io
 def call(
     callable_obj: Object,
-    own args: list[Object],
-    own kwargs: list[tuple[str, Object]],
+    args: list[Object],
+    kwargs: list[tuple[str, Object]],
 ) -> Result[Object, PythonError]:
     try:
         kwargs_keys: list[str] = _keys_from_keyed_objects(kwargs)
@@ -229,8 +229,8 @@ def call(
 def call_attr(
     obj: Object,
     name: str,
-    own args: list[Object],
-    own kwargs: list[tuple[str, Object]],
+    args: list[Object],
+    kwargs: list[tuple[str, Object]],
 ) -> Result[Object, PythonError]:
     try:
         kwargs_keys: list[str] = _keys_from_keyed_objects(kwargs)


### PR DESCRIPTION
## Summary
- make `sifr.python.call` and `call_attr` borrow positional and keyword argument collections, matching their read-only Rust bridge contract and preserving caller-owned handles
- emit the current-task cancellation accessor only for async Python declarations that use it, removing a forbidden generated `#[allow(dead_code)]`
- add regression coverage for the exported Python call conventions and task-scope-only cancellation preamble

## Validation
- `cargo test -p sifr_driver python_call_helpers_borrow_argument_collections`
- Python interop dataframe examples: 3/3 passed
- Python interop ML examples: 2/2 passed
- Python interop library examples: 7/7 passed
- focused generated-code panic scan for `concurrency-runtime-readiness`: passed
- focused generated-code clippy for `concurrency-runtime-readiness`: passed
- `scripts/run_all_tests.sh --profile create-pr`: passed (130/130 e2e; cold-cache warm-time advisory only)
- merge profile through generated-code representative lane: all preceding lanes passed, including all 15 Python-interoperability variants; the discovered cancellation-accessor finding is fixed and its focused panic/clippy gates pass
