### PR TITLE
M9 Wave 2: execute current and foreign Python callbacks

### DIFF
--- a/crates/sifr_codegen/src/class_emitter.rs
+++ b/crates/sifr_codegen/src/class_emitter.rs
@@ -137,10 +137,28 @@ impl RustEmitter {
         module_public: bool,
     ) -> Vec<(String, RustType)> {
         if class.python_opaque_declaration().is_some() {
-            return vec![(
-                "__sifr_python_object".to_string(),
-                RustType::Named("sifr_runtime::python::ObjectHandle".to_string()),
-            )];
+            let mut fields = vec![
+                (
+                    "__sifr_python_object".to_string(),
+                    RustType::Named("sifr_runtime::python::ObjectHandle".to_string()),
+                ),
+                (
+                    "__sifr_python_callbacks".to_string(),
+                    RustType::Named("sifr_runtime::python::CallbackOwnerSlot".to_string()),
+                ),
+            ];
+            if let Some(errors) = self.python_retained_callback_errors.get(&class.name) {
+                fields.extend(errors.iter().enumerate().map(|(index, error)| {
+                    (
+                        format!("__sifr_python_callback_failure_{index}"),
+                        RustType::Named(format!(
+                            "sifr_runtime::python::CallbackFailureSlot<{}>",
+                            self.rust_type_with_generics(error)
+                        )),
+                    )
+                }));
+            }
+            return fields;
         }
         let mut fields = Vec::new();
         if let Some(parent) = &class.parent_class {
@@ -196,6 +214,58 @@ impl RustEmitter {
             ));
         }
         fields
+    }
+
+    fn python_opaque_constructor_item(&self, class: &HirClass) -> RustItem {
+        let mut fields = vec![
+            (
+                "__sifr_python_object".to_string(),
+                RustExpr::Ident("__sifr_python_object".to_string()),
+            ),
+            (
+                "__sifr_python_callbacks".to_string(),
+                RustExpr::FnCall {
+                    func: Box::new(RustExpr::Path(vec![
+                        "sifr_runtime".to_string(),
+                        "python".to_string(),
+                        "CallbackOwnerSlot".to_string(),
+                        "empty".to_string(),
+                    ])),
+                    args: Vec::new(),
+                },
+            ),
+        ];
+        if let Some(errors) = self.python_retained_callback_errors.get(&class.name) {
+            fields.extend(errors.iter().enumerate().map(|(index, _)| {
+                (
+                    format!("__sifr_python_callback_failure_{index}"),
+                    RustExpr::FnCall {
+                        func: Box::new(RustExpr::Path(vec![
+                            "sifr_runtime".to_string(),
+                            "python".to_string(),
+                            "CallbackFailureSlot".to_string(),
+                            "new".to_string(),
+                        ])),
+                        args: Vec::new(),
+                    },
+                )
+            }));
+        }
+        RustItem::Fn {
+            name: "__sifr_from_python_object".to_string(),
+            visibility: Visibility::Private,
+            type_params: Vec::new(),
+            params: vec![RustParam::Named {
+                name: "__sifr_python_object".to_string(),
+                ty: RustType::Named("sifr_runtime::python::ObjectHandle".to_string()),
+            }],
+            ret: Some(RustType::Named("Self".to_string())),
+            body: vec![RustStmt::Return(Some(RustExpr::StructInit {
+                name: "Self".to_string(),
+                fields,
+            }))],
+            is_async: false,
+        }
     }
 
     pub(crate) fn lower_default_constructor_item(
@@ -469,6 +539,9 @@ impl RustEmitter {
         let saved_class_name = self.current_class_name.clone();
         self.current_class_name = Some(class.name.clone());
         let mut impl_items = Vec::new();
+        if is_python_opaque {
+            impl_items.push(self.python_opaque_constructor_item(class));
+        }
         let has_constructor = class.methods.iter().any(|method| method.name == "new");
         if !is_python_opaque
             && !has_constructor

--- a/crates/sifr_codegen/src/class_method_emitter.rs
+++ b/crates/sifr_codegen/src/class_method_emitter.rs
@@ -2,7 +2,7 @@ use crate::{
     function_emitter::{is_result_int_type, result_int_return_type_to_sifr_int, result_method_key},
     helpers::{body_contains_field_assign_codegen, collect_mutated_vars_with_sigs},
     hir_analysis::traversal::{self, TraversalConfig},
-    python_interop_direct::python_interop_method_body,
+    python_interop_direct::python_interop_method_body_with_retained_errors,
     rust_interop_direct::rust_interop_method_body,
     RustEmitter, RustExpr, RustItem, RustLiteral, RustParam, RustStmt, RustType, RustTypeParam,
     Visibility,
@@ -277,6 +277,20 @@ impl RustEmitter {
         param_ty: &Type,
         convention: ParamConvention,
     ) -> RustType {
+        if let Some(callback) = method
+            .python_interop
+            .iter()
+            .flat_map(|declaration| &declaration.callbacks)
+            .find(|callback| callback.parameter_name == param_name)
+        {
+            if callback.dispatch == sifr_ir::PythonCallbackDispatch::Foreign {
+                return self.lower_python_callback_param_type(
+                    param_ty,
+                    convention,
+                    callback.lifetime != sifr_ir::PythonCallbackLifetime::Call,
+                );
+            }
+        }
         if method.name == "new" {
             let is_recursive = self
                 .recursive_fields
@@ -774,10 +788,14 @@ impl RustEmitter {
             );
         }
 
-        let mut body = if let Some(interop_body) = python_interop_method_body(
+        let mut body = if let Some(interop_body) = python_interop_method_body_with_retained_errors(
             method,
             &self.python_opaque_classes,
             class.python_opaque_declaration(),
+            &self.python_retained_callback_errors,
+            self.python_retained_callback_errors
+                .get(&class.name)
+                .map_or(&[], Vec::as_slice),
         ) {
             interop_body
         } else if let Some(interop_body) = rust_interop_method_body(method) {

--- a/crates/sifr_codegen/src/function_emitter/generator_bodies.rs
+++ b/crates/sifr_codegen/src/function_emitter/generator_bodies.rs
@@ -1,10 +1,13 @@
 use super::{
     body_contains_yield, collect_mutated_vars_with_sigs, collect_reassigned_vars,
-    python_callback_bounds::python_callback_bound_param_names, HirFunction, HirStmt, OwnershipKind,
-    RustEmitter, RustExpr, RustItem, RustLiteral, RustParam, RustStmt, RustType, Type, Visibility,
+    python_callback_bounds::{
+        python_callback_bound_param_names, python_callback_static_param_names,
+    },
+    HirFunction, HirStmt, OwnershipKind, RustEmitter, RustExpr, RustItem, RustLiteral, RustParam,
+    RustStmt, RustType, Type, Visibility,
 };
 use crate::python_interop_common::python_omit_parameter_indices;
-use crate::python_interop_direct::python_interop_function_body;
+use crate::python_interop_direct::python_interop_function_body_with_retained_errors;
 use crate::rust_interop_direct::rust_interop_function_body;
 use std::collections::HashSet;
 impl RustEmitter {
@@ -309,6 +312,7 @@ impl RustEmitter {
         self.apply_mutable_param_shadowing(&mutable_param_shadows);
 
         let callback_bound_params = python_callback_bound_param_names(func);
+        let callback_static_params = python_callback_static_param_names(func);
         let python_omit_params = func
             .python_interop
             .first()
@@ -320,7 +324,11 @@ impl RustEmitter {
             .enumerate()
             .map(|(param_idx, param)| {
                 let rust_ty = if callback_bound_params.contains(&param.name) {
-                    self.lower_python_callback_param_type(&param.ty, param.convention)
+                    self.lower_python_callback_param_type(
+                        &param.ty,
+                        param.convention,
+                        callback_static_params.contains(&param.name),
+                    )
                 } else {
                     self.lower_module_function_param_type(&func.name, param_idx, param)
                 };
@@ -343,8 +351,12 @@ impl RustEmitter {
             })
             .collect::<Vec<_>>();
 
-        let interop_body = python_interop_function_body(func, &self.python_opaque_classes)
-            .or_else(|| rust_interop_function_body(func));
+        let interop_body = python_interop_function_body_with_retained_errors(
+            func,
+            &self.python_opaque_classes,
+            &self.python_retained_callback_errors,
+        )
+        .or_else(|| rust_interop_function_body(func));
         let interop_body_supplied = interop_body.is_some();
         let mut lowered_body = if let Some(interop_body) = interop_body {
             interop_body

--- a/crates/sifr_codegen/src/function_emitter/python_callback_bounds.rs
+++ b/crates/sifr_codegen/src/function_emitter/python_callback_bounds.rs
@@ -1,6 +1,14 @@
 use super::{HashSet, HirExpr, HirFunction, HirStmt, Type};
 
 pub(super) fn python_callback_bound_param_names(func: &HirFunction) -> HashSet<String> {
+    python_callback_param_names(func, false)
+}
+
+pub(super) fn python_callback_static_param_names(func: &HirFunction) -> HashSet<String> {
+    python_callback_param_names(func, true)
+}
+
+fn python_callback_param_names(func: &HirFunction, require_static: bool) -> HashSet<String> {
     let callable_params = func
         .params
         .iter()
@@ -12,6 +20,20 @@ pub(super) fn python_callback_bound_param_names(func: &HirFunction) -> HashSet<S
     }
 
     let mut names = HashSet::new();
+    for callback in func
+        .python_interop
+        .iter()
+        .flat_map(|declaration| &declaration.callbacks)
+        .filter(|callback| {
+            (callback.dispatch == sifr_ir::PythonCallbackDispatch::Foreign
+                || callback.dispatch == sifr_ir::PythonCallbackDispatch::Asyncio)
+                && (!require_static
+                    || callback.lifetime != sifr_ir::PythonCallbackLifetime::Call
+                    || callback.dispatch == sifr_ir::PythonCallbackDispatch::Asyncio)
+        })
+    {
+        names.insert(callback.parameter_name.clone());
+    }
     for stmt in &func.body {
         collect_python_callback_bound_names_stmt(stmt, &callable_params, &mut names);
     }

--- a/crates/sifr_codegen/src/function_emitter/scope_and_function_types.rs
+++ b/crates/sifr_codegen/src/function_emitter/scope_and_function_types.rs
@@ -805,12 +805,17 @@ impl RustEmitter {
         &self,
         ty: &Type,
         convention: ParamConvention,
+        require_static: bool,
     ) -> RustType {
         let Type::Callable(..) = ty.resolve_alias() else {
             return self.lower_function_param_type(ty, convention);
         };
         let base = self.rust_type_with_generics(ty);
-        let bounded = format!("{base} + Send + Sync + 'static");
+        let bounded = if require_static {
+            format!("{base} + Send + Sync + 'static")
+        } else {
+            format!("{base} + Send + Sync")
+        };
         if ty.ownership() != sifr_type_system::OwnershipKind::Copy && convention.is_borrowed() {
             RustType::Ref {
                 mutable: convention.is_mut_borrow(),
@@ -830,7 +835,7 @@ impl RustEmitter {
         if matches!(func_name, "py_local_callback" | "py_threadsafe_callback")
             && matches!(param.ty.resolve_alias(), Type::Callable(..))
         {
-            return self.lower_python_callback_param_type(&param.ty, param.convention);
+            return self.lower_python_callback_param_type(&param.ty, param.convention, true);
         }
         if self.function_param_lowers_to_sifr_int(func_name, param_idx)
             && matches!(

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -86,8 +86,10 @@ pub use preamble::*;
 mod python_interop_async;
 #[cfg(test)]
 mod python_interop_async_tests;
+mod python_interop_callbacks;
 mod python_interop_common;
 mod python_interop_direct;
+mod python_interop_direct_conversions;
 #[cfg(test)]
 mod python_interop_direct_tests;
 mod python_interop_plan;

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -66,6 +66,8 @@ pub struct RustEmitter {
     pub(crate) generic_class_templates: HashMap<String, sifr_ir::HirClass>,
     /// Opaque Python class declarations available to direct wrapper lowering.
     pub(crate) python_opaque_classes: HashMap<String, sifr_ir::PythonInteropDeclaration>,
+    /// Exact typed retained-callback failures stored on each opaque owner.
+    pub(crate) python_retained_callback_errors: HashMap<String, Vec<Type>>,
     /// Set of parameter names that are borrowed (&T) in the current function.
     /// Used to emit dereference (*name) in comparisons where &String != String.
     pub(crate) borrowed_params: HashSet<String>,
@@ -219,6 +221,7 @@ impl RustEmitter {
             generic_class_params: HashMap::new(),
             generic_class_templates: HashMap::new(),
             python_opaque_classes: HashMap::new(),
+            python_retained_callback_errors: HashMap::new(),
             borrowed_params: HashSet::new(),
             mut_borrowed_params: HashSet::new(),
             generator_functions: HashSet::new(),

--- a/crates/sifr_codegen/src/module_body.rs
+++ b/crates/sifr_codegen/src/module_body.rs
@@ -18,6 +18,7 @@ impl RustEmitter {
                     .map(|declaration| (class.name.clone(), declaration))
             })
             .collect();
+        self.python_retained_callback_errors = collect_retained_callback_errors(module);
         self.emit_module_classes(module, module_public);
         self.emit_module_functions(module, module_public, test_mode);
     }
@@ -41,4 +42,28 @@ impl RustEmitter {
             self.emit_function(func, module_public, test_mode);
         }
     }
+}
+
+fn collect_retained_callback_errors(
+    module: &HirModule,
+) -> std::collections::HashMap<String, Vec<sifr_type_system::Type>> {
+    let mut by_owner = std::collections::HashMap::<String, Vec<sifr_type_system::Type>>::new();
+    let functions = module
+        .functions
+        .iter()
+        .chain(module.classes.iter().flat_map(|class| class.methods.iter()));
+    for callback in functions
+        .flat_map(|function| &function.python_interop)
+        .flat_map(|declaration| &declaration.callbacks)
+    {
+        let (Some(owner), Some(error)) = (&callback.owner_class, &callback.handler_error_type)
+        else {
+            continue;
+        };
+        let errors = by_owner.entry(owner.clone()).or_default();
+        if !errors.iter().any(|existing| existing == error) {
+            errors.push(error.clone());
+        }
+    }
+    by_owner
 }

--- a/crates/sifr_codegen/src/python_interop_async/conversions.rs
+++ b/crates/sifr_codegen/src/python_interop_async/conversions.rs
@@ -539,14 +539,14 @@ pub(crate) fn async_output_value(
     } = ty.resolve_alias()
     {
         if opaque_classes.contains_key(class_name) {
-            return Some(RustExpr::StructInit {
-                name: class_name.clone(),
-                fields: vec![(
-                    "__sifr_python_object".to_string(),
-                    mapped_try(
-                        runtime_call("async_to_object", vec![RustExpr::Ident(name.to_string())]),
-                        error_type,
-                    ),
+            return Some(RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec![
+                    class_name.clone(),
+                    "__sifr_from_python_object".to_string(),
+                ])),
+                args: vec![mapped_try(
+                    runtime_call("async_to_object", vec![RustExpr::Ident(name.to_string())]),
+                    error_type,
                 )],
             });
         }

--- a/crates/sifr_codegen/src/python_interop_async_tests.rs
+++ b/crates/sifr_codegen/src/python_interop_async_tests.rs
@@ -101,7 +101,7 @@ fn recursive_factory_emits_loop_thread_schema_and_owned_opaque_result() {
     assert!(rendered.contains("\"pkg\".to_string()"), "{rendered}");
     assert!(rendered.contains("\"Client\".to_string()"), "{rendered}");
     assert!(rendered.contains("async_to_object"), "{rendered}");
-    assert!(rendered.contains("Client { __sifr_python_object:"));
+    assert!(rendered.contains("Client::__sifr_from_python_object("));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/python_interop_callbacks.rs
+++ b/crates/sifr_codegen/src/python_interop_callbacks.rs
@@ -1,0 +1,469 @@
+use crate::python_interop_direct::{callback_output_value_expr, input_conversion, runtime_call};
+use crate::{RustExpr, RustLiteral, RustParam, RustStmt, RustType};
+use sifr_ir::{
+    PythonCallbackConcurrency, PythonCallbackDeclaration, PythonCallbackDispatch,
+    PythonCallbackLifetime, PythonCleanupPolicy, PythonInteropDeclaration,
+};
+use sifr_type_system::{ParamConvention, Type};
+use std::collections::HashMap;
+
+pub(crate) struct CallbackSetup {
+    pub(crate) statements: Vec<RustStmt>,
+    pub(crate) callback_var: String,
+    pub(crate) failure_slot: Option<(String, Type)>,
+    pub(crate) dispatch: PythonCallbackDispatch,
+    pub(crate) lifetime: PythonCallbackLifetime,
+}
+
+pub(crate) fn callback_setup(
+    callback: &PythonCallbackDeclaration,
+    handler_name: &str,
+    callback_index: usize,
+    error_type: &Type,
+    opaque_classes: &HashMap<String, sifr_ir::PythonInteropDeclaration>,
+    owner: RustExpr,
+    failure_slot_source: Option<RustExpr>,
+) -> Option<CallbackSetup> {
+    if callback.dispatch == PythonCallbackDispatch::Asyncio {
+        return None;
+    }
+    if callback.dispatch == PythonCallbackDispatch::Current
+        && callback.lifetime != PythonCallbackLifetime::Call
+    {
+        return None;
+    }
+    let callback_var = format!("__sifr_callback_{callback_index}");
+    let slot_var = format!("__sifr_callback_failure_{callback_index}");
+    let handler_slot_var = format!("__sifr_callback_failure_for_handler_{callback_index}");
+    let mut statements = Vec::new();
+    if callback.handler_error_type.is_some() {
+        statements.push(RustStmt::Let {
+            mutable: false,
+            name: slot_var.clone(),
+            ty: None,
+            value: failure_slot_source.unwrap_or_else(|| RustExpr::FnCall {
+                func: Box::new(callback_runtime_path("CallbackFailureSlot::new")),
+                args: Vec::new(),
+            }),
+        });
+        statements.push(RustStmt::Let {
+            mutable: false,
+            name: handler_slot_var.clone(),
+            ty: None,
+            value: RustExpr::Clone(Box::new(RustExpr::Ident(slot_var.clone()))),
+        });
+    }
+
+    let factory = match callback.dispatch {
+        PythonCallbackDispatch::Current => "current_callback_with_owner",
+        PythonCallbackDispatch::Foreign if callback.lifetime == PythonCallbackLifetime::Call => {
+            "foreign_callback_scoped_with_owner"
+        }
+        PythonCallbackDispatch::Foreign => "foreign_callback_with_owner",
+        PythonCallbackDispatch::Asyncio => return None,
+    };
+    let mut factory_args = vec![owner];
+    factory_args.extend([
+        RustExpr::Literal(RustLiteral::Int(
+            i64::try_from(callback_index.checked_add(1)?).ok()?,
+        )),
+        RustExpr::Literal(RustLiteral::Int(
+            i64::try_from(callback.argument_types.len()).ok()?,
+        )),
+    ]);
+    if callback.dispatch == PythonCallbackDispatch::Foreign {
+        factory_args.push(concurrency_expr(callback.concurrency?));
+    }
+    factory_args.push(decoder(callback, opaque_classes)?);
+    factory_args.push(handler_adapter(
+        callback,
+        handler_name,
+        callback
+            .handler_error_type
+            .as_ref()
+            .map(|_| handler_slot_var.as_str()),
+    ));
+    factory_args.push(encoder(callback, opaque_classes)?);
+    statements.push(RustStmt::Let {
+        mutable: false,
+        name: callback_var.clone(),
+        ty: None,
+        value: mapped_try(runtime_call(factory, factory_args), error_type),
+    });
+    Some(CallbackSetup {
+        statements,
+        callback_var,
+        failure_slot: callback
+            .handler_error_type
+            .clone()
+            .map(|error| (slot_var, error)),
+        dispatch: callback.dispatch,
+        lifetime: callback.lifetime,
+    })
+}
+
+pub(crate) fn retained_failure_field(
+    callback: &PythonCallbackDeclaration,
+    errors: &HashMap<String, Vec<Type>>,
+) -> Option<String> {
+    let owner = callback.owner_class.as_ref()?;
+    let error = callback.handler_error_type.as_ref()?;
+    let index = errors
+        .get(owner)?
+        .iter()
+        .position(|candidate| candidate == error)?;
+    Some(format!("__sifr_python_callback_failure_{index}"))
+}
+
+pub(crate) fn append_retained_failure_slots(
+    body: &mut Vec<RustStmt>,
+    declaration: &PythonInteropDeclaration,
+    retained_callback_errors: &HashMap<String, Vec<Type>>,
+    lifetime: PythonCallbackLifetime,
+) {
+    let mut fields = Vec::new();
+    for callback in &declaration.callbacks {
+        if callback.lifetime != lifetime {
+            continue;
+        }
+        let Some(field) = retained_failure_field(callback, retained_callback_errors) else {
+            continue;
+        };
+        if fields.contains(&field) {
+            continue;
+        }
+        body.push(RustStmt::Let {
+            mutable: false,
+            name: retained_slot_var(&field),
+            ty: None,
+            value: runtime_call("CallbackFailureSlot::new", Vec::new()),
+        });
+        fields.push(field);
+    }
+}
+
+pub(crate) fn retained_slot_source(
+    callback: &PythonCallbackDeclaration,
+    retained_callback_errors: &HashMap<String, Vec<Type>>,
+    lifetime: PythonCallbackLifetime,
+) -> Option<RustExpr> {
+    if callback.lifetime != lifetime {
+        return None;
+    }
+    retained_failure_field(callback, retained_callback_errors)
+        .map(|field| RustExpr::Clone(Box::new(RustExpr::Ident(retained_slot_var(&field)))))
+}
+
+pub(crate) fn append_retained_failure_transfers(
+    body: &mut Vec<RustStmt>,
+    declaration: &PythonInteropDeclaration,
+    retained_callback_errors: &HashMap<String, Vec<Type>>,
+    converted: &str,
+) {
+    let mut fields = Vec::new();
+    for callback in &declaration.callbacks {
+        if callback.lifetime != PythonCallbackLifetime::Result {
+            continue;
+        }
+        let Some(field) = retained_failure_field(callback, retained_callback_errors) else {
+            continue;
+        };
+        if fields.contains(&field) {
+            continue;
+        }
+        body.push(RustStmt::Assign {
+            target: RustExpr::Field {
+                expr: Box::new(RustExpr::Ident(converted.to_string())),
+                field: field.clone(),
+            },
+            value: RustExpr::Ident(retained_slot_var(&field)),
+        });
+        fields.push(field);
+    }
+}
+
+fn retained_slot_var(field: &str) -> String {
+    format!("__sifr_retained{field}")
+}
+
+pub(crate) fn retained_cleanup_expr(cleanup: PythonCleanupPolicy) -> Option<RustExpr> {
+    let variant = match cleanup {
+        PythonCleanupPolicy::Close => "Close",
+        PythonCleanupPolicy::Context => "Context",
+        PythonCleanupPolicy::Drop
+        | PythonCleanupPolicy::AsyncClose
+        | PythonCleanupPolicy::AsyncContext => return None,
+    };
+    Some(RustExpr::Path(vec![
+        "sifr_runtime".to_string(),
+        "python".to_string(),
+        "RetainedCallbackCleanup".to_string(),
+        variant.to_string(),
+    ]))
+}
+
+pub(crate) fn callback_object_expr(setup: &CallbackSetup) -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::Ident(setup.callback_var.clone())),
+        method: "object".to_string(),
+        args: Vec::new(),
+    }
+}
+
+pub(crate) fn callback_owner_expr(setup: &CallbackSetup) -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::Ident(setup.callback_var.clone())),
+        method: "owner".to_string(),
+        args: Vec::new(),
+    }
+}
+
+pub(crate) fn callback_cleanup_expr(setup: &CallbackSetup) -> RustExpr {
+    debug_assert_eq!(setup.lifetime, PythonCallbackLifetime::Call);
+    let method = match setup.dispatch {
+        PythonCallbackDispatch::Current => "close",
+        PythonCallbackDispatch::Foreign => "close_call_scope",
+        PythonCallbackDispatch::Asyncio => {
+            unreachable!("asyncio callback cleanup uses the asynchronous emitter")
+        }
+    };
+    RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::Ident(setup.callback_var.clone())),
+        method: method.to_string(),
+        args: Vec::new(),
+    }
+}
+
+pub(crate) fn append_retained_callback_retention(
+    body: &mut Vec<RustStmt>,
+    setups: &[CallbackSetup],
+    error_type: &Type,
+) {
+    for setup in setups {
+        if setup.lifetime == PythonCallbackLifetime::Call {
+            continue;
+        }
+        body.push(RustStmt::Expr(mapped_try(
+            RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident(setup.callback_var.clone())),
+                method: "retain_in_owner".to_string(),
+                args: Vec::new(),
+            },
+            error_type,
+        )));
+    }
+}
+
+pub(crate) fn failure_reconciliation_stmt(
+    slot: &str,
+    handler_error_type: &Type,
+    enclosing_error_type: &Type,
+    owner: RustExpr,
+) -> RustStmt {
+    RustStmt::IfLet {
+        pattern: "Some(__sifr_callback_handler_error)".to_string(),
+        expr: RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Ident(slot.to_string())),
+            method: "take_if_owner_first".to_string(),
+            args: vec![RustExpr::Ref {
+                mutable: false,
+                expr: Box::new(owner),
+            }],
+        },
+        then_body: vec![RustStmt::Return(Some(RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec!["Err".to_string()])),
+            args: vec![error_channel_value(
+                RustExpr::Ident("__sifr_callback_handler_error".to_string()),
+                handler_error_type,
+                enclosing_error_type,
+            )],
+        }))],
+        else_body: None,
+    }
+}
+
+fn decoder(
+    callback: &PythonCallbackDeclaration,
+    opaque_classes: &HashMap<String, sifr_ir::PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    let mut body = Vec::new();
+    let mut converted = Vec::new();
+    for (index, ty) in callback.argument_types.iter().enumerate() {
+        let handle = format!("__sifr_callback_arg_{index}");
+        body.push(RustStmt::Let {
+            mutable: false,
+            name: handle.clone(),
+            ty: None,
+            value: RustExpr::Clone(Box::new(RustExpr::Index {
+                expr: Box::new(RustExpr::Ident("__sifr_callback_args".to_string())),
+                index: Box::new(RustExpr::Literal(RustLiteral::Int(
+                    i64::try_from(index).ok()?,
+                ))),
+            })),
+        });
+        converted.push(callback_output_value_expr(&handle, ty, opaque_classes)?);
+    }
+    body.push(RustStmt::Return(Some(RustExpr::FnCall {
+        func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
+        args: vec![RustExpr::Tuple(converted)],
+    })));
+    Some(RustExpr::ClosureBlock {
+        params: vec![RustParam::Named {
+            name: "__sifr_callback_args".to_string(),
+            ty: RustType::Named("_".to_string()),
+        }],
+        body,
+        is_move: true,
+        is_async: false,
+    })
+}
+
+fn handler_adapter(
+    callback: &PythonCallbackDeclaration,
+    handler_name: &str,
+    failure_slot: Option<&str>,
+) -> RustExpr {
+    let handler_args = callback
+        .argument_conventions
+        .iter()
+        .enumerate()
+        .map(|(index, convention)| convention_arg(index, *convention))
+        .collect();
+    let handler_call = RustExpr::FnCall {
+        func: Box::new(RustExpr::Ident(handler_name.to_string())),
+        args: handler_args,
+    };
+    let result = if let (Some(error_type), Some(slot)) =
+        (&callback.handler_error_type, failure_slot)
+    {
+        RustExpr::MethodCall {
+            receiver: Box::new(handler_call),
+            method: "map_err".to_string(),
+            args: vec![RustExpr::ClosureBlock {
+                params: vec![RustParam::Named {
+                    name: "__sifr_callback_error".to_string(),
+                    ty: RustType::Named("_".to_string()),
+                }],
+                body: vec![
+                    RustStmt::Expr(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident(slot.to_string())),
+                        method: "record".to_string(),
+                        args: vec![
+                            RustExpr::Ident("__sifr_callback_sequence".to_string()),
+                            RustExpr::Ident("__sifr_callback_error".to_string()),
+                        ],
+                    }),
+                    RustStmt::Return(Some(RustExpr::FnCall {
+                        func: Box::new(callback_runtime_path("CallbackExecutionError::Handler")),
+                        args: vec![RustExpr::FnCall {
+                            func: Box::new(callback_runtime_path("CallbackHandlerFailure::new")),
+                            args: vec![
+                                RustExpr::Literal(RustLiteral::Str(error_type.to_string())),
+                                RustExpr::Literal(RustLiteral::Str(
+                                    "Sifr callback handler returned an error".to_string(),
+                                )),
+                            ],
+                        }],
+                    })),
+                ],
+                is_move: true,
+                is_async: false,
+            }],
+        }
+    } else {
+        RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
+            args: vec![handler_call],
+        }
+    };
+    RustExpr::Closure {
+        params: vec![
+            RustParam::Named {
+                name: "__sifr_callback_sequence".to_string(),
+                ty: RustType::Named("_".to_string()),
+            },
+            if callback
+                .argument_conventions
+                .iter()
+                .any(|convention| convention.is_mut_borrow())
+            {
+                RustParam::NamedMut {
+                    name: "__sifr_callback_values".to_string(),
+                    ty: RustType::Named("_".to_string()),
+                }
+            } else {
+                RustParam::Named {
+                    name: "__sifr_callback_values".to_string(),
+                    ty: RustType::Named("_".to_string()),
+                }
+            },
+        ],
+        body: Box::new(result),
+        is_move: true,
+    }
+}
+
+fn encoder(
+    callback: &PythonCallbackDeclaration,
+    opaque_classes: &HashMap<String, sifr_ir::PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    Some(RustExpr::Closure {
+        params: vec![RustParam::Named {
+            name: "__sifr_callback_result".to_string(),
+            ty: RustType::Named("_".to_string()),
+        }],
+        body: Box::new(input_conversion(
+            "__sifr_callback_result",
+            &callback.success_type,
+            opaque_classes,
+        )?),
+        is_move: true,
+    })
+}
+
+fn convention_arg(index: usize, convention: ParamConvention) -> RustExpr {
+    let field = RustExpr::Field {
+        expr: Box::new(RustExpr::Ident("__sifr_callback_values".to_string())),
+        field: index.to_string(),
+    };
+    if convention.is_borrowed() {
+        RustExpr::Ref {
+            mutable: convention.is_mut_borrow(),
+            expr: Box::new(field),
+        }
+    } else {
+        field
+    }
+}
+
+fn concurrency_expr(concurrency: PythonCallbackConcurrency) -> RustExpr {
+    callback_runtime_path(match concurrency {
+        PythonCallbackConcurrency::Serial => "ForeignCallbackConcurrency::Serial",
+        PythonCallbackConcurrency::Parallel => "ForeignCallbackConcurrency::Parallel",
+    })
+}
+
+fn error_channel_value(value: RustExpr, source: &Type, target: &Type) -> RustExpr {
+    if source.resolve_alias() == target.resolve_alias() {
+        return value;
+    }
+    if let Type::Union(members) = target.resolve_alias() {
+        if let Some(variant) = crate::helpers::find_union_variant(members, source) {
+            return RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec![target.union_enum_name(), variant])),
+                args: vec![value],
+            };
+        }
+    }
+    value
+}
+
+fn mapped_try(value: RustExpr, error_type: &Type) -> RustExpr {
+    crate::python_interop_direct::mapped_try(value, error_type)
+}
+
+fn callback_runtime_path(item: &str) -> RustExpr {
+    let mut path = vec!["sifr_runtime".to_string(), "python".to_string()];
+    path.extend(item.split("::").map(str::to_string));
+    RustExpr::Path(path)
+}

