### PR TITLE
Reorganize concurrency docs into one guided section

### DIFF
--- a/docs/concurrency/api.mdx
+++ b/docs/concurrency/api.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Concurrency Primitives: Tasks, Channels, and Parallelism"
+title: "Concurrency API"
 sidebarTitle: "Concurrency API"
-description: "Concurrency API reference for Sifr: structured tasks, typed channels, CPU parallelism, subprocesses, runtime diagnostics, and cleanup helpers."
+description: "API reference for Sifr concurrency: structured tasks, typed channels, CPU parallelism, subprocesses, runtime diagnostics, and cleanup helpers."
 ---
 
-Sifr's concurrency modules are a native structured-concurrency substrate that compiles to Rust's async runtime. Unlike CPython's `asyncio`, there is no exposed event-loop object, no global task registry, and no fire-and-forget detachment. Every task belongs to a scope, every value that crosses a task boundary must be owned and sendable, and every error is a typed value you handle explicitly.
+This page is the API reference for Sifr's concurrency modules. Read the concept pages first if you are new to the model: [Async and Await](/concurrency/async-and-await), [Structured Tasks](/concurrency/structured-tasks), [Cancellation and Timeouts](/concurrency/cancellation-and-timeouts), [Ownership Across Tasks](/concurrency/ownership-across-tasks), and [Parallel Work](/concurrency/parallel-work).
 
-This page is the stdlib reference for concurrency. For the concepts behind scopes, task-boundary ownership, cancellation, and Python `asyncio` differences, start with [Concurrency Overview](/language/concurrency).
+Every task belongs to a scope. Values that cross task, thread, or process boundaries must be owned and sendable. Errors are typed values you handle explicitly. There is no exposed event-loop object, no global task registry, and no fire-and-forget detachment.
 
 ## `sifr.task` — Structured Tasks
 
@@ -414,3 +414,14 @@ Language-level cleanup under task cancellation is part of Sifr's structured runt
 <Note>
 `ExitStack`, `AsyncExitStack`, `closing`, and `aclosing` are unsupported. Cleanup helpers do not provide a dynamic stack of arbitrary callbacks; all resource lifetimes are visible in the ownership graph.
 </Note>
+
+## Related Concept Pages
+
+<CardGroup cols={2}>
+  <Card title="Concurrency Overview" icon="workflow" href="/language/concurrency">
+    Start here for the structured concurrency mental model.
+  </Card>
+  <Card title="Parallel Work" icon="microchip" href="/concurrency/parallel-work">
+    When to use `sifr.parallel` instead of async tasks.
+  </Card>
+</CardGroup>

--- a/docs/concurrency/async-and-await.mdx
+++ b/docs/concurrency/async-and-await.mdx
@@ -64,18 +64,15 @@ Sifr has no exposed event-loop object. You do not call `get_event_loop`, mutate 
 
 Do not run blocking I/O or CPU-heavy functions directly inside async code. Sifr reports this as an async diagnostic because blocking the runtime would prevent other tasks from making progress.
 
-Use async APIs for I/O, and use `sifr.parallel` for CPU-heavy maps over owned data.
+Use async APIs for I/O. For CPU-heavy maps over owned data, continue with [Parallel Work](/concurrency/parallel-work).
 
-```python
-from sifr.parallel import map as parallel_map
+## Next Steps
 
-def heavy(value: int) -> int:
-    return value * value
-
-def run_cpu_work(values: list[int]) -> list[int]:
-    return parallel_map(values, heavy)
-```
-
-<Tip>
-  If the next thing you want is "run two things at once", continue with [Structured Tasks](/concurrency/structured-tasks).
-</Tip>
+<CardGroup cols={2}>
+  <Card title="Structured Tasks" icon="workflow" href="/concurrency/structured-tasks">
+    Run two or more async operations together inside a scope.
+  </Card>
+  <Card title="Cancellation and Timeouts" icon="clock-alert" href="/concurrency/cancellation-and-timeouts">
+    Bound the lifetime of awaited work.
+  </Card>
+</CardGroup>

