### PR TITLE
Prove Python callback capture safety

### DIFF
--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -604,6 +604,15 @@ pub(in crate::lower) fn collect_class_type(
                     // For @classmethod and regular methods, skip `self`/`cls`
                     let is_static = has_decorator(func, "staticmethod");
                     let skip_count = usize::from(!is_static);
+                    let callback_policies = crate::lower::python_interop::callback_call_policies(
+                        &func.decorator_list,
+                        &func.parameters,
+                        !is_static,
+                    );
+                    if !callback_policies.is_empty() {
+                        ctx.python_callback_call_policies
+                            .insert(format!("{class_name}.{method_name}"), callback_policies);
+                    }
                     let mut params = Vec::new();
                     let mut method_locals: HashMap<String, Type> = HashMap::new();
                     for param in func.parameters.args.iter().skip(skip_count) {

--- a/crates/sifr_lowering/src/lower/expressions.rs
+++ b/crates/sifr_lowering/src/lower/expressions.rs
@@ -34,7 +34,7 @@ use super::generic_constructor_specialization::refine_constructor_return_type_fr
 use super::generic_receiver_specialization::refine_generic_class_binding_expr;
 use super::method_call_args::{
     lower_function_call_args, lower_method_call_args, lower_python_function_call_args,
-    lower_signature_call_args, resolved_method_arg_ranges,
+    lower_signature_call_args,
 };
 use super::method_diagnostics::{
     method_count_range, reject_exact_method_arg_count, reject_max_method_arg_count,

--- a/crates/sifr_lowering/src/lower/expressions/methods_lambdas_and_comprehensions.rs
+++ b/crates/sifr_lowering/src/lower/expressions/methods_lambdas_and_comprehensions.rs
@@ -9,13 +9,14 @@ use super::{
     resolve_decimal_method_type, resolve_dict_method_type, resolve_enum_method_type,
     resolve_fixed_width_method_type, resolve_list_method_type, resolve_newtype_method_type,
     resolve_protocol_method_type, resolve_set_method_type, resolve_str_method_type,
-    resolve_tuple_method_type, resolved_method_arg_ranges, str, tsc, ClassMethodSurface,
-    DiagnosticCode, Expr, ExprAttribute, ExprCall, ExprDictComp, ExprGenerator, ExprLambda,
-    ExprListComp, ExprNamed, ExprSetComp, FunctionType, HirExpr, HirIteratorOp, HirParam, LowerCtx,
-    ParamConvention, Ranged, TextRange, Type, DEFAULTDICT_INT_ALIAS, DEFAULTDICT_LIST_ALIAS,
-    DEFAULTDICT_SET_ALIAS,
+    resolve_tuple_method_type, str, tsc, ClassMethodSurface, DiagnosticCode, Expr, ExprAttribute,
+    ExprCall, ExprDictComp, ExprGenerator, ExprLambda, ExprListComp, ExprNamed, ExprSetComp,
+    FunctionType, HirExpr, HirIteratorOp, HirParam, LowerCtx, ParamConvention, Ranged, TextRange,
+    Type, DEFAULTDICT_INT_ALIAS, DEFAULTDICT_LIST_ALIAS, DEFAULTDICT_SET_ALIAS,
 };
-use crate::lower::python_interop::reject_python_context_borrow_storage;
+use crate::lower::python_interop::{
+    callback_method_arg_ranges, reject_python_context_borrow_storage,
+};
 use crate::lower::{parallel_calls, task_join_set_calls, task_scope_offload_calls};
 use sifr_ir::CompilerIntrinsicId;
 pub(in crate::lower) fn lower_method_call(
@@ -29,7 +30,6 @@ pub(in crate::lower) fn lower_method_call(
             if name.id.as_str() == "super" {
                 let method_name = attr.attr.to_string();
                 if let Some(parent_name) = ctx.current_parent_class.clone() {
-                    // Lower arguments
                     let mut args = Vec::new();
                     for arg in &call.arguments.args {
                         let expr = lower_expr(arg, ctx)?;
@@ -192,7 +192,8 @@ pub(in crate::lower) fn lower_method_call(
     ) {
         return None;
     }
-    let method_arg_ranges = resolved_method_arg_ranges(&object_ty_for_args, &method_name, call);
+    let method_arg_ranges =
+        callback_method_arg_ranges(&object, &object_ty_for_args, &method_name, call, &args, ctx);
     let resolved_method_type = resolve_method_type(
         &object_ty,
         &method_name,

--- a/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
@@ -312,6 +312,14 @@ pub(super) fn lower_regular_call(
         call,
         ctx,
     );
+    crate::lower::python_interop::validate_callback_call_captures(
+        &func_name,
+        &args,
+        &arg_ranges,
+        None,
+        call.range(),
+        ctx,
+    );
     if func_name == "require_serializable" {
         // This marker is checked entirely during lowering. Emit a concrete
         // expression so statement-position calls do not generate an ambiguous

--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -94,6 +94,9 @@ pub(in crate::lower) struct LowerCtx {
     pub(in crate::lower) vararg_functions: HashMap<String, usize>,
     /// Declaration-first Python parameter kinds, retained for call-shape lowering.
     pub(in crate::lower) python_call_shapes: HashMap<String, Vec<sifr_ir::PythonParameterKind>>,
+    /// Callback attachment policies keyed by the callable surface used at each call site.
+    pub(in crate::lower) python_callback_call_policies:
+        HashMap<String, Vec<super::python_interop::CallbackCallPolicy>>,
     /// Set of registered type variable names (e.g., T, K, V from `TypeVar` declarations)
     pub(in crate::lower) type_vars: std::collections::HashSet<String>,
     /// Map of generic function names to their type variable names
@@ -183,6 +186,7 @@ impl LowerCtx {
             error_hierarchy: HashMap::new(),
             vararg_functions: HashMap::new(),
             python_call_shapes: HashMap::new(),
+            python_callback_call_policies: HashMap::new(),
             type_vars: std::collections::HashSet::new(),
             generic_functions: HashMap::new(),
             type_param_bounds: HashMap::new(),

--- a/crates/sifr_lowering/src/lower/mod_impl.rs
+++ b/crates/sifr_lowering/src/lower/mod_impl.rs
@@ -169,6 +169,15 @@ pub(in crate::lower) fn lower_module_impl(
 
             collect_function_defaults(&mut ctx, &function_name, func);
             if python_interop::has_python_interop_decorator_syntax(&func.decorator_list) {
+                let callback_policies = python_interop::callback_call_policies(
+                    &func.decorator_list,
+                    &func.parameters,
+                    false,
+                );
+                if !callback_policies.is_empty() {
+                    ctx.python_callback_call_policies
+                        .insert(function_name.clone(), callback_policies);
+                }
                 ctx.python_call_shapes.insert(
                     function_name.clone(),
                     python_interop::python_parameter_kinds(&func.parameters),

--- a/crates/sifr_lowering/src/lower/nested_function_inference/capture_collection.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/capture_collection.rs
@@ -19,9 +19,10 @@ pub(super) fn collect_nested_function_captures(
             continue;
         };
         let function_captures = collect_function_captures(func, state, env);
-        if !function_captures.is_empty() {
-            captures.insert(func.name.to_string(), function_captures);
-        }
+        // Keep capture-free nested functions in the map as positive evidence
+        // that the callable was inspected. Consumers must distinguish them
+        // from callable values whose closure environment is unknown.
+        captures.insert(func.name.to_string(), function_captures);
     }
     captures
 }

--- a/crates/sifr_lowering/src/lower/nested_function_inference/state_collection.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/state_collection.rs
@@ -118,8 +118,16 @@ pub(in crate::lower) fn infer_nested_function_types(
     ctx: &mut LowerCtx,
 ) -> NestedFunctionInference {
     let mut states = collect_nested_function_states(stmts, ctx);
+    let outer_bindings = ctx
+        .scope
+        .visible_local_bindings()
+        .into_iter()
+        .collect::<HashMap<_, _>>();
     if states.is_empty() {
-        let mut env = FunctionEnv::default();
+        let mut env = FunctionEnv {
+            vars: outer_bindings,
+            call_return_origins: HashMap::new(),
+        };
         analyze_block(stmts, &mut env, &mut states, None, ctx);
         return NestedFunctionInference {
             function_types: HashMap::new(),
@@ -128,7 +136,7 @@ pub(in crate::lower) fn infer_nested_function_types(
         };
     }
 
-    let mut binding_hints = HashMap::new();
+    let mut binding_hints = outer_bindings;
     for _ in 0..MAX_INFERENCE_PASSES {
         let previous = snapshot_signatures(&states);
         let mut env = FunctionEnv {

--- a/crates/sifr_lowering/src/lower/python_interop.rs
+++ b/crates/sifr_lowering/src/lower/python_interop.rs
@@ -9,10 +9,15 @@ use sifr_python_ast::{Decorator, Expr, ExprCall, Parameters, Stmt};
 use sifr_type_system::Type;
 
 mod callbacks;
+mod callsite;
 mod context;
 mod parameters;
 mod stub_syntax;
 
+pub(in crate::lower) use callsite::{
+    callback_call_policies, callback_method_arg_ranges, validate_callback_call_captures,
+    CallbackCallPolicy,
+};
 pub(super) use parameters::{parameter_metadata, receiver_is_owned};
 
 pub(in crate::lower) use context::{

--- a/crates/sifr_lowering/src/lower/python_interop/callbacks.rs
+++ b/crates/sifr_lowering/src/lower/python_interop/callbacks.rs
@@ -240,7 +240,7 @@ pub(super) fn parse(
     })
 }
 
-fn policy_atom(expr: &sifr_python_ast::Expr) -> Option<String> {
+pub(super) fn policy_atom(expr: &sifr_python_ast::Expr) -> Option<String> {
     decorator_path(expr)
         .filter(|segments| segments.len() == 1)
         .and_then(|segments| segments.into_iter().next())
@@ -598,7 +598,7 @@ pub(super) fn python_error_type(ctx: &LowerCtx) -> Type {
         })
 }
 
-fn contains_python_identity(ty: &Type, ctx: &LowerCtx) -> bool {
+pub(super) fn contains_python_identity(ty: &Type, ctx: &LowerCtx) -> bool {
     match ty.resolve_alias() {
         Type::Class { name, fields, .. } => {
             name == "Object"

--- a/crates/sifr_lowering/src/lower/python_interop/callsite.rs
+++ b/crates/sifr_lowering/src/lower/python_interop/callsite.rs
@@ -1,0 +1,213 @@
+use super::{callbacks, decorator_path, parameter_metadata, LowerCtx};
+use ruff_text_size::TextRange;
+use sifr_diagnostics::DiagnosticCode;
+use sifr_ir::{HirExpr, PythonCallbackConcurrency, PythonCallbackDispatch, PythonCallbackLifetime};
+use sifr_python_ast::{Decorator, Expr, ExprCall, Parameters};
+
+#[derive(Clone, Copy, Debug)]
+pub(in crate::lower) struct CallbackCallPolicy {
+    pub(in crate::lower) parameter_index: usize,
+    pub(in crate::lower) lifetime: PythonCallbackLifetime,
+    pub(in crate::lower) dispatch: PythonCallbackDispatch,
+    pub(in crate::lower) concurrency: Option<PythonCallbackConcurrency>,
+}
+
+pub(in crate::lower) fn callback_call_policies(
+    decorators: &[Decorator],
+    parameters: &Parameters,
+    has_receiver: bool,
+) -> Vec<CallbackCallPolicy> {
+    let metadata = parameter_metadata(parameters);
+    decorators
+        .iter()
+        .filter_map(|decorator| {
+            let Expr::Call(call) = &decorator.expression else {
+                return None;
+            };
+            if decorator_path(&call.func)
+                .is_none_or(|path| path.as_slice() != ["python", "callback"])
+            {
+                return None;
+            }
+            if call.arguments.args.len() != 1 {
+                return None;
+            }
+            let parameter_path = decorator_path(&call.arguments.args[0])?;
+            let [parameter_name] = parameter_path.as_slice() else {
+                return None;
+            };
+            let raw_index = metadata
+                .iter()
+                .position(|candidate| candidate.name == *parameter_name)?;
+            let parameter_index = raw_index.checked_sub(usize::from(has_receiver))?;
+            let mut lifetime = None;
+            let mut dispatch = None;
+            let mut concurrency = None;
+            for keyword in &call.arguments.keywords {
+                let name = keyword.arg.as_ref()?.as_str();
+                let value = callbacks::policy_atom(&keyword.value)?;
+                match (name, value.as_str()) {
+                    ("lifetime", "call") => lifetime = Some(PythonCallbackLifetime::Call),
+                    ("lifetime", "result") => lifetime = Some(PythonCallbackLifetime::Result),
+                    ("lifetime", "Self") => lifetime = Some(PythonCallbackLifetime::Receiver),
+                    ("dispatch", "current") => dispatch = Some(PythonCallbackDispatch::Current),
+                    ("dispatch", "foreign") => dispatch = Some(PythonCallbackDispatch::Foreign),
+                    ("dispatch", "asyncio") => dispatch = Some(PythonCallbackDispatch::Asyncio),
+                    ("concurrency", "serial") => {
+                        concurrency = Some(PythonCallbackConcurrency::Serial);
+                    }
+                    ("concurrency", "parallel") => {
+                        concurrency = Some(PythonCallbackConcurrency::Parallel);
+                    }
+                    _ => {}
+                }
+            }
+            Some(CallbackCallPolicy {
+                parameter_index,
+                lifetime: lifetime?,
+                dispatch: dispatch?,
+                concurrency,
+            })
+        })
+        .collect()
+}
+
+pub(in crate::lower) fn validate_callback_call_captures(
+    callable: &str,
+    args: &[HirExpr],
+    argument_ranges: &[Option<TextRange>],
+    receiver_name: Option<&str>,
+    fallback_range: TextRange,
+    ctx: &mut LowerCtx,
+) {
+    let Some(policies) = ctx.python_callback_call_policies.get(callable).cloned() else {
+        return;
+    };
+    for policy in policies {
+        if policy.dispatch == PythonCallbackDispatch::Current {
+            continue;
+        }
+        let Some(HirExpr::Name { name, .. }) = args.get(policy.parameter_index) else {
+            reject_unverifiable_handler(
+                policy.parameter_index,
+                argument_ranges,
+                fallback_range,
+                ctx,
+            );
+            continue;
+        };
+        let range = argument_range(policy.parameter_index, argument_ranges, fallback_range);
+        let Some(captures) = ctx.nested_function_captures.get(name).cloned() else {
+            if !ctx.scope.resolves_to_module_binding(name) {
+                reject_unproven_named_handler(name, range, ctx);
+            }
+            continue;
+        };
+        for (capture_name, capture_ty) in captures {
+            let reason =
+                capture_rejection_reason(policy, &capture_name, &capture_ty, receiver_name, ctx);
+            if let Some(reason) = reason {
+                ctx.error_with_code_at(
+                    DiagnosticCode::PYCB_INVALID_DECLARATION,
+                    format!(
+                        "invalid Python callback attachment: handler `{name}` capture `{capture_name}` of type `{}` {reason}",
+                        capture_ty.display_name()
+                    ),
+                    range,
+                );
+            }
+        }
+    }
+}
+
+fn reject_unproven_named_handler(name: &str, range: TextRange, ctx: &mut LowerCtx) {
+    ctx.error_with_code_at(
+        DiagnosticCode::PYCB_INVALID_DECLARATION,
+        format!(
+            "invalid Python callback attachment: handler `{name}` is a callable value whose captures cannot be proven safe; use a top-level function or a directly declared nested function"
+        ),
+        range,
+    );
+}
+
+pub(in crate::lower) fn callback_method_arg_ranges(
+    object: &HirExpr,
+    object_ty: &sifr_type_system::Type,
+    method_name: &str,
+    call: &ExprCall,
+    args: &[HirExpr],
+    ctx: &mut LowerCtx,
+) -> Vec<TextRange> {
+    let ranges =
+        crate::lower::method_call_args::resolved_method_arg_ranges(object_ty, method_name, call);
+    if let sifr_type_system::Type::Class { name, .. } = object_ty.resolve_alias() {
+        let receiver_name = match object {
+            HirExpr::Name { name, .. } => Some(name.as_str()),
+            _ => None,
+        };
+        validate_callback_call_captures(
+            &format!("{name}.{method_name}"),
+            args,
+            &ranges.iter().copied().map(Some).collect::<Vec<_>>(),
+            receiver_name,
+            call.range,
+            ctx,
+        );
+    }
+    ranges
+}
+
+fn capture_rejection_reason(
+    policy: CallbackCallPolicy,
+    capture_name: &str,
+    capture_ty: &sifr_type_system::Type,
+    receiver_name: Option<&str>,
+    ctx: &LowerCtx,
+) -> Option<String> {
+    (policy.lifetime == PythonCallbackLifetime::Receiver && receiver_name == Some(capture_name))
+        .then_some(
+            "captures its retained owner; same-owner close from a callback cannot be proven absent"
+                .to_string(),
+        )
+        .or_else(|| {
+            (policy.dispatch == PythonCallbackDispatch::Foreign
+                && callbacks::contains_python_identity(capture_ty, ctx))
+            .then_some("contains Python identity".to_string())
+        })
+        .or_else(|| {
+            crate::lower::task_scope_calls::non_send_reason(capture_ty)
+                .map(|reason| format!("is not sendable: {reason}"))
+        })
+        .or_else(|| {
+            (policy.concurrency == Some(PythonCallbackConcurrency::Parallel))
+                .then(|| crate::lower::task_scope_calls::non_share_safe_reason(capture_ty))
+                .flatten()
+                .map(|reason| format!("is not share-safe: {reason}"))
+        })
+}
+
+fn reject_unverifiable_handler(
+    parameter_index: usize,
+    argument_ranges: &[Option<TextRange>],
+    fallback_range: TextRange,
+    ctx: &mut LowerCtx,
+) {
+    ctx.error_with_code_at(
+        DiagnosticCode::PYCB_INVALID_DECLARATION,
+        "invalid Python callback attachment: foreign and asyncio handlers must be a named function so captures can be proven safe"
+            .to_string(),
+        argument_range(parameter_index, argument_ranges, fallback_range),
+    );
+}
+
+fn argument_range(
+    parameter_index: usize,
+    argument_ranges: &[Option<TextRange>],
+    fallback_range: TextRange,
+) -> TextRange {
+    argument_ranges
+        .get(parameter_index)
+        .copied()
+        .flatten()
+        .unwrap_or(fallback_range)
+}

--- a/crates/sifr_lowering/src/lower/python_interop_callback_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_interop_callback_tests.rs
@@ -2,6 +2,28 @@ use crate::{lower_module, HirDiagnostic};
 use sifr_diagnostics::DiagnosticCode;
 use sifr_python_parser::parse_module;
 
+#[test]
+fn callback_call_policy_is_available_before_body_lowering() {
+    let parsed = parse_module(
+        "@python.callback(handler, lifetime=call, dispatch=foreign, concurrency=serial)\n@python(pkg.compute)\ndef compute(handler: Callable[[int], int]) -> int: ...\n",
+    )
+    .expect("source should parse");
+    let sifr_python_ast::Stmt::FunctionDef(function) = &parsed.suite()[0] else {
+        panic!("expected function");
+    };
+    let policies = crate::lower::python_interop::callback_call_policies(
+        &function.decorator_list,
+        &function.parameters,
+        false,
+    );
+    assert_eq!(policies.len(), 1);
+    assert_eq!(policies[0].parameter_index, 0);
+    assert_eq!(
+        policies[0].dispatch,
+        sifr_ir::PythonCallbackDispatch::Foreign
+    );
+}
+
 fn lower_errors(source: &str) -> Vec<HirDiagnostic> {
     let parsed = parse_module(source).expect("source should parse");
     match lower_module(parsed.suite()) {
@@ -401,5 +423,143 @@ def subscribe(
 ) -> Result[Subscription, PythonError | HandlerError]: ...
 ",
         "owner cleanup `Subscription.close` error channel must contain handler error `HandlerError`",
+    );
+}
+
+#[test]
+fn foreign_callback_rejects_non_send_handler_capture_at_attachment() {
+    assert_callback_error(
+        r"
+class PythonError(Error):
+    message: str
+
+class LocalState(NonSend):
+    value: int
+
+@python.callback(handler, lifetime=call, dispatch=foreign, concurrency=serial)
+@python(pkg.compute)
+def compute(handler: Callable[[int], int]) -> Result[int, PythonError]: ...
+
+def run(state: LocalState) -> Result[int, PythonError]:
+    def handler(value: int) -> int:
+        return value + state.value
+    return compute(handler)
+",
+        "handler `handler` capture `state`",
+    );
+}
+
+#[test]
+fn foreign_callback_rejects_python_identity_handler_capture_at_attachment() {
+    assert_callback_error(
+        r"
+class PythonError(Error):
+    message: str
+
+@python.opaque(type=pkg.Client, cleanup=close)
+class Client:
+    @python(Self.value)
+    def value(self) -> Result[int, PythonError]: ...
+
+    @python(Self.close)
+    def close(own self) -> Result[None, PythonError]: ...
+
+@python.callback(handler, lifetime=call, dispatch=foreign, concurrency=serial)
+@python(pkg.compute)
+def compute(handler: Callable[[int], int]) -> Result[int, PythonError]: ...
+
+def run(client: Client) -> Result[int, PythonError]:
+    def captured(value: int) -> int:
+        _ = client.value()
+        return value
+    return compute(captured)
+",
+        "capture `client` of type `Client`",
+    );
+}
+
+#[test]
+fn parallel_callback_rejects_mutable_handler_capture_at_attachment() {
+    assert_callback_error(
+        r"
+class PythonError(Error):
+    message: str
+
+@python.callback(handler, lifetime=call, dispatch=foreign, concurrency=parallel)
+@python(pkg.compute)
+def compute(handler: Callable[[int], int]) -> Result[int, PythonError]: ...
+
+def run(values: list[int]) -> Result[int, PythonError]:
+    def handler(value: int) -> int:
+        return value + len(values)
+    return compute(handler)
+",
+        "is not share-safe",
+    );
+}
+
+#[test]
+fn receiver_callback_rejects_capturing_its_owner() {
+    assert_callback_error(
+        r"
+class PythonError(Error):
+    message: str
+
+@python.opaque(type=pkg.Client, cleanup=close)
+class Client:
+    @python.callback(handler, lifetime=Self, dispatch=asyncio, concurrency=serial)
+    @python.coroutine(Self.register)
+    async def register(self, own handler: AsyncCallable[[int], int]) -> Result[None, PythonError]: ...
+
+    @python(Self.value)
+    def value(self) -> Result[int, PythonError]: ...
+
+    @python(Self.close)
+    def close(own self) -> Result[None, PythonError]: ...
+
+async def run(client: Client) -> Result[None, PythonError]:
+    async def handler(value: int) -> int:
+        _ = client.value()
+        return value
+    return await client.register(handler)
+",
+        "captures its retained owner",
+    );
+}
+
+#[test]
+fn foreign_callback_rejects_forwarded_callable_with_unknown_captures() {
+    assert_callback_error(
+        r"
+class PythonError(Error):
+    message: str
+
+@python.callback(handler, lifetime=call, dispatch=foreign, concurrency=serial)
+@python(pkg.compute)
+def compute(handler: Callable[[int], int]) -> Result[int, PythonError]: ...
+
+def run(handler: Callable[[int], int]) -> Result[int, PythonError]:
+    return compute(handler)
+",
+        "callable value whose captures cannot be proven safe",
+    );
+}
+
+#[test]
+fn foreign_callback_accepts_capture_free_nested_handler() {
+    lower_success(
+        r"
+class PythonError(Error):
+    message: str
+
+@python.callback(handler, lifetime=call, dispatch=foreign, concurrency=serial)
+@python(pkg.compute)
+def compute(handler: Callable[[int], int]) -> Result[int, PythonError]: ...
+
+def run() -> Result[int, PythonError]:
+    def handler(value: int) -> int:
+        return value + 1
+    return compute(handler)
+",
     );
 }

--- a/crates/sifr_lowering/src/lower/task_scope_calls.rs
+++ b/crates/sifr_lowering/src/lower/task_scope_calls.rs
@@ -280,7 +280,7 @@ pub(in crate::lower) fn non_send_reason(ty: &Type) -> Option<String> {
     non_send_reason_inner(ty.resolve_alias(), &mut HashSet::new())
 }
 
-fn non_share_safe_reason(ty: &Type) -> Option<String> {
+pub(in crate::lower) fn non_share_safe_reason(ty: &Type) -> Option<String> {
     non_share_safe_reason_inner(ty.resolve_alias(), &mut HashSet::new())
 }
 

--- a/crates/sifr_lowering/src/scope.rs
+++ b/crates/sifr_lowering/src/scope.rs
@@ -138,6 +138,25 @@ impl Scope {
         self.frames.len()
     }
 
+    pub(crate) fn visible_local_bindings(&self) -> Vec<(String, Type)> {
+        let mut bindings = HashMap::new();
+        for frame in self.frames.iter().skip(1) {
+            for (name, info) in frame {
+                bindings.insert(name.clone(), info.effective_type().clone());
+            }
+        }
+        bindings.into_iter().collect()
+    }
+
+    pub(crate) fn resolves_to_module_binding(&self, name: &str) -> bool {
+        self.frames
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(index, frame)| frame.contains_key(name).then_some(index == 0))
+            .unwrap_or(false)
+    }
+
     /// Define a variable in the current (innermost) scope.
     pub fn define(&mut self, name: String, ty: Type) {
         self.define_binding(name, ty, true, BindingKind::Local, false);

--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -691,6 +691,11 @@ Delivery waves:
   131/131 create-PR and 651/651 merge-profile E2E fixtures, 261 hardening
   variants, and compiled CFFI, Kafka, asyncio, and Pub/Sub evidence through
   `demos/m9_demo`).
+- [x] Aggregate-review remediation Wave 1 — attachment-site proof for foreign
+  and asyncio handler captures, including non-send and Python-identity
+  exclusion, parallel share safety, same-owner rejection, and unproven callable
+  rejection ([PR #2981](https://github.com/sifr-lang/sifr/pull/2981);
+  [GPT-5.6-Sol High review pass 1](../../reviews/active/ad-hoc-declaration-first-python-interop-m9-codex-5-6-sol-high-review-pass-1.md)).
 - [ ] Milestone review — review the complete merged M9 implementation before
   closing the milestone checkbox.
 

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m9-codex-5-6-sol-high-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m9-codex-5-6-sol-high-review-pass-1.md
@@ -1,0 +1,90 @@
+## Blocking findings
+
+1. **Critical — foreign/asyncio handler captures are not type-checked for sendability or Python identity.**
+   [callbacks.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_lowering/src/lower/python_interop/callbacks.rs:489) validates only callback arguments, success values, and handler-error types—not the actual handler’s captures. The generated foreign bound in [scope_and_function_types.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_codegen/src/function_emitter/scope_and_function_types.rs:804) is only a Rust backstop. Worse, opaque Python wrappers contain sendable runtime fields without a Rust-level non-`Send` marker in [class_emitter.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_codegen/src/class_emitter.rs:139), so a nested handler capturing an opaque Python owner can satisfy `Send + Sync + 'static` and execute that captured identity on a foreign thread. The required static close-from-callback analysis is also absent; only the runtime thread-local guard exists in [state.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/callbacks/state.rs:269).
+   **Required fix:** analyze resolved handler captures at each callback attachment, reject all non-send captures, reject Python identity recursively for foreign dispatch, require immutable/shareable captures for parallel dispatch, add a Rust auto-trait backstop for opaque wrappers, and implement the promised static same-owner close rejection.
+
+2. **Critical — asyncio cancellation is not bidirectional, and close/shutdown can wait forever.**
+   The only cancellation edge is Python future → Sifr carrier in [asyncio.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/callbacks/asyncio.rs:288). The fallback aborts the Tokio task at [asyncio.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/callbacks/asyncio.rs:330), but Sifr-side cancellation never cancels the exact Python future. An aborted task also exits before `schedule_completion`, leaving that Python future pending. Owner close merely waits for `active_calls == 0` in [state.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/callbacks/state.rs:463); it neither requests cancellation nor joins terminal acknowledgements. A pending handler can therefore hang semantic close or process shutdown indefinitely.
+   **Required fix:** give each accepted asyncio entry one CAS-controlled terminal record containing its carrier, task, and Python future; implement both cancellation directions; always schedule terminal Python cancellation on Sifr abort; register active entries with the owner; and cancel/join them asynchronously during close.
+
+3. **High — runtime shutdown cannot execute async unregister authority.**
+   Shutdown changes the loop lifecycle to `Stopping` and removes the loop handle before callback shutdown in [async_runtime.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/async_runtime.rs:394). Callback owners are then shut down at [async_runtime.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/async_runtime.rs:419). Async-close and async-context unregister actions submit through the normal blocking declaration path in [ownership.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/callbacks/ownership.rs:247), whose `ensure_started` rejects `Stopping`. Normal runtime shutdown of such a retained owner therefore reports failure and closes locally without successfully running Python unregister-first cleanup.
+   **Required fix:** distinguish public admission shutdown from internal cleanup submission, retaining the loop authority until callback unregister and drain finish.
+
+4. **High — retained asyncio rollback is not exception-safe and can synchronously deadlock the executor.**
+   Explicit async rollback covers only a failed Python submission in [callback_frame.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_codegen/src/python_interop_async/callback_frame.rs:310). Handler reconciliation, result conversion, and owner conversion/commit can still return early afterward. The provisional group’s `Drop` then invokes synchronous condition-variable draining in [ownership.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/callbacks/ownership.rs:103). If an accepted handler needs the same current-thread Tokio executor, this blocks that executor and deadlocks.
+   **Required fix:** generate one async finalization frame covering submission, handler reconciliation, conversion, and attachment, with explicit awaited rollback on every failure path. Async groups must never depend on blocking `Drop` for correctness.
+
+5. **High — retained typed handler failures are lost on async close/context and ordinary later owner operations.**
+   Async method codegen receives but deliberately ignores `_owner_retained_errors` in [conversions.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_codegen/src/python_interop_async/conversions.rs:74). Runtime close uses the “typed observer” variant, which suppresses the redacted runtime error in [state.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/callbacks/state.rs:257), assuming generated code will extract the typed slot—but async close does not. Async context exit similarly consumes the callback owner without generated typed-slot reconciliation in [async_context.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/async_context.rs:49). Non-consuming owner methods also never inspect retained failure slots; only the synchronous consuming-close branch does so in [python_interop_direct.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_codegen/src/python_interop_direct.rs:546).
+   **Required fix:** capture the owner and every typed slot before consuming async close/context state, reconcile after drain, preserve primary/secondary ordering, and check retained failures on later owner operations as documented.
+
+6. **High — synchronous Python-primary reconciliation can miss late handler failures and cleanup failures.**
+   Sync wrappers attach callback evidence before draining at [python_interop_direct.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_codegen/src/python_interop_direct.rs:269). They drain afterward, but then map the Python result at [python_interop_direct.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_codegen/src/python_interop_direct.rs:288), which returns early on the Python error before post-drain typed reconciliation or cleanup-result processing. A background callback that fails during drain is therefore absent from the promised Python-primary secondary evidence. Context exit also discards `callback_close` whenever exit itself fails in [ownership.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/callbacks/ownership.rs:241).
+   **Required fix:** drain first, then perform one reconciliation step over the Python outcome, typed failures, and cleanup outcome, preserving deterministic primary/secondary ordering.
+
+7. **High — escaped retained foreign callables retain Sifr captures after owner close.**
+   `foreign_callback_with_owner` captures `decode`, `handler`, and `encode` directly inside the Python `PyCFunction` in [foreign.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/callbacks/foreign.rs:320). `retain_in_owner` retains and later closes only one Python object handle in [foreign.rs](/Users/yaseralnajjar/work/sifr/codebase/crates/sifr_runtime/src/python/callbacks/foreign.rs:169). An escaped additional Python reference keeps the function closure—and all captured Sifr resources—alive after owner close. Calls reject correctly, but capture release and declared-owner lifetime do not hold.
+   **Required fix:** make retained foreign shells capture only an owner/token indirection, with the actual typed target owned and released by the callback group after unregister and drain, matching the asyncio/current architecture.
+
+8. **High — the claimed validation/evidence gate is not the gate that runs compiled callback examples.**
+   Profiles select the `callbacks` suite, for example [create-pr.json](/Users/yaseralnajjar/work/sifr/codebase/verification/profiles/create-pr.json:112). That command maps only to `--group callbacks` in [runner.py](/Users/yaseralnajjar/work/sifr/codebase/verification/areas/python_interop/runner.py:57), not `--callback-examples`, whose compiled execution path is separate in [run.py](/Users/yaseralnajjar/work/sifr/codebase/verification/areas/python_interop/runner/run.py:266). Thus CFFI/Kafka/asyncio/PubSub binaries are not unconditionally registered in create-PR, merge, nightly, and release as claimed.
+
+   Additional evidence overclaims:
+
+   - Cancellation evidence covers only Python future → Sifr handler in [callback_evidence.json](/Users/yaseralnajjar/work/sifr/codebase/verification/areas/python_interop/fixtures/callback/callback_evidence.json:19), not exact bidirectional cancellation.
+   - The Pub/Sub fixture awaits `emit` completely before `aclose` in [declaration_callback.sifr](/Users/yaseralnajjar/work/sifr/codebase/verification/areas/python_interop/fixtures/pubsub/declaration_callback.sifr:27), so its `close=drained` marker proves no concurrent drain.
+   - CFFI exercises only current-thread dispatch in [declaration_callback.sifr](/Users/yaseralnajjar/work/sifr/codebase/verification/areas/python_interop/fixtures/cffi_callback/declaration_callback.sifr:4), not the design’s native/background foreign case.
+
+   **Required fix:** add a manifest suite for compiled callback examples and select it in all four profiles; add true active-close/drain, Sifr→Python cancellation, async concurrent-close/shutdown, capture rejection, and CFFI foreign-thread cases before marking evidence passing.
+
+9. **Medium — durable status documentation contradicts atomic activation.**
+   The embedded architecture says `PYCB` remains reserved in [python_interop_architecture.md](/Users/yaseralnajjar/work/sifr/codebase/internal_docs/python_interop_architecture.md:173), the declaration architecture says callback decorators remain reserved in [python_interop_declaration_architecture.md](/Users/yaseralnajjar/work/sifr/codebase/internal_docs/python_interop_declaration_architecture.md:322), and the roadmap still says callbacks are sequenced next in [roadmap.md](/Users/yaseralnajjar/work/sifr/codebase/plans/roadmap.md:129). This directly misses the Wave 3 durable-doc/roadmap task.
+   **Required fix:** reconcile all durable status authorities after the implementation and evidence gaps are closed.
+
+## Non-blocking findings
+
+None.
+
+## M9 task mapping
+
+| M9 task | Status |
+|---|---|
+| Callback lifetime/dispatch/concurrency metadata | Implemented |
+| Checked argument/result conversion and `SifrCallbackError` | Partial; reconciliation gaps |
+| Current-thread non-escape/non-send behavior | Implemented |
+| Foreign `Send + Sync`, serial/parallel, identity exclusion | Blocked by missing capture analysis |
+| Asyncio `AsyncCallable` and bidirectional cancellation | Blocked |
+| Net-new `AsyncCallable` type/ABI support | Implemented; no independent ABI defect found |
+| Required concurrency and pre-wait reentrancy | Implemented |
+| Retained owner aggregation/rollback | Blocked by foreign capture retention and async rollback deadlock |
+| Open/closing/closed, unregister-first, drain/release/shutdown | Sync paths largely implemented; async/runtime shutdown blocked |
+| Static/runtime close-from-callback rejection | Runtime implemented; static analysis missing |
+
+## Acceptance mapping
+
+| Acceptance item | Result |
+|---|---|
+| No callback outlives its declared owner | Fail: retained foreign captures can outlive owner |
+| Foreign callbacks cannot smuggle Python identity | Fail: captured identity is unchecked |
+| Serial reentrancy fails deterministically | Pass for inspected foreign and asyncio paths |
+| Owner close drains accepted calls and rejects later calls | Partial: synchronous paths pass; async close can hang and does not cancel |
+| Async callbacks block neither executor | Fail: implicit retained-group rollback can block/deadlock Tokio |
+
+## Validation and evidence mapping
+
+- Current, foreign serial/parallel, and asyncio round trips: present.
+- Wrong arity/type/result conversion: present.
+- Serial reentrancy and foreign parallel overlap: present.
+- Capture/sendability and Python-identity exclusion: insufficient; boundary types only.
+- Concurrent close, callback-after-close, shutdown: synchronous coverage exists; async concurrent-close and shutdown semantics are absent/broken.
+- Swallowed handler failure and lowest-entry selection: unit coverage exists.
+- Python-primary plus secondary handler failure: does not cover failure arriving during drain.
+- Bidirectional cancellation: only Python→Sifr is tested.
+- Compiled CFFI/Kafka/asyncio/PubSub fixtures: present and reportedly runnable, but not selected by authoritative profiles; Pub/Sub does not exercise active drain.
+- Atomic activation: unsupported because active capability rows overclaim cancellation, cleanup, and compiled-gate evidence.
+
+Read-only inspection covered the complete requested commit range. `git diff --check` was clean, all touched callback/compiler modules remain under 900 lines, and the only current worktree change remains the explicitly ignored `third_party/ruff` submodule.
+
+VERDICT: BLOCKED


### PR DESCRIPTION
## Summary
- preserve the aggregate GPT-5.6-Sol High M9 review and remediate its static callback-safety finding
- collect callback policy before body lowering and validate actual nested-handler captures at each foreign/asyncio attachment
- reject non-send, Python-identity, parallel non-share-safe, same-owner, anonymous, and unproven forwarded callable captures
- seed nested capture inference from visible outer bindings while distinguishing inspected capture-free handlers from unknown callable values

## Validation
- `scripts/run_all_tests.sh --profile create-pr` — 131/131 E2E, signature `7c39b8c1dd4fec7c`; all lanes green
- `cargo test -p sifr_lowering python_interop_callback_tests` — 18/18
- `cargo test -p sifr_lowering` — 709 passed, 1 ignored
- `cargo clippy -p sifr_lowering -- -D warnings`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `git diff --check`

## Review context
This is M9 aggregate-review remediation wave 1. A global Rust `!Send` marker for opaque wrappers was tested and rejected because it invalidates supported Send async futures that legitimately hold an opaque owner across an await. The compiler instead performs precise attachment-site proof while retaining Rust `Send + Sync + 'static` closure bounds as a secondary backstop.

The remaining aggregate findings (async cancellation/shutdown authority, rollback/reconciliation/capture release, and compiled evidence/docs) are intentionally handled in subsequent focused remediation waves before the M9 checkbox can close.