--- a/crates/sifr_codegen/src/python_interop_direct.rs
+++ b/crates/sifr_codegen/src/python_interop_direct.rs
@@ -1,15 +1,35 @@
 use sifr_ir::{
-    HirFunction, PythonInteropDeclaration, PythonInteropDecoratorKind, PythonParameterKind,
+    HirFunction, PythonCallbackLifetime, PythonInteropDeclaration, PythonInteropDecoratorKind,
+    PythonParameterKind,
 };
 use sifr_type_system::Type;
 use std::collections::HashMap;
 
+use crate::python_interop_callbacks::{
+    append_retained_callback_retention, append_retained_failure_slots,
+    append_retained_failure_transfers, callback_cleanup_expr, callback_object_expr,
+    callback_owner_expr, callback_setup, failure_reconciliation_stmt, retained_cleanup_expr,
+    retained_failure_field, retained_slot_source,
+};
 use crate::rust_interop_error_mapping::bridge_error_expr;
 use crate::{RustExpr, RustLiteral, RustParam, RustStmt, RustType};
+
+pub(crate) use crate::python_interop_direct_conversions::{
+    callback_output_value_expr, input_conversion, input_conversion_borrowed, is_python_object,
+    output_value_expr,
+};
 
 pub(crate) fn python_interop_function_body(
     func: &HirFunction,
     opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<Vec<RustStmt>> {
+    python_interop_function_body_with_retained_errors(func, opaque_classes, &HashMap::new())
+}
+
+pub(crate) fn python_interop_function_body_with_retained_errors(
+    func: &HirFunction,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+    retained_callback_errors: &HashMap<String, Vec<Type>>,
 ) -> Option<Vec<RustStmt>> {
     let declaration = func.python_interop.first()?;
     if declaration.kind == PythonInteropDecoratorKind::Coroutine {
@@ -47,9 +67,87 @@ pub(crate) fn python_interop_function_body(
 
     body.push(vector_let("__sifr_python_args"));
     body.push(vector_let("__sifr_python_kwargs"));
+    if declaration
+        .callbacks
+        .iter()
+        .any(|callback| callback.lifetime == PythonCallbackLifetime::Call)
+    {
+        body.push(mapped_let(
+            "__sifr_callback_call_owner",
+            runtime_call("CallbackOwnerState::new_call_scoped", Vec::new()),
+            error_type,
+        ));
+    }
+    let retained_result = declaration
+        .callbacks
+        .iter()
+        .find(|callback| callback.lifetime == PythonCallbackLifetime::Result);
+    if retained_result.is_some() {
+        body.push(RustStmt::Let {
+            mutable: true,
+            name: "__sifr_callback_group".to_string(),
+            ty: None,
+            value: mapped_try(
+                runtime_call("RetainedCallbackGroup::new", Vec::new()),
+                error_type,
+            ),
+        });
+        append_retained_failure_slots(
+            &mut body,
+            declaration,
+            retained_callback_errors,
+            PythonCallbackLifetime::Result,
+        );
+    }
     let mut forward_positional_by_name = false;
+    let mut callback_setups = Vec::new();
     for (index, (param, shape)) in func.params.iter().zip(&declaration.parameters).enumerate() {
         let handle_name = format!("__sifr_python_arg_{index}");
+        if let Some(callback) = declaration
+            .callbacks
+            .iter()
+            .find(|callback| callback.parameter_name == param.name)
+        {
+            let owner = match callback.lifetime {
+                PythonCallbackLifetime::Call => Some(RustExpr::Clone(Box::new(RustExpr::Ident(
+                    "__sifr_callback_call_owner".to_string(),
+                )))),
+                PythonCallbackLifetime::Result => {
+                    Some(RustExpr::Clone(Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident("__sifr_callback_group".to_string())),
+                        method: "owner".to_string(),
+                        args: Vec::new(),
+                    })))
+                }
+                PythonCallbackLifetime::Receiver => None,
+            }?;
+            let failure_slot_source = retained_slot_source(
+                callback,
+                retained_callback_errors,
+                PythonCallbackLifetime::Result,
+            );
+            let setup = callback_setup(
+                callback,
+                &param.name,
+                index,
+                error_type,
+                opaque_classes,
+                owner,
+                failure_slot_source,
+            )?;
+            body.extend(setup.statements.clone());
+            body.push(mapped_let(
+                &handle_name,
+                runtime_call(
+                    "temporary_argument_handle",
+                    vec![callback_object_expr(&setup)],
+                ),
+                error_type,
+            ));
+            body.push(push_for_shape(shape.kind, &shape.name, &handle_name)?);
+            callback_setups.push(setup);
+            continue;
+        }
         if shape.omit_when_absent {
             if shape.kind == PythonParameterKind::Positional {
                 forward_positional_by_name = true;
@@ -65,7 +163,7 @@ pub(crate) fn python_interop_function_body(
                     push_named_keyword(&shape.name, &handle_name)
                 }
                 PythonParameterKind::PositionalVariadic | PythonParameterKind::KeywordVariadic => {
-                    return None
+                    return None;
                 }
             });
             body.push(RustStmt::IfLet {
@@ -152,20 +250,109 @@ pub(crate) fn python_interop_function_body(
         }
     }
 
-    body.push(mapped_let(
-        "__sifr_python_result",
-        runtime_call(
-            "call_object_owned",
-            vec![
-                reference("__sifr_python_target"),
-                reference("__sifr_python_args"),
-                reference("__sifr_python_kwargs"),
-            ],
-        ),
-        error_type,
-    ));
+    let call = runtime_call(
+        "call_object_owned",
+        vec![
+            reference("__sifr_python_target"),
+            reference("__sifr_python_args"),
+            reference("__sifr_python_kwargs"),
+        ],
+    );
+    if callback_setups.is_empty() {
+        body.push(mapped_let("__sifr_python_result", call, error_type));
+    } else {
+        body.push(RustStmt::Let {
+            mutable: false,
+            name: "__sifr_python_outcome".to_string(),
+            ty: None,
+            value: callback_outcome_with_evidence(call, &callback_setups),
+        });
+        let mut cleanup_names = Vec::new();
+        for (index, setup) in callback_setups.iter().enumerate() {
+            if setup.lifetime == PythonCallbackLifetime::Call {
+                let name = format!("__sifr_callback_cleanup_{index}");
+                body.push(RustStmt::Let {
+                    mutable: false,
+                    name: name.clone(),
+                    ty: None,
+                    value: callback_cleanup_expr(setup),
+                });
+                cleanup_names.push(name);
+            }
+        }
+        body.push(mapped_let(
+            "__sifr_python_result",
+            RustExpr::Ident("__sifr_python_outcome".to_string()),
+            error_type,
+        ));
+        for setup in &callback_setups {
+            if let Some((slot, handler_error_type)) = &setup.failure_slot {
+                body.push(failure_reconciliation_stmt(
+                    slot,
+                    handler_error_type,
+                    error_type,
+                    callback_owner_expr(setup),
+                ));
+            }
+        }
+        append_retained_callback_retention(&mut body, &callback_setups, error_type);
+        for cleanup in cleanup_names {
+            body.push(RustStmt::Expr(mapped_try(
+                RustExpr::Ident(cleanup),
+                error_type,
+            )));
+        }
+    }
 
     let converted = output_value_expr("__sifr_python_result", ok_type, error_type, opaque_classes)?;
+    if let Some(callback) = retained_result {
+        let cleanup = retained_cleanup_expr(callback.owner_cleanup?)?;
+        body.push(RustStmt::Let {
+            mutable: true,
+            name: "__sifr_python_converted".to_string(),
+            ty: None,
+            value: converted,
+        });
+        append_retained_failure_transfers(
+            &mut body,
+            declaration,
+            retained_callback_errors,
+            "__sifr_python_converted",
+        );
+        body.push(mapped_let(
+            "__sifr_callback_owner",
+            RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("__sifr_callback_group".to_string())),
+                method: "commit_for_object".to_string(),
+                args: vec![
+                    RustExpr::Ref {
+                        mutable: false,
+                        expr: Box::new(RustExpr::Field {
+                            expr: Box::new(RustExpr::Ident("__sifr_python_converted".to_string())),
+                            field: "__sifr_python_object".to_string(),
+                        }),
+                    },
+                    cleanup,
+                ],
+            },
+            error_type,
+        ));
+        body.push(RustStmt::Assign {
+            target: RustExpr::Field {
+                expr: Box::new(RustExpr::Ident("__sifr_python_converted".to_string())),
+                field: "__sifr_python_callbacks".to_string(),
+            },
+            value: runtime_call(
+                "CallbackOwnerSlot::from_owner",
+                vec![RustExpr::Ident("__sifr_callback_owner".to_string())],
+            ),
+        });
+        body.push(RustStmt::Return(Some(RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
+            args: vec![RustExpr::Ident("__sifr_python_converted".to_string())],
+        })));
+        return Some(body);
+    }
     body.push(RustStmt::Return(Some(RustExpr::FnCall {
         func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
         args: vec![converted],
@@ -173,10 +360,50 @@ pub(crate) fn python_interop_function_body(
     Some(body)
 }
 
+fn callback_outcome_with_evidence(
+    outcome: RustExpr,
+    callbacks: &[crate::python_interop_callbacks::CallbackSetup],
+) -> RustExpr {
+    runtime_call(
+        "attach_callback_failure_evidence",
+        vec![
+            outcome,
+            RustExpr::Ref {
+                mutable: false,
+                expr: Box::new(RustExpr::Array(
+                    callbacks
+                        .iter()
+                        .map(|callback| RustExpr::Ref {
+                            mutable: false,
+                            expr: Box::new(callback_owner_expr(callback)),
+                        })
+                        .collect(),
+                )),
+            },
+        ],
+    )
+}
+
 pub(crate) fn python_interop_method_body(
     func: &HirFunction,
     opaque_classes: &HashMap<String, PythonInteropDeclaration>,
     owner_declaration: Option<&PythonInteropDeclaration>,
+) -> Option<Vec<RustStmt>> {
+    python_interop_method_body_with_retained_errors(
+        func,
+        opaque_classes,
+        owner_declaration,
+        &HashMap::new(),
+        &[],
+    )
+}
+
+pub(crate) fn python_interop_method_body_with_retained_errors(
+    func: &HirFunction,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+    owner_declaration: Option<&PythonInteropDeclaration>,
+    retained_callback_errors: &HashMap<String, Vec<Type>>,
+    owner_retained_errors: &[Type],
 ) -> Option<Vec<RustStmt>> {
     let declaration = func.python_interop.first()?;
     if declaration.kind == PythonInteropDecoratorKind::Coroutine {
@@ -194,8 +421,126 @@ pub(crate) fn python_interop_method_body(
         body.push(vector_let("__sifr_python_args"));
         body.push(vector_let("__sifr_python_kwargs"));
     }
+    if declaration
+        .callbacks
+        .iter()
+        .any(|callback| callback.lifetime == PythonCallbackLifetime::Call)
+    {
+        body.push(mapped_let(
+            "__sifr_callback_call_owner",
+            runtime_call("CallbackOwnerState::new_call_scoped", Vec::new()),
+            error_type,
+        ));
+    }
+    let retained_receiver = declaration
+        .callbacks
+        .iter()
+        .find(|callback| callback.lifetime == PythonCallbackLifetime::Receiver);
+    if let Some(callback) = retained_receiver {
+        body.push(mapped_let(
+            "__sifr_callback_owner",
+            RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Field {
+                    expr: Box::new(RustExpr::Ident("self".to_string())),
+                    field: "__sifr_python_callbacks".to_string(),
+                }),
+                method: "owner_or_insert".to_string(),
+                args: vec![
+                    RustExpr::Ref {
+                        mutable: false,
+                        expr: Box::new(RustExpr::Field {
+                            expr: Box::new(RustExpr::Ident("self".to_string())),
+                            field: "__sifr_python_object".to_string(),
+                        }),
+                    },
+                    retained_cleanup_expr(callback.owner_cleanup?)?,
+                ],
+            },
+            error_type,
+        ));
+    }
+    let retained_result = declaration
+        .callbacks
+        .iter()
+        .find(|callback| callback.lifetime == PythonCallbackLifetime::Result);
+    if retained_result.is_some() {
+        body.push(RustStmt::Let {
+            mutable: true,
+            name: "__sifr_callback_group".to_string(),
+            ty: None,
+            value: mapped_try(
+                runtime_call("RetainedCallbackGroup::new", Vec::new()),
+                error_type,
+            ),
+        });
+        append_retained_failure_slots(
+            &mut body,
+            declaration,
+            retained_callback_errors,
+            PythonCallbackLifetime::Result,
+        );
+    }
+    let mut callback_setups = Vec::new();
     for (index, (param, shape)) in func.params.iter().zip(&declaration.parameters).enumerate() {
         let handle = format!("__sifr_python_arg_{index}");
+        if let Some(callback) = declaration
+            .callbacks
+            .iter()
+            .find(|callback| callback.parameter_name == param.name)
+        {
+            let retained_owner = match callback.lifetime {
+                PythonCallbackLifetime::Call => Some(RustExpr::Clone(Box::new(RustExpr::Ident(
+                    "__sifr_callback_call_owner".to_string(),
+                )))),
+                PythonCallbackLifetime::Result => {
+                    Some(RustExpr::Clone(Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident("__sifr_callback_group".to_string())),
+                        method: "owner".to_string(),
+                        args: Vec::new(),
+                    })))
+                }
+                PythonCallbackLifetime::Receiver => Some(RustExpr::Clone(Box::new(
+                    RustExpr::Ident("__sifr_callback_owner".to_string()),
+                ))),
+            };
+            let failure_slot_source = match callback.lifetime {
+                PythonCallbackLifetime::Call => None,
+                PythonCallbackLifetime::Result => retained_slot_source(
+                    callback,
+                    retained_callback_errors,
+                    PythonCallbackLifetime::Result,
+                ),
+                PythonCallbackLifetime::Receiver => {
+                    retained_failure_field(callback, retained_callback_errors).map(|field| {
+                        RustExpr::Clone(Box::new(RustExpr::Field {
+                            expr: Box::new(RustExpr::Ident("self".to_string())),
+                            field,
+                        }))
+                    })
+                }
+            };
+            let setup = callback_setup(
+                callback,
+                &param.name,
+                index,
+                error_type,
+                opaque_classes,
+                retained_owner?,
+                failure_slot_source,
+            )?;
+            body.extend(setup.statements.clone());
+            body.push(mapped_let(
+                &handle,
+                runtime_call(
+                    "temporary_argument_handle",
+                    vec![callback_object_expr(&setup)],
+                ),
+                error_type,
+            ));
+            body.push(push_for_shape(shape.kind, &shape.name, &handle)?);
+            callback_setups.push(setup);
+            continue;
+        }
         body.push(mapped_let(
             &handle,
             input_conversion(&param.name, &param.ty, opaque_classes)?,
@@ -215,22 +560,77 @@ pub(crate) fn python_interop_method_body(
         {
             return None;
         }
+        if !owner_retained_errors.is_empty() {
+            body.push(RustStmt::Let {
+                mutable: false,
+                name: "__sifr_callback_owner_for_failure".to_string(),
+                ty: None,
+                value: RustExpr::MethodCall {
+                    receiver: Box::new(RustExpr::Field {
+                        expr: Box::new(RustExpr::Ident("self".to_string())),
+                        field: "__sifr_python_callbacks".to_string(),
+                    }),
+                    method: "owner".to_string(),
+                    args: Vec::new(),
+                },
+            });
+            for index in 0..owner_retained_errors.len() {
+                body.push(RustStmt::Let {
+                    mutable: false,
+                    name: format!("__sifr_callback_owner_failure_{index}"),
+                    ty: None,
+                    value: RustExpr::Field {
+                        expr: Box::new(RustExpr::Ident("self".to_string())),
+                        field: format!("__sifr_python_callback_failure_{index}"),
+                    },
+                });
+            }
+        }
         let closed = mapped_try(
             runtime_call(
-                "semantic_close",
+                "semantic_close_with_callbacks",
                 vec![
                     RustExpr::Field {
                         expr: Box::new(RustExpr::Ident("self".to_string())),
                         field: "__sifr_python_object".to_string(),
                     },
                     RustExpr::Literal(RustLiteral::Str(member?.to_string())),
+                    RustExpr::Field {
+                        expr: Box::new(RustExpr::Ident("self".to_string())),
+                        field: "__sifr_python_callbacks".to_string(),
+                    },
                 ],
             ),
             error_type,
         );
+        body.push(RustStmt::Let {
+            mutable: false,
+            name: "__sifr_python_closed".to_string(),
+            ty: None,
+            value: closed,
+        });
+        if !owner_retained_errors.is_empty() {
+            body.push(RustStmt::IfLet {
+                pattern: "Some(__sifr_callback_owner_for_failure_value)".to_string(),
+                expr: RustExpr::Ident("__sifr_callback_owner_for_failure".to_string()),
+                then_body: owner_retained_errors
+                    .iter()
+                    .enumerate()
+                    .map(|(index, handler_error_type)| {
+                        failure_reconciliation_stmt(
+                            &format!("__sifr_callback_owner_failure_{index}"),
+                            handler_error_type,
+                            error_type,
+                            RustExpr::Ident("__sifr_callback_owner_for_failure_value".to_string()),
+                        )
+                    })
+                    .collect(),
+                else_body: None,
+            });
+        }
         body.push(RustStmt::Return(Some(RustExpr::FnCall {
             func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
-            args: vec![closed],
+            args: vec![RustExpr::Ident("__sifr_python_closed".to_string())],
         })));
         return Some(body);
     }
@@ -295,508 +695,104 @@ pub(crate) fn python_interop_method_body(
         }
         _ => return None,
     };
-    body.push(mapped_let("__sifr_python_result", operation, error_type));
+    if callback_setups.is_empty() {
+        body.push(mapped_let("__sifr_python_result", operation, error_type));
+    } else {
+        body.push(RustStmt::Let {
+            mutable: false,
+            name: "__sifr_python_outcome".to_string(),
+            ty: None,
+            value: callback_outcome_with_evidence(operation, &callback_setups),
+        });
+        let mut cleanup_names = Vec::new();
+        for (index, setup) in callback_setups.iter().enumerate() {
+            if setup.lifetime == PythonCallbackLifetime::Call {
+                let name = format!("__sifr_callback_cleanup_{index}");
+                body.push(RustStmt::Let {
+                    mutable: false,
+                    name: name.clone(),
+                    ty: None,
+                    value: callback_cleanup_expr(setup),
+                });
+                cleanup_names.push(name);
+            }
+        }
+        body.push(mapped_let(
+            "__sifr_python_result",
+            RustExpr::Ident("__sifr_python_outcome".to_string()),
+            error_type,
+        ));
+        for setup in &callback_setups {
+            if let Some((slot, handler_error_type)) = &setup.failure_slot {
+                body.push(failure_reconciliation_stmt(
+                    slot,
+                    handler_error_type,
+                    error_type,
+                    callback_owner_expr(setup),
+                ));
+            }
+        }
+        append_retained_callback_retention(&mut body, &callback_setups, error_type);
+        for cleanup in cleanup_names {
+            body.push(RustStmt::Expr(mapped_try(
+                RustExpr::Ident(cleanup),
+                error_type,
+            )));
+        }
+    }
     let converted = output_value_expr("__sifr_python_result", ok_type, error_type, opaque_classes)?;
+    if let Some(callback) = retained_result {
+        body.push(RustStmt::Let {
+            mutable: true,
+            name: "__sifr_python_converted".to_string(),
+            ty: None,
+            value: converted,
+        });
+        append_retained_failure_transfers(
+            &mut body,
+            declaration,
+            retained_callback_errors,
+            "__sifr_python_converted",
+        );
+        body.push(mapped_let(
+            "__sifr_result_callback_owner",
+            RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("__sifr_callback_group".to_string())),
+                method: "commit_for_object".to_string(),
+                args: vec![
+                    RustExpr::Ref {
+                        mutable: false,
+                        expr: Box::new(RustExpr::Field {
+                            expr: Box::new(RustExpr::Ident("__sifr_python_converted".to_string())),
+                            field: "__sifr_python_object".to_string(),
+                        }),
+                    },
+                    retained_cleanup_expr(callback.owner_cleanup?)?,
+                ],
+            },
+            error_type,
+        ));
+        body.push(RustStmt::Assign {
+            target: RustExpr::Field {
+                expr: Box::new(RustExpr::Ident("__sifr_python_converted".to_string())),
+                field: "__sifr_python_callbacks".to_string(),
+            },
+            value: runtime_call(
+                "CallbackOwnerSlot::from_owner",
+                vec![RustExpr::Ident("__sifr_result_callback_owner".to_string())],
+            ),
+        });
+        body.push(RustStmt::Return(Some(RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
+            args: vec![RustExpr::Ident("__sifr_python_converted".to_string())],
+        })));
+        return Some(body);
+    }
     body.push(RustStmt::Return(Some(RustExpr::FnCall {
         func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
         args: vec![converted],
     })));
     Some(body)