--- a/docs/concurrency/cancellation-and-timeouts.mdx
+++ b/docs/concurrency/cancellation-and-timeouts.mdx
@@ -61,13 +61,13 @@ The handle still has one owner and one observation path.
   Do not use task cancellation as a hidden control-flow side channel. Treat timeout and cancellation as typed evidence that the caller must handle.
 </Warning>
 
-## Related
+## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Structured Tasks" icon="workflow" href="/concurrency/structured-tasks">
-    Learn how child task scopes own and clean up spawned work.
+  <Card title="Ownership Across Tasks" icon="shield-check" href="/concurrency/ownership-across-tasks">
+    See what values can cross spawn and await boundaries.
   </Card>
-  <Card title="Error Handling" icon="triangle-alert" href="/language/error-handling">
-    Review how typed errors flow through Sifr programs.
+  <Card title="Structured Tasks" icon="workflow" href="/concurrency/structured-tasks">
+    Review how scopes own and clean up spawned work.
   </Card>
 </CardGroup>

--- a/docs/concurrency/ownership-across-tasks.mdx
+++ b/docs/concurrency/ownership-across-tasks.mdx
@@ -68,13 +68,13 @@ async def main() -> Result[None, ScopeFailure]:
   Lock guards, borrowed references, and mutable borrows cannot cross task or await boundaries. Move owned values, clone when copying is intended, or use `sifr.sync` primitives.
 </Warning>
 
-## Related
+## Next Steps
 
 <CardGroup cols={2}>
+  <Card title="Parallel Work" icon="microchip" href="/concurrency/parallel-work">
+    Apply the same ownership rules to CPU worker boundaries.
+  </Card>
   <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
     Review `mut`, `own`, `own mut`, and borrowed-value escape rules.
-  </Card>
-  <Card title="Concurrency API" icon="library" href="/stdlib/concurrency">
-    Browse channels, locks, shared values, and task APIs.
   </Card>
 </CardGroup>

--- a/docs/concurrency/parallel-work.mdx
+++ b/docs/concurrency/parallel-work.mdx
@@ -1,0 +1,77 @@
+---
+title: "Parallel Work"
+sidebarTitle: "Parallel Work"
+description: "Use sifr.parallel for CPU-heavy maps and worker pools when async concurrency is not enough."
+---
+
+Async tasks overlap waiting work. CPU-heavy work needs real parallelism. Use `sifr.parallel` when a map over owned data would otherwise block the async runtime.
+
+## When to Use Parallel Work
+
+| Kind of work | Prefer |
+| --- | --- |
+| Network, timers, waiting on I/O | Async tasks with `await` and scopes |
+| CPU-heavy transform over a collection | `sifr.parallel.map` or a `Pool` |
+| Blocking library call inside async code | Move it out of the async path, or offload with parallel helpers |
+
+Sifr rejects blocking or CPU-heavy calls that sit directly inside async code, because they prevent other tasks from making progress.
+
+## Parallel Map
+
+`map` preserves output order. Inputs and outputs must be owned and sendable across the worker boundary.
+
+```python
+from sifr.parallel import map as parallel_map
+
+def heavy(value: int) -> int:
+    return value * value
+
+def run_cpu_work(values: list[int]) -> list[int]:
+    return parallel_map(values, heavy)
+```
+
+Use `try_map` when each item can fail independently and you want typed per-item outcomes:
+
+```python
+from sifr.parallel import try_map, WorkerError
+
+outcomes: list[Result[int, WorkerError]] = try_map(
+    [1, 0, 3],
+    lambda x: 10 // x,
+)
+```
+
+## Worker Pools
+
+For repeated parallel work in a long-lived process, configure a `Pool` explicitly:
+
+```python
+from sifr.parallel import Pool, PoolConfig
+
+config: PoolConfig = PoolConfig(workers=4)
+pool: Pool = Pool(config)
+
+results: list[str] = pool.map(["a", "b", "c"], str.upper)
+pool.close()
+```
+
+<Note>
+  Lock guards, task handles, and borrowed values cannot cross the worker boundary. Pass owned data in, and receive owned results back.
+</Note>
+
+## Async Concurrency vs Parallelism
+
+- Use [Structured Tasks](/concurrency/structured-tasks) to run many async operations together.
+- Use `sifr.parallel` to speed up CPU-bound transforms.
+- Keep mutable borrows and lock guards out of both paths; see [Ownership Across Tasks](/concurrency/ownership-across-tasks).
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Concurrency API" icon="library" href="/concurrency/api">
+    Full `sifr.parallel`, `sifr.task`, and `sifr.sync` reference.
+  </Card>
+  <Card title="Async and Await" icon="timer" href="/concurrency/async-and-await">
+    Review suspension points and why blocking work is rejected.
+  </Card>
+</CardGroup>

