### PR TITLE
Add library-first interop guides

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -172,6 +172,18 @@
               "guides/rust-developers/index",
               "guides/rust-developers/rust-concepts"
             ]
+          },
+          {
+            "group": "Interop",
+            "icon": "plug-zap",
+            "pages": [
+              "guides/interop/index",
+              "guides/interop/blake3",
+              "guides/interop/reqwest",
+              "guides/interop/schwifty",
+              "guides/interop/numpy",
+              "guides/interop/kafka"
+            ]
           }
         ]
       },

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -32,4 +32,12 @@ Guides are written as paths, not reference pages. Use them when you want to buil
   >
     Connect Sifr ownership, typed errors, and generated Rust to Rust concepts.
   </Card>
+  <Card
+    icon="plug-zap"
+    title="Interop by library"
+    href="/guides/interop"
+    cta="Follow a library"
+  >
+    Walk through blake3, reqwest, schwifty, NumPy, and Kafka with concepts first.
+  </Card>
 </CardGroup>

--- a/docs/guides/interop/blake3.mdx
+++ b/docs/guides/interop/blake3.mdx
@@ -1,0 +1,92 @@
+---
+title: "Hash bytes with blake3"
+sidebarTitle: "blake3"
+description: "Use a direct @rust binding to hash bytes with the blake3 crate, with an explicit panic policy."
+---
+
+This guide uses [blake3](https://crates.io/crates/blake3) to hash bytes from Sifr. blake3 is a good first Rust interop example because `blake3::hash` already has a bridge-compatible shape: bytes in, digest bytes out.
+
+<Info>
+blake3 produces a BLAKE3 digest, not SHA-1 or SHA-256. If you need those algorithms, bind a crate such as `sha1` or `sha2` the same way.
+</Info>
+
+## Why this shape
+
+Rust interop is source-level Cargo integration. Sifr does not `dlopen` a Rust crate or invent a C ABI. You declare a Sifr function whose target is a Rust item, and the compiler checks that the Rust signature matches before codegen.
+
+Three rules drive the blake3 declaration:
+
+1. **Compatible signatures can bind directly.** Prefer `@rust(blake3.hash, ...)` when the public Rust function already maps to Sifr types.
+2. **Panic policy is part of the contract.** Recoverable builds must not let a Rust panic unwind through Sifr user code. Choose `trusted_no_panic` only with trust evidence, or `map_error(...)` to convert panics into a declared error.
+3. **Stub bodies are intentional.** Package-authored declarations use `...`. Behavior comes from validated Rust interop metadata, not from a Sifr function body.
+
+If the crate API needed lifetimes, generics, borrowed returns, or trait objects, you would write a local bridge under `src/bridges` instead. blake3's one-shot hash does not need that.
+
+## Package setup
+
+Add the crate and declare Rust interop policy:
+
+```toml Cargo.toml
+[dependencies]
+blake3 = "1"
+```
+
+```toml sifr.toml
+[rust]
+bridge-version = 1
+bridges = ["src/bridges"]
+
+[trust]
+rust-build-scripts = []
+rust-proc-macros = []
+native-links = []
+unsafe-rust-bridges = []
+rust-no-panic = []
+rust-panic-abort = []
+```
+
+Use `sifr bridge check` so decorator parsing, target resolution, and panic policy match ordinary `sifr check`.
+
+## Declare and call
+
+```sifr
+class HashError(Error):
+    message: str
+
+@rust(blake3.hash, panic=map_error(bridge.hash.map_panic))
+def blake3_hash(data: bytes) -> Result[bytes, HashError | RustPanicError]: ...
+
+def digest_message(message: bytes) -> Result[bytes, HashError | RustPanicError]:
+    return blake3_hash(message)
+```
+
+The dotted target `blake3.hash` resolves through Cargo metadata to the `blake3` dependency. The return type keeps failure visible: either digest bytes or a checked error channel that includes panic mapping.
+
+If you have audited evidence that the target cannot panic, you can instead declare `panic=trusted_no_panic` and list `blake3.hash` under `[trust].rust-no-panic`. Prefer `map_error` until that evidence exists.
+
+## When to switch to a bridge
+
+Stay on a direct binding for one-shot hashing. Move to a bridge when you need output shaping, such as hex encoding:
+
+```rust src/bridges/hash.rs
+pub fn hash_hex(input: &[u8]) -> Result<String, HashErrorBridge> {
+    Ok(format!("{}", blake3::hash(input).to_hex()))
+}
+
+pub fn map_panic(message: &str) -> HashErrorBridge {
+    HashErrorBridge {
+        message: message.to_owned(),
+    }
+}
+```
+
+```sifr
+@rust(bridge.hash.hash_hex, panic=map_error(bridge.hash.map_panic))
+def blake3_hex(data: bytes) -> Result[str, HashError | RustPanicError]: ...
+```
+
+## Next steps
+
+- Full contract catalog: [Rust Interop](/rust-interop)
+- Async HTTP with a bridge: [reqwest](/guides/interop/reqwest)
+- Trust and Cargo policy: [Package Manifest](/packages/manifest)

--- a/docs/guides/interop/index.mdx
+++ b/docs/guides/interop/index.mdx
@@ -1,0 +1,61 @@
+---
+title: Interop guides
+sidebarTitle: Overview
+description: Library-first walkthroughs for Rust and Python interop in Sifr.
+contextual: false
+mode: center
+---
+
+These guides teach interop by walking through one well-known library at a time. Each page starts with the concepts that force Sifr's declaration style, then shows a minimal working path.
+
+Use the [Rust Interop](/rust-interop) and [Embedded Python Interop](/python-interop) references when you need the full contract catalog.
+
+## Rust crates
+
+<CardGroup cols={2}>
+  <Card
+    icon="fingerprint"
+    title="blake3"
+    href="/guides/interop/blake3"
+    cta="Hash bytes"
+  >
+    Direct `@rust` binding for a compatible hashing function, plus panic policy.
+  </Card>
+  <Card
+    icon="globe"
+    title="reqwest"
+    href="/guides/interop/reqwest"
+    cta="Send a request"
+  >
+    Async HTTP through a local bridge that shapes responses into Sifr types.
+  </Card>
+</CardGroup>
+
+## Python packages
+
+<CardGroup cols={2}>
+  <Card
+    icon="landmark"
+    title="schwifty"
+    href="/guides/interop/schwifty"
+    cta="Validate an IBAN"
+  >
+    Typed opaque Python objects for IBAN validation with checked `Result` errors.
+  </Card>
+  <Card
+    icon="grid-3x3"
+    title="numpy"
+    href="/guides/interop/numpy"
+    cta="Multiply matrices"
+  >
+    Native-trusted NumPy work behind a typed bridge, with buffer notes for views.
+  </Card>
+  <Card
+    icon="radio"
+    title="kafka-python"
+    href="/guides/interop/kafka"
+    cta="Handle a callback"
+  >
+    Foreign-thread Kafka callbacks with explicit lifetime and concurrency policy.
+  </Card>
+</CardGroup>

--- a/docs/guides/interop/kafka.mdx
+++ b/docs/guides/interop/kafka.mdx
@@ -1,0 +1,126 @@
+---
+title: "Handle a Kafka callback with kafka-python"
+sidebarTitle: "kafka-python"
+description: "Register a Sifr callback for kafka-python with explicit foreign-thread dispatch, lifetime, and concurrency policy."
+---
+
+This guide uses [kafka-python](https://kafka-python.readthedocs.io/) to acknowledge a consumed message from a Sifr callback. Kafka is a good callback example because broker clients often invoke handlers from worker threads that Sifr did not create.
+
+## Why this shape
+
+Crossing into Kafka means more than importing a client. The important contract is what happens when Python calls back into Sifr from another thread.
+
+Five rules drive the Kafka path:
+
+1. **Callbacks need an attached policy.** `@python.callback(...)` names the parameter that becomes the Python callable and states lifetime, dispatch, and concurrency.
+2. **Foreign threads are explicit.** `dispatch=foreign` means Python-created threads may enter the handler. Captures must be sendable and thread-safe.
+3. **Lifetime drains accepted work.** `lifetime=call` keeps the callable only until the declaration returns, then drains it. Longer lifetimes need an opaque owner with deterministic cleanup.
+4. **Bridge the broker workflow.** Producer/consumer setup, polling, and thread handoff belong in `src/python_bridges/`. The Sifr declaration stays a typed boundary.
+5. **Trust the import root.** Authorize `kafka` under `[trust].python`. Add `[trust].python-native` only if the chosen client loads native extensions in-process.
+
+Sifr rejects callback contracts that hide storage, omit shutdown behavior, or capture values that cannot cross the declared thread boundary.
+
+## Package setup
+
+Install `kafka-python` in the root uv project:
+
+```toml sifr.toml
+[trust]
+python = ["kafka"]
+```
+
+```bash
+sifr python check
+sifr python doctor
+```
+
+## Bridge the poll-and-callback workflow
+
+```python src/python_bridges/kafka_consumer.py
+import threading
+
+from kafka import KafkaConsumer
+
+
+def poll(handler, endpoint: str, topic: str) -> str:
+    consumer = KafkaConsumer(
+        topic,
+        bootstrap_servers=endpoint,
+        auto_offset_reset="earliest",
+        enable_auto_commit=False,
+        consumer_timeout_ms=30_000,
+    )
+    try:
+        for message in consumer:
+            payload = message.value.decode("utf-8")
+            return _invoke_foreign(handler, payload)
+    finally:
+        consumer.close()
+    raise RuntimeError("Kafka poll returned no message")
+
+
+def _invoke_foreign(handler, value: str) -> str:
+    results = []
+    errors = []
+
+    def invoke() -> None:
+        try:
+            results.append(handler(value))
+        except BaseException as error:  # rethrow on the declaration thread
+            errors.append(error)
+
+    worker = threading.Thread(target=invoke, name="sifr-kafka-callback")
+    worker.start()
+    worker.join(timeout=30)
+    if worker.is_alive():
+        raise RuntimeError("Kafka Sifr callback did not finish")
+    if errors:
+        raise errors[0]
+    if len(results) != 1:
+        raise RuntimeError("Kafka Sifr callback produced no result")
+    return results[0]
+```
+
+The bridge owns Kafka client lifetime. The foreign thread is intentional, so the Sifr declaration must use `dispatch=foreign`.
+
+## Declare the callback boundary
+
+```sifr
+from sifr.python import PythonError
+
+@python.callback(handler, lifetime=call, dispatch=foreign, concurrency=serial)
+@python(bridge.kafka_consumer.poll)
+def poll(
+    handler: Callable[[str], str],
+    endpoint: str,
+    topic: str,
+) -> Result[str, PythonError]: ...
+
+def acknowledge(message: str) -> str:
+    return "ack:" + message
+
+@blocking_io
+def consume_once(endpoint: str, topic: str) -> Result[str, PythonError]:
+    try:
+        return poll(acknowledge, endpoint, topic)
+    except PythonError as error:
+        raise error
+```
+
+| Policy | Why it is required here |
+| --- | --- |
+| `lifetime=call` | Drain the handler before `poll` returns. |
+| `dispatch=foreign` | kafka-python may enter from a worker thread. |
+| `concurrency=serial` | Reject overlapping handler entry instead of deadlocking on recursive waits. |
+
+Handler failures cross Python as `SifrCallbackError` and still return through the declared `Result` channel. If Python also fails, the Python error stays primary.
+
+## Retention and cleanup
+
+This example uses call-scoped callbacks. If the consumer must retain a handler across many polls, switch to `lifetime=result` or `lifetime=Self` on an opaque owner with `close`, `async_close`, `context`, or `async_context` cleanup. Owner shutdown must unregister first, reject new entries, drain accepted invocations, and release captures exactly once.
+
+## Next steps
+
+- Full callback and resource contracts: [Embedded Python Interop](/python-interop#callbacks)
+- Typed package objects without callbacks: [schwifty](/guides/interop/schwifty)
+- Native numerical work: [numpy](/guides/interop/numpy)

--- a/docs/guides/interop/numpy.mdx
+++ b/docs/guides/interop/numpy.mdx
@@ -1,0 +1,92 @@
+---
+title: "Multiply matrices with numpy"
+sidebarTitle: "numpy"
+description: "Call NumPy matrix multiplication through a typed Python bridge, with native trust and notes on buffer views."
+---
+
+This guide uses [NumPy](https://numpy.org/) to multiply matrices from Sifr. NumPy is a good Python interop example because most useful work is a small workflow, not a single primitive conversion, and the package loads a native extension.
+
+## Why this shape
+
+NumPy is both a Python import root and a native extension. Sifr treats those as separate trust decisions. Matrix multiplication also tends to involve temporary arrays, dtype choices, and result shaping. That adaptation belongs in a package-local Python bridge under `src/python_bridges/`.
+
+Five rules drive the NumPy path:
+
+1. **Authorize Python and native roots separately.** `[trust].python` allows execution; `[trust].python-native` allows loading the native extension in-process.
+2. **Keep the Sifr boundary typed.** Expose `multiply_matrices(...) -> Result[...]` from a bridge instead of leaking `ndarray` details into every caller.
+3. **Opaque Python values are non-send by default.** Do not assume a NumPy object can move across threads without an explicit contract.
+4. **Public Python calls are blocking.** Call NumPy from `@blocking_io` code, or offload from async Sifr.
+5. **Zero-copy is opt-in and fail-closed.** Buffer and DLPack declarations never silently copy. Use them only when you need a view, not for ordinary multiply-and-return workflows.
+
+## Package setup
+
+Install NumPy in the root uv project, then declare trust:
+
+```toml sifr.toml
+[trust]
+python = ["numpy"]
+python-native = ["numpy"]
+```
+
+```bash
+sifr python check
+sifr python doctor
+```
+
+Native trust is required because NumPy loads extension modules. That is the explicit exception to Sifr-attributable no-panic guarantees for the native root.
+
+## Bridge the multiply workflow
+
+Put adaptation code in the owning package's `src/python_bridges/`:
+
+```python src/python_bridges/linalg.py
+import numpy as np
+
+
+def multiply(left: list[list[float]], right: list[list[float]]) -> list[list[float]]:
+    product = np.matmul(np.asarray(left, dtype="float64"), np.asarray(right, dtype="float64"))
+    return product.tolist()
+```
+
+Ordinary static imports are inventoried. The bridge converts Sifr-friendly lists into NumPy arrays, multiplies, and returns plain nested lists again.
+
+## Declare and call
+
+```sifr
+from sifr.python import PythonError
+
+@python(bridge.linalg.multiply)
+def multiply_matrices(
+    left: list[list[float]],
+    right: list[list[float]],
+) -> Result[list[list[float]], PythonError]: ...
+
+@blocking_io
+def area_scale() -> Result[list[list[float]], PythonError]:
+    try:
+        return multiply_matrices(
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+        )
+    except PythonError as error:
+        raise error
+```
+
+`bridge.linalg.multiply` resolves only against this package's inventoried bridge modules. Generated binaries embed that bridge under an isolated runtime namespace; they do not read the `.py` file from disk at runtime.
+
+## When to use buffers instead
+
+Use `@python.buffer` when Sifr code must read or write array memory without copying the whole payload into nested lists:
+
+```sifr
+@python.buffer(bridge.numpy_buffer.make_range, access=write, layout=c_contiguous)
+def numpy_range(stop: int) -> Result[python.Buffer[int64], PythonError]: ...
+```
+
+Buffer values are affine and non-send. Release them explicitly or let ownership drop exactly once. Do not use buffer declarations for ordinary multiply-and-return helpers; keep those on the typed bridge path above.
+
+## Next steps
+
+- Buffer, Arrow, and DLPack contracts: [Embedded Python Interop](/python-interop#zero-copy-interop)
+- Simpler typed package call: [schwifty](/guides/interop/schwifty)
+- Callback-heavy brokers: [kafka-python](/guides/interop/kafka)

--- a/docs/guides/interop/reqwest.mdx
+++ b/docs/guides/interop/reqwest.mdx
@@ -1,0 +1,111 @@
+---
+title: "Send an HTTP request with reqwest"
+sidebarTitle: "reqwest"
+description: "Call reqwest through an async Sifr declaration and a local bridge that returns checked Result values."
+---
+
+This guide uses [reqwest](https://crates.io/crates/reqwest) to send an HTTP GET from Sifr. reqwest is a good async Rust interop example because real HTTP work usually needs a bridge: response shaping, error normalization, and an explicit async contract.
+
+## Why this shape
+
+A raw `reqwest::Client` API is richer than a Sifr declaration should expose. Status codes, body bytes, header maps, and error variants all need a stable Sifr-facing shape. That adaptation belongs in a local bridge under `src/bridges`.
+
+Four rules drive the reqwest path:
+
+1. **Async Rust targets need `async def`.** Sifr rejects hiding a future behind a sync declaration.
+2. **Futures are `Send` by default.** Current-thread-only futures need an explicit `@rust.async(thread_affinity=tokio_current_thread)` contract.
+3. **Bridges adapt; declarations stay typed.** Convert Rust types into Sifr records or `Result` channels in the bridge, then bind the bridge function with `@rust(...)`.
+4. **No hidden runtimes or blocking.** Sifr does not invent a Tokio runtime for you, and it rejects hiding `block_on` inside an async path.
+
+Direct `@rust(reqwest....)` bindings are only for Rust items whose signatures already match Sifr. Prefer a bridge for HTTP.
+
+## Package setup
+
+```toml Cargo.toml
+[dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+```
+
+```toml sifr.toml
+[rust]
+bridge-version = 1
+bridges = ["src/bridges"]
+
+[trust]
+rust-build-scripts = []
+rust-proc-macros = []
+native-links = []
+unsafe-rust-bridges = []
+rust-no-panic = []
+rust-panic-abort = []
+```
+
+Run `sifr bridge check` before you rely on the declaration in ordinary builds.
+
+## Write the bridge
+
+```rust src/bridges/http.rs
+pub struct HttpErrorBridge {
+    pub message: String,
+}
+
+pub async fn fetch_text(url: String) -> Result<String, HttpErrorBridge> {
+    let response = reqwest::get(url)
+        .await
+        .map_err(|error| HttpErrorBridge {
+            message: error.to_string(),
+        })?;
+    response
+        .text()
+        .await
+        .map_err(|error| HttpErrorBridge {
+            message: error.to_string(),
+        })
+}
+
+pub fn map_panic(message: &str) -> HttpErrorBridge {
+    HttpErrorBridge {
+        message: message.to_owned(),
+    }
+}
+```
+
+The bridge owns reqwest details. The Sifr side only sees `str` in and `Result[str, ...]` out.
+
+## Declare and call
+
+```sifr
+class HttpError(Error):
+    message: str
+
+@rust(bridge.http.fetch_text, panic=map_error(bridge.http.map_panic))
+async def fetch_text(url: str) -> Result[str, HttpError | RustPanicError]: ...
+
+async def load_health() -> Result[str, HttpError | RustPanicError]:
+    return await fetch_text("https://example.com/health")
+```
+
+`bridge.http.fetch_text` resolves to your package-local module under `src/bridges`. Panic mapping keeps Rust panics inside the declared error union.
+
+If you need status and body together, return a Sifr record from the bridge instead of a bare string:
+
+```sifr
+class HttpResponse:
+    status: uint32
+    body: str
+
+@rust(bridge.http.fetch, panic=map_error(bridge.http.map_panic))
+async def fetch(url: str) -> Result[HttpResponse, HttpError | RustPanicError]: ...
+```
+
+## What not to do
+
+- Do not call blocking reqwest APIs from async Sifr without an explicit blocking offload annotation and workflow.
+- Do not store borrowed response views across `await` points.
+- Do not expect Sifr to start Tokio for you outside the package's normal async runtime setup.
+
+## Next steps
+
+- Full async, opaque-handle, and panic contracts: [Rust Interop](/rust-interop)
+- Simpler direct binding: [blake3](/guides/interop/blake3)
+- Structured async in Sifr: [Async and Await](/concurrency/async-and-await)

--- a/docs/guides/interop/schwifty.mdx
+++ b/docs/guides/interop/schwifty.mdx
@@ -1,0 +1,87 @@
+---
+title: "Validate an IBAN with schwifty"
+sidebarTitle: "schwifty"
+description: "Embed CPython and call schwifty through typed opaque declarations to validate an IBAN."
+---
+
+This guide uses [schwifty](https://pypi.org/project/schwifty/) to validate an IBAN from Sifr. schwifty is a good first Python interop example because construction and attribute reads map cleanly onto typed opaque declarations.
+
+## Why this shape
+
+Embedded Python interop is not "write Python inside Sifr." Sifr embeds one uv-created CPython environment and calls installed packages through checked declarations.
+
+Four rules drive the schwifty path:
+
+1. **The root app owns the environment.** Sifr verifies a uv project (`.venv`, lock, interpreter). It does not run `uv sync` or invent a host-global Python.
+2. **Import roots need trust.** Declaring `@python(schwifty.IBAN)` creates a requirement; the root `[trust].python` list authorizes execution.
+3. **Python objects stay opaque.** An `IBAN` instance is not a Sifr record. Expose only the attributes and methods you need through `@python.opaque` and `@python.attr`.
+4. **Failures stay in `Result`.** Invalid IBANs and other Python exceptions become structured `PythonError` values. They do not unwind through Sifr user code.
+
+Prefer typed declarations for ordinary package calls. Use dynamic `Object` only when a boundary cannot be declared.
+
+## Package setup
+
+Install schwifty in the root uv project, then authorize the import root:
+
+```toml sifr.toml
+[trust]
+python = ["schwifty"]
+```
+
+Inspect the plan before building:
+
+```bash
+sifr python check
+sifr python doctor
+```
+
+## Declare the IBAN surface
+
+```sifr
+from sifr.python import PythonError
+
+@python.opaque(type=schwifty.IBAN, cleanup=drop)
+class Iban:
+    @python.attr(Self.country_code)
+    def country_code(self) -> Result[str, PythonError]: ...
+
+    @python.attr(Self.bank_code)
+    def bank_code(self) -> Result[str, PythonError]: ...
+
+    @python.attr(Self.account_code)
+    def account_code(self) -> Result[str, PythonError]: ...
+
+@python(schwifty.IBAN)
+def parse_iban(text: str) -> Result[Iban, PythonError]: ...
+```
+
+`@python(schwifty.IBAN)` binds the constructor. Invalid input fails through `PythonError` instead of raising across the Sifr boundary. `cleanup=drop` is enough here because IBAN values do not need deterministic close semantics beyond ordinary Python object lifetime.
+
+## Validate in application code
+
+Every public `sifr.python` call is `@blocking_io`. Keep the call on a blocking path, or offload it from async code:
+
+```sifr
+@blocking_io
+def validate_iban(text: str) -> Result[str, PythonError]:
+    try:
+        iban: Iban = parse_iban(text)
+        country: str = iban.country_code()
+        bank: str = iban.bank_code()
+        account: str = iban.account_code()
+        return country + ":" + bank + ":" + account
+    except PythonError as error:
+        raise error
+```
+
+Example input: `"DE89 3704 0044 0532 0130 00"`. On success you get the country, bank, and account components after schwifty's validation. On failure you get a checked `PythonError` with message, kind, exception type, traceback, and context.
+
+## Why not import schwifty like ordinary Python
+
+Sifr application code does not execute `import schwifty` as host Python would. The declaration is the import plan: Sifr inventories the root, probes the selected interpreter, and embeds the verified environment into the binary. That keeps environment ownership, trust, and conversion contracts compile-time visible.
+
+## Next steps
+
+- Full environment, trust, and binding reference: [Embedded Python Interop](/python-interop)
+- Native arrays next: [numpy](/guides/interop/numpy)
+- Foreign-thread callbacks: [kafka-python](/guides/interop/kafka)

--- a/docs/guides/python-developers/index.mdx
+++ b/docs/guides/python-developers/index.mdx
@@ -22,6 +22,9 @@ If you know Python, Sifr lets you keep much of the syntax while changing the con
   <Card title="Ownership and Mutability" icon="refresh-cw" href="/language/ownership">
     Learn `mut`, `own`, and borrow-by-default calls.
   </Card>
+  <Card title="Interop by library" icon="plug-zap" href="/guides/interop">
+    Walk through schwifty, NumPy, and Kafka before reading the full reference.
+  </Card>
 </CardGroup>
 
 ## Learning Sequence

--- a/docs/guides/rust-developers/index.mdx
+++ b/docs/guides/rust-developers/index.mdx
@@ -22,6 +22,9 @@ If you know Rust, Sifr's safety model will feel familiar, but the source languag
   <Card title="Rust Interop" icon="plug-zap" href="/rust-interop">
     Expose Rust crates and bridge modules through checked Sifr declarations.
   </Card>
+  <Card title="Interop by library" icon="book-open" href="/guides/interop">
+    Walk through blake3 and reqwest before reading the full reference.
+  </Card>
   <Card title="Build and Run" icon="terminal" href="/cli/build-run">
     Compile Sifr into native binaries.
   </Card>

--- a/docs/python-interop.mdx
+++ b/docs/python-interop.mdx
@@ -8,6 +8,8 @@ Sifr can embed one uv-created CPython environment in a compiled application. Use
 
 This is not Python source compatibility and not a generic `dlopen` layer. Prefer `sifr.*` for Sifr code; use `sifr.python` only when you intentionally cross into Python packages.
 
+For library-first walkthroughs, start with [schwifty](/guides/interop/schwifty), [NumPy](/guides/interop/numpy), or [kafka-python](/guides/interop/kafka).
+
 ## Package Setup
 
 The root application owns the Python environment. Sifr verifies and consumes it; it does not run `uv sync`, install packages, or fall back to host-global Python.

--- a/docs/rust-interop.mdx
+++ b/docs/rust-interop.mdx
@@ -8,6 +8,8 @@ Rust interop lets a Sifr package expose Rust-backed declarations while keeping t
 
 Rust interop is source-level Cargo integration. It is not Rust ABI loading, `dlopen`, or a C FFI layer.
 
+For library-first walkthroughs, start with [blake3](/guides/interop/blake3) or [reqwest](/guides/interop/reqwest).
+
 ## Package Setup
 
 Declare Rust dependencies in `Cargo.toml` and Sifr interop policy in `sifr.toml`:


### PR DESCRIPTION
## Summary
- Add a Guides → Interop section with one how-to page per library: blake3, reqwest, schwifty, NumPy, and kafka-python
- Each guide leads with the contracts that force Sifr's declaration style, then a minimal working path
- Wire the new pages into docs navigation and cross-link from the Rust/Python interop references and developer guide overviews

## Test plan
- [ ] Confirm Guides → Interop appears in Mintlify nav with all six pages
- [ ] Spot-check each library page for broken internal links
- [ ] Verify reference pages (`/rust-interop`, `/python-interop`) link to the new guides


Made with [Cursor](https://cursor.com)