### PR TITLE
fix(python): join asyncio callbacks during owner close

### DIFF
--- a/crates/sifr_runtime/src/python/async_declaration.rs
+++ b/crates/sifr_runtime/src/python/async_declaration.rs
@@ -1,6 +1,6 @@
 use super::async_runtime::{
-    finish_submission, register_submission, release_pending_submission, reserve_submission,
-    terminal_for_submission, SubmissionCancellationBridge,
+    finish_submission, register_submission, release_pending_submission, reserve_cleanup_submission,
+    reserve_submission, terminal_for_submission, SubmissionCancellationBridge,
 };
 use super::async_terminal::{
     PythonTerminal, PythonTerminalError, PythonTerminalOutcome, PythonTerminalValue,
@@ -26,7 +26,7 @@ pub async fn submit_async_declaration(
     let callback_origin = super::callbacks::current_callback_origin();
     super::async_runtime::ensure_started().map_err(PythonError::runtime)?;
     validate_keywords(&request)?;
-    let submitted = super::attach(|py| submit_typed(py, request, carrier, callback_origin))
+    let submitted = super::attach(|py| submit_typed(py, request, carrier, callback_origin, false))
         .map_err(PythonError::runtime)?;
     let terminal = match submitted {
         Ok(terminal) => terminal,
@@ -59,13 +59,13 @@ pub async fn submit_async_declaration(
     }
 }
 
-pub(super) fn submit_async_declaration_blocking(
+pub(super) fn submit_async_declaration_cleanup_blocking(
     request: PythonAsyncRequest,
 ) -> Result<PythonAsyncValue, PythonError> {
-    super::async_runtime::ensure_started().map_err(PythonError::runtime)?;
+    super::async_runtime::ensure_cleanup_submission_available().map_err(PythonError::runtime)?;
     validate_keywords(&request)?;
-    let submitted =
-        super::attach(|py| submit_typed(py, request, None, None)).map_err(PythonError::runtime)?;
+    let submitted = super::attach(|py| submit_typed(py, request, None, None, true))
+        .map_err(PythonError::runtime)?;
     let terminal = submitted.map_err(terminal_error)?;
     match terminal.wait() {
         Ok(PythonTerminalValue::Typed(value)) => Ok(value),
@@ -84,7 +84,7 @@ pub(super) async fn submit_async_context_request(
 ) -> Result<PythonExitDecision, PythonError> {
     let callback_origin = super::callbacks::current_callback_origin();
     super::async_runtime::ensure_started().map_err(PythonError::runtime)?;
-    let submitted = super::attach(|py| submit_typed(py, request, carrier, callback_origin))
+    let submitted = super::attach(|py| submit_typed(py, request, carrier, callback_origin, false))
         .map_err(PythonError::runtime)?;
     let terminal = match submitted {
         Ok(terminal) => terminal,
@@ -117,12 +117,12 @@ pub(super) async fn submit_async_context_request(
     }
 }
 
-pub(super) fn submit_async_context_request_blocking(
+pub(super) fn submit_async_context_cleanup_blocking(
     request: PythonAsyncRequest,
 ) -> Result<PythonExitDecision, PythonError> {
-    super::async_runtime::ensure_started().map_err(PythonError::runtime)?;
-    let submitted =
-        super::attach(|py| submit_typed(py, request, None, None)).map_err(PythonError::runtime)?;
+    super::async_runtime::ensure_cleanup_submission_available().map_err(PythonError::runtime)?;
+    let submitted = super::attach(|py| submit_typed(py, request, None, None, true))
+        .map_err(PythonError::runtime)?;
     let terminal = submitted.map_err(terminal_error)?;
     match terminal.wait() {
         Ok(PythonTerminalValue::ExitDecision(decision)) => Ok(decision),
@@ -164,10 +164,15 @@ fn submit_typed(
     request: PythonAsyncRequest,
     carrier: Option<&CancellationCarrier>,
     callback_origin: Option<(u64, u64)>,
+    shutdown_cleanup: bool,
 ) -> Result<PythonTerminal, PythonTerminalError> {
     let (terminal, cancellation) = terminal_for_submission(carrier)?;
-    let (submission_id, loop_object) =
-        reserve_submission(py, &terminal).map_err(PythonTerminalError::Runtime)?;
+    let (submission_id, loop_object) = if shutdown_cleanup {
+        reserve_cleanup_submission(py, &terminal)
+    } else {
+        reserve_submission(py, &terminal)
+    }
+    .map_err(PythonTerminalError::Runtime)?;
     let context = request_context(&request);
     let request = Arc::new(request);
     let done_callback = build_done_callback(

--- a/crates/sifr_runtime/src/python/async_runtime.rs
+++ b/crates/sifr_runtime/src/python/async_runtime.rs
@@ -170,6 +170,20 @@ pub(super) fn ensure_started() -> Result<(), PythonRuntimeError> {
     start()
 }
 
+pub(super) fn ensure_cleanup_submission_available() -> Result<(), PythonRuntimeError> {
+    {
+        let state = lock_state()?;
+        if matches!(
+            state.lifecycle,
+            AsyncLifecycle::Running | AsyncLifecycle::Stopping
+        ) && state.loop_object.is_some()
+        {
+            return Ok(());
+        }
+    }
+    start()
+}
+
 pub(super) fn is_owned_loop(
     py: Python<'_>,
     candidate: &Bound<'_, PyAny>,
@@ -392,7 +406,7 @@ fn cancellation_hook(bridge: &Arc<SubmissionCancellationBridge>) -> Cancellation
 }
 
 pub(super) fn shutdown() -> Result<(), PythonRuntimeError> {
-    let resources = {
+    let initial_failure = {
         let mut state = lock_state()?;
         match state.lifecycle {
             AsyncLifecycle::Disabled | AsyncLifecycle::Stopped => return Ok(()),
@@ -405,17 +419,11 @@ pub(super) fn shutdown() -> Result<(), PythonRuntimeError> {
         while !state.pending_submissions.is_empty() && state.lifecycle != AsyncLifecycle::Failed {
             state = wait_for_change(state)?;
         }
-        ShutdownResources {
-            loop_object: state.loop_object.take(),
-            loop_thread: state.loop_thread.take(),
-            failure: state.failure.take(),
-        }
+        state.failure.clone()
     };
     record_shutdown_phase(ShutdownPhase::AdmissionsStopped);
 
-    let mut first_error = resources
-        .failure
-        .map(PythonRuntimeError::AsyncRuntimeFailed);
+    let mut first_error = initial_failure.map(PythonRuntimeError::AsyncRuntimeFailed);
     record_shutdown_phase(ShutdownPhase::CallbackShutdown);
     retain_first_error(
         &mut first_error,
@@ -426,6 +434,21 @@ pub(super) fn shutdown() -> Result<(), PythonRuntimeError> {
         &mut first_error,
         super::shutdown_hooks::run_registered_async_cleanup(),
     );
+
+    let resources = {
+        let mut state = lock_state()?;
+        ShutdownResources {
+            loop_object: state.loop_object.take(),
+            loop_thread: state.loop_thread.take(),
+            failure: state.failure.take(),
+        }
+    };
+    if let Some(message) = resources.failure.as_ref() {
+        retain_first_error(
+            &mut first_error,
+            Err(PythonRuntimeError::AsyncRuntimeFailed(message.clone())),
+        );
+    }
 
     record_shutdown_phase(ShutdownPhase::SubmissionCancellation);
     if let Err(error) = cancel_registered_submissions() {
@@ -579,8 +602,25 @@ pub(super) fn reserve_submission(
     py: Python<'_>,
     terminal: &PythonTerminal,
 ) -> Result<(u64, Py<PyAny>), PythonRuntimeError> {
+    reserve_submission_with_admission(py, terminal, false)
+}
+
+pub(super) fn reserve_cleanup_submission(
+    py: Python<'_>,
+    terminal: &PythonTerminal,
+) -> Result<(u64, Py<PyAny>), PythonRuntimeError> {
+    reserve_submission_with_admission(py, terminal, true)
+}
+
+fn reserve_submission_with_admission(
+    py: Python<'_>,
+    terminal: &PythonTerminal,
+    shutdown_cleanup: bool,
+) -> Result<(u64, Py<PyAny>), PythonRuntimeError> {
     let mut state = lock_state()?;
-    if state.lifecycle != AsyncLifecycle::Running {
+    let admitted = state.lifecycle == AsyncLifecycle::Running
+        || (shutdown_cleanup && state.lifecycle == AsyncLifecycle::Stopping);
+    if !admitted {
         return Err(if state.lifecycle == AsyncLifecycle::Stopping {
             PythonRuntimeError::AsyncRuntimeStopping
         } else {

--- a/crates/sifr_runtime/src/python/async_runtime_tests.rs
+++ b/crates/sifr_runtime/src/python/async_runtime_tests.rs
@@ -291,6 +291,52 @@ fn shutdown_terminally_drains_claimed_task_and_finally() {
 }
 
 #[test]
+fn shutdown_retains_owned_loop_authority_for_async_callback_unregister() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    let mut config = test_config("async-callback-unregister-shutdown");
+    config.start_async_loop = true;
+    initialize_runtime(config).expect("init should start the owned loop");
+
+    let (object, marker) = super::super::attach(|py| {
+        let module = PyModule::from_code(
+            py,
+            c"import asyncio\nmarker = []\n\nclass Resource:\n    async def aclose(self):\n        await asyncio.sleep(0)\n        marker.append('closed')\n",
+            c"<sifr-async-unregister-shutdown-test>",
+            c"__sifr_async_unregister_shutdown_test__",
+        )
+        .expect("async unregister test module should compile");
+        let object = module
+            .getattr("Resource")
+            .expect("resource class should resolve")
+            .call0()
+            .expect("resource should construct");
+        let object = super::super::object_ops::store_object(object.unbind())?;
+        let marker = module
+            .getattr("marker")
+            .expect("marker should resolve")
+            .unbind();
+        Ok::<_, super::super::PythonError>((object, marker))
+    })
+    .expect("runtime should attach")
+    .expect("resource should store");
+    let mut group =
+        super::super::RetainedCallbackGroup::new().expect("retained callback group should create");
+    let owner = group
+        .commit_for_object(&object, super::super::RetainedCallbackCleanup::AsyncClose)
+        .expect("async close unregister should commit");
+    drop(group);
+
+    shutdown().expect("shutdown should run async callback unregister before stopping the loop");
+
+    super::super::attach(|py| {
+        assert_eq!(marker.bind(py).len().expect("marker should have length"), 1);
+    })
+    .expect("runtime should attach");
+    assert_eq!(owner.status(), super::super::CallbackOwnerStatus::Closed);
+}
+
+#[test]
 fn invalid_awaitable_setup_resolves_without_leaking_submission_counts() {
     let _guard = test_guard();
     reset_runtime_state_for_tests();

--- a/crates/sifr_runtime/src/python/callbacks/asyncio.rs
+++ b/crates/sifr_runtime/src/python/callbacks/asyncio.rs
@@ -1,9 +1,10 @@
+use super::asyncio_entry::AsyncioCallbackEntry;
 use super::execution::{
     collect_args, execution_error, python_error, result_object, validate_call_shape,
     CallbackExecutionError,
 };
 use super::{errors, CallbackInvocationLease, CallbackOwnerState};
-use crate::cancellation::{CancellationBind, CancellationCarrier};
+use crate::cancellation::CancellationCarrier;
 use crate::python::{object_ops, ObjectHandle, PythonError, PythonRuntimeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyCFunction, PyDict, PyTuple};
@@ -290,8 +291,16 @@ where
                     erase_future_lifetime(prepared.invoke(entry_sequence, cancellation.clone()))
                 };
                 let future = loop_object.call_method0("create_future")?;
-                let cancel_carrier = cancellation.clone();
-                let cancel_callback = PyCFunction::new_closure(
+                let entry = AsyncioCallbackEntry::register(
+                    &shell_owner,
+                    entry_sequence,
+                    cancellation,
+                    loop_object.clone().unbind(),
+                    future.clone().unbind(),
+                )
+                .map_err(python_error)?;
+                let callback_entry = Arc::clone(&entry);
+                let cancel_callback = match PyCFunction::new_closure(
                     py,
                     Some(c"__sifr_asyncio_callback_cancel"),
                     None,
@@ -300,15 +309,28 @@ where
                             .get_item(0)?
                             .call_method0("cancelled")?
                             .extract::<bool>()?;
-                        if cancelled {
-                            let _outcome = cancel_carrier.request_cancel();
-                        }
+                        callback_entry.python_finished(cancelled);
                         Ok::<(), PyErr>(())
                     },
-                )?;
-                future.call_method1("add_done_callback", (cancel_callback,))?;
+                ) {
+                    Ok(callback) => callback,
+                    Err(error) => {
+                        entry.setup_failed();
+                        return Err(error);
+                    }
+                };
+                if let Err(error) = future.call_method1("add_done_callback", (cancel_callback,)) {
+                    entry.setup_failed();
+                    return Err(error);
+                }
                 let serial_ticket = if concurrency == AsyncioCallbackConcurrency::Serial {
-                    Some(AsyncFifo::reserve(&fifo).map_err(python_error)?)
+                    match AsyncFifo::reserve(&fifo) {
+                        Ok(ticket) => Some(ticket),
+                        Err(error) => {
+                            entry.setup_failed();
+                            return Err(python_error(error));
+                        }
+                    }
                 } else {
                     None
                 };
@@ -319,24 +341,32 @@ where
                 let task_loop = loop_object.clone().unbind();
                 let task_python_future = future.clone().unbind();
                 let task_owner = shell_owner.clone();
-                let task = runtime.spawn(async move {
+                let worker = runtime.spawn(async move {
                     let _permit = match serial_ticket {
                         Some(ticket) => Some(ticket.await),
                         None => None,
                     };
-                    let completion = task_future.await;
-                    schedule_completion(task_loop, task_python_future, task_owner, completion);
+                    task_future.await
                 });
-                let abort = task.abort_handle();
-                match cancellation.bind_fallback(Arc::new(move || abort.abort())) {
-                    CancellationBind::Bound | CancellationBind::InvokedPendingCancellation => {}
-                    CancellationBind::AlreadyBound | CancellationBind::StateUnavailable => {
-                        task.abort();
-                        return Err(python_error(errors::unavailable(
-                            "asyncio cancellation fallback",
-                        )));
+                entry.install_worker_abort(worker.abort_handle());
+                let supervisor_entry = Arc::clone(&entry);
+                let _supervisor = runtime.spawn(async move {
+                    match worker.await {
+                        Ok(completion) => {
+                            if schedule_completion(
+                                task_loop,
+                                task_python_future,
+                                task_owner,
+                                completion,
+                            ) {
+                                supervisor_entry.task_finished();
+                            } else {
+                                supervisor_entry.task_aborted();
+                            }
+                        }
+                        Err(_join_error) => supervisor_entry.task_aborted(),
                     }
-                }
+                });
                 Ok(future.unbind())
             },
         )
@@ -419,7 +449,7 @@ fn schedule_completion(
     future: Py<PyAny>,
     owner: CallbackOwnerState,
     completion: InvocationCompletion,
-) {
+) -> bool {
     let state = Arc::new(Mutex::new(Some(completion)));
     let attached = Python::try_attach(|py| {
         let callback_state = Arc::clone(&state);
@@ -486,7 +516,9 @@ fn schedule_completion(
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .take(),
         );
+        return false;
     }
+    true
 }
 
 #[derive(Default)]

--- a/crates/sifr_runtime/src/python/callbacks/asyncio_entry.rs
+++ b/crates/sifr_runtime/src/python/callbacks/asyncio_entry.rs
@@ -1,0 +1,222 @@
+use super::state::CallbackAsyncEntryLease;
+use super::{errors, CallbackOwnerState};
+use crate::cancellation::{CancellationBind, CancellationCarrier};
+use crate::python::PythonError;
+use pyo3::prelude::*;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::task::AbortHandle;
+
+const TASK_TERMINAL: u8 = 1;
+const PYTHON_TERMINAL: u8 = 2;
+const ENTRY_TERMINAL: u8 = 4;
+
+pub(super) struct AsyncioCallbackEntry {
+    cancellation: CancellationCarrier,
+    terminal: AtomicU8,
+    state: Mutex<EntryState>,
+}
+
+struct EntryState {
+    owner_lease: Option<CallbackAsyncEntryLease>,
+    loop_object: Option<Py<PyAny>>,
+    python_future: Option<Py<PyAny>>,
+    worker_abort: Option<AbortHandle>,
+    python_cancel_queued: bool,
+    worker_abort_requested: bool,
+}
+
+impl AsyncioCallbackEntry {
+    pub(super) fn register(
+        owner: &CallbackOwnerState,
+        entry_sequence: u64,
+        cancellation: CancellationCarrier,
+        loop_object: Py<PyAny>,
+        python_future: Py<PyAny>,
+    ) -> Result<Arc<Self>, PythonError> {
+        let entry = Arc::new(Self {
+            cancellation,
+            terminal: AtomicU8::new(0),
+            state: Mutex::new(EntryState {
+                owner_lease: None,
+                loop_object: Some(loop_object),
+                python_future: Some(python_future),
+                worker_abort: None,
+                python_cancel_queued: false,
+                worker_abort_requested: false,
+            }),
+        });
+        let weak_entry = Arc::downgrade(&entry);
+        match entry.cancellation.bind_fallback(Arc::new(move || {
+            if let Some(entry) = weak_entry.upgrade() {
+                entry.cancel_python_and_abort_worker();
+            }
+        })) {
+            CancellationBind::Bound => {}
+            CancellationBind::InvokedPendingCancellation => {
+                return Err(errors::unavailable(
+                    "asyncio callback cancellation before entry registration",
+                ));
+            }
+            CancellationBind::AlreadyBound | CancellationBind::StateUnavailable => {
+                return Err(errors::unavailable(
+                    "asyncio callback cancellation fallback",
+                ));
+            }
+        }
+
+        let weak_entry = Arc::downgrade(&entry);
+        let owner_lease = owner.register_async_entry(
+            entry_sequence,
+            Arc::new(move || {
+                if let Some(entry) = weak_entry.upgrade() {
+                    entry.cancel_from_owner();
+                }
+            }),
+        )?;
+        entry
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .owner_lease = Some(owner_lease);
+        Ok(entry)
+    }
+
+    pub(super) fn install_worker_abort(&self, abort: AbortHandle) {
+        let abort_now = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if state.worker_abort_requested {
+                true
+            } else {
+                state.worker_abort = Some(abort.clone());
+                false
+            }
+        };
+        if abort_now {
+            abort.abort();
+        }
+    }
+
+    pub(super) fn python_finished(&self, cancelled: bool) {
+        if cancelled {
+            let _outcome = self.cancellation.request_cancel();
+        }
+        self.mark_terminal(PYTHON_TERMINAL);
+    }
+
+    pub(super) fn task_finished(&self) {
+        self.mark_terminal(TASK_TERMINAL);
+    }
+
+    pub(super) fn task_aborted(&self) {
+        self.queue_python_cancel();
+        self.mark_terminal(TASK_TERMINAL);
+    }
+
+    pub(super) fn setup_failed(&self) {
+        self.queue_python_cancel();
+        self.mark_terminal(TASK_TERMINAL);
+        self.mark_terminal(PYTHON_TERMINAL);
+    }
+
+    fn cancel_from_owner(&self) {
+        self.queue_python_cancel();
+        let _outcome = self.cancellation.request_cancel();
+        self.abort_worker();
+    }
+
+    fn cancel_python_and_abort_worker(&self) {
+        self.queue_python_cancel();
+        self.abort_worker();
+    }
+
+    fn queue_python_cancel(&self) {
+        let should_queue = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if state.python_cancel_queued {
+                return;
+            }
+            state.python_cancel_queued = true;
+            state.loop_object.is_some() && state.python_future.is_some()
+        };
+        if !should_queue {
+            return;
+        }
+        let queued = Python::try_attach(|py| {
+            let handles = {
+                let state = self
+                    .state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                state
+                    .loop_object
+                    .as_ref()
+                    .zip(state.python_future.as_ref())
+                    .map(|(loop_object, future)| (loop_object.clone_ref(py), future.clone_ref(py)))
+            };
+            let Some((loop_object, future)) = handles else {
+                return Ok::<(), PyErr>(());
+            };
+            let cancel = future.bind(py).getattr("cancel")?;
+            loop_object
+                .bind(py)
+                .call_method1("call_soon_threadsafe", (cancel,))?;
+            Ok::<(), PyErr>(())
+        });
+        if !matches!(queued, Some(Ok(()))) {
+            self.mark_terminal(PYTHON_TERMINAL);
+        }
+    }
+
+    fn abort_worker(&self) {
+        let abort = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.worker_abort_requested = true;
+            state.worker_abort.clone()
+        };
+        if let Some(abort) = abort {
+            abort.abort();
+        }
+    }
+
+    fn mark_terminal(&self, terminal: u8) {
+        let previous = self.terminal.fetch_or(terminal, Ordering::AcqRel);
+        if (previous | terminal) != (TASK_TERMINAL | PYTHON_TERMINAL) {
+            return;
+        }
+        if self
+            .terminal
+            .compare_exchange(
+                TASK_TERMINAL | PYTHON_TERMINAL,
+                TASK_TERMINAL | PYTHON_TERMINAL | ENTRY_TERMINAL,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return;
+        }
+        let resources = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            (
+                state.owner_lease.take(),
+                state.loop_object.take(),
+                state.python_future.take(),
+                state.worker_abort.take(),
+            )
+        };
+        let _attached = Python::try_attach(move |_py| drop(resources));
+    }
+}

--- a/crates/sifr_runtime/src/python/callbacks/asyncio_tests.rs
+++ b/crates/sifr_runtime/src/python/callbacks/asyncio_tests.rs
@@ -1,6 +1,6 @@
 use super::{
     asyncio_callback_scoped_with_owner, asyncio_callback_with_owner, AsyncioCallbackConcurrency,
-    CallbackExecutionError, CallbackOwnerState, RetainedCallbackGroup,
+    CallbackExecutionError, CallbackOwnerState, CallbackOwnerStatus, RetainedCallbackGroup,
 };
 use crate::cancellation::CancellationCarrier;
 use crate::python::{
@@ -153,7 +153,55 @@ async fn serial_reentrancy_is_rejected_before_waiting_for_the_fifo() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn retained_asyncio_rollback_drains_without_blocking_the_executor() {
+async fn call_scoped_close_cancels_and_joins_an_active_asyncio_callback() {
+    let _guard = test_guard();
+    initialize_callback_runtime("asyncio-callback-call-close");
+    let started = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let started_by_handler = Arc::clone(&started);
+    let release_by_handler = Arc::clone(&release);
+    let owner = CallbackOwnerState::new_call_scoped().expect("owner should create");
+    let callback = asyncio_callback_scoped_with_owner(
+        owner.clone(),
+        4,
+        1,
+        AsyncioCallbackConcurrency::Parallel,
+        |args| crate::python::to_int(&args[0]),
+        move |_, value, _| {
+            let started = Arc::clone(&started_by_handler);
+            let release = Arc::clone(&release_by_handler);
+            async move {
+                started.notify_one();
+                release.notified().await;
+                Ok(value)
+            }
+        },
+        crate::python::from_int,
+    )
+    .expect("asyncio callback should create");
+    let request = function_request(
+        "invoke_catching_cancel",
+        vec![
+            async_from_object(callback.object()).expect("callback transport"),
+            async_from_int(41).expect("argument transport"),
+        ],
+    );
+
+    let controller = async {
+        started.notified().await;
+        callback.close_call_scope().await
+    };
+    let (invocation, close) = tokio::join!(submit_async_declaration(request, None), controller);
+    close.expect("call-scoped close should cancel and join the invocation");
+    let value = async_to_int(invocation.expect("Python should observe callback cancellation"))
+        .expect("cancellation result should convert");
+    assert_eq!(value, -1);
+    assert_eq!(owner.status(), CallbackOwnerStatus::Closed);
+    reset_runtime_state_for_tests();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn retained_asyncio_rollback_cancels_and_joins_without_blocking_the_executor() {
     let _guard = test_guard();
     initialize_callback_runtime("asyncio-callback-retained-rollback");
     let started = Arc::new(tokio::sync::Notify::new());
@@ -163,7 +211,7 @@ async fn retained_asyncio_rollback_drains_without_blocking_the_executor() {
     let mut group = RetainedCallbackGroup::new().expect("retained group should create");
     let callback = asyncio_callback_with_owner(
         group.owner().clone(),
-        4,
+        5,
         1,
         AsyncioCallbackConcurrency::Parallel,
         |args| crate::python::to_int(&args[0]),
@@ -183,7 +231,7 @@ async fn retained_asyncio_rollback_drains_without_blocking_the_executor() {
         .retain_in_owner()
         .expect("retained callback should transfer into its owner");
     let request = function_request(
-        "invoke",
+        "invoke_catching_cancel",
         vec![
             async_from_object(callback.object()).expect("callback transport"),
             async_from_int(41).expect("argument transport"),
@@ -192,19 +240,13 @@ async fn retained_asyncio_rollback_drains_without_blocking_the_executor() {
 
     let controller = async {
         started.notified().await;
-        let release_task = tokio::spawn(async move {
-            tokio::task::yield_now().await;
-            release.notify_one();
-        });
-        let outcome = group.rollback_async().await;
-        release_task.await.expect("release task should complete");
-        outcome
+        group.rollback_async().await
     };
     let (invocation, rollback) = tokio::join!(submit_async_declaration(request, None), controller);
-    rollback.expect("retained rollback should drain accepted invocation");
-    let value = async_to_int(invocation.expect("accepted callback should complete"))
-        .expect("callback result should convert");
-    assert_eq!(value, 42);
+    rollback.expect("retained rollback should cancel and join the invocation");
+    let value = async_to_int(invocation.expect("Python should observe callback cancellation"))
+        .expect("cancellation result should convert");
+    assert_eq!(value, -1);
     reset_runtime_state_for_tests();
 }
 
@@ -221,7 +263,7 @@ fn initialize_callback_runtime(label: &str) {
 fn install_module(py: Python<'_>) {
     let module = PyModule::from_code(
         py,
-        c"import asyncio\n\nstored = None\n\nasync def invoke(callback, value):\n    return await callback(value)\n\nasync def cancel(callback):\n    task = asyncio.ensure_future(callback(1))\n    await asyncio.sleep(0)\n    task.cancel()\n    try:\n        await task\n    except asyncio.CancelledError:\n        return 1\n    return 0\n\nasync def install_and_invoke(callback):\n    global stored\n    stored = callback\n    return await callback(1)\n\nasync def reenter():\n    return await stored(2)\n",
+        c"import asyncio\n\nstored = None\n\nasync def invoke(callback, value):\n    return await callback(value)\n\nasync def invoke_catching_cancel(callback, value):\n    try:\n        return await callback(value)\n    except asyncio.CancelledError:\n        return -1\n\nasync def cancel(callback):\n    task = asyncio.ensure_future(callback(1))\n    await asyncio.sleep(0)\n    task.cancel()\n    try:\n        await task\n    except asyncio.CancelledError:\n        return 1\n    return 0\n\nasync def install_and_invoke(callback):\n    global stored\n    stored = callback\n    return await callback(1)\n\nasync def reenter():\n    return await stored(2)\n",
         c"__sifr_asyncio_callback_tests__.py",
         c"__sifr_asyncio_callback_tests__",
     )

--- a/crates/sifr_runtime/src/python/callbacks/mod.rs
+++ b/crates/sifr_runtime/src/python/callbacks/mod.rs
@@ -1,4 +1,5 @@
 mod asyncio;
+mod asyncio_entry;
 #[cfg(test)]
 mod asyncio_tests;
 mod current;

--- a/crates/sifr_runtime/src/python/callbacks/ownership.rs
+++ b/crates/sifr_runtime/src/python/callbacks/ownership.rs
@@ -253,7 +253,7 @@ fn unregister_action(object: ObjectHandle, cleanup: RetainedCallbackCleanup) -> 
                 object.clone(),
                 "aclose".to_string(),
             )?;
-            super::super::async_declaration::submit_async_declaration_blocking(request)
+            super::super::async_declaration::submit_async_declaration_cleanup_blocking(request)
                 .map(|_value| ())
         }
         RetainedCallbackCleanup::AsyncContext => {
@@ -262,7 +262,7 @@ fn unregister_action(object: ObjectHandle, cleanup: RetainedCallbackCleanup) -> 
                     object.clone(),
                     super::super::PythonAsyncExitCause::Normal,
                 )?;
-            super::super::async_declaration::submit_async_context_request_blocking(request)
+            super::super::async_declaration::submit_async_context_cleanup_blocking(request)
                 .map(|_decision| ())
         }
     })

--- a/crates/sifr_runtime/src/python/callbacks/state.rs
+++ b/crates/sifr_runtime/src/python/callbacks/state.rs
@@ -1,12 +1,14 @@
 use super::super::PythonError;
 use super::{errors, registry};
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use tokio::sync::Notify;
 
 type UnregisterAction = Arc<dyn Fn() -> Result<(), PythonError> + Send + Sync + 'static>;
 type CaptureReleaseAction = Box<dyn FnOnce() + Send + 'static>;
+type AsyncCancellationAction = Arc<dyn Fn() + Send + Sync + 'static>;
 
 static NEXT_OWNER_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -51,6 +53,12 @@ struct OwnerData {
     first_failure_observed: bool,
     captures_released: bool,
     unregister_status: CallbackUnregisterStatus,
+    async_entries: BTreeMap<u64, AsyncEntry>,
+}
+
+struct AsyncEntry {
+    cancel: AsyncCancellationAction,
+    cancellation_requested: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -77,6 +85,12 @@ pub struct CallbackInvocationGuard {
 pub struct CallbackInvocationPollGuard {
     owner_id: u64,
     callback_id: u64,
+    active: bool,
+}
+
+pub(super) struct CallbackAsyncEntryLease {
+    owner: CallbackOwnerState,
+    entry_sequence: u64,
     active: bool,
 }
 
@@ -131,6 +145,7 @@ impl CallbackOwnerState {
                 first_failure_observed: false,
                 captures_released: false,
                 unregister_status: CallbackUnregisterStatus::NotStarted,
+                async_entries: BTreeMap::new(),
             }),
             changed: Condvar::new(),
             async_changed: Notify::new(),
@@ -204,6 +219,38 @@ impl CallbackOwnerState {
             return Err(errors::reentrant(self.inner.id, callback_id));
         }
         Ok(())
+    }
+
+    pub(super) fn register_async_entry(
+        &self,
+        entry_sequence: u64,
+        cancel: AsyncCancellationAction,
+    ) -> Result<CallbackAsyncEntryLease, PythonError> {
+        let cancel_now = {
+            let mut state = lock_state(&self.inner);
+            if state.async_entries.contains_key(&entry_sequence) {
+                return Err(errors::unavailable("async callback entry identity"));
+            }
+            let cancel_now = state.status != CallbackOwnerStatus::Open;
+            state.async_entries.insert(
+                entry_sequence,
+                AsyncEntry {
+                    cancel: Arc::clone(&cancel),
+                    cancellation_requested: cancel_now,
+                },
+            );
+            self.inner.changed.notify_all();
+            self.inner.async_changed.notify_waiters();
+            cancel_now
+        };
+        if cancel_now {
+            cancel();
+        }
+        Ok(CallbackAsyncEntryLease {
+            owner: self.clone(),
+            entry_sequence,
+            active: true,
+        })
     }
 
     pub fn close_call_scope(&self) -> Result<(), PythonError> {
@@ -390,12 +437,22 @@ impl CallbackOwnerState {
                 state.status = CallbackOwnerStatus::Closing;
             }
         }
-        while state.active_calls > 0 {
-            state = self
-                .inner
-                .changed
-                .wait(state)
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        loop {
+            let cancellations = pending_async_cancellations(&mut state);
+            if state.active_calls == 0 && state.async_entries.is_empty() {
+                break;
+            }
+            if cancellations.is_empty() {
+                state = self
+                    .inner
+                    .changed
+                    .wait(state)
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+            } else {
+                drop(state);
+                invoke_cancellations(cancellations);
+                state = lock_state(&self.inner);
+            }
         }
         drop(state);
         let releases = std::mem::take(
@@ -462,7 +519,16 @@ impl CallbackOwnerState {
         }
         loop {
             let notified = self.inner.async_changed.notified();
-            if lock_state(&self.inner).active_calls == 0 {
+            let (finished, cancellations) = {
+                let mut state = lock_state(&self.inner);
+                let cancellations = pending_async_cancellations(&mut state);
+                (
+                    state.active_calls == 0 && state.async_entries.is_empty(),
+                    cancellations,
+                )
+            };
+            invoke_cancellations(cancellations);
+            if finished {
                 break;
             }
             notified.await;
@@ -552,6 +618,19 @@ impl Drop for CallbackInvocationLease {
     }
 }
 
+impl Drop for CallbackAsyncEntryLease {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.active = false;
+        let mut state = lock_state(&self.owner.inner);
+        state.async_entries.remove(&self.entry_sequence);
+        self.owner.inner.changed.notify_all();
+        self.owner.inner.async_changed.notify_waiters();
+    }
+}
+
 impl Drop for CallbackInvocationGuard {
     fn drop(&mut self) {
         if !self.active {
@@ -618,6 +697,26 @@ fn remove_active_callback(owner_id: u64, callback_id: u64) {
             active.remove(index);
         }
     });
+}
+
+fn pending_async_cancellations(state: &mut OwnerData) -> Vec<AsyncCancellationAction> {
+    state
+        .async_entries
+        .values_mut()
+        .filter_map(|entry| {
+            if entry.cancellation_requested {
+                return None;
+            }
+            entry.cancellation_requested = true;
+            Some(Arc::clone(&entry.cancel))
+        })
+        .collect()
+}
+
+fn invoke_cancellations(cancellations: Vec<AsyncCancellationAction>) {
+    for cancel in cancellations {
+        cancel();
+    }
 }
 
 fn lock_state(owner: &CallbackOwnerInner) -> std::sync::MutexGuard<'_, OwnerData> {


### PR DESCRIPTION
## Summary
- add one terminal record per accepted asyncio callback entry and track it in the callback owner
- propagate cancellation in both directions, cancel the exact Python future, abort or join the Sifr worker, and wait for both terminal acknowledgements before capture release
- retain owned-loop authority for async retained-owner unregister during runtime shutdown
- cover call-scoped close, retained rollback, Python-to-Sifr cancellation, and async unregister during shutdown

## Validation
- `cargo test -p sifr_runtime --features python -- --nocapture` (173 passed)
- `scripts/run_all_tests.sh --profile create-pr` (131/131 e2e, `7c39b8c1dd4fec7c`)
- `scripts/run_all_tests.sh` (651/651 e2e, 261 hardening variants, `ee5e5d44306f270c`)
- file-size and HIR maintainability guardrails pass

## Review context
Remediates aggregate M9 review findings 2 and 3 and the active-close portion of finding 4. The broader M9 implementation will receive a large-scope Codex `gpt-5.6-sol` high/fast review after the remaining aggregate findings are remediated.