--- a/docs/concurrency/structured-tasks.mdx
+++ b/docs/concurrency/structured-tasks.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Structured Tasks"
 description: "Use task scopes, spawned handles, gather, select, and TaskGroup in Sifr."
 ---
 
-Spawned tasks live inside a scope. The scope owns the children and waits for them before the block exits.
+Spawned tasks live inside a scope. The scope owns the children and waits for them before the block exits. Start from [Async and Await](/concurrency/async-and-await) if you still need the suspension model.
 
 ## Scoped Spawn
 
@@ -74,9 +74,9 @@ async with task.TaskGroup() as group:
 
 <CardGroup cols={2}>
   <Card title="Cancellation and Timeouts" icon="clock-alert" href="/concurrency/cancellation-and-timeouts">
-    Bound the lifetime of async work.
+    Bound the lifetime of async work and handle cancellation evidence.
   </Card>
-  <Card title="Concurrency API" icon="library" href="/stdlib/concurrency">
-    See the full `sifr.task` API reference.
+  <Card title="Ownership Across Tasks" icon="shield-check" href="/concurrency/ownership-across-tasks">
+    Learn what can cross a spawn boundary.
   </Card>
 </CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -120,7 +120,6 @@
               "stdlib/collections",
               "stdlib/io-filesystem",
               "stdlib/networking",
-              "stdlib/concurrency",
               "stdlib/text-encoding"
             ]
           },
@@ -132,7 +131,9 @@
               "concurrency/async-and-await",
               "concurrency/structured-tasks",
               "concurrency/cancellation-and-timeouts",
