### PR TITLE
Fix Mintlify MDX syntax errors in generated error pages

### DIFF
--- a/crates/sifr_diagnostics/src/bin/gen-error-docs.rs
+++ b/crates/sifr_diagnostics/src/bin/gen-error-docs.rs
@@ -412,7 +412,7 @@ fn active_code_page(entry: &DiagnosticRegistryEntry, example: Option<&str>) -> S
     ));
     out.push_str("</Info>\n\n");
     if let Some(example) = example {
-        out.push_str(example);
+        out.push_str(&escape_mdx_outside_code_fences(example));
         out.push_str("\n\n");
     }
     out.push_str("## Details\n\n");
@@ -424,25 +424,52 @@ fn active_code_page(entry: &DiagnosticRegistryEntry, example: Option<&str>) -> S
     out.push_str("| Stability | stable |\n");
     out.push_str(&format!(
         "| Owner | {} |\n",
-        optional_code(entry.owner_module)
-    ));
-    out.push_str(&format!(
-        "| Message template | {} |\n",
-        optional_code(entry.message_template)
+        optional_code_mdx(entry.owner_module)
     ));
     out.push_str(&format!(
         "| Representative fixture | {} |\n",
-        optional_code(entry.representative_fixture_path)
-    ));
-    out.push_str(&format!("| Declared args | {} |\n", declared_args(entry)));
-    out.push_str(&format!(
-        "| Dedupe args | {} |\n",
-        string_list(entry.dedupe_args)
+        optional_code_mdx(entry.representative_fixture_path)
     ));
     out.push_str(
         "\nSee the [Error Codes index](/diagnostics/error-codes) for the complete catalog.\n",
     );
     out
