### PR TITLE
test(python): certify current callback dispatch

### DIFF
--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -721,7 +721,8 @@ Delivery waves:
   fixture as `dispatch=foreign` evidence, and correct capability ownership and
   verification documentation after the complete merged M9 review exposed the
   certification mismatch
-  ([GPT-5.6-Sol High complete review pass 1](../../reviews/active/ad-hoc-declaration-first-python-interop-m9-complete-codex-5-6-sol-high-review-pass-1.md));
+  ([PR #2985](https://github.com/sifr-lang/sifr/pull/2985);
+  [GPT-5.6-Sol High complete review pass 1](../../reviews/active/ad-hoc-declaration-first-python-interop-m9-complete-codex-5-6-sol-high-review-pass-1.md));
   focused callback examples pass all seven compiled binaries and the
   authoritative create-PR gate passes `131/131`, signature
   `7c39b8c1dd4fec7c`.

--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -703,7 +703,7 @@ Delivery waves:
   create-PR `131/131`, signature `7c39b8c1dd4fec7c`; merge `651/651`,
   signature `ee5e5d44306f270c`, 261 hardening variants; addresses review findings
   2 and 3 and the active-close portion of finding 4).
-- [ ] Aggregate-review remediation Wave 3 — cancellation/finalization race
+- [x] Aggregate-review remediation Wave 3 — cancellation/finalization race
   closure, failed context-entry owner reconciliation, terminal provisional
   receiver rollback, and an emitted Rust `!Send`/`!Sync` opaque-identity
   backstop ([PR #2984](https://github.com/sifr-lang/sifr/pull/2984);
@@ -716,6 +716,15 @@ Delivery waves:
   entry, owner-local retained foreign callback identities, awaited foreign
   drains in async wrappers, nested typed-error-union registration/mapping, and
   compiled typed handler-error plus post-call closure evidence.
+- [ ] Aggregate-review remediation Wave 4 — add a distinct compiled CFFI
+  caller-thread fixture for `dispatch=current`, retain the worker-thread CFFI
+  fixture as `dispatch=foreign` evidence, and correct capability ownership and
+  verification documentation after the complete merged M9 review exposed the
+  certification mismatch
+  ([GPT-5.6-Sol High complete review pass 1](../../reviews/active/ad-hoc-declaration-first-python-interop-m9-complete-codex-5-6-sol-high-review-pass-1.md));
+  focused callback examples pass all seven compiled binaries and the
+  authoritative create-PR gate passes `131/131`, signature
+  `7c39b8c1dd4fec7c`.
 - [ ] Milestone review — review the complete merged M9 implementation before
   closing the milestone checkbox.
 

--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -722,7 +722,8 @@ Delivery waves:
   verification documentation after the complete merged M9 review exposed the
   certification mismatch
   ([PR #2985](https://github.com/sifr-lang/sifr/pull/2985);
-  [GPT-5.6-Sol High complete review pass 1](../../reviews/active/ad-hoc-declaration-first-python-interop-m9-complete-codex-5-6-sol-high-review-pass-1.md));
+  [GPT-5.6-Sol High complete review pass 1](../../reviews/active/ad-hoc-declaration-first-python-interop-m9-complete-codex-5-6-sol-high-review-pass-1.md),
+  [remediation review pass 1](../../reviews/active/ad-hoc-declaration-first-python-interop-m9-current-dispatch-remediation-codex-5-6-sol-high-review-pass-1.md));
   focused callback examples pass all seven compiled binaries and the
   authoritative create-PR gate passes `131/131`, signature
   `7c39b8c1dd4fec7c`.

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m9-complete-codex-5-6-sol-high-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m9-complete-codex-5-6-sol-high-review-pass-1.md
@@ -1,0 +1,27 @@
+# M9 complete implementation — Codex 5.6 Sol high review pass 1
+
+Reviewer configuration: `gpt-5.6-sol`, high reasoning, fast service tier,
+read-only review of the complete merged M9 range from pre-M9 base
+`62878588d79bdee0667123ed246235b1eddcf958` through merge
+`2c5c6555faf475c7bfbc62c0a3ab8e079d3bef11`.
+
+## Verdict: blocked
+
+The runtime, lowering, code generation, callback lifecycle, cancellation,
+drain, finalization, shutdown, and sendability mechanisms satisfy the reviewed
+M9 contracts. Milestone closure is blocked by one false required live-evidence
+claim and the resulting stale completion tracking.
+
+## Findings
+
+1. **P1 — required `dispatch=current` compiled/live evidence is missing and
+   falsely attributed.** The capability ledger names the compiled CFFI example
+   as current-thread evidence, but the only compiled CFFI declaration uses
+   `dispatch=foreign` and its Python bridge invokes the callback from a worker
+   thread. Add a separate compiled same-thread `dispatch=current` fixture,
+   register it in the callback suite, correct the capability evidence owner and
+   README, and retain the existing CFFI fixture as foreign evidence.
+2. **P2 — merged Wave 3 remains recorded as incomplete.** Mark Wave 3 complete
+   after correcting the evidence gap, while keeping the milestone-review item
+   open until the remediation is merged and the complete M9 review is
+   satisfied.

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m9-current-dispatch-remediation-codex-5-6-sol-high-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m9-current-dispatch-remediation-codex-5-6-sol-high-review-pass-1.md
@@ -1,0 +1,16 @@
+# M9 current-dispatch evidence remediation — Codex 5.6 Sol high review pass 1
+
+Reviewer configuration: `gpt-5.6-sol`, high reasoning, fast service tier,
+read-only review of the complete PR #2985 diff against the M9 callback contract
+and the complete-review pass 1 blockers.
+
+## Verdict: satisfied
+
+The compiled CFFI fixture exercises guarded caller-thread `dispatch=current`,
+preserves the existing foreign-thread evidence, has accurate suite
+registration and trust roots, corrects the capability and README claims, and
+truthfully resolves both recorded blockers. No actionable defects remain.
+
+The reviewer traced the compiled declaration through code generation into the
+runtime creator-thread guard and reconciled the seven-case callback report with
+the create-PR, merge, nightly, and release profile registration.

--- a/verification/areas/python_interop/README.md
+++ b/verification/areas/python_interop/README.md
@@ -59,9 +59,10 @@ Python object to a Sifr `threadsafe_callback` handler, and the report labels
 that portion as a source-checked callback contract rather than a live Sifr binary
 invocation.
 Declaration-first callback evidence is also compiled offline with
-`runner/run.py --callback-examples`: real CFFI current-thread dispatch,
-kafka-python foreign-thread dispatch, application-owned asyncio dispatch, and a
-retained Pub/Sub-style owner with consuming async-close drain.
+`runner/run.py --callback-examples`: separate real CFFI caller-thread and
+worker-thread fixtures for current and foreign dispatch, kafka-python
+foreign-thread dispatch, application-owned asyncio dispatch, and a retained
+Pub/Sub-style owner with consuming async-close drain.
 The policy service aliases map to these concrete cases: `pubsub-compatible`
 uses LocalStack SNS fanout to an SQS subscription, `aws-compatible-sns` uses
 LocalStack SNS delivery to SQS, `aws-compatible-sqs` uses direct LocalStack SQS,

--- a/verification/areas/python_interop/declaration_capabilities.json
+++ b/verification/areas/python_interop/declaration_capabilities.json
@@ -119,7 +119,7 @@
         {"kind": "negative", "status": "passing", "owner": "callback policy, escape, shape, and conversion diagnostics"},
         {"kind": "cleanup", "status": "passing", "owner": "call-scoped owner drain and exact-once capture release matrix"},
         {"kind": "cancellation", "status": "not-applicable", "owner": "current-thread callable is synchronous"},
-        {"kind": "live", "status": "passing", "owner": "compiled real CFFI callback example"}
+        {"kind": "live", "status": "passing", "owner": "cffi_callback/current_declaration_callback.sifr compiled against real CFFI with synchronous caller-thread invocation"}
       ]
     },
     {

--- a/verification/areas/python_interop/fixtures/cffi_callback/current_declaration_callback.sifr
+++ b/verification/areas/python_interop/fixtures/cffi_callback/current_declaration_callback.sifr
@@ -1,0 +1,22 @@
+from sifr.python import PythonError
+
+
+@python.callback(handler, lifetime=call, dispatch=current)
+@python(bridge.cffi_declaration.apply_current)
+def cffi_apply_current(
+    handler: Callable[[int], int],
+    value: int,
+) -> Result[int, PythonError]: ...
+
+
+def plus_one(value: int) -> int:
+    return value + 1
+
+
+def main() -> Result[None, PythonError]:
+    try:
+        result: int = cffi_apply_current(plus_one, 41)
+        print("sifr-python-interop:callback:cffi-current=" + str(result))
+    except PythonError as error:
+        raise error
+    return None

--- a/verification/areas/python_interop/fixtures/cffi_callback/python_bridges/cffi_declaration.py
+++ b/verification/areas/python_interop/fixtures/cffi_callback/python_bridges/cffi_declaration.py
@@ -2,6 +2,12 @@ import cffi
 import threading
 
 
+def apply_current(handler, value):
+    ffi = cffi.FFI()
+    callback = ffi.callback("long long(long long)", handler)
+    return callback(value)
+
+
 def apply(handler, value):
     ffi = cffi.FFI()
     callback = ffi.callback("long long(long long)", handler)

--- a/verification/areas/python_interop/runner/callback_examples.py
+++ b/verification/areas/python_interop/runner/callback_examples.py
@@ -8,6 +8,13 @@ from example_packages import ExampleCase, build_examples_report, run_examples_se
 
 
 CALLBACK_CASES = {
+    "cffi-current-thread": ExampleCase(
+        case_id="cffi-current-thread",
+        relative_source="cffi_callback/current_declaration_callback.sifr",
+        stdout_marker="sifr-python-interop:callback:cffi-current=42",
+        import_roots=("cffi", "threading"),
+        native_roots=("cffi",),
+    ),
     "cffi-foreign-thread": ExampleCase(
         case_id="cffi-foreign-thread",
         relative_source="cffi_callback/declaration_callback.sifr",


### PR DESCRIPTION
Closes the remaining M9 complete-review evidence gap by adding a genuine compiled CFFI dispatch=current fixture while retaining the existing worker-thread dispatch=foreign fixture. Corrects capability ownership and verification documentation, and records the blocking review.\n\nValidation:\n- focused callback examples: 7 compiled binaries passed\n- Python interop scaffold: passed\n- scripts/run_all_tests.sh --profile create-pr: passed (131/131 E2E, signature 7c39b8c1dd4fec7c)