-}
-
-pub(crate) fn input_conversion(
-    name: &str,
-    ty: &Type,
-    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
-) -> Option<RustExpr> {
-    if let Some(inner) = option_inner(ty) {
-        let receiver = RustExpr::Ident(name.to_string());
-        let borrowed_inner = !matches!(
-            inner.resolve_alias(),
-            Type::None | Type::Bool | Type::Int | Type::Float
-        );
-        let inner_value = RustExpr::MethodCall {
-            receiver: Box::new(if borrowed_inner {
-                RustExpr::MethodCall {
-                    receiver: Box::new(receiver.clone()),
-                    method: "as_ref".to_string(),
-                    args: Vec::new(),
-                }
-            } else {
-                receiver.clone()
-            }),
-            method: "unwrap".to_string(),
-            args: Vec::new(),
-        };
-        return Some(RustExpr::If {
-            cond: Box::new(RustExpr::MethodCall {
-                receiver: Box::new(receiver),
-                method: "is_some".to_string(),
-                args: Vec::new(),
-            }),
-            then_expr: Box::new(input_conversion_value(inner_value, inner, opaque_classes)?),
-            else_expr: Some(Box::new(runtime_call("from_none", Vec::new()))),
-        });
-    }
-    if matches!(ty.resolve_alias(), Type::Class { name: class_name, .. } if opaque_classes.contains_key(class_name))
-    {
-        return Some(runtime_call(
-            "temporary_argument_handle",
-            vec![RustExpr::Ref {
-                mutable: false,
-                expr: Box::new(RustExpr::Field {
-                    expr: Box::new(RustExpr::Ident(name.to_string())),
-                    field: "__sifr_python_object".to_string(),
-                }),
-            }],
-        ));
-    }
-    match ty.resolve_alias() {
-        Type::List(item) => {
-            let iter = RustExpr::MethodCall {
-                receiver: Box::new(RustExpr::Ident(name.to_string())),
-                method: "iter".to_string(),
-                args: Vec::new(),
-            };
-            let converted = mapped_collection_results(
-                iter,
-                "__sifr_python_item",
-                input_conversion_borrowed("__sifr_python_item", item, opaque_classes)?,
-            );
-            return Some(runtime_call("from_list_results", vec![converted]));
-        }
-        Type::Tuple(items) => {
-            let values = items
-                .iter()
-                .enumerate()
-                .map(|(index, item)| {
-                    input_conversion(&format!("{name}.{index}"), item, opaque_classes)
-                })
-                .collect::<Option<Vec<_>>>()?;
-            return Some(runtime_call(
-                "from_tuple_results",
-                vec![RustExpr::Vec(values)],
-            ));
-        }
-        Type::Dict(key, value) if key.resolve_alias() == &Type::Str => {
-            let iter = RustExpr::MethodCall {
-                receiver: Box::new(RustExpr::Ident(name.to_string())),
-                method: "iter".to_string(),
-                args: Vec::new(),
-            };
-            let pair = RustExpr::Tuple(vec![
-                RustExpr::Clone(Box::new(RustExpr::Ident("__sifr_python_key".to_string()))),
-                input_conversion_borrowed("__sifr_python_value", value, opaque_classes)?,
-            ]);
-            let converted =
-                mapped_collection_results(iter, "(__sifr_python_key, __sifr_python_value)", pair);
-            return Some(runtime_call("from_dict_results", vec![converted]));
-        }
-        Type::Class {
-            name: class_name,
-            fields,
-            ..
-        } if !fields.is_empty() && !opaque_classes.contains_key(class_name) => {
-            let values = fields
-                .iter()
-                .map(|(field, field_type)| {
-                    Some(RustExpr::Tuple(vec![
-                        RustExpr::Literal(RustLiteral::Str(field.clone())),
-                        input_conversion(&format!("{name}.{field}"), field_type, opaque_classes)?,
-                    ]))
-                })
-                .collect::<Option<Vec<_>>>()?;
-            return Some(runtime_call(
-                "from_record_results",
-                vec![RustExpr::Vec(values)],
-            ));
-        }
-        _ => {}
-    }
-    let ident = RustExpr::Ident(name.to_string());
-    let (function, value) = match ty.resolve_alias() {
-        Type::None => ("from_none", None),
-        Type::Bool => ("from_bool", Some(ident)),
-        Type::Int => ("from_int", Some(ident)),
-        Type::Float => ("from_float", Some(ident)),
-        Type::Str => ("from_str", Some(reference(name))),
-        Type::Bytes => ("from_bytes", Some(reference(name))),
-        _ => return None,
-    };
-    Some(runtime_call(function, value.into_iter().collect()))
-}
-
-pub(crate) fn output_value_expr(
-    value_name: &str,
-    ty: &Type,
-    error_type: &Type,
-    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
-) -> Option<RustExpr> {
-    if let Some(inner) = option_inner(ty) {
-        let is_none = mapped_try(
-            runtime_call("object_is_none", vec![reference(value_name)]),
-            error_type,
-        );
-        return Some(RustExpr::Block {
-            stmts: vec![RustStmt::Let {
-                mutable: false,
-                name: "__sifr_python_is_none".to_string(),
-                ty: None,
-                value: is_none,
-            }],
-            expr: Some(Box::new(RustExpr::If {
-                cond: Box::new(RustExpr::Ident("__sifr_python_is_none".to_string())),
-                then_expr: Box::new(RustExpr::Literal(RustLiteral::None)),
-                else_expr: Some(Box::new(RustExpr::FnCall {
-                    func: Box::new(RustExpr::Path(vec!["Some".to_string()])),
-                    args: vec![output_value_expr(
-                        value_name,
-                        inner,
-                        error_type,
-                        opaque_classes,
-                    )?],
-                })),
-            })),
-        });
-    }
-    if is_python_object(ty) {
-        return Some(RustExpr::Ident(value_name.to_string()));
-    }
-    if let Type::Class { name, .. } = ty.resolve_alias() {
-        if let Some(opaque) = opaque_classes.get(name) {
-            let target = opaque.target.as_ref()?;
-            let checked = mapped_try(
-                runtime_call(
-                    "expect_instance",
-                    vec![
-                        RustExpr::Ident(value_name.to_string()),
-                        RustExpr::Ref {
-                            mutable: false,
-                            expr: Box::new(RustExpr::Array(
-                                target
-                                    .segments
-                                    .iter()
-                                    .map(|segment| {
-                                        RustExpr::Literal(RustLiteral::Str(segment.clone()))
-                                    })
-                                    .collect(),
-                            )),
-                        },
-                    ],
-                ),
-                error_type,
-            );
-            return Some(RustExpr::StructInit {
-                name: name.clone(),
-                fields: vec![("__sifr_python_object".to_string(), checked)],
-            });
-        }
-    }
-    match ty.resolve_alias() {
-        Type::List(item) => {
-            let mut body = vec![RustStmt::Let {
-                mutable: false,
-                name: "__sifr_python_value".to_string(),
-                ty: None,
-                value: output_value_expr("__sifr_python_item", item, error_type, opaque_classes)?,
-            }];
-            body.push(push_to("__sifr_python_values", "__sifr_python_value"));
-            return Some(RustExpr::Block {
-                stmts: vec![
-                    mapped_let(
-                        "__sifr_python_items",
-                        runtime_call("list_items", vec![reference(value_name)]),
-                        error_type,
-                    ),
-                    vector_let("__sifr_python_values"),
-                    RustStmt::For {
-                        var: "__sifr_python_item".to_string(),
-                        iter: RustExpr::MethodCall {
-                            receiver: Box::new(RustExpr::Ident("__sifr_python_items".to_string())),
-                            method: "into_iter".to_string(),
-                            args: Vec::new(),
-                        },
-                        body,
-                    },
-                ],
-                expr: Some(Box::new(RustExpr::Ident(
-                    "__sifr_python_values".to_string(),
-                ))),
-            });
-        }
-        Type::Tuple(items) => {
-            let mut statements = vec![mapped_let(
-                "__sifr_python_items",
-                runtime_call("tuple_items", vec![reference(value_name)]),
-                error_type,
-            )];
-            let mut values = Vec::with_capacity(items.len());
-            for (index, item) in items.iter().enumerate() {
-                let binding = format!("__sifr_python_tuple_{index}");
-                statements.push(RustStmt::Let {
-                    mutable: false,
-                    name: binding.clone(),
-                    ty: None,
-                    value: RustExpr::MethodCall {
-                        receiver: Box::new(RustExpr::Ident("__sifr_python_items".to_string())),
-                        method: "remove".to_string(),
-                        args: vec![RustExpr::Literal(RustLiteral::Int(0))],
-                    },
-                });
-                values.push(output_value_expr(
-                    &binding,
-                    item,
-                    error_type,
-                    opaque_classes,
-                )?);
-            }
-            statements.insert(
-                0,
-                RustStmt::Let {
-                    mutable: true,
-                    name: "__sifr_python_items".to_string(),
-                    ty: None,
-                    value: mapped_try(
-                        runtime_call("tuple_items", vec![reference(value_name)]),
-                        error_type,
-                    ),
-                },
-            );
-            statements.remove(1);
-            return Some(RustExpr::Block {
-                stmts: statements,
-                expr: Some(Box::new(RustExpr::Tuple(values))),
-            });
-        }
-        Type::Dict(key, value) if key.resolve_alias() == &Type::Str => {
-            let converted =
-                output_value_expr("__sifr_python_item", value, error_type, opaque_classes)?;
-            return Some(RustExpr::Block {
-                stmts: vec![
-                    mapped_let(
-                        "__sifr_python_items",
-                        runtime_call("dict_str_items", vec![reference(value_name)]),
-                        error_type,
-                    ),
-                    RustStmt::Let {
-                        mutable: true,
-                        name: "__sifr_python_values".to_string(),
-                        ty: None,
-                        value: RustExpr::FnCall {
-                            func: Box::new(RustExpr::Path(vec![
-                                "Default".to_string(),
-                                "default".to_string(),
-                            ])),
-                            args: Vec::new(),
-                        },
-                    },
-                    RustStmt::For {
-                        var: "(__sifr_python_key, __sifr_python_item)".to_string(),
-                        iter: RustExpr::MethodCall {
-                            receiver: Box::new(RustExpr::Ident("__sifr_python_items".to_string())),
-                            method: "into_iter".to_string(),
-                            args: Vec::new(),
-                        },
-                        body: vec![RustStmt::Expr(RustExpr::MethodCall {
-                            receiver: Box::new(RustExpr::Ident("__sifr_python_values".to_string())),
-                            method: "insert".to_string(),
-                            args: vec![RustExpr::Ident("__sifr_python_key".to_string()), converted],
-                        })],
-                    },
-                ],
-                expr: Some(Box::new(RustExpr::Ident(
-                    "__sifr_python_values".to_string(),
-                ))),
-            });
-        }
-        Type::Class { name, fields, .. } if !fields.is_empty() => {
-            let mut statements = Vec::new();
-            let mut converted_fields = Vec::new();
-            for (field, field_type) in fields {
-                let handle = format!("__sifr_python_field_{field}");
-                statements.push(mapped_let(
-                    &handle,
-                    runtime_call(
-                        "record_field",
-                        vec![
-                            reference(value_name),
-                            RustExpr::Literal(RustLiteral::Str(field.clone())),
-                        ],
-                    ),
-                    error_type,
-                ));
-                converted_fields.push((
-                    field.clone(),
-                    output_value_expr(&handle, field_type, error_type, opaque_classes)?,
-                ));
-            }
-            return Some(RustExpr::Block {
-                stmts: statements,
-                expr: Some(Box::new(RustExpr::StructInit {
-                    name: name.clone(),
-                    fields: converted_fields,
-                })),
-            });
-        }
-        _ => {}
-    }
-    Some(mapped_try(output_conversion(value_name, ty)?, error_type))
-}
-
-fn input_conversion_value(
-    value: RustExpr,
-    ty: &Type,
-    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
-) -> Option<RustExpr> {
-    if is_python_object(ty) {
-        return Some(runtime_call("temporary_argument_handle", vec![value]));
-    }
-    if matches!(ty.resolve_alias(), Type::Class { name, .. } if opaque_classes.contains_key(name)) {
-        return Some(runtime_call(
-            "temporary_argument_handle",
-            vec![RustExpr::Ref {
-                mutable: false,
-                expr: Box::new(RustExpr::Field {
-                    expr: Box::new(value),
-                    field: "__sifr_python_object".to_string(),
-                }),
-            }],
-        ));
-    }
-    if matches!(
-        ty.resolve_alias(),
-        Type::List(_) | Type::Tuple(_) | Type::Dict(_, _) | Type::Class { .. }
-    ) {
-        return Some(RustExpr::Block {
-            stmts: vec![RustStmt::Let {
-                mutable: false,
-                name: "__sifr_python_nested".to_string(),
-                ty: None,
-                value,
-            }],
-            expr: Some(Box::new(input_conversion(
-                "__sifr_python_nested",
-                ty,
-                opaque_classes,
-            )?)),
-        });
-    }
-    let function = match ty.resolve_alias() {
-        Type::Bool => "from_bool",
-        Type::Int => "from_int",
-        Type::Float => "from_float",
-        Type::Str => "from_str",
-        Type::Bytes => "from_bytes",
-        _ => return None,
-    };
-    Some(runtime_call(function, vec![value]))
-}
-
-fn option_inner(ty: &Type) -> Option<&Type> {
-    let Type::Union(variants) = ty.resolve_alias() else {
-        return None;
-    };
-    if variants.len() != 2
-        || !variants
-            .iter()
-            .any(|variant| variant.resolve_alias() == &Type::None)
-    {
-        return None;
-    }
-    variants
-        .iter()
-        .find(|variant| variant.resolve_alias() != &Type::None)
-}
-
-fn input_conversion_borrowed(
-    name: &str,
-    ty: &Type,
-    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
-) -> Option<RustExpr> {
-    if option_inner(ty).is_some() {
-        return input_conversion(name, ty, opaque_classes);
-    }
-    if matches!(
-        ty.resolve_alias(),
-        Type::List(_) | Type::Tuple(_) | Type::Dict(_, _) | Type::Class { .. }
-    ) && !is_python_object(ty)
-        && !matches!(ty.resolve_alias(), Type::Class { name, .. } if opaque_classes.contains_key(name))
-    {
-        return input_conversion(name, ty, opaque_classes);
-    }
-    let value = match ty.resolve_alias() {
-        Type::Bool | Type::Int | Type::Float => {
-            RustExpr::Deref(Box::new(RustExpr::Ident(name.to_string())))
-        }
-        Type::Str | Type::Bytes => RustExpr::Ident(name.to_string()),
-        _ if is_python_object(ty) => {
-            return Some(runtime_call(
-                "temporary_argument_handle",
-                vec![RustExpr::Ident(name.to_string())],
-            ));
-        }
-        Type::Class {
-            name: class_name, ..
-        } if opaque_classes.contains_key(class_name) => {
-            return Some(runtime_call(
-                "temporary_argument_handle",
-                vec![RustExpr::Ref {
-                    mutable: false,
-                    expr: Box::new(RustExpr::Field {
-                        expr: Box::new(RustExpr::Ident(name.to_string())),
-                        field: "__sifr_python_object".to_string(),
-                    }),
-                }],
-            ));
-        }
-        _ => return None,
-    };
-    let function = match ty.resolve_alias() {
-        Type::Bool => "from_bool",
-        Type::Int => "from_int",
-        Type::Float => "from_float",
-        Type::Str => "from_str",
-        Type::Bytes => "from_bytes",
-        _ => return None,
-    };
-    Some(runtime_call(function, vec![value]))
-}
-
-fn mapped_collection_results(iter: RustExpr, parameter: &str, body: RustExpr) -> RustExpr {
-    let mapped = RustExpr::MethodCall {
-        receiver: Box::new(iter),
-        method: "map".to_string(),
-        args: vec![RustExpr::Closure {
-            params: vec![RustParam::Named {
-                name: parameter.to_string(),
-                ty: RustType::Named("_".to_string()),
-            }],
-            body: Box::new(body),
-            is_move: false,
-        }],
-    };
-    RustExpr::MethodCall {
-        receiver: Box::new(mapped),
-        method: "collect".to_string(),
-        args: Vec::new(),
-    }
-}
-
-fn output_conversion(name: &str, ty: &Type) -> Option<RustExpr> {
-    let function = match ty.resolve_alias() {
-        Type::None => "to_none",
-        Type::Bool => "to_bool",
-        Type::Int => "to_int",
-        Type::Float => "to_float",
-        Type::Str => "to_str",
-        Type::Bytes => "to_bytes",
-        _ => return None,
-    };
-    Some(runtime_call(function, vec![reference(name)]))
-}
-
-fn is_python_object(ty: &Type) -> bool {
-    matches!(ty.resolve_alias(), Type::Class { name, .. } if name == "Object")
 }
 
 pub(crate) fn runtime_call(function: &str, args: Vec<RustExpr>) -> RustExpr {
@@ -810,7 +806,7 @@ pub(crate) fn runtime_call(function: &str, args: Vec<RustExpr>) -> RustExpr {
     }
 }
 
-fn mapped_let(name: &str, value: RustExpr, error_type: &Type) -> RustStmt {
+pub(crate) fn mapped_let(name: &str, value: RustExpr, error_type: &Type) -> RustStmt {
     RustStmt::Let {
         mutable: false,
         name: name.to_string(),
@@ -838,14 +834,14 @@ pub(crate) fn mapped_try(value: RustExpr, error_type: &Type) -> RustExpr {
     }))
 }
 