+}
+
+/// Escape MDX-significant characters in prose while leaving fenced code blocks untouched.
+fn escape_mdx_outside_code_fences(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut in_fence = false;
+    for line in text.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            in_fence = !in_fence;
+            out.push_str(line);
+            continue;
+        }
+        if in_fence {
+            out.push_str(line);
+        } else {
+            out.push_str(&escape_mdx_text(line));
+        }
+    }
+    out
+}
+
+fn escape_mdx_text(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('{', "&#123;")
+        .replace('}', "&#125;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn optional_code_mdx(value: Option<&str>) -> String {
+    value.map_or_else(
+        || "n/a".to_owned(),
+        |value| format!("`{}`", escape_mdx_text(&escape_table(value))),
+    )
 }
 
 fn lowercase_sentence_start(text: &str) -> String {

--- a/docs/errors/SIFR-ASYNC-0001.mdx
+++ b/docs/errors/SIFR-ASYNC-0001.mdx
@@ -43,9 +43,6 @@ def cached() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::typing_and_functions` |
-| Message template | `{message}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/async_no_suspend_rejected.sifr` |
-| Declared args | `message (message+json)` |
-| Dedupe args | `message` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0002.mdx
+++ b/docs/errors/SIFR-ASYNC-0002.mdx
@@ -50,9 +50,6 @@ async def main() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::async_await` |
-| Message template | `{message}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/async_transitive_no_suspend_await_rejected.sifr` |
-| Declared args | `message (message+json)` |
-| Dedupe args | `message` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0003.mdx
+++ b/docs/errors/SIFR-ASYNC-0003.mdx
@@ -51,9 +51,6 @@ async def load() -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::workload_annotations` |
-| Message template | `{message}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/blocking_io_direct_call_in_async_rejected.sifr` |
-| Declared args | `message (message+json)` |
-| Dedupe args | `message` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0004.mdx
+++ b/docs/errors/SIFR-ASYNC-0004.mdx
@@ -54,9 +54,6 @@ async def main(values: list[int]) -> list[int]:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::workload_annotations` |
-| Message template | `{message}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/cpu_heavy_direct_call_in_async_rejected.sifr` |
-| Declared args | `message (message+json)` |
-| Dedupe args | `message` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0005.mdx
+++ b/docs/errors/SIFR-ASYNC-0005.mdx
@@ -46,9 +46,6 @@ async def main() -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::workload_annotations` |
-| Message template | `{message}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/spawn_blocking_unannotated_rejected.sifr` |
-| Declared args | `message (message+json)` |
-| Dedupe args | `message` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0006.mdx
+++ b/docs/errors/SIFR-ASYNC-0006.mdx
@@ -46,9 +46,6 @@ def load() -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::typing_and_functions` |
-| Message template | `{message}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/blocking_io_on_async_def_rejected.sifr` |
-| Declared args | `message (message+json)` |
-| Dedupe args | `message` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ASYNC-0007.mdx
+++ b/docs/errors/SIFR-ASYNC-0007.mdx
@@ -47,9 +47,6 @@ async def version() -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::workload_annotations` |
-| Message template | `{message}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/process_shell_exec_direct_async_rejected.sifr` |
-| Declared args | `message (message+json)` |
-| Dedupe args | `message` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0002.mdx
+++ b/docs/errors/SIFR-BUILD-0002.mdx
@@ -41,9 +41,6 @@ sifr build app.sifr --output build
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::materialize` |
-| Message template | `failed to materialize build file {path}` |
 | Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
-| Declared args | `path (message+json)` |
-| Dedupe args | `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0003.mdx
+++ b/docs/errors/SIFR-BUILD-0003.mdx
@@ -41,9 +41,6 @@ sifr build app.sifr --output build
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::workspace` |
-| Message template | `failed to create temporary build workspace {path}` |
 | Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
-| Declared args | `path (message+json)` |
-| Dedupe args | `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0004.mdx
+++ b/docs/errors/SIFR-BUILD-0004.mdx
@@ -41,9 +41,6 @@ sifr build app.sifr --output build
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::workspace` |
-| Message template | `failed to generate Cargo manifest at {path}` |
 | Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
-| Declared args | `path (message+json)` |
-| Dedupe args | `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0005.mdx
+++ b/docs/errors/SIFR-BUILD-0005.mdx
@@ -41,9 +41,6 @@ sifr build app.sifr --output build
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::workspace` |
-| Message template | `{tool} failed with exit status {status}` |
 | Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
-| Declared args | `tool (message+json)`, `status (message+json)` |
-| Dedupe args | `tool`, `status` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0006.mdx
+++ b/docs/errors/SIFR-BUILD-0006.mdx
@@ -41,9 +41,6 @@ sifr build app.sifr --output build
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::workspace` |
-| Message template | `expected build artifact {path} was not produced` |
 | Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
-| Declared args | `path (message+json)` |
-| Dedupe args | `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-BUILD-0901.mdx
+++ b/docs/errors/SIFR-BUILD-0901.mdx
@@ -41,9 +41,6 @@ sifr build app.sifr --output build
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr::self_update_receipt` |
-| Message template | `{message}` |
 | Representative fixture | `crates/sifr/src/self_update_receipt.rs` |
-| Declared args | `message (message+json)` |
-| Dedupe args | `message` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CALL-0001.mdx
+++ b/docs/errors/SIFR-CALL-0001.mdx
@@ -47,9 +47,6 @@ message = greet("Sifr")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `{callable} takes {quantifier} {expected_count} argument(s), got {actual_count}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/stdlib_wrong_arg_count.sifr` |
-| Declared args | `callable (message+json)`, `quantifier (message+json)`, `expected_count (message+json)`, `actual_count (message+json)` |
-| Dedupe args | `callable`, `quantifier`, `expected_count`, `actual_count` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CALL-0002.mdx
+++ b/docs/errors/SIFR-CALL-0002.mdx
@@ -47,9 +47,6 @@ message = greet("Sifr")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `{callable} got an unexpected keyword argument '{keyword}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/sorted_unexpected_keyword.sifr` |
-| Declared args | `callable (message+json)`, `keyword (message+json)` |
-| Dedupe args | `callable`, `keyword` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CALL-0003.mdx
+++ b/docs/errors/SIFR-CALL-0003.mdx
@@ -47,9 +47,6 @@ message = greet("Sifr")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `{callable} got multiple values for argument '{argument}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/keyword_after_positional_error.sifr` |
-| Declared args | `callable (message+json)`, `argument (message+json)` |
-| Dedupe args | `callable`, `argument` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CALL-0004.mdx
+++ b/docs/errors/SIFR-CALL-0004.mdx
@@ -47,9 +47,6 @@ message = greet("Sifr")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `{callable} missing required argument '{argument}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/missing_required_argument.sifr` |
-| Declared args | `callable (message+json)`, `argument (message+json)` |
-| Dedupe args | `callable`, `argument` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CALL-0005.mdx
+++ b/docs/errors/SIFR-CALL-0005.mdx
@@ -47,9 +47,6 @@ message = greet("Sifr")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `{callable} callable expects {expected_count} argument(s), got {actual_count} iterable(s)` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/map_callable_arity_mismatch.sifr` |
-| Declared args | `callable (message+json)`, `expected_count (message+json)`, `actual_count (message+json)` |
-| Dedupe args | `callable`, `expected_count`, `actual_count` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0001.mdx
+++ b/docs/errors/SIFR-CLASS-0001.mdx
@@ -50,9 +50,6 @@ user = User("Ada")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::classes` |
-| Message template | `class '{class_name}' has fields but no __init__; parent fields will not be initialized. Define an explicit __init__ with super().__init__(...)` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/auto_init_inheritance_missing_super.sifr` |
-| Declared args | `class_name (message+json)` |
-| Dedupe args | `class_name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0002.mdx
+++ b/docs/errors/SIFR-CLASS-0002.mdx
@@ -50,9 +50,6 @@ user = User("Ada")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::classes` |
-| Message template | `class '{class_name}': required field '{field}' declared after field with default value` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/auto_init_required_after_default.sifr` |
-| Declared args | `class_name (message+json)`, `field (message+json)` |
-| Dedupe args | `class_name`, `field` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0003.mdx
+++ b/docs/errors/SIFR-CLASS-0003.mdx
@@ -50,9 +50,6 @@ user = User("Ada")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::classes` |
-| Message template | `enum '{enum_name}' has duplicate value {value}: variants '{existing_variant}' and '{duplicate_variant}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/enum_duplicate_value.sifr` |
-| Declared args | `enum_name (message+json)`, `value (message+json)`, `existing_variant (message+json)`, `duplicate_variant (message+json)` |
-| Dedupe args | `enum_name`, `value`, `existing_variant`, `duplicate_variant` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0004.mdx
+++ b/docs/errors/SIFR-CLASS-0004.mdx
@@ -50,9 +50,6 @@ user = User("Ada")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::expressions` |
-| Message template | `type '{type_name}' has no field '{field}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/missing_field.sifr` |
-| Declared args | `type_name (message+json)`, `field (message+json)` |
-| Dedupe args | `type_name`, `field` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0005.mdx
+++ b/docs/errors/SIFR-CLASS-0005.mdx
@@ -50,9 +50,6 @@ user = User("Ada")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::classes` |
-| Message template | `invalid base class for '{class_name}': {reason}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/class_unknown_parent.sifr` |
-| Declared args | `class_name (message+json)`, `reason (message+json)` |
-| Dedupe args | `class_name`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-CLASS-0006.mdx
+++ b/docs/errors/SIFR-CLASS-0006.mdx
@@ -50,9 +50,6 @@ user = User("Ada")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::classes` |
-| Message template | `unsupported class declaration in '{class_name}': {detail}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/class_unsupported_field_default.sifr` |
-| Declared args | `class_name (message+json)`, `detail (message+json)` |
-| Dedupe args | `class_name`, `detail` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0001.mdx
+++ b/docs/errors/SIFR-DECIMAL-0001.mdx
@@ -41,9 +41,6 @@ amount = Decimal("1.25")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `invalid Decimal literal: {literal}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/decimal_invalid_literal_string.sifr` |
-| Declared args | `literal (message+json)` |
-| Dedupe args | `literal` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0002.mdx
+++ b/docs/errors/SIFR-DECIMAL-0002.mdx
@@ -41,9 +41,6 @@ amount = Decimal("1.25")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `invalid BigDecimal literal: {literal}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/bigdecimal_invalid_literal_string.sifr` |
-| Declared args | `literal (message+json)` |
-| Dedupe args | `literal` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0003.mdx
+++ b/docs/errors/SIFR-DECIMAL-0003.mdx
@@ -41,9 +41,6 @@ amount = Decimal("1.25")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_type_system` |
-| Message template | `cannot mix float with {decimal_type}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/decimal_float_mixed_arithmetic.sifr` |
-| Declared args | `decimal_type (message+json)` |
-| Dedupe args | `decimal_type` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0004.mdx
+++ b/docs/errors/SIFR-DECIMAL-0004.mdx
@@ -41,9 +41,6 @@ amount = Decimal("1.25")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_type_system` |
-| Message template | `cannot mix Decimal and BigDecimal` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/decimal_bigdecimal_mixed_arithmetic.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0005.mdx
+++ b/docs/errors/SIFR-DECIMAL-0005.mdx
@@ -41,9 +41,6 @@ amount = Decimal("1.25")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `Decimal cannot be constructed from float value {value}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/decimal_constructor_float.sifr` |
-| Declared args | `value (message+json)` |
-| Dedupe args | `value` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0006.mdx
+++ b/docs/errors/SIFR-DECIMAL-0006.mdx
@@ -41,9 +41,6 @@ amount = Decimal("1.25")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `BigDecimal cannot be constructed from float value {value}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/bigdecimal_constructor_float.sifr` |
-| Declared args | `value (message+json)` |
-| Dedupe args | `value` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0007.mdx
+++ b/docs/errors/SIFR-DECIMAL-0007.mdx
@@ -41,9 +41,6 @@ amount = Decimal("1.25")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::decimal_methods` |
-| Message template | `invalid Decimal scale {scale}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/decimal_round_scale_out_of_range.sifr` |
-| Declared args | `scale (message+json)`, `operation (json-only)` |
-| Dedupe args | `scale`, `operation` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-DECIMAL-0008.mdx
+++ b/docs/errors/SIFR-DECIMAL-0008.mdx
@@ -41,9 +41,6 @@ amount = Decimal("1.25")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::decimal_methods` |
-| Message template | `invalid BigDecimal {argument}: {value}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/bigdecimal_quantize_negative_scale_context.sifr` |
-| Declared args | `argument (message+json)`, `value (message+json)`, `operation (json-only)` |
-| Dedupe args | `argument`, `value`, `operation` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-ENCODING-0803.mdx
+++ b/docs/errors/SIFR-ENCODING-0803.mdx
@@ -41,9 +41,6 @@ text = decode(data, "utf-8", "strict")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::bytes_methods` |
-| Message template | `encoding error handlers must be statically known typed values` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/text_i18n_dynamic_errors_handler.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0001.mdx
+++ b/docs/errors/SIFR-FLOW-0001.mdx
@@ -46,9 +46,6 @@ def label(value: int) -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `'break' outside of loop` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/break_outside_loop.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0002.mdx
+++ b/docs/errors/SIFR-FLOW-0002.mdx
@@ -46,9 +46,6 @@ def label(value: int) -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `'continue' outside of loop` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/continue_outside_loop.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0003.mdx
+++ b/docs/errors/SIFR-FLOW-0003.mdx
@@ -46,9 +46,6 @@ def label(value: int) -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `recursive nested function '{function}' cannot mutate captured state with nonlocal yet` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/nested_function_recursive_nonlocal_unsupported.sifr` |
-| Declared args | `function (message+json)` |
-| Dedupe args | `function` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0004.mdx
+++ b/docs/errors/SIFR-FLOW-0004.mdx
@@ -46,9 +46,6 @@ def label(value: int) -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::typing_and_functions` |
-| Message template | `function '{function}' must return a value of type '{return_type}' on all control-flow paths` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/missing_return_value.sifr` |
-| Declared args | `function (message+json)`, `return_type (message+json)` |
-| Dedupe args | `function`, `return_type` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0005.mdx
+++ b/docs/errors/SIFR-FLOW-0005.mdx
@@ -46,9 +46,6 @@ def label(value: int) -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::control_flow_conditions` |
-| Message template | `{keyword} condition must be bool or collection/string truthiness, got '{actual}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/if_condition_numeric_truthiness.sifr` |
-| Declared args | `keyword (message+json)`, `actual (message+json)` |
-| Dedupe args | `keyword`, `actual` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0006.mdx
+++ b/docs/errors/SIFR-FLOW-0006.mdx
@@ -46,9 +46,6 @@ def label(value: int) -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `unsupported statement form: {form}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/yield_without_value.sifr` |
-| Declared args | `form (message+json)` |
-| Dedupe args | `form` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0007.mdx
+++ b/docs/errors/SIFR-FLOW-0007.mdx
@@ -46,9 +46,6 @@ def label(value: int) -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `invalid assignment target: {target}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/invalid_assignment_target_attribute_base.sifr` |
-| Declared args | `target (message+json)` |
-| Dedupe args | `target` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0008.mdx
+++ b/docs/errors/SIFR-FLOW-0008.mdx
@@ -46,9 +46,6 @@ def label(value: int) -> str:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `invalid for-loop iteration: {reason}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/for_loop_invalid_iterable.sifr` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FLOW-0901.mdx
+++ b/docs/errors/SIFR-FLOW-0901.mdx
@@ -46,9 +46,6 @@ def label(value: int) -> str:
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `unreachable statement ignored` |
 | Representative fixture | `crates/sifr_driver/src/tests/single_file_frontend.rs::test_type_check_source_surfaces_unreachable_statement_as_structured_warning` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-FMT-0001.mdx
+++ b/docs/errors/SIFR-FMT-0001.mdx
@@ -43,9 +43,6 @@ def main() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_format` |
-| Message template | `source is not formatted with sifr fmt` |
 | Representative fixture | `crates/sifr_format/src/lib.rs::check_reports_formatting_drift` |
-| Declared args | `path (message+json)` |
-| Dedupe args | `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0001.mdx
+++ b/docs/errors/SIFR-IMPORT-0001.mdx
@@ -41,9 +41,6 @@ from sifr.io import read_text
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `cannot import from '{module}' — private sysroot declarations can only be imported by public sysroot stdlib source` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/stdlib_intrinsic_direct_import.sifr` |
-| Declared args | `module (message+json)` |
-| Dedupe args | `module` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0002.mdx
+++ b/docs/errors/SIFR-IMPORT-0002.mdx
@@ -24,7 +24,7 @@ from math import sqrt
 
 ## How To Fix It
 
-Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.&lt;module&gt; import &lt;name&gt;`.
 
 ## Fixed Code
 
@@ -41,9 +41,6 @@ from sifr.math import sqrt
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `unknown import target: '{module}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/import_nonexistent_local.sifr` |
-| Declared args | `module (message+json)` |
-| Dedupe args | `module` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0003.mdx
+++ b/docs/errors/SIFR-IMPORT-0003.mdx
@@ -24,7 +24,7 @@ from math import sqrt
 
 ## How To Fix It
 
-Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.&lt;module&gt; import &lt;name&gt;`.
 
 ## Fixed Code
 
@@ -41,9 +41,6 @@ from sifr.math import sqrt
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `unsupported import form: {form}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/unsupported_import_statement.sifr` |
-| Declared args | `form (message+json)` |
-| Dedupe args | `form` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0004.mdx
+++ b/docs/errors/SIFR-IMPORT-0004.mdx
@@ -24,7 +24,7 @@ from math import sqrt
 
 ## How To Fix It
 
-Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.&lt;module&gt; import &lt;name&gt;`.
 
 ## Fixed Code
 
@@ -41,9 +41,6 @@ from sifr.math import sqrt
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `cannot import private name '{name}' from module '{module}'` |
 | Representative fixture | `crates/sifr_lowering/src/lower/name_import_diagnostics_tests.rs` |
-| Declared args | `name (message+json)`, `module (message+json)` |
-| Dedupe args | `name`, `module` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0005.mdx
+++ b/docs/errors/SIFR-IMPORT-0005.mdx
@@ -24,7 +24,7 @@ from math import sqrt
 
 ## How To Fix It
 
-Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.&lt;module&gt; import &lt;name&gt;`.
 
 ## Fixed Code
 
@@ -41,9 +41,6 @@ from sifr.math import sqrt
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::project::discovery` |
-| Message template | `ambiguous import target: '{module}'` |
 | Representative fixture | `verification/areas/project_workspace/fixtures/project/workspace_ambiguous_import_canonical` |
-| Declared args | `module (message+json)`, `candidate_paths (json-only)`, `resolution_scope (json-only)` |
-| Dedupe args | `module`, `candidate_paths`, `resolution_scope` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0006.mdx
+++ b/docs/errors/SIFR-IMPORT-0006.mdx
@@ -24,7 +24,7 @@ from math import sqrt
 
 ## How To Fix It
 
-Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.&lt;module&gt; import &lt;name&gt;`.
 
 ## Fixed Code
 
@@ -41,9 +41,6 @@ from sifr.math import sqrt
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::project::discovery` |
-| Message template | `import target '{module}' collides with a namespace package` |
 | Representative fixture | `verification/areas/project_workspace/fixtures/project/workspace_namespace_collision_canonical` |
-| Declared args | `module (message+json)`, `resolved_path (json-only)`, `parent_path (json-only)` |
-| Dedupe args | `module`, `resolved_path`, `parent_path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0007.mdx
+++ b/docs/errors/SIFR-IMPORT-0007.mdx
@@ -24,7 +24,7 @@ from math import sqrt
 
 ## How To Fix It
 
-Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.&lt;module&gt; import &lt;name&gt;`.
 
 ## Fixed Code
 
@@ -41,9 +41,6 @@ from sifr.math import sqrt
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::project::compile_order` |
-| Message template | `circular import detected: {cycle}` |
 | Representative fixture | `verification/areas/project_workspace/fixtures/project/import_cycle_source_spans` |
-| Declared args | `cycle (message+json)`, `cycle_edges (json-only)` |
-| Dedupe args | `cycle`, `cycle_edges` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0008.mdx
+++ b/docs/errors/SIFR-IMPORT-0008.mdx
@@ -24,7 +24,7 @@ from math import sqrt
 
 ## How To Fix It
 
-Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.&lt;module&gt; import &lt;name&gt;`.
 
 ## Fixed Code
 
@@ -41,9 +41,6 @@ from sifr.math import sqrt
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower / sifr_driver::project::discovery` |
-| Message template | `bare stdlib import '{bare_module}'; Sifr stdlib lives under 'sifr.*'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/bare_stdlib_from_math.sifr` |
-| Declared args | `bare_module (message+json)`, `suggested_module (json-only)`, `imported_names (json-only)` |
-| Dedupe args | `bare_module`, `suggested_module`, `imported_names` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IMPORT-0009.mdx
+++ b/docs/errors/SIFR-IMPORT-0009.mdx
@@ -24,7 +24,7 @@ from math import sqrt
 
 ## How To Fix It
 
-Use Sifr's explicit module namespace and import concrete symbols with `from sifr.<module> import <name>`.
+Use Sifr's explicit module namespace and import concrete symbols with `from sifr.&lt;module&gt; import &lt;name&gt;`.
 
 ## Fixed Code
 
@@ -41,9 +41,6 @@ from sifr.math import sqrt
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `legacy stdlib module '{legacy_module}' is unsupported; use '{suggested_module}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/legacy_sifr_asyncio_removed.sifr` |
-| Declared args | `legacy_module (message+json)`, `suggested_module (message+json)`, `imported_names (json-only)`, `reason (json-only)` |
-| Dedupe args | `legacy_module`, `suggested_module`, `imported_names`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0001.mdx
+++ b/docs/errors/SIFR-INT-0001.mdx
@@ -42,9 +42,6 @@ wide: int = 200
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::fixed_width_fitting` |
-| Message template | `integer value {value} does not fit target type {target_type}; valid range is {min_value}..={max_value}` |
 | Representative fixture | `crates/sifr_lowering/src/lower/expressions_tests.rs::test_fixed_width_literal_assignment_out_of_range_has_int_code` |
-| Declared args | `value (message+json)`, `target_type (message+json)`, `min_value (message+json)`, `max_value (message+json)` |
-| Dedupe args | `value`, `target_type`, `min_value`, `max_value` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0003.mdx
+++ b/docs/errors/SIFR-INT-0003.mdx
@@ -42,9 +42,6 @@ wide: int = 200
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::typing_and_functions` |
-| Message template | `reserved integer width name {name} is not supported yet` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/reserved_int128_annotation.sifr` |
-| Declared args | `name (message+json)` |
-| Dedupe args | `name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0004.mdx
+++ b/docs/errors/SIFR-INT-0004.mdx
@@ -42,9 +42,6 @@ wide: int = 200
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::integer_literal_diagnostics` |
-| Message template | `integer literal exceeds compile-time evaluation budget: {digits} decimal digits (max {max_digits})` |
 | Representative fixture | `crates/sifr_lowering/src/lower/expressions_tests.rs::test_large_integer_literal_over_budget_has_int_code` |
-| Declared args | `digits (message+json)`, `max_digits (message+json)` |
-| Dedupe args | `digits`, `max_digits` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0005.mdx
+++ b/docs/errors/SIFR-INT-0005.mdx
@@ -42,9 +42,6 @@ wide: int = 200
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::integer_failure_diagnostics` |
-| Message template | `integer division, modulo, or exponentiation requires handling a typed integer failure unless the compiler can prove this operation is safe` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/exact_int_division_requires_handling.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0006.mdx
+++ b/docs/errors/SIFR-INT-0006.mdx
@@ -42,9 +42,6 @@ wide: int = 200
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_type_system` |
-| Message template | `exact integer to float conversion requires handling possible overflow or precision loss` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/exact_int_true_division_requires_handling.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0007.mdx
+++ b/docs/errors/SIFR-INT-0007.mdx
@@ -42,9 +42,6 @@ wide: int = 200
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_type_system` |
-| Message template | `cannot compare bool and integer values without explicit conversion` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/bool_integer_comparison.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INT-0011.mdx
+++ b/docs/errors/SIFR-INT-0011.mdx
@@ -42,9 +42,6 @@ wide: int = 200
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::typing_and_functions` |
-| Message template | `bigint is a temporary transition alias; use int for exact integers or an explicit fixed-width type for representation-sensitive values` |
 | Representative fixture | `crates/sifr_driver/src/tests/single_file_frontend.rs::test_type_check_source_surfaces_bigint_transition_warning` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INTERNAL-0001.mdx
+++ b/docs/errors/SIFR-INTERNAL-0001.mdx
@@ -41,9 +41,6 @@ report the smallest reproducer with the Sifr version and diagnostic output
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::diagnostics` |
-| Message template | `internal compiler error` |
 | Representative fixture | `crates/sifr_driver/src/tests/panic_boundary.rs::planned_internal_0001` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-INTERNAL-0002.mdx
+++ b/docs/errors/SIFR-INTERNAL-0002.mdx
@@ -41,9 +41,6 @@ report the smallest reproducer with the Sifr version and diagnostic output
 | Severity | Note |
 | Stability | stable |
 | Owner | `sifr_driver::diagnostics` |
-| Message template | `{omitted_count} additional {omitted_kind} omitted by recovery cap ({cap_kind})` |
 | Representative fixture | `crates/sifr_driver/src/tests/diagnostics.rs::test_apply_diagnostic_recovery_limits_summarizes_similar_diagnostics` |
-| Declared args | `omitted_count (message+json)`, `omitted_kind (message+json)`, `cap_kind (message+json)` |
-| Dedupe args | `cap_kind` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IO-0801.mdx
+++ b/docs/errors/SIFR-IO-0801.mdx
@@ -45,9 +45,6 @@ file = open_text("notes.txt", encoding="utf-8")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::expressions::call_shadowable_builtins` |
-| Message template | `text-mode open requires an explicit encoding; Sifr does not use locale-derived default encodings` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/text_i18n_open_without_encoding.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-IO-0802.mdx
+++ b/docs/errors/SIFR-IO-0802.mdx
@@ -45,9 +45,6 @@ file = open_text("notes.txt", encoding="utf-8")
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::expressions::call_shadowable_builtins` |
-| Message template | `open mode must be a string literal so Sifr can choose a binary or text handle type` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/text_i18n_open_dynamic_mode.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0001.mdx
+++ b/docs/errors/SIFR-LINT-0001.mdx
@@ -49,9 +49,6 @@ f(flag=True)
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lint::suppressions` |
-| Message template | `unknown Sifr policy rule id '{rule}'` |
 | Representative fixture | `crates/sifr_lint/src/lib.rs::unknown_and_unused_suppressions_are_reported` |
-| Declared args | `rule (message+json)` |
-| Dedupe args | `rule` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0002.mdx
+++ b/docs/errors/SIFR-LINT-0002.mdx
@@ -49,9 +49,6 @@ f(flag=True)
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lint::suppressions` |
-| Message template | `unused Sifr suppression for policy rule '{rule}'` |
 | Representative fixture | `crates/sifr_lint/src/lib.rs::unknown_and_unused_suppressions_are_reported` |
-| Declared args | `rule (message+json)` |
-| Dedupe args | `rule` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0003.mdx
+++ b/docs/errors/SIFR-LINT-0003.mdx
@@ -49,9 +49,6 @@ f(flag=True)
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lint::suppressions` |
-| Message template | `sifr suppression must list explicit policy rule ids` |
 | Representative fixture | `crates/sifr_lint/src/lib.rs::blanket_suppression_is_reported` |
-| Declared args | `rule (message+json)` |
-| Dedupe args | `rule` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0004.mdx
+++ b/docs/errors/SIFR-LINT-0004.mdx
@@ -49,9 +49,6 @@ f(flag=True)
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lint::rules::trailing_whitespace` |
-| Message template | `line has trailing whitespace` |
 | Representative fixture | `crates/sifr_lint/src/lib.rs::suppression_only_suppresses_matching_policy_rule` |
-| Declared args | `rule (message+json)` |
-| Dedupe args | `rule` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0005.mdx
+++ b/docs/errors/SIFR-LINT-0005.mdx
@@ -49,9 +49,6 @@ f(flag=True)
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lint::rules::todo_comment` |
-| Message template | `comment contains tracked task marker '{marker}'` |
 | Representative fixture | `crates/sifr_lint/src/rules/todo_comment.rs::todo_comment_reports_tracked_marker` |
-| Declared args | `rule (message+json)`, `marker (message+json)` |
-| Dedupe args | `rule`, `marker` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0006.mdx
+++ b/docs/errors/SIFR-LINT-0006.mdx
@@ -49,9 +49,6 @@ f(flag=True)
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lint::rules::boolean_positional_argument` |
-| Message template | `boolean literal passed as a positional argument` |
 | Representative fixture | `crates/sifr_lint/src/rules/boolean_positional_argument.rs::boolean_positional_argument_reports_literal_call_arg` |
-| Declared args | `rule (message+json)` |
-| Dedupe args | `rule` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0007.mdx
+++ b/docs/errors/SIFR-LINT-0007.mdx
@@ -49,9 +49,6 @@ f(flag=True)
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lint::rules::large_parameter_list` |
-| Message template | `function '{function}' has {count} parameters, exceeding the policy limit of {limit}` |
 | Representative fixture | `crates/sifr_lint/src/rules/large_parameter_list.rs::large_parameter_list_reports_hir_function` |
-| Declared args | `rule (message+json)`, `function (message+json)`, `count (message+json)`, `limit (message+json)` |
-| Dedupe args | `rule`, `function`, `count`, `limit` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-LINT-0008.mdx
+++ b/docs/errors/SIFR-LINT-0008.mdx
@@ -49,9 +49,6 @@ f(flag=True)
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lint::rules::duplicate_import` |
-| Message template | `duplicate import of '{import}'` |
 | Representative fixture | `crates/sifr_lint/src/rules/duplicate_import.rs::duplicate_import_reports_repeated_import` |
-| Declared args | `rule (message+json)`, `import (message+json)` |
-| Dedupe args | `rule`, `import` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-MATCH-0001.mdx
+++ b/docs/errors/SIFR-MATCH-0001.mdx
@@ -47,9 +47,6 @@ match value:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `non-exhaustive match: enum {enum_name} has uncovered variants: {uncovered}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/enum_match_non_exhaustive.sifr` |
-| Declared args | `enum_name (message+json)`, `uncovered (message+json)` |
-| Dedupe args | `enum_name`, `uncovered` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-MATCH-0002.mdx
+++ b/docs/errors/SIFR-MATCH-0002.mdx
@@ -47,9 +47,6 @@ match value:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `match guard must be a bool expression, got {actual}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/match_type_mismatch_guard.sifr` |
-| Declared args | `actual (message+json)` |
-| Dedupe args | `actual` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-MATCH-0003.mdx
+++ b/docs/errors/SIFR-MATCH-0003.mdx
@@ -47,9 +47,6 @@ match value:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `class {class_name} has no field {field}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/match_invalid_field_name.sifr` |
-| Declared args | `field (message+json)`, `class_name (message+json)` |
-| Dedupe args | `field`, `class_name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-MATCH-0004.mdx
+++ b/docs/errors/SIFR-MATCH-0004.mdx
@@ -47,9 +47,6 @@ match value:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `invalid match pattern: {reason}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/match_tuple_pattern_requires_tuple_subject.sifr` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0001.mdx
+++ b/docs/errors/SIFR-NAME-0001.mdx
@@ -43,9 +43,6 @@ total = subtotal + tax
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `undefined variable: '{name}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/undefined_var.sifr` |
-| Declared args | `name (message+json)` |
-| Dedupe args | `name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0002.mdx
+++ b/docs/errors/SIFR-NAME-0002.mdx
@@ -43,9 +43,6 @@ total = subtotal + tax
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `undefined function: '{name}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/undefined_function.sifr` |
-| Declared args | `name (message+json)` |
-| Dedupe args | `name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0003.mdx
+++ b/docs/errors/SIFR-NAME-0003.mdx
@@ -43,9 +43,6 @@ total = subtotal + tax
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::typing_and_functions` |
-| Message template | `unknown type: {name}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/generic_class_missing_type_arg.sifr` |
-| Declared args | `name (message+json)` |
-| Dedupe args | `name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0004.mdx
+++ b/docs/errors/SIFR-NAME-0004.mdx
@@ -43,9 +43,6 @@ total = subtotal + tax
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `module '{container}' has no member '{member}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/stdlib_missing_function.sifr` |
-| Declared args | `member (message+json)`, `container (message+json)` |
-| Dedupe args | `member`, `container` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0005.mdx
+++ b/docs/errors/SIFR-NAME-0005.mdx
@@ -43,9 +43,6 @@ total = subtotal + tax
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::module_function_registry` |
-| Message template | `duplicate function definition in module: '{name}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/duplicate_function_definition.sifr` |
-| Declared args | `name (message+json)` |
-| Dedupe args | `name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-NAME-0006.mdx
+++ b/docs/errors/SIFR-NAME-0006.mdx
@@ -43,9 +43,6 @@ total = subtotal + tax
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `variable '{name}' must be initialized` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/annotated_variable_requires_initializer.sifr` |
-| Declared args | `name (message+json)` |
-| Dedupe args | `name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0001.mdx
+++ b/docs/errors/SIFR-OWN-0001.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `use of moved value {binding}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/use_after_move.sifr` |
-| Declared args | `binding (message+json)` |
-| Dedupe args | `binding` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0002.mdx
+++ b/docs/errors/SIFR-OWN-0002.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `borrow conflict for {binding} in the same call` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/double_mut_borrow.sifr` |
-| Declared args | `binding (message+json)` |
-| Dedupe args | `binding` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0003.mdx
+++ b/docs/errors/SIFR-OWN-0003.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `borrowed parameter {binding} escapes` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/borrow_escape_return.sifr` |
-| Declared args | `binding (message+json)`, `escape_kind (json-only)` |
-| Dedupe args | `binding`, `escape_kind` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0004.mdx
+++ b/docs/errors/SIFR-OWN-0004.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `moved value {binding} is reused across loop iterations` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/use_after_move_loop.sifr` |
-| Declared args | `binding (message+json)` |
-| Dedupe args | `binding` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0005.mdx
+++ b/docs/errors/SIFR-OWN-0005.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `cannot mutate through immutable parameter {binding}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/own_parameter_mutation_requires_mut.sifr` |
-| Declared args | `binding (message+json)` |
-| Dedupe args | `binding` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0006.mdx
+++ b/docs/errors/SIFR-OWN-0006.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `cannot reassign immutable parameter {binding}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/own_parameter_reassignment_requires_mut.sifr` |
-| Declared args | `binding (message+json)` |
-| Dedupe args | `binding` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0007.mdx
+++ b/docs/errors/SIFR-OWN-0007.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `bytes is immutable; subscript assignment is not supported` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/bytes_subscript_assignment_unsupported.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0008.mdx
+++ b/docs/errors/SIFR-OWN-0008.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::aug_assign_lowering` |
-| Message template | `bytes is immutable; augmented subscript assignment is not supported` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/bytes_augmented_subscript_assignment_unsupported.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0009.mdx
+++ b/docs/errors/SIFR-OWN-0009.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `mutable borrow {binding} cannot cross await` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/borrow_across_await_rejected.sifr` |
-| Declared args | `binding (message+json)` |
-| Dedupe args | `binding` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0010.mdx
+++ b/docs/errors/SIFR-OWN-0010.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::task_scope_calls` |
-| Message template | `scope.spawn() cannot move {value} of type {type_name} across a task boundary` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/spawn_non_send_field_rejected.sifr` |
-| Declared args | `value (message+json)`, `type_name (message+json)`, `reason (json-only)` |
-| Dedupe args | `value`, `type_name`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0011.mdx
+++ b/docs/errors/SIFR-OWN-0011.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `channel send cannot transfer {value} of type {type_name}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/channel_non_send_element_rejected.sifr` |
-| Declared args | `value (message+json)`, `type_name (message+json)`, `reason (json-only)` |
-| Dedupe args | `value`, `type_name`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0012.mdx
+++ b/docs/errors/SIFR-OWN-0012.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `Shared cannot publish {value} of type {type_name}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/shared_mut_without_lock_rejected.sifr` |
-| Declared args | `value (message+json)`, `type_name (message+json)`, `reason (json-only)` |
-| Dedupe args | `value`, `type_name`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-OWN-0013.mdx
+++ b/docs/errors/SIFR-OWN-0013.mdx
@@ -51,9 +51,6 @@ taken: int = consume(items)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::ipc_payload_calls` |
-| Message template | `typed IPC payload cannot transfer {value} of type {type_name}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/ipc_payload_process_resource_rejected.sifr` |
-| Declared args | `value (message+json)`, `type_name (message+json)`, `reason (json-only)` |
-| Dedupe args | `value`, `type_name`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0001.mdx
+++ b/docs/errors/SIFR-PACKAGE-0001.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::manifest::metadata` |
-| Message template | `invalid [package.metadata.sifr]: {reason}` |
 | Representative fixture | `crates/sifr_package/src/manifest/metadata.rs::tests` |
-| Declared args | `reason (message+json)`, `cargo_package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0002.mdx
+++ b/docs/errors/SIFR-PACKAGE-0002.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::manifest::sifr` |
-| Message template | `invalid sifr.toml: {reason}` |
 | Representative fixture | `crates/sifr_package/src/manifest/sifr.rs::tests` |
-| Declared args | `reason (message+json)`, `cargo_package_id (json-only)`, `manifest_path (json-only)` |
-| Dedupe args | `cargo_package_id`, `manifest_path`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0003.mdx
+++ b/docs/errors/SIFR-PACKAGE-0003.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::manifest::metadata` |
-| Message template | `unsupported Sifr compiler metadata in Cargo metadata: {key}` |
 | Representative fixture | `crates/sifr_package/src/manifest/metadata.rs::tests` |
-| Declared args | `key (message+json)`, `cargo_package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `key` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0101.mdx
+++ b/docs/errors/SIFR-PACKAGE-0101.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::cargo::errors` |
-| Message template | `cargo {action} failed` |
 | Representative fixture | `crates/sifr_package/src/cargo_backend_integration_tests.rs::cargo_failure_mapping_redacts_private_credentials` |
-| Declared args | `action (message+json)`, `reason (message+json)` |
-| Dedupe args | `action`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0102.mdx
+++ b/docs/errors/SIFR-PACKAGE-0102.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::graph::workspace` |
-| Message template | `selected Rust-only package '{package_name}'` |
 | Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::explicit_rust_only_selection_reports_0102` |
-| Declared args | `package_name (message+json)`, `cargo_package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `package_name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0103.mdx
+++ b/docs/errors/SIFR-PACKAGE-0103.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::cargo::metadata` |
-| Message template | `could not parse cargo metadata: {reason}` |
 | Representative fixture | `crates/sifr_package/src/cargo/metadata.rs::tests` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0104.mdx
+++ b/docs/errors/SIFR-PACKAGE-0104.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::cargo::lock_modes` |
-| Message template | `package source unavailable in {lock_mode} mode` |
 | Representative fixture | `crates/sifr_package/src/cargo_backend_integration_tests.rs::offline_mode_reports_missing_sifr_source_package` |
-| Declared args | `lock_mode (message+json)`, `cargo_package_id (json-only)`, `package_path (json-only)` |
-| Dedupe args | `cargo_package_id`, `package_path`, `lock_mode` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0106.mdx
+++ b/docs/errors/SIFR-PACKAGE-0106.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::graph::workspace` |
-| Message template | `Rust-only package depends on Sifr package` |
 | Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::rust_only_member_depending_on_sifr_reports_0106` |
-| Declared args | `from_cargo_package_id (json-only)`, `to_cargo_package_id (json-only)` |
-| Dedupe args | `from_cargo_package_id`, `to_cargo_package_id` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0201.mdx
+++ b/docs/errors/SIFR-PACKAGE-0201.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::graph::scopes` |
-| Message template | `ambiguous package import root '{import_root}'` |
 | Representative fixture | `crates/sifr_package/src/package_dependency_scope_tests.rs::duplicate_direct_import_root_in_one_scope_reports_0201` |
-| Declared args | `import_root (message+json)`, `cargo_package_id (json-only)`, `candidates (json-only)` |
-| Dedupe args | `cargo_package_id`, `import_root`, `candidates` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0202.mdx
+++ b/docs/errors/SIFR-PACKAGE-0202.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::imports::source_map` |
-| Message template | `undeclared direct package import '{import_path}'` |
 | Representative fixture | `crates/sifr_package/src/package_source_map_tests.rs::transitive_dependency_import_reports_0202` |
-| Declared args | `import_path (message+json)`, `cargo_package_id (json-only)`, `package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `package_id`, `import_path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0203.mdx
+++ b/docs/errors/SIFR-PACKAGE-0203.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::imports::source_map` |
-| Message template | `private package module access '{import_path}'` |
 | Representative fixture | `crates/sifr_package/src/package_source_map_tests.rs::private_dependency_module_reports_0203` |
-| Declared args | `import_path (message+json)`, `cargo_package_id (json-only)`, `package_id (json-only)`, `target_package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `package_id`, `target_package_id`, `import_path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0204.mdx
+++ b/docs/errors/SIFR-PACKAGE-0204.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::graph::type_identity` |
-| Message template | `package type identity mismatch: expected {expected}, got {actual}` |
 | Representative fixture | `crates/sifr_package/src/package_dependency_scope_tests.rs::type_identity_mismatch_reports_0204_for_distinct_package_instances` |
-| Declared args | `expected (message+json)`, `actual (message+json)`, `cargo_package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `expected`, `actual` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0301.mdx
+++ b/docs/errors/SIFR-PACKAGE-0301.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::cargo::trust` |
-| Message template | `untrusted backend crate '{backend_name}'` |
 | Representative fixture | `crates/sifr_package/src/cargo_backend_integration_tests.rs::backend_trust_reports_untrusted_direct_backend_crate` |
-| Declared args | `backend_name (message+json)`, `cargo_package_id (json-only)`, `package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `package_id`, `backend_name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0305.mdx
+++ b/docs/errors/SIFR-PACKAGE-0305.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::cargo::trust` |
-| Message template | `trusted backend crate '{backend_name}' is not direct` |
 | Representative fixture | `crates/sifr_package/src/cargo_backend_integration_tests.rs::backend_trust_rejects_stale_non_direct_trust_entry` |
-| Declared args | `backend_name (message+json)`, `cargo_package_id (json-only)`, `package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `package_id`, `backend_name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0401.mdx
+++ b/docs/errors/SIFR-PACKAGE-0401.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::cargo::package` |
-| Message template | `package '{package_id}' archive contains no .sifr source files` |
 | Representative fixture | `crates/sifr_package/src/package_publish_archive_tests.rs::archive_missing_sifr_source_reports_0401` |
-| Declared args | `cargo_package_id (json-only)`, `package_id (message+json)` |
-| Dedupe args | `cargo_package_id`, `package_id` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0402.mdx
+++ b/docs/errors/SIFR-PACKAGE-0402.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::cargo::package` |
-| Message template | `package publish validation failed: {reason}` |
 | Representative fixture | `crates/sifr_package/src/package_publish_archive_tests.rs::publish_validation_failed_reports_0402` |
-| Declared args | `reason (message+json)`, `cargo_package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0403.mdx
+++ b/docs/errors/SIFR-PACKAGE-0403.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::cargo::package` |
-| Message template | `Cargo package include/exclude rules omit required Sifr file '{path}'` |
 | Representative fixture | `crates/sifr_package/src/package_publish_archive_tests.rs::archive_missing_required_entry_reports_0403` |
-| Declared args | `path (message+json)`, `cargo_package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0404.mdx
+++ b/docs/errors/SIFR-PACKAGE-0404.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::cargo::package` |
-| Message template | `Cargo package archive entry escapes the package root: {path}` |
 | Representative fixture | `crates/sifr_package/src/package_publish_archive_tests.rs::archive_traversal_reports_0404` |
-| Declared args | `path (message+json)`, `cargo_package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0501.mdx
+++ b/docs/errors/SIFR-PACKAGE-0501.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::source::layout` |
-| Message template | `pure Sifr package marker contains Rust implementation: {reason}` |
 | Representative fixture | `crates/sifr_package/src/source/layout.rs::tests` |
-| Declared args | `reason (message+json)`, `cargo_package_id (json-only)`, `marker_path (json-only)` |
-| Dedupe args | `cargo_package_id`, `marker_path`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0601.mdx
+++ b/docs/errors/SIFR-PACKAGE-0601.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::graph::filters` |
-| Message template | `package selector '{selector}' is ambiguous or invalid` |
 | Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::ambiguous_filter_reports_0601` |
-| Declared args | `selector (message+json)`, `candidates (json-only)` |
-| Dedupe args | `selector`, `candidates` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0602.mdx
+++ b/docs/errors/SIFR-PACKAGE-0602.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::graph::workspace` |
-| Message template | `duplicate workspace import root '{import_root}'` |
 | Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::workspace_duplicate_import_roots_report_0602` |
-| Declared args | `import_root (message+json)`, `packages (json-only)` |
-| Dedupe args | `import_root`, `packages` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0603.mdx
+++ b/docs/errors/SIFR-PACKAGE-0603.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::graph::changed` |
-| Message template | `changed path '{path}' does not map to one Sifr package` |
 | Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::changed_file_mapping_reports_0603` |
-| Declared args | `path (message+json)` |
-| Dedupe args | `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0604.mdx
+++ b/docs/errors/SIFR-PACKAGE-0604.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::ops::read` |
-| Message template | `outdated query unsupported for source '{source}'` |
 | Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::outdated_unknown_source_reports_0604` |
-| Declared args | `source (message+json)`, `cargo_package_id (json-only)` |
-| Dedupe args | `cargo_package_id`, `source` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0605.mdx
+++ b/docs/errors/SIFR-PACKAGE-0605.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::ops::session` |
-| Message template | `ambiguous package run target: {selector}` |
 | Representative fixture | `crates/sifr_package/src/package_session_tests.rs::package_session_reports_script_target_ambiguity` |
-| Declared args | `selector (message+json)`, `candidates (json-only)` |
-| Dedupe args | `selector`, `candidates` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0606.mdx
+++ b/docs/errors/SIFR-PACKAGE-0606.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::ops::session` |
-| Message template | `invalid package app target name: {target}` |
 | Representative fixture | `crates/sifr_package/src/package_session_tests.rs::package_session_rejects_invalid_nested_target_name` |
-| Declared args | `target (message+json)` |
-| Dedupe args | `target` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0607.mdx
+++ b/docs/errors/SIFR-PACKAGE-0607.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::graph::workspace` |
-| Message template | `duplicate Sifr package name in workspace: {package}` |
 | Representative fixture | `crates/sifr_package/src/package_workspace_query_tests.rs::workspace_duplicate_sifr_names_report_0607` |
-| Declared args | `package (message+json)`, `members (json-only)` |
-| Dedupe args | `package`, `members` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0701.mdx
+++ b/docs/errors/SIFR-PACKAGE-0701.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::manifest::sifr` |
-| Message template | `production sifr.toml uses [exports].modules` |
 | Representative fixture | `crates/sifr_package/src/package_public_api_tests.rs::production_manifest_exports_report_0701` |
-| Declared args | `cargo_package_id (json-only)`, `manifest_path (json-only)` |
-| Dedupe args | `cargo_package_id`, `manifest_path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0703.mdx
+++ b/docs/errors/SIFR-PACKAGE-0703.mdx
@@ -53,9 +53,6 @@ manifest = "sifr.toml"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::projection` |
-| Message template | `Cargo projection manifest pointer drift` |
 | Representative fixture | `crates/sifr_package/src/package_projection_tests.rs::repair_check_reports_missing_manifest_pointer_0703` |
-| Declared args | `cargo_package_id (json-only)`, `path (json-only)`, `reason (message+json)` |
-| Dedupe args | `cargo_package_id`, `path`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0704.mdx
+++ b/docs/errors/SIFR-PACKAGE-0704.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::projection` |
-| Message template | `Cargo projection include rules omit required entry '{required}'` |
 | Representative fixture | `crates/sifr_package/src/package_projection_tests.rs::repair_check_reports_missing_required_include_0704` |
-| Declared args | `cargo_package_id (json-only)`, `path (json-only)`, `required (message+json)` |
-| Dedupe args | `cargo_package_id`, `path`, `required` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0709.mdx
+++ b/docs/errors/SIFR-PACKAGE-0709.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::projection` |
-| Message template | `pure Sifr package marker is missing` |
 | Representative fixture | `crates/sifr_package/src/package_projection_tests.rs::repair_regenerates_missing_pure_marker` |
-| Declared args | `cargo_package_id (json-only)`, `marker_path (json-only)` |
-| Dedupe args | `cargo_package_id`, `marker_path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0710.mdx
+++ b/docs/errors/SIFR-PACKAGE-0710.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::ops::session` |
-| Message template | `explicit file is outside package source root` |
 | Representative fixture | `crates/sifr_package/src/package_session_tests.rs::package_session_rejects_explicit_file_outside_source_root` |
-| Declared args | `file (message+json)`, `source_root (message+json)` |
-| Dedupe args | `file`, `source_root` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0711.mdx
+++ b/docs/errors/SIFR-PACKAGE-0711.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::manifest::sifr` |
-| Message template | `production sifr.toml uses [[bin]]` |
 | Representative fixture | `crates/sifr_package/src/package_public_api_tests.rs::production_manifest_bin_tables_report_0711` |
-| Declared args | `cargo_package_id (json-only)`, `manifest_path (json-only)` |
-| Dedupe args | `cargo_package_id`, `manifest_path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0713.mdx
+++ b/docs/errors/SIFR-PACKAGE-0713.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::imports::namespace_api` |
-| Message template | `duplicate public API symbol '{symbol}'` |
 | Representative fixture | `crates/sifr_package/src/package_public_api_tests.rs::duplicate_init_public_symbol_reports_0713` |
-| Declared args | `symbol (message+json)`, `cargo_package_id (json-only)`, `manifest_path (json-only)` |
-| Dedupe args | `cargo_package_id`, `manifest_path`, `symbol` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PACKAGE-0714.mdx
+++ b/docs/errors/SIFR-PACKAGE-0714.mdx
@@ -47,9 +47,6 @@ source-root = "src"
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::ops::session` |
-| Message template | `package script recursion is not allowed: {script}` |
 | Representative fixture | `crates/sifr_package/src/package_session_tests.rs::package_session_rejects_nested_script_expansion` |
-| Declared args | `script (message+json)` |
-| Dedupe args | `script` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0002.mdx
+++ b/docs/errors/SIFR-PARSE-0002.mdx
@@ -43,9 +43,6 @@ def main() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::frontend::api` |
-| Message template | `syntax error: expected {expected}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/parser_expected_token.sifr` |
-| Declared args | `expected (message+json)`, `parser_category (json-only)` |
-| Dedupe args | `expected`, `parser_category` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0003.mdx
+++ b/docs/errors/SIFR-PARSE-0003.mdx
@@ -43,9 +43,6 @@ def main() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::frontend::api` |
-| Message template | `lexical error: {reason}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/parser_malformed_string.sifr` |
-| Declared args | `reason (message+json)`, `parser_category (json-only)` |
-| Dedupe args | `reason`, `parser_category` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0004.mdx
+++ b/docs/errors/SIFR-PARSE-0004.mdx
@@ -43,9 +43,6 @@ def main() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::frontend::api` |
-| Message template | `invalid source layout: {reason}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/parser_invalid_layout.sifr` |
-| Declared args | `reason (message+json)`, `parser_category (json-only)` |
-| Dedupe args | `reason`, `parser_category` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0005.mdx
+++ b/docs/errors/SIFR-PARSE-0005.mdx
@@ -43,9 +43,6 @@ def main() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::frontend::api` |
-| Message template | `invalid target syntax: {target_kind}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/parser_invalid_target.sifr` |
-| Declared args | `target_kind (message+json)`, `parser_category (json-only)` |
-| Dedupe args | `target_kind`, `parser_category` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0006.mdx
+++ b/docs/errors/SIFR-PARSE-0006.mdx
@@ -43,9 +43,6 @@ def main() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::frontend::api` |
-| Message template | `invalid call argument syntax: {reason}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/parser_invalid_call_arguments.sifr` |
-| Declared args | `reason (message+json)`, `parser_category (json-only)` |
-| Dedupe args | `reason`, `parser_category` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0007.mdx
+++ b/docs/errors/SIFR-PARSE-0007.mdx
@@ -43,9 +43,6 @@ def main() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::frontend::api` |
-| Message template | `malformed declaration list: {declaration_kind}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/parser_malformed_declaration_list.sifr` |
-| Declared args | `declaration_kind (message+json)`, `parser_category (json-only)` |
-| Dedupe args | `declaration_kind`, `parser_category` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0008.mdx
+++ b/docs/errors/SIFR-PARSE-0008.mdx
@@ -43,9 +43,6 @@ def main() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::frontend::api` |
-| Message template | `invalid match pattern syntax: {reason}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/parser_invalid_match_pattern.sifr` |
-| Declared args | `reason (message+json)`, `parser_category (json-only)` |
-| Dedupe args | `reason`, `parser_category` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PARSE-0009.mdx
+++ b/docs/errors/SIFR-PARSE-0009.mdx
@@ -43,9 +43,6 @@ def main() -> int:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::frontend::api` |
-| Message template | `unsupported syntax: {syntax_kind}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/parser_unsupported_syntax.sifr` |
-| Declared args | `syntax_kind (message+json)`, `parser_category (json-only)` |
-| Dedupe args | `syntax_kind`, `parser_category` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PROTO-0001.mdx
+++ b/docs/errors/SIFR-PROTO-0001.mdx
@@ -47,9 +47,6 @@ for item in Items():
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `type '{actual}' does not implement protocol '{protocol}' required by type parameter '{type_param}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/generic_bounds_not_satisfied.sifr` |
-| Declared args | `actual (message+json)`, `protocol (message+json)`, `type_param (message+json)` |
-| Dedupe args | `actual`, `protocol`, `type_param` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PROTO-0002.mdx
+++ b/docs/errors/SIFR-PROTO-0002.mdx
@@ -47,9 +47,6 @@ for item in Items():
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::classes` |
-| Message template | `class '{type_name}' must return {expected}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/invalid_iter_signature.sifr` |
-| Declared args | `type_name (message+json)`, `expected (message+json)` |
-| Dedupe args | `type_name`, `expected` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PROTO-0003.mdx
+++ b/docs/errors/SIFR-PROTO-0003.mdx
@@ -47,9 +47,6 @@ for item in Items():
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `type '{type_name}' does not implement the ContextManager protocol (missing __enter__ and __exit__ methods)` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/with_non_context_manager.sifr` |
-| Declared args | `type_name (message+json)` |
-| Dedupe args | `type_name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PROTO-0004.mdx
+++ b/docs/errors/SIFR-PROTO-0004.mdx
@@ -47,9 +47,6 @@ for item in Items():
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::expressions` |
-| Message template | `hash() argument must be hashable, got '{type_name}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/unhashable_dict_key.sifr` |
-| Declared args | `type_name (message+json)` |
-| Dedupe args | `type_name` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYCALL-0001.mdx
+++ b/docs/errors/SIFR-PYCALL-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYCALL-0001` locally to see the renderer's exact messag
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering` |
-| Message template | `invalid Python declaration call shape: {reason}` |
 | Representative fixture | `crates/sifr_lowering/src/lower/python_interop_tests.rs::invalid_python_declaration_shape_reports_pycall_0001` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYCB-0001.mdx
+++ b/docs/errors/SIFR-PYCB-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYCB-0001` locally to see the renderer's exact message 
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering` |
-| Message template | `invalid Python callback declaration: {reason}` |
 | Representative fixture | `crates/sifr_lowering/src/lower/python_interop_callback_tests.rs::callback_policy_validates_before_reservation` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYCONV-0001.mdx
+++ b/docs/errors/SIFR-PYCONV-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYCONV-0001` locally to see the renderer's exact messag
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering` |
-| Message template | `unsupported Python declaration conversion type: {reason}` |
 | Representative fixture | `crates/sifr_lowering/src/lower/python_interop_validation_tests.rs::unsupported_python_conversion_reports_pyconv_0001` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYCTX-0001.mdx
+++ b/docs/errors/SIFR-PYCTX-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYCTX-0001` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering` |
-| Message template | `invalid Python context declaration: {reason}` |
 | Representative fixture | `crates/sifr_lowering/src/lower/python_interop_tests.rs::invalid_python_context_declaration_reports_pyctx_0001` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0001.mdx
+++ b/docs/errors/SIFR-PYENV-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0001` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `invalid Python environment configuration: {reason}` |
 | Representative fixture | `crates/sifr_package/src/python/tests.rs::invalid_python_manifest_config_reports_pyenv_0001` |
-| Declared args | `reason (message+json)`, `cargo_package_id (json-only)`, `manifest_path (json-only)`, `key (json-only)` |
-| Dedupe args | `cargo_package_id`, `manifest_path`, `key`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0002.mdx
+++ b/docs/errors/SIFR-PYENV-0002.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0002` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `multiple Python environments are selected: {venvs}` |
 | Representative fixture | `crates/sifr_package/src/python/tests.rs::multiple_python_environment_selections_report_pyenv_0002` |
-| Declared args | `venvs (message+json)`, `package_ids (json-only)` |
-| Dedupe args | `package_ids`, `venvs` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0003.mdx
+++ b/docs/errors/SIFR-PYENV-0003.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0003` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `Python imports are required but no Python environment is selected` |
 | Representative fixture | `crates/sifr_package/src/python/tests.rs::missing_uv_environment_selection_reports_pyenv_0003` |
-| Declared args | `package_ids (json-only)`, `imports (json-only)` |
-| Dedupe args | `package_ids`, `imports` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0004.mdx
+++ b/docs/errors/SIFR-PYENV-0004.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0004` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `Python environment probe failed: {reason}` |
 | Representative fixture | `crates/sifr_package/src/python/probe_validation_tests.rs::probe_rejects_missing_interpreter_with_pyenv_0004` |
-| Declared args | `reason (message+json)`, `interpreter (json-only)`, `venv (json-only)` |
-| Dedupe args | `interpreter`, `venv`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0005.mdx
+++ b/docs/errors/SIFR-PYENV-0005.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0005` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `unsupported Python interpreter: {implementation}` |
 | Representative fixture | `crates/sifr_package/src/python/probe_validation_tests.rs::probe_rejects_non_cpython_json_with_pyenv_0005` |
-| Declared args | `implementation (message+json)`, `interpreter (json-only)`, `venv (json-only)` |
-| Dedupe args | `interpreter`, `venv`, `implementation` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0006.mdx
+++ b/docs/errors/SIFR-PYENV-0006.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0006` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `Python sys.prefix is outside the selected virtual environment` |
 | Representative fixture | `crates/sifr_package/src/python/probe_validation_tests.rs::probe_rejects_prefix_outside_venv_with_pyenv_0006` |
-| Declared args | `interpreter (json-only)`, `venv (json-only)`, `sys_prefix (json-only)` |
-| Dedupe args | `interpreter`, `venv`, `sys_prefix` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0007.mdx
+++ b/docs/errors/SIFR-PYENV-0007.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0007` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `selected Python environment has no site-packages path` |
 | Representative fixture | `crates/sifr_package/src/python/probe_validation_tests.rs::probe_rejects_missing_site_packages_with_pyenv_0007` |
-| Declared args | `interpreter (json-only)`, `venv (json-only)` |
-| Dedupe args | `interpreter`, `venv` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0008.mdx
+++ b/docs/errors/SIFR-PYENV-0008.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0008` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `declared Python import root is missing: {import_root}` |
 | Representative fixture | `crates/sifr_package/src/python/probe_validation_tests.rs::probe_rejects_missing_declared_import_with_pyenv_0008` |
-| Declared args | `import_root (message+json)`, `interpreter (json-only)`, `venv (json-only)` |
-| Dedupe args | `interpreter`, `venv`, `import_root` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0009.mdx
+++ b/docs/errors/SIFR-PYENV-0009.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0009` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `trusted native Python import root failed to load: {import_root}` |
 | Representative fixture | `crates/sifr_package/src/python/probe_validation_tests.rs::probe_rejects_native_import_failure_with_pyenv_0009` |
-| Declared args | `import_root (message+json)`, `reason (message+json)`, `interpreter (json-only)`, `venv (json-only)` |
-| Dedupe args | `interpreter`, `venv`, `import_root`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0010.mdx
+++ b/docs/errors/SIFR-PYENV-0010.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0010` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `free-threaded CPython is not supported` |
 | Representative fixture | `crates/sifr_package/src/python/probe_validation_tests.rs::probe_rejects_free_threaded_cpython_with_pyenv_0010` |
-| Declared args | `interpreter (json-only)`, `venv (json-only)` |
-| Dedupe args | `interpreter`, `venv` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYENV-0011.mdx
+++ b/docs/errors/SIFR-PYENV-0011.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYENV-0011` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `Python environment metadata is stale: {reason}` |
 | Representative fixture | `crates/sifr_package/src/python/probe_validation_tests.rs::probe_rejects_missing_lock_digest_with_pyenv_0011` |
-| Declared args | `reason (message+json)`, `interpreter (json-only)`, `venv (json-only)` |
-| Dedupe args | `interpreter`, `venv`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYIMP-0001.mdx
+++ b/docs/errors/SIFR-PYIMP-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYIMP-0001` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering` |
-| Message template | `invalid Python declaration target: {reason}` |
 | Representative fixture | `crates/sifr_lowering/src/lower/python_interop_tests.rs::invalid_python_target_reports_pyimp_0001` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYIMP-0002.mdx
+++ b/docs/errors/SIFR-PYIMP-0002.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYIMP-0002` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `invalid package-local Python bridge: {reason}` |
 | Representative fixture | `crates/sifr_package/src/python/bridge_inventory_tests.rs::invalid_python_bridge_source_reports_pyimp_0002` |
-| Declared args | `reason (message+json)`, `cargo_package_id (json-only)`, `bridge_path (json-only)` |
-| Dedupe args | `cargo_package_id`, `bridge_path`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYIMP-0003.mdx
+++ b/docs/errors/SIFR-PYIMP-0003.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYIMP-0003` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_runtime::python::bridge_loader` |
-| Message template | `reserved Python bridge namespace collision at '{module}'` |
 | Representative fixture | `crates/sifr_runtime/src/python/bridge_loader.rs::loader_is_hermetic_rewrites_imports_and_restores_first_position` |
-| Declared args | `module (message+json)` |
-| Dedupe args | `module` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYRES-0002.mdx
+++ b/docs/errors/SIFR-PYRES-0002.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYRES-0002` locally to see the renderer's exact message
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering` |
-| Message template | `unsupported Python resource declaration: {reason}` |
 | Representative fixture | `crates/sifr_lowering/src/lower/python_interop_validation_tests.rs::bridge_opaque_target_is_terminally_unsupported` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYTRUST-0001.mdx
+++ b/docs/errors/SIFR-PYTRUST-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYTRUST-0001` locally to see the renderer's exact messa
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `Python wildcard import root is rejected` |
 | Representative fixture | `crates/sifr_package/src/python/trust_policy_tests.rs::dependency_python_requirement_wildcard_is_rejected` |
-| Declared args | `cargo_package_id (json-only)` |
-| Dedupe args | `cargo_package_id` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYTRUST-0003.mdx
+++ b/docs/errors/SIFR-PYTRUST-0003.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYTRUST-0003` locally to see the renderer's exact messa
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `native Python import root is trusted but not required: {import_root}` |
 | Representative fixture | `crates/sifr_package/src/python/trust_policy_tests.rs::native_trust_requires_a_canonical_requirement` |
-| Declared args | `import_root (message+json)` |
-| Dedupe args | `import_root` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYTRUST-0004.mdx
+++ b/docs/errors/SIFR-PYTRUST-0004.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYTRUST-0004` locally to see the renderer's exact messa
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering` |
-| Message template | `dynamic Python import requires @trust_python_dynamic` |
 | Representative fixture | `crates/sifr_lowering/src/lower/python_trust_tests.rs::dynamic_python_import_requires_trust_decorator` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYTRUST-0005.mdx
+++ b/docs/errors/SIFR-PYTRUST-0005.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYTRUST-0005` locally to see the renderer's exact messa
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_package::python` |
-| Message template | `required Python import root is not authorized by the root application: {import_root}` |
 | Representative fixture | `crates/sifr_package/src/python/trust_policy_tests.rs::required_python_root_must_be_authorized_by_root` |
-| Declared args | `import_root (message+json)` |
-| Dedupe args | `import_root` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-PYZC-0001.mdx
+++ b/docs/errors/SIFR-PYZC-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-PYZC-0001` locally to see the renderer's exact message 
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering` |
-| Message template | `invalid Python zero-copy declaration: {reason}` |
 | Representative fixture | `crates/sifr_lowering/src/lower/python_buffer_contract_tests.rs::buffer_policy_and_return_contract_fail_with_pyzc_0001` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0001.mdx
+++ b/docs/errors/SIFR-RESULT-0001.mdx
@@ -44,9 +44,6 @@ except IOError as e:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `unused Result value` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/unused_result.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0002.mdx
+++ b/docs/errors/SIFR-RESULT-0002.mdx
@@ -44,9 +44,6 @@ except IOError as e:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `invalid Result error type {error_type}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/error_str_not_allowed.sifr` |
-| Declared args | `error_type (message+json)` |
-| Dedupe args | `error_type` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0003.mdx
+++ b/docs/errors/SIFR-RESULT-0003.mdx
@@ -44,9 +44,6 @@ except IOError as e:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `invalid raise expression of type {actual}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/error_raise_str.sifr` |
-| Declared args | `actual (message+json)` |
-| Dedupe args | `actual` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0004.mdx
+++ b/docs/errors/SIFR-RESULT-0004.mdx
@@ -44,9 +44,6 @@ except IOError as e:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `unknown except error type '{error_type}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/unknown_except_error_type.sifr` |
-| Declared args | `error_type (message+json)` |
-| Dedupe args | `error_type` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0005.mdx
+++ b/docs/errors/SIFR-RESULT-0005.mdx
@@ -44,9 +44,6 @@ except IOError as e:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `except arms do not cover all error types from try body: {uncovered}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/try_except_uncovered_error_types.sifr` |
-| Declared args | `uncovered (message+json)` |
-| Dedupe args | `uncovered` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RESULT-0006.mdx
+++ b/docs/errors/SIFR-RESULT-0006.mdx
@@ -44,9 +44,6 @@ except IOError as e:
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::statements` |
-| Message template | `invalid except error type: {reason}` |
 | Representative fixture | `crates/sifr_lowering/src/lower/statement_diagnostics_tests.rs` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RUST-ASYNC-0001.mdx
+++ b/docs/errors/SIFR-RUST-ASYNC-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-RUST-ASYNC-0001` locally to see the renderer's exact me
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::rust_interop` |
-| Message template | `invalid Rust async contract: {reason}` |
 | Representative fixture | `crates/sifr_driver/src/build/rust_interop_async_contract_tests.rs::package_rust_interop_async_requires_send_future_by_default` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RUST-CARGO-0001.mdx
+++ b/docs/errors/SIFR-RUST-CARGO-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-RUST-CARGO-0001` locally to see the renderer's exact me
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::rust_interop` |
-| Message template | `Rust interop declarations require a Sifr package Cargo context` |
 | Representative fixture | `crates/sifr_driver/src/build/rust_interop_tests.rs::package_rust_interop_requires_cargo_context` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RUST-CB-0001.mdx
+++ b/docs/errors/SIFR-RUST-CB-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-RUST-CB-0001` locally to see the renderer's exact messa
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::rust_interop` |
-| Message template | `invalid Rust callback contract for {target}: {reason}` |
 | Representative fixture | `crates/sifr_driver/src/build/rust_interop_callback_contract_tests.rs::package_rust_interop_rejects_callback_missing_backpressure` |
-| Declared args | `target (message+json)`, `reason (message+json)` |
-| Dedupe args | `target`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RUST-CONFIG-0001.mdx
+++ b/docs/errors/SIFR-RUST-CONFIG-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-RUST-CONFIG-0001` locally to see the renderer's exact m
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::rust_interop` |
-| Message template | `malformed Rust interop decorator: {reason}` |
 | Representative fixture | `crates/sifr_lowering/src/lower/rust_interop_tests.rs::rust_interop_rejects_string_target` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RUST-HANDLE-0001.mdx
+++ b/docs/errors/SIFR-RUST-HANDLE-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-RUST-HANDLE-0001` locally to see the renderer's exact m
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::rust_interop` |
-| Message template | `opaque Rust handle {target} requires {method} cleanup method` |
 | Representative fixture | `crates/sifr_driver/src/build/rust_interop_contract_tests.rs::package_rust_interop_opaque_close_policy_requires_close_method_contract` |
-| Declared args | `target (message+json)`, `method (message+json)` |
-| Dedupe args | `target`, `method` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RUST-PANIC-0001.mdx
+++ b/docs/errors/SIFR-RUST-PANIC-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-RUST-PANIC-0001` locally to see the renderer's exact me
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::rust_interop` |
-| Message template | `invalid Rust panic boundary contract: {reason}` |
 | Representative fixture | `crates/sifr_driver/src/build/rust_interop_panic_contract_tests.rs::package_rust_interop_rejects_unknown_panic_policy` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RUST-RESOLVE-0001.mdx
+++ b/docs/errors/SIFR-RUST-RESOLVE-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-RUST-RESOLVE-0001` locally to see the renderer's exact 
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::rust_interop` |
-| Message template | `unresolved Rust target root {root}` |
 | Representative fixture | `crates/sifr_driver/src/build/rust_interop_tests.rs::package_rust_interop_rejects_unknown_target_root` |
-| Declared args | `root (message+json)`, `target (message+json)` |
-| Dedupe args | `root`, `target` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RUST-TRUST-0001.mdx
+++ b/docs/errors/SIFR-RUST-TRUST-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-RUST-TRUST-0001` locally to see the renderer's exact me
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::rust_interop` |
-| Message template | `missing Rust interop trust declaration for {target}` |
 | Representative fixture | `crates/sifr_driver/src/build/rust_interop_tests.rs::package_rust_interop_rejects_untrusted_build_script` |
-| Declared args | `target (message+json)`, `required_trust (message+json)`, `evidence (message+json)` |
-| Dedupe args | `target`, `required_trust`, `evidence` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RUST-TYPE-0001.mdx
+++ b/docs/errors/SIFR-RUST-TYPE-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-RUST-TYPE-0001` locally to see the renderer's exact mes
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::rust_interop` |
-| Message template | `Rust bridge probe failed for {target}` |
 | Representative fixture | `crates/sifr_driver/src/build/rust_interop_tests.rs::package_rust_interop_rejects_unrepresentable_probe_owner` |
-| Declared args | `target (message+json)` |
-| Dedupe args | `target` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-RUST-ZC-0001.mdx
+++ b/docs/errors/SIFR-RUST-ZC-0001.mdx
@@ -25,9 +25,6 @@ Use `sifr --explain SIFR-RUST-ZC-0001` locally to see the renderer's exact messa
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::build::rust_interop` |
-| Message template | `invalid Rust zero-copy/view contract: {reason}` |
 | Representative fixture | `crates/sifr_driver/src/build/rust_interop_zero_copy_contract_tests.rs::package_rust_interop_zero_copy_requires_view_contract` |
-| Declared args | `reason (message+json)` |
-| Dedupe args | `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-STDLIB-0001.mdx
+++ b/docs/errors/SIFR-STDLIB-0001.mdx
@@ -43,9 +43,6 @@ values = defaultdict(lambda: 0)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::builtin_calls` |
-| Message template | `defaultdict() does not support keyword arguments` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/defaultdict_keyword_constructor_unsupported.sifr` |
-| Declared args | n/a |
-| Dedupe args | n/a |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-STDLIB-0003.mdx
+++ b/docs/errors/SIFR-STDLIB-0003.mdx
@@ -43,9 +43,6 @@ values = defaultdict(lambda: 0)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::stdlib::bootstrap` |
-| Message template | `embedded standard library bootstrap failed during {operation}` |
 | Representative fixture | `crates/sifr_driver/src/tests/stdlib_exports.rs` |
-| Declared args | `operation (message+json)` |
-| Dedupe args | `operation` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-STDLIB-0004.mdx
+++ b/docs/errors/SIFR-STDLIB-0004.mdx
@@ -43,9 +43,6 @@ values = defaultdict(lambda: 0)
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::stdlib::cache` |
-| Message template | `standard-library cache failed during {operation}` |
 | Representative fixture | `crates/sifr_driver/src/tests/project_build_check.rs` |
-| Declared args | `operation (message+json)` |
-| Dedupe args | `operation` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0002.mdx
+++ b/docs/errors/SIFR-TYPE-0002.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower` |
-| Message template | `type mismatch: expected {expected}, got {actual}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/type_mismatch.sifr` |
-| Declared args | `expected (message+json)`, `actual (message+json)` |
-| Dedupe args | `expected`, `actual` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0003.mdx
+++ b/docs/errors/SIFR-TYPE-0003.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::if_expression` |
-| Message template | `conditional branches have incompatible types: {then_type} and {else_type}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/ternary_type_mismatch.sifr` |
-| Declared args | `then_type (message+json)`, `else_type (message+json)` |
-| Dedupe args | `then_type`, `else_type` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0004.mdx
+++ b/docs/errors/SIFR-TYPE-0004.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::typing_and_functions` |
-| Message template | `missing type annotation for {name}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/missing_type_annotation.sifr` |
-| Declared args | `name (message+json)`, `declaration_kind (json-only)` |
-| Dedupe args | `name`, `declaration_kind` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0005.mdx
+++ b/docs/errors/SIFR-TYPE-0005.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_type_system` |
-| Message template | `unsupported operator {operator} for {operand_types}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/optional_arithmetic_without_narrowing.sifr` |
-| Declared args | `operator (message+json)`, `operand_types (message+json)` |
-| Dedupe args | `operator`, `operand_types` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0006.mdx
+++ b/docs/errors/SIFR-TYPE-0006.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_type_system` |
-| Message template | `cannot mix int and bigint with operator {operator}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/bigint_int_mixed_arithmetic.sifr` |
-| Declared args | `operator (message+json)` |
-| Dedupe args | `operator` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0007.mdx
+++ b/docs/errors/SIFR-TYPE-0007.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::typing_and_functions` |
-| Message template | `invalid type annotation for {annotation_kind}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/invalid_type_annotation.sifr` |
-| Declared args | `annotation_kind (message+json)` |
-| Dedupe args | `annotation_kind` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0008.mdx
+++ b/docs/errors/SIFR-TYPE-0008.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::container_literal_specialization` |
-| Message template | `container literal has conflicting {element_kind} types: {expected} and {actual}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/container_literal_type_conflict.sifr` |
-| Declared args | `element_kind (message+json)`, `expected (message+json)`, `actual (message+json)` |
-| Dedupe args | `element_kind`, `expected`, `actual` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0009.mdx
+++ b/docs/errors/SIFR-TYPE-0009.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::tuple_unpack` |
-| Message template | `tuple unpacking: expected {expected_count} values, got {actual_count}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/tuple_unpack_shape_mismatch.sifr` |
-| Declared args | `expected_count (message+json)`, `actual_count (message+json)` |
-| Dedupe args | `expected_count`, `actual_count` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0010.mdx
+++ b/docs/errors/SIFR-TYPE-0010.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::expressions` |
-| Message template | `type '{actual}' does not satisfy constraints ({constraints}) required by type parameter '{type_param}'` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/typevar_constraints_violation.sifr` |
-| Declared args | `actual (message+json)`, `constraints (message+json)`, `type_param (message+json)` |
-| Dedupe args | `actual`, `constraints`, `type_param` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0011.mdx
+++ b/docs/errors/SIFR-TYPE-0011.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::typing_and_functions` |
-| Message template | `function {function}: unsupported default argument expression for parameter {parameter}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/unsupported_default_expr_call.sifr` |
-| Declared args | `function (message+json)`, `parameter (message+json)` |
-| Dedupe args | `function`, `parameter` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0012.mdx
+++ b/docs/errors/SIFR-TYPE-0012.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::expressions` |
-| Message template | `unsupported expression form: {form}` |
 | Representative fixture | `crates/sifr/tests/e2e/fail/unsupported_yield_expression.sifr` |
-| Declared args | `form (message+json)` |
-| Dedupe args | `form` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0901.mdx
+++ b/docs/errors/SIFR-TYPE-0901.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Warning |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::arithmetic_warnings` |
-| Message template | `integer {operation} may overflow at runtime` |
 | Representative fixture | `crates/sifr_driver/src/tests/single_file_frontend.rs::test_type_check_source_surfaces_arithmetic_overflow_as_structured_warning` |
-| Declared args | `operation (message+json)` |
-| Dedupe args | `operation` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-TYPE-0902.mdx
+++ b/docs/errors/SIFR-TYPE-0902.mdx
@@ -41,9 +41,6 @@ count: int = 3
 | Severity | Note |
 | Stability | stable |
 | Owner | `sifr_lowering::lower::builtin_calls` |
-| Message template | `revealed type is {revealed_type}` |
 | Representative fixture | `crates/sifr_driver/src/tests/single_file_frontend.rs::test_type_check_source_surfaces_reveal_type_as_structured_note` |
-| Declared args | `revealed_type (message+json)` |
-| Dedupe args | `revealed_type` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0001.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0001.mdx
@@ -43,9 +43,6 @@ members = ["crates/app"]
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::workspace` |
-| Message template | `could not parse workspace manifest at {path}: {reason}` |
 | Representative fixture | `verification/areas/project_workspace/fixtures/project/workspace_malformed_manifest` |
-| Declared args | `path (message+json)`, `reason (message+json)` |
-| Dedupe args | `path`, `reason` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0002.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0002.mdx
@@ -43,9 +43,6 @@ members = ["crates/app"]
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::workspace` |
-| Message template | `source root {path} escapes the workspace root` |
 | Representative fixture | `crates/sifr_driver/src/tests/discovery_and_workspace.rs` |
-| Declared args | `path (message+json)` |
-| Dedupe args | `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0003.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0003.mdx
@@ -43,9 +43,6 @@ members = ["crates/app"]
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::workspace` |
-| Message template | `source root {path} is not a directory` |
 | Representative fixture | `crates/sifr_driver/src/tests/discovery_and_workspace.rs` |
-| Declared args | `path (message+json)` |
-| Dedupe args | `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0004.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0004.mdx
@@ -43,9 +43,6 @@ members = ["crates/app"]
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::workspace` |
-| Message template | `invalid source root entry {entry}` |
 | Representative fixture | `crates/sifr_driver/src/tests/discovery_and_workspace.rs` |
-| Declared args | `entry (message+json)` |
-| Dedupe args | `entry` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0101.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0101.mdx
@@ -43,9 +43,6 @@ members = ["crates/app"]
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::project::discovery` |
-| Message template | `could not resolve import {module}` |
 | Representative fixture | `verification/areas/project_workspace/fixtures/project/workspace_unresolved_import` |
-| Declared args | `module (message+json)`, `searched_paths (json-only)` |
-| Dedupe args | `module`, `searched_paths` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0102.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0102.mdx
@@ -43,9 +43,6 @@ members = ["crates/app"]
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::project::discovery` |
-| Message template | `module {module} is ambiguous in workspace {workspace}` |
 | Representative fixture | `verification/areas/project_workspace/fixtures/project/workspace_ambiguous_import` |
-| Declared args | `module (message+json)`, `workspace (message+json)`, `candidate_paths (json-only)` |
-| Dedupe args | `module`, `workspace`, `candidate_paths` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0103.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0103.mdx
@@ -43,9 +43,6 @@ members = ["crates/app"]
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::project::discovery` |
-| Message template | `module {module} collides with namespace path {path}` |
 | Representative fixture | `crates/sifr_driver/src/tests/discovery_and_workspace.rs` |
-| Declared args | `module (message+json)`, `path (message+json)` |
-| Dedupe args | `module`, `path` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.

--- a/docs/errors/SIFR-WORKSPACE-0104.mdx
+++ b/docs/errors/SIFR-WORKSPACE-0104.mdx
@@ -43,9 +43,6 @@ members = ["crates/app"]
 | Severity | Error |
 | Stability | stable |
 | Owner | `sifr_driver::project::compile_order` |
-| Message template | `workspace import cycle detected: {cycle}` |
 | Representative fixture | `crates/sifr_driver/src/tests/project_graph.rs` |
-| Declared args | `cycle (message+json)` |
-| Dedupe args | `cycle` |
 
 See the [Error Codes index](/diagnostics/error-codes) for the complete catalog.


### PR DESCRIPTION
## Summary
- Mintlify rejected the previous error-page deploy because MDX treated `{reason}`-style message templates as JSX.
- Stop emitting message-template / args rows on public MDX pages, and escape `<...>` in example prose outside code fences.

## Test plan
- [x] `cargo run -q -p sifr_diagnostics --bin gen-error-docs -- --check`
- [ ] Confirm Mintlify deploy succeeds after merge


Made with [Cursor](https://cursor.com)