### PR TITLE
Fix broken Option type cells in docs tables

### DIFF
--- a/docs/from-python.mdx
+++ b/docs/from-python.mdx
@@ -14,7 +14,7 @@ If you know Python, start by keeping the surface model and changing the failure 
 | --- | --- | --- |
 | Type hints | Type annotations | Enforced by the compiler, not optional metadata |
 | Exceptions | `Result[T, E]` plus `try`/`except` | Recoverable errors are values, not stack unwinds |
-| Missing values | `T | None` | You must check `None` before using the inner value |
+| Missing values | `T \| None` | You must check `None` before using the inner value |
 | Imports | `sifr.*` modules and packages | Bare CPython stdlib names are not aliases |
 | Integers | Exact `int` plus explicit fixed-width types | Ordinary arithmetic stays simple; representation-sensitive widths are explicit |
 | Bytes | First-class `bytes` | Encode and decode at typed boundaries; do not rely on platform-default text behavior |

--- a/docs/guides/python-developers/mental-model.mdx
+++ b/docs/guides/python-developers/mental-model.mdx
@@ -27,7 +27,7 @@ def describe(value: int | str) -> str:
 | --- | --- |
 | Type hints document intent | Type annotations are checked |
 | Exceptions carry recoverable failure | `Result[T, E]` carries recoverable failure |
-| Missing keys raise later | Missing lookups return `T | None` |
+| Missing keys raise later | Missing lookups return `T \| None` |
 | Imports mirror CPython names | Standard-library imports use `sifr.*` |
 | Any parameter can be mutated locally | Parameter mutation needs `mut` |
 | Background async tasks can detach | Tasks live in structured scopes |

--- a/docs/guides/rust-developers/rust-concepts.mdx
+++ b/docs/guides/rust-developers/rust-concepts.mdx
@@ -16,7 +16,7 @@ Use Rust as the safety model, not as the syntax model.
 | Mutable borrow | `mut items: list[int]` |
 | Move ownership | `own items: list[int]` |
 | Owned mutable value | `own mut items: list[int]` |
-| `Option<T>` | `T | None` |
+| `Option<T>` | `T \| None` |
 | `Result<T, E>` | `Result[T, E]` plus `raise` and `try`/`except` |
 | `async` tasks | Structured `sifr.task` scopes and handles |
 | Cargo-backed binary | `sifr build` native executable |


### PR DESCRIPTION
## Summary
- Escape `|` in `T | None` markdown table cells so they render as one column
- Fixes the broken Option row on the Rust Concepts guide, plus the same pattern on two related pages

## Test plan
- [x] Skipped per request (docs-only change)
- [ ] Confirm Concept Map Option row renders as `T | None` on the docs site after deploy


Made with [Cursor](https://cursor.com)