-fn reference(name: &str) -> RustExpr {
+pub(crate) fn reference(name: &str) -> RustExpr {
     RustExpr::Ref {
         mutable: false,
         expr: Box::new(RustExpr::Ident(name.to_string())),
     }
 }
 
-fn vector_let(name: &str) -> RustStmt {
+pub(crate) fn vector_let(name: &str) -> RustStmt {
     RustStmt::Let {
         mutable: true,
         name: name.to_string(),
@@ -880,7 +876,7 @@ fn push_positional(handle: &str) -> RustStmt {
     })
 }
 
-fn push_to(vector: &str, value: &str) -> RustStmt {
+pub(crate) fn push_to(vector: &str, value: &str) -> RustStmt {
     RustStmt::Expr(RustExpr::MethodCall {
         receiver: Box::new(RustExpr::Ident(vector.to_string())),
         method: "push".to_string(),
@@ -888,7 +884,7 @@ fn push_to(vector: &str, value: &str) -> RustStmt {
     })
 }
 
-fn push_keyword_expr(key: RustExpr, handle: &str) -> RustStmt {
+pub(crate) fn push_keyword_expr(key: RustExpr, handle: &str) -> RustStmt {
     RustStmt::Expr(RustExpr::MethodCall {
         receiver: Box::new(RustExpr::Ident("__sifr_python_kwargs".to_string())),
         method: "push".to_string(),

--- a/crates/sifr_codegen/src/python_interop_direct_conversions.rs
+++ b/crates/sifr_codegen/src/python_interop_direct_conversions.rs
@@ -1,0 +1,558 @@
+use crate::python_interop_direct::{mapped_try, push_to, reference, runtime_call, vector_let};
+use crate::{RustExpr, RustLiteral, RustParam, RustStmt, RustType};
+use sifr_ir::PythonInteropDeclaration;
+use sifr_type_system::Type;
+use std::collections::HashMap;
+
+pub(crate) fn input_conversion(
+    name: &str,
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if let Some(inner) = option_inner(ty) {
+        let receiver = RustExpr::Ident(name.to_string());
+        let borrowed_inner = !matches!(
+            inner.resolve_alias(),
+            Type::None | Type::Bool | Type::Int | Type::Float
+        );
+        let inner_value = RustExpr::MethodCall {
+            receiver: Box::new(if borrowed_inner {
+                RustExpr::MethodCall {
+                    receiver: Box::new(receiver.clone()),
+                    method: "as_ref".to_string(),
+                    args: Vec::new(),
+                }
+            } else {
+                receiver.clone()
+            }),
+            method: "unwrap".to_string(),
+            args: Vec::new(),
+        };
+        return Some(RustExpr::If {
+            cond: Box::new(RustExpr::MethodCall {
+                receiver: Box::new(receiver),
+                method: "is_some".to_string(),
+                args: Vec::new(),
+            }),
+            then_expr: Box::new(input_conversion_value(inner_value, inner, opaque_classes)?),
+            else_expr: Some(Box::new(runtime_call("from_none", Vec::new()))),
+        });
+    }
+    if matches!(ty.resolve_alias(), Type::Class { name: class_name, .. } if opaque_classes.contains_key(class_name))
+    {
+        return Some(runtime_call(
+            "temporary_argument_handle",
+            vec![RustExpr::Ref {
+                mutable: false,
+                expr: Box::new(RustExpr::Field {
+                    expr: Box::new(RustExpr::Ident(name.to_string())),
+                    field: "__sifr_python_object".to_string(),
+                }),
+            }],
+        ));
+    }
+    match ty.resolve_alias() {
+        Type::List(item) => {
+            let iter = RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident(name.to_string())),
+                method: "iter".to_string(),
+                args: Vec::new(),
+            };
+            let converted = mapped_collection_results(
+                iter,
+                "__sifr_python_item",
+                input_conversion_borrowed("__sifr_python_item", item, opaque_classes)?,
+            );
+            return Some(runtime_call("from_list_results", vec![converted]));
+        }
+        Type::Tuple(items) => {
+            let values = items
+                .iter()
+                .enumerate()
+                .map(|(index, item)| {
+                    input_conversion(&format!("{name}.{index}"), item, opaque_classes)
+                })
+                .collect::<Option<Vec<_>>>()?;
+            return Some(runtime_call(
+                "from_tuple_results",
+                vec![RustExpr::Vec(values)],
+            ));
+        }
+        Type::Dict(key, value) if key.resolve_alias() == &Type::Str => {
+            let iter = RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident(name.to_string())),
+                method: "iter".to_string(),
+                args: Vec::new(),
+            };
+            let pair = RustExpr::Tuple(vec![
+                RustExpr::Clone(Box::new(RustExpr::Ident("__sifr_python_key".to_string()))),
+                input_conversion_borrowed("__sifr_python_value", value, opaque_classes)?,
+            ]);
+            let converted =
+                mapped_collection_results(iter, "(__sifr_python_key, __sifr_python_value)", pair);
+            return Some(runtime_call("from_dict_results", vec![converted]));
+        }
+        Type::Class {
+            name: class_name,
+            fields,
+            ..
+        } if !fields.is_empty() && !opaque_classes.contains_key(class_name) => {
+            let values = fields
+                .iter()
+                .map(|(field, field_type)| {
+                    Some(RustExpr::Tuple(vec![
+                        RustExpr::Literal(RustLiteral::Str(field.clone())),
+                        input_conversion(&format!("{name}.{field}"), field_type, opaque_classes)?,
+                    ]))
+                })
+                .collect::<Option<Vec<_>>>()?;
+            return Some(runtime_call(
+                "from_record_results",
+                vec![RustExpr::Vec(values)],
+            ));
+        }
+        _ => {}
+    }
+    let ident = RustExpr::Ident(name.to_string());
+    let (function, value) = match ty.resolve_alias() {
+        Type::None => ("from_none", None),
+        Type::Bool => ("from_bool", Some(ident)),
+        Type::Int => ("from_int", Some(ident)),
+        Type::Float => ("from_float", Some(ident)),
+        Type::Str => ("from_str", Some(reference(name))),
+        Type::Bytes => ("from_bytes", Some(reference(name))),
+        _ => return None,
+    };
+    Some(runtime_call(function, value.into_iter().collect()))
+}
+
+pub(crate) fn output_value_expr(
+    value_name: &str,
+    ty: &Type,
+    error_type: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    output_value_expr_with(value_name, ty, Some(error_type), opaque_classes)
+}
+
+pub(crate) fn callback_output_value_expr(
+    value_name: &str,
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    output_value_expr_with(value_name, ty, None, opaque_classes)
+}
+
+fn output_value_expr_with(
+    value_name: &str,
+    ty: &Type,
+    error_type: Option<&Type>,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if let Some(inner) = option_inner(ty) {
+        let is_none = conversion_try(
+            runtime_call("object_is_none", vec![reference(value_name)]),
+            error_type,
+        );
+        return Some(RustExpr::Block {
+            stmts: vec![RustStmt::Let {
+                mutable: false,
+                name: "__sifr_python_is_none".to_string(),
+                ty: None,
+                value: is_none,
+            }],
+            expr: Some(Box::new(RustExpr::If {
+                cond: Box::new(RustExpr::Ident("__sifr_python_is_none".to_string())),
+                then_expr: Box::new(RustExpr::Literal(RustLiteral::None)),
+                else_expr: Some(Box::new(RustExpr::FnCall {
+                    func: Box::new(RustExpr::Path(vec!["Some".to_string()])),
+                    args: vec![output_value_expr_with(
+                        value_name,
+                        inner,
+                        error_type,
+                        opaque_classes,
+                    )?],
+                })),
+            })),
+        });
+    }
+    if is_python_object(ty) {
+        return Some(RustExpr::Ident(value_name.to_string()));
+    }
+    if let Type::Class { name, .. } = ty.resolve_alias() {
+        if let Some(opaque) = opaque_classes.get(name) {
+            let target = opaque.target.as_ref()?;
+            let checked = conversion_try(
+                runtime_call(
+                    "expect_instance",
+                    vec![
+                        RustExpr::Ident(value_name.to_string()),
+                        RustExpr::Ref {
+                            mutable: false,
+                            expr: Box::new(RustExpr::Array(
+                                target
+                                    .segments
+                                    .iter()
+                                    .map(|segment| {
+                                        RustExpr::Literal(RustLiteral::Str(segment.clone()))
+                                    })
+                                    .collect(),
+                            )),
+                        },
+                    ],
+                ),
+                error_type,
+            );
+            return Some(RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec![
+                    name.clone(),
+                    "__sifr_from_python_object".to_string(),
+                ])),
+                args: vec![checked],
+            });
+        }
+    }
+    match ty.resolve_alias() {
+        Type::List(item) => {
+            let mut body = vec![RustStmt::Let {
+                mutable: false,
+                name: "__sifr_python_value".to_string(),
+                ty: None,
+                value: output_value_expr_with(
+                    "__sifr_python_item",
+                    item,
+                    error_type,
+                    opaque_classes,
+                )?,
+            }];
+            body.push(push_to("__sifr_python_values", "__sifr_python_value"));
+            return Some(RustExpr::Block {
+                stmts: vec![
+                    conversion_let(
+                        "__sifr_python_items",
+                        runtime_call("list_items", vec![reference(value_name)]),
+                        error_type,
+                    ),
+                    vector_let("__sifr_python_values"),
+                    RustStmt::For {
+                        var: "__sifr_python_item".to_string(),
+                        iter: RustExpr::MethodCall {
+                            receiver: Box::new(RustExpr::Ident("__sifr_python_items".to_string())),
+                            method: "into_iter".to_string(),
+                            args: Vec::new(),
+                        },
+                        body,
+                    },
+                ],
+                expr: Some(Box::new(RustExpr::Ident(
+                    "__sifr_python_values".to_string(),
+                ))),
+            });
+        }
+        Type::Tuple(items) => {
+            let mut statements = vec![conversion_let(
+                "__sifr_python_items",
+                runtime_call(
+                    "tuple_items_exact",
+                    vec![
+                        reference(value_name),
+                        RustExpr::Literal(RustLiteral::Int(i64::try_from(items.len()).ok()?)),
+                    ],
+                ),
+                error_type,
+            )];
+            let mut values = Vec::with_capacity(items.len());
+            for (index, item) in items.iter().enumerate() {
+                let binding = format!("__sifr_python_tuple_{index}");
+                statements.push(RustStmt::Let {
+                    mutable: false,
+                    name: binding.clone(),
+                    ty: None,
+                    value: RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident("__sifr_python_items".to_string())),
+                        method: "remove".to_string(),
+                        args: vec![RustExpr::Literal(RustLiteral::Int(0))],
+                    },
+                });
+                values.push(output_value_expr_with(
+                    &binding,
+                    item,
+                    error_type,
+                    opaque_classes,
+                )?);
+            }
+            statements.insert(
+                0,
+                RustStmt::Let {
+                    mutable: true,
+                    name: "__sifr_python_items".to_string(),
+                    ty: None,
+                    value: conversion_try(
+                        runtime_call(
+                            "tuple_items_exact",
+                            vec![
+                                reference(value_name),
+                                RustExpr::Literal(RustLiteral::Int(
+                                    i64::try_from(items.len()).ok()?,
+                                )),
+                            ],
+                        ),
+                        error_type,
+                    ),
+                },
+            );
+            statements.remove(1);
+            return Some(RustExpr::Block {
+                stmts: statements,
+                expr: Some(Box::new(RustExpr::Tuple(values))),
+            });
+        }
+        Type::Dict(key, value) if key.resolve_alias() == &Type::Str => {
+            let converted =
+                output_value_expr_with("__sifr_python_item", value, error_type, opaque_classes)?;
+            return Some(RustExpr::Block {
+                stmts: vec![
+                    conversion_let(
+                        "__sifr_python_items",
+                        runtime_call("dict_str_items", vec![reference(value_name)]),
+                        error_type,
+                    ),
+                    RustStmt::Let {
+                        mutable: true,
+                        name: "__sifr_python_values".to_string(),
+                        ty: None,
+                        value: RustExpr::FnCall {
+                            func: Box::new(RustExpr::Path(vec![
+                                "Default".to_string(),
+                                "default".to_string(),
+                            ])),
+                            args: Vec::new(),
+                        },
+                    },
+                    RustStmt::For {
+                        var: "(__sifr_python_key, __sifr_python_item)".to_string(),
+                        iter: RustExpr::MethodCall {
+                            receiver: Box::new(RustExpr::Ident("__sifr_python_items".to_string())),
+                            method: "into_iter".to_string(),
+                            args: Vec::new(),
+                        },
+                        body: vec![RustStmt::Expr(RustExpr::MethodCall {
+                            receiver: Box::new(RustExpr::Ident("__sifr_python_values".to_string())),
+                            method: "insert".to_string(),
+                            args: vec![RustExpr::Ident("__sifr_python_key".to_string()), converted],
+                        })],
+                    },
+                ],
+                expr: Some(Box::new(RustExpr::Ident(
+                    "__sifr_python_values".to_string(),
+                ))),
+            });
+        }
+        Type::Class { name, fields, .. } if !fields.is_empty() => {
+            let mut statements = Vec::new();
+            let mut converted_fields = Vec::new();
+            for (field, field_type) in fields {
+                let handle = format!("__sifr_python_field_{field}");
+                statements.push(conversion_let(
+                    &handle,
+                    runtime_call(
+                        "record_field",
+                        vec![
+                            reference(value_name),
+                            RustExpr::Literal(RustLiteral::Str(field.clone())),
+                        ],
+                    ),
+                    error_type,
+                ));
+                converted_fields.push((
+                    field.clone(),
+                    output_value_expr_with(&handle, field_type, error_type, opaque_classes)?,
+                ));
+            }
+            return Some(RustExpr::Block {
+                stmts: statements,
+                expr: Some(Box::new(RustExpr::StructInit {
+                    name: name.clone(),
+                    fields: converted_fields,
+                })),
+            });
+        }
+        _ => {}
+    }
+    Some(conversion_try(
+        output_conversion(value_name, ty)?,
+        error_type,
+    ))
+}
+
+fn conversion_try(value: RustExpr, error_type: Option<&Type>) -> RustExpr {
+    match error_type {
+        Some(error_type) => mapped_try(value, error_type),
+        None => RustExpr::Try(Box::new(value)),
+    }
+}
+
+fn conversion_let(name: &str, value: RustExpr, error_type: Option<&Type>) -> RustStmt {
+    RustStmt::Let {
+        mutable: false,
+        name: name.to_string(),
+        ty: None,
+        value: conversion_try(value, error_type),
+    }
+}
+
+fn input_conversion_value(
+    value: RustExpr,
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if is_python_object(ty) {
+        return Some(runtime_call("temporary_argument_handle", vec![value]));
+    }
+    if matches!(ty.resolve_alias(), Type::Class { name, .. } if opaque_classes.contains_key(name)) {
+        return Some(runtime_call(
+            "temporary_argument_handle",
+            vec![RustExpr::Ref {
+                mutable: false,
+                expr: Box::new(RustExpr::Field {
+                    expr: Box::new(value),
+                    field: "__sifr_python_object".to_string(),
+                }),
+            }],
+        ));
+    }
+    if matches!(
+        ty.resolve_alias(),
+        Type::List(_) | Type::Tuple(_) | Type::Dict(_, _) | Type::Class { .. }
+    ) {
+        return Some(RustExpr::Block {
+            stmts: vec![RustStmt::Let {
+                mutable: false,
+                name: "__sifr_python_nested".to_string(),
+                ty: None,
+                value,
+            }],
+            expr: Some(Box::new(input_conversion(
+                "__sifr_python_nested",
+                ty,
+                opaque_classes,
+            )?)),
+        });
+    }
+    let function = match ty.resolve_alias() {
+        Type::Bool => "from_bool",
+        Type::Int => "from_int",
+        Type::Float => "from_float",
+        Type::Str => "from_str",
+        Type::Bytes => "from_bytes",
+        _ => return None,
+    };
+    Some(runtime_call(function, vec![value]))
+}
+
+fn option_inner(ty: &Type) -> Option<&Type> {
+    let Type::Union(variants) = ty.resolve_alias() else {
+        return None;
+    };
+    if variants.len() != 2
+        || !variants
+            .iter()
+            .any(|variant| variant.resolve_alias() == &Type::None)
+    {
+        return None;
+    }
+    variants
+        .iter()
+        .find(|variant| variant.resolve_alias() != &Type::None)
+}
+
+pub(crate) fn input_conversion_borrowed(
+    name: &str,
+    ty: &Type,
+    opaque_classes: &HashMap<String, PythonInteropDeclaration>,
+) -> Option<RustExpr> {
+    if option_inner(ty).is_some() {
+        return input_conversion(name, ty, opaque_classes);
+    }
+    if matches!(
+        ty.resolve_alias(),
+        Type::List(_) | Type::Tuple(_) | Type::Dict(_, _) | Type::Class { .. }
+    ) && !is_python_object(ty)
+        && !matches!(ty.resolve_alias(), Type::Class { name, .. } if opaque_classes.contains_key(name))
+    {
+        return input_conversion(name, ty, opaque_classes);
+    }
+    let value = match ty.resolve_alias() {
+        Type::Bool | Type::Int | Type::Float => {
+            RustExpr::Deref(Box::new(RustExpr::Ident(name.to_string())))
+        }
+        Type::Str | Type::Bytes => RustExpr::Ident(name.to_string()),
+        _ if is_python_object(ty) => {
+            return Some(runtime_call(
+                "temporary_argument_handle",
+                vec![RustExpr::Ident(name.to_string())],
+            ));
+        }
+        Type::Class {
+            name: class_name, ..
+        } if opaque_classes.contains_key(class_name) => {
+            return Some(runtime_call(
+                "temporary_argument_handle",
+                vec![RustExpr::Ref {
+                    mutable: false,
+                    expr: Box::new(RustExpr::Field {
+                        expr: Box::new(RustExpr::Ident(name.to_string())),
+                        field: "__sifr_python_object".to_string(),
+                    }),
+                }],
+            ));
+        }
+        _ => return None,
+    };
+    let function = match ty.resolve_alias() {
+        Type::Bool => "from_bool",
+        Type::Int => "from_int",
+        Type::Float => "from_float",
+        Type::Str => "from_str",
+        Type::Bytes => "from_bytes",
+        _ => return None,
+    };
+    Some(runtime_call(function, vec![value]))
+}
+
+fn mapped_collection_results(iter: RustExpr, parameter: &str, body: RustExpr) -> RustExpr {
+    let mapped = RustExpr::MethodCall {
+        receiver: Box::new(iter),
+        method: "map".to_string(),
+        args: vec![RustExpr::Closure {
+            params: vec![RustParam::Named {
+                name: parameter.to_string(),
+                ty: RustType::Named("_".to_string()),
+            }],
+            body: Box::new(body),
+            is_move: false,
+        }],
+    };
+    RustExpr::MethodCall {
+        receiver: Box::new(mapped),
+        method: "collect".to_string(),
+        args: Vec::new(),
+    }
+}
+
+pub(crate) fn output_conversion(name: &str, ty: &Type) -> Option<RustExpr> {
+    let function = match ty.resolve_alias() {
+        Type::None => "to_none",
+        Type::Bool => "to_bool",
+        Type::Int => "to_int",
+        Type::Float => "to_float",
+        Type::Str => "to_str",
+        Type::Bytes => "to_bytes",
+        _ => return None,
+    };
+    Some(runtime_call(function, vec![reference(name)]))
+}
+
+pub(crate) fn is_python_object(ty: &Type) -> bool {
+    matches!(ty.resolve_alias(), Type::Class { name, .. } if name == "Object")
+}

--- a/crates/sifr_codegen/src/python_interop_direct_tests.rs
+++ b/crates/sifr_codegen/src/python_interop_direct_tests.rs
@@ -1,11 +1,16 @@
 use crate::python_interop_direct::{
-    input_conversion, output_value_expr, python_interop_function_body, python_interop_method_body,
+    input_conversion, output_value_expr, python_interop_function_body,
+    python_interop_function_body_with_retained_errors, python_interop_method_body,
+    python_interop_method_body_with_retained_errors,
 };
-use crate::render_stmts;
+use crate::{generate_rust, render_stmts};
 use ruff_text_size::TextRange;
 use sifr_ir::{
-    HirFunction, HirParam, MethodKind, PythonInteropDeclaration, PythonInteropDecoratorKind,
-    PythonInteropEffect, PythonInteropParameter, PythonParameterKind, PythonTargetPath,
+    HirClass, HirClassKind, HirFunction, HirModule, HirParam, MethodKind,
+    PythonCallbackConcurrency, PythonCallbackDeclaration, PythonCallbackDispatch,
+    PythonCallbackLifetime, PythonCleanupPolicy, PythonInteropDeclaration,
+    PythonInteropDecoratorKind, PythonInteropEffect, PythonInteropParameter, PythonParameterKind,
+    PythonTargetPath,
 };
 use sifr_type_system::{ParamConvention, Type};
 
@@ -226,7 +231,396 @@ fn consuming_opaque_close_emits_semantic_close_operation() {
         &python_interop_method_body(&method, &Default::default(), None)
             .expect("consuming close should lower"),
     );
