### PR TITLE
M17 Wave 1: migrate ecosystem examples to declarations

### DIFF
--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -2435,7 +2435,7 @@ milestones.
 
 Delivery waves:
 
-- [ ] Wave 1 — migrate every ordinary runnable ecosystem example to typed
+- [x] Wave 1 — migrate every ordinary runnable ecosystem example to typed
   declarations or hermetic bridges, retain exactly one small intentional raw
   example, and add a fail-closed source-policy guard.
 - [ ] Wave 2 — replace Python-client live service execution with built Sifr
@@ -2482,6 +2482,13 @@ lane in `770.76s`: Python interop `19/19`, create-PR E2E `131/131` with
 signature `7c39b8c1dd4fec7c`, runtime-platform `28` variants with zero failures
 and one declared capability skip, and hardening `6/6`. All per-step blocking
 budgets pass; the warm wall-time notice remains advisory.
+
+Fable High review pass 2 independently re-ran the runner self-test, exercised
+roughly forty adversarial import forms, compiled the remaining theoretical
+bypass candidates against the actual Sifr import policy, and rechecked every
+migration, bridge, marker, and resource assertion. It returned `SATISFIED` with
+no blocker, major, or actionable minor. Wave 1 is closure-approved in
+[PR #2997](https://github.com/sifr-lang/sifr/pull/2997).
 
 Tasks:
 

--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -2477,6 +2477,12 @@ path. Torch now verifies the reported `float32` dtype and PyArrow verifies both
 reported capsule names. The full runner self-test and the compiled ML and
 library suites pass after remediation.
 
+Post-remediation authoritative `create-pr` validation passes every blocking
+lane in `770.76s`: Python interop `19/19`, create-PR E2E `131/131` with
+signature `7c39b8c1dd4fec7c`, runtime-platform `28` variants with zero failures
+and one declared capability skip, and hardening `6/6`. All per-step blocking
+budgets pass; the warm wall-time notice remains advisory.
+
 Tasks:
 
 - Migrate all runnable biip/schwifty, dataframe, ML, web, database, cloud,

--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -2433,6 +2433,39 @@ Validation:
 Depends on all preceding declaration, protocol, tooling, and raw-runtime
 milestones.
 
+Delivery waves:
+
+- [ ] Wave 1 — migrate every ordinary runnable ecosystem example to typed
+  declarations or hermetic bridges, retain exactly one small intentional raw
+  example, and add a fail-closed source-policy guard.
+- [ ] Wave 2 — replace Python-client live service execution with built Sifr
+  binaries for Redis, Postgres, Kafka, direct SQS, and SNS-to-SQS delivery,
+  including callback handoff and structured host skips.
+- [ ] Wave 3 — consolidate compiled callback, async HTTP, Arrow, DLPack, and
+  resource-zero evidence into the capability certification ledger; add the M17
+  demo and finish public/internal documentation.
+- [ ] Wave 4 — run authoritative validation, repeat whole-milestone and
+  whole-phase review to satisfaction, merge, update phase/roadmap/architecture
+  status, and archive the completed phase.
+
+Initial inventory after M16 closure found eleven ordinary runnable examples
+still using raw `Object` plumbing and manual close chains: NumPy, pandas,
+Polars, PyArrow, Torch, scikit-learn, FastAPI/Pydantic,
+cryptography/CFFI, boto3/botocore, Redis/fakeredis/hiredis, and
+SQLAlchemy/Alembic/psycopg. The live lane only type-checked six Sifr sources,
+then executed every service operation in Python clients. These are the two
+primary M17 gaps; existing compiled declaration suites already own async HTTP,
+callbacks, Arrow, DLPack, context, buffer, cancellation, and cleanup evidence
+and must remain executable certification inputs rather than inventory claims.
+
+Wave 1 pre-review validation passes the authoritative `create-pr` profile in
+`1341.56s`: Python interop `19/19`, create-PR E2E `131/131` with signature
+`7c39b8c1dd4fec7c`, runtime-platform `28/28` with one declared capability skip,
+and hardening `6/6`. Every blocking step budget passes; the cold-cache wall-time
+notice is advisory. All eleven inventoried ordinary examples now execute typed
+declarations backed by package-local hermetic bridges, and the shared runner
+records `compiled-sifr-declaration` evidence while rejecting raw API imports.
+
 Tasks:
 
 - Migrate all runnable biip/schwifty, dataframe, ML, web, database, cloud,

--- a/plans/issues/active/ad-hoc-declaration-first-python-interop.md
+++ b/plans/issues/active/ad-hoc-declaration-first-python-interop.md
@@ -2466,6 +2466,17 @@ notice is advisory. All eleven inventoried ordinary examples now execute typed
 declarations backed by package-local hermetic bridges, and the shared runner
 records `compiled-sifr-declaration` evidence while rejecting raw API imports.
 
+Fable High review pass 1 confirmed that all eleven migrations are faithful,
+deterministic, hermetic, and leak-checked, but returned `NOT SATISFIED` because
+the initial raw-symbol denylist missed `from_value`/`to_value`, method-style raw
+calls, `sifr.python_core`, module imports, and legal whitespace/continuation
+forms. The remediation replaces it with a token-aware allowlist across both
+public Python modules, fails closed on tokenization errors and dynamic trust,
+and drives eight adversarial sources through the complete report rejection
+path. Torch now verifies the reported `float32` dtype and PyArrow verifies both
+reported capsule names. The full runner self-test and the compiled ML and
+library suites pass after remediation.
+
 Tasks:
 
 - Migrate all runnable biip/schwifty, dataframe, ML, web, database, cloud,

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m17-wave1-fable-high-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m17-wave1-fable-high-review-pass-1.md
@@ -1,0 +1,56 @@
+I have everything I need. All bypass vectors were verified empirically against the actual guard code. Here is the review.
+
+---
+
+# Review: M17 Wave 1 — PR #2997 (75198e226..1ca5d91b5)
+
+## Scope verified
+
+I read the complete one-commit diff (28 files: 11 migrated `.sifr` fixtures, 11 new bridges, 4 runner files, README, plan), the M17 contract in `plans/issues/active/ad-hoc-declaration-first-python-interop.md:2431-2510`, the full post-diff `example_packages.py`, the raw API surface in `stdlib/sifr/python.sifr` / `python_core.sifr`, the compiler trust gate in `sifr_lowering`, and the remaining raw fixtures. I ran the new guard function directly against candidate bypass inputs.
+
+What holds up well: all eleven inventoried examples are genuinely migrated with faithful assertion parity (numpy/pandas/polars/pyarrow/torch/sklearn/fastapi/crypto/boto3/redis/sqlalchemy bridges reproduce every semantic check the old raw fixtures made, and each `.sifr` main adds a before/after `resource_diagnostics()` equality check); bridges are hermetic, deterministic (Stubber, fakeredis, in-memory SQLite, fixed `random_state`), copied file-by-file via `bridge_files` whitelists so co-resident bridges like `numpy_buffer/python_bridges/buffer_*.py` don't leak into example packages; source-policy failures do fail the whole suite closed (`build_examples_report` returns `examples-failed` with zero cases run, `example_packages.py:63-73`); failures propagate as `PythonError` through `Result` — no panic paths; the one intentional raw example (`demos/m16_raw_api`, with `fixtures/primitive_conversion/raw_typed_ergonomics.sifr` as its verification counterpart) lives outside the ordinary suites; and cases really execute compiled Sifr binaries via `cargo run -p sifr -- run`.
+
+## Findings
+
+### MAJOR 1 — The "fail-closed" source-policy guard is a bypassable denylist; the report and README certify a policy the guard does not enforce
+
+`verification/areas/python_interop/runner/example_packages.py:15-39` (`RAW_API_SYMBOLS`) and `:280-289` (`imported_raw_api_symbols`).
+
+The wave's headline deliverable is that "the runner fails closed if ordinary examples use the raw Python API or `@trust_python_dynamic`", and every report now stamps `source_policy: "ordinary-examples-forbid-raw-python-api"` (`example_packages.py:558`). I verified four independent bypass classes empirically — all return an empty match set from the guard:
+
+1. **Unguarded raw symbols.** The denylist holds 23 names; `stdlib/sifr/python.sifr` exports ~70 raw functions/types. Missing: `from_value` (`python.sifr:103` — a universal `Object` constructor), `to_value`, `kwarg`, all `copy_list_*`/`copy_tuple_*`/`copy_dict_str_*`/`copy_record_fields`/`copy_as_bytes`/`copy_buffer_bytes`, all sized conversions `to_i8`…`to_usize`, all `zero_copy_*`/`export_arrow_*`/`release_*` protocol helpers, `enter_context`/`exit_context`/`with_context`, `run_coroutine_blocking`, `BufferView`, `ArrowCapsule`, `DlpackTensor`, and the callback constructors.
+2. **The M16 method-style raw API needs no import at all.** `fixtures/primitive_conversion/raw_typed_ergonomics.sifr:22-38` demonstrates `.get_item`, `.get_attr`, `.call`, `.call_method` directly on `Object`, and Sifr allows unannotated locals (e.g. `demos/runtime_observability_boundary_demo.sifr:7`), so an ordinary example can write `x = from_value(...)`, then `x.call_method(...)` / `to_value(...)` — genuine raw-object plumbing — while importing only unguarded names. The `@trust_python_dynamic` substring check is no backstop: the compiler requires that decorator only for *dynamic* `import_module` targets (`crates/sifr_lowering/src/lower/expressions/regular_calls.rs:53-61`); every pre-migration raw example compiled without it.
+3. **`from sifr.python_core import Object`** is not matched by the regex (`sifr\.python\s+import` doesn't match `sifr.python_core`), yet `python_core` publicly exports `Object`, `LocalCallback` (whose `callable: Object` field is another handle source), and the callback constructors.
+4. **Legal-grammar textual evasions.** `from sifr . python import Object, import_module` (spaces around the dot) and backslash line continuation both parse as ordinary Python (the Ruff-fork grammar) and both slip through — the non-parenthesized branch captures only up to end-of-line.
+
+Consequently `verification/areas/python_interop/README.md:69-74` overclaims: "the example runner rejects raw `Object` imports, raw call/conversion helpers, and `@trust_python_dynamic` before execution" — most conversion helpers and all import-free call helpers are not rejected. Today's eleven examples are honestly migrated (I read them all), so no current certification is false — but the mechanism that is supposed to keep the certification honest going forward is fail-open across the most ergonomic raw path the project itself just built in M16.
+
+**Remediation:** invert to an allowlist. For ordinary example sources, flag any name imported from `sifr.python`/`sifr.python_core` outside `{PythonError, ResourceDiagnostics, resource_diagnostics, ExitCause, ExitCauseKind, ExitDecision}` (the set the migrated + biip-schwifty + sqlite-context fixtures actually need), with a whitespace-tolerant module pattern (`sifr\s*\.\s*python(_core)?`) that also spans continuations (scan with the newline-insensitive parenthesized branch or strip `\\\n` first). Additionally reject the import-free raw-method tokens (`.call_method(`, `.get_attr(`, `.get_item(`, `.call(` on non-declaration values is harder textually — at minimum reject `from_value`/`to_value` via the allowlist, which removes every `Object` source). Longer-term, the durable fix is a compiler/driver-enforced package policy (declaration-first mode) instead of a regex, consistent with how every other trust decision in this phase is compiler-owned.
+
+### MINOR 2 — The new rejection path is never exercised end-to-end by self-tests
+
+`example_packages.py:166-168` unit-tests `imported_raw_api_symbols` against one seed string, but no self-test drives a raw-importing source through `validate_source_presence`/`build_examples_report`, so the actual fail-closed branch (`example_packages.py:218-231`) and its `examples-failed` propagation are untested. A regression that, e.g., inverts the condition or drops the `continue` would pass all 19/19 today. **Remediation:** add a self-test that writes a synthetic fixture containing `from sifr.python import Object` into a temp fixtures root and asserts the report is `examples-failed` with the `ordinary example uses raw Python API` reason (and a sibling for `@trust_python_dynamic`).
+
+### MINOR 3 — Two stdout markers now assert metadata the bridges no longer verify
+
+- Torch: marker `...:dtype=float32` (`runner/ml_examples.py:14`), but `torch_dlpack/python_bridges/torch_example.py` never asserts `doubled.dtype == torch.float32` — the old fixture checked `DlpackTensor.dtype == "float32"` from typed protocol metadata.
+- PyArrow: marker `...:kind=array:...` (`runner/library_examples.py:20`), but `pyarrow_capsule/python_bridges/pyarrow_example.py` infers "array" only from `len(capsules) == 2`; the old fixture asserted `ArrowCapsule.kind == "array"` and `copy_possible`. Checking the two PyCapsule names (`arrow_array`/`arrow_schema`) would restore exactness.
+
+Both are one-line bridge assertions. Reports should not print protocol facts the run didn't check.
+
+### INFO 4 — `execution_model` is asserted, not derived
+
+`_run_case` hardcodes `"execution_model": "compiled-sifr-declaration"` (`example_packages.py:479`), so the report-level `invalid_execution_models` check (`:81-91`) is tautological for real runs. It is truthful — the case genuinely builds and runs a Sifr package through the sifr CLI — but the field is a label rather than evidence. Acceptable for Wave 1; worth keeping in mind when Wave 3 consolidates these rows into the certification ledger.
+
+### Observations (not actionable)
+
+- All eleven migrations chose the hermetic-bridge path (single `run() -> str`); none bind library symbols as direct typed declarations. The contract explicitly permits "declarations **or** hermetic bridges", and `biip-schwifty`/`sqlite-context` cover the direct-declaration shape, so this conforms — but the compiled-Sifr side of each ecosystem example now exercises only one declaration call plus diagnostics; the library work is Python-side. Wave 2/3 compiled-binary service evidence is what will carry the heavier compiled-Sifr claims.
+- Raw usage remaining in `fixtures/` (live roundtrips, buffer/arrow/dlpack/callback mechanics, `primitive_roundtrip`) is sanctioned: live lanes are Wave 2 scope and the rest are certification inputs per the README's new paragraph.
+- The Wave 1 checkbox in the plan is still `- [ ]` while the added prose describes completion — consistent with the repo's convention of flipping at closure; not a defect.
+- AGENTS.md constraints hold: no compiler code touched, all files well under the size cap, lockfile untouched, no new panic paths, and the dirty `third_party/ruff` submodule is outside the diff as stated.
+
+## Verdict
+
+The migration itself is honest, complete over the inventoried eleven, deterministic, and leak-checked. But the wave's defining deliverable — a *fail-closed* source-policy guard — is demonstrably fail-open across four bypass classes (including the raw-method API this project shipped one milestone ago), and the README/report certify enforcement the code doesn't provide. That is an actionable major finding against the stated intended outcome.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/active/ad-hoc-declaration-first-python-interop-m17-wave1-fable-high-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-declaration-first-python-interop-m17-wave1-fable-high-review-pass-2.md
@@ -1,0 +1,29 @@
+# Review: M17 Wave 1 — PR #2997, pass 2 (75198e226..d51e679f7)
+
+## Scope verified
+
+I read the complete three-commit diff (30 files), the M17 Wave 1 contract in `plans/issues/active/ad-hoc-declaration-first-python-interop.md`, the pass-1 artifact, the full post-diff runner (`example_packages.py`, `ordinary_example_policy.py`, all three ordinary suite files, `run.py` wiring), all eleven migrated `.sifr` callers and their bridges, the stdlib surface (`sifr/python.sifr`, `sifr/python_core.sifr`, private `_sifr/python.sifr`), and the compiler's import-policy crate. I executed the new guard against ~40 adversarial sources, compile-checked the residual bypass candidates against the actual `sifr` CLI, and independently re-ran the runner self-test lane.
+
+## Pass-1 findings: all remediated and verified
+
+**MAJOR 1 (fail-open denylist) — closed.** The guard is now a tokenizer-driven allowlist (`ordinary_python_api_policy_violations`, `example_packages.py:260`) restricting `sifr.python`/`sifr.python_core` imports to six names (`PythonError`, `ResourceDiagnostics`, `resource_diagnostics`, `ExitCause`, `ExitCauseKind`, `ExitDecision` — each used by real fixtures, none exposing an `Object`-typed field). I reproduced every pass-1 bypass and probed new ones; all are caught: unlisted names (`from_value`, `to_value`, every copy/zero-copy/protocol helper — anything not allowlisted), `sifr.python_core`, spaced dots, backslash continuations, aliases (including aliasing to an allowed name), star imports, parenthesized multiline imports with comments, semicolon-separated statements, direct module imports with comma lists and `as`, `from sifr import python/python_core`, nested/conditional/class-body imports, and `@trust_python_dynamic` in spaced and continued decorator spellings. Strings and comments are correctly not flagged; tokenization failures fail closed as `unparseable-source`.
+
+The import-free M16 method-style path is also closed by construction: the only sources of an `Object` value are imports the allowlist blocks, `_sifr.*` is compiler-rejected for user code (`SIFR-IMPORT-0001`, verified by compile), and the allowed types carry only str/enum/bool/int fields. I also compiler-verified the guard's blind spots are unreachable: bare `import python` (`SIFR-IMPORT-0008`), `import sifr` (`SIFR-IMPORT-0003`), `from sifr import *` and `sifr.python.sub` (`SIFR-IMPORT-0002`), `from sifr.python import *` (`SIFR-NAME-0004`) — and the guard independently flags `*` anyway. The README/report certification now matches enforced behavior.
+
+**MINOR 2 (no end-to-end negative tests) — closed.** Eight `POLICY_REJECTION_SEEDS` covering every pass-1 bypass class are driven through the full `build_examples_report` path per suite, asserting `examples-failed`, the declaration-first reason string, and that the example runner is never invoked (`_assert_policy_seed_rejected`, `example_packages.py:381`). I re-ran `runner/run.py --self-test` through the locked uv project: passes.
+
+**MINOR 3 (unverified marker facts) — closed.** The torch bridge now asserts `doubled.dtype != torch.float32` and the PyArrow bridge asserts both PyCapsule names via `repr`, in the correct Arrow C-interface order (schema first, array second).
+
+## Rest of implementation and migrations
+
+All eleven `.sifr` callers are uniform and policy-clean: allowed imports only, one typed `@python(bridge.<module>.run)` declaration, before/after `resource_diagnostics()` equality on live and leaked objects, `PythonError` propagation through `Result`, deterministic markers checked by the runner. All bridges are hermetic and deterministic (Stubber, fakeredis, hiredis parse-only, in-memory SQLite, `make_conninfo` without connecting, fixed `random_state`), copied via `bridge_files` whitelists. The guard also now applies to the six protocol/async example suites sharing `build_examples_report` — I verified all seventeen of those fixtures are policy-clean, consistent with the 19/19 result. `demos/m16_raw_api` is the single intentional raw example (the m12–m14 demos import only `PythonError`); remaining raw fixtures are sanctioned certification inputs per the README. The plan's Wave 1/validation record matches the stated results, the Wave 1 checkbox stays unchecked per closure convention, `example_packages.py` is 698 lines (under the cap), and no compiler code or lockfile was touched.
+
+## Residual observations (not actionable for Wave 1)
+
+- The policy remains a runner-owned tokenizer guard rather than a compiler-enforced declaration-first package mode; pass-1's long-term note stands and fits Wave 3+.
+- `execution_model` is still asserted rather than derived (pass-1 INFO, unchanged, acceptable).
+- The eight policy seeds re-run once per suite (11×) in `--self-test` — redundant but cheap.
+
+No blocker or major remains. Wave 1's deliverables — eleven honest migrations, one intentional raw example, and a genuinely fail-closed source-policy guard with end-to-end negative coverage — are all present and verified.
+
+VERDICT: SATISFIED

--- a/verification/areas/python_interop/README.md
+++ b/verification/areas/python_interop/README.md
@@ -66,6 +66,15 @@ positive, negative, cleanup, cancellation, and live evidence. The scaffold and
 self-test suites reject missing ownership, unsupported states, duplicate rows,
 or a supported claim without the evidence required by that row.
 
+Ordinary runnable ecosystem examples are declaration-first. Library-specific
+dynamic workflows live in package-local `python_bridges/` modules and expose
+only typed Sifr declarations; the example runner rejects raw `Object` imports,
+raw call/conversion helpers, and `@trust_python_dynamic` before execution. The
+one intentional dynamic-API demo remains, with
+`fixtures/primitive_conversion/raw_typed_ergonomics.sifr` as its focused
+verification counterpart. Low-level negative and protocol-mechanics fixtures
+remain certification inputs rather than user-facing ecosystem examples.
+
 Live dependency examples are intentionally opt-in. The `python-interop-live`
 profile uses selected-areas-only execution and runs both:
 
@@ -129,9 +138,10 @@ package execution gates exist.
 Dataframe examples are offline but executable. The `dataframe-examples` case
 links a temporary Sifr package to the area-local locked uv environment and runs
 real Sifr programs for NumPy, pandas, and Polars. These examples cover array or
-dataframe construction, library operations, conversion back into typed Sifr
-values, explicit result assertions, and deterministic stdout markers checked by
-the runner. They are separate from the dataframes matrix case so reviewers can
+dataframe construction and library operations behind hermetic package-local
+bridges, typed declaration results, resource-diagnostic equality, and
+deterministic stdout markers checked by the runner. They are separate from the
+dataframes matrix case so reviewers can
 distinguish package-certification metadata from compiled Sifr execution
 evidence. Runner self-tests validate report aggregation and fixture drift; the
 actual Cargo/Sifr/venv execution path is covered by `--dataframe-examples`.
@@ -155,11 +165,11 @@ runner self-test.
 
 ML examples are offline but executable. The `ml-examples` suite uses the same
 temporary-package execution path and runs real Sifr programs for torch and
-scikit-learn. The torch example constructs a CPU `float32` tensor, performs
-tensor math, converts results back to typed Sifr values, and validates DLPack
-metadata/release. The scikit-learn example trains a deterministic decision tree,
-predicts labels, copies predictions/classes back into typed Sifr lists, and
-checks deterministic stdout markers.
+scikit-learn through typed declarations over hermetic bridges. The torch bridge
+constructs a CPU `float32` tensor and validates tensor math and shape metadata;
+the scikit-learn bridge trains a deterministic decision tree and checks its
+predictions/classes. Both compiled Sifr callers require resource diagnostics to
+return to their baseline and emit deterministic markers.
 
 DLPack declaration examples are offline, compiled, and blocking in every
 delivery profile. The `dlpack-examples` suite runs real PyTorch and TensorFlow
@@ -175,7 +185,9 @@ stream/device mismatches, and exact-once cleanup remain blocking evidence.
 
 Library examples are offline but executable. The `library-examples` suite covers
 the remaining non-service, non-host-dependent library contracts that previously
-had only matrix or JSON/source-fixture evidence:
+had only matrix or JSON/source-fixture evidence. Complex library-specific
+object graphs stay in hermetic bridges; compiled Sifr calls typed declarations
+and verifies that ordinary object/leak diagnostics return to their baseline:
 
 - biip GTIN parsing and schwifty BIC validation.
 - pyarrow array compute plus Arrow PyCapsule metadata/release.

--- a/verification/areas/python_interop/README.md
+++ b/verification/areas/python_interop/README.md
@@ -68,9 +68,11 @@ or a supported claim without the evidence required by that row.
 
 Ordinary runnable ecosystem examples are declaration-first. Library-specific
 dynamic workflows live in package-local `python_bridges/` modules and expose
-only typed Sifr declarations; the example runner rejects raw `Object` imports,
-raw call/conversion helpers, and `@trust_python_dynamic` before execution. The
-one intentional dynamic-API demo remains, with
+only typed Sifr declarations. A token-aware allowlist restricts ordinary
+examples to the error, exit, and resource-diagnostic names they need from
+`sifr.python`; imports from `sifr.python_core`, module-style access, every raw
+object/conversion/protocol helper, and `@trust_python_dynamic` fail before
+execution. One intentional dynamic-API demo remains, with
 `fixtures/primitive_conversion/raw_typed_ergonomics.sifr` as its focused
 verification counterpart. Low-level negative and protocol-mechanics fixtures
 remain certification inputs rather than user-facing ecosystem examples.

--- a/verification/areas/python_interop/fixtures/aws_sqs/boto3_botocore_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/aws_sqs/boto3_botocore_full_example.sifr
@@ -1,74 +1,18 @@
-from sifr.python import (
-    Object,
-    PythonError,
-    call,
-    call_attr,
-    close,
-    from_dict_str,
-    from_str,
-    get_attr,
-    get_item,
-    import_module,
-    to_str,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
+@python(bridge.boto3_botocore_example.run)
+def run_example() -> Result[str, PythonError]: ...
+
+
 def main() -> Result[None, PythonError]:
     try:
-        boto3: Object = import_module("boto3")
-        stub_module: Object = import_module("botocore.stub")
-
-        service: Object = from_str("sqs")
-        region: Object = from_str("us-east-1")
-        access_key: Object = from_str("test")
-        secret_key: Object = from_str("test")
-        client: Object = call_attr(
-            boto3,
-            "client",
-            [service],
-            [("region_name", region), ("aws_access_key_id", access_key), ("aws_secret_access_key", secret_key)],
-        )
-
-        stubber_class: Object = get_attr(stub_module, "Stubber")
-        stubber: Object = call(stubber_class, [client], [])
-        operation: Object = from_str("create_queue")
-        queue_url_value: Object = from_str("https://sqs.us-east-1.amazonaws.com/123456789012/sifr-queue")
-        response: Object = from_dict_str([("QueueUrl", queue_url_value)])
-        queue_name_value: Object = from_str("sifr-queue")
-        expected_params: Object = from_dict_str([("QueueName", queue_name_value)])
-        add_result: Object = call_attr(stubber, "add_response", [operation, response, expected_params], [])
-        activate_result: Object = call_attr(stubber, "activate", [], [])
-        request_queue_name: Object = from_str("sifr-queue")
-        create_result: Object = call_attr(client, "create_queue", [], [("QueueName", request_queue_name)])
-        queue_url_obj: Object = get_item(create_result, "QueueUrl")
-        queue_url: str = to_str(queue_url_obj)
-        deactivate_result: Object = call_attr(stubber, "deactivate", [], [])
-
-        passed: bool = queue_url == "https://sqs.us-east-1.amazonaws.com/123456789012/sifr-queue"
-
-        closed_deactivate_result: None = close(deactivate_result)
-        closed_queue_url_obj: None = close(queue_url_obj)
-        closed_create_result: None = close(create_result)
-        closed_request_queue_name: None = close(request_queue_name)
-        closed_activate_result: None = close(activate_result)
-        closed_add_result: None = close(add_result)
-        closed_expected_params: None = close(expected_params)
-        closed_response: None = close(response)
-        closed_operation: None = close(operation)
-        closed_stubber: None = close(stubber)
-        closed_stubber_class: None = close(stubber_class)
-        closed_client: None = close(client)
-        closed_secret_key: None = close(secret_key)
-        closed_access_key: None = close(access_key)
-        closed_region: None = close(region)
-        closed_service: None = close(service)
-        closed_stub_module: None = close(stub_module)
-        closed_boto3: None = close(boto3)
-        if passed:
-            print("sifr-python-interop:boto3-botocore:queue=https://sqs.us-east-1.amazonaws.com/123456789012/sifr-queue")
-        else:
-            raise PythonError("boto3/botocore full example did not validate expected SQS stub result")
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("boto3/botocore bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/fixtures/aws_sqs/python_bridges/boto3_botocore_example.py
+++ b/verification/areas/python_interop/fixtures/aws_sqs/python_bridges/boto3_botocore_example.py
@@ -1,0 +1,24 @@
+import boto3
+from botocore.stub import Stubber
+
+
+QUEUE_URL = "https://sqs.us-east-1.amazonaws.com/123456789012/sifr-queue"
+
+
+def run() -> str:
+    client = boto3.client(
+        "sqs",
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    with Stubber(client) as stubber:
+        stubber.add_response(
+            "create_queue",
+            {"QueueUrl": QUEUE_URL},
+            {"QueueName": "sifr-queue"},
+        )
+        queue_url = client.create_queue(QueueName="sifr-queue")["QueueUrl"]
+    if queue_url != QUEUE_URL:
+        raise RuntimeError("boto3/botocore SQS stub returned an unexpected URL")
+    return f"sifr-python-interop:boto3-botocore:queue={queue_url}"

--- a/verification/areas/python_interop/fixtures/cryptography_tls/cryptography_cffi_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/cryptography_tls/cryptography_cffi_full_example.sifr
@@ -1,58 +1,18 @@
-from sifr.python import (
-    Object,
-    PythonError,
-    call,
-    call_attr,
-    close,
-    from_bytes,
-    from_str,
-    get_attr,
-    import_module,
-    to_bytes,
-    to_str,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
+@python(bridge.cryptography_cffi_example.run)
+def run_example() -> Result[str, PythonError]: ...
+
+
 def main() -> Result[None, PythonError]:
     try:
-        certifi: Object = import_module("certifi")
-        cffi: Object = import_module("cffi")
-        fernet_module: Object = import_module("cryptography.fernet")
-
-        fernet_class: Object = get_attr(fernet_module, "Fernet")
-        key: Object = call_attr(fernet_class, "generate_key", [], [])
-        cipher: Object = call(fernet_class, [key], [])
-        message: Object = from_bytes(b"sifr-secret")
-        token: Object = call_attr(cipher, "encrypt", [message], [])
-        decrypted: Object = call_attr(cipher, "decrypt", [token], [])
-        roundtrip: bytes = to_bytes(decrypted)
-
-        ffi: Object = call_attr(cffi, "FFI", [], [])
-        declaration: Object = from_str("int add(int, int);")
-        cdef_result: Object = call_attr(ffi, "cdef", [declaration], [])
-        cert_path_obj: Object = call_attr(certifi, "where", [], [])
-        cert_path: str = to_str(cert_path_obj)
-
-        passed: bool = roundtrip == b"sifr-secret" and cert_path != ""
-
-        closed_cert_path_obj: None = close(cert_path_obj)
-        closed_cdef_result: None = close(cdef_result)
-        closed_declaration: None = close(declaration)
-        closed_ffi: None = close(ffi)
-        closed_decrypted: None = close(decrypted)
-        closed_token: None = close(token)
-        closed_message: None = close(message)
-        closed_cipher: None = close(cipher)
-        closed_key: None = close(key)
-        closed_fernet_class: None = close(fernet_class)
-        closed_fernet_module: None = close(fernet_module)
-        closed_cffi: None = close(cffi)
-        closed_certifi: None = close(certifi)
-        if passed:
-            print("sifr-python-interop:cryptography-cffi:roundtrip=sifr-secret:certifi=ok")
-        else:
-            raise PythonError("cryptography/CFFI full example did not validate expected results")
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("cryptography/CFFI bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/fixtures/cryptography_tls/python_bridges/cryptography_cffi_example.py
+++ b/verification/areas/python_interop/fixtures/cryptography_tls/python_bridges/cryptography_cffi_example.py
@@ -1,0 +1,15 @@
+import certifi
+import cffi
+from cryptography.fernet import Fernet
+
+
+def run() -> str:
+    key = Fernet.generate_key()
+    cipher = Fernet(key)
+    if cipher.decrypt(cipher.encrypt(b"sifr-secret")) != b"sifr-secret":
+        raise RuntimeError("Fernet round trip failed")
+    ffi = cffi.FFI()
+    ffi.cdef("int add(int, int);")
+    if not certifi.where():
+        raise RuntimeError("certifi returned an empty certificate path")
+    return "sifr-python-interop:cryptography-cffi:roundtrip=sifr-secret:certifi=ok"

--- a/verification/areas/python_interop/fixtures/fastapi_app/fastapi_pydantic_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/fastapi_app/fastapi_pydantic_full_example.sifr
@@ -1,78 +1,18 @@
-from sifr.python import (
-    Object,
-    PythonError,
-    call,
-    call_attr,
-    close,
-    from_bool,
-    from_dict_str,
-    from_int,
-    from_str,
-    get_attr,
-    import_module,
-    to_bytes,
-    to_int,
-    to_str,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
+@python(bridge.fastapi_pydantic_example.run)
+def run_example() -> Result[str, PythonError]: ...
+
+
 def main() -> Result[None, PythonError]:
     try:
-        builtins: Object = import_module("builtins")
-        fastapi: Object = import_module("fastapi")
-        pydantic: Object = import_module("pydantic")
-        responses: Object = import_module("starlette.responses")
-
-        title_value: Object = from_str("Sifr API")
-        app: Object = call_attr(fastapi, "FastAPI", [], [("title", title_value)])
-        title_obj: Object = get_attr(app, "title")
-        title: str = to_str(title_obj)
-
-        int_type: Object = get_attr(builtins, "int")
-        adapter_module: Object = from_str("builtins")
-        parent_depth: Object = from_int(0)
-        # Embedded calls may not provide Pydantic's default two-frame caller context.
-        adapter: Object = call_attr(pydantic, "TypeAdapter", [int_type], [("_parent_depth", parent_depth), ("module", adapter_module)])
-        raw_value: Object = from_str("42")
-        validated_obj: Object = call_attr(adapter, "validate_python", [raw_value], [])
-        value: int = to_int(validated_obj)
-
-        ok_value: Object = from_bool(True)
-        content: Object = from_dict_str([("ok", ok_value)])
-        status_arg: Object = from_int(201)
-        response_class: Object = get_attr(responses, "JSONResponse")
-        response: Object = call(response_class, [content], [("status_code", status_arg)])
-        status_obj: Object = get_attr(response, "status_code")
-        status: int = to_int(status_obj)
-        rendered: Object = call_attr(response, "render", [content], [])
-        rendered_body: bytes = to_bytes(rendered)
-
-        passed: bool = value == 42 and title == "Sifr API" and status == 201 and rendered_body == b"{\"ok\":true}"
-
-        closed_rendered: None = close(rendered)
-        closed_status_obj: None = close(status_obj)
-        closed_response: None = close(response)
-        closed_response_class: None = close(response_class)
-        closed_status_arg: None = close(status_arg)
-        closed_content: None = close(content)
-        closed_validated_obj: None = close(validated_obj)
-        closed_raw_value: None = close(raw_value)
-        closed_adapter: None = close(adapter)
-        closed_parent_depth: None = close(parent_depth)
-        closed_adapter_module: None = close(adapter_module)
-        closed_int_type: None = close(int_type)
-        closed_title_obj: None = close(title_obj)
-        closed_app: None = close(app)
-        closed_title_value: None = close(title_value)
-        closed_responses: None = close(responses)
-        closed_pydantic: None = close(pydantic)
-        closed_fastapi: None = close(fastapi)
-        closed_builtins: None = close(builtins)
-        if passed:
-            print("sifr-python-interop:fastapi-pydantic:value=42:title=Sifr API:status=201")
-        else:
-            raise PythonError("FastAPI/Pydantic full example did not validate expected results")
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("FastAPI/Pydantic bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/fixtures/fastapi_app/python_bridges/fastapi_pydantic_example.py
+++ b/verification/areas/python_interop/fixtures/fastapi_app/python_bridges/fastapi_pydantic_example.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+from pydantic import TypeAdapter
+from starlette.responses import JSONResponse
+
+
+def run() -> str:
+    app = FastAPI(title="Sifr API")
+    value = TypeAdapter(int).validate_python("42")
+    response = JSONResponse({"ok": True}, status_code=201)
+    if value != 42 or app.title != "Sifr API" or response.status_code != 201:
+        raise RuntimeError("FastAPI/Pydantic full example did not validate expected results")
+    if response.body != b'{"ok":true}':
+        raise RuntimeError("FastAPI response body did not match")
+    return "sifr-python-interop:fastapi-pydantic:value=42:title=Sifr API:status=201"

--- a/verification/areas/python_interop/fixtures/numpy_buffer/numpy_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/numpy_buffer/numpy_full_example.sifr
@@ -1,64 +1,18 @@
-from sifr.python import (
-    Object,
-    PythonError,
-    call_attr,
-    close,
-    copy_list_int,
-    from_int,
-    from_list,
-    from_str,
-    import_module,
-    to_int,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
-def run_example() -> Result[None, PythonError]:
-    try:
-        np: Object = import_module("numpy")
-        one: Object = from_int(1)
-        two: Object = from_int(2)
-        three: Object = from_int(3)
-        four: Object = from_int(4)
-        values: Object = from_list([one, two, three, four])
-        dtype: Object = from_str("int64")
-        array: Object = call_attr(np, "array", [values], [("dtype", dtype)])
-        rows: Object = from_int(2)
-        cols: Object = from_int(2)
-        reshaped: Object = call_attr(array, "reshape", [rows, cols], [])
-        factor: Object = from_int(2)
-        doubled: Object = call_attr(np, "multiply", [reshaped, factor], [])
-        total_obj: Object = call_attr(doubled, "sum", [], [])
-        total: int = to_int(total_obj)
-        flattened: Object = call_attr(doubled, "ravel", [], [])
-        list_obj: Object = call_attr(flattened, "tolist", [], [])
-        copied: list[int] = copy_list_int(list_obj)
-
-        passed: bool = len(copied) == 4 and copied[0] == 2 and copied[3] == 8 and total == 20
-        closed_list: None = close(list_obj)
-        closed_flattened: None = close(flattened)
-        closed_total: None = close(total_obj)
-        closed_doubled: None = close(doubled)
-        closed_factor: None = close(factor)
-        closed_reshaped: None = close(reshaped)
-        closed_cols: None = close(cols)
-        closed_rows: None = close(rows)
-        closed_array: None = close(array)
-        closed_dtype: None = close(dtype)
-        closed_values: None = close(values)
-        closed_np: None = close(np)
-        if passed:
-            print("sifr-python-interop:numpy:sum=20:values=2,4,6,8")
-        else:
-            raise PythonError("numpy full example did not round-trip expected values")
-    except PythonError as e:
-        raise e
-    return None
+@python(bridge.numpy_example.run)
+def run_example() -> Result[str, PythonError]: ...
 
 
 def main() -> Result[None, PythonError]:
     try:
-        completed: None = run_example()
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("NumPy bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/fixtures/numpy_buffer/python_bridges/numpy_example.py
+++ b/verification/areas/python_interop/fixtures/numpy_buffer/python_bridges/numpy_example.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+
+def run() -> str:
+    values = np.array([1, 2, 3, 4], dtype="int64").reshape(2, 2)
+    doubled = np.multiply(values, 2)
+    copied = doubled.ravel().tolist()
+    if copied != [2, 4, 6, 8] or int(doubled.sum()) != 20:
+        raise RuntimeError("NumPy full example did not round-trip expected values")
+    return "sifr-python-interop:numpy:sum=20:values=2,4,6,8"

--- a/verification/areas/python_interop/fixtures/pandas_arrow/pandas_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/pandas_arrow/pandas_full_example.sifr
@@ -1,72 +1,18 @@
-from sifr.python import (
-    Object,
-    PythonError,
-    call_attr,
-    close,
-    copy_list_int,
-    from_dict_str,
-    from_int,
-    from_list,
-    from_str,
-    get_item,
-    import_module,
-    to_int,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
-def run_example() -> Result[None, PythonError]:
-    try:
-        pd: Object = import_module("pandas")
-        city_a: Object = from_str("oslo")
-        city_b: Object = from_str("oslo")
-        city_c: Object = from_str("paris")
-        cities: Object = from_list([city_a, city_b, city_c])
-        value_a: Object = from_int(2)
-        value_b: Object = from_int(3)
-        value_c: Object = from_int(5)
-        values: Object = from_list([value_a, value_b, value_c])
-        data: Object = from_dict_str([("city", cities), ("value", values)])
-        frame: Object = call_attr(pd, "DataFrame", [data], [])
-        value_series: Object = get_item(frame, "value")
-        factor: Object = from_int(2)
-        doubled_series: Object = call_attr(value_series, "mul", [factor], [])
-        assigned: Object = call_attr(frame, "assign", [], [("double", doubled_series)])
-        city_key: Object = from_str("city")
-        grouped: Object = call_attr(assigned, "groupby", [city_key], [])
-        summed: Object = call_attr(grouped, "sum", [], [])
-        double_totals: Object = get_item(summed, "double")
-        total_obj: Object = call_attr(double_totals, "sum", [], [])
-        total: int = to_int(total_obj)
-        value_list_obj: Object = call_attr(value_series, "tolist", [], [])
-        copied: list[int] = copy_list_int(value_list_obj)
-
-        passed: bool = len(copied) == 3 and copied[0] == 2 and copied[2] == 5 and total == 20
-        closed_value_list: None = close(value_list_obj)
-        closed_total: None = close(total_obj)
-        closed_double_totals: None = close(double_totals)
-        closed_summed: None = close(summed)
-        closed_grouped: None = close(grouped)
-        closed_city_key: None = close(city_key)
-        closed_assigned: None = close(assigned)
-        closed_doubled: None = close(doubled_series)
-        closed_factor: None = close(factor)
-        closed_value_series: None = close(value_series)
-        closed_frame: None = close(frame)
-        closed_data: None = close(data)
-        closed_pd: None = close(pd)
-        if passed:
-            print("sifr-python-interop:pandas:double-total=20:values=2,3,5")
-        else:
-            raise PythonError("pandas full example did not round-trip expected values")
-    except PythonError as e:
-        raise e
-    return None
+@python(bridge.pandas_example.run)
+def run_example() -> Result[str, PythonError]: ...
 
 
 def main() -> Result[None, PythonError]:
     try:
-        completed: None = run_example()
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("pandas bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/fixtures/pandas_arrow/python_bridges/pandas_example.py
+++ b/verification/areas/python_interop/fixtures/pandas_arrow/python_bridges/pandas_example.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+
+def run() -> str:
+    frame = pd.DataFrame({"city": ["oslo", "oslo", "paris"], "value": [2, 3, 5]})
+    values = frame["value"].tolist()
+    grouped = frame.assign(double=frame["value"].mul(2)).groupby("city").sum()
+    if values != [2, 3, 5] or int(grouped["double"].sum()) != 20:
+        raise RuntimeError("pandas full example did not round-trip expected values")
+    return "sifr-python-interop:pandas:double-total=20:values=2,3,5"

--- a/verification/areas/python_interop/fixtures/polars_arrow/polars_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/polars_arrow/polars_full_example.sifr
@@ -1,68 +1,18 @@
-from sifr.python import (
-    Object,
-    PythonError,
-    call_attr,
-    close,
-    copy_list_int,
-    copy_list_str,
-    from_dict_str,
-    from_int,
-    from_list,
-    from_str,
-    get_item,
-    import_module,
-    to_int,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
-def run_example() -> Result[None, PythonError]:
-    try:
-        pl: Object = import_module("polars")
-        city_a: Object = from_str("paris")
-        city_b: Object = from_str("oslo")
-        city_c: Object = from_str("rome")
-        cities: Object = from_list([city_a, city_b, city_c])
-        value_a: Object = from_int(5)
-        value_b: Object = from_int(2)
-        value_c: Object = from_int(3)
-        values: Object = from_list([value_a, value_b, value_c])
-        data: Object = from_dict_str([("city", cities), ("value", values)])
-        frame: Object = call_attr(pl, "DataFrame", [data], [])
-        sort_key: Object = from_str("value")
-        sorted_frame: Object = call_attr(frame, "sort", [sort_key], [])
-        value_series: Object = get_item(sorted_frame, "value")
-        city_series: Object = get_item(sorted_frame, "city")
-        total_obj: Object = call_attr(value_series, "sum", [], [])
-        total: int = to_int(total_obj)
-        value_list_obj: Object = call_attr(value_series, "to_list", [], [])
-        city_list_obj: Object = call_attr(city_series, "to_list", [], [])
-        copied_values: list[int] = copy_list_int(value_list_obj)
-        copied_cities: list[str] = copy_list_str(city_list_obj)
-
-        passed: bool = len(copied_values) == 3 and copied_values[0] == 2 and copied_values[2] == 5 and copied_cities[0] == "oslo" and total == 10
-        closed_city_list: None = close(city_list_obj)
-        closed_value_list: None = close(value_list_obj)
-        closed_total: None = close(total_obj)
-        closed_city_series: None = close(city_series)
-        closed_value_series: None = close(value_series)
-        closed_sorted: None = close(sorted_frame)
-        closed_sort_key: None = close(sort_key)
-        closed_frame: None = close(frame)
-        closed_data: None = close(data)
-        closed_pl: None = close(pl)
-        if passed:
-            print("sifr-python-interop:polars:sum=10:first-city=oslo")
-        else:
-            raise PythonError("polars full example did not round-trip expected values")
-    except PythonError as e:
-        raise e
-    return None
+@python(bridge.polars_example.run)
+def run_example() -> Result[str, PythonError]: ...
 
 
 def main() -> Result[None, PythonError]:
     try:
-        completed: None = run_example()
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("Polars bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/fixtures/polars_arrow/python_bridges/polars_example.py
+++ b/verification/areas/python_interop/fixtures/polars_arrow/python_bridges/polars_example.py
@@ -1,0 +1,11 @@
+import polars as pl
+
+
+def run() -> str:
+    frame = pl.DataFrame({"city": ["paris", "oslo", "rome"], "value": [5, 2, 3]})
+    sorted_frame = frame.sort("value")
+    values = sorted_frame["value"].to_list()
+    cities = sorted_frame["city"].to_list()
+    if values != [2, 3, 5] or cities[0] != "oslo" or int(sum(values)) != 10:
+        raise RuntimeError("Polars full example did not round-trip expected values")
+    return "sifr-python-interop:polars:sum=10:first-city=oslo"

--- a/verification/areas/python_interop/fixtures/pyarrow_capsule/pyarrow_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/pyarrow_capsule/pyarrow_full_example.sifr
@@ -1,53 +1,18 @@
-from sifr.python import (
-    ArrowCapsule,
-    Object,
-    PythonError,
-    call_attr,
-    close,
-    export_arrow_array,
-    from_int,
-    from_list,
-    import_module,
-    release_arrow,
-    to_int,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
+@python(bridge.pyarrow_example.run)
+def run_example() -> Result[str, PythonError]: ...
+
+
 def main() -> Result[None, PythonError]:
     try:
-        pyarrow: Object = import_module("pyarrow")
-        compute: Object = import_module("pyarrow.compute")
-        one: Object = from_int(1)
-        two: Object = from_int(2)
-        three: Object = from_int(3)
-        four: Object = from_int(4)
-        values: Object = from_list([one, two, three, four])
-        array: Object = call_attr(pyarrow, "array", [values], [])
-        sum_scalar: Object = call_attr(compute, "sum", [array], [])
-        sum_obj: Object = call_attr(sum_scalar, "as_py", [], [])
-        total: int = to_int(sum_obj)
-        capsule: ArrowCapsule = export_arrow_array(array)
-
-        capsule_ok: bool = (
-            capsule.kind == "array"
-            and capsule.copy_possible
-            and len(capsule.capsule_names) == 2
-            and capsule.producer_module == "pyarrow.lib"
-        )
-        passed: bool = total == 10 and capsule_ok
-
-        released: None = release_arrow(capsule)
-        closed_sum_obj: None = close(sum_obj)
-        closed_sum_scalar: None = close(sum_scalar)
-        closed_array: None = close(array)
-        closed_values: None = close(values)
-        closed_compute: None = close(compute)
-        closed_pyarrow: None = close(pyarrow)
-        if passed:
-            print("sifr-python-interop:pyarrow:sum=10:kind=array:producer=pyarrow.lib")
-        else:
-            raise PythonError("pyarrow full example did not validate expected Arrow results")
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("PyArrow bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/fixtures/pyarrow_capsule/python_bridges/pyarrow_example.py
+++ b/verification/areas/python_interop/fixtures/pyarrow_capsule/python_bridges/pyarrow_example.py
@@ -1,0 +1,11 @@
+import pyarrow as pa
+import pyarrow.compute as pc
+
+
+def run() -> str:
+    array = pa.array([1, 2, 3, 4])
+    capsules = array.__arrow_c_array__()
+    total = pc.sum(array).as_py()
+    if total != 10 or len(capsules) != 2 or type(array).__module__ != "pyarrow.lib":
+        raise RuntimeError("PyArrow full example did not validate expected Arrow results")
+    return "sifr-python-interop:pyarrow:sum=10:kind=array:producer=pyarrow.lib"

--- a/verification/areas/python_interop/fixtures/pyarrow_capsule/python_bridges/pyarrow_example.py
+++ b/verification/areas/python_interop/fixtures/pyarrow_capsule/python_bridges/pyarrow_example.py
@@ -5,7 +5,14 @@ import pyarrow.compute as pc
 def run() -> str:
     array = pa.array([1, 2, 3, 4])
     capsules = array.__arrow_c_array__()
+    capsule_names = tuple(repr(capsule) for capsule in capsules)
     total = pc.sum(array).as_py()
-    if total != 10 or len(capsules) != 2 or type(array).__module__ != "pyarrow.lib":
+    if (
+        total != 10
+        or len(capsules) != 2
+        or '"arrow_schema"' not in capsule_names[0]
+        or '"arrow_array"' not in capsule_names[1]
+        or type(array).__module__ != "pyarrow.lib"
+    ):
         raise RuntimeError("PyArrow full example did not validate expected Arrow results")
     return "sifr-python-interop:pyarrow:sum=10:kind=array:producer=pyarrow.lib"

--- a/verification/areas/python_interop/fixtures/redis/python_bridges/redis_fakeredis_example.py
+++ b/verification/areas/python_interop/fixtures/redis/python_bridges/redis_fakeredis_example.py
@@ -1,0 +1,15 @@
+import fakeredis
+import hiredis
+import redis
+
+
+def run() -> str:
+    client = fakeredis.FakeRedis(decode_responses=True)
+    client.set("sifr:library:redis", "ready")
+    observed = client.get("sifr:library:redis")
+    reader = hiredis.Reader()
+    reader.feed(b"+PONG\r\n")
+    reply = reader.gets()
+    if observed != "ready" or reply != b"PONG" or not redis.__version__:
+        raise RuntimeError("Redis/fakeredis/hiredis full example failed")
+    return "sifr-python-interop:redis-fakeredis:value=ready:reply=PONG"

--- a/verification/areas/python_interop/fixtures/redis/redis_fakeredis_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/redis/redis_fakeredis_full_example.sifr
@@ -1,64 +1,18 @@
-from sifr.python import (
-    Object,
-    PythonError,
-    call,
-    call_attr,
-    close,
-    from_bool,
-    from_bytes,
-    from_str,
-    get_attr,
-    import_module,
-    to_bytes,
-    to_str,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
+@python(bridge.redis_fakeredis_example.run)
+def run_example() -> Result[str, PythonError]: ...
+
+
 def main() -> Result[None, PythonError]:
     try:
-        redis_module: Object = import_module("redis")
-        fakeredis: Object = import_module("fakeredis")
-        hiredis: Object = import_module("hiredis")
-
-        decode: Object = from_bool(True)
-        fake_client: Object = call_attr(fakeredis, "FakeRedis", [], [("decode_responses", decode)])
-        key: Object = from_str("sifr:library:redis")
-        value: Object = from_str("ready")
-        set_result: Object = call_attr(fake_client, "set", [key, value], [])
-        get_result: Object = call_attr(fake_client, "get", [key], [])
-        observed: str = to_str(get_result)
-
-        reader_class: Object = get_attr(hiredis, "Reader")
-        reader: Object = call(reader_class, [], [])
-        payload: Object = from_bytes(b"+PONG\r\n")
-        feed_result: Object = call_attr(reader, "feed", [payload], [])
-        reply_obj: Object = call_attr(reader, "gets", [], [])
-        reply: bytes = to_bytes(reply_obj)
-
-        redis_version_obj: Object = get_attr(redis_module, "__version__")
-        redis_version: str = to_str(redis_version_obj)
-        passed: bool = observed == "ready" and reply == b"PONG" and redis_version != ""
-
-        closed_redis_version_obj: None = close(redis_version_obj)
-        closed_reply_obj: None = close(reply_obj)
-        closed_feed_result: None = close(feed_result)
-        closed_payload: None = close(payload)
-        closed_reader: None = close(reader)
-        closed_reader_class: None = close(reader_class)
-        closed_get_result: None = close(get_result)
-        closed_set_result: None = close(set_result)
-        closed_value: None = close(value)
-        closed_key: None = close(key)
-        closed_fake_client: None = close(fake_client)
-        closed_decode: None = close(decode)
-        closed_hiredis: None = close(hiredis)
-        closed_fakeredis: None = close(fakeredis)
-        closed_redis_module: None = close(redis_module)
-        if passed:
-            print("sifr-python-interop:redis-fakeredis:value=ready:reply=PONG")
-        else:
-            raise PythonError("redis/fakeredis/hiredis full example did not validate expected results")
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("Redis/fakeredis bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/fixtures/sklearn/python_bridges/sklearn_example.py
+++ b/verification/areas/python_interop/fixtures/sklearn/python_bridges/sklearn_example.py
@@ -1,0 +1,11 @@
+from sklearn.tree import DecisionTreeClassifier
+
+
+def run() -> str:
+    model = DecisionTreeClassifier(random_state=11)
+    model.fit([[0, 0], [0, 1], [2, 2], [3, 2]], [0, 0, 1, 1])
+    predictions = model.predict([[0, 0], [3, 3]]).tolist()
+    classes = model.classes_.tolist()
+    if predictions != [0, 1] or classes != [0, 1]:
+        raise RuntimeError("scikit-learn full example returned unexpected predictions")
+    return "sifr-python-interop:sklearn:predictions=0,1:classes=0,1"

--- a/verification/areas/python_interop/fixtures/sklearn/sklearn_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/sklearn/sklearn_full_example.sifr
@@ -1,83 +1,18 @@
-from sifr.python import (
-    Object,
-    PythonError,
-    call_attr,
-    close,
-    copy_list_int,
-    from_int,
-    from_list,
-    get_attr,
-    import_module,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
-def run_example() -> Result[None, PythonError]:
-    try:
-        tree: Object = import_module("sklearn.tree")
-        train_a_x: Object = from_int(0)
-        train_a_y: Object = from_int(0)
-        train_b_x: Object = from_int(0)
-        train_b_y: Object = from_int(1)
-        train_c_x: Object = from_int(2)
-        train_c_y: Object = from_int(2)
-        train_d_x: Object = from_int(3)
-        train_d_y: Object = from_int(2)
-        train_a: Object = from_list([train_a_x, train_a_y])
-        train_b: Object = from_list([train_b_x, train_b_y])
-        train_c: Object = from_list([train_c_x, train_c_y])
-        train_d: Object = from_list([train_d_x, train_d_y])
-        x_train: Object = from_list([train_a, train_b, train_c, train_d])
-        label_a: Object = from_int(0)
-        label_b: Object = from_int(0)
-        label_c: Object = from_int(1)
-        label_d: Object = from_int(1)
-        y_train: Object = from_list([label_a, label_b, label_c, label_d])
-        random_state: Object = from_int(11)
-        model: Object = call_attr(tree, "DecisionTreeClassifier", [], [("random_state", random_state)])
-        fitted: Object = call_attr(model, "fit", [x_train, y_train], [])
-
-        query_a_x: Object = from_int(0)
-        query_a_y: Object = from_int(0)
-        query_b_x: Object = from_int(3)
-        query_b_y: Object = from_int(3)
-        query_a: Object = from_list([query_a_x, query_a_y])
-        query_b: Object = from_list([query_b_x, query_b_y])
-        x_query: Object = from_list([query_a, query_b])
-        predictions_obj: Object = call_attr(fitted, "predict", [x_query], [])
-        predictions_list_obj: Object = call_attr(predictions_obj, "tolist", [], [])
-        predictions: list[int] = copy_list_int(predictions_list_obj)
-        classes_obj: Object = get_attr(fitted, "classes_")
-        classes_list_obj: Object = call_attr(classes_obj, "tolist", [], [])
-        classes: list[int] = copy_list_int(classes_list_obj)
-
-        predictions_ok: bool = len(predictions) == 2 and predictions[0] == 0 and predictions[1] == 1
-        classes_ok: bool = len(classes) == 2 and classes[0] == 0 and classes[1] == 1
-        passed: bool = predictions_ok and classes_ok
-
-        closed_classes_list: None = close(classes_list_obj)
-        closed_classes: None = close(classes_obj)
-        closed_predictions_list: None = close(predictions_list_obj)
-        closed_predictions: None = close(predictions_obj)
-        closed_x_query: None = close(x_query)
-        closed_fitted: None = close(fitted)
-        closed_model: None = close(model)
-        closed_random_state: None = close(random_state)
-        closed_y_train: None = close(y_train)
-        closed_x_train: None = close(x_train)
-        closed_tree: None = close(tree)
-        if passed:
-            print("sifr-python-interop:sklearn:predictions=0,1:classes=0,1")
-        else:
-            raise PythonError("scikit-learn full example did not round-trip expected predictions")
-    except PythonError as e:
-        raise e
-    return None
+@python(bridge.sklearn_example.run)
+def run_example() -> Result[str, PythonError]: ...
 
 
 def main() -> Result[None, PythonError]:
     try:
-        completed: None = run_example()
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("scikit-learn bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/fixtures/sqlalchemy_psycopg/python_bridges/sqlalchemy_psycopg_example.py
+++ b/verification/areas/python_interop/fixtures/sqlalchemy_psycopg/python_bridges/sqlalchemy_psycopg_example.py
@@ -1,0 +1,16 @@
+from alembic.runtime.migration import MigrationContext
+import psycopg
+from psycopg.conninfo import make_conninfo
+import sqlalchemy
+
+
+def run() -> str:
+    engine = sqlalchemy.create_engine("sqlite+pysqlite:///:memory:")
+    with engine.connect() as connection:
+        scalar = connection.execute(sqlalchemy.text("select 40 + 2")).scalar_one()
+        dialect_name = MigrationContext.configure(connection).dialect.name
+    engine.dispose()
+    conninfo = make_conninfo(host="localhost", dbname="postgres")
+    if scalar != 42 or dialect_name != "sqlite" or not psycopg.__version__ or not conninfo:
+        raise RuntimeError("SQLAlchemy/psycopg full example failed")
+    return "sifr-python-interop:sqlalchemy-psycopg:scalar=42:dialect=sqlite:conninfo=ok"

--- a/verification/areas/python_interop/fixtures/sqlalchemy_psycopg/sqlalchemy_psycopg_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/sqlalchemy_psycopg/sqlalchemy_psycopg_full_example.sifr
@@ -1,75 +1,18 @@
-from sifr.python import (
-    Object,
-    PythonError,
-    call_attr,
-    close,
-    from_str,
-    get_attr,
-    import_module,
-    to_int,
-    to_str,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
+@python(bridge.sqlalchemy_psycopg_example.run)
+def run_example() -> Result[str, PythonError]: ...
+
+
 def main() -> Result[None, PythonError]:
     try:
-        alembic_migration: Object = import_module("alembic.runtime.migration")
-        psycopg: Object = import_module("psycopg")
-        sqlalchemy: Object = import_module("sqlalchemy")
-        conninfo_module: Object = import_module("psycopg.conninfo")
-
-        url: Object = from_str("sqlite+pysqlite:///:memory:")
-        engine: Object = call_attr(sqlalchemy, "create_engine", [url], [])
-        connection: Object = call_attr(engine, "connect", [], [])
-        query_text: Object = from_str("select 40 + 2")
-        statement: Object = call_attr(sqlalchemy, "text", [query_text], [])
-        result: Object = call_attr(connection, "execute", [statement], [])
-        scalar_obj: Object = call_attr(result, "scalar_one", [], [])
-        scalar: int = to_int(scalar_obj)
-
-        migration_context_class: Object = get_attr(alembic_migration, "MigrationContext")
-        migration_context: Object = call_attr(migration_context_class, "configure", [connection], [])
-        dialect: Object = get_attr(migration_context, "dialect")
-        dialect_name_obj: Object = get_attr(dialect, "name")
-        dialect_name: str = to_str(dialect_name_obj)
-
-        psycopg_version_obj: Object = get_attr(psycopg, "__version__")
-        psycopg_version: str = to_str(psycopg_version_obj)
-        host: Object = from_str("localhost")
-        dbname: Object = from_str("postgres")
-        conninfo_obj: Object = call_attr(conninfo_module, "make_conninfo", [], [("host", host), ("dbname", dbname)])
-        conninfo: str = to_str(conninfo_obj)
-
-        close_result: Object = call_attr(connection, "close", [], [])
-        dispose_result: Object = call_attr(engine, "dispose", [], [])
-        passed: bool = scalar == 42 and dialect_name == "sqlite" and psycopg_version != "" and conninfo != ""
-
-        closed_dispose_result: None = close(dispose_result)
-        closed_close_result: None = close(close_result)
-        closed_conninfo_obj: None = close(conninfo_obj)
-        closed_dbname: None = close(dbname)
-        closed_host: None = close(host)
-        closed_psycopg_version_obj: None = close(psycopg_version_obj)
-        closed_dialect_name_obj: None = close(dialect_name_obj)
-        closed_dialect: None = close(dialect)
-        closed_migration_context: None = close(migration_context)
-        closed_migration_context_class: None = close(migration_context_class)
-        closed_scalar_obj: None = close(scalar_obj)
-        closed_result: None = close(result)
-        closed_statement: None = close(statement)
-        closed_query_text: None = close(query_text)
-        closed_connection: None = close(connection)
-        closed_engine: None = close(engine)
-        closed_url: None = close(url)
-        closed_conninfo_module: None = close(conninfo_module)
-        closed_sqlalchemy: None = close(sqlalchemy)
-        closed_psycopg: None = close(psycopg)
-        closed_alembic_migration: None = close(alembic_migration)
-        if passed:
-            print("sifr-python-interop:sqlalchemy-psycopg:scalar=42:dialect=sqlite:conninfo=ok")
-        else:
-            raise PythonError("SQLAlchemy/psycopg full example did not validate expected results")
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("SQLAlchemy/psycopg bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/fixtures/torch_dlpack/python_bridges/torch_example.py
+++ b/verification/areas/python_interop/fixtures/torch_dlpack/python_bridges/torch_example.py
@@ -7,6 +7,10 @@ def run() -> str:
     values = doubled.flatten().tolist()
     if values != [2.0, 4.0, 6.0, 8.0, 10.0, 12.0]:
         raise RuntimeError("Torch values did not round-trip")
-    if float(doubled.sum().item()) != 42.0 or list(doubled.shape) != [2, 3]:
+    if (
+        float(doubled.sum().item()) != 42.0
+        or list(doubled.shape) != [2, 3]
+        or doubled.dtype != torch.float32
+    ):
         raise RuntimeError("Torch metadata did not match")
     return "sifr-python-interop:torch:sum=42.0:shape=2x3:dtype=float32"

--- a/verification/areas/python_interop/fixtures/torch_dlpack/python_bridges/torch_example.py
+++ b/verification/areas/python_interop/fixtures/torch_dlpack/python_bridges/torch_example.py
@@ -1,0 +1,12 @@
+import torch
+
+
+def run() -> str:
+    tensor = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=torch.float32)
+    doubled = torch.mul(tensor.reshape(2, 3), 2.0)
+    values = doubled.flatten().tolist()
+    if values != [2.0, 4.0, 6.0, 8.0, 10.0, 12.0]:
+        raise RuntimeError("Torch values did not round-trip")
+    if float(doubled.sum().item()) != 42.0 or list(doubled.shape) != [2, 3]:
+        raise RuntimeError("Torch metadata did not match")
+    return "sifr-python-interop:torch:sum=42.0:shape=2x3:dtype=float32"

--- a/verification/areas/python_interop/fixtures/torch_dlpack/torch_full_example.sifr
+++ b/verification/areas/python_interop/fixtures/torch_dlpack/torch_full_example.sifr
@@ -1,79 +1,18 @@
-from sifr.python import (
-    DlpackTensor,
-    Object,
-    PythonError,
-    call_attr,
-    close,
-    copy_list_float,
-    from_float,
-    from_int,
-    from_list,
-    get_attr,
-    import_module,
-    release_dlpack,
-    to_float,
-    zero_copy_dlpack_tensor,
-)
+from sifr.python import PythonError, ResourceDiagnostics, resource_diagnostics
 
 
-@blocking_io
-def run_example() -> Result[None, PythonError]:
-    try:
-        torch: Object = import_module("torch")
-        one: Object = from_float(1.0)
-        two: Object = from_float(2.0)
-        three: Object = from_float(3.0)
-        four: Object = from_float(4.0)
-        five: Object = from_float(5.0)
-        six: Object = from_float(6.0)
-        values: Object = from_list([one, two, three, four, five, six])
-        dtype: Object = get_attr(torch, "float32")
-        tensor: Object = call_attr(torch, "tensor", [values], [("dtype", dtype)])
-        rows: Object = from_int(2)
-        cols: Object = from_int(3)
-        shaped: Object = call_attr(tensor, "reshape", [rows, cols], [])
-        factor: Object = from_float(2.0)
-        doubled: Object = call_attr(torch, "mul", [shaped, factor], [])
-        total_tensor: Object = call_attr(doubled, "sum", [], [])
-        total_obj: Object = call_attr(total_tensor, "item", [], [])
-        total: float = to_float(total_obj)
-        flattened: Object = call_attr(doubled, "flatten", [], [])
-        list_obj: Object = call_attr(flattened, "tolist", [], [])
-        copied: list[float] = copy_list_float(list_obj)
-        dlpack: DlpackTensor = zero_copy_dlpack_tensor(doubled)
-
-        shape_ok: bool = len(dlpack.shape) == 2 and dlpack.shape[0] == 2 and dlpack.shape[1] == 3
-        values_ok: bool = len(copied) == 6 and copied[0] == 2.0 and copied[5] == 12.0
-        metadata_ok: bool = dlpack.dtype == "float32" and dlpack.dimensions == 2 and shape_ok
-        total_ok: bool = total == 42.0
-        passed: bool = values_ok and metadata_ok and total_ok
-
-        released: None = release_dlpack(dlpack)
-        closed_list: None = close(list_obj)
-        closed_flattened: None = close(flattened)
-        closed_total_obj: None = close(total_obj)
-        closed_total_tensor: None = close(total_tensor)
-        closed_doubled: None = close(doubled)
-        closed_factor: None = close(factor)
-        closed_shaped: None = close(shaped)
-        closed_cols: None = close(cols)
-        closed_rows: None = close(rows)
-        closed_tensor: None = close(tensor)
-        closed_dtype: None = close(dtype)
-        closed_values: None = close(values)
-        closed_torch: None = close(torch)
-        if passed:
-            print("sifr-python-interop:torch:sum=42.0:shape=2x3:dtype=float32")
-        else:
-            raise PythonError("torch full example did not round-trip expected values")
-    except PythonError as e:
-        raise e
-    return None
+@python(bridge.torch_example.run)
+def run_example() -> Result[str, PythonError]: ...
 
 
 def main() -> Result[None, PythonError]:
     try:
-        completed: None = run_example()
-    except PythonError as e:
-        raise e
+        before: ResourceDiagnostics = resource_diagnostics()
+        marker: str = run_example()
+        after: ResourceDiagnostics = resource_diagnostics()
+        if after.live_objects != before.live_objects or after.leaked_objects != before.leaked_objects:
+            raise PythonError("Torch bridge leaked Python objects")
+        print(marker)
+    except PythonError as error:
+        raise error
     return None

--- a/verification/areas/python_interop/runner/dataframe_examples.py
+++ b/verification/areas/python_interop/runner/dataframe_examples.py
@@ -12,19 +12,21 @@ DATAFRAME_EXAMPLE_CASES = {
         relative_source="numpy_buffer/numpy_full_example.sifr",
         stdout_marker="sifr-python-interop:numpy:sum=20:values=2,4,6,8",
         import_roots=("numpy",),
-        copy_bridges=False,
+        bridge_files=("numpy_example.py",),
     ),
     "pandas": ExampleCase(
         case_id="pandas",
         relative_source="pandas_arrow/pandas_full_example.sifr",
         stdout_marker="sifr-python-interop:pandas:double-total=20:values=2,3,5",
         import_roots=("numpy", "pandas"),
+        bridge_files=("pandas_example.py",),
     ),
     "polars": ExampleCase(
         case_id="polars",
         relative_source="polars_arrow/polars_full_example.sifr",
         stdout_marker="sifr-python-interop:polars:sum=10:first-city=oslo",
         import_roots=("polars",),
+        bridge_files=("polars_example.py",),
     ),
 }
 
@@ -52,9 +54,9 @@ def run_dataframe_examples_self_tests(paths: RunnerPaths) -> None:
         for case_id, case in DATAFRAME_EXAMPLE_CASES.items()
     }
     expected_policy = {
-        "numpy": (("numpy",), None, False, None),
-        "pandas": (("numpy", "pandas"), None, True, None),
-        "polars": (("polars",), None, True, None),
+        "numpy": (("numpy",), None, True, ("numpy_example.py",)),
+        "pandas": (("numpy", "pandas"), None, True, ("pandas_example.py",)),
+        "polars": (("polars",), None, True, ("polars_example.py",)),
     }
     if observed_policy != expected_policy:
         raise SystemExit(f"dataframe example package-policy drift: {observed_policy}")

--- a/verification/areas/python_interop/runner/example_packages.py
+++ b/verification/areas/python_interop/runner/example_packages.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import time
@@ -11,6 +12,31 @@ from typing import Any
 from env import RunnerPaths, cargo_env_for_repo_manifest
 
 EXAMPLE_TIMEOUT_SECONDS = 600
+RAW_API_SYMBOLS = {
+    "Object",
+    "call",
+    "call_attr",
+    "close",
+    "from_bool",
+    "from_bytes",
+    "from_dict_str",
+    "from_float",
+    "from_int",
+    "from_list",
+    "from_none",
+    "from_record",
+    "from_str",
+    "from_tuple",
+    "get_attr",
+    "get_item",
+    "import_module",
+    "to_bool",
+    "to_bytes",
+    "to_float",
+    "to_int",
+    "to_none",
+    "to_str",
+}
 
 
 @dataclass(frozen=True)
@@ -52,8 +78,15 @@ def build_examples_report(
     case_results = runner(paths)
     failures = sum(1 for case in case_results if case["status"] != "example-passed")
     observed_case_ids = [case.get("id") for case in case_results]
-    if len(observed_case_ids) != len(set(observed_case_ids)) or set(observed_case_ids) != set(
-        cases_by_id
+    invalid_execution_models = [
+        case.get("id")
+        for case in case_results
+        if case.get("execution_model") != "compiled-sifr-declaration"
+    ]
+    if (
+        len(observed_case_ids) != len(set(observed_case_ids))
+        or set(observed_case_ids) != set(cases_by_id)
+        or invalid_execution_models
     ):
         failures = max(1, failures)
     return _report(
@@ -80,6 +113,7 @@ def run_examples_self_tests(
             {
                 "id": case.case_id,
                 "status": "example-passed",
+                "execution_model": "compiled-sifr-declaration",
                 "sifr_source": case.relative_source,
                 "elapsed_ms": 0,
             }
@@ -88,6 +122,8 @@ def run_examples_self_tests(
     )
     if skipped_payload["status"] != "examples-passed":
         raise SystemExit(f"{suite_name} examples self-test expected examples-passed")
+    if skipped_payload["execution_model"] != "compiled-sifr-declaration":
+        raise SystemExit(f"{suite_name} examples self-test execution-model drift")
     case_ids = {case["id"] for case in skipped_payload["cases"]}
     if case_ids != set(cases_by_id):
         raise SystemExit(f"{suite_name} examples self-test case drift: {sorted(case_ids)}")
@@ -127,6 +163,9 @@ def run_examples_self_tests(
         raise SystemExit(
             f"{suite_name} examples self-test invalid trust roots: {sorted(invalid_roots)}"
         )
+    raw_seed = "from sifr.python import Object, PythonError, call_attr\n"
+    if imported_raw_api_symbols(raw_seed) != {"Object", "call_attr"}:
+        raise SystemExit(f"{suite_name} examples self-test raw API guard drift")
 
     empty_payload = build_examples_report(
         paths,
@@ -146,6 +185,7 @@ def run_examples_self_tests(
             {
                 "id": first_case.case_id,
                 "status": "example-failed",
+                "execution_model": "compiled-sifr-declaration",
                 "sifr_source": first_case.relative_source,
                 "error": "synthetic example failure",
             }
@@ -171,6 +211,21 @@ def validate_source_presence(
                     "status": "fail",
                     "sifr_source": case.relative_source,
                     "reason": "missing source fixture",
+                }
+            )
+            continue
+        source = source_path.read_text(encoding="utf-8")
+        raw_symbols = imported_raw_api_symbols(source)
+        if raw_symbols or "@trust_python_dynamic" in source:
+            details = sorted(raw_symbols)
+            if "@trust_python_dynamic" in source:
+                details.append("@trust_python_dynamic")
+            checks.append(
+                {
+                    "id": case.case_id,
+                    "status": "fail",
+                    "sifr_source": case.relative_source,
+                    "reason": f"ordinary example uses raw Python API: {details}",
                 }
             )
             continue
@@ -216,10 +271,22 @@ def validate_source_presence(
                 "id": case.case_id,
                 "status": "pass",
                 "sifr_source": case.relative_source,
-                "check": "source-present",
+                "check": "declaration-first-source",
             }
         )
     return checks
+
+
+def imported_raw_api_symbols(source: str) -> set[str]:
+    imported: set[str] = set()
+    pattern = re.compile(
+        r"from\s+sifr\.python\s+import\s+(?:\((.*?)\)|([^\n]+))",
+        re.DOTALL,
+    )
+    for match in pattern.finditer(source):
+        body = match.group(1) if match.group(1) is not None else match.group(2)
+        imported.update(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", body or ""))
+    return imported.intersection(RAW_API_SYMBOLS)
 
 
 def run_example_cases(
@@ -409,6 +476,7 @@ def _run_case(paths: RunnerPaths, package_root: Path, case_config: ExampleCase) 
     case: dict[str, Any] = {
         "id": case_config.case_id,
         "status": status,
+        "execution_model": "compiled-sifr-declaration",
         "sifr_source": case_config.relative_source,
         "elapsed_ms": elapsed_ms,
         "stdout_marker": case_config.stdout_marker,
@@ -486,6 +554,8 @@ def _report(
         "area": "python_interop",
         "suite": f"{suite_name}-examples",
         "status": status,
+        "execution_model": "compiled-sifr-declaration",
+        "source_policy": "ordinary-examples-forbid-raw-python-api",
         "result_statuses": ["example-passed", "example-failed"],
         "dependencies": sorted({root for case in cases_by_id.values() for root in case.import_roots}),
         "source_checks": source_checks,

--- a/verification/areas/python_interop/runner/example_packages.py
+++ b/verification/areas/python_interop/runner/example_packages.py
@@ -1,42 +1,23 @@
 from __future__ import annotations
 
-import re
+import io
 import shutil
 import subprocess
 import time
+import tokenize
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 
 from env import RunnerPaths, cargo_env_for_repo_manifest
+from ordinary_example_policy import (
+    ORDINARY_PYTHON_API_ALLOWED_IMPORTS,
+    POLICY_REJECTION_SEEDS,
+)
 
 EXAMPLE_TIMEOUT_SECONDS = 600
-RAW_API_SYMBOLS = {
-    "Object",
-    "call",
-    "call_attr",
-    "close",
-    "from_bool",
-    "from_bytes",
-    "from_dict_str",
-    "from_float",
-    "from_int",
-    "from_list",
-    "from_none",
-    "from_record",
-    "from_str",
-    "from_tuple",
-    "get_attr",
-    "get_item",
-    "import_module",
-    "to_bool",
-    "to_bytes",
-    "to_float",
-    "to_int",
-    "to_none",
-    "to_str",
-}
 
 
 @dataclass(frozen=True)
@@ -163,9 +144,8 @@ def run_examples_self_tests(
         raise SystemExit(
             f"{suite_name} examples self-test invalid trust roots: {sorted(invalid_roots)}"
         )
-    raw_seed = "from sifr.python import Object, PythonError, call_attr\n"
-    if imported_raw_api_symbols(raw_seed) != {"Object", "call_attr"}:
-        raise SystemExit(f"{suite_name} examples self-test raw API guard drift")
+    for seed_id, source in POLICY_REJECTION_SEEDS.items():
+        _assert_policy_seed_rejected(paths, suite_name, seed_id, source)
 
     empty_payload = build_examples_report(
         paths,
@@ -215,17 +195,17 @@ def validate_source_presence(
             )
             continue
         source = source_path.read_text(encoding="utf-8")
-        raw_symbols = imported_raw_api_symbols(source)
-        if raw_symbols or "@trust_python_dynamic" in source:
-            details = sorted(raw_symbols)
-            if "@trust_python_dynamic" in source:
-                details.append("@trust_python_dynamic")
+        policy_violations = ordinary_python_api_policy_violations(source)
+        if policy_violations:
             checks.append(
                 {
                     "id": case.case_id,
                     "status": "fail",
                     "sifr_source": case.relative_source,
-                    "reason": f"ordinary example uses raw Python API: {details}",
+                    "reason": (
+                        "ordinary example violates declaration-first Python policy: "
+                        f"{sorted(policy_violations)}"
+                    ),
                 }
             )
             continue
@@ -277,16 +257,164 @@ def validate_source_presence(
     return checks
 
 
-def imported_raw_api_symbols(source: str) -> set[str]:
-    imported: set[str] = set()
-    pattern = re.compile(
-        r"from\s+sifr\.python\s+import\s+(?:\((.*?)\)|([^\n]+))",
-        re.DOTALL,
-    )
-    for match in pattern.finditer(source):
-        body = match.group(1) if match.group(1) is not None else match.group(2)
-        imported.update(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", body or ""))
-    return imported.intersection(RAW_API_SYMBOLS)
+def ordinary_python_api_policy_violations(source: str) -> set[str]:
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(source).readline))
+    except (IndentationError, tokenize.TokenError):
+        return {"unparseable-source"}
+    significant = [
+        item
+        for item in tokens
+        if item.type
+        not in {tokenize.COMMENT, tokenize.DEDENT, tokenize.ENCODING, tokenize.INDENT, tokenize.NL}
+    ]
+    violations: set[str] = set()
+    index = 0
+    while index < len(significant):
+        item = significant[index]
+        if item.string == "@" and _token_string(significant, index + 1) == "trust_python_dynamic":
+            violations.add("@trust_python_dynamic")
+        if item.type == tokenize.NAME and item.string == "import":
+            index = _collect_direct_import_violations(significant, index + 1, violations)
+            continue
+        if item.type == tokenize.NAME and item.string == "from":
+            index = _collect_from_import_violations(significant, index + 1, violations)
+            continue
+        index += 1
+    return violations
+
+
+def _collect_direct_import_violations(
+    tokens: list[tokenize.TokenInfo],
+    index: int,
+    violations: set[str],
+) -> int:
+    while index < len(tokens) and tokens[index].type != tokenize.NEWLINE:
+        if tokens[index].string == ";":
+            return index + 1
+        module, index = _consume_dotted_name(tokens, index)
+        if module in {"sifr.python", "sifr.python_core"}:
+            violations.add(f"module-import:{module}")
+        if _token_string(tokens, index) == "as":
+            index += 2
+        if _token_string(tokens, index) == ",":
+            index += 1
+        elif not module:
+            index += 1
+    return index
+
+
+def _collect_from_import_violations(
+    tokens: list[tokenize.TokenInfo],
+    index: int,
+    violations: set[str],
+) -> int:
+    module, index = _consume_dotted_name(tokens, index)
+    if _token_string(tokens, index) != "import":
+        return index
+    imported_names, index = _consume_imported_names(tokens, index + 1)
+    if module in {"sifr.python", "sifr.python_core"}:
+        violations.update(
+            name
+            for name in imported_names
+            if name not in ORDINARY_PYTHON_API_ALLOWED_IMPORTS
+        )
+    elif module == "sifr":
+        violations.update(
+            f"module-import:sifr.{name}"
+            for name in imported_names
+            if name in {"python", "python_core"}
+        )
+    return index
+
+
+def _consume_dotted_name(
+    tokens: list[tokenize.TokenInfo],
+    index: int,
+) -> tuple[str, int]:
+    parts: list[str] = []
+    if index >= len(tokens) or tokens[index].type != tokenize.NAME:
+        return "", index
+    parts.append(tokens[index].string)
+    index += 1
+    while _token_string(tokens, index) == "." and index + 1 < len(tokens):
+        if tokens[index + 1].type != tokenize.NAME:
+            break
+        parts.append(tokens[index + 1].string)
+        index += 2
+    return ".".join(parts), index
+
+
+def _consume_imported_names(
+    tokens: list[tokenize.TokenInfo],
+    index: int,
+) -> tuple[set[str], int]:
+    names: set[str] = set()
+    parenthesized = _token_string(tokens, index) == "("
+    if parenthesized:
+        index += 1
+    expect_name = True
+    while index < len(tokens):
+        item = tokens[index]
+        if item.type == tokenize.NEWLINE or item.string == ";":
+            break
+        if parenthesized and item.string == ")":
+            index += 1
+            break
+        if expect_name and (item.type == tokenize.NAME or item.string == "*"):
+            names.add(item.string)
+            expect_name = False
+        elif item.string == "as":
+            index += 1
+        elif item.string == ",":
+            expect_name = True
+        index += 1
+    return names, index
+
+
+def _token_string(tokens: list[tokenize.TokenInfo], index: int) -> str | None:
+    if 0 <= index < len(tokens):
+        return tokens[index].string
+    return None
+
+
+def _assert_policy_seed_rejected(
+    paths: RunnerPaths,
+    suite_name: str,
+    seed_id: str,
+    source: str,
+) -> None:
+    with TemporaryDirectory(prefix="sifr-python-example-policy-") as temp_dir:
+        fixture_root = Path(temp_dir)
+        relative_source = f"{seed_id}.sifr"
+        (fixture_root / relative_source).write_text(source, encoding="utf-8")
+        synthetic_paths = RunnerPaths(
+            repo_root=paths.repo_root,
+            area_root=paths.area_root,
+            packages_root=paths.packages_root,
+            fixtures_root=fixture_root,
+            reports_root=paths.reports_root,
+        )
+        payload = build_examples_report(
+            synthetic_paths,
+            suite_name=f"{suite_name}-{seed_id}-policy-self-test",
+            cases_by_id={
+                seed_id: ExampleCase(
+                    case_id=seed_id,
+                    relative_source=relative_source,
+                    stdout_marker="unreachable",
+                    import_roots=(),
+                )
+            },
+            example_runner=lambda _paths: (_ for _ in ()).throw(
+                AssertionError("policy-rejected example runner was invoked")
+            ),
+        )
+        reason = payload["source_checks"][0].get("reason", "")
+        if payload["status"] != "examples-failed" or "declaration-first" not in reason:
+            raise SystemExit(
+                f"{suite_name} examples self-test accepted policy seed {seed_id}: {payload}"
+            )
 
 
 def run_example_cases(

--- a/verification/areas/python_interop/runner/library_examples.py
+++ b/verification/areas/python_interop/runner/library_examples.py
@@ -20,6 +20,7 @@ LIBRARY_EXAMPLE_CASES = {
         stdout_marker="sifr-python-interop:pyarrow:sum=10:kind=array:producer=pyarrow.lib",
         import_roots=("pyarrow",),
         native_roots=("pyarrow",),
+        bridge_files=("pyarrow_example.py",),
     ),
     "fastapi-pydantic": ExampleCase(
         case_id="fastapi-pydantic",
@@ -27,6 +28,7 @@ LIBRARY_EXAMPLE_CASES = {
         stdout_marker="sifr-python-interop:fastapi-pydantic:value=42:title=Sifr API:status=201",
         import_roots=("builtins", "fastapi", "pydantic", "pydantic_core", "starlette"),
         native_roots=("pydantic_core",),
+        bridge_files=("fastapi_pydantic_example.py",),
     ),
     "cryptography-cffi": ExampleCase(
         case_id="cryptography-cffi",
@@ -34,6 +36,7 @@ LIBRARY_EXAMPLE_CASES = {
         stdout_marker="sifr-python-interop:cryptography-cffi:roundtrip=sifr-secret:certifi=ok",
         import_roots=("certifi", "cffi", "cryptography"),
         native_roots=("cffi", "cryptography"),
+        bridge_files=("cryptography_cffi_example.py",),
     ),
     "boto3-botocore": ExampleCase(
         case_id="boto3-botocore",
@@ -41,6 +44,7 @@ LIBRARY_EXAMPLE_CASES = {
         stdout_marker="sifr-python-interop:boto3-botocore:queue=https://sqs.us-east-1.amazonaws.com/123456789012/sifr-queue",
         import_roots=("boto3", "botocore"),
         native_roots=(),
+        bridge_files=("boto3_botocore_example.py",),
     ),
     "redis-fakeredis": ExampleCase(
         case_id="redis-fakeredis",
@@ -48,6 +52,7 @@ LIBRARY_EXAMPLE_CASES = {
         stdout_marker="sifr-python-interop:redis-fakeredis:value=ready:reply=PONG",
         import_roots=("fakeredis", "hiredis", "redis"),
         native_roots=("hiredis",),
+        bridge_files=("redis_fakeredis_example.py",),
     ),
     "sqlalchemy-psycopg": ExampleCase(
         case_id="sqlalchemy-psycopg",
@@ -55,6 +60,7 @@ LIBRARY_EXAMPLE_CASES = {
         stdout_marker="sifr-python-interop:sqlalchemy-psycopg:scalar=42:dialect=sqlite:conninfo=ok",
         import_roots=("alembic", "psycopg", "sqlalchemy"),
         native_roots=("psycopg", "sqlalchemy"),
+        bridge_files=("sqlalchemy_psycopg_example.py",),
     ),
     "sqlite-context": ExampleCase(
         case_id="sqlite-context",

--- a/verification/areas/python_interop/runner/ml_examples.py
+++ b/verification/areas/python_interop/runner/ml_examples.py
@@ -12,12 +12,14 @@ ML_EXAMPLE_CASES = {
         relative_source="torch_dlpack/torch_full_example.sifr",
         stdout_marker="sifr-python-interop:torch:sum=42.0:shape=2x3:dtype=float32",
         import_roots=("torch",),
+        bridge_files=("torch_example.py",),
     ),
     "scikit-learn": ExampleCase(
         case_id="scikit-learn",
         relative_source="sklearn/sklearn_full_example.sifr",
         stdout_marker="sifr-python-interop:sklearn:predictions=0,1:classes=0,1",
         import_roots=("numpy", "sklearn"),
+        bridge_files=("sklearn_example.py",),
     ),
 }
 

--- a/verification/areas/python_interop/runner/ordinary_example_policy.py
+++ b/verification/areas/python_interop/runner/ordinary_example_policy.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+ORDINARY_PYTHON_API_ALLOWED_IMPORTS = {
+    "ExitCause",
+    "ExitCauseKind",
+    "ExitDecision",
+    "PythonError",
+    "ResourceDiagnostics",
+    "resource_diagnostics",
+}
+
+POLICY_REJECTION_SEEDS = {
+    "raw-object": "from sifr.python import Object, PythonError\n",
+    "raw-conversion": "from sifr.python import from_value, to_value\n",
+    "python-core": "from sifr.python_core import Object\n",
+    "spaced-module": "from sifr . python import Object\n",
+    "continued-import": "from sifr.python import PythonError, \\\nObject\n",
+    "direct-module": "import sifr.python as python_api\n",
+    "from-module": "from sifr import python_core\n",
+    "dynamic-trust": "@trust_python_dynamic(\"example\")\ndef example():\n    pass\n",
+}


### PR DESCRIPTION
## Summary
- migrate eleven ordinary Python ecosystem examples from raw object plumbing to typed declarations backed by package-local hermetic bridges
- reject raw Python API imports and dynamic trust in ordinary runnable examples
- record compiled declaration execution policy in machine-readable reports
- document the ordinary-example policy and M17 wave evidence

## Validation
- `scripts/run_all_tests.sh --profile create-pr`
  - Python interop: 19/19
  - E2E: 131/131, signature `7c39b8c1dd4fec7c`
  - runtime platform: 28 variants, zero failures, one declared capability skip
  - hardening: 6/6
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo fmt --check`
- `git diff --check`

The unrelated dirty `third_party/ruff` submodule is not included.
