### PR TITLE
feat(python): add typed buffer runtime substrate

### DIFF
--- a/crates/sifr_runtime/src/python.rs
+++ b/crates/sifr_runtime/src/python.rs
@@ -61,10 +61,7 @@ pub use async_value::{
     async_value_is_none, PythonAsyncRequest, PythonAsyncType, PythonAsyncValue,
 };
 pub use bridge_loader::PythonBridgeSource;
-pub use buffer_ops::{
-    buffer_shape, buffer_strides, buffer_suboffsets, buffer_u8, copy_buffer_u8, release_buffer,
-    BufferHandle, PythonBufferMetadata,
-};
+pub use buffer_ops::*;
 use call_depth::{enter_python_call, python_call_depth};
 pub use callback_ops::{
     close_callback, local_callback, local_callback_echo, threadsafe_callback,

--- a/crates/sifr_runtime/src/python/buffer_ops.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops.rs
@@ -117,15 +117,12 @@ impl TrackedBuffer {
         }
     }
 
-    fn release(&self, py: Python<'_>) -> Result<(), PythonError> {
-        let buffer = self
-            .buffer
+    fn take_for_release(&self) -> Result<OwnedPyBuffer, PythonError> {
+        self.buffer
             .lock()
             .map_err(|_| buffer_state_error())?
             .take()
-            .ok_or_else(|| closed_error(-1))?;
-        buffer.release(py);
-        super::update_object_count(-1).map_err(PythonError::runtime)
+            .ok_or_else(|| closed_error(-1))
     }
 }
 
@@ -282,7 +279,9 @@ pub fn release_buffer((handle, token): BufferHandle) -> Result<(), PythonError> 
         }
     }
     .ok_or_else(|| closed_error(handle))?;