-    assert!(rendered.contains("semantic_close(self.__sifr_python_object"));
+    assert!(rendered.contains("semantic_close_with_callbacks(self.__sifr_python_object"));
+    assert!(rendered.contains("self.__sifr_python_callbacks"));
+}
+
+#[test]
+fn typed_current_callback_emits_checked_adapter_failure_reconciliation_and_cleanup() {
+    let python_error = python_error_type();
+    let handler_error = Type::Class {
+        name: "HandlerError".to_string(),
+        fields: vec![("message".to_string(), Type::Str)],
+        methods: Vec::new(),
+        parent_class: Some("Error".to_string()),
+    };
+    let error = Type::Union(vec![python_error, handler_error.clone()]);
+    let handler_type = Type::Callable(
+        vec![Type::List(Box::new(Type::Int))],
+        vec![ParamConvention::own()],
+        Box::new(Type::Result(
+            Box::new(Type::Int),
+            Box::new(handler_error.clone()),
+        )),
+    );
+    let mut declaration = declaration();
+    declaration.parameters = vec![shape("handler", PythonParameterKind::Positional, false)];
+    let mut callback = callback_declaration(
+        PythonCallbackLifetime::Call,
+        PythonCallbackDispatch::Current,
+        None,
+        Some(handler_error),
+        None,
+    );
+    callback.argument_types = vec![Type::List(Box::new(Type::Int))];
+    declaration.callbacks = vec![callback];
+    let function = HirFunction {
+        name: "map".to_string(),
+        params: vec![param("handler", handler_type, ParamConvention::own())],
+        return_type: Type::Result(Box::new(Type::Int), Box::new(error)),
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        decorators: Vec::new(),
+        rust_interop: Vec::new(),
+        python_interop: vec![declaration],
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    };
+
+    let rendered = render_stmts(
+        &python_interop_function_body(&function, &Default::default()).expect("callback wrapper"),
+    );
+    assert!(rendered.contains("CallbackFailureSlot::new"), "{rendered}");
+    assert!(
+        rendered.contains("current_callback_with_owner"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("list_items"), "{rendered}");
+    assert!(rendered.contains("Sifr callback handler returned an error"));
+    assert!(rendered.contains("__sifr_callback_0.close()"), "{rendered}");
+    assert!(
+        rendered.contains("__sifr_callback_failure_0.take_if_owner_first"),
+        "{rendered}"
+    );
+    syn::parse_file(&format!("fn generated() {{ {rendered} }}"))
+        .expect("generated callback statements should be valid Rust syntax");
+}
+
+#[test]
+fn retained_foreign_callback_is_aggregated_into_the_opaque_result_owner() {
+    let subscription_type = Type::Class {
+        name: "Subscription".to_string(),
+        fields: Vec::new(),
+        methods: Vec::new(),
+        parent_class: Some("NonSend".to_string()),
+    };
+    let opaque = PythonInteropDeclaration {
+        kind: PythonInteropDecoratorKind::Opaque,
+        target: Some(PythonTargetPath {
+            segments: vec!["pkg".to_string(), "Subscription".to_string()],
+            span: TextRange::default(),
+        }),
+        span: TextRange::default(),
+        effect: PythonInteropEffect::BlockingIo,
+        cleanup: Some(PythonCleanupPolicy::Close),
+        consumes_receiver: false,
+        parameters: Vec::new(),
+        required_import_root: Some("pkg".to_string()),
+        callbacks: Vec::new(),
+    };
+    let mut opaque_classes = std::collections::HashMap::new();
+    opaque_classes.insert("Subscription".to_string(), opaque);
+    let mut declaration = declaration();
+    declaration.parameters = vec![shape("handler", PythonParameterKind::Positional, false)];
+    declaration.callbacks = vec![callback_declaration(
+        PythonCallbackLifetime::Result,
+        PythonCallbackDispatch::Foreign,
+        Some(PythonCallbackConcurrency::Serial),
+        None,
+        Some(PythonCleanupPolicy::Close),
+    )];
+    let handler_type = Type::Callable(
+        vec![Type::Int],
+        vec![ParamConvention::own()],
+        Box::new(Type::Int),
+    );
+    let function = HirFunction {
+        name: "subscribe".to_string(),
+        params: vec![param("handler", handler_type, ParamConvention::own())],
+        return_type: Type::Result(Box::new(subscription_type), Box::new(python_error_type())),
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        decorators: Vec::new(),
+        rust_interop: Vec::new(),
+        python_interop: vec![declaration],
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    };
+
+    let rendered = render_stmts(
+        &python_interop_function_body(&function, &opaque_classes).expect("retained wrapper"),
+    );
+    assert!(
+        rendered.contains("RetainedCallbackGroup::new"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("foreign_callback_with_owner"));
+    assert!(rendered.contains("retain_in_owner"));
+    assert!(rendered.contains("commit_for_object"));
+    assert!(rendered.contains("CallbackOwnerSlot::from_owner"));
+    assert!(!rendered.contains("close_call_scope"));
+    syn::parse_file(&format!("fn generated() {{ {rendered} }}"))
+        .expect("generated retained callback statements should be valid Rust syntax");
+}
+
+#[test]
+fn receiver_retained_callback_reuses_the_opaque_owner_slot() {
+    let mut declaration = declaration();
+    declaration.target = Some(PythonTargetPath {
+        segments: vec!["Self".to_string(), "register".to_string()],
+        span: TextRange::default(),
+    });
+    declaration.parameters = vec![shape("handler", PythonParameterKind::Positional, false)];
+    declaration.callbacks = vec![callback_declaration(
+        PythonCallbackLifetime::Receiver,
+        PythonCallbackDispatch::Foreign,
+        Some(PythonCallbackConcurrency::Parallel),
+        None,
+        Some(PythonCleanupPolicy::Close),
+    )];
+    let method = HirFunction {
+        name: "register".to_string(),
+        params: vec![param(
+            "handler",
+            Type::Callable(
+                vec![Type::Int],
+                vec![ParamConvention::own()],
+                Box::new(Type::Int),
+            ),
+            ParamConvention::own(),
+        )],
+        return_type: Type::Result(Box::new(Type::None), Box::new(python_error_type())),
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        decorators: Vec::new(),
+        rust_interop: Vec::new(),
+        python_interop: vec![declaration],
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    };
+
+    let rendered = render_stmts(
+        &python_interop_method_body(&method, &Default::default(), None)
+            .expect("receiver callback wrapper"),
+    );
+    assert!(rendered.contains("__sifr_python_callbacks.owner_or_insert"));
+    assert!(rendered.contains("foreign_callback_with_owner"));
+    assert!(rendered.contains("retain_in_owner"));
+    assert!(!rendered.contains("close_call_scope"));
+    let class = HirClass {
+        name: "Subscription".to_string(),
+        fields: Vec::new(),
+        methods: vec![method.clone()],
+        is_hashable: false,
+        is_error_type: false,
+        kind: HirClassKind::Regular,
+        operator_impls: Vec::new(),
+        newtype_inner: None,
+        implements_protocols: Vec::new(),
+        parent_class: None,
+        type_params: Vec::new(),
+        enum_variants: Vec::new(),
+        rust_interop: Vec::new(),
+    };
+    let emitter = crate::RustEmitter::new();
+    let bounded = emitter.lower_class_method_param_type(
+        &class,
+        &method,
+        "handler",
+        &method.params[0].ty,
+        method.params[0].convention,
+    );
+    let bounded = crate::render_type(&bounded);
+    assert!(bounded.contains("+ Send + Sync + 'static"), "{bounded}");
+    syn::parse_file(&format!("fn generated() {{ {rendered} }}"))
+        .expect("generated receiver callback statements should be valid Rust syntax");
+}
+
+#[test]
+fn retained_handler_failure_moves_into_typed_owner_sidecar_and_close_observes_it() {
+    let handler_error = Type::Class {
+        name: "HandlerError".to_string(),
+        fields: Vec::new(),
+        methods: Vec::new(),
+        parent_class: Some("Error".to_string()),
+    };
+    let error_channel = Type::Union(vec![python_error_type(), handler_error.clone()]);
+    let subscription_type = Type::Class {
+        name: "Subscription".to_string(),
+        fields: Vec::new(),
+        methods: Vec::new(),
+        parent_class: Some("NonSend".to_string()),
+    };
+    let mut opaque = declaration();
+    opaque.kind = PythonInteropDecoratorKind::Opaque;
+    opaque.cleanup = Some(PythonCleanupPolicy::Close);
+    opaque.target = Some(PythonTargetPath {
+        segments: vec!["pkg".to_string(), "Subscription".to_string()],
+        span: TextRange::default(),
+    });
+    let mut opaque_classes = std::collections::HashMap::new();
+    opaque_classes.insert("Subscription".to_string(), opaque.clone());
+    let mut retained_errors = std::collections::HashMap::new();
+    retained_errors.insert("Subscription".to_string(), vec![handler_error.clone()]);
+
+    let mut subscribe_declaration = declaration();
+    subscribe_declaration.parameters =
+        vec![shape("handler", PythonParameterKind::Positional, false)];
+    subscribe_declaration.callbacks = vec![callback_declaration(
+        PythonCallbackLifetime::Result,
+        PythonCallbackDispatch::Foreign,
+        Some(PythonCallbackConcurrency::Serial),
+        Some(handler_error.clone()),
+        Some(PythonCleanupPolicy::Close),
+    )];
+    let subscribe = HirFunction {
+        name: "subscribe".to_string(),
+        params: vec![param(
+            "handler",
+            Type::Callable(
+                vec![Type::Int],
+                vec![ParamConvention::own()],
+                Box::new(Type::Result(
+                    Box::new(Type::Int),
+                    Box::new(handler_error.clone()),
+                )),
+            ),
+            ParamConvention::own(),
+        )],
+        return_type: Type::Result(Box::new(subscription_type), Box::new(error_channel.clone())),
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        decorators: Vec::new(),
+        rust_interop: Vec::new(),
+        python_interop: vec![subscribe_declaration],
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    };
+    let subscribe_rendered = render_stmts(
+        &python_interop_function_body_with_retained_errors(
+            &subscribe,
+            &opaque_classes,
+            &retained_errors,
+        )
+        .expect("retained typed wrapper"),
+    );
+    assert!(
+        subscribe_rendered.contains("__sifr_python_callback_failure_0 ="),
+        "{subscribe_rendered}"
+    );
+    assert!(
+        subscribe_rendered.contains("__sifr_retained__sifr_python_callback_failure_0.clone()"),
+        "{subscribe_rendered}"
+    );
+
+    let mut close_declaration = declaration();
+    close_declaration.target = Some(PythonTargetPath {
+        segments: vec!["Self".to_string(), "close".to_string()],
+        span: TextRange::default(),
+    });
+    close_declaration.consumes_receiver = true;
+    close_declaration.parameters.clear();
+    let close = HirFunction {
+        name: "close".to_string(),
+        params: Vec::new(),
+        return_type: Type::Result(Box::new(Type::None), Box::new(error_channel)),
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        decorators: Vec::new(),
+        rust_interop: Vec::new(),
+        python_interop: vec![close_declaration],
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    };
+    let close_rendered = render_stmts(
+        &python_interop_method_body_with_retained_errors(
+            &close,
+            &opaque_classes,
+            Some(&opaque),
+            &retained_errors,
+            &[handler_error],
+        )
+        .expect("typed close wrapper"),
+    );
+    assert!(
+        close_rendered.contains("__sifr_python_callbacks.owner()"),
+        "{close_rendered}"
+    );
+    assert!(
+        close_rendered.contains("take_if_owner_first"),
+        "{close_rendered}"
+    );
+    syn::parse_file(&format!(
+        "fn subscribe_generated() {{ {subscribe_rendered} }} fn close_generated() {{ {close_rendered} }}"
+    ))
+    .expect("generated typed owner statements should be valid Rust syntax");
+
+    let module = HirModule {
+        functions: vec![subscribe],
+        classes: vec![HirClass {
+            name: "Subscription".to_string(),
+            fields: Vec::new(),
+            methods: vec![close],
+            is_hashable: false,
+            is_error_type: false,
+            kind: HirClassKind::PythonOpaque(opaque),
+            operator_impls: Vec::new(),
+            newtype_inner: None,
+            implements_protocols: Vec::new(),
+            parent_class: Some("NonSend".to_string()),
+            type_params: Vec::new(),
+            enum_variants: Vec::new(),
+            rust_interop: Vec::new(),
+        }],
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: Default::default(),
+        type_param_bounds: Default::default(),
+    };
+    let generated_module = generate_rust(&module);
+    assert!(
+        generated_module.contains(
+            "__sifr_python_callback_failure_0: sifr_runtime::python::CallbackFailureSlot<HandlerError>"
+        ),
+        "{generated_module}"
+    );
+    assert!(
+        generated_module.contains("fn __sifr_from_python_object("),
+        "{generated_module}"
+    );
+    assert!(
+        generated_module.contains("+ Send + Sync + 'static"),
+        "{generated_module}"
+    );
+    syn::parse_file(&generated_module).expect("complete typed owner module should parse as Rust");
+}
+
+fn callback_declaration(
+    lifetime: PythonCallbackLifetime,
+    dispatch: PythonCallbackDispatch,
+    concurrency: Option<PythonCallbackConcurrency>,
+    handler_error_type: Option<Type>,
+    owner_cleanup: Option<PythonCleanupPolicy>,
+) -> PythonCallbackDeclaration {
+    PythonCallbackDeclaration {
+        parameter_name: "handler".to_string(),
+        span: TextRange::default(),
+        lifetime,
+        dispatch,
+        concurrency,
+        argument_types: vec![Type::Int],
+        argument_conventions: vec![ParamConvention::own()],
+        success_type: Type::Int,
+        handler_error_type,
+        is_async: false,
+        owner_class: (lifetime != PythonCallbackLifetime::Call).then(|| "Subscription".to_string()),
+        owner_cleanup,
+    }
 }
 
 fn python_error_type() -> Type {

--- a/crates/sifr_codegen/src/stmt_support_emitter/python_context/sync.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/python_context/sync.rs
@@ -1,4 +1,5 @@
 use crate::hir_analysis::queries;
+use crate::python_interop_callbacks::failure_reconciliation_stmt;
 use crate::python_interop_direct::{mapped_try, output_value_expr, runtime_call};
 use crate::{HirStmt, RustEmitter, RustExpr, RustStmt, Type};
 use crate::{RustLiteral, RustMatchArm, RustType, RustWithItem};
@@ -120,10 +121,22 @@ impl RustEmitter {
         let outcome = format!("__sifr_python_context_outcome_{suffix}");
         let error = format!("__sifr_python_context_error_{suffix}");
         let cleanup = format!("__sifr_python_context_cleanup_{suffix}");
+        let owner_retained_errors = match item.context.ty().resolve_alias() {
+            Type::Class { name, .. } => self
+                .python_retained_callback_errors
+                .get(name)
+                .cloned()
+                .unwrap_or_default(),
+            _ => Vec::new(),
+        };
 
         let manager_handle = || RustExpr::Field {
             expr: Box::new(RustExpr::Ident(manager.clone())),
             field: "__sifr_python_object".to_string(),
+        };
+        let manager_callbacks = || RustExpr::Field {
+            expr: Box::new(RustExpr::Ident(manager.clone())),
+            field: "__sifr_python_callbacks".to_string(),
         };
         let entered = output_value_expr(
             &entered_raw,
@@ -152,6 +165,7 @@ impl RustEmitter {
 
         let conversion_error_body = Self::non_python_error_exit_body(
             manager_handle(),
+            manager_callbacks(),
             &error,
             &cleanup,
             &active_error_type,
@@ -184,17 +198,26 @@ impl RustEmitter {
         };
 
         let normal_exit = || {
-            RustStmt::Expr(mapped_try(
-                runtime_call("context_exit_normal", vec![manager_handle()]),
+            Self::normal_context_exit_body(
+                &RustExpr::Ident(manager.clone()),
                 exit_error_type,
-            ))
+                &owner_retained_errors,
+                suffix,
+            )
         };
         let can_break_or_continue = !self.loop_else_stack.is_empty();
         let active_error_body = if active_is_python_error {
-            Self::python_error_exit_body(manager_handle(), &error, &cleanup, &active_error_type)
+            Self::python_error_exit_body(
+                manager_handle(),
+                manager_callbacks(),
+                &error,
+                &cleanup,
+                &active_error_type,
+            )
         } else {
             Self::non_python_error_exit_body(
                 manager_handle(),
+                manager_callbacks(),
                 &error,
                 &cleanup,
                 &active_error_type,
@@ -206,17 +229,20 @@ impl RustEmitter {
             pattern: "Ok(Ok(None))".to_string(),
             bindings: vec![],
             guard: None,
-            body: vec![normal_exit()],
+            body: normal_exit(),
         }];
         if self.try_closure_depth > 0 {
             outcome_arms.push(RustMatchArm {
                 pattern: "Ok(Ok(Some(__sifr_context_return)))".to_string(),
                 bindings: vec!["__sifr_context_return".to_string()],
                 guard: None,
-                body: vec![
-                    normal_exit(),
-                    RustStmt::Return(Some(RustExpr::Ident("__sifr_context_return".to_string()))),
-                ],
+                body: {
+                    let mut exit = normal_exit();
+                    exit.push(RustStmt::Return(Some(RustExpr::Ident(
+                        "__sifr_context_return".to_string(),
+                    ))));
+                    exit
+                },
             });
         } else {
             outcome_arms.push(RustMatchArm {
@@ -237,13 +263,21 @@ impl RustEmitter {
                     pattern: "Ok(Err(false))".to_string(),
                     bindings: vec![],
                     guard: None,
-                    body: vec![normal_exit(), RustStmt::Break],
+                    body: {
+                        let mut exit = normal_exit();
+                        exit.push(RustStmt::Break);
+                        exit
+                    },
                 },
                 RustMatchArm {
                     pattern: "Ok(Err(true))".to_string(),
                     bindings: vec![],
                     guard: None,
-                    body: vec![normal_exit(), RustStmt::Continue],
+                    body: {
+                        let mut exit = normal_exit();
+                        exit.push(RustStmt::Continue);
+                        exit
+                    },
                 },
             ]);
         } else {
@@ -368,8 +402,79 @@ impl RustEmitter {
         format!("Result<{ok_type}, {error_type}>")
     }
 
+    fn normal_context_exit_body(
+        manager: &RustExpr,
+        exit_error_type: &Type,
+        owner_retained_errors: &[Type],
+        suffix: usize,
+    ) -> Vec<RustStmt> {
+        let owner = format!("__sifr_python_context_callback_owner_{suffix}");
+        let manager_handle = RustExpr::Field {
+            expr: Box::new(manager.clone()),
+            field: "__sifr_python_object".to_string(),
+        };
+        let manager_callbacks = RustExpr::Field {
+            expr: Box::new(manager.clone()),
+            field: "__sifr_python_callbacks".to_string(),
+        };
+        let mut body = Vec::new();
+        if !owner_retained_errors.is_empty() {
+            body.push(RustStmt::Let {
+                mutable: false,
+                name: owner.clone(),
+                ty: None,
+                value: RustExpr::MethodCall {
+                    receiver: Box::new(manager_callbacks.clone()),
+                    method: "owner".to_string(),
+                    args: Vec::new(),
+                },
+            });
+            for index in 0..owner_retained_errors.len() {
+                body.push(RustStmt::Let {
+                    mutable: false,
+                    name: format!("__sifr_python_context_callback_failure_{suffix}_{index}"),
+                    ty: None,
+                    value: RustExpr::Field {
+                        expr: Box::new(manager.clone()),
+                        field: format!("__sifr_python_callback_failure_{index}"),
+                    },
+                });
+            }
+        }
+        body.push(RustStmt::Expr(mapped_try(
+            runtime_call(
+                "context_exit_normal_with_callbacks",
+                vec![manager_handle, manager_callbacks],
+            ),
+            exit_error_type,
+        )));
+        if !owner_retained_errors.is_empty() {
+            body.push(RustStmt::IfLet {
+                pattern: "Some(__sifr_python_context_callback_owner_value)".to_string(),
+                expr: RustExpr::Ident(owner),
+                then_body: owner_retained_errors
+                    .iter()
+                    .enumerate()
+                    .map(|(index, handler_error_type)| {
+                        failure_reconciliation_stmt(
+                            &format!("__sifr_python_context_callback_failure_{suffix}_{index}"),
+                            handler_error_type,
+                            exit_error_type,
+                            RustExpr::Ident(
+                                "__sifr_python_context_callback_owner_value".to_string(),
+                            ),
+                        )
+                    })
+                    .collect(),
+                else_body: None,
+            });
+        }
+        body
+    }
+
     fn python_error_exit_body(
         manager_handle: RustExpr,
+        manager_callbacks: RustExpr,
         error: &str,
         cleanup: &str,
         primary_type: &str,
@@ -379,10 +484,11 @@ impl RustEmitter {
             expr: method(field(error, "__sifr_python_error"), "as_ref", vec![]),
             then_body: vec![RustStmt::Match {
                 expr: runtime_call(
-                    "context_exit_python_error",
+                    "context_exit_python_error_with_callbacks",
                     vec![
                         manager_handle.clone(),
                         RustExpr::Ident("__sifr_python_replay".into()),
+                        manager_callbacks.clone(),
                     ],
                 ),
                 arms: vec![
@@ -436,6 +542,7 @@ impl RustEmitter {
             }],
             else_body: Some(Self::non_python_error_exit_body(
                 manager_handle,
+                manager_callbacks,
                 error,
                 cleanup,
                 primary_type,
@@ -446,6 +553,7 @@ impl RustEmitter {
 
     fn non_python_error_exit_body(
         manager_handle: RustExpr,
+        manager_callbacks: RustExpr,
         error: &str,
         cleanup: &str,
         primary_type: &str,
@@ -491,10 +599,11 @@ impl RustEmitter {
             },
             RustStmt::Match {
                 expr: runtime_call(
-                    "context_exit_sifr_cause",
+                    "context_exit_sifr_cause_with_callbacks",
                     vec![
                         manager_handle,
                         reference(RustExpr::Ident(cause.to_string())),
+                        manager_callbacks,
                     ],
                 ),
                 arms: vec![

--- a/crates/sifr_codegen/src/stmt_support_emitter/python_context_tests.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/python_context_tests.rs
@@ -75,14 +75,39 @@ fn python_context_emits_enter_outcome_and_replay_aware_exit() {
     assert!(
         rendered.contains("enter_context(&__sifr_python_context_manager_0.__sifr_python_object)")
     );
-    assert!(rendered
-        .contains("context_exit_normal(__sifr_python_context_manager_0.__sifr_python_object)"));
-    assert!(rendered.contains("context_exit_python_error("));
-    assert!(rendered.contains("context_exit_sifr_cause("));
+    assert!(rendered.contains(
+        "context_exit_normal_with_callbacks(__sifr_python_context_manager_0.__sifr_python_object"
+    ));
+    assert!(rendered.contains("context_exit_python_error_with_callbacks("));
+    assert!(rendered.contains("context_exit_sifr_cause_with_callbacks("));
     assert!(rendered.contains("Ok(Ok(Some(_)))"));
     assert!(!rendered.contains("return __sifr_context_return"));
     syn::parse_file(&format!("fn generated() {{ {rendered} }}"))
         .expect("rendered context lowering should be valid Rust syntax");
+}
+
+#[test]
+fn normal_context_exit_observes_typed_retained_callback_failure() {
+    let mut emitter = emitter();
+    emitter
+        .python_retained_callback_errors
+        .insert("Manager".to_string(), vec![class_type("HandlerError")]);
+    let lowered = emitter
+        .try_lower_python_context_with_for_ir(&[python_item("entered", "manager")], &[])
+        .expect("lowering should succeed")
+        .expect("Python context should lower");
+    let rendered = crate::render_stmts(&[lowered]);
+    assert!(
+        rendered.contains("__sifr_python_context_manager_0.__sifr_python_callbacks.owner()"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("__sifr_python_context_manager_0.__sifr_python_callback_failure_0"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("take_if_owner_first"), "{rendered}");
+    syn::parse_file(&format!("fn generated() {{ {rendered} }}"))
+        .expect("typed context callback cleanup should be valid Rust syntax");
 }
 
 #[test]
@@ -107,10 +132,10 @@ fn multiple_python_contexts_nest_for_reverse_exit_order() {
         .find("enter_context(&__sifr_python_context_manager_0.")
         .expect("inner enter");
     let inner_exit = rendered
-        .find("context_exit_normal(__sifr_python_context_manager_0.")
+        .find("context_exit_normal_with_callbacks(__sifr_python_context_manager_0.")
         .expect("inner exit");
     let outer_exit = rendered
-        .find("context_exit_normal(__sifr_python_context_manager_1.")
+        .find("context_exit_normal_with_callbacks(__sifr_python_context_manager_1.")
         .expect("outer exit");
     assert!(outer_enter < inner_enter && inner_enter < inner_exit && inner_exit < outer_exit);
 }

--- a/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
@@ -406,8 +406,15 @@ pub(in crate::lower) fn lower_class(
                     Type::Any
                 };
                 ctx.scope.define(param_name.clone(), param_ty.clone());
-                let convention = if ctx.must_use_obligation_for_type(&param_ty).is_some() {
-                    ast_convention_to_param(param.parameter.convention, &param_ty)
+                let declared_convention =
+                    ast_convention_to_param(param.parameter.convention, &param_ty);
+                let convention = if ctx.must_use_obligation_for_type(&param_ty).is_some()
+                    || (matches!(
+                        param_ty.resolve_alias(),
+                        Type::Callable(..) | Type::AsyncCallable(..)
+                    ) && declared_convention.is_owned())
+                {
+                    declared_convention
                 } else {
                     ParamConvention::default()
                 };

--- a/crates/sifr_lowering/src/lower/mod_impl.rs
+++ b/crates/sifr_lowering/src/lower/mod_impl.rs
@@ -845,6 +845,7 @@ pub(in crate::lower) fn lower_module_impl(
             _ => {}
         }
     }
+    python_interop::validate_retained_callback_owner_errors(&functions, &classes, &mut ctx);
     if ctx.errors.is_empty() {
         let module = HirModule {
             functions,

--- a/crates/sifr_lowering/src/lower/python_interop.rs
+++ b/crates/sifr_lowering/src/lower/python_interop.rs
@@ -26,6 +26,14 @@ pub(in crate::lower) use stub_syntax::{
     is_bodyless_python_coroutine,
 };
 
+pub(in crate::lower) fn validate_retained_callback_owner_errors(
+    functions: &[sifr_ir::HirFunction],
+    classes: &[sifr_ir::HirClass],
+    ctx: &mut LowerCtx,
+) {
+    callbacks::validate_retained_owner_error_channels(functions, classes, ctx);
+}
+
 pub(in crate::lower) fn is_python_omit(expr: &Expr) -> bool {
     decorator_path(expr).is_some_and(|path| path == ["python", "omit"])
 }

--- a/crates/sifr_lowering/src/lower/python_interop/callbacks.rs
+++ b/crates/sifr_lowering/src/lower/python_interop/callbacks.rs
@@ -141,7 +141,7 @@ pub(super) fn parse(
                             ctx,
                             "unknown callback lifetime policy",
                             keyword.value.range(),
-                        )
+                        );
                     }
                 };
             }
@@ -155,7 +155,7 @@ pub(super) fn parse(
                             ctx,
                             "unknown callback dispatch policy",
                             keyword.value.range(),
-                        )
+                        );
                     }
                 };
             }
@@ -168,7 +168,7 @@ pub(super) fn parse(
                             ctx,
                             "unknown callback concurrency policy",
                             keyword.value.range(),
-                        )
+                        );
                     }
                 };
             }
@@ -284,6 +284,16 @@ pub(super) fn validate(
             );
             continue;
         };
+        if callback.lifetime != PythonCallbackLifetime::Call && !parameter.convention.is_owned() {
+            invalid(
+                ctx,
+                &format!(
+                    "retained callback parameter `{}` must be declared with `own` ownership",
+                    callback.parameter_name
+                ),
+                callback.span,
+            );
+        }
         validate_dispatch(callback, is_async, declaration_effect, ctx);
 
         let (success_type, handler_error_type) = match callback_return.resolve_alias() {
@@ -316,6 +326,63 @@ pub(super) fn validate(
         callback.success_type = success_type;
         callback.handler_error_type = handler_error_type;
         callback.is_async = is_async;
+    }
+}
+
+pub(super) fn validate_retained_owner_error_channels(
+    functions: &[sifr_ir::HirFunction],
+    classes: &[sifr_ir::HirClass],
+    ctx: &mut LowerCtx,
+) {
+    let mut invalid_owner_channel = false;
+    let callbacks = functions
+        .iter()
+        .chain(classes.iter().flat_map(|class| class.methods.iter()))
+        .flat_map(|function| &function.python_interop)
+        .flat_map(|declaration| &declaration.callbacks)
+        .filter_map(|callback| {
+            Some((
+                callback.owner_class.as_ref()?,
+                callback.handler_error_type.as_ref()?,
+                callback.span,
+            ))
+        })
+        .collect::<Vec<_>>();
+    for (owner_name, handler_error, span) in callbacks {
+        let Some(owner) = classes.iter().find(|class| &class.name == owner_name) else {
+            continue;
+        };
+        for cleanup in owner.methods.iter().filter(|method| {
+            method.python_interop.first().is_some_and(|declaration| {
+                declaration.consumes_receiver
+                    || matches!(
+                        declaration.kind,
+                        sifr_ir::PythonInteropDecoratorKind::ContextExit
+                            | sifr_ir::PythonInteropDecoratorKind::ContextAsyncExit
+                    )
+            })
+        }) {
+            let Type::Result(_, error_channel) = cleanup.return_type.resolve_alias() else {
+                continue;
+            };
+            if !error_channel_contains(error_channel.as_ref(), handler_error) {
+                invalid_owner_channel = true;
+                invalid(
+                    ctx,
+                    &format!(
+                        "retained callback owner cleanup `{}.{}` error channel must contain handler error `{}`",
+                        owner.name,
+                        cleanup.name,
+                        handler_error.display_name()
+                    ),
+                    span,
+                );
+            }
+        }
+    }
+    if invalid_owner_channel {
+        ctx.errors
+            .retain(|error| error.code != Some(DiagnosticCode::PYRES_UNIMPLEMENTED_DECLARATION));
     }
 }
 
@@ -354,9 +421,11 @@ fn validate_dispatch(
         PythonCallbackDispatch::Current if is_async => {
             Some("`dispatch=current` requires a synchronous `Callable` parameter")
         }
-        PythonCallbackDispatch::Current if declaration_effect == PythonInteropEffect::Async => Some(
-            "`dispatch=current` requires a synchronous `@python(...)` target so non-send captures remain on their creating thread",
-        ),
+        PythonCallbackDispatch::Current if declaration_effect == PythonInteropEffect::Async => {
+            Some(
+                "`dispatch=current` requires a synchronous `@python(...)` target so non-send captures remain on their creating thread",
+            )
+        }
         PythonCallbackDispatch::Foreign if is_async => {
             Some("`dispatch=foreign` requires a synchronous `Callable` parameter")
         }

--- a/crates/sifr_lowering/src/lower/python_interop_callback_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_interop_callback_tests.rs
@@ -347,19 +347,22 @@ class PythonError(Error):
 class Client:
     @python.callback(handler, lifetime=Self, dispatch=foreign, concurrency=serial)
     @python(Self.register)
-    def register(self, handler: Callable[[int], int]) -> Result[None, PythonError]: ...
+    def register(self, own handler: Callable[[int], int]) -> Result[None, PythonError]: ...
 
     @python(Self.close)
     def close(own self) -> Result[None, PythonError]: ...
 
 @python.callback(handler, lifetime=result, dispatch=foreign, concurrency=parallel)
 @python(pkg.create)
-def create(handler: Callable[[int], int]) -> Result[Client, PythonError]: ...
+def create(own handler: Callable[[int], int]) -> Result[Client, PythonError]: ...
 ",
     );
-    assert!(!errors
-        .iter()
-        .any(|error| error.code == Some(DiagnosticCode::PYCB_INVALID_DECLARATION)));
+    assert!(
+        !errors
+            .iter()
+            .any(|error| error.code == Some(DiagnosticCode::PYCB_INVALID_DECLARATION)),
+        "unexpected diagnostics: {errors:?}"
+    );
     assert_eq!(
         errors
             .iter()
@@ -397,4 +400,29 @@ class Client:
             "`lifetime=Self` is valid only on an opaque receiver method",
         );
     }
+}
+
+#[test]
+fn retained_handler_error_must_be_declared_by_owner_cleanup() {
+    assert_callback_error(
+        r"
+class PythonError(Error):
+    message: str
+
+class HandlerError(Error):
+    message: str
+
+@python.opaque(type=pkg.Subscription, cleanup=close)
+class Subscription:
+    @python(Self.close)
+    def close(own self) -> Result[None, PythonError]: ...
+
+@python.callback(handler, lifetime=result, dispatch=foreign, concurrency=serial)
+@python(pkg.subscribe)
+def subscribe(
+    own handler: Callable[[int], Result[int, HandlerError]],
+) -> Result[Subscription, PythonError | HandlerError]: ...
+",
+        "owner cleanup `Subscription.close` error channel must contain handler error `HandlerError`",
+    );
 }

--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -101,7 +101,7 @@ pub use opaque_ops::semantic_close;
 pub use python_error::PythonError;
 pub use recursive_ops::{
     at_path, dict_str_items, from_dict_results, from_list_results, from_record_results,
-    from_tuple_results, list_items, object_is_none, record_field, tuple_items,
+    from_tuple_results, list_items, object_is_none, record_field, tuple_items, tuple_items_exact,
 };
 pub use resource_identity::PythonResourceIdentity;
 pub use resource_ops::{exit_context_with_error, resource_diagnostics, PythonResourceDiagnostics};

--- a/crates/sifr_runtime/src/python/callbacks/current.rs
+++ b/crates/sifr_runtime/src/python/callbacks/current.rs
@@ -1,0 +1,215 @@
+use super::execution::{
+    collect_args, execution_error, python_error, result_object, validate_call_shape,
+    CallbackExecutionError,
+};
+use super::{errors, CallbackOwnerState};
+use crate::python::{object_ops, ObjectHandle, PythonError};
+use pyo3::prelude::*;
+use pyo3::types::{PyCFunction, PyDict, PyTuple};
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+type CurrentTarget<'a> = dyn for<'py> Fn(
+        u64,
+        Python<'py>,
+        &Bound<'py, PyTuple>,
+        Option<&Bound<'py, PyDict>>,
+    ) -> PyResult<Py<PyAny>>
+    + 'a;
+
+#[derive(Clone, Copy)]
+struct CurrentTargetPtr(*const CurrentTarget<'static>);
+
+#[allow(clippy::transmute_ptr_to_ptr)]
+unsafe fn erase_target_lifetime(target: *const CurrentTarget<'_>) -> CurrentTargetPtr {
+    // SAFETY: callers must keep the target alive until this pointer is removed
+    // from the thread-local registry and all admitted invocations have drained.
+    CurrentTargetPtr(unsafe {
+        std::mem::transmute::<*const CurrentTarget<'_>, *const CurrentTarget<'static>>(target)
+    })
+}
+
+thread_local! {
+    static CURRENT_TARGETS: RefCell<HashMap<u64, CurrentTargetPtr>> = RefCell::new(HashMap::new());
+}
+
+pub struct CurrentCallback<'a> {
+    object: ObjectHandle,
+    owner: CallbackOwnerState,
+    target: Option<Box<CurrentTarget<'a>>>,
+    token: u64,
+    callback_id: u64,
+    creator: std::thread::ThreadId,
+    closed: Cell<bool>,
+    _not_send: PhantomData<Rc<()>>,
+}
+
+static NEXT_CURRENT_TOKEN: AtomicU64 = AtomicU64::new(0);
+
+impl CurrentCallback<'_> {
+    #[must_use]
+    pub fn object(&self) -> &ObjectHandle {
+        &self.object
+    }
+
+    #[must_use]
+    pub fn owner(&self) -> &CallbackOwnerState {
+        &self.owner
+    }
+
+    pub fn close(&self) -> Result<(), PythonError> {
+        if self.closed.get() {
+            return Ok(());
+        }
+        if std::thread::current().id() != self.creator {
+            return Err(errors::wrong_thread(
+                self.owner.owner_id(),
+                self.callback_id,
+            ));
+        }
+        self.owner.close_call_scope()?;
+        CURRENT_TARGETS.with(|targets| {
+            targets.borrow_mut().remove(&self.token);
+        });
+        self.closed.set(true);
+        object_ops::close_object(self.object.clone())
+    }
+}
+
+impl Drop for CurrentCallback<'_> {
+    fn drop(&mut self) {
+        if self.close().is_err() && !self.closed.get() {
+            // A safe caller can arrange for the wrapper to be dropped
+            // reentrantly from its own non-Send handler through shared local
+            // state. Closing correctly rejects that operation, but Drop must
+            // then keep the currently executing target alive. Leaking only on
+            // this contract violation preserves memory safety and leaves the
+            // shell guarded by its still-open owner.
+            if let Some(target) = self.target.take() {
+                Box::leak(target);
+            }
+        }
+    }
+}
+
+pub fn current_callback<'a, A, R, Decode, Handler, Encode>(
+    callback_id: u64,
+    expected_arity: usize,
+    decode: Decode,
+    handler: Handler,
+    encode: Encode,
+) -> Result<CurrentCallback<'a>, PythonError>
+where
+    A: 'a,
+    R: 'a,
+    Decode: Fn(Vec<ObjectHandle>) -> Result<A, PythonError> + 'a,
+    Handler: Fn(u64, A) -> Result<R, CallbackExecutionError> + 'a,
+    Encode: Fn(R) -> Result<ObjectHandle, PythonError> + 'a,
+{
+    let owner = CallbackOwnerState::new_call_scoped()?;
+    current_callback_with_owner(owner, callback_id, expected_arity, decode, handler, encode)
+}
+
+pub fn current_callback_with_owner<'a, A, R, Decode, Handler, Encode>(
+    owner: CallbackOwnerState,
+    callback_id: u64,
+    expected_arity: usize,
+    decode: Decode,
+    handler: Handler,
+    encode: Encode,
+) -> Result<CurrentCallback<'a>, PythonError>
+where
+    A: 'a,
+    R: 'a,
+    Decode: Fn(Vec<ObjectHandle>) -> Result<A, PythonError> + 'a,
+    Handler: Fn(u64, A) -> Result<R, CallbackExecutionError> + 'a,
+    Encode: Fn(R) -> Result<ObjectHandle, PythonError> + 'a,
+{
+    let token = NEXT_CURRENT_TOKEN
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            current.checked_add(1)
+        })
+        .map_err(|_| errors::unavailable("current callback token space"))?
+        .checked_add(1)
+        .ok_or_else(|| errors::unavailable("current callback token space"))?;
+    let target_owner = owner.clone();
+    let target: Box<CurrentTarget<'a>> = Box::new(move |entry_sequence, py, args, kwargs| {
+        validate_call_shape(args, kwargs, expected_arity)?;
+        let args = collect_args(args).map_err(python_error)?;
+        let decoded = decode(args).map_err(python_error)?;
+        let result = handler(entry_sequence, decoded)
+            .map_err(|error| execution_error(py, &target_owner, entry_sequence, error))?;
+        let result = encode(result).map_err(python_error)?;
+        result_object(py, result).map_err(python_error)
+    });
+    let target_ptr: *const CurrentTarget<'a> = &*target;
+    // `CurrentCallback` owns the boxed target and removes this pointer from the
+    // creator thread's registry before the box is dropped. Dereferencing the
+    // lifetime-erased pointer remains confined to the guarded shell below.
+    // SAFETY: the owning callback removes the pointer before dropping `target`.
+    let target_ptr = unsafe { erase_target_lifetime(target_ptr) };
+    CURRENT_TARGETS.with(|targets| {
+        targets.borrow_mut().insert(token, target_ptr);
+    });
+
+    let creator = std::thread::current().id();
+    let shell_creator = creator;
+    let shell_owner = owner.clone();
+    let object = crate::python::attach(|py| {
+        let callback = PyCFunction::new_closure(
+            py,
+            Some(c"sifr_current_callback"),
+            None,
+            move |args: &Bound<'_, PyTuple>, kwargs: Option<&Bound<'_, PyDict>>| {
+                if std::thread::current().id() != shell_creator {
+                    return Err(python_error(errors::wrong_thread(
+                        shell_owner.owner_id(),
+                        callback_id,
+                    )));
+                }
+                let invocation = shell_owner
+                    .accept(callback_id, false)
+                    .map_err(python_error)?;
+                let entry_sequence = invocation.entry_sequence();
+                let _guard = invocation.enter().map_err(python_error)?;
+                CURRENT_TARGETS.with(|targets| {
+                    targets.borrow().get(&token).map_or_else(
+                        || Err(python_error(errors::closed(shell_owner.owner_id()))),
+                        |target| {
+                            // SAFETY: registry membership is bounded by the
+                            // owning `CurrentCallback` as documented above.
+                            unsafe { (&*target.0)(entry_sequence, args.py(), args, kwargs) }
+                        },
+                    )
+                })
+            },
+        )
+        .map_err(|error| PythonError::from_pyerr(py, error, "callback", "current callback"))?;
+        object_ops::store_object(callback.into_any().unbind())
+    })
+    .map_err(PythonError::runtime)
+    .and_then(|outcome| outcome);
+    let object = match object {
+        Ok(object) => object,
+        Err(error) => {
+            CURRENT_TARGETS.with(|targets| {
+                targets.borrow_mut().remove(&token);
+            });
+            return Err(error);
+        }
+    };
+
+    Ok(CurrentCallback {
+        object,
+        owner,
+        target: Some(target),
+        token,
+        callback_id,
+        creator,
+        closed: Cell::new(false),
+        _not_send: PhantomData,
+    })
+}