-              "concurrency/ownership-across-tasks"
+              "concurrency/ownership-across-tasks",
+              "concurrency/parallel-work",
+              "concurrency/api"
             ]
           },
           {

--- a/docs/language/concurrency.mdx
+++ b/docs/language/concurrency.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Concurrency Overview"
 sidebarTitle: "Overview"
-description: "Understand Sifr's structured concurrency model: scoped tasks, explicit cancellation, ownership at task boundaries, and no global event loop."
+description: "Understand Sifr's structured concurrency model: async await, scoped tasks, cancellation, ownership at task boundaries, and parallel CPU work."
 ---
 
 Sifr's concurrency model is structured: every task belongs to an explicit scope, and the scope cannot exit until its children have finished or been cancelled. There are no fire-and-forget tasks, no global event-loop object, and no hidden task registry.
 
 The compiler applies the same safety model at concurrency boundaries that it applies everywhere else. Values crossing task, thread, or process boundaries must be owned and sendable. Mutable borrows and lock guards stay scoped.
 
-## The Mental Model
+## Read This Section In Order
 
 <CardGroup cols={2}>
   <Card title="Async and Await" icon="timer" href="/concurrency/async-and-await">
@@ -23,6 +23,12 @@ The compiler applies the same safety model at concurrency boundaries that it app
   <Card title="Ownership Across Tasks" icon="shield-check" href="/concurrency/ownership-across-tasks">
     Learn what can cross task boundaries and why borrowed values cannot escape.
   </Card>
+  <Card title="Parallel Work" icon="microchip" href="/concurrency/parallel-work">
+    Offload CPU-heavy maps and worker pools with `sifr.parallel`.
+  </Card>
+  <Card title="Concurrency API" icon="library" href="/concurrency/api">
+    Reference for `sifr.task`, `sifr.sync`, `sifr.parallel`, process helpers, signals, and cleanup.
+  </Card>
 </CardGroup>
 
 ## What Is Different From Python
@@ -35,10 +41,7 @@ Python `asyncio` exposes event loops, detached tasks, and ambient task registrie
 | Reach for a global event loop | Use `async def`, `await`, and `sifr.task` scopes |
 | Share mutable objects between tasks | Move owned values, use channels, or use explicit sync primitives |
 | Treat cancellation as ambient | Observe typed cancellation or timeout evidence |
-
-## Where APIs Live
-
-This section explains the concepts. The API reference for `sifr.task`, `sifr.sync`, `sifr.parallel`, process helpers, signals, runtime diagnostics, and cleanup helpers lives in [Concurrency API](/stdlib/concurrency).
+| Run CPU work on the event loop | Use `sifr.parallel` for owned, sendable data |
 
 ## Related Pages
 

--- a/docs/stdlib/module-index.mdx
+++ b/docs/stdlib/module-index.mdx
@@ -27,8 +27,8 @@ This page is an orientation map. The deeper reference pages cover the modules mo
   <Card title="Networking" icon="radio" href="/stdlib/networking">
     TCP, HTTP, TLS, URLs, and typed network errors.
   </Card>
-  <Card title="Concurrency API" icon="workflow" href="/stdlib/concurrency">
-    Tasks, channels, locks, pools, process helpers, and signals.
+  <Card title="Text and Encoding" icon="languages" href="/stdlib/text-encoding">
+    Strings, encoding boundaries, Unicode, and i18n helpers.
   </Card>
 </CardGroup>
 
@@ -89,6 +89,8 @@ This page is an orientation map. The deeper reference pages cover the modules mo
 | `sifr.bytes` | Byte construction, search, and UTF-8 conversion helpers. |
 
 ## Concurrency and Runtime
+
+Concurrency concepts and the full API live in the [Concurrency](/language/concurrency) section. The modules below are the inventory map:
 
 | Module | Purpose |
 | --- | --- |

--- a/docs/stdlib/networking.mdx
+++ b/docs/stdlib/networking.mdx
@@ -52,7 +52,7 @@ async def echo_server(port: int) -> None:
 ```
 
 <Note>
-Network operations consume Sifr's concurrency runtime for cancellation, deadlines, and backpressure. Use `task.scope()` or `task.timeout()` from `sifr.task` to bound the lifetime of network operations. See [Concurrency Overview](/language/concurrency) for the structured task model.
+Network operations consume Sifr's concurrency runtime for cancellation, deadlines, and backpressure. Use `task.scope()` or `task.timeout()` from `sifr.task` to bound the lifetime of network operations. See [Concurrency Overview](/language/concurrency) for the structured task model, and [Concurrency API](/concurrency/api) for the full `sifr.task` surface.
 </Note>
 
 ## TLS with `sifr.tls`

--- a/docs/stdlib/overview.mdx
+++ b/docs/stdlib/overview.mdx
@@ -90,6 +90,8 @@ If a real user-defined or third-party top-level module named `math`, `json`, or 
 
 <Accordion title="Concurrency and Parallelism">
 
+Concurrency has its own docs section. Start with the [Concurrency Overview](/language/concurrency), then use the [Concurrency API](/concurrency/api) for module reference.
+
 | Module | Description |
 |---|---|
 | `sifr.task` | Structured task management: `TaskGroup`, `TaskHandle[T, E]`, scoped `spawn`, `timeout`, `deadline`, `gather`, and `select`. |


### PR DESCRIPTION
## Summary
- Move Concurrency API from Standard Library into the Concurrency section
- Add a Parallel Work concept page and order the guide as async → structured tasks → cancellation → ownership → parallel → API
- Update overview/module-index/networking links so concurrency content lives in one place

## Test plan
- [x] Skipped automated tests per request (docs-only change)
- [ ] Spot-check Concurrency sidebar order in Mintlify
- [ ] Confirm `/concurrency/api` and `/concurrency/parallel-work` resolve
- [ ] Confirm Standard Library nav no longer lists Concurrency API


Made with [Cursor](https://cursor.com)