-    super::attach(|py| entry.buffer.release(py)).map_err(PythonError::runtime)?
+    let buffer = entry.buffer.take_for_release()?;
+    super::attach(|py| buffer.release(py)).map_err(PythonError::runtime)?;
+    super::update_object_count(-1).map_err(PythonError::runtime)
 }
 
 fn buffer_snapshot(
@@ -350,32 +349,76 @@ where
         .collect()
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BufferAccessError {
+    State,
+    Closed(i64),
+    Type(&'static str),
+    Buffer {
+        message: &'static str,
+        context: &'static str,
+    },
+    Index(&'static str),
+}
+
+impl BufferAccessError {
+    fn into_python(self, py: Python<'_>) -> PythonError {
+        match self {
+            Self::State => buffer_state_error(),
+            Self::Closed(handle) => closed_error(handle),
+            Self::Type(message) => type_error(py, message),
+            Self::Buffer { message, context } => buffer_error(py, message, context),
+            Self::Index(message) => index_error(py, message),
+        }
+    }
+}
+
 fn with_live_buffer<R>(
     buffer: BufferHandle,
     expected: PythonBufferElement,
     require_write: bool,
-    operation: impl FnOnce(Python<'_>, &OwnedPyBuffer) -> Result<R, PythonError>,
+    operation: impl FnOnce(&OwnedPyBuffer) -> Result<R, BufferAccessError>,
+) -> Result<R, PythonError> {
+    with_live_buffer_and_converter(buffer, expected, require_write, operation, |error| {
+        super::attach(|py| error.into_python(py))
+    })
+}
+
+fn with_live_buffer_and_converter<R>(
+    buffer: BufferHandle,
+    expected: PythonBufferElement,
+    require_write: bool,
+    operation: impl FnOnce(&OwnedPyBuffer) -> Result<R, BufferAccessError>,
+    convert_error: impl FnOnce(BufferAccessError) -> Result<PythonError, PythonRuntimeError>,
 ) -> Result<R, PythonError> {
     let (tracked, _) = buffer_snapshot(buffer)?;
-    super::attach(|py| {
-        let state = tracked.buffer.lock().map_err(|_| buffer_state_error())?;
-        let value = state.as_ref().ok_or_else(|| closed_error(buffer.0))?;
+    let outcome = super::attach(|_py| {
+        let state = tracked
+            .buffer
+            .lock()
+            .map_err(|_| BufferAccessError::State)?;
+        let value = state.as_ref().ok_or(BufferAccessError::Closed(buffer.0))?;
         if tracked.element != expected {
-            return Err(type_error(
-                py,
+            return Err(BufferAccessError::Type(
                 "buffer element type does not match accessor",
             ));
         }
         if require_write && tracked.access != PythonBufferAccess::Write {
-            return Err(buffer_error(
-                py,
-                "buffer was acquired with read-only declaration access",
-                "buffer element write",
-            ));
+            return Err(BufferAccessError::Buffer {
+                message: "buffer was acquired with read-only declaration access",
+                context: "buffer element write",
+            });
         }
-        operation(py, value)
+        operation(value)
     })
-    .map_err(PythonError::runtime)?
+    .map_err(PythonError::runtime)?;
+    match outcome {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            let error = convert_error(error).map_err(PythonError::runtime)?;
+            Err(error)
+        }
+    }
 }
 
 fn buffer_error(py: Python<'_>, message: &str, context: &str) -> PythonError {

--- a/crates/sifr_runtime/src/python/buffer_ops.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops.rs
@@ -1,11 +1,15 @@
 use super::object_ops::clone_handle;
 use super::{ObjectHandle, PythonError, PythonRuntimeError};
-use pyo3::buffer::{Element, PyBuffer};
 use pyo3::exceptions::{PyBufferError, PyIndexError, PyTypeError};
 use pyo3::Python;
 use std::collections::HashMap;
 use std::hash::BuildHasher;
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
+
+mod access;
+mod raw;
+pub use access::*;
+use raw::{OwnedPyBuffer, ValidatedBuffer};
 
 static BUFFER_STORE: LazyLock<Mutex<BufferStore>> =
     LazyLock::new(|| Mutex::new(BufferStore::default()));
@@ -98,23 +102,43 @@ struct BufferEntry {
     metadata: PythonBufferMetadata,
 }
 
-enum TrackedBuffer {
-    I8(PyBuffer<i8>),
-    I16(PyBuffer<i16>),
-    I32(PyBuffer<i32>),
-    I64(PyBuffer<i64>),
-    ISize(PyBuffer<isize>),
-    U8(PyBuffer<u8>),
-    U16(PyBuffer<u16>),
-    U32(PyBuffer<u32>),
-    U64(PyBuffer<u64>),
-    USize(PyBuffer<usize>),
-    F64(PyBuffer<f64>),
+struct TrackedBuffer {
+    element: PythonBufferElement,
+    access: PythonBufferAccess,
+    buffer: Mutex<Option<OwnedPyBuffer>>,
+}
+
+impl TrackedBuffer {
+    fn new(buffer: OwnedPyBuffer, request: PythonBufferRequest) -> Self {
+        Self {
+            element: request.element,
+            access: request.access,
+            buffer: Mutex::new(Some(buffer)),
+        }
+    }
+
+    fn release(&self, py: Python<'_>) -> Result<(), PythonError> {
+        let buffer = self
+            .buffer
+            .lock()
+            .map_err(|_| buffer_state_error())?
+            .take()
+            .ok_or_else(|| closed_error(-1))?;
+        buffer.release(py);
+        super::update_object_count(-1).map_err(PythonError::runtime)
+    }
 }
 
 impl Drop for TrackedBuffer {
     fn drop(&mut self) {
-        let _ignored = super::update_object_count(-1);
+        let state = match self.buffer.get_mut() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(buffer) = state.take() {
+            drop(buffer);
+            let _ignored = super::update_object_count(-1);
+        }
     }
 }
 
@@ -125,19 +149,22 @@ pub fn acquire_buffer(
     super::attach(|py| {
         let object = clone_handle(py, object)?;
         let object = object.bind(py);
-        match request.element {
-            PythonBufferElement::I8 => acquire_typed(object, request, TrackedBuffer::I8),
-            PythonBufferElement::I16 => acquire_typed(object, request, TrackedBuffer::I16),
-            PythonBufferElement::I32 => acquire_typed(object, request, TrackedBuffer::I32),
-            PythonBufferElement::I64 => acquire_typed(object, request, TrackedBuffer::I64),
-            PythonBufferElement::ISize => acquire_typed(object, request, TrackedBuffer::ISize),
-            PythonBufferElement::U8 => acquire_typed(object, request, TrackedBuffer::U8),
-            PythonBufferElement::U16 => acquire_typed(object, request, TrackedBuffer::U16),
-            PythonBufferElement::U32 => acquire_typed(object, request, TrackedBuffer::U32),
-            PythonBufferElement::U64 => acquire_typed(object, request, TrackedBuffer::U64),
-            PythonBufferElement::USize => acquire_typed(object, request, TrackedBuffer::USize),
-            PythonBufferElement::F64 => acquire_typed(object, request, TrackedBuffer::F64),
-        }
+        let buffer =
+            OwnedPyBuffer::acquire(py, object, request.access == PythonBufferAccess::Write)
+                .map_err(|error| {
+                    PythonError::from_pyerr(
+                        py,
+                        error,
+                        "zero-copy",
+                        format!("Py_buffer<{}>", request.element.source_name()),
+                    )
+                })?;
+        let validated = buffer
+            .validate(request.element)
+            .map_err(|message| buffer_error(py, &message, "buffer metadata validation"))?;
+        validate_request(py, &validated, request)?;
+        let metadata = metadata_for_buffer(&validated, request.element)?;
+        store_buffer(buffer, request, metadata)
     })
     .map_err(PythonError::runtime)?
 }
@@ -160,31 +187,12 @@ pub fn buffer_u8(
     )
 }
 
-fn acquire_typed<T: Element>(
-    object: &pyo3::Bound<'_, pyo3::types::PyAny>,
-    request: PythonBufferRequest,
-    wrap: fn(PyBuffer<T>) -> TrackedBuffer,
-) -> Result<PythonBufferMetadata, PythonError> {
-    let py = object.py();
-    let buffer = PyBuffer::<T>::get(object).map_err(|error| {
-        PythonError::from_pyerr(
-            py,
-            error,
-            "zero-copy",
-            format!("Py_buffer<{}>", request.element.source_name()),
-        )
-    })?;
-    validate_request(py, &buffer, request)?;
-    let metadata = metadata_for_buffer(&buffer, request.element)?;
-    store_buffer(wrap(buffer), metadata)
-}
-
-fn validate_request<T: Element>(
+fn validate_request(
     py: Python<'_>,
-    buffer: &PyBuffer<T>,
+    buffer: &ValidatedBuffer,
     request: PythonBufferRequest,
 ) -> Result<(), PythonError> {
-    if request.access == PythonBufferAccess::Write && buffer.readonly() {
+    if request.access == PythonBufferAccess::Write && buffer.readonly {
         return Err(buffer_error(
             py,
             "requested writable buffer from readonly exporter",
@@ -193,8 +201,8 @@ fn validate_request<T: Element>(
     }
     let layout_valid = match request.layout {
         PythonBufferLayout::Any => true,
-        PythonBufferLayout::CContiguous => buffer.is_c_contiguous(),
-        PythonBufferLayout::FContiguous => buffer.is_fortran_contiguous(),
+        PythonBufferLayout::CContiguous => buffer.c_contiguous,
+        PythonBufferLayout::FContiguous => buffer.f_contiguous,
     };
     if !layout_valid {
         return Err(buffer_error(
@@ -203,73 +211,33 @@ fn validate_request<T: Element>(
             "buffer layout validation",
         ));
     }
-    let dimensions = buffer.dimensions();
-    if buffer.shape().len() != dimensions || buffer.strides().len() != dimensions {
-        return Err(buffer_error(
-            py,
-            "exporter returned inconsistent shape or stride metadata",
-            "buffer metadata validation",
-        ));
-    }
-    if buffer
-        .suboffsets()
-        .is_some_and(|suboffsets| suboffsets.len() != dimensions)
-    {
-        return Err(buffer_error(
-            py,
-            "exporter returned inconsistent suboffset metadata",
-            "buffer metadata validation",
-        ));
-    }
-    let logical_items = if dimensions == 0 {
-        1
-    } else {
-        buffer
-            .shape()
-            .iter()
-            .try_fold(1_usize, |count, dimension| {
-                count.checked_mul(*dimension).ok_or_else(|| {
-                    buffer_error(
-                        py,
-                        "buffer shape exceeds the supported address space",
-                        "buffer metadata validation",
-                    )
-                })
-            })?
-    };
-    if logical_items != buffer.item_count() {
-        return Err(buffer_error(
-            py,
-            "exporter length does not match its shape and item size",
-            "buffer metadata validation",
-        ));
-    }
     Ok(())
 }
 
-fn metadata_for_buffer<T: Element>(
-    buffer: &PyBuffer<T>,
+fn metadata_for_buffer(
+    buffer: &ValidatedBuffer,
     element: PythonBufferElement,
 ) -> Result<PythonBufferMetadata, PythonError> {
     Ok(PythonBufferMetadata {
         handle: -1,
         token: 0,
         element,
-        len_bytes: checked_i64(buffer.len_bytes(), "buffer length")?,
-        item_size: checked_i64(buffer.item_size(), "buffer item size")?,
-        readonly: buffer.readonly(),
-        dimensions: checked_i64(buffer.dimensions(), "buffer dimensions")?,
-        shape: checked_i64_vec(buffer.shape(), "buffer shape")?,
-        strides: checked_i64_vec(buffer.strides(), "buffer strides")?,
-        suboffsets: checked_i64_vec(buffer.suboffsets().unwrap_or(&[]), "buffer suboffsets")?,
-        c_contiguous: buffer.is_c_contiguous(),
-        f_contiguous: buffer.is_fortran_contiguous(),
-        format: buffer.format().to_string_lossy().into_owned(),
+        len_bytes: checked_i64(buffer.len_bytes, "buffer length")?,
+        item_size: checked_i64(buffer.item_size, "buffer item size")?,
+        readonly: buffer.readonly,
+        dimensions: checked_i64(buffer.dimensions, "buffer dimensions")?,
+        shape: checked_i64_vec(&buffer.shape, "buffer shape")?,
+        strides: checked_i64_vec(&buffer.strides, "buffer strides")?,
+        suboffsets: checked_i64_vec(&buffer.suboffsets, "buffer suboffsets")?,
+        c_contiguous: buffer.c_contiguous,
+        f_contiguous: buffer.f_contiguous,
+        format: buffer.format.clone(),
     })
 }
 
 fn store_buffer(
-    buffer: TrackedBuffer,
+    buffer: OwnedPyBuffer,
+    request: PythonBufferRequest,
     mut metadata: PythonBufferMetadata,
 ) -> Result<PythonBufferMetadata, PythonError> {
     let mut store = buffer_store()?;
@@ -281,22 +249,11 @@ fn store_buffer(
         handle,
         BufferEntry {
             token,
-            buffer: Arc::new(buffer),
+            buffer: Arc::new(TrackedBuffer::new(buffer, request)),
             metadata: metadata.clone(),
         },
     );
     Ok(metadata)
-}
-
-pub fn copy_buffer_u8(buffer: BufferHandle) -> Result<Vec<u8>, PythonError> {
-    let (tracked, _) = buffer_snapshot(buffer)?;
-    super::attach(|py| match tracked.as_ref() {
-        TrackedBuffer::U8(value) => value.to_vec(py).map_err(|error| {
-            PythonError::from_pyerr(py, error, "zero-copy", "copy Py_buffer<uint8>")
-        }),
-        _ => Err(type_error(py, "buffer element type is not uint8")),
-    })
-    .map_err(PythonError::runtime)?
 }
 
 pub fn buffer_shape(buffer: BufferHandle) -> Result<Vec<i64>, PythonError> {
@@ -311,221 +268,6 @@ pub fn buffer_suboffsets(buffer: BufferHandle) -> Result<Vec<i64>, PythonError> 
     buffer_metadata(buffer).map(|metadata| metadata.suboffsets)
 }
 
-macro_rules! typed_buffer_accessors {
-    ($read:ident, $write:ident, $copy:ident, $variant:ident, $ty:ty) => {
-        pub fn $read(buffer: BufferHandle, index: i64) -> Result<$ty, PythonError> {
-            let (tracked, _) = buffer_snapshot(buffer)?;
-            super::attach(|py| match tracked.as_ref() {
-                TrackedBuffer::$variant(value) => read_typed(py, value, index),
-                _ => Err(type_error(
-                    py,
-                    "buffer element type does not match accessor",
-                )),
-            })
-            .map_err(PythonError::runtime)?
-        }
-
-        pub fn $write(buffer: BufferHandle, index: i64, value: $ty) -> Result<(), PythonError> {
-            let (tracked, _) = buffer_snapshot(buffer)?;
-            super::attach(|py| match tracked.as_ref() {
-                TrackedBuffer::$variant(target) => write_typed(py, target, index, value),
-                _ => Err(type_error(
-                    py,
-                    "buffer element type does not match accessor",
-                )),
-            })
-            .map_err(PythonError::runtime)?
-        }
-
-        pub fn $copy(
-            buffer: BufferHandle,
-            start: i64,
-            length: i64,
-        ) -> Result<Vec<$ty>, PythonError> {
-            let (tracked, _) = buffer_snapshot(buffer)?;
-            super::attach(|py| match tracked.as_ref() {
-                TrackedBuffer::$variant(value) => copy_typed_slice(py, value, start, length),
-                _ => Err(type_error(
-                    py,
-                    "buffer element type does not match accessor",
-                )),
-            })
-            .map_err(PythonError::runtime)?
-        }
-    };
-}
-
-typed_buffer_accessors!(
-    buffer_read_i8,
-    buffer_write_i8,
-    copy_buffer_slice_i8,
-    I8,
-    i8
-);
-typed_buffer_accessors!(
-    buffer_read_i16,
-    buffer_write_i16,
-    copy_buffer_slice_i16,
-    I16,
-    i16
-);
-typed_buffer_accessors!(
-    buffer_read_i32,
-    buffer_write_i32,
-    copy_buffer_slice_i32,
-    I32,
-    i32
-);
-typed_buffer_accessors!(
-    buffer_read_i64,
-    buffer_write_i64,
-    copy_buffer_slice_i64,
-    I64,
-    i64
-);
-typed_buffer_accessors!(
-    buffer_read_isize,
-    buffer_write_isize,
-    copy_buffer_slice_isize,
-    ISize,
-    isize
-);
-typed_buffer_accessors!(
-    buffer_read_u8,
-    buffer_write_u8,
-    copy_buffer_slice_u8,
-    U8,
-    u8
-);
-typed_buffer_accessors!(
-    buffer_read_u16,
-    buffer_write_u16,
-    copy_buffer_slice_u16,
-    U16,
-    u16
-);
-typed_buffer_accessors!(
-    buffer_read_u32,
-    buffer_write_u32,
-    copy_buffer_slice_u32,
-    U32,
-    u32
-);
-typed_buffer_accessors!(
-    buffer_read_u64,
-    buffer_write_u64,
-    copy_buffer_slice_u64,
-    U64,
-    u64
-);
-typed_buffer_accessors!(
-    buffer_read_usize,
-    buffer_write_usize,
-    copy_buffer_slice_usize,
-    USize,
-    usize
-);
-typed_buffer_accessors!(
-    buffer_read_f64,
-    buffer_write_f64,
-    copy_buffer_slice_f64,
-    F64,
-    f64
-);
-
-fn read_typed<T: Element>(
-    py: Python<'_>,
-    buffer: &PyBuffer<T>,
-    index: i64,
-) -> Result<T, PythonError> {
-    let index = checked_index(py, index, buffer.item_count())?;
-    readable_slice(py, buffer)?
-        .get(index)
-        .map(pyo3::buffer::ReadOnlyCell::get)
-        .ok_or_else(|| index_error(py, "buffer index is out of bounds"))
-}
-
-fn write_typed<T: Element>(
-    py: Python<'_>,
-    buffer: &PyBuffer<T>,
-    index: i64,
-    value: T,
-) -> Result<(), PythonError> {
-    let index = checked_index(py, index, buffer.item_count())?;
-    let slice = buffer
-        .as_mut_slice(py)
-        .or_else(|| buffer.as_fortran_mut_slice(py))
-        .ok_or_else(|| {
-            buffer_error(
-                py,
-                "writable typed access requires a writable contiguous buffer",
-                "buffer element write",
-            )
-        })?;
-    slice
-        .get(index)
-        .ok_or_else(|| index_error(py, "buffer index is out of bounds"))?
-        .set(value);
-    Ok(())
-}
-
-fn copy_typed_slice<T: Element>(
-    py: Python<'_>,
-    buffer: &PyBuffer<T>,
-    start: i64,
-    length: i64,
-) -> Result<Vec<T>, PythonError> {
-    let start = checked_index_inclusive(py, start, buffer.item_count())?;
-    let length = usize::try_from(length)
-        .map_err(|_| index_error(py, "buffer slice length must be non-negative"))?;
-    let end = start
-        .checked_add(length)
-        .filter(|end| *end <= buffer.item_count())
-        .ok_or_else(|| index_error(py, "buffer slice is out of bounds"))?;
-    Ok(readable_slice(py, buffer)?[start..end]
-        .iter()
-        .map(pyo3::buffer::ReadOnlyCell::get)
-        .collect())
-}
-
-fn readable_slice<'a, T: Element>(
-    py: Python<'a>,
-    buffer: &'a PyBuffer<T>,
-) -> Result<&'a [pyo3::buffer::ReadOnlyCell<T>], PythonError> {
-    buffer
-        .as_slice(py)
-        .or_else(|| buffer.as_fortran_slice(py))
-        .ok_or_else(|| {
-            buffer_error(
-                py,
-                "typed access requires a contiguous buffer",
-                "buffer element access",
-            )
-        })
-}
-
-fn checked_index(py: Python<'_>, index: i64, length: usize) -> Result<usize, PythonError> {
-    let index =
-        usize::try_from(index).map_err(|_| index_error(py, "buffer index must be non-negative"))?;
-    if index >= length {
-        return Err(index_error(py, "buffer index is out of bounds"));
-    }
-    Ok(index)
-}
-
-fn checked_index_inclusive(
-    py: Python<'_>,
-    index: i64,
-    length: usize,
-) -> Result<usize, PythonError> {
-    let index = usize::try_from(index)
-        .map_err(|_| index_error(py, "buffer slice start must be non-negative"))?;
-    if index > length {
-        return Err(index_error(py, "buffer slice start is out of bounds"));
-    }
-    Ok(index)
-}
-
 pub fn release_buffer((handle, token): BufferHandle) -> Result<(), PythonError> {
     let entry = {
         let mut store = buffer_store()?;
@@ -538,9 +280,9 @@ pub fn release_buffer((handle, token): BufferHandle) -> Result<(), PythonError> 
         } else {
             return Err(closed_error(handle));
         }
-    };
-    super::attach(|_py| drop(entry)).map_err(PythonError::runtime)?;
-    Ok(())
+    }
+    .ok_or_else(|| closed_error(handle))?;
+    super::attach(|py| entry.buffer.release(py)).map_err(PythonError::runtime)?
 }
 
 fn buffer_snapshot(
@@ -608,6 +350,34 @@ where
         .collect()
 }
 
+fn with_live_buffer<R>(
+    buffer: BufferHandle,
+    expected: PythonBufferElement,
+    require_write: bool,
+    operation: impl FnOnce(Python<'_>, &OwnedPyBuffer) -> Result<R, PythonError>,
+) -> Result<R, PythonError> {
+    let (tracked, _) = buffer_snapshot(buffer)?;
+    super::attach(|py| {
+        if tracked.element != expected {
+            return Err(type_error(
+                py,
+                "buffer element type does not match accessor",
+            ));
+        }
+        if require_write && tracked.access != PythonBufferAccess::Write {
+            return Err(buffer_error(
+                py,
+                "buffer was acquired with read-only declaration access",
+                "buffer element write",
+            ));
+        }
+        let state = tracked.buffer.lock().map_err(|_| buffer_state_error())?;
+        let value = state.as_ref().ok_or_else(|| closed_error(buffer.0))?;
+        operation(py, value)
+    })
+    .map_err(PythonError::runtime)?
+}
+
 fn buffer_error(py: Python<'_>, message: &str, context: &str) -> PythonError {
     PythonError::from_pyerr(
         py,
@@ -642,6 +412,17 @@ fn closed_error(handle: i64) -> PythonError {
         message: format!("Python buffer handle {handle} is closed"),
         traceback: String::new(),
         context: "buffer handle lookup".to_string(),
+        replay: None,
+    }
+}
+
+fn buffer_state_error() -> PythonError {
+    PythonError {
+        kind: "runtime".to_string(),
+        exception_type: "SifrPythonRuntimeError".to_string(),
+        message: "Python buffer state is unavailable".to_string(),
+        traceback: String::new(),
+        context: "buffer state".to_string(),
         replay: None,
     }
 }

--- a/crates/sifr_runtime/src/python/buffer_ops.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops.rs
@@ -358,6 +358,8 @@ fn with_live_buffer<R>(
 ) -> Result<R, PythonError> {
     let (tracked, _) = buffer_snapshot(buffer)?;
     super::attach(|py| {
+        let state = tracked.buffer.lock().map_err(|_| buffer_state_error())?;
+        let value = state.as_ref().ok_or_else(|| closed_error(buffer.0))?;
         if tracked.element != expected {
             return Err(type_error(
                 py,
@@ -371,8 +373,6 @@ fn with_live_buffer<R>(
                 "buffer element write",
             ));
         }
-        let state = tracked.buffer.lock().map_err(|_| buffer_state_error())?;
-        let value = state.as_ref().ok_or_else(|| closed_error(buffer.0))?;
         operation(py, value)
     })
     .map_err(PythonError::runtime)?

--- a/crates/sifr_runtime/src/python/buffer_ops.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops.rs
@@ -1,10 +1,11 @@
 use super::object_ops::clone_handle;
 use super::{ObjectHandle, PythonError, PythonRuntimeError};
-use pyo3::buffer::PyBuffer;
-use pyo3::exceptions::PyBufferError;
+use pyo3::buffer::{Element, PyBuffer};
+use pyo3::exceptions::{PyBufferError, PyIndexError, PyTypeError};
+use pyo3::Python;
 use std::collections::HashMap;
 use std::hash::BuildHasher;
-use std::sync::{LazyLock, Mutex, MutexGuard};
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard};
 
 static BUFFER_STORE: LazyLock<Mutex<BufferStore>> =
     LazyLock::new(|| Mutex::new(BufferStore::default()));
@@ -13,10 +14,65 @@ static TOKEN_HASHER: LazyLock<std::collections::hash_map::RandomState> =
 
 pub type BufferHandle = (i64, i64);
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PythonBufferElement {
+    I8,
+    I16,
+    I32,
+    I64,
+    ISize,
+    U8,
+    U16,
+    U32,
+    U64,
+    USize,
+    F64,
+}
+
+impl PythonBufferElement {
+    #[must_use]
+    pub const fn source_name(self) -> &'static str {
+        match self {
+            Self::I8 => "int8",
+            Self::I16 => "int16",
+            Self::I32 => "int32",
+            Self::I64 => "int64",
+            Self::ISize => "isize",
+            Self::U8 => "uint8",
+            Self::U16 => "uint16",
+            Self::U32 => "uint32",
+            Self::U64 => "uint64",
+            Self::USize => "usize",
+            Self::F64 => "float",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PythonBufferAccess {
+    Read,
+    Write,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PythonBufferLayout {
+    Any,
+    CContiguous,
+    FContiguous,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PythonBufferRequest {
+    pub element: PythonBufferElement,
+    pub access: PythonBufferAccess,
+    pub layout: PythonBufferLayout,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PythonBufferMetadata {
     pub handle: i64,
     pub token: i64,
+    pub element: PythonBufferElement,
     pub len_bytes: i64,
     pub item_size: i64,
     pub readonly: bool,
@@ -38,57 +94,207 @@ struct BufferStore {
 
 struct BufferEntry {
     token: i64,
-    buffer: TrackedBuffer,
+    buffer: Arc<TrackedBuffer>,
     metadata: PythonBufferMetadata,
 }
 
-struct TrackedBuffer {
-    buffer: Option<PyBuffer<u8>>,
+enum TrackedBuffer {
+    I8(PyBuffer<i8>),
+    I16(PyBuffer<i16>),
+    I32(PyBuffer<i32>),
+    I64(PyBuffer<i64>),
+    ISize(PyBuffer<isize>),
+    U8(PyBuffer<u8>),
+    U16(PyBuffer<u16>),
+    U32(PyBuffer<u32>),
+    U64(PyBuffer<u64>),
+    USize(PyBuffer<usize>),
+    F64(PyBuffer<f64>),
 }
 
 impl Drop for TrackedBuffer {
     fn drop(&mut self) {
-        let Some(buffer) = self.buffer.take() else {
-            return;
-        };
-        drop(buffer);
         let _ignored = super::update_object_count(-1);
     }
+}
+
+pub fn acquire_buffer(
+    object: &ObjectHandle,
+    request: PythonBufferRequest,
+) -> Result<PythonBufferMetadata, PythonError> {
+    super::attach(|py| {
+        let object = clone_handle(py, object)?;
+        let object = object.bind(py);
+        match request.element {
+            PythonBufferElement::I8 => acquire_typed(object, request, TrackedBuffer::I8),
+            PythonBufferElement::I16 => acquire_typed(object, request, TrackedBuffer::I16),
+            PythonBufferElement::I32 => acquire_typed(object, request, TrackedBuffer::I32),
+            PythonBufferElement::I64 => acquire_typed(object, request, TrackedBuffer::I64),
+            PythonBufferElement::ISize => acquire_typed(object, request, TrackedBuffer::ISize),
+            PythonBufferElement::U8 => acquire_typed(object, request, TrackedBuffer::U8),
+            PythonBufferElement::U16 => acquire_typed(object, request, TrackedBuffer::U16),
+            PythonBufferElement::U32 => acquire_typed(object, request, TrackedBuffer::U32),
+            PythonBufferElement::U64 => acquire_typed(object, request, TrackedBuffer::U64),
+            PythonBufferElement::USize => acquire_typed(object, request, TrackedBuffer::USize),
+            PythonBufferElement::F64 => acquire_typed(object, request, TrackedBuffer::F64),
+        }
+    })
+    .map_err(PythonError::runtime)?
 }
 
 pub fn buffer_u8(
     object: &ObjectHandle,
     require_writable: bool,
 ) -> Result<PythonBufferMetadata, PythonError> {
-    super::attach(|py| {
-        let object = clone_handle(py, object)?;
-        let buffer = PyBuffer::<u8>::get(object.bind(py))
-            .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "Py_buffer<u8>"))?;
-        if require_writable && buffer.readonly() {
-            return Err(PythonError::from_pyerr(
-                py,
-                PyBufferError::new_err("requested writable buffer from readonly exporter"),
-                "zero-copy",
-                "writable Py_buffer<u8>",
-            ));
-        }
-        let metadata = metadata_for_buffer(&buffer)?;
-        store_buffer(buffer, metadata)
+    acquire_buffer(
+        object,
+        PythonBufferRequest {
+            element: PythonBufferElement::U8,
+            access: if require_writable {
+                PythonBufferAccess::Write
+            } else {
+                PythonBufferAccess::Read
+            },
+            layout: PythonBufferLayout::Any,
+        },
+    )
+}
+
+fn acquire_typed<T: Element>(
+    object: &pyo3::Bound<'_, pyo3::types::PyAny>,
+    request: PythonBufferRequest,
+    wrap: fn(PyBuffer<T>) -> TrackedBuffer,
+) -> Result<PythonBufferMetadata, PythonError> {
+    let py = object.py();
+    let buffer = PyBuffer::<T>::get(object).map_err(|error| {
+        PythonError::from_pyerr(
+            py,
+            error,
+            "zero-copy",
+            format!("Py_buffer<{}>", request.element.source_name()),
+        )
+    })?;
+    validate_request(py, &buffer, request)?;
+    let metadata = metadata_for_buffer(&buffer, request.element)?;
+    store_buffer(wrap(buffer), metadata)
+}
+
+fn validate_request<T: Element>(
+    py: Python<'_>,
+    buffer: &PyBuffer<T>,
+    request: PythonBufferRequest,
+) -> Result<(), PythonError> {
+    if request.access == PythonBufferAccess::Write && buffer.readonly() {
+        return Err(buffer_error(
+            py,
+            "requested writable buffer from readonly exporter",
+            "writable buffer acquisition",
+        ));
+    }
+    let layout_valid = match request.layout {
+        PythonBufferLayout::Any => true,
+        PythonBufferLayout::CContiguous => buffer.is_c_contiguous(),
+        PythonBufferLayout::FContiguous => buffer.is_fortran_contiguous(),
+    };
+    if !layout_valid {
+        return Err(buffer_error(
+            py,
+            "exporter does not satisfy the declared buffer layout",
+            "buffer layout validation",
+        ));
+    }
+    let dimensions = buffer.dimensions();
+    if buffer.shape().len() != dimensions || buffer.strides().len() != dimensions {
+        return Err(buffer_error(
+            py,
+            "exporter returned inconsistent shape or stride metadata",
+            "buffer metadata validation",
+        ));
+    }
+    if buffer
+        .suboffsets()
+        .is_some_and(|suboffsets| suboffsets.len() != dimensions)
+    {
+        return Err(buffer_error(
+            py,
+            "exporter returned inconsistent suboffset metadata",
+            "buffer metadata validation",
+        ));
+    }
+    let logical_items = if dimensions == 0 {
+        1
+    } else {
+        buffer
+            .shape()
+            .iter()
+            .try_fold(1_usize, |count, dimension| {
+                count.checked_mul(*dimension).ok_or_else(|| {
+                    buffer_error(
+                        py,
+                        "buffer shape exceeds the supported address space",
+                        "buffer metadata validation",
+                    )
+                })
+            })?
+    };
+    if logical_items != buffer.item_count() {
+        return Err(buffer_error(
+            py,
+            "exporter length does not match its shape and item size",
+            "buffer metadata validation",
+        ));
+    }
+    Ok(())
+}
+
+fn metadata_for_buffer<T: Element>(
+    buffer: &PyBuffer<T>,
+    element: PythonBufferElement,
+) -> Result<PythonBufferMetadata, PythonError> {
+    Ok(PythonBufferMetadata {
+        handle: -1,
+        token: 0,
+        element,
+        len_bytes: checked_i64(buffer.len_bytes(), "buffer length")?,
+        item_size: checked_i64(buffer.item_size(), "buffer item size")?,
+        readonly: buffer.readonly(),
+        dimensions: checked_i64(buffer.dimensions(), "buffer dimensions")?,
+        shape: checked_i64_vec(buffer.shape(), "buffer shape")?,
+        strides: checked_i64_vec(buffer.strides(), "buffer strides")?,
+        suboffsets: checked_i64_vec(buffer.suboffsets().unwrap_or(&[]), "buffer suboffsets")?,
+        c_contiguous: buffer.is_c_contiguous(),
+        f_contiguous: buffer.is_fortran_contiguous(),
+        format: buffer.format().to_string_lossy().into_owned(),
     })
-    .map_err(PythonError::runtime)?
+}
+
+fn store_buffer(
+    buffer: TrackedBuffer,
+    mut metadata: PythonBufferMetadata,
+) -> Result<PythonBufferMetadata, PythonError> {
+    let mut store = buffer_store()?;
+    let (handle, token) = reserve_handle(&mut store)?;
+    super::update_object_count(1).map_err(PythonError::runtime)?;
+    metadata.handle = handle;
+    metadata.token = token;
+    store.buffers.insert(
+        handle,
+        BufferEntry {
+            token,
+            buffer: Arc::new(buffer),
+            metadata: metadata.clone(),
+        },
+    );
+    Ok(metadata)
 }
 
 pub fn copy_buffer_u8(buffer: BufferHandle) -> Result<Vec<u8>, PythonError> {
-    super::attach(|py| {
-        let store = buffer_store()?;
-        let entry = lookup_buffer(&store, buffer)?;
-        entry
-            .buffer
-            .buffer
-            .as_ref()
-            .ok_or_else(|| closed_error(buffer.0))?
-            .to_vec(py)
-            .map_err(|error| PythonError::from_pyerr(py, error, "zero-copy", "copy Py_buffer<u8>"))
+    let (tracked, _) = buffer_snapshot(buffer)?;
+    super::attach(|py| match tracked.as_ref() {
+        TrackedBuffer::U8(value) => value.to_vec(py).map_err(|error| {
+            PythonError::from_pyerr(py, error, "zero-copy", "copy Py_buffer<uint8>")
+        }),
+        _ => Err(type_error(py, "buffer element type is not uint8")),
     })
     .map_err(PythonError::runtime)?
 }
@@ -103,6 +309,221 @@ pub fn buffer_strides(buffer: BufferHandle) -> Result<Vec<i64>, PythonError> {
 
 pub fn buffer_suboffsets(buffer: BufferHandle) -> Result<Vec<i64>, PythonError> {
     buffer_metadata(buffer).map(|metadata| metadata.suboffsets)
+}
+
+macro_rules! typed_buffer_accessors {
+    ($read:ident, $write:ident, $copy:ident, $variant:ident, $ty:ty) => {
+        pub fn $read(buffer: BufferHandle, index: i64) -> Result<$ty, PythonError> {
+            let (tracked, _) = buffer_snapshot(buffer)?;
+            super::attach(|py| match tracked.as_ref() {
+                TrackedBuffer::$variant(value) => read_typed(py, value, index),
+                _ => Err(type_error(
+                    py,
+                    "buffer element type does not match accessor",
+                )),
+            })
+            .map_err(PythonError::runtime)?
+        }
+
+        pub fn $write(buffer: BufferHandle, index: i64, value: $ty) -> Result<(), PythonError> {
+            let (tracked, _) = buffer_snapshot(buffer)?;
+            super::attach(|py| match tracked.as_ref() {
+                TrackedBuffer::$variant(target) => write_typed(py, target, index, value),
+                _ => Err(type_error(
+                    py,
+                    "buffer element type does not match accessor",
+                )),
+            })
+            .map_err(PythonError::runtime)?
+        }
+
+        pub fn $copy(
+            buffer: BufferHandle,
+            start: i64,
+            length: i64,
+        ) -> Result<Vec<$ty>, PythonError> {
+            let (tracked, _) = buffer_snapshot(buffer)?;
+            super::attach(|py| match tracked.as_ref() {
+                TrackedBuffer::$variant(value) => copy_typed_slice(py, value, start, length),
+                _ => Err(type_error(
+                    py,
+                    "buffer element type does not match accessor",
+                )),
+            })
+            .map_err(PythonError::runtime)?
+        }
+    };
+}
+
+typed_buffer_accessors!(
+    buffer_read_i8,
+    buffer_write_i8,
+    copy_buffer_slice_i8,
+    I8,
+    i8
+);
+typed_buffer_accessors!(
+    buffer_read_i16,
+    buffer_write_i16,
+    copy_buffer_slice_i16,
+    I16,
+    i16
+);
+typed_buffer_accessors!(
+    buffer_read_i32,
+    buffer_write_i32,
+    copy_buffer_slice_i32,
+    I32,
+    i32
+);
+typed_buffer_accessors!(
+    buffer_read_i64,
+    buffer_write_i64,
+    copy_buffer_slice_i64,
+    I64,
+    i64
+);
+typed_buffer_accessors!(
+    buffer_read_isize,
+    buffer_write_isize,
+    copy_buffer_slice_isize,
+    ISize,
+    isize
+);
+typed_buffer_accessors!(
+    buffer_read_u8,
+    buffer_write_u8,
+    copy_buffer_slice_u8,
+    U8,
+    u8
+);
+typed_buffer_accessors!(
+    buffer_read_u16,
+    buffer_write_u16,
+    copy_buffer_slice_u16,
+    U16,
+    u16
+);
+typed_buffer_accessors!(
+    buffer_read_u32,
+    buffer_write_u32,
+    copy_buffer_slice_u32,
+    U32,
+    u32
+);
+typed_buffer_accessors!(
+    buffer_read_u64,
+    buffer_write_u64,
+    copy_buffer_slice_u64,
+    U64,
+    u64
+);
+typed_buffer_accessors!(
+    buffer_read_usize,
+    buffer_write_usize,
+    copy_buffer_slice_usize,
+    USize,
+    usize
+);
+typed_buffer_accessors!(
+    buffer_read_f64,
+    buffer_write_f64,
+    copy_buffer_slice_f64,
+    F64,
+    f64
+);
+
+fn read_typed<T: Element>(
+    py: Python<'_>,
+    buffer: &PyBuffer<T>,
+    index: i64,
+) -> Result<T, PythonError> {
+    let index = checked_index(py, index, buffer.item_count())?;
+    readable_slice(py, buffer)?
+        .get(index)
+        .map(pyo3::buffer::ReadOnlyCell::get)
+        .ok_or_else(|| index_error(py, "buffer index is out of bounds"))
+}
+
+fn write_typed<T: Element>(
+    py: Python<'_>,
+    buffer: &PyBuffer<T>,
+    index: i64,
+    value: T,
+) -> Result<(), PythonError> {
+    let index = checked_index(py, index, buffer.item_count())?;
+    let slice = buffer
+        .as_mut_slice(py)
+        .or_else(|| buffer.as_fortran_mut_slice(py))
+        .ok_or_else(|| {
+            buffer_error(
+                py,
+                "writable typed access requires a writable contiguous buffer",
+                "buffer element write",
+            )
+        })?;
+    slice
+        .get(index)
+        .ok_or_else(|| index_error(py, "buffer index is out of bounds"))?
+        .set(value);
+    Ok(())
+}
+
+fn copy_typed_slice<T: Element>(
+    py: Python<'_>,
+    buffer: &PyBuffer<T>,
+    start: i64,
+    length: i64,
+) -> Result<Vec<T>, PythonError> {
+    let start = checked_index_inclusive(py, start, buffer.item_count())?;
+    let length = usize::try_from(length)
+        .map_err(|_| index_error(py, "buffer slice length must be non-negative"))?;
+    let end = start
+        .checked_add(length)
+        .filter(|end| *end <= buffer.item_count())
+        .ok_or_else(|| index_error(py, "buffer slice is out of bounds"))?;
+    Ok(readable_slice(py, buffer)?[start..end]
+        .iter()
+        .map(pyo3::buffer::ReadOnlyCell::get)
+        .collect())
+}
+
+fn readable_slice<'a, T: Element>(
+    py: Python<'a>,
+    buffer: &'a PyBuffer<T>,
+) -> Result<&'a [pyo3::buffer::ReadOnlyCell<T>], PythonError> {
+    buffer
+        .as_slice(py)
+        .or_else(|| buffer.as_fortran_slice(py))
+        .ok_or_else(|| {
+            buffer_error(
+                py,
+                "typed access requires a contiguous buffer",
+                "buffer element access",
+            )
+        })
+}
+
+fn checked_index(py: Python<'_>, index: i64, length: usize) -> Result<usize, PythonError> {
+    let index =
+        usize::try_from(index).map_err(|_| index_error(py, "buffer index must be non-negative"))?;
+    if index >= length {
+        return Err(index_error(py, "buffer index is out of bounds"));
+    }
+    Ok(index)
+}
+
+fn checked_index_inclusive(
+    py: Python<'_>,
+    index: i64,
+    length: usize,
+) -> Result<usize, PythonError> {
+    let index = usize::try_from(index)
+        .map_err(|_| index_error(py, "buffer slice start must be non-negative"))?;
+    if index > length {
+        return Err(index_error(py, "buffer slice start is out of bounds"));
+    }
+    Ok(index)
 }
 
 pub fn release_buffer((handle, token): BufferHandle) -> Result<(), PythonError> {
@@ -122,48 +543,16 @@ pub fn release_buffer((handle, token): BufferHandle) -> Result<(), PythonError> 
     Ok(())
 }
 
-fn metadata_for_buffer(buffer: &PyBuffer<u8>) -> Result<PythonBufferMetadata, PythonError> {
-    Ok(PythonBufferMetadata {
-        handle: -1,
-        token: 0,
-        len_bytes: checked_i64(buffer.len_bytes(), "buffer length")?,
-        item_size: checked_i64(buffer.item_size(), "buffer item size")?,
-        readonly: buffer.readonly(),
-        dimensions: checked_i64(buffer.dimensions(), "buffer dimensions")?,
-        shape: checked_i64_vec(buffer.shape(), "buffer shape")?,
-        strides: checked_i64_vec(buffer.strides(), "buffer strides")?,
-        suboffsets: checked_i64_vec(buffer.suboffsets().unwrap_or(&[]), "buffer suboffsets")?,
-        c_contiguous: buffer.is_c_contiguous(),
-        f_contiguous: buffer.is_fortran_contiguous(),
-        format: buffer.format().to_string_lossy().into_owned(),
-    })
-}
-
-fn store_buffer(
-    buffer: PyBuffer<u8>,
-    mut metadata: PythonBufferMetadata,
-) -> Result<PythonBufferMetadata, PythonError> {
-    let mut store = buffer_store()?;
-    let (handle, token) = reserve_handle(&mut store)?;
-    super::update_object_count(1).map_err(PythonError::runtime)?;
-    metadata.handle = handle;
-    metadata.token = token;
-    store.buffers.insert(
-        handle,
-        BufferEntry {
-            token,
-            buffer: TrackedBuffer {
-                buffer: Some(buffer),
-            },
-            metadata: metadata.clone(),
-        },
-    );
-    Ok(metadata)
+fn buffer_snapshot(
+    buffer: BufferHandle,
+) -> Result<(Arc<TrackedBuffer>, PythonBufferMetadata), PythonError> {
+    let store = buffer_store()?;
+    let entry = lookup_buffer(&store, buffer)?;
+    Ok((Arc::clone(&entry.buffer), entry.metadata.clone()))
 }
 
 fn buffer_metadata(buffer: BufferHandle) -> Result<PythonBufferMetadata, PythonError> {
-    let store = buffer_store()?;
-    lookup_buffer(&store, buffer).map(|entry| entry.metadata.clone())
+    buffer_snapshot(buffer).map(|(_, metadata)| metadata)
 }
 
 fn lookup_buffer(
@@ -219,6 +608,33 @@ where
         .collect()
 }
 
+fn buffer_error(py: Python<'_>, message: &str, context: &str) -> PythonError {
+    PythonError::from_pyerr(
+        py,
+        PyBufferError::new_err(message.to_string()),
+        "zero-copy",
+        context,
+    )
+}
+
+fn type_error(py: Python<'_>, message: &str) -> PythonError {
+    PythonError::from_pyerr(
+        py,
+        PyTypeError::new_err(message.to_string()),
+        "zero-copy",
+        "buffer typed access",
+    )
+}
+
+fn index_error(py: Python<'_>, message: &str) -> PythonError {
+    PythonError::from_pyerr(
+        py,
+        PyIndexError::new_err(message.to_string()),
+        "zero-copy",
+        "buffer bounds validation",
+    )
+}
+
 fn closed_error(handle: i64) -> PythonError {
     PythonError {
         kind: "resource".to_string(),
@@ -247,113 +663,4 @@ fn buffer_store() -> Result<MutexGuard<'static, BufferStore>, PythonError> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::python::{
-        close_object, from_bytes, from_int, initialize_runtime, reset_runtime_state_for_tests,
-        resource_diagnostics, test_config, test_guard, PythonResourceDiagnostics,
-        PythonResourceIdentity,
-    };
-
-    #[test]
-    fn buffer_view_tracks_metadata_copy_and_release() {
-        let _guard = test_guard();
-        reset_runtime_state_for_tests();
-        initialize_runtime(test_config("buffer-view")).expect("init should succeed");
-
-        let object = from_bytes(&[1, 2, 3]).expect("bytes should be stored");
-        let view = buffer_u8(&object, false).expect("bytes should expose u8 buffer");
-
-        assert_eq!(view.len_bytes, 3);
-        assert_eq!(view.item_size, 1);
-        assert!(view.readonly);
-        assert!(view.c_contiguous);
-        assert_eq!(
-            copy_buffer_u8((view.handle, view.token)).expect("buffer should copy"),
-            vec![1, 2, 3]
-        );
-        assert_eq!(
-            resource_diagnostics().expect("diagnostics should be available"),
-            PythonResourceDiagnostics {
-                initialized: true,
-                live_objects: 2,
-                leaked_objects: 0,
-            }
-        );
-        release_buffer((view.handle, view.token)).expect("buffer should release");
-        close_object(object).expect("object should close");
-        assert_eq!(
-            resource_diagnostics().expect("diagnostics should be available"),
-            PythonResourceDiagnostics {
-                initialized: true,
-                live_objects: 0,
-                leaked_objects: 0,
-            }
-        );
-    }
-
-    #[test]
-    fn buffer_double_release_is_deterministic_resource_error() {
-        let _guard = test_guard();
-        reset_runtime_state_for_tests();
-        initialize_runtime(test_config("buffer-double-release")).expect("init should succeed");
-
-        let object = from_bytes(&[1]).expect("bytes should be stored");
-        let view = buffer_u8(&object, false).expect("bytes should expose u8 buffer");
-        release_buffer((view.handle, view.token)).expect("buffer should release");
-        let error = release_buffer((view.handle, view.token)).expect_err("second release fails");
-        let copy_error =
-            copy_buffer_u8((view.handle, view.token)).expect_err("copy after release fails");
-
-        assert_eq!(error.kind, "resource");
-        assert_eq!(error.exception_type, "SifrPythonClosedBuffer");
-        assert_eq!(copy_error.kind, "resource");
-        assert_eq!(copy_error.exception_type, "SifrPythonClosedBuffer");
-        close_object(object).expect("object should close");
-    }
-
-    #[test]
-    fn sealed_resource_identity_drop_releases_buffer_and_metadata() {
-        let _guard = test_guard();
-        reset_runtime_state_for_tests();
-        initialize_runtime(test_config("buffer-identity-drop")).expect("init should succeed");
-
-        let object = from_bytes(&[1, 2]).expect("bytes should be stored");
-        let view = buffer_u8(&object, false).expect("bytes should expose u8 buffer");
-        let key = (view.handle, view.token);
-        let identity = PythonResourceIdentity::buffer(key);
-        assert_eq!(buffer_shape(key).expect("metadata should be live"), vec![2]);
-
-        drop(identity);
-
-        let error = buffer_shape(key).expect_err("metadata drops with the resource");
-        assert_eq!(error.exception_type, "SifrPythonClosedBuffer");
-        close_object(object).expect("object should close");
-        assert_eq!(
-            resource_diagnostics().expect("diagnostics should be available"),
-            PythonResourceDiagnostics {
-                initialized: true,
-                live_objects: 0,
-                leaked_objects: 0,
-            }
-        );
-    }
-
-    #[test]
-    fn buffer_rejects_wrong_dtype_and_readonly_writable_request() {
-        let _guard = test_guard();
-        reset_runtime_state_for_tests();
-        initialize_runtime(test_config("buffer-rejects")).expect("init should succeed");
-
-        let object = from_bytes(&[1]).expect("bytes should be stored");
-        let writable = buffer_u8(&object, true).expect_err("bytes are readonly");
-        assert_eq!(writable.kind, "zero-copy");
-
-        let integer = from_int(1).expect("int should be stored");
-        let unsupported = buffer_u8(&integer, false).expect_err("int has no u8 buffer");
-        assert_eq!(unsupported.kind, "zero-copy");
-
-        close_object(object).expect("object should close");
-        close_object(integer).expect("integer should close");
-    }
-}
+mod tests;

--- a/crates/sifr_runtime/src/python/buffer_ops/access.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops/access.rs
@@ -1,0 +1,201 @@
+use super::raw::OwnedPyBuffer;
+use super::{index_error, with_live_buffer, BufferHandle, PythonBufferElement, PythonError};
+use pyo3::Python;
+use std::ptr;
+
+macro_rules! typed_buffer_accessors {
+    ($read:ident, $write:ident, $copy:ident, $element:ident, $ty:ty) => {
+        pub fn $read(buffer: BufferHandle, index: i64) -> Result<$ty, PythonError> {
+            with_live_buffer(buffer, PythonBufferElement::$element, false, |py, value| {
+                read_typed(py, value, index)
+            })
+        }
+
+        pub fn $write(buffer: BufferHandle, index: i64, value: $ty) -> Result<(), PythonError> {
+            with_live_buffer(buffer, PythonBufferElement::$element, true, |py, target| {
+                write_typed(py, target, index, value)
+            })
+        }
+
+        pub fn $copy(
+            buffer: BufferHandle,
+            start: i64,
+            length: i64,
+        ) -> Result<Vec<$ty>, PythonError> {
+            with_live_buffer(buffer, PythonBufferElement::$element, false, |py, value| {
+                copy_typed_slice(py, value, start, length)
+            })
+        }
+    };
+}
+
+typed_buffer_accessors!(
+    buffer_read_i8,
+    buffer_write_i8,
+    copy_buffer_slice_i8,
+    I8,
+    i8
+);
+typed_buffer_accessors!(
+    buffer_read_i16,
+    buffer_write_i16,
+    copy_buffer_slice_i16,
+    I16,
+    i16
+);
+typed_buffer_accessors!(
+    buffer_read_i32,
+    buffer_write_i32,
+    copy_buffer_slice_i32,
+    I32,
+    i32
+);
+typed_buffer_accessors!(
+    buffer_read_i64,
+    buffer_write_i64,
+    copy_buffer_slice_i64,
+    I64,
+    i64
+);
+typed_buffer_accessors!(
+    buffer_read_isize,
+    buffer_write_isize,
+    copy_buffer_slice_isize,
+    ISize,
+    isize
+);
+typed_buffer_accessors!(
+    buffer_read_u8,
+    buffer_write_u8,
+    copy_buffer_slice_u8,
+    U8,
+    u8
+);
+typed_buffer_accessors!(
+    buffer_read_u16,
+    buffer_write_u16,
+    copy_buffer_slice_u16,
+    U16,
+    u16
+);
+typed_buffer_accessors!(
+    buffer_read_u32,
+    buffer_write_u32,
+    copy_buffer_slice_u32,
+    U32,
+    u32
+);
+typed_buffer_accessors!(
+    buffer_read_u64,
+    buffer_write_u64,
+    copy_buffer_slice_u64,
+    U64,
+    u64
+);
+typed_buffer_accessors!(
+    buffer_read_usize,
+    buffer_write_usize,
+    copy_buffer_slice_usize,
+    USize,
+    usize
+);
+typed_buffer_accessors!(
+    buffer_read_f64,
+    buffer_write_f64,
+    copy_buffer_slice_f64,
+    F64,
+    f64
+);
+
+pub fn copy_buffer_u8(buffer: BufferHandle) -> Result<Vec<u8>, PythonError> {
+    with_live_buffer(buffer, PythonBufferElement::U8, false, |py, value| {
+        copy_typed_range(py, value, 0, value.item_count())
+    })
+}
+
+fn read_typed<T: Copy>(
+    py: Python<'_>,
+    buffer: &OwnedPyBuffer,
+    index: i64,
+) -> Result<T, PythonError> {
+    let index = checked_index(py, index, buffer.item_count())?;
+    let pointer = buffer
+        .item_ptr(index)
+        .ok_or_else(|| index_error(py, "buffer index is out of bounds"))?;
+    // SAFETY: acquisition validated the element format and width. The pointer
+    // addresses one logical element and unaligned access handles arbitrary
+    // valid PEP 3118 strides.
+    Ok(unsafe { ptr::read_unaligned(pointer.cast::<T>()) })
+}
+
+fn write_typed<T: Copy>(
+    py: Python<'_>,
+    buffer: &OwnedPyBuffer,
+    index: i64,
+    value: T,
+) -> Result<(), PythonError> {
+    let index = checked_index(py, index, buffer.item_count())?;
+    let pointer = buffer
+        .item_ptr(index)
+        .ok_or_else(|| index_error(py, "buffer index is out of bounds"))?;
+    // SAFETY: write admission is checked against both the declaration and the
+    // exporter request. Format/width validation and unaligned writes make this
+    // valid for arbitrary accepted strides.
+    unsafe { ptr::write_unaligned(pointer.cast::<T>(), value) };
+    Ok(())
+}
+
+fn copy_typed_slice<T: Copy>(
+    py: Python<'_>,
+    buffer: &OwnedPyBuffer,
+    start: i64,
+    length: i64,
+) -> Result<Vec<T>, PythonError> {
+    let start = checked_index_inclusive(py, start, buffer.item_count())?;
+    let length = usize::try_from(length)
+        .map_err(|_| index_error(py, "buffer slice length must be non-negative"))?;
+    let end = start
+        .checked_add(length)
+        .filter(|end| *end <= buffer.item_count())
+        .ok_or_else(|| index_error(py, "buffer slice is out of bounds"))?;
+    copy_typed_range(py, buffer, start, end)
+}
+
+fn copy_typed_range<T: Copy>(
+    py: Python<'_>,
+    buffer: &OwnedPyBuffer,
+    start: usize,
+    end: usize,
+) -> Result<Vec<T>, PythonError> {
+    let mut values = Vec::with_capacity(end.saturating_sub(start));
+    for index in start..end {
+        let pointer = buffer
+            .item_ptr(index)
+            .ok_or_else(|| index_error(py, "buffer slice is out of bounds"))?;
+        // SAFETY: identical to `read_typed`, repeated in logical C order.
+        values.push(unsafe { ptr::read_unaligned(pointer.cast::<T>()) });
+    }
+    Ok(values)
+}
+
+fn checked_index(py: Python<'_>, index: i64, length: usize) -> Result<usize, PythonError> {
+    let index =
+        usize::try_from(index).map_err(|_| index_error(py, "buffer index must be non-negative"))?;
+    if index >= length {
+        return Err(index_error(py, "buffer index is out of bounds"));
+    }
+    Ok(index)
+}
+
+fn checked_index_inclusive(
+    py: Python<'_>,
+    index: i64,
+    length: usize,
+) -> Result<usize, PythonError> {
+    let index = usize::try_from(index)
+        .map_err(|_| index_error(py, "buffer slice start must be non-negative"))?;
+    if index > length {
+        return Err(index_error(py, "buffer slice start is out of bounds"));
+    }
+    Ok(index)
+}

--- a/crates/sifr_runtime/src/python/buffer_ops/access.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops/access.rs
@@ -1,19 +1,18 @@
 use super::raw::OwnedPyBuffer;
-use super::{index_error, with_live_buffer, BufferHandle, PythonBufferElement, PythonError};
-use pyo3::Python;
+use super::{with_live_buffer, BufferAccessError, BufferHandle, PythonBufferElement, PythonError};
 use std::ptr;
 
 macro_rules! typed_buffer_accessors {
     ($read:ident, $write:ident, $copy:ident, $element:ident, $ty:ty) => {
         pub fn $read(buffer: BufferHandle, index: i64) -> Result<$ty, PythonError> {
-            with_live_buffer(buffer, PythonBufferElement::$element, false, |py, value| {
-                read_typed(py, value, index)
+            with_live_buffer(buffer, PythonBufferElement::$element, false, |value| {
+                read_typed(value, index)
             })
         }
 
         pub fn $write(buffer: BufferHandle, index: i64, value: $ty) -> Result<(), PythonError> {
-            with_live_buffer(buffer, PythonBufferElement::$element, true, |py, target| {
-                write_typed(py, target, index, value)
+            with_live_buffer(buffer, PythonBufferElement::$element, true, |target| {
+                write_typed(target, index, value)
             })
         }
 
@@ -22,8 +21,8 @@ macro_rules! typed_buffer_accessors {
             start: i64,
             length: i64,
         ) -> Result<Vec<$ty>, PythonError> {
-            with_live_buffer(buffer, PythonBufferElement::$element, false, |py, value| {
-                copy_typed_slice(py, value, start, length)
+            with_live_buffer(buffer, PythonBufferElement::$element, false, |value| {
+                copy_typed_slice(value, start, length)
             })
         }
     };
@@ -108,20 +107,16 @@ typed_buffer_accessors!(
 );
 
 pub fn copy_buffer_u8(buffer: BufferHandle) -> Result<Vec<u8>, PythonError> {
-    with_live_buffer(buffer, PythonBufferElement::U8, false, |py, value| {
-        copy_typed_range(py, value, 0, value.item_count())
+    with_live_buffer(buffer, PythonBufferElement::U8, false, |value| {
+        copy_typed_range(value, 0, value.item_count())
     })
 }
 
-fn read_typed<T: Copy>(
-    py: Python<'_>,
-    buffer: &OwnedPyBuffer,
-    index: i64,
-) -> Result<T, PythonError> {
-    let index = checked_index(py, index, buffer.item_count())?;
+fn read_typed<T: Copy>(buffer: &OwnedPyBuffer, index: i64) -> Result<T, BufferAccessError> {
+    let index = checked_index(index, buffer.item_count())?;
     let pointer = buffer
         .item_ptr(index)
-        .ok_or_else(|| index_error(py, "buffer index is out of bounds"))?;
+        .ok_or(BufferAccessError::Index("buffer index is out of bounds"))?;
     // SAFETY: acquisition validated the element format and width. The pointer
     // addresses one logical element and unaligned access handles arbitrary
     // valid PEP 3118 strides.
@@ -129,15 +124,14 @@ fn read_typed<T: Copy>(
 }
 
 fn write_typed<T: Copy>(
-    py: Python<'_>,
     buffer: &OwnedPyBuffer,
     index: i64,
     value: T,
-) -> Result<(), PythonError> {
-    let index = checked_index(py, index, buffer.item_count())?;
+) -> Result<(), BufferAccessError> {
+    let index = checked_index(index, buffer.item_count())?;
     let pointer = buffer
         .item_ptr(index)
-        .ok_or_else(|| index_error(py, "buffer index is out of bounds"))?;
+        .ok_or(BufferAccessError::Index("buffer index is out of bounds"))?;
     // SAFETY: write admission is checked against both the declaration and the
     // exporter request. Format/width validation and unaligned writes make this
     // valid for arbitrary accepted strides.
@@ -146,56 +140,52 @@ fn write_typed<T: Copy>(
 }
 
 fn copy_typed_slice<T: Copy>(
-    py: Python<'_>,
     buffer: &OwnedPyBuffer,
     start: i64,
     length: i64,
-) -> Result<Vec<T>, PythonError> {
-    let start = checked_index_inclusive(py, start, buffer.item_count())?;
+) -> Result<Vec<T>, BufferAccessError> {
+    let start = checked_index_inclusive(start, buffer.item_count())?;
     let length = usize::try_from(length)
-        .map_err(|_| index_error(py, "buffer slice length must be non-negative"))?;
+        .map_err(|_| BufferAccessError::Index("buffer slice length must be non-negative"))?;
     let end = start
         .checked_add(length)
         .filter(|end| *end <= buffer.item_count())
-        .ok_or_else(|| index_error(py, "buffer slice is out of bounds"))?;
-    copy_typed_range(py, buffer, start, end)
+        .ok_or(BufferAccessError::Index("buffer slice is out of bounds"))?;
+    copy_typed_range(buffer, start, end)
 }
 
 fn copy_typed_range<T: Copy>(
-    py: Python<'_>,
     buffer: &OwnedPyBuffer,
     start: usize,
     end: usize,
-) -> Result<Vec<T>, PythonError> {
+) -> Result<Vec<T>, BufferAccessError> {
     let mut values = Vec::with_capacity(end.saturating_sub(start));
     for index in start..end {
         let pointer = buffer
             .item_ptr(index)
-            .ok_or_else(|| index_error(py, "buffer slice is out of bounds"))?;
+            .ok_or(BufferAccessError::Index("buffer slice is out of bounds"))?;
         // SAFETY: identical to `read_typed`, repeated in logical C order.
         values.push(unsafe { ptr::read_unaligned(pointer.cast::<T>()) });
     }
     Ok(values)
 }
 
-fn checked_index(py: Python<'_>, index: i64, length: usize) -> Result<usize, PythonError> {
-    let index =
-        usize::try_from(index).map_err(|_| index_error(py, "buffer index must be non-negative"))?;
+fn checked_index(index: i64, length: usize) -> Result<usize, BufferAccessError> {
+    let index = usize::try_from(index)
+        .map_err(|_| BufferAccessError::Index("buffer index must be non-negative"))?;
     if index >= length {
-        return Err(index_error(py, "buffer index is out of bounds"));
+        return Err(BufferAccessError::Index("buffer index is out of bounds"));
     }
     Ok(index)
 }
 
-fn checked_index_inclusive(
-    py: Python<'_>,
-    index: i64,
-    length: usize,
-) -> Result<usize, PythonError> {
+fn checked_index_inclusive(index: i64, length: usize) -> Result<usize, BufferAccessError> {
     let index = usize::try_from(index)
-        .map_err(|_| index_error(py, "buffer slice start must be non-negative"))?;
+        .map_err(|_| BufferAccessError::Index("buffer slice start must be non-negative"))?;
     if index > length {
-        return Err(index_error(py, "buffer slice start is out of bounds"));
+        return Err(BufferAccessError::Index(
+            "buffer slice start is out of bounds",
+        ));
     }
     Ok(index)
 }

--- a/crates/sifr_runtime/src/python/buffer_ops/raw.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops/raw.rs
@@ -84,7 +84,7 @@ impl OwnedPyBuffer {
         }
         let dimensions = usize::try_from(raw.ndim)
             .map_err(|_| "exporter returned a negative dimension count".to_string())?;
-        if dimensions > ffi::PyBUF_MAX_NDIM {
+        if dimensions > buffer_dimension_limit(ffi::PyBUF_MAX_NDIM)? {
             return Err("exporter exceeds PyBUF_MAX_NDIM".to_string());
         }
         if len_bytes > 0 && raw.buf.is_null() {
@@ -189,6 +189,15 @@ impl Drop for OwnedPyBuffer {
 }
 
 type MetadataVectors = (Vec<usize>, Vec<isize>, Vec<isize>);
+
+fn buffer_dimension_limit<T>(limit: T) -> Result<usize, String>
+where
+    T: TryInto<usize>,
+{
+    limit
+        .try_into()
+        .map_err(|_| "PyBUF_MAX_NDIM does not fit usize".to_string())
+}
 
 fn metadata_vectors(raw: &ffi::Py_buffer, dimensions: usize) -> Result<MetadataVectors, String> {
     if dimensions == 0 {
@@ -421,6 +430,12 @@ mod tests {
         assert_eq!(native_endian(Some(b'<')), cfg!(target_endian = "little"));
         assert_eq!(native_endian(Some(b'>')), cfg!(target_endian = "big"));
         assert_eq!(native_endian(Some(b'!')), cfg!(target_endian = "big"));
+    }
+
+    #[test]
+    fn dimension_limit_accepts_both_supported_ffi_constant_types() {
+        assert_eq!(buffer_dimension_limit(64_i32), Ok(64));
+        assert_eq!(buffer_dimension_limit(64_usize), Ok(64));
     }
 
     #[test]

--- a/crates/sifr_runtime/src/python/buffer_ops/raw.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops/raw.rs
@@ -1,0 +1,450 @@
+use super::PythonBufferElement;
+use pyo3::ffi;
+use pyo3::types::PyAny;
+use pyo3::{Bound, PyErr, Python};
+use std::ffi::CStr;
+use std::marker::PhantomPinned;
+use std::mem::size_of;
+use std::pin::Pin;
+use std::ptr;
+use std::slice;
+
+#[derive(Clone, Debug)]
+pub(super) struct ValidatedBuffer {
+    pub len_bytes: usize,
+    pub item_size: usize,
+    pub dimensions: usize,
+    pub shape: Vec<usize>,
+    pub strides: Vec<isize>,
+    pub suboffsets: Vec<isize>,
+    pub readonly: bool,
+    pub c_contiguous: bool,
+    pub f_contiguous: bool,
+    pub format: String,
+}
+
+#[repr(transparent)]
+struct RawBuffer(ffi::Py_buffer, PhantomPinned);
+
+/// An owned `Py_buffer` whose address stays stable for exporters that keep
+/// self-references inside the view. `Sifr` rejects free-threaded `CPython`, and all
+/// access and release operations attach to the interpreter before touching it.
+pub(super) struct OwnedPyBuffer {
+    raw: Pin<Box<RawBuffer>>,
+}
+
+// SAFETY: This matches PyO3's `PyUntypedBuffer` guarantees. The pointer is
+// never dereferenced without attaching to the supported GIL-bound interpreter.
+unsafe impl Send for OwnedPyBuffer {}
+// SAFETY: See the `Send` implementation. Sifr's public buffer identity is
+// non-Send/non-Sync, while the runtime store serializes each view separately.
+unsafe impl Sync for OwnedPyBuffer {}
+
+impl OwnedPyBuffer {
+    pub(super) fn acquire(
+        py: Python<'_>,
+        object: &Bound<'_, PyAny>,
+        writable: bool,
+    ) -> Result<Self, PyErr> {
+        let mut raw = Box::pin(RawBuffer(ffi::Py_buffer::new(), PhantomPinned));
+        let flags = if writable {
+            ffi::PyBUF_FULL
+        } else {
+            ffi::PyBUF_FULL_RO
+        };
+        // SAFETY: `raw` is initialized, pinned, and remains alive for the
+        // lifetime of the acquired view. The call runs while attached.
+        let result = unsafe {
+            ffi::PyObject_GetBuffer(
+                object.as_ptr(),
+                ptr::from_mut(&mut raw_mut(raw.as_mut()).0),
+                flags,
+            )
+        };
+        if result != 0 {
+            return Err(PyErr::fetch(py));
+        }
+        Ok(Self { raw })
+    }
+
+    pub(super) fn validate(&self, element: PythonBufferElement) -> Result<ValidatedBuffer, String> {
+        let raw = self.raw();
+        let len_bytes = usize::try_from(raw.len)
+            .map_err(|_| "exporter returned a negative buffer length".to_string())?;
+        let item_size = usize::try_from(raw.itemsize)
+            .map_err(|_| "exporter returned a negative item size".to_string())?;
+        if item_size == 0 {
+            return Err("exporter returned a zero item size".to_string());
+        }
+        let dimensions = usize::try_from(raw.ndim)
+            .map_err(|_| "exporter returned a negative dimension count".to_string())?;
+        if dimensions > ffi::PyBUF_MAX_NDIM {
+            return Err("exporter exceeds PyBUF_MAX_NDIM".to_string());
+        }
+        if len_bytes > 0 && raw.buf.is_null() {
+            return Err("exporter returned a null data pointer for a non-empty buffer".to_string());
+        }
+
+        let (shape, strides, suboffsets) = metadata_vectors(raw, dimensions)?;
+        let item_count = shape_item_count(&shape, dimensions)?;
+        validate_byte_length(item_count, item_size, len_bytes)?;
+        validate_format(raw, element, item_size)?;
+
+        Ok(ValidatedBuffer {
+            len_bytes,
+            item_size,
+            dimensions,
+            shape,
+            strides,
+            suboffsets,
+            readonly: raw.readonly != 0,
+            c_contiguous: self.is_contiguous(b'C'),
+            f_contiguous: self.is_contiguous(b'F'),
+            format: format_string(raw)?,
+        })
+    }
+
+    pub(super) fn item_count(&self) -> usize {
+        let raw = self.raw();
+        usize::try_from(raw.len)
+            .ok()
+            .zip(usize::try_from(raw.itemsize).ok())
+            .and_then(|(len, size)| len.checked_div(size))
+            .unwrap_or(0)
+    }
+
+    pub(super) fn item_ptr(&self, flat_index: usize) -> Option<*mut core::ffi::c_void> {
+        let raw = self.raw();
+        let dimensions = usize::try_from(raw.ndim).ok()?;
+        if flat_index >= self.item_count() {
+            return None;
+        }
+        if dimensions == 0 {
+            return (!raw.buf.is_null()).then_some(raw.buf);
+        }
+        if raw.shape.is_null() {
+            return None;
+        }
+        // SAFETY: acquisition validation requires `shape` to contain `ndim`
+        // non-negative entries, and the owned view remains live.
+        let shape = unsafe { slice::from_raw_parts(raw.shape, dimensions) };
+        let mut remaining = flat_index;
+        let mut indices = vec![0_isize; dimensions];
+        for dimension in (0..dimensions).rev() {
+            let size = usize::try_from(shape[dimension]).ok()?;
+            if size == 0 {
+                return None;
+            }
+            indices[dimension] = isize::try_from(remaining % size).ok()?;
+            remaining /= size;
+        }
+        // SAFETY: the indices vector has exactly `ndim` entries, each within
+        // the validated shape. CPython handles strides and suboffsets.
+        let pointer = unsafe { ffi::PyBuffer_GetPointer(raw, indices.as_ptr()) };
+        (!pointer.is_null()).then_some(pointer)
+    }
+
+    pub(super) fn release(mut self, _py: Python<'_>) {
+        self.release_raw();
+    }
+
+    fn is_contiguous(&self, order: u8) -> bool {
+        let Ok(order) = core::ffi::c_char::try_from(order) else {
+            return false;
+        };
+        // SAFETY: the view is live and the call only inspects its metadata.
+        unsafe { ffi::PyBuffer_IsContiguous(self.raw(), order) != 0 }
+    }
+
+    fn raw(&self) -> &ffi::Py_buffer {
+        &self.raw.as_ref().get_ref().0
+    }
+
+    fn release_raw(&mut self) {
+        // SAFETY: this is the sole owner of the pinned `Py_buffer`; `obj` is
+        // cleared after release so Drop cannot release it twice.
+        let raw = unsafe { &mut raw_mut(self.raw.as_mut()).0 };
+        if !raw.obj.is_null() {
+            unsafe { ffi::PyBuffer_Release(raw) };
+            raw.obj = ptr::null_mut();
+        }
+    }
+}
+
+impl Drop for OwnedPyBuffer {
+    fn drop(&mut self) {
+        if self.raw().obj.is_null() {
+            return;
+        }
+        let _ignored = Python::try_attach(|_py| self.release_raw());
+    }
+}
+
+type MetadataVectors = (Vec<usize>, Vec<isize>, Vec<isize>);
+
+fn metadata_vectors(raw: &ffi::Py_buffer, dimensions: usize) -> Result<MetadataVectors, String> {
+    if dimensions == 0 {
+        if !raw.shape.is_null() || !raw.strides.is_null() || !raw.suboffsets.is_null() {
+            return Err("zero-dimensional buffer metadata must use null vectors".to_string());
+        }
+        return Ok((Vec::new(), Vec::new(), Vec::new()));
+    }
+    if raw.shape.is_null() || raw.strides.is_null() {
+        return Err("exporter returned null shape or strides metadata".to_string());
+    }
+    // SAFETY: the FULL/FULL_RO request requires vectors with `ndim` entries.
+    let shape_raw = unsafe { slice::from_raw_parts(raw.shape, dimensions) };
+    let strides = unsafe { slice::from_raw_parts(raw.strides, dimensions) }.to_vec();
+    let shape = shape_raw
+        .iter()
+        .copied()
+        .map(|value| {
+            usize::try_from(value)
+                .map_err(|_| "exporter returned a negative shape dimension".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let suboffsets = if raw.suboffsets.is_null() {
+        Vec::new()
+    } else {
+        // SAFETY: a non-null suboffset vector contains `ndim` entries.
+        unsafe { slice::from_raw_parts(raw.suboffsets, dimensions) }.to_vec()
+    };
+    Ok((shape, strides, suboffsets))
+}
+
+fn shape_item_count(shape: &[usize], dimensions: usize) -> Result<usize, String> {
+    if dimensions == 0 {
+        return Ok(1);
+    }
+    shape.iter().try_fold(1_usize, |count, dimension| {
+        count
+            .checked_mul(*dimension)
+            .ok_or_else(|| "buffer shape exceeds the supported address space".to_string())
+    })
+}
+
+fn validate_byte_length(
+    item_count: usize,
+    item_size: usize,
+    len_bytes: usize,
+) -> Result<(), String> {
+    let expected = item_count
+        .checked_mul(item_size)
+        .ok_or_else(|| "buffer byte length exceeds the supported address space".to_string())?;
+    if expected != len_bytes {
+        return Err(
+            "exporter byte length does not equal shape product times item size".to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn validate_format(
+    raw: &ffi::Py_buffer,
+    element: PythonBufferElement,
+    item_size: usize,
+) -> Result<(), String> {
+    let format = format_bytes(raw)?;
+    validate_format_bytes(format, element, item_size)
+}
+
+fn validate_format_bytes(
+    format: &[u8],
+    element: PythonBufferElement,
+    item_size: usize,
+) -> Result<(), String> {
+    let (prefix, code) = match format {
+        [code] => (None, *code),
+        [prefix @ (b'@' | b'=' | b'<' | b'>' | b'!'), code] => (Some(*prefix), *code),
+        _ => return Err("buffer format is not a supported scalar PEP 3118 type".to_string()),
+    };
+    let (category, declared_size) = format_category_and_size(prefix, code)
+        .ok_or_else(|| "buffer format is not a supported scalar PEP 3118 type".to_string())?;
+    if category != element.category() || declared_size != item_size || item_size != element.width()
+    {
+        return Err(format!(
+            "buffer contents are not compatible with {}",
+            element.source_name()
+        ));
+    }
+    if item_size > 1 && !native_endian(prefix) {
+        return Err("buffer byte order does not match the native target".to_string());
+    }
+    Ok(())
+}
+
+fn format_category_and_size(prefix: Option<u8>, code: u8) -> Option<(FormatCategory, usize)> {
+    let native_sizes = prefix.is_none() || prefix == Some(b'@');
+    let value = match code {
+        b'b' => (FormatCategory::Signed, 1),
+        b'B' => (FormatCategory::Unsigned, 1),
+        b'h' => (
+            FormatCategory::Signed,
+            if native_sizes {
+                size_of::<libc::c_short>()
+            } else {
+                2
+            },
+        ),
+        b'H' => (
+            FormatCategory::Unsigned,
+            if native_sizes {
+                size_of::<libc::c_ushort>()
+            } else {
+                2
+            },
+        ),
+        b'i' => (
+            FormatCategory::Signed,
+            if native_sizes {
+                size_of::<libc::c_int>()
+            } else {
+                4
+            },
+        ),
+        b'I' => (
+            FormatCategory::Unsigned,
+            if native_sizes {
+                size_of::<libc::c_uint>()
+            } else {
+                4
+            },
+        ),
+        b'l' => (
+            FormatCategory::Signed,
+            if native_sizes {
+                size_of::<libc::c_long>()
+            } else {
+                4
+            },
+        ),
+        b'L' => (
+            FormatCategory::Unsigned,
+            if native_sizes {
+                size_of::<libc::c_ulong>()
+            } else {
+                4
+            },
+        ),
+        b'q' => (FormatCategory::Signed, 8),
+        b'Q' => (FormatCategory::Unsigned, 8),
+        b'n' if native_sizes => (FormatCategory::Signed, size_of::<isize>()),
+        b'N' if native_sizes => (FormatCategory::Unsigned, size_of::<usize>()),
+        b'f' => (FormatCategory::Float, 4),
+        b'd' => (FormatCategory::Float, 8),
+        _ => return None,
+    };
+    Some(value)
+}
+
+const fn native_endian(prefix: Option<u8>) -> bool {
+    match prefix {
+        None | Some(b'@' | b'=') => true,
+        Some(b'<') => cfg!(target_endian = "little"),
+        Some(b'>' | b'!') => cfg!(target_endian = "big"),
+        _ => false,
+    }
+}
+
+fn format_bytes(raw: &ffi::Py_buffer) -> Result<&[u8], String> {
+    if raw.format.is_null() {
+        return Err("exporter omitted the requested PEP 3118 format".to_string());
+    }
+    // SAFETY: a successful formatted buffer request supplies a NUL-terminated
+    // format string that remains valid until `PyBuffer_Release`.
+    Ok(unsafe { CStr::from_ptr(raw.format) }.to_bytes())
+}
+
+fn format_string(raw: &ffi::Py_buffer) -> Result<String, String> {
+    Ok(String::from_utf8_lossy(format_bytes(raw)?).into_owned())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FormatCategory {
+    Signed,
+    Unsigned,
+    Float,
+}
+
+impl PythonBufferElement {
+    const fn category(self) -> FormatCategory {
+        match self {
+            Self::I8 | Self::I16 | Self::I32 | Self::I64 | Self::ISize => FormatCategory::Signed,
+            Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::USize => FormatCategory::Unsigned,
+            Self::F64 => FormatCategory::Float,
+        }
+    }
+
+    const fn width(self) -> usize {
+        match self {
+            Self::I8 | Self::U8 => 1,
+            Self::I16 | Self::U16 => 2,
+            Self::I32 | Self::U32 => 4,
+            Self::I64 | Self::U64 | Self::F64 => 8,
+            Self::ISize | Self::USize => size_of::<usize>(),
+        }
+    }
+}
+
+unsafe fn raw_mut(raw: Pin<&mut RawBuffer>) -> &mut RawBuffer {
+    // SAFETY: callers do not move the pinned value; they only mutate fields in
+    // the stable allocation passed to CPython.
+    unsafe { Pin::get_unchecked_mut(raw) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endian_contract_accepts_only_native_multibyte_formats() {
+        assert!(native_endian(None));
+        assert!(native_endian(Some(b'@')));
+        assert!(native_endian(Some(b'=')));
+        assert_eq!(native_endian(Some(b'<')), cfg!(target_endian = "little"));
+        assert_eq!(native_endian(Some(b'>')), cfg!(target_endian = "big"));
+        assert_eq!(native_endian(Some(b'!')), cfg!(target_endian = "big"));
+    }
+
+    #[test]
+    fn byte_length_validation_rejects_floor_division_mismatch() {
+        assert!(validate_byte_length(1, 4, 4).is_ok());
+        assert!(validate_byte_length(1, 4, 5).is_err());
+    }
+
+    #[test]
+    fn primitive_format_matrix_enforces_native_endian_for_every_multibyte_family() {
+        let native = if cfg!(target_endian = "little") {
+            b'<'
+        } else {
+            b'>'
+        };
+        let foreign = if cfg!(target_endian = "little") {
+            b'>'
+        } else {
+            b'<'
+        };
+        let families = [
+            (PythonBufferElement::I16, b'h', 2),
+            (PythonBufferElement::U16, b'H', 2),
+            (PythonBufferElement::I32, b'i', 4),
+            (PythonBufferElement::U32, b'I', 4),
+            (PythonBufferElement::I64, b'q', 8),
+            (PythonBufferElement::U64, b'Q', 8),
+            (PythonBufferElement::F64, b'd', 8),
+        ];
+        for (element, code, width) in families {
+            assert!(validate_format_bytes(&[code], element, width).is_ok());
+            assert!(validate_format_bytes(&[b'=', code], element, width).is_ok());
+            assert!(validate_format_bytes(&[native, code], element, width).is_ok());
+            assert!(validate_format_bytes(&[foreign, code], element, width).is_err());
+            assert_eq!(
+                validate_format_bytes(&[b'!', code], element, width).is_ok(),
+                cfg!(target_endian = "big")
+            );
+        }
+
+        assert!(validate_format_bytes(b">b", PythonBufferElement::I8, 1).is_ok());
+        assert!(validate_format_bytes(b"!B", PythonBufferElement::U8, 1).is_ok());
+    }
+}

--- a/crates/sifr_runtime/src/python/buffer_ops/raw.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops/raw.rs
@@ -36,9 +36,6 @@ pub(super) struct OwnedPyBuffer {
 // SAFETY: This matches PyO3's `PyUntypedBuffer` guarantees. The pointer is
 // never dereferenced without attaching to the supported GIL-bound interpreter.
 unsafe impl Send for OwnedPyBuffer {}
-// SAFETY: See the `Send` implementation. Sifr's public buffer identity is
-// non-Send/non-Sync, while the runtime store serializes each view separately.
-unsafe impl Sync for OwnedPyBuffer {}
 
 impl OwnedPyBuffer {
     pub(super) fn acquire(

--- a/crates/sifr_runtime/src/python/buffer_ops/raw.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops/raw.rs
@@ -1,4 +1,5 @@
 use super::PythonBufferElement;
+use pyo3::exceptions::PyBufferError;
 use pyo3::ffi;
 use pyo3::types::PyAny;
 use pyo3::{Bound, PyErr, Python};
@@ -61,11 +62,19 @@ impl OwnedPyBuffer {
         if result != 0 {
             return Err(PyErr::fetch(py));
         }
+        if raw.as_ref().get_ref().0.obj.is_null() {
+            return Err(PyBufferError::new_err(
+                "exporter returned a successful buffer without an owner",
+            ));
+        }
         Ok(Self { raw })
     }
 
     pub(super) fn validate(&self, element: PythonBufferElement) -> Result<ValidatedBuffer, String> {
         let raw = self.raw();
+        if raw.obj.is_null() {
+            return Err("exporter returned a successful buffer without an owner".to_string());
+        }
         let len_bytes = usize::try_from(raw.len)
             .map_err(|_| "exporter returned a negative buffer length".to_string())?;
         let item_size = usize::try_from(raw.itemsize)
@@ -137,7 +146,9 @@ impl OwnedPyBuffer {
         }
         // SAFETY: the indices vector has exactly `ndim` entries, each within
         // the validated shape. CPython handles strides and suboffsets.
-        let pointer = unsafe { ffi::PyBuffer_GetPointer(raw, indices.as_ptr()) };
+        let pointer = unsafe {
+            ffi::PyBuffer_GetPointer(ptr::from_ref(raw).cast_mut(), indices.as_mut_ptr())
+        };
         (!pointer.is_null()).then_some(pointer)
     }
 
@@ -204,7 +215,13 @@ fn metadata_vectors(raw: &ffi::Py_buffer, dimensions: usize) -> Result<MetadataV
         Vec::new()
     } else {
         // SAFETY: a non-null suboffset vector contains `ndim` entries.
-        unsafe { slice::from_raw_parts(raw.suboffsets, dimensions) }.to_vec()
+        let values = unsafe { slice::from_raw_parts(raw.suboffsets, dimensions) }.to_vec();
+        if values.iter().all(|value| *value < 0) {
+            return Err(
+                "exporter returned a non-null suboffset vector without indirection".to_string(),
+            );
+        }
+        values
     };
     Ok((shape, strides, suboffsets))
 }
@@ -212,6 +229,9 @@ fn metadata_vectors(raw: &ffi::Py_buffer, dimensions: usize) -> Result<MetadataV
 fn shape_item_count(shape: &[usize], dimensions: usize) -> Result<usize, String> {
     if dimensions == 0 {
         return Ok(1);
+    }
+    if shape.contains(&0) {
+        return Ok(0);
     }
     shape.iter().try_fold(1_usize, |count, dimension| {
         count
@@ -407,6 +427,49 @@ mod tests {
     fn byte_length_validation_rejects_floor_division_mismatch() {
         assert!(validate_byte_length(1, 4, 4).is_ok());
         assert!(validate_byte_length(1, 4, 5).is_err());
+    }
+
+    #[test]
+    fn malformed_successful_view_without_owner_is_rejected() {
+        let mut raw = ffi::Py_buffer::new();
+        raw.buf = ptr::dangling_mut::<u8>().cast();
+        raw.len = 1;
+        raw.itemsize = 1;
+        raw.readonly = 1;
+        raw.ndim = 1;
+        raw.format = c"B".as_ptr().cast_mut();
+        raw.shape = &mut raw.len;
+        raw.strides = &mut raw.itemsize;
+
+        let buffer = OwnedPyBuffer {
+            raw: Box::pin(RawBuffer(raw, PhantomPinned)),
+        };
+        let error = buffer
+            .validate(PythonBufferElement::U8)
+            .expect_err("null ownership must not enter the safe buffer API");
+
+        assert!(error.contains("without an owner"));
+    }
+
+    #[test]
+    fn empty_shape_short_circuits_product_overflow() {
+        let shape = [usize::MAX, 2, 0];
+        assert_eq!(shape_item_count(&shape, shape.len()), Ok(0));
+    }
+
+    #[test]
+    fn all_negative_non_null_suboffsets_are_rejected() {
+        let mut raw = ffi::Py_buffer::new();
+        let mut shape = [2_isize, 2];
+        let mut strides = [2_isize, 1];
+        let mut suboffsets = [-1_isize, -1];
+        raw.ndim = 2;
+        raw.shape = shape.as_mut_ptr();
+        raw.strides = strides.as_mut_ptr();
+        raw.suboffsets = suboffsets.as_mut_ptr();
+
+        let error = metadata_vectors(&raw, 2).expect_err("all-negative vector is malformed");
+        assert!(error.contains("without indirection"));
     }
 
     #[test]

--- a/crates/sifr_runtime/src/python/buffer_ops/tests.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops/tests.rs
@@ -5,6 +5,8 @@ use crate::python::{
     PythonResourceIdentity,
 };
 use pyo3::types::PyAnyMethods;
+use pyo3::{ffi, Bound};
+use std::{mem::size_of, ptr};
 
 #[test]
 fn buffer_view_tracks_metadata_copy_and_release() {
@@ -250,6 +252,86 @@ fn any_layout_supports_strided_logical_access() {
 }
 
 #[test]
+fn any_layout_supports_negative_stride_read_write_and_release() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-negative-stride")).expect("init should succeed");
+
+    let object = negative_strided_byte_view();
+    let view = acquire_buffer(
+        &object,
+        PythonBufferRequest {
+            element: PythonBufferElement::U8,
+            access: PythonBufferAccess::Write,
+            layout: PythonBufferLayout::Any,
+        },
+    )
+    .expect("writable negative-stride view should acquire");
+    let key = (view.handle, view.token);
+
+    assert_eq!(view.strides, vec![-1]);
+    assert_eq!(
+        copy_buffer_slice_u8(key, 0, 4).expect("logical copy"),
+        vec![4, 3, 2, 1]
+    );
+    buffer_write_u8(key, 1, 9).expect("logical write through negative stride");
+    assert_eq!(buffer_read_u8(key, 1).expect("read after write"), 9);
+    assert_eq!(
+        buffer_read_u8(key, 4)
+            .expect_err("upper bound must be rejected")
+            .exception_type,
+        "IndexError"
+    );
+
+    release_buffer(key).expect("release");
+    close_object(object).expect("close exporter");
+}
+
+#[test]
+fn any_layout_supports_indirect_pointer_read_write_and_release() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-indirect-pointer")).expect("init should succeed");
+
+    let (object, storage) = indirect_byte_memoryview();
+    let view = acquire_buffer(
+        &object,
+        PythonBufferRequest {
+            element: PythonBufferElement::U8,
+            access: PythonBufferAccess::Write,
+            layout: PythonBufferLayout::Any,
+        },
+    )
+    .expect("writable indirect view should acquire");
+    let key = (view.handle, view.token);
+
+    assert_eq!(view.shape, vec![2, 2]);
+    assert_eq!(view.suboffsets, vec![0, -1]);
+    assert_eq!(
+        copy_buffer_slice_u8(key, 0, 4).expect("logical copy"),
+        vec![1, 2, 3, 4]
+    );
+    buffer_write_u8(key, 2, 9).expect("write through intermediate row pointer");
+    assert_eq!(buffer_read_u8(key, 2).expect("read after write"), 9);
+    assert_eq!(
+        copy_buffer_slice_u8(key, 1, 2).expect("bounded slice"),
+        vec![2, 9]
+    );
+    assert_eq!(
+        buffer_write_u8(key, 4, 0)
+            .expect_err("upper bound must be rejected")
+            .exception_type,
+        "IndexError"
+    );
+
+    release_buffer(key).expect("release");
+    close_object(object).expect("close exporter");
+    assert_eq!(*storage.first, [1, 2]);
+    assert_eq!(*storage.second, [9, 4]);
+    drop(storage);
+}
+
+#[test]
 fn scalar_native_endian_buffer_has_empty_metadata_vectors() {
     let _guard = test_guard();
     reset_runtime_state_for_tests();
@@ -341,4 +423,68 @@ fn strided_byte_view() -> ObjectHandle {
     })
     .expect("attach should succeed")
     .expect("strided view should create")
+}
+
+fn negative_strided_byte_view() -> ObjectHandle {
+    super::super::attach(|py| {
+        let builtins = py.import("builtins")?;
+        let bytes = builtins.getattr("bytearray")?.call1(([1_u8, 2, 3, 4],))?;
+        let view = builtins.getattr("memoryview")?.call1((bytes,))?;
+        let slice =
+            view.call_method1("__getitem__", (pyo3::types::PySlice::new(py, 3, -5, -1),))?;
+        super::super::object_ops::store_object(slice.unbind())
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    })
+    .expect("attach should succeed")
+    .expect("negative-stride view should create")
+}
+
+struct IndirectByteStorage {
+    first: Box<[u8; 2]>,
+    second: Box<[u8; 2]>,
+    rows: Box<[*mut u8; 2]>,
+    shape: Box<[isize; 2]>,
+    strides: Box<[isize; 2]>,
+    suboffsets: Box<[isize; 2]>,
+}
+
+fn indirect_byte_memoryview() -> (ObjectHandle, IndirectByteStorage) {
+    let mut first = Box::new([1_u8, 2]);
+    let mut second = Box::new([3_u8, 4]);
+    let rows = Box::new([first.as_mut_ptr(), second.as_mut_ptr()]);
+    let mut storage = IndirectByteStorage {
+        first,
+        second,
+        rows,
+        shape: Box::new([2_isize, 2]),
+        strides: Box::new([
+            isize::try_from(size_of::<*mut u8>()).expect("pointer width fits Py_ssize_t"),
+            1,
+        ]),
+        suboffsets: Box::new([0_isize, -1]),
+    };
+    let object = super::super::attach(|py| {
+        let view = ffi::Py_buffer {
+            buf: storage.rows.as_mut_ptr().cast(),
+            obj: ptr::null_mut(),
+            len: 4,
+            itemsize: 1,
+            readonly: 0,
+            ndim: 2,
+            format: c"B".as_ptr().cast_mut(),
+            shape: storage.shape.as_mut_ptr(),
+            strides: storage.strides.as_mut_ptr(),
+            suboffsets: storage.suboffsets.as_mut_ptr(),
+            internal: ptr::null_mut(),
+        };
+        // SAFETY: `storage` owns stable boxed data and metadata until after the
+        // returned memoryview and acquired buffer are explicitly closed.
+        let memoryview =
+            unsafe { Bound::from_owned_ptr_or_err(py, ffi::PyMemoryView_FromBuffer(&view))? };
+        super::super::object_ops::store_object(memoryview.unbind())
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    })
+    .expect("attach should succeed")
+    .expect("indirect memoryview should create");
+    (object, storage)
 }

--- a/crates/sifr_runtime/src/python/buffer_ops/tests.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops/tests.rs
@@ -1,0 +1,194 @@
+use super::*;
+use crate::python::{
+    close_object, from_bytes, from_int, initialize_runtime, reset_runtime_state_for_tests,
+    resource_diagnostics, test_config, test_guard, PythonResourceDiagnostics,
+    PythonResourceIdentity,
+};
+use pyo3::types::PyAnyMethods;
+
+#[test]
+fn buffer_view_tracks_metadata_copy_and_release() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-view")).expect("init should succeed");
+
+    let object = from_bytes(&[1, 2, 3]).expect("bytes should be stored");
+    let view = buffer_u8(&object, false).expect("bytes should expose u8 buffer");
+
+    assert_eq!(view.element, PythonBufferElement::U8);
+    assert_eq!(view.len_bytes, 3);
+    assert_eq!(view.item_size, 1);
+    assert!(view.readonly);
+    assert!(view.c_contiguous);
+    assert_eq!(
+        buffer_read_u8((view.handle, view.token), 1).expect("read"),
+        2
+    );
+    assert_eq!(
+        copy_buffer_slice_u8((view.handle, view.token), 1, 2).expect("slice should copy"),
+        vec![2, 3]
+    );
+    assert_eq!(
+        copy_buffer_u8((view.handle, view.token)).expect("buffer should copy"),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        resource_diagnostics().expect("diagnostics should be available"),
+        PythonResourceDiagnostics {
+            initialized: true,
+            live_objects: 2,
+            leaked_objects: 0,
+        }
+    );
+    release_buffer((view.handle, view.token)).expect("buffer should release");
+    close_object(object).expect("object should close");
+    assert_eq!(
+        resource_diagnostics().expect("diagnostics should be available"),
+        PythonResourceDiagnostics {
+            initialized: true,
+            live_objects: 0,
+            leaked_objects: 0,
+        }
+    );
+}
+
+#[test]
+fn buffer_double_release_and_use_after_release_are_deterministic() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-double-release")).expect("init should succeed");
+
+    let object = from_bytes(&[1]).expect("bytes should be stored");
+    let view = buffer_u8(&object, false).expect("bytes should expose u8 buffer");
+    release_buffer((view.handle, view.token)).expect("buffer should release");
+    let error = release_buffer((view.handle, view.token)).expect_err("second release fails");
+    let copy_error =
+        copy_buffer_u8((view.handle, view.token)).expect_err("copy after release fails");
+
+    assert_eq!(error.kind, "resource");
+    assert_eq!(error.exception_type, "SifrPythonClosedBuffer");
+    assert_eq!(copy_error.kind, "resource");
+    assert_eq!(copy_error.exception_type, "SifrPythonClosedBuffer");
+    close_object(object).expect("object should close");
+}
+
+#[test]
+fn sealed_resource_identity_drop_releases_buffer_and_metadata() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-identity-drop")).expect("init should succeed");
+
+    let object = from_bytes(&[1, 2]).expect("bytes should be stored");
+    let view = buffer_u8(&object, false).expect("bytes should expose u8 buffer");
+    let key = (view.handle, view.token);
+    let identity = PythonResourceIdentity::buffer(key);
+    assert_eq!(buffer_shape(key).expect("metadata should be live"), vec![2]);
+
+    drop(identity);
+
+    let error = buffer_shape(key).expect_err("metadata drops with the resource");
+    assert_eq!(error.exception_type, "SifrPythonClosedBuffer");
+    close_object(object).expect("object should close");
+    assert_eq!(
+        resource_diagnostics().expect("diagnostics should be available"),
+        PythonResourceDiagnostics {
+            initialized: true,
+            live_objects: 0,
+            leaked_objects: 0,
+        }
+    );
+}
+
+#[test]
+fn buffer_rejects_wrong_dtype_layout_bounds_and_readonly_write() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-rejects")).expect("init should succeed");
+
+    let object = from_bytes(&[1]).expect("bytes should be stored");
+    let writable = buffer_u8(&object, true).expect_err("bytes are readonly");
+    assert_eq!(writable.kind, "zero-copy");
+    let wrong_type = acquire_buffer(
+        &object,
+        PythonBufferRequest {
+            element: PythonBufferElement::I16,
+            access: PythonBufferAccess::Read,
+            layout: PythonBufferLayout::CContiguous,
+        },
+    )
+    .expect_err("bytes are not int16");
+    assert_eq!(wrong_type.kind, "zero-copy");
+
+    let strided = super::super::attach(|py| {
+        let builtins = py.import("builtins")?;
+        let bytes = builtins.getattr("bytearray")?.call1(([1_u8, 2, 3, 4],))?;
+        let view = builtins.getattr("memoryview")?.call1((bytes,))?;
+        let slice = view.call_method1("__getitem__", (pyo3::types::PySlice::new(py, 0, 4, 2),))?;
+        super::super::object_ops::store_object(slice.unbind())
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    })
+    .expect("attach should succeed")
+    .expect("strided view should create");
+    let wrong_layout = acquire_buffer(
+        &strided,
+        PythonBufferRequest {
+            element: PythonBufferElement::U8,
+            access: PythonBufferAccess::Read,
+            layout: PythonBufferLayout::CContiguous,
+        },
+    )
+    .expect_err("strided view is not C contiguous");
+    assert_eq!(wrong_layout.exception_type, "BufferError");
+
+    let view = buffer_u8(&object, false).expect("bytes view");
+    let bounds = buffer_read_u8((view.handle, view.token), 1).expect_err("bounds fail");
+    assert_eq!(bounds.exception_type, "IndexError");
+    release_buffer((view.handle, view.token)).expect("release");
+
+    let integer = from_int(1).expect("int should be stored");
+    let unsupported = buffer_u8(&integer, false).expect_err("int has no u8 buffer");
+    assert_eq!(unsupported.kind, "zero-copy");
+
+    close_object(object).expect("object should close");
+    close_object(strided).expect("strided view should close");
+    close_object(integer).expect("integer should close");
+}
+
+#[test]
+fn typed_writable_buffer_supports_checked_read_write_and_slice_copy() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-typed-write")).expect("init should succeed");
+
+    let object = super::super::attach(|py| {
+        let array = py
+            .import("array")?
+            .getattr("array")?
+            .call1(("i", [10_i32, 20, 30]))?;
+        super::super::object_ops::store_object(array.unbind())
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    })
+    .expect("attach should succeed")
+    .expect("array should create");
+    let view = acquire_buffer(
+        &object,
+        PythonBufferRequest {
+            element: PythonBufferElement::I32,
+            access: PythonBufferAccess::Write,
+            layout: PythonBufferLayout::CContiguous,
+        },
+    )
+    .expect("typed buffer should acquire");
+    let key = (view.handle, view.token);
+
+    assert_eq!(buffer_read_i32(key, 1).expect("read"), 20);
+    buffer_write_i32(key, 1, 25).expect("write");
+    assert_eq!(buffer_read_i32(key, 1).expect("read after write"), 25);
+    assert_eq!(
+        copy_buffer_slice_i32(key, 0, 3).expect("slice"),
+        vec![10, 25, 30]
+    );
+
+    release_buffer(key).expect("release");
+    close_object(object).expect("close exporter");
+}

--- a/crates/sifr_runtime/src/python/buffer_ops/tests.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops/tests.rs
@@ -7,6 +7,13 @@ use crate::python::{
 use pyo3::types::PyAnyMethods;
 use pyo3::{ffi, Bound};
 use std::{mem::size_of, ptr};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc, Barrier,
+    },
+    time::Duration,
+};
 
 #[test]
 fn buffer_view_tracks_metadata_copy_and_release() {
@@ -400,6 +407,51 @@ fn explicit_release_drops_export_even_when_a_runtime_snapshot_exists() {
 
     drop(snapshot);
     close_object(object).expect("close exporter");
+}
+
+#[test]
+fn error_conversion_runs_after_unlock_during_concurrent_release() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-error-release-race")).expect("init should succeed");
+
+    let object = from_bytes(&[1]).expect("bytes should be stored");
+    let view = buffer_u8(&object, false).expect("view should acquire");
+    let key = (view.handle, view.token);
+    let barrier = Arc::new(Barrier::new(2));
+    let release_barrier = Arc::clone(&barrier);
+    let (released_tx, released_rx) = mpsc::sync_channel(1);
+    let release_thread = std::thread::spawn(move || {
+        release_barrier.wait();
+        let result = release_buffer(key);
+        released_tx
+            .send(result)
+            .expect("error conversion observer should remain live");
+    });
+    let release_completed_during_conversion = Arc::new(AtomicBool::new(false));
+    let observed = Arc::clone(&release_completed_during_conversion);
+
+    let error = with_live_buffer_and_converter(
+        key,
+        PythonBufferElement::U8,
+        false,
+        |_value| Err::<(), _>(BufferAccessError::Index("forced bounds failure")),
+        |error| {
+            barrier.wait();
+            let converted = super::super::attach(|py| error.into_python(py));
+            if let Ok(result) = released_rx.recv_timeout(Duration::from_secs(2)) {
+                result.expect("concurrent release should succeed");
+                observed.store(true, Ordering::SeqCst);
+            }
+            converted
+        },
+    )
+    .expect_err("forced access failure should be converted");
+
+    release_thread.join().expect("release thread should finish");
+    assert!(release_completed_during_conversion.load(Ordering::SeqCst));
+    assert_eq!(error.exception_type, "IndexError");
+    close_object(object).expect("exporter should close");
 }
 
 fn python_i32_array(values: [i32; 3]) -> ObjectHandle {

--- a/crates/sifr_runtime/src/python/buffer_ops/tests.rs
+++ b/crates/sifr_runtime/src/python/buffer_ops/tests.rs
@@ -192,3 +192,153 @@ fn typed_writable_buffer_supports_checked_read_write_and_slice_copy() {
     release_buffer(key).expect("release");
     close_object(object).expect("close exporter");
 }
+
+#[test]
+fn read_declaration_rejects_write_on_mutable_exporter() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-read-access")).expect("init should succeed");
+
+    let object = python_i32_array([10_i32, 20, 30]);
+    let view = acquire_buffer(
+        &object,
+        PythonBufferRequest {
+            element: PythonBufferElement::I32,
+            access: PythonBufferAccess::Read,
+            layout: PythonBufferLayout::Any,
+        },
+    )
+    .expect("read view should acquire from mutable exporter");
+    let key = (view.handle, view.token);
+
+    let error = buffer_write_i32(key, 1, 25).expect_err("read declaration blocks mutation");
+    assert_eq!(error.exception_type, "BufferError");
+    assert_eq!(buffer_read_i32(key, 1).expect("read remains valid"), 20);
+
+    release_buffer(key).expect("release");
+    close_object(object).expect("close exporter");
+}
+
+#[test]
+fn any_layout_supports_strided_logical_access() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-any-layout")).expect("init should succeed");
+
+    let object = strided_byte_view();
+    let view = acquire_buffer(
+        &object,
+        PythonBufferRequest {
+            element: PythonBufferElement::U8,
+            access: PythonBufferAccess::Read,
+            layout: PythonBufferLayout::Any,
+        },
+    )
+    .expect("any layout should accept a strided view");
+    let key = (view.handle, view.token);
+
+    assert!(!view.c_contiguous);
+    assert_eq!(buffer_read_u8(key, 0).expect("first logical item"), 1);
+    assert_eq!(buffer_read_u8(key, 1).expect("second logical item"), 3);
+    assert_eq!(
+        copy_buffer_slice_u8(key, 0, 2).expect("logical copy"),
+        vec![1, 3]
+    );
+
+    release_buffer(key).expect("release");
+    close_object(object).expect("close exporter");
+}
+
+#[test]
+fn scalar_native_endian_buffer_has_empty_metadata_vectors() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-scalar")).expect("init should succeed");
+
+    let object = super::super::attach(|py| {
+        let scalar = py
+            .import("ctypes")?
+            .getattr("c_int32")?
+            .call1((0x0102_0304_i32,))?;
+        super::super::object_ops::store_object(scalar.unbind())
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    })
+    .expect("attach should succeed")
+    .expect("ctypes scalar should create");
+    let view = acquire_buffer(
+        &object,
+        PythonBufferRequest {
+            element: PythonBufferElement::I32,
+            access: PythonBufferAccess::Read,
+            layout: PythonBufferLayout::Any,
+        },
+    )
+    .expect("zero-dimensional scalar should acquire");
+    let key = (view.handle, view.token);
+
+    assert_eq!(view.dimensions, 0);
+    assert!(view.shape.is_empty());
+    assert!(view.strides.is_empty());
+    assert!(view.suboffsets.is_empty());
+    assert_eq!(buffer_read_i32(key, 0).expect("scalar read"), 0x0102_0304);
+
+    release_buffer(key).expect("release");
+    close_object(object).expect("close exporter");
+}
+
+#[test]
+fn explicit_release_drops_export_even_when_a_runtime_snapshot_exists() {
+    let _guard = test_guard();
+    reset_runtime_state_for_tests();
+    initialize_runtime(test_config("buffer-release-linearization")).expect("init should succeed");
+
+    let object = super::super::attach(|py| {
+        let exporter = py
+            .import("builtins")?
+            .getattr("bytearray")?
+            .call1(([1_u8],))?;
+        super::super::object_ops::store_object(exporter.unbind())
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    })
+    .expect("attach should succeed")
+    .expect("bytearray should create");
+    let view = buffer_u8(&object, false).expect("view should acquire");
+    let key = (view.handle, view.token);
+    let (snapshot, _) = buffer_snapshot(key).expect("runtime snapshot should exist");
+
+    release_buffer(key).expect("explicit release should drain and release");
+    super::super::attach(|py| {
+        let exporter = clone_handle(py, &object)
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))?;
+        exporter.bind(py).call_method1("append", (2_u8,))?;
+        Ok::<(), pyo3::PyErr>(())
+    })
+    .expect("attach should succeed")
+    .expect("resize proves PyBuffer_Release completed");
+
+    drop(snapshot);
+    close_object(object).expect("close exporter");
+}
+
+fn python_i32_array(values: [i32; 3]) -> ObjectHandle {
+    super::super::attach(|py| {
+        let array = py.import("array")?.getattr("array")?.call1(("i", values))?;
+        super::super::object_ops::store_object(array.unbind())
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    })
+    .expect("attach should succeed")
+    .expect("array should create")
+}
+
+fn strided_byte_view() -> ObjectHandle {
+    super::super::attach(|py| {
+        let builtins = py.import("builtins")?;
+        let bytes = builtins.getattr("bytearray")?.call1(([1_u8, 2, 3, 4],))?;
+        let view = builtins.getattr("memoryview")?.call1((bytes,))?;
+        let slice = view.call_method1("__getitem__", (pyo3::types::PySlice::new(py, 0, 4, 2),))?;
+        super::super::object_ops::store_object(slice.unbind())
+            .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+    })
+    .expect("attach should succeed")
+    .expect("strided view should create")
+}

--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -5,13 +5,13 @@
 In progress. The phase defines one complete end-state architecture and an
 ordered implementation sequence. Opus High pass 5 approved the complete design;
 a final independent Fable High audit found no blockers and its eight
-non-blocking precision refinements are incorporated. M0 through M9 are
-implemented, locally validated, reviewed, and linked below. Typed synchronous
-and asynchronous declarations and context managers run on the application-owned
-Python loop with structured cancellation and consuming cleanup; M9
-current-thread, foreign-thread, and asyncio callback execution plus
+non-blocking precision refinements are incorporated. M0 through M9 and M10
+Wave 1 are implemented, locally validated, reviewed, and linked below. Typed
+synchronous and asynchronous declarations and context managers run on the
+application-owned Python loop with structured cancellation and consuming
+cleanup; M9 current-thread, foreign-thread, and asyncio callback execution plus
 retained-owner integration are merged, publicly active, and milestone-reviewed.
-M10 is next and later milestones are not yet implemented. Milestones sequence
+M10 Wave 2 is next and later milestones are not yet implemented. Milestones sequence
 delivery; they do not create reduced language versions, temporary public
 contracts, dual authorities, or alternate lowering paths.
 
@@ -768,10 +768,18 @@ Tasks:
 
 Delivery waves:
 
-- [ ] Wave 1 — keep `@python.buffer` reserved while replacing the legacy
+- [x] Wave 1 — keep `@python.buffer` reserved while replacing the legacy
   `uint8`-only store with a closed typed buffer request, complete metadata and
   layout validation, lock-free Python operations, bounded typed access, and
-  exact-once sealed-resource release.
+  exact-once sealed-resource release
+  ([PR #2987](https://github.com/sifr-lang/sifr/pull/2987);
+  [review pass 1](../../reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-1.md),
+  [pass 2](../../reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-2.md),
+  [pass 3](../../reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-3.md),
+  [satisfied pass 4](../../reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-4.md));
+  focused buffer tests pass `19/19`, the complete Python runtime suite passes
+  `145/145`, and the authoritative create-PR gate passes Python interop `10/10`
+  plus E2E `131/131` with signature `7c39b8c1dd4fec7c`.
 - [ ] Wave 2 — add the compiler-known affine `python.Buffer[T]` contract,
   decorator validation, `Self` and call-then-acquire lowering/code generation,
   exclusive writable borrowing, early release, and atomic public activation.

--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -766,6 +766,21 @@ Tasks:
 - Implement exact-once automatic and explicit early `PyBuffer_Release`.
 - Expose checked runtime metadata and typed bounded element/slice accessors.
 
+Delivery waves:
+
+- [ ] Wave 1 — keep `@python.buffer` reserved while replacing the legacy
+  `uint8`-only store with a closed typed buffer request, complete metadata and
+  layout validation, lock-free Python operations, bounded typed access, and
+  exact-once sealed-resource release.
+- [ ] Wave 2 — add the compiler-known affine `python.Buffer[T]` contract,
+  decorator validation, `Self` and call-then-acquire lowering/code generation,
+  exclusive writable borrowing, early release, and atomic public activation.
+- [ ] Wave 3 — add complete positive/negative/cleanup matrices, compiled
+  import-root, bridge, receiver, and NumPy-compatible evidence, demo and public
+  documentation, and capability-ledger activation.
+- [ ] Milestone review — review the complete merged M10 implementation before
+  closing the milestone checkbox.
+
 Acceptance:
 
 - A buffer view cannot outlive its exporter or be released while borrowed.

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-1.md
@@ -1,0 +1,32 @@
+# M10 Wave 1 review — Codex 5.6 Sol high, pass 1
+
+- Date: 2026-07-14
+- Pull request: [#2987](https://github.com/sifr-lang/sifr/pull/2987)
+- Reviewer: Codex CLI `gpt-5.6-sol`
+- Reasoning/service tier: high / fast
+- Scope: complete M10 Wave 1 diff against `main`
+- Verdict: **blocked**
+
+The reviewer confirmed that `@python.buffer` remained reserved, the capability
+ledger remained gated, Python and `Py_buffer` operations did not run while the
+global buffer-store mutex was held, and all changed Rust files remained below
+the 900-line limit. It identified six actionable correctness gaps:
+
+1. `access=read` was not retained or enforced by write accessors, and writable
+   acquisition did not request `PyBUF_WRITABLE` from the exporter.
+2. Typed compatibility inherited PyO3 0.29.0's reversed little-endian predicate,
+   which could reject native buffers and accept byte-swapped buffers.
+3. An `Arc` snapshot could keep the exported view live and successfully access
+   it after `release_buffer` returned.
+4. PyO3's typed acquisition rejected valid zero-dimensional buffers with null
+   shape and stride vectors.
+5. Metadata validation used floor-divided item counts instead of enforcing
+   `product(shape) * itemsize == len` exactly.
+6. `layout=any` admitted non-contiguous views even though the accessors only
+   supported contiguous slices.
+
+Required remediation was to implement correct C-API acquisition flags, an
+independent primitive PEP 3118 format/endian validator, scalar-aware raw
+metadata validation, per-resource release/admission linearization, exact byte
+length checking, and stride/suboffset-aware bounded access, with focused
+regression coverage for every issue.

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-2.md
@@ -1,0 +1,30 @@
+# M10 Wave 1 review — Codex 5.6 Sol high, pass 2
+
+- Date: 2026-07-15
+- Pull request: [#2987](https://github.com/sifr-lang/sifr/pull/2987)
+- Reviewer: Codex CLI `gpt-5.6-sol`
+- Reasoning/service tier: high / fast
+- Scope: complete M10 Wave 1 diff against `main`, including pass-1 remediation
+- Verdict: **blocked**
+
+The reviewer confirmed that all six pass-1 remediations were present and that
+the public decorator and capability ledger remained gated. It identified five
+remaining actionable issues:
+
+1. `PyBuffer_GetPointer` used pointer types that compile on CPython 3.11+ but
+   not against PyO3's CPython 3.8–3.10 FFI signature.
+2. A malformed exporter could report success with `Py_buffer.obj == NULL`,
+   bypassing exporter retention and release before entering safe typed access.
+3. Shape-product validation could overflow before observing a later zero
+   dimension in a valid empty buffer.
+4. Metadata validation accepted a non-null suboffset vector whose entries were
+   all negative, which the buffer protocol requires exporters to represent as
+   a null vector.
+5. Unsafe logical access needed explicit negative-stride and indirect-pointer
+   regression coverage.
+
+Required remediation was to use cross-version-compatible mutable FFI pointers,
+reject null ownership before storing a successful view, short-circuit empty
+shape products, enforce the suboffset representation invariant, and add real
+negative-stride and indirect memoryview fixtures covering reads, writes,
+bounds, logical ordering, and release.

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-3.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-3.md
@@ -1,0 +1,26 @@
+# M10 Wave 1 review — Codex 5.6 Sol high, pass 3
+
+- Date: 2026-07-15
+- Pull request: [#2987](https://github.com/sifr-lang/sifr/pull/2987)
+- Reviewer: Codex CLI `gpt-5.6-sol`
+- Reasoning/service tier: high / fast
+- Scope: complete M10 Wave 1 diff against `main`, including pass-1 and pass-2 remediation
+- Verdict: **blocked**
+
+The reviewer confirmed that the eleven findings from the first two passes were
+represented by remediation code and tests, and that the public decorator and
+capability ledger remained gated. It identified two remaining merge blockers:
+
+1. `PyBUF_MAX_NDIM` has a `c_int` FFI type on CPython 3.8–3.10 and a `usize`
+   type on CPython 3.11+, so comparing it directly with a `usize` dimension
+   count did not compile across the supported CPython range.
+2. Typed-access failures constructed `PythonError` while holding the
+   per-buffer lifecycle mutex. Traceback formatting can execute Python and
+   release the GIL, allowing a concurrent release to acquire the GIL and then
+   wait on the mutex while the accessor waits to reacquire the GIL.
+
+Required remediation was to normalize the cross-version dimension constant
+through a checked conversion with compile-shape coverage for both FFI types,
+and to return Python-free internal errors from the locked access section,
+release the mutex, and only then perform Python error conversion. A
+deterministic concurrent-release regression was also required.

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-4.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m10-wave1-codex-5-6-sol-high-review-pass-4.md
@@ -1,0 +1,15 @@
+# M10 Wave 1 review — Codex 5.6 Sol high, pass 4
+
+- Date: 2026-07-15
+- Pull request: [#2987](https://github.com/sifr-lang/sifr/pull/2987)
+- Reviewer: Codex CLI `gpt-5.6-sol`
+- Reasoning/service tier: high / fast
+- Scope: complete M10 Wave 1 diff against `main`, including all prior remediation
+- Verdict: **satisfied**
+
+The reviewer audited the complete `main...HEAD` wave and found no actionable
+issues. It confirmed that all thirteen findings from the first three passes are
+genuinely remediated with focused tests. Ownership, exact release
+linearization, GIL/mutex ordering, CPython 3.8–3.13 FFI compatibility,
+metadata/type/layout/endian/bounds validation, API gating, phase scope, and
+file-size guardrails were all judged sound.


### PR DESCRIPTION
## Summary
- replace the legacy uint8-only buffer store with a closed typed buffer request model
- validate element format, access mode, layout, shape, strides, and suboffset metadata
- provide bounded typed accessors and exact-once release without holding the global store lock across Python operations
- split focused buffer runtime tests and define M10 delivery waves

## Validation
- `cargo test -p sifr_runtime buffer_ --features python`
- `cargo test -p sifr_runtime --features python`
- `cargo test -p sifr_stdlib python --features python`
- `cargo fmt --all`
- `python3 scripts/check_file_size_guardrails.py`
- `scripts/run_all_tests.sh --profile create-pr` (131/131 E2E; all gates pass)