--- a/crates/sifr_runtime/src/python/callbacks/errors.rs
+++ b/crates/sifr_runtime/src/python/callbacks/errors.rs
@@ -11,7 +11,7 @@ pub(super) fn register_callback_errors(py: Python<'_>) -> Result<(), PythonRunti
     }
     let module = PyModule::from_code(
         py,
-        c"class SifrCallbackError(RuntimeError):\n    def __init__(self, handler_type, message):\n        super().__init__(message)\n        self.handler_type = handler_type\n        self.message = message\n\nclass SifrCallbackClosedError(RuntimeError):\n    pass\n\nclass SifrCallbackReentrancyError(RuntimeError):\n    pass\n\nclass SifrCallbackCloseReentrancyError(RuntimeError):\n    pass\n",
+        c"class SifrCallbackError(RuntimeError):\n    def __init__(self, handler_type, message):\n        super().__init__(message)\n        self.handler_type = handler_type\n        self.message = message\n\nclass SifrCallbackClosedError(RuntimeError):\n    pass\n\nclass SifrCallbackReentrancyError(RuntimeError):\n    pass\n\nclass SifrCallbackCloseReentrancyError(RuntimeError):\n    pass\n\nclass SifrCallbackThreadError(RuntimeError):\n    pass\n",
         c"__sifr_callbacks__.py",
         c"__sifr_callbacks__",
     )
@@ -21,6 +21,7 @@ pub(super) fn register_callback_errors(py: Python<'_>) -> Result<(), PythonRunti
         "SifrCallbackClosedError",
         "SifrCallbackReentrancyError",
         "SifrCallbackCloseReentrancyError",
+        "SifrCallbackThreadError",
     ] {
         let _validated_type = callback_type(&module, name)?;
     }
@@ -64,6 +65,7 @@ pub(super) fn registered_exception_names(py: Python<'_>) -> Option<Vec<String>> 
         "SifrCallbackClosedError",
         "SifrCallbackReentrancyError",
         "SifrCallbackCloseReentrancyError",
+        "SifrCallbackThreadError",
     ]
     .into_iter()
     .map(|name| {
@@ -100,6 +102,30 @@ pub(super) fn close_from_invocation(owner_id: u64) -> PythonError {
         "SifrCallbackCloseReentrancyError",
         format!("callback owner {owner_id} cannot close from an accepted invocation"),
         "callback owner close",
+    )
+}
+
+pub(super) fn wrong_thread(owner_id: u64, callback_id: u64) -> PythonError {
+    callback_error(
+        "SifrCallbackThreadError",
+        format!(
+            "current callback {callback_id} for owner {owner_id} was invoked on a foreign thread"
+        ),
+        "callback admission",
+    )
+}
+
+pub(super) fn recorded_handler_failure(
+    owner_id: u64,
+    evidence: &super::CallbackFailureEvidence,
+) -> PythonError {
+    callback_error(
+        "SifrCallbackError",
+        format!(
+            "retained callback owner {owner_id} recorded {} at entry {}: {}",
+            evidence.exception_type, evidence.entry_sequence, evidence.message
+        ),
+        "retained callback failure",
     )
 }
 

--- a/crates/sifr_runtime/src/python/callbacks/execution.rs
+++ b/crates/sifr_runtime/src/python/callbacks/execution.rs
@@ -1,0 +1,230 @@
+use super::super::{object_ops, ObjectHandle, PythonError};
+use super::CallbackOwnerState;
+use pyo3::exceptions::{PyRuntimeError, PyTypeError};
+use pyo3::prelude::*;
+use pyo3::types::{PyAnyMethods, PyDict, PyTuple, PyType};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+pub struct CallbackFailureSlot<E> {
+    first: Arc<Mutex<Option<(u64, E)>>>,
+}
+
+impl<E> CallbackFailureSlot<E> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            first: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn record(&self, entry_sequence: u64, error: E) {
+        let mut first = self
+            .first
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if first
+            .as_ref()
+            .is_none_or(|(current, _)| entry_sequence < *current)
+        {
+            *first = Some((entry_sequence, error));
+        }
+    }
+
+    pub fn take(&self) -> Option<E> {
+        self.first
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+            .map(|(_, error)| error)
+    }
+
+    pub fn take_if_owner_first(&self, owner: &CallbackOwnerState) -> Option<E> {
+        let sequence = owner.first_failure()?.entry_sequence;
+        let mut first = self
+            .first
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if first.as_ref().map(|(current, _)| *current) != Some(sequence) {
+            return None;
+        }
+        let (_, error) = first.take()?;
+        owner.observe_failure(sequence);
+        Some(error)
+    }
+
+    #[must_use]
+    pub fn first_sequence(&self) -> Option<u64> {
+        self.first
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .map(|(sequence, _)| *sequence)
+    }
+}
+
+impl<E> Clone for CallbackFailureSlot<E> {
+    fn clone(&self) -> Self {
+        Self {
+            first: Arc::clone(&self.first),
+        }
+    }
+}
+
+impl<E> Default for CallbackFailureSlot<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallbackHandlerFailure {
+    pub exception_type: String,
+    pub message: String,
+}
+
+impl CallbackHandlerFailure {
+    #[must_use]
+    pub fn new(exception_type: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            exception_type: exception_type.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum CallbackExecutionError {
+    Handler(CallbackHandlerFailure),
+    Infrastructure(PythonError),
+}
+
+impl From<PythonError> for CallbackExecutionError {
+    fn from(error: PythonError) -> Self {
+        Self::Infrastructure(error)
+    }
+}
+
+pub(super) fn validate_call_shape(
+    args: &Bound<'_, PyTuple>,
+    kwargs: Option<&Bound<'_, PyDict>>,
+    expected_arity: usize,
+) -> PyResult<()> {
+    if kwargs.is_some_and(|values| !values.is_empty()) {
+        return Err(PyTypeError::new_err(
+            "Sifr callback parameters are positional-only",
+        ));
+    }
+    if args.len() != expected_arity {
+        return Err(PyTypeError::new_err(format!(
+            "Sifr callback expected {expected_arity} positional arguments, received {}",
+            args.len()
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn collect_args(args: &Bound<'_, PyTuple>) -> Result<Vec<ObjectHandle>, PythonError> {
+    args.iter()
+        .map(|value| object_ops::store_object(value.unbind()))
+        .collect()
+}
+
+pub(super) fn result_object(
+    py: Python<'_>,
+    result: ObjectHandle,
+) -> Result<Py<PyAny>, PythonError> {
+    let cloned = object_ops::clone_handle(py, &result);
+    drop(result);
+    cloned
+}
+
+pub fn attach_callback_failure_evidence<T>(
+    mut outcome: Result<T, PythonError>,
+    owners: &[&CallbackOwnerState],
+) -> Result<T, PythonError> {
+    let Err(primary) = &mut outcome else {
+        return outcome;
+    };
+    let mut seen_owners = Vec::new();
+    for owner in owners {
+        if seen_owners.contains(&owner.owner_id()) {
+            continue;
+        }
+        seen_owners.push(owner.owner_id());
+        let Some(evidence) = owner.first_failure() else {
+            continue;
+        };
+        let secondary = format!(
+            "secondary Sifr callback failure {} at entry {}: {}",
+            evidence.exception_type, evidence.entry_sequence, evidence.message
+        );
+        if primary.context.is_empty() {
+            primary.context = secondary;
+        } else {
+            primary.context.push_str("; ");
+            primary.context.push_str(&secondary);
+        }
+    }
+    outcome
+}
+
+pub(super) fn execution_error(
+    py: Python<'_>,
+    owner: &super::CallbackOwnerState,
+    entry_sequence: u64,
+    error: CallbackExecutionError,
+) -> PyErr {
+    match error {
+        CallbackExecutionError::Handler(failure) => {
+            owner.record_failure(
+                entry_sequence,
+                failure.exception_type.clone(),
+                failure.message.clone(),
+            );
+            handler_error(py, &failure)
+        }
+        CallbackExecutionError::Infrastructure(error) => python_error(error),
+    }
+}
+
+pub(super) fn python_error(error: PythonError) -> PyErr {
+    let message = error.to_string();
+    let exception_type = error.exception_type;
+    let kind = error.kind;
+    if exception_type == "TypeError" || kind == "conversion" {
+        PyTypeError::new_err(message)
+    } else if exception_type.starts_with("SifrCallback") {
+        Python::try_attach(|py| named_callback_error(py, &exception_type, message.clone()))
+            .unwrap_or_else(|| PyRuntimeError::new_err(message))
+    } else {
+        PyRuntimeError::new_err(message)
+    }
+}
+
+fn handler_error(py: Python<'_>, failure: &CallbackHandlerFailure) -> PyErr {
+    let error_type = py
+        .import("__sifr_callbacks__")
+        .and_then(|module| module.getattr("SifrCallbackError"))
+        .and_then(|value| value.cast_into::<PyType>().map_err(Into::into));
+    error_type.map_or_else(
+        |error| PyRuntimeError::new_err(format!("failed to construct SifrCallbackError: {error}")),
+        |error_type| {
+            PyErr::from_type(
+                error_type,
+                (failure.exception_type.clone(), failure.message.clone()),
+            )
+        },
+    )
+}
+
+fn named_callback_error(py: Python<'_>, name: &str, message: String) -> PyErr {
+    let error_type = py
+        .import("__sifr_callbacks__")
+        .and_then(|module| module.getattr(name))
+        .and_then(|value| value.cast_into::<PyType>().map_err(Into::into));
+    match error_type {
+        Ok(error_type) => PyErr::from_type(error_type, (message,)),
+        Err(_) => PyRuntimeError::new_err(message),
+    }
+}

--- a/crates/sifr_runtime/src/python/callbacks/foreign.rs
+++ b/crates/sifr_runtime/src/python/callbacks/foreign.rs
@@ -1,0 +1,682 @@
+use super::execution::{
+    collect_args, execution_error, python_error, result_object, validate_call_shape,
+    CallbackExecutionError,
+};
+use super::CallbackOwnerState;
+use crate::python::{object_ops, ObjectHandle, PythonError};
+use pyo3::prelude::*;
+use pyo3::types::{PyCFunction, PyDict, PyTuple};
+use std::cell::Cell;
+use std::collections::BTreeSet;
+use std::marker::PhantomData;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+
+trait ForeignTarget<'a>: Send + Sync {
+    fn prepare(
+        &self,
+        args: Vec<ObjectHandle>,
+    ) -> Result<Box<dyn ForeignPrepared<'a> + 'a>, PythonError>;
+}
+
+trait ForeignPrepared<'a>: Send {
+    fn invoke(
+        self: Box<Self>,
+        entry_sequence: u64,
+    ) -> Result<Box<dyn ForeignOutput + 'a>, CallbackExecutionError>;
+}
+
+trait ForeignOutput: Send {
+    fn encode(self: Box<Self>) -> Result<ObjectHandle, PythonError>;
+}
+
+struct TypedForeignTarget<Decode, Handler, Encode> {
+    decode: Arc<Decode>,
+    handler: Arc<Handler>,
+    encode: Arc<Encode>,
+}
+
+struct TypedForeignPrepared<A, R, Handler, Encode> {
+    value: A,
+    handler: Arc<Handler>,
+    encode: Arc<Encode>,
+    _result: PhantomData<R>,
+}
+
+struct TypedForeignOutput<R, Encode> {
+    value: R,
+    encode: Arc<Encode>,
+}
+
+impl<'a, A, R, Decode, Handler, Encode> ForeignTarget<'a>
+    for TypedForeignTarget<Decode, Handler, Encode>
+where
+    A: Send + 'a,
+    R: Send + 'a,
+    Decode: Fn(Vec<ObjectHandle>) -> Result<A, PythonError> + Send + Sync + 'a,
+    Handler: Fn(u64, A) -> Result<R, CallbackExecutionError> + Send + Sync + 'a,
+    Encode: Fn(R) -> Result<ObjectHandle, PythonError> + Send + Sync + 'a,
+{
+    fn prepare(
+        &self,
+        args: Vec<ObjectHandle>,
+    ) -> Result<Box<dyn ForeignPrepared<'a> + 'a>, PythonError> {
+        Ok(Box::new(TypedForeignPrepared {
+            value: (self.decode)(args)?,
+            handler: Arc::clone(&self.handler),
+            encode: Arc::clone(&self.encode),
+            _result: PhantomData,
+        }))
+    }
+}
+
+impl<'a, A, R, Handler, Encode> ForeignPrepared<'a> for TypedForeignPrepared<A, R, Handler, Encode>
+where
+    A: Send + 'a,
+    R: Send + 'a,
+    Handler: Fn(u64, A) -> Result<R, CallbackExecutionError> + Send + Sync + 'a,
+    Encode: Fn(R) -> Result<ObjectHandle, PythonError> + Send + Sync + 'a,
+{
+    fn invoke(
+        self: Box<Self>,
+        entry_sequence: u64,
+    ) -> Result<Box<dyn ForeignOutput + 'a>, CallbackExecutionError> {
+        let value = (self.handler)(entry_sequence, self.value)?;
+        Ok(Box::new(TypedForeignOutput {
+            value,
+            encode: self.encode,
+        }))
+    }
+}
+
+impl<R, Encode> ForeignOutput for TypedForeignOutput<R, Encode>
+where
+    R: Send,
+    Encode: Fn(R) -> Result<ObjectHandle, PythonError> + Send + Sync,
+{
+    fn encode(self: Box<Self>) -> Result<ObjectHandle, PythonError> {
+        (self.encode)(self.value)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ForeignTargetPtr(*const (dyn ForeignTarget<'static> + 'static));
+
+#[allow(clippy::transmute_ptr_to_ptr)]
+unsafe fn erase_target_lifetime(target: *const (dyn ForeignTarget<'_> + '_)) -> ForeignTargetPtr {
+    // SAFETY: callers must keep the target alive until owner admission closes
+    // and every accepted invocation has drained.
+    ForeignTargetPtr(unsafe {
+        std::mem::transmute::<
+            *const (dyn ForeignTarget<'_> + '_),
+            *const (dyn ForeignTarget<'static> + 'static),
+        >(target)
+    })
+}
+
+// SAFETY: the pointer is only dereferenced after owner admission. Call-scoped
+// close rejects new entries and drains all accepted calls before its owning box
+// can be dropped.
+unsafe impl Send for ForeignTargetPtr {}
+// SAFETY: `ForeignTarget` is `Sync`, and its owner provides the lifetime proof.
+unsafe impl Sync for ForeignTargetPtr {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForeignCallbackConcurrency {
+    Serial,
+    Parallel,
+}
+
+pub struct ForeignCallback<'a> {
+    object: ObjectHandle,
+    owner: CallbackOwnerState,
+    target: Option<Box<dyn ForeignTarget<'a> + 'a>>,
+    closed: Cell<bool>,
+    retained: Cell<bool>,
+    admission: Arc<AtomicBool>,
+    _not_send: PhantomData<Rc<()>>,
+}
+
+impl ForeignCallback<'_> {
+    #[must_use]
+    pub fn object(&self) -> &ObjectHandle {
+        &self.object
+    }
+
+    #[must_use]
+    pub fn owner(&self) -> &CallbackOwnerState {
+        &self.owner
+    }
+
+    pub fn close_call_scope(&self) -> Result<(), PythonError> {
+        if self.closed.get() {
+            return Ok(());
+        }
+        self.owner.close_call_scope()?;
+        self.admission.store(false, Ordering::Release);
+        self.closed.set(true);
+        object_ops::close_object(self.object.clone())
+    }
+
+    pub fn close_after_owner_unregister(&self) -> Result<(), PythonError> {
+        self.owner.close_after_owner_unregister()?;
+        self.admission.store(false, Ordering::Release);
+        self.closed.set(true);
+        object_ops::close_object(self.object.clone())
+    }
+
+    pub fn retain_in_owner(&self) -> Result<(), PythonError> {
+        if self.retained.get() {
+            return Ok(());
+        }
+        let object = self.object.clone();
+        self.owner
+            .retain_capture(move || super::ownership::release_callable(object))?;
+        self.retained.set(true);
+        Ok(())
+    }
+}
+
+impl Drop for ForeignCallback<'_> {
+    fn drop(&mut self) {
+        if self.target.is_some() && self.close_call_scope().is_err() && !self.closed.get() {
+            // See `CurrentCallback::drop`: a reentrant ownership violation
+            // must not deallocate the target while its shell is executing.
+            if let Some(target) = self.target.take() {
+                Box::leak(target);
+            }
+        }
+        if self.target.is_none() && !self.retained.get() && !self.closed.get() {
+            self.admission.store(false, Ordering::Release);
+            let _ignored = object_ops::close_object(self.object.clone());
+        }
+    }
+}
+
+pub fn foreign_callback<'a, A, R, Decode, Handler, Encode>(
+    callback_id: u64,
+    expected_arity: usize,
+    concurrency: ForeignCallbackConcurrency,
+    decode: Decode,
+    handler: Handler,
+    encode: Encode,
+) -> Result<ForeignCallback<'a>, PythonError>
+where
+    A: Send + 'a,
+    R: Send + 'a,
+    Decode: Fn(Vec<ObjectHandle>) -> Result<A, PythonError> + Send + Sync + 'a,
+    Handler: Fn(u64, A) -> Result<R, CallbackExecutionError> + Send + Sync + 'a,
+    Encode: Fn(R) -> Result<ObjectHandle, PythonError> + Send + Sync + 'a,
+{
+    let owner = CallbackOwnerState::new_call_scoped()?;
+    foreign_callback_scoped_with_owner(
+        owner,
+        callback_id,
+        expected_arity,
+        concurrency,
+        decode,
+        handler,
+        encode,
+    )
+}
+
+pub fn foreign_callback_scoped_with_owner<'a, A, R, Decode, Handler, Encode>(
+    owner: CallbackOwnerState,
+    callback_id: u64,
+    expected_arity: usize,
+    concurrency: ForeignCallbackConcurrency,
+    decode: Decode,
+    handler: Handler,
+    encode: Encode,
+) -> Result<ForeignCallback<'a>, PythonError>
+where
+    A: Send + 'a,
+    R: Send + 'a,
+    Decode: Fn(Vec<ObjectHandle>) -> Result<A, PythonError> + Send + Sync + 'a,
+    Handler: Fn(u64, A) -> Result<R, CallbackExecutionError> + Send + Sync + 'a,
+    Encode: Fn(R) -> Result<ObjectHandle, PythonError> + Send + Sync + 'a,
+{
+    let target: Box<dyn ForeignTarget<'a> + 'a> = Box::new(TypedForeignTarget {
+        decode: Arc::new(decode),
+        handler: Arc::new(handler),
+        encode: Arc::new(encode),
+    });
+    let target_ptr: *const (dyn ForeignTarget<'a> + 'a) = &*target;
+    // The returned callback owns `target`, and `close_call_scope` drains every
+    // invocation before the lifetime-erased pointer is dereferenced or dropped.
+    // SAFETY: `close_call_scope` drains the owner before `_target` is dropped.
+    let target_ptr = Arc::new(unsafe { erase_target_lifetime(target_ptr) });
+    let fifo = Arc::new(FifoSerial::default());
+    let admission = Arc::new(Mutex::new(()));
+    let callback_admission = Arc::new(AtomicBool::new(true));
+    let shell_callback_admission = Arc::clone(&callback_admission);
+    let shell_owner = owner.clone();
+    let object = crate::python::attach(|py| {
+        let callback = PyCFunction::new_closure(
+            py,
+            Some(c"sifr_foreign_callback"),
+            None,
+            move |args: &Bound<'_, PyTuple>, kwargs: Option<&Bound<'_, PyDict>>| {
+                let py = args.py();
+                if !shell_callback_admission.load(Ordering::Acquire) {
+                    return Err(python_error(super::errors::closed(shell_owner.owner_id())));
+                }
+                let (invocation, serial_ticket) =
+                    admit(&shell_owner, callback_id, concurrency, &admission, &fifo)?;
+                let entry_sequence = invocation.entry_sequence();
+                let invocation = invocation.enter().map_err(python_error)?;
+                validate_call_shape(args, kwargs, expected_arity)?;
+                let args = collect_args(args).map_err(python_error)?;
+                // SAFETY: owner admission now spans checked Python decoding,
+                // detached handler execution, and result encoding. Closing
+                // cannot drop the borrowed target until this invocation drains.
+                let prepared = unsafe { (&*target_ptr.0).prepare(args) }.map_err(python_error)?;
+                let outcome = py.detach(move || {
+                    let _permit = serial_ticket.map(FifoTicket::acquire);
+                    prepared
+                        .invoke(entry_sequence)
+                        .map(|result| (invocation, result))
+                });
+                let (invocation, result) = outcome
+                    .map_err(|error| execution_error(py, &shell_owner, entry_sequence, error))?;
+                let result = result.encode().map_err(python_error)?;
+                let result = result_object(py, result).map_err(python_error);
+                drop(invocation);
+                result
+            },
+        )
+        .map_err(|error| PythonError::from_pyerr(py, error, "callback", "foreign callback"))?;
+        object_ops::store_object(callback.into_any().unbind())
+    })
+    .map_err(PythonError::runtime)??;
+    Ok(ForeignCallback {
+        object,
+        owner,
+        target: Some(target),
+        closed: Cell::new(false),
+        retained: Cell::new(false),
+        admission: callback_admission,
+        _not_send: PhantomData,
+    })
+}
+
+pub fn foreign_callback_with_owner<A, R, Decode, Handler, Encode>(
+    owner: CallbackOwnerState,
+    callback_id: u64,
+    expected_arity: usize,
+    concurrency: ForeignCallbackConcurrency,
+    decode: Decode,
+    handler: Handler,
+    encode: Encode,
+) -> Result<ForeignCallback<'static>, PythonError>
+where
+    A: Send + 'static,
+    R: Send + 'static,
+    Decode: Fn(Vec<ObjectHandle>) -> Result<A, PythonError> + Send + Sync + 'static,
+    Handler: Fn(u64, A) -> Result<R, CallbackExecutionError> + Send + Sync + 'static,
+    Encode: Fn(R) -> Result<ObjectHandle, PythonError> + Send + Sync + 'static,
+{
+    let decode = Arc::new(decode);
+    let handler = Arc::new(handler);
+    let encode = Arc::new(encode);
+    let fifo = Arc::new(FifoSerial::default());
+    let admission = Arc::new(Mutex::new(()));
+    let callback_admission = Arc::new(AtomicBool::new(true));
+    let shell_callback_admission = Arc::clone(&callback_admission);
+    let shell_owner = owner.clone();
+    let object = crate::python::attach(|py| {
+        let callback = PyCFunction::new_closure(
+            py,
+            Some(c"sifr_foreign_callback"),
+            None,
+            move |args: &Bound<'_, PyTuple>, kwargs: Option<&Bound<'_, PyDict>>| {
+                let py = args.py();
+                if !shell_callback_admission.load(Ordering::Acquire) {
+                    return Err(python_error(super::errors::closed(shell_owner.owner_id())));
+                }
+                let (invocation, serial_ticket) =
+                    admit(&shell_owner, callback_id, concurrency, &admission, &fifo)?;
+                let entry_sequence = invocation.entry_sequence();
+                let invocation = invocation.enter().map_err(python_error)?;
+                validate_call_shape(args, kwargs, expected_arity)?;
+                let args = collect_args(args).map_err(python_error)?;
+                let decoded = decode(args).map_err(python_error)?;
+                let handler = Arc::clone(&handler);
+                let outcome = py.detach(move || {
+                    let _permit = serial_ticket.map(FifoTicket::acquire);
+                    handler(entry_sequence, decoded).map(|result| (invocation, result))
+                });
+                let (invocation, result) = outcome
+                    .map_err(|error| execution_error(py, &shell_owner, entry_sequence, error))?;
+                let result = encode(result).map_err(python_error)?;
+                let result = result_object(py, result).map_err(python_error);
+                drop(invocation);
+                result
+            },
+        )
+        .map_err(|error| PythonError::from_pyerr(py, error, "callback", "foreign callback"))?;
+        object_ops::store_object(callback.into_any().unbind())
+    })
+    .map_err(PythonError::runtime)??;
+    Ok(ForeignCallback {
+        object,
+        owner,
+        target: None,
+        closed: Cell::new(false),
+        retained: Cell::new(false),
+        admission: callback_admission,
+        _not_send: PhantomData,
+    })
+}
+
+fn admit(
+    owner: &CallbackOwnerState,
+    callback_id: u64,
+    concurrency: ForeignCallbackConcurrency,
+    admission: &Mutex<()>,
+    fifo: &Arc<FifoSerial>,
+) -> PyResult<(super::CallbackInvocationLease, Option<FifoTicket>)> {
+    if concurrency == ForeignCallbackConcurrency::Serial {
+        owner
+            .reject_serial_reentrancy(callback_id)
+            .map_err(python_error)?;
+        let _admission = admission
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let invocation = owner.accept(callback_id, true).map_err(python_error)?;
+        Ok((invocation, Some(FifoSerial::reserve(fifo))))
+    } else {
+        owner
+            .accept(callback_id, false)
+            .map(|invocation| (invocation, None))
+            .map_err(python_error)
+    }
+}
+
+#[derive(Default)]
+struct FifoSerial {
+    state: Mutex<FifoState>,
+    changed: Condvar,
+}
+
+#[derive(Default)]
+struct FifoState {
+    next_ticket: u64,
+    serving: u64,
+    cancelled: BTreeSet<u64>,
+}
+
+struct FifoTicket {
+    fifo: Arc<FifoSerial>,
+    ticket: u64,
+    pending: bool,
+}
+
+struct FifoPermit {
+    fifo: Arc<FifoSerial>,
+}
+
+impl FifoSerial {
+    fn reserve(fifo: &Arc<Self>) -> FifoTicket {
+        let mut state = fifo
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let ticket = state.next_ticket;
+        state.next_ticket = state.next_ticket.saturating_add(1);
+        FifoTicket {
+            fifo: Arc::clone(fifo),
+            ticket,
+            pending: true,
+        }
+    }
+
+    fn cancel(&self, ticket: u64) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if ticket == state.serving {
+            state.serving = state.serving.saturating_add(1);
+            advance_cancelled(&mut state);
+            self.changed.notify_all();
+        } else {
+            state.cancelled.insert(ticket);
+        }
+    }
+}
+
+impl FifoTicket {
+    fn acquire(mut self) -> FifoPermit {
+        let mut state = self
+            .fifo
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while state.serving != self.ticket {
+            state = self
+                .fifo
+                .changed
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+        drop(state);
+        self.pending = false;
+        FifoPermit {
+            fifo: Arc::clone(&self.fifo),
+        }
+    }
+}
+
+impl Drop for FifoTicket {
+    fn drop(&mut self) {
+        if self.pending {
+            self.fifo.cancel(self.ticket);
+        }
+    }
+}
+
+impl Drop for FifoPermit {
+    fn drop(&mut self) {
+        let mut state = self
+            .fifo
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.serving = state.serving.saturating_add(1);
+        advance_cancelled(&mut state);
+        self.fifo.changed.notify_all();
+    }
+}
+
+fn advance_cancelled(state: &mut FifoState) {
+    while state.cancelled.remove(&state.serving) {
+        state.serving = state.serving.saturating_add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::python::{
+        initialize_runtime, reset_runtime_state_for_tests, test_config, test_guard,
+    };
+    use pyo3::types::PyAnyMethods;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Barrier;
+
+    #[test]
+    fn uncommitted_retained_callback_invalidates_escaped_shell_without_closing_group() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("retained-callback-rollback"))
+            .expect("runtime should initialize");
+        let owner = CallbackOwnerState::new_retained(|| Ok(())).expect("owner should create");
+        let callback = foreign_callback_with_owner(
+            owner.clone(),
+            44,
+            1,
+            ForeignCallbackConcurrency::Parallel,
+            |args| crate::python::to_int(&args[0]),
+            |_, value| Ok(value),
+            crate::python::from_int,
+        )
+        .expect("callback should create");
+        let escaped = crate::python::attach(|py| {
+            crate::python::object_ops::clone_handle(py, callback.object())
+        })
+        .expect("runtime should attach")
+        .expect("callable should clone");
+        drop(callback);
+
+        assert_eq!(owner.status(), super::super::CallbackOwnerStatus::Open);
+        let exception = crate::python::attach(|py| match escaped.bind(py).call1((1_i64,)) {
+            Ok(_) => Ok(None),
+            Err(error) => error
+                .get_type(py)
+                .getattr("__name__")
+                .and_then(|name| name.extract::<String>())
+                .map(Some),
+        })
+        .expect("runtime should attach")
+        .expect("exception name should resolve");
+        assert_eq!(exception.as_deref(), Some("SifrCallbackClosedError"));
+        owner
+            .shutdown_from_runtime()
+            .expect("group should remain independently closeable");
+    }
+
+    #[test]
+    fn escaped_retained_callable_rejects_before_validating_after_owner_close() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("retained-callback-after-close"))
+            .expect("runtime should initialize");
+        let owner = CallbackOwnerState::new_retained(|| Ok(())).expect("owner should create");
+        let callback = foreign_callback_with_owner(
+            owner.clone(),
+            31,
+            1,
+            ForeignCallbackConcurrency::Parallel,
+            |args| crate::python::to_int(&args[0]),
+            |_, value| Ok(value),
+            crate::python::from_int,
+        )
+        .expect("callback should create");
+        callback
+            .retain_in_owner()
+            .expect("callable should be retained by owner");
+        let escaped = crate::python::attach(|py| {
+            crate::python::object_ops::clone_handle(py, callback.object())
+        })
+        .expect("runtime should attach")
+        .expect("callable should clone");
+
+        let unregister = owner
+            .begin_owner_unregister()
+            .expect("unregister should begin");
+        drop(unregister);
+        owner
+            .close_after_owner_unregister()
+            .expect("owner should close");
+        for outcome in crate::python::attach(|py| {
+            [escaped.bind(py).call1((1_i64,)), escaped.bind(py).call0()]
+                .into_iter()
+                .map(|outcome| match outcome {
+                    Ok(_) => Ok(None),
+                    Err(error) => error
+                        .get_type(py)
+                        .getattr("__name__")
+                        .and_then(|name| name.extract::<String>())
+                        .map(Some),
+                })
+                .collect::<Vec<_>>()
+        })
+        .expect("runtime should attach")
+        {
+            let exception_name = outcome
+                .expect("exception name should resolve")
+                .expect("escaped callable must reject entry after close");
+            assert_eq!(exception_name, "SifrCallbackClosedError");
+        }
+    }
+
+    #[test]
+    fn serial_conversion_failure_does_not_strand_fifo_admission() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("foreign-serial-conversion"))
+            .expect("runtime should initialize");
+        let callback = foreign_callback(
+            45,
+            1,
+            ForeignCallbackConcurrency::Serial,
+            |args| crate::python::to_int(&args[0]),
+            |_, value| Ok(value),
+            crate::python::from_int,
+        )
+        .expect("callback should create");
+        let wrong = crate::python::from_str("wrong").expect("argument should create");
+        crate::python::call_object_owned(callback.object(), &[wrong], &[])
+            .expect_err("conversion should fail before FIFO admission");
+        let valid = crate::python::from_int(7).expect("argument should create");
+        let result = crate::python::call_object_owned(callback.object(), &[valid], &[])
+            .and_then(|value| crate::python::to_int(&value))
+            .expect("later serial invocation must not be stranded");
+        assert_eq!(result, 7);
+        callback.close_call_scope().expect("callback should close");
+    }
+
+    #[test]
+    fn call_scope_close_drains_borrowed_target_while_decoding() {
+        let _guard = test_guard();
+        reset_runtime_state_for_tests();
+        initialize_runtime(test_config("foreign-decode-drain")).expect("runtime should initialize");
+        let entered_decode = Arc::new(Barrier::new(2));
+        let release_decode = Arc::new(Barrier::new(2));
+        let borrowed_decode_count = AtomicUsize::new(0);
+        let entered_for_decode = Arc::clone(&entered_decode);
+        let release_for_decode = Arc::clone(&release_decode);
+        let callback = foreign_callback(
+            46,
+            1,
+            ForeignCallbackConcurrency::Parallel,
+            |args| {
+                borrowed_decode_count.fetch_add(1, Ordering::SeqCst);
+                entered_for_decode.wait();
+                release_for_decode.wait();
+                crate::python::to_int(&args[0])
+            },
+            |_, value| Ok(value),
+            crate::python::from_int,
+        )
+        .expect("callback should create");
+        let escaped = callback.object().clone();
+        let invocation = std::thread::spawn(move || {
+            let argument = crate::python::from_int(9).expect("argument should create");
+            crate::python::call_object_owned(&escaped, &[argument], &[])
+                .and_then(|result| crate::python::to_int(&result))
+                .expect("callback should finish")
+        });
+        entered_decode.wait();
+
+        let owner = callback.owner().clone();
+        let close_finished = Arc::new(AtomicBool::new(false));
+        let close_finished_in_thread = Arc::clone(&close_finished);
+        let close = std::thread::spawn(move || {
+            owner.close_call_scope().expect("close should drain decode");
+            close_finished_in_thread.store(true, Ordering::SeqCst);
+        });
+        while callback.owner().status() == super::super::CallbackOwnerStatus::Open {
+            std::thread::yield_now();
+        }
+        assert!(!close_finished.load(Ordering::SeqCst));
+        assert_eq!(borrowed_decode_count.load(Ordering::SeqCst), 1);
+
+        release_decode.wait();
+        close.join().expect("close thread should join");
+        drop(callback);
+        assert_eq!(invocation.join().expect("invocation should join"), 9);
+    }
+}

--- a/crates/sifr_runtime/src/python/callbacks/mod.rs
+++ b/crates/sifr_runtime/src/python/callbacks/mod.rs
@@ -1,7 +1,25 @@
+mod current;
 mod errors;
+mod execution;
+mod foreign;
+mod ownership;
 mod registry;
 mod state;
 
+pub use current::{current_callback, current_callback_with_owner, CurrentCallback};
+pub use execution::{
+    attach_callback_failure_evidence, CallbackExecutionError, CallbackFailureSlot,
+    CallbackHandlerFailure,
+};
+pub use foreign::{
+    foreign_callback, foreign_callback_scoped_with_owner, foreign_callback_with_owner,
+    ForeignCallback, ForeignCallbackConcurrency,
+};
+pub use ownership::{
+    context_exit_normal_with_callbacks, context_exit_python_error_with_callbacks,
+    context_exit_sifr_cause_with_callbacks, semantic_close_with_callbacks, CallbackOwnerSlot,
+    RetainedCallbackCleanup, RetainedCallbackGroup,
+};
 pub use state::{
     CallbackFailureEvidence, CallbackInvocationGuard, CallbackInvocationLease, CallbackOwnerState,
     CallbackOwnerStatus, CallbackOwnerUnregisterGuard,

--- a/crates/sifr_runtime/src/python/callbacks/ownership.rs
+++ b/crates/sifr_runtime/src/python/callbacks/ownership.rs
@@ -1,0 +1,221 @@
+use super::CallbackOwnerState;
+use crate::python::{
+    context_exit_normal, context_exit_python_error, context_exit_sifr_cause, object_ops,
+    semantic_close, ObjectHandle, PythonError, PythonExitDecision, SifrExitCause,
+};
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+type UnregisterAction = Arc<dyn Fn() -> Result<(), PythonError> + Send + Sync + 'static>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RetainedCallbackCleanup {
+    Close,
+    Context,
+}
+
+pub struct RetainedCallbackGroup {
+    owner: CallbackOwnerState,
+    unregister: Arc<Mutex<Option<UnregisterAction>>>,
+    committed: bool,
+}
+
+pub struct CallbackOwnerSlot {
+    owner: Mutex<Option<CallbackOwnerState>>,
+}
+
+impl fmt::Debug for CallbackOwnerSlot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let owner = self
+            .owner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        formatter
+            .debug_struct("CallbackOwnerSlot")
+            .field(
+                "owner_id",
+                &owner.as_ref().map(CallbackOwnerState::owner_id),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl RetainedCallbackGroup {
+    pub fn new() -> Result<Self, PythonError> {
+        let unregister = Arc::new(Mutex::new(None::<UnregisterAction>));
+        let deferred = Arc::clone(&unregister);
+        let owner = CallbackOwnerState::new_retained(move || {
+            let action = deferred
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            action.map_or(Ok(()), |action| action())
+        })?;
+        Ok(Self {
+            owner,
+            unregister,
+            committed: false,
+        })
+    }
+
+    #[must_use]
+    pub fn owner(&self) -> &CallbackOwnerState {
+        &self.owner
+    }
+
+    pub fn commit_for_object(
+        &mut self,
+        object: &ObjectHandle,
+        cleanup: RetainedCallbackCleanup,
+    ) -> Result<CallbackOwnerState, PythonError> {
+        let action = unregister_action(object.clone(), cleanup);
+        let mut unregister = self
+            .unregister
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if unregister.is_some() {
+            return Err(super::errors::unavailable(
+                "retained callback owner already committed",
+            ));
+        }
+        *unregister = Some(action);
+        self.committed = true;
+        Ok(self.owner.clone())
+    }
+}
+
+impl Drop for RetainedCallbackGroup {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        if let Ok(guard) = self.owner.begin_owner_unregister() {
+            drop(guard);
+        }
+        let _ignored = self.owner.close_after_owner_unregister();
+    }
+}
+
+impl CallbackOwnerSlot {
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            owner: Mutex::new(None),
+        }
+    }
+
+    #[must_use]
+    pub fn from_owner(owner: CallbackOwnerState) -> Self {
+        Self {
+            owner: Mutex::new(Some(owner)),
+        }
+    }
+
+    pub fn owner_or_insert(
+        &self,
+        object: &ObjectHandle,
+        cleanup: RetainedCallbackCleanup,
+    ) -> Result<CallbackOwnerState, PythonError> {
+        let mut slot = self
+            .owner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(owner) = slot.as_ref() {
+            return Ok(owner.clone());
+        }
+        let action = unregister_action(object.clone(), cleanup);
+        let owner = CallbackOwnerState::new_retained(move || action())?;
+        *slot = Some(owner.clone());
+        Ok(owner)
+    }
+
+    #[must_use]
+    pub fn owner(&self) -> Option<CallbackOwnerState> {
+        self.owner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    fn take(self) -> Option<CallbackOwnerState> {
+        self.owner
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+pub fn semantic_close_with_callbacks(
+    object: ObjectHandle,
+    method: impl AsRef<str>,
+    callbacks: CallbackOwnerSlot,
+) -> Result<(), PythonError> {
+    let Some(owner) = callbacks.take() else {
+        return semantic_close(object, method);
+    };
+    let unregister = owner.begin_owner_unregister()?;
+    let primary = semantic_close(object, method);
+    drop(unregister);
+    let callback_close = owner.close_after_owner_unregister_with_typed_observer();
+    match primary {
+        Err(primary) => super::attach_callback_failure_evidence::<()>(Err(primary), &[&owner]),
+        Ok(()) => callback_close,
+    }
+}
+
+pub fn context_exit_normal_with_callbacks(
+    object: ObjectHandle,
+    callbacks: CallbackOwnerSlot,
+) -> Result<PythonExitDecision, PythonError> {
+    finish_context_callbacks(callbacks, true, || context_exit_normal(object))
+}
+
+pub fn context_exit_python_error_with_callbacks(
+    object: ObjectHandle,
+    error: &PythonError,
+    callbacks: CallbackOwnerSlot,
+) -> Result<PythonExitDecision, PythonError> {
+    finish_context_callbacks(callbacks, false, || {
+        context_exit_python_error(object, error)
+    })
+}
+
+pub fn context_exit_sifr_cause_with_callbacks(
+    object: ObjectHandle,
+    cause: &SifrExitCause,
+    callbacks: CallbackOwnerSlot,
+) -> Result<PythonExitDecision, PythonError> {
+    finish_context_callbacks(callbacks, false, || context_exit_sifr_cause(object, cause))
+}
+
+fn finish_context_callbacks(
+    callbacks: CallbackOwnerSlot,
+    typed_observer: bool,
+    exit: impl FnOnce() -> Result<PythonExitDecision, PythonError>,
+) -> Result<PythonExitDecision, PythonError> {
+    let Some(owner) = callbacks.take() else {
+        return exit();
+    };
+    let unregister = owner.begin_owner_unregister()?;
+    let primary = exit();
+    drop(unregister);
+    let callback_close = if typed_observer {
+        owner.close_after_owner_unregister_with_typed_observer()
+    } else {
+        owner.close_after_owner_unregister()
+    };
+    match primary {
+        Err(primary) => Err(primary),
+        Ok(decision) => callback_close.map(|()| decision),
+    }
+}
+
+fn unregister_action(object: ObjectHandle, cleanup: RetainedCallbackCleanup) -> UnregisterAction {
+    Arc::new(move || match cleanup {
+        RetainedCallbackCleanup::Close => semantic_close(object.clone(), "close"),
+        RetainedCallbackCleanup::Context => context_exit_normal(object.clone()).map(|_decision| ()),
+    })
+}
+
+pub(super) fn release_callable(object: ObjectHandle) {
+    let _ignored = object_ops::close_object(object);
+}

--- a/crates/sifr_runtime/src/python/callbacks/state.rs
+++ b/crates/sifr_runtime/src/python/callbacks/state.rs
@@ -37,7 +37,7 @@ pub(super) struct CallbackOwnerInner {
     state: Mutex<OwnerData>,
     changed: Condvar,
     unregister: Option<UnregisterAction>,
-    release: Mutex<Option<CaptureReleaseAction>>,
+    releases: Mutex<Vec<CaptureReleaseAction>>,
     retained: bool,
 }
 
@@ -46,6 +46,7 @@ struct OwnerData {
     active_calls: usize,
     next_sequence: u64,
     first_failure: Option<CallbackFailureEvidence>,
+    first_failure_observed: bool,
     captures_released: bool,
     unregister_status: CallbackUnregisterStatus,
 }
@@ -119,12 +120,13 @@ impl CallbackOwnerState {
                 active_calls: 0,
                 next_sequence: 0,
                 first_failure: None,
+                first_failure_observed: false,
                 captures_released: false,
                 unregister_status: CallbackUnregisterStatus::NotStarted,
             }),
             changed: Condvar::new(),
             unregister,
-            release: Mutex::new(release),
+            releases: Mutex::new(release.into_iter().collect()),
             retained,
         });
         if retained {
@@ -188,13 +190,20 @@ impl CallbackOwnerState {
         })
     }
 
+    pub fn reject_serial_reentrancy(&self, callback_id: u64) -> Result<(), PythonError> {
+        if callback_is_active(self.inner.id, callback_id) {
+            return Err(errors::reentrant(self.inner.id, callback_id));
+        }
+        Ok(())
+    }
+
     pub fn close_call_scope(&self) -> Result<(), PythonError> {
         if self.inner.retained {
             return Err(errors::unavailable(
                 "retained owner close without unregister authority",
             ));
         }
-        self.close_after_unregister(false)
+        self.close_after_unregister(false, true)
     }
 
     pub fn close_after_owner_unregister(&self) -> Result<(), PythonError> {
@@ -204,7 +213,17 @@ impl CallbackOwnerState {
                 return Err(errors::unavailable("owner unregister authority"));
             }
         }
-        self.close_after_unregister(false)
+        self.close_after_unregister(false, true)
+    }
+
+    pub fn close_after_owner_unregister_with_typed_observer(&self) -> Result<(), PythonError> {
+        if self.inner.unregister.is_some() {
+            let state = lock_state(&self.inner);
+            if state.unregister_status == CallbackUnregisterStatus::NotStarted {
+                return Err(errors::unavailable("owner unregister authority"));
+            }
+        }
+        self.close_after_unregister(false, false)
     }
 
     pub fn begin_owner_unregister(
@@ -244,7 +263,36 @@ impl CallbackOwnerState {
                 exception_type: exception_type.into(),
                 message: message.into(),
             });
+            state.first_failure_observed = false;
         }
+    }
+
+    pub fn observe_failure(&self, entry_sequence: u64) {
+        let mut state = lock_state(&self.inner);
+        if state
+            .first_failure
+            .as_ref()
+            .map(|failure| failure.entry_sequence)
+            == Some(entry_sequence)
+        {
+            state.first_failure_observed = true;
+        }
+    }
+
+    pub fn retain_capture(
+        &self,
+        release: impl FnOnce() + Send + 'static,
+    ) -> Result<(), PythonError> {
+        let state = lock_state(&self.inner);
+        if state.status != CallbackOwnerStatus::Open {
+            return Err(errors::closed(self.inner.id));
+        }
+        self.inner
+            .releases
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(Box::new(release));
+        Ok(())
     }
 
     #[must_use]
@@ -262,11 +310,15 @@ impl CallbackOwnerState {
                 drop(unregister_guard);
             }
         }
-        self.close_after_unregister(true)?;
-        unregister_error.map_or(Ok(()), Err)
+        let close_error = self.close_after_unregister(true, true).err();
+        unregister_error.or(close_error).map_or(Ok(()), Err)
     }
 
-    fn close_after_unregister(&self, runtime_shutdown: bool) -> Result<(), PythonError> {
+    fn close_after_unregister(
+        &self,
+        runtime_shutdown: bool,
+        surface_retained_failure: bool,
+    ) -> Result<(), PythonError> {
         if !runtime_shutdown && owner_is_active(self.inner.id) {
             return Err(errors::close_from_invocation(self.inner.id));
         }
@@ -279,7 +331,10 @@ impl CallbackOwnerState {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
         }
         match state.status {
-            CallbackOwnerStatus::Closed => return Ok(()),
+            CallbackOwnerStatus::Closed => {
+                drop(state);
+                return self.retained_failure_result(surface_retained_failure);
+            }
             CallbackOwnerStatus::Closing => {
                 while state.status != CallbackOwnerStatus::Closed {
                     state = self
@@ -288,7 +343,8 @@ impl CallbackOwnerState {
                         .wait(state)
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
                 }
-                return Ok(());
+                drop(state);
+                return self.retained_failure_result(surface_retained_failure);
             }
             CallbackOwnerStatus::Open => {
                 state.status = CallbackOwnerStatus::Closing;
@@ -302,13 +358,14 @@ impl CallbackOwnerState {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
         }
         drop(state);
-        let release = self
-            .inner
-            .release
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        if let Some(release) = release {
+        let releases = std::mem::take(
+            &mut *self
+                .inner
+                .releases
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+        for release in releases {
             release();
         }
         let mut state = lock_state(&self.inner);
@@ -318,6 +375,18 @@ impl CallbackOwnerState {
         drop(state);
         if self.inner.retained {
             registry::unregister(self.inner.id);
+        }
+        self.retained_failure_result(surface_retained_failure)
+    }
+
+    fn retained_failure_result(&self, surface: bool) -> Result<(), PythonError> {
+        if self.inner.retained && surface {
+            let state = lock_state(&self.inner);
+            if !state.first_failure_observed {
+                if let Some(evidence) = &state.first_failure {
+                    return Err(errors::recorded_handler_failure(self.inner.id, evidence));
+                }
+            }
         }
         Ok(())
     }

--- a/crates/sifr_runtime/src/python/callbacks/tests.rs
+++ b/crates/sifr_runtime/src/python/callbacks/tests.rs
@@ -1,11 +1,22 @@
 use super::errors::registered_exception_names;
 use super::registry::{retained_owner_count, shutdown_registered_callback_owners};
-use super::{CallbackOwnerState, CallbackOwnerStatus};
-use crate::python::{
-    initialize_runtime, reset_runtime_state_for_tests, test_config, test_guard, PythonError,
+use super::{
+    attach_callback_failure_evidence, current_callback, current_callback_with_owner,
+    foreign_callback, foreign_callback_with_owner, CallbackExecutionError, CallbackFailureSlot,
+    CallbackHandlerFailure, CallbackOwnerSlot, CallbackOwnerState, CallbackOwnerStatus,
+    ForeignCallbackConcurrency, RetainedCallbackCleanup, RetainedCallbackGroup,
 };
+use crate::python::{
+    call_object_owned, close_object, context_exit_normal_with_callbacks, enter_context, from_int,
+    from_str, initialize_runtime, reset_runtime_state_for_tests, resolve_target,
+    semantic_close_with_callbacks, test_config, test_guard, to_int, ObjectHandle, PythonError,
+};
+use pyo3::types::PyAnyMethods;
+use std::cell::Cell;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
+use std::time::Duration;
 
 #[test]
 fn runtime_initialization_registers_stable_callback_exception_types() {
@@ -23,8 +34,368 @@ fn runtime_initialization_registers_stable_callback_exception_types() {
             "SifrCallbackClosedError",
             "SifrCallbackReentrancyError",
             "SifrCallbackCloseReentrancyError",
+            "SifrCallbackThreadError",
         ]
     );
+}
+
+#[test]
+fn current_callback_keeps_non_send_capture_on_creator_thread_and_checks_shape() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("current-callback")).expect("runtime should initialize");
+    let capture = Rc::new(Cell::new(0_i64));
+    let handler_capture = Rc::clone(&capture);
+    let callback = current_callback(
+        1,
+        1,
+        |args| {
+            assert_eq!(unsafe { pyo3::ffi::PyGILState_Check() }, 1);
+            to_int(&args[0])
+        },
+        move |_, value| {
+            handler_capture.set(handler_capture.get() + value);
+            Ok(value + 1)
+        },
+        |value| {
+            assert_eq!(unsafe { pyo3::ffi::PyGILState_Check() }, 1);
+            from_int(value)
+        },
+    )
+    .expect("callback should create");
+
+    let arg = from_int(41).expect("argument should convert");
+    let result = call_object_owned(callback.object(), &[arg], &[])
+        .and_then(|value| to_int(&value))
+        .expect("callback should execute");
+    assert_eq!(result, 42);
+    assert_eq!(capture.get(), 41);
+
+    let shape_error = call_object_owned(callback.object(), &[], &[])
+        .expect_err("wrong arity should fail before the handler");
+    assert_eq!(shape_error.exception_type, "TypeError");
+    let wrong_type = from_str("not-an-int").expect("argument should convert");
+    let conversion_error = call_object_owned(callback.object(), &[wrong_type], &[])
+        .expect_err("wrong argument type should fail before the handler");
+    assert_eq!(conversion_error.exception_type, "TypeError");
+
+    let foreign_handle = callback.object().clone();
+    let thread_error = std::thread::spawn(move || {
+        let arg = from_int(1).expect("argument should convert");
+        call_object_owned(&foreign_handle, &[arg], &[])
+            .expect_err("current callback must reject a foreign thread")
+    })
+    .join()
+    .expect("foreign caller should join");
+    assert_eq!(thread_error.exception_type, "SifrCallbackThreadError");
+    callback.close().expect("call scope should close");
+}
+
+#[test]
+fn callback_result_conversion_failure_crosses_python_as_type_error() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("callback-result-conversion"))
+        .expect("runtime should initialize");
+    let callback = current_callback(
+        22,
+        1,
+        |args| to_int(&args[0]),
+        |_, value| Ok(value),
+        |_value| {
+            Err(PythonError::without_replay(
+                "conversion",
+                "TypeError",
+                "callback result has the wrong type",
+                "",
+                "callback result",
+            ))
+        },
+    )
+    .expect("callback should create");
+    let arg = from_int(1).expect("argument should convert");
+    let error = call_object_owned(callback.object(), &[arg], &[])
+        .expect_err("result conversion should fail");
+    assert_eq!(error.exception_type, "TypeError");
+    callback.close().expect("callback should close");
+}
+
+#[test]
+fn call_scoped_callbacks_accept_borrowed_handler_state() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("scoped-callback-borrows")).expect("runtime should initialize");
+
+    let current_total = Cell::new(0_i64);
+    {
+        let callback = current_callback(
+            20,
+            1,
+            |args| to_int(&args[0]),
+            |_, value| {
+                current_total.set(current_total.get() + value);
+                Ok(value)
+            },
+            from_int,
+        )
+        .expect("borrowed current callback should create");
+        let arg = from_int(3).expect("argument should convert");
+        call_object_owned(callback.object(), &[arg], &[]).expect("callback should execute");
+        callback.close().expect("callback should close");
+    }
+    assert_eq!(current_total.get(), 3);
+
+    let foreign_total = AtomicUsize::new(0);
+    {
+        let callback = foreign_callback(
+            21,
+            1,
+            ForeignCallbackConcurrency::Parallel,
+            |args| to_int(&args[0]),
+            |_, value| {
+                foreign_total.fetch_add(usize::try_from(value).unwrap_or(0), Ordering::SeqCst);
+                Ok(value)
+            },
+            from_int,
+        )
+        .expect("borrowed foreign callback should create");
+        invoke_from_threads(callback.object(), 4);
+        callback.close_call_scope().expect("callback should close");
+    }
+    assert_eq!(foreign_total.load(Ordering::SeqCst), 6);
+}
+
+#[test]
+fn handler_failure_raises_registered_error_and_retains_first_entry_evidence() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("callback-handler-error")).expect("runtime should initialize");
+    let callback = current_callback(
+        2,
+        1,
+        |args| to_int(&args[0]),
+        |_, _| -> Result<i64, CallbackExecutionError> {
+            Err(CallbackExecutionError::Handler(
+                CallbackHandlerFailure::new("DomainError", "handler rejected value"),
+            ))
+        },
+        from_int,
+    )
+    .expect("callback should create");
+    let arg = from_int(7).expect("argument should convert");
+    let error = call_object_owned(callback.object(), &[arg], &[])
+        .expect_err("handler failure should cross Python as a registered error");
+    assert_eq!(error.exception_type, "SifrCallbackError");
+    let evidence = callback
+        .owner()
+        .first_failure()
+        .expect("typed adapter should retain redacted evidence");
+    assert_eq!(evidence.entry_sequence, 1);
+    assert_eq!(evidence.exception_type, "DomainError");
+    assert_eq!(evidence.message, "handler rejected value");
+    callback.close().expect("call scope should close");
+}
+
+#[test]
+fn swallowed_python_callback_error_remains_in_typed_failure_slot() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("swallowed-callback-error")).expect("runtime should initialize");
+    let failures = CallbackFailureSlot::new();
+    let failures_for_handler = failures.clone();
+    let callback = current_callback(
+        23,
+        1,
+        |args| to_int(&args[0]),
+        move |sequence, _| -> Result<i64, CallbackExecutionError> {
+            failures_for_handler.record(sequence, "typed handler failure".to_string());
+            Err(CallbackExecutionError::Handler(
+                CallbackHandlerFailure::new("HandlerError", "handler failed"),
+            ))
+        },
+        from_int,
+    )
+    .expect("callback should create");
+    let catcher = crate::python::attach(|py| {
+        let module = pyo3::types::PyModule::from_code(
+            py,
+            c"def invoke(callback):\n    try:\n        return callback(1)\n    except Exception:\n        return 99\n",
+            c"callback_catcher.py",
+            c"callback_catcher",
+        )
+        .expect("catcher module should compile");
+        let invoke = module.getattr("invoke").expect("invoke should exist");
+        super::super::object_ops::store_object(invoke.unbind())
+            .expect("catcher should enter object store")
+    })
+    .expect("runtime should attach");
+    let callback_arg = super::super::object_ops::temporary_argument_handle(callback.object())
+        .expect("callback argument should clone");
+    let result = call_object_owned(&catcher, &[callback_arg], &[])
+        .and_then(|value| to_int(&value))
+        .expect("Python target should swallow the callback exception");
+    assert_eq!(result, 99);
+    assert_eq!(failures.take().as_deref(), Some("typed handler failure"));
+    callback.close().expect("callback should close");
+    close_object(catcher).expect("catcher should close");
+}
+
+#[test]
+fn python_error_remains_primary_with_callback_failure_as_secondary_evidence() {
+    let owner = CallbackOwnerState::new_call_scoped().expect("owner should create");
+    owner.record_failure(4, "HandlerError", "handler failed");
+    let primary =
+        PythonError::without_replay("call", "ValueError", "target failed", "", "python target");
+    let error = attach_callback_failure_evidence::<()>(Err(primary), &[&owner, &owner])
+        .expect_err("Python failure should remain primary");
+    assert_eq!(error.exception_type, "ValueError");
+    assert!(error.context.contains("python target"));
+    assert!(error.context.contains("secondary Sifr callback failure"));
+    assert!(error.context.contains("HandlerError at entry 4"));
+    assert_eq!(
+        error
+            .context
+            .matches("secondary Sifr callback failure")
+            .count(),
+        1
+    );
+    owner.close_call_scope().expect("owner should close");
+}
+
+#[test]
+fn foreign_serial_callback_is_fifo_and_runs_without_the_gil() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("foreign-serial-callback")).expect("runtime should initialize");
+    let execution_order = Arc::new(Mutex::new(Vec::new()));
+    let active = Arc::new(AtomicUsize::new(0));
+    let max_active = Arc::new(AtomicUsize::new(0));
+    let order_for_handler = Arc::clone(&execution_order);
+    let active_for_handler = Arc::clone(&active);
+    let max_for_handler = Arc::clone(&max_active);
+    let callback = foreign_callback(
+        3,
+        1,
+        ForeignCallbackConcurrency::Serial,
+        |args| {
+            assert_eq!(unsafe { pyo3::ffi::PyGILState_Check() }, 1);
+            to_int(&args[0])
+        },
+        move |entry_sequence, value| {
+            assert_eq!(unsafe { pyo3::ffi::PyGILState_Check() }, 0);
+            let now = active_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+            max_for_handler.fetch_max(now, Ordering::SeqCst);
+            order_for_handler
+                .lock()
+                .expect("order lock")
+                .push(entry_sequence);
+            std::thread::sleep(Duration::from_millis(5));
+            active_for_handler.fetch_sub(1, Ordering::SeqCst);
+            Ok(value)
+        },
+        |value| {
+            assert_eq!(unsafe { pyo3::ffi::PyGILState_Check() }, 1);
+            from_int(value)
+        },
+    )
+    .expect("callback should create");
+    invoke_from_threads(callback.object(), 8);
+    assert_eq!(max_active.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *execution_order.lock().expect("order lock"),
+        (1_u64..=8).collect::<Vec<_>>()
+    );
+    callback
+        .close_call_scope()
+        .expect("foreign call scope should close");
+}
+
+#[test]
+fn foreign_parallel_overlaps_and_serial_reentrancy_fails_before_handler_lock() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("foreign-parallel-callback"))
+        .expect("runtime should initialize");
+    let entered = Arc::new(Barrier::new(4));
+    let active = Arc::new(AtomicUsize::new(0));
+    let max_active = Arc::new(AtomicUsize::new(0));
+    let entered_for_handler = Arc::clone(&entered);
+    let active_for_handler = Arc::clone(&active);
+    let max_for_handler = Arc::clone(&max_active);
+    let parallel = foreign_callback(
+        4,
+        1,
+        ForeignCallbackConcurrency::Parallel,
+        |args| to_int(&args[0]),
+        move |_, value| {
+            let now = active_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+            max_for_handler.fetch_max(now, Ordering::SeqCst);
+            entered_for_handler.wait();
+            active_for_handler.fetch_sub(1, Ordering::SeqCst);
+            Ok(value)
+        },
+        from_int,
+    )
+    .expect("parallel callback should create");
+    invoke_from_threads(parallel.object(), 4);
+    assert_eq!(max_active.load(Ordering::SeqCst), 4);
+    parallel
+        .close_call_scope()
+        .expect("parallel scope should close");
+
+    let callback_slot = Arc::new(Mutex::new(None::<ObjectHandle>));
+    let slot_for_handler = Arc::clone(&callback_slot);
+    let owner = CallbackOwnerState::new_call_scoped().expect("owner should create");
+    let reentrant = foreign_callback_with_owner(
+        owner.clone(),
+        5,
+        1,
+        ForeignCallbackConcurrency::Serial,
+        |args| to_int(&args[0]),
+        move |_, value| {
+            let callback = slot_for_handler
+                .lock()
+                .expect("callback slot")
+                .clone()
+                .expect("callback should be installed");
+            let arg = from_int(value)?;
+            call_object_owned(&callback, &[arg], &[])
+                .map(|_| value)
+                .map_err(CallbackExecutionError::from)
+        },
+        from_int,
+    )
+    .expect("serial callback should create");
+    *callback_slot.lock().expect("callback slot") = Some(reentrant.object().clone());
+    let arg = from_int(1).expect("argument should convert");
+    let error = call_object_owned(reentrant.object(), &[arg], &[])
+        .expect_err("recursive serial entry should fail");
+    assert_eq!(error.exception_type, "SifrCallbackReentrancyError");
+    assert_eq!(owner.active_calls(), 0);
+    reentrant
+        .close_call_scope()
+        .expect("serial scope should close");
+}
+
+fn invoke_from_threads(callback: &ObjectHandle, count: usize) {
+    let start = Arc::new(Barrier::new(count));
+    let mut threads = Vec::new();
+    for value in 0..count {
+        let callback = callback.clone();
+        let start = Arc::clone(&start);
+        threads.push(std::thread::spawn(move || {
+            start.wait();
+            let value = i64::try_from(value).expect("test value should fit");
+            let arg = from_int(value).expect("argument should convert");
+            let result = call_object_owned(&callback, &[arg], &[])
+                .and_then(|value| to_int(&value))
+                .expect("callback should execute");
+            assert_eq!(result, value);
+        }));
+    }
+    for thread in threads {
+        thread.join().expect("callback thread should join");
+    }
 }
 
 #[test]
@@ -234,6 +605,194 @@ fn retained_owner_close_requires_unregister_authority_claim() {
     owner
         .shutdown_from_runtime()
         .expect("runtime should still close owner");
+}
+
+#[test]
+fn retained_owner_shutdown_surfaces_unobserved_handler_failure() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    let owner = CallbackOwnerState::new_retained(|| Ok(())).expect("owner should create");
+    owner.record_failure(3, "HandlerError", "retained handler failed");
+    let error = owner
+        .shutdown_from_runtime()
+        .expect_err("unobserved retained failure should surface at shutdown");
+    assert_eq!(error.exception_type, "SifrCallbackError");
+    assert!(error.message.contains("HandlerError at entry 3"));
+    assert_eq!(owner.status(), CallbackOwnerStatus::Closed);
+    assert_eq!(retained_owner_count(), 0);
+}
+
+#[test]
+fn semantic_close_leaves_retained_failure_for_typed_owner_observer() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("retained-typed-observer")).expect("runtime should initialize");
+    let target = resolve_target(&["contextlib".to_string(), "ExitStack".to_string()])
+        .expect("ExitStack should resolve");
+    let object = call_object_owned(&target, &[], &[]).expect("ExitStack should construct");
+    let failures = CallbackFailureSlot::new();
+    failures.record(1, "typed retained failure".to_string());
+
+    let mut group = RetainedCallbackGroup::new().expect("group should create");
+    group
+        .owner()
+        .record_failure(1, "HandlerError", "retained handler failed");
+    let owner = group
+        .commit_for_object(&object, RetainedCallbackCleanup::Close)
+        .expect("owner should commit");
+    semantic_close_with_callbacks(
+        object,
+        "close",
+        CallbackOwnerSlot::from_owner(owner.clone()),
+    )
+    .expect("semantic cleanup should leave typed handler failure to generated code");
+
+    assert_eq!(
+        failures.take_if_owner_first(&owner).as_deref(),
+        Some("typed retained failure")
+    );
+    assert_eq!(owner.status(), CallbackOwnerStatus::Closed);
+    close_object(target).expect("target should close");
+}
+
+#[test]
+fn shared_call_scope_selects_first_failure_across_callback_parameters() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("shared-call-callback-owner"))
+        .expect("runtime should initialize");
+    let owner = CallbackOwnerState::new_call_scoped().expect("owner should create");
+    let first_slot = CallbackFailureSlot::new();
+    let first_handler_slot = first_slot.clone();
+    let first = current_callback_with_owner(
+        owner.clone(),
+        1,
+        1,
+        |args| to_int(&args[0]),
+        move |sequence, _| -> Result<i64, CallbackExecutionError> {
+            first_handler_slot.record(sequence, "first parameter".to_string());
+            Err(CallbackExecutionError::Handler(
+                CallbackHandlerFailure::new("FirstError", "first parameter failed"),
+            ))
+        },
+        from_int,
+    )
+    .expect("first callback should create");
+    let second_slot = CallbackFailureSlot::new();
+    let second_handler_slot = second_slot.clone();
+    let second = current_callback_with_owner(
+        owner.clone(),
+        2,
+        1,
+        |args| to_int(&args[0]),
+        move |sequence, _| -> Result<i64, CallbackExecutionError> {
+            second_handler_slot.record(sequence, "second parameter".to_string());
+            Err(CallbackExecutionError::Handler(
+                CallbackHandlerFailure::new("SecondError", "second parameter failed"),
+            ))
+        },
+        from_int,
+    )
+    .expect("second callback should create");
+
+    for callback in [&second, &first] {
+        let arg = from_int(1).expect("argument should convert");
+        call_object_owned(callback.object(), &[arg], &[])
+            .expect_err("handler should fail through Python");
+    }
+    assert_eq!(first_slot.take_if_owner_first(&owner), None);
+    assert_eq!(
+        second_slot.take_if_owner_first(&owner).as_deref(),
+        Some("second parameter")
+    );
+    first.close().expect("shared scope should close");
+    second
+        .close()
+        .expect("second callable should close idempotently");
+}
+
+#[test]
+fn retained_group_commits_to_opaque_slot_and_semantic_close_releases_captures() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("retained-callback-slot")).expect("runtime should initialize");
+    let target = resolve_target(&["contextlib".to_string(), "ExitStack".to_string()])
+        .expect("ExitStack should resolve");
+    let object = call_object_owned(&target, &[], &[]).expect("ExitStack should construct");
+
+    let released = Arc::new(AtomicUsize::new(0));
+    let released_by_owner = Arc::clone(&released);
+    let mut group = RetainedCallbackGroup::new().expect("group should create");
+    group
+        .owner()
+        .retain_capture(move || {
+            released_by_owner.fetch_add(1, Ordering::SeqCst);
+        })
+        .expect("capture should attach");
+    let owner = group
+        .commit_for_object(&object, RetainedCallbackCleanup::Close)
+        .expect("owner should commit");
+    let slot = CallbackOwnerSlot::from_owner(owner.clone());
+
+    semantic_close_with_callbacks(object, "close", slot)
+        .expect("semantic close should unregister and drain callbacks");
+    assert_eq!(owner.status(), CallbackOwnerStatus::Closed);
+    assert_eq!(released.load(Ordering::SeqCst), 1);
+    assert_eq!(retained_owner_count(), 0);
+    close_object(target).expect("target should close");
+}
+
+#[test]
+fn retained_context_owner_exits_before_callback_capture_release() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("retained-context-callback-slot"))
+        .expect("runtime should initialize");
+    let target = resolve_target(&["contextlib".to_string(), "ExitStack".to_string()])
+        .expect("ExitStack should resolve");
+    let object = call_object_owned(&target, &[], &[]).expect("ExitStack should construct");
+    let entered = enter_context(&object).expect("context should enter");
+    close_object(entered).expect("entered alias should close");
+
+    let released = Arc::new(AtomicUsize::new(0));
+    let released_by_owner = Arc::clone(&released);
+    let mut group = RetainedCallbackGroup::new().expect("group should create");
+    group
+        .owner()
+        .retain_capture(move || {
+            released_by_owner.fetch_add(1, Ordering::SeqCst);
+        })
+        .expect("capture should attach");
+    let owner = group
+        .commit_for_object(&object, RetainedCallbackCleanup::Context)
+        .expect("owner should commit");
+    let slot = CallbackOwnerSlot::from_owner(owner.clone());
+
+    context_exit_normal_with_callbacks(object, slot).expect("context exit should drain callbacks");
+    assert_eq!(owner.status(), CallbackOwnerStatus::Closed);
+    assert_eq!(released.load(Ordering::SeqCst), 1);
+    close_object(target).expect("target should close");
+}
+
+#[test]
+fn uncommitted_retained_group_releases_provisional_captures() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    let released = Arc::new(AtomicUsize::new(0));
+    let released_by_owner = Arc::clone(&released);
+    let owner = {
+        let group = RetainedCallbackGroup::new().expect("group should create");
+        group
+            .owner()
+            .retain_capture(move || {
+                released_by_owner.fetch_add(1, Ordering::SeqCst);
+            })
+            .expect("capture should attach");
+        group.owner().clone()
+    };
+    assert_eq!(owner.status(), CallbackOwnerStatus::Closed);
+    assert_eq!(released.load(Ordering::SeqCst), 1);
+    assert_eq!(retained_owner_count(), 0);
 }
 
 #[test]

--- a/crates/sifr_runtime/src/python/object_ops_tests.rs
+++ b/crates/sifr_runtime/src/python/object_ops_tests.rs
@@ -1,7 +1,7 @@
 use super::object_ops::*;
 use super::{
     initialize_runtime, list_items, record_field, reset_runtime_state_for_tests, semantic_close,
-    shutdown_diagnostics, test_config, test_guard, PythonRuntimeDiagnostics,
+    shutdown_diagnostics, test_config, test_guard, tuple_items_exact, PythonRuntimeDiagnostics,
 };
 
 #[test]
@@ -190,6 +190,10 @@ fn recursive_handles_report_exact_nested_paths_and_required_record_fields() {
     let error = to_int(&inner_item).expect_err("nested conversion should fail");
     assert!(error.context.contains("[0][0]"), "{error:?}");
 
+    let tuple = from_tuple(std::slice::from_ref(&bad)).expect("tuple should be stored");
+    let tuple_error = tuple_items_exact(&tuple, 2).expect_err("wrong tuple arity should fail");
+    assert!(tuple_error.message.contains("tuple of length 2"));
+
     let record = from_record(&[("present", bad.clone()), ("extra", bad.clone())])
         .expect("record should be stored");
     let present = record_field(&record, "present").expect("required field should extract");
@@ -198,7 +202,9 @@ fn recursive_handles_report_exact_nested_paths_and_required_record_fields() {
     drop(error);
     drop(missing);
 
-    for handle in [bad, inner, outer, outer_item, inner_item, record, present] {
+    for handle in [
+        bad, inner, outer, outer_item, inner_item, tuple, record, present,
+    ] {
         close_object(handle).expect("object should close");
     }
     assert_eq!(

--- a/crates/sifr_runtime/src/python/recursive_ops.rs
+++ b/crates/sifr_runtime/src/python/recursive_ops.rs
@@ -98,6 +98,20 @@ pub fn tuple_items(object: &ObjectHandle) -> Result<Vec<ObjectHandle>, PythonErr
     .map_err(PythonError::runtime)?
 }
 
+pub fn tuple_items_exact(
+    object: &ObjectHandle,
+    expected_len: usize,
+) -> Result<Vec<ObjectHandle>, PythonError> {
+    let items = tuple_items(object)?;
+    if items.len() != expected_len {
+        return Err(conversion_error(
+            format!("expected Python tuple of length {expected_len}"),
+            object.boundary_path(),
+        ));
+    }
+    Ok(items)
+}
+
 pub fn dict_str_items(object: &ObjectHandle) -> Result<Vec<(String, ObjectHandle)>, PythonError> {
     let parent_path = object.boundary_path().to_string();
     super::attach(|py| {


### PR DESCRIPTION
## Summary

- add checked current-thread and foreign-thread callback trampolines with typed argument/result conversion
- enforce shared owner admission, serial FIFO/reentrancy rules, concurrent close draining, callback-after-close rejection, and first-failure evidence
- integrate retained result/Self callback groups with generated opaque-owner cleanup and typed handler-error reconciliation
- preserve owned callable conventions only where callback ownership requires them and split callback/conversion code by responsibility

## Safety review

- audited lifetime-erased callback targets and extended owner admission across validation, decode, detached handler execution, and result encoding
- verified close rejects new calls before borrowed targets can be released and drains all accepted calls
- verified serial conversion failures cancel FIFO tickets and cannot strand later callers
- frozen diff has no formatting, whitespace, submodule, file-size, or HIR-maintainability violations

## Validation

- `scripts/run_all_tests.sh --profile create-pr`: pass; 131/131 E2E; zero failures
- `scripts/run_all_tests.sh`: pass; 651/651 E2E; 261 hardening variants; zero failures; zero blocking failures
- merge E2E signature: `ee5e5d44306f270c`
- targeted callback runtime, lowering, codegen, and Python-runtime suites passed before the authoritative gates

## Phase

M9 Wave 2 of `plans/issues/active/ad-hoc-declaration-first-python-interop.md`. Public callback syntax remains gated until Wave 3 adds asyncio dispatch and atomic activation evidence.