### PR TITLE
Restore authoritative local validation

### DIFF
--- a/crates/sifr/src/explain_cli.rs
+++ b/crates/sifr/src/explain_cli.rs
@@ -61,22 +61,48 @@ fn source_tree_diagnostic_explanation(code: &str) -> Option<String> {
         .parent()?
         .parent()?
         .to_path_buf();
-    let path = repo_root.join("docs/errors").join(format!("{code}.md"));
+    let path = repo_root.join("docs/errors").join(format!("{code}.mdx"));
     let text = DiskSourceProvider::new().read_file(&path).ok()?;
-    let mut lines = text
-        .as_str()
-        .lines()
-        .filter(|line| !line.starts_with("<!--") && !line.starts_with('|'));
-    let title = lines.find(|line| line.starts_with("# "))?;
-    let summary = lines.find(|line| !line.trim().is_empty()).unwrap_or("");
+    let title = mdx_frontmatter_value(text.as_str(), "sidebarTitle: ")?;
+    let summary = mdx_frontmatter_value(text.as_str(), "description: ")?;
     Some(format!(
-        "{}\n\n{}\n\nDocs: https://docs.sifr.sh/errors/{code}",
-        title.trim_start_matches("# "),
-        summary,
+        "{title}\n\n{summary}\n\nDocs: https://docs.sifr.sh/errors/{code}"
     ))
+}
+
+#[cfg(debug_assertions)]
+fn mdx_frontmatter_value<'a>(text: &'a str, key: &str) -> Option<&'a str> {
+    let mut lines = text.lines();
+    if lines.next()? != "---" {
+        return None;
+    }
+    for line in lines {
+        if line == "---" {
+            return None;
+        }
+        if let Some(value) = line.strip_prefix(key) {
+            return Some(value.trim().trim_matches('"')).filter(|value| !value.is_empty());
+        }
+    }
+    None
 }
 
 #[cfg(not(debug_assertions))]
 fn source_tree_diagnostic_explanation(_code: &str) -> Option<String> {
     None
+}
+
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use super::source_tree_diagnostic_explanation;
+
+    #[test]
+    fn debug_explanation_reads_generated_mdx_frontmatter() {
+        let explanation = source_tree_diagnostic_explanation("SIFR-IMPORT-0001")
+            .expect("generated diagnostic MDX should be readable");
+        assert_eq!(
+            explanation,
+            "SIFR-IMPORT-0001\n\nForbidden private sysroot declaration import.\n\nDocs: https://docs.sifr.sh/errors/SIFR-IMPORT-0001"
+        );
+    }
 }

--- a/crates/sifr_diagnostics/src/bin/gen-error-docs.rs
+++ b/crates/sifr_diagnostics/src/bin/gen-error-docs.rs
@@ -184,9 +184,8 @@ fn check_active_doc_casing(repo_root: &Path, drift: &mut Vec<String>) {
         let is_mdx = path
             .extension()
             .is_some_and(|extension| extension.eq_ignore_ascii_case("mdx"));
-        let is_active_mdx = is_mdx
-            && actual_name.starts_with("SIFR-")
-            && !expected_names.contains(&actual_name);
+        let is_active_mdx =
+            is_mdx && actual_name.starts_with("SIFR-") && !expected_names.contains(&actual_name);
         if is_active_mdx {
             drift.push(format!(
                 "docs/errors contains orphan generated diagnostic page {actual_name}"
@@ -622,7 +621,10 @@ fn reference_error_codes_group(root: &mut Value) -> io::Result<&mut Map<String, 
         .iter_mut()
         .find(|tab| tab.get("tab").and_then(Value::as_str) == Some("Reference"))
         .ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidData, "docs.json missing Reference tab")
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "docs.json missing Reference tab",
+            )
         })?;
 
     let groups = reference_tab

--- a/crates/sifr_driver/src/python_binding.rs
+++ b/crates/sifr_driver/src/python_binding.rs
@@ -229,7 +229,7 @@ fn validate_declaration(
     }
     match declaration.return_type.as_deref() {
         Some(return_type) => {
-            validate_type(&declaration.name, return_type, module, class_names, errors)
+            validate_type(&declaration.name, return_type, module, class_names, errors);
         }
         None => errors.push(format!(
             "Python function '{}' has no resolved return type",
@@ -271,9 +271,7 @@ fn normalize_direct_type(
         }
     }
 
-    let Some(union_parts) = split_top_level(ty, '|') else {
-        return None;
-    };
+    let union_parts = split_top_level(ty, '|')?;
     if union_parts.len() > 1 {
         if !allow_option
             || union_parts.len() != 2
@@ -286,16 +284,12 @@ fn normalize_direct_type(
         return Some(format!("{normalized} | None"));
     }
 
-    let Some(open) = ty.find('[') else {
-        return None;
-    };
+    let open = ty.find('[')?;
     if !ty.ends_with(']') {
         return None;
     }
     let base = ty[..open].trim();
-    let Some(arguments) = split_top_level(&ty[open + 1..ty.len() - 1], ',') else {
-        return None;
-    };
+    let arguments = split_top_level(&ty[open + 1..ty.len() - 1], ',')?;
     match base {
         "list" if arguments.len() == 1 => {
             normalize_direct_type(arguments[0], module, class_names, true)

--- a/crates/sifr_lowering/src/lower/ownership_diagnostics.rs
+++ b/crates/sifr_lowering/src/lower/ownership_diagnostics.rs
@@ -121,8 +121,7 @@ pub(in crate::lower) fn must_use_reusable_callable_capture(
     ctx.error_with_code_at(
         DiagnosticCode::PYZC_INVALID_DECLARATION,
         format!(
-            "{callable_kind} cannot capture '{name}' of type '{}' because reusable callables cannot own or repeatedly expose an affine or must-use Python resource",
-            captured_resource
+            "{callable_kind} cannot capture '{name}' of type '{captured_resource}' because reusable callables cannot own or repeatedly expose an affine or must-use Python resource"
         ),
         range,
     );

--- a/plans/reviews/active/authoritative-local-validation-restoration-claude-opus-review-pass-1.md
+++ b/plans/reviews/active/authoritative-local-validation-restoration-claude-opus-review-pass-1.md
@@ -1,0 +1,32 @@
+I inspected every file in the intended diff and independently verified the load-bearing claims rather than accepting the summary.
+
+## Verification performed
+
+**A. MDX migration**
+- `docs/errors/` contains 205 `.mdx` per-code pages and zero per-code `.md` files; the only `.md` is `diagnostic-codes.md`, which `gen-error-docs.rs:56,164,283` still generates *intentionally* alongside `diagnostic-codes.mdx` (dual index: relative-markdown + Mintlify route). So the canonicalization check reading `docs/errors/diagnostic-codes.md` at line 135 is correct, not stale.
+- Every other consumer had **already** migrated: `registry_tests.rs:60,128`, `code_baseline_coverage.py:172`, `scripts/check_docs_error_code_links.py:29` all expect `.mdx`. `code_coverage.py:174` and the canonicalization check were the last two `.md` stragglers. Migration is now complete — no remaining `.md` per-code assumptions anywhere in `crates/`, `scripts/`, `verification/`.
+- `explain_cli.rs`: frontmatter parser is sound against the real corpus — I checked all 205 files: every `sidebarTitle`/`description` is a single-line, double-quoted value with no embedded escaped quotes, so `trim_matches('"')` cannot corrupt a value. The `---` terminator guard and the empty-value `.filter()` prevent body content leaking in.
+- Not a fallback: dropping `.unwrap_or("")` means a malformed page returns `None` and `diagnostic_explanation` falls through to `registry_entry` (`explain_cli.rs:51`) — an existing, correct path, not a new one. The debug path is `#[cfg(debug_assertions)]`-gated with a release counterpart; no behavior change shipped.
+- `gen-error-docs.rs`: both hunks are pure rustfmt reflow. No logic touched.
+- Canonicalization self-test seed now writes real MDX frontmatter and `.mdx` index links, matching the production index format I confirmed at `diagnostic-codes.md:76`.
+
+**B. Clippy drift — no semantics hidden in the rewrites**
+- `python_binding.rs:232`: `validate_declaration` returns `()` (confirmed at line 180) and `validate_type` returns `()` (line 247). The added semicolon is a no-op.
+- Three `let-else { return None }` → `?` conversions are all inside `normalize_direct_type`, which returns `Option<String>`. Exactly equivalent.
+- `ownership_diagnostics.rs:124`: inlining `{captured_resource}` produces a byte-identical message string; same `Display` impl, same variable.
+
+**C. Ruff evidence is honest**
+- Submodule gitlink is pinned at `e024f2a487` — the JSON now matches reality; it previously claimed `8111415`, which was the drift.
+- `8111415..e024f2a` is exactly **one commit**, `crates/ruff_python_parser/src/parser/expression.rs`, +1/−2. I read the diff: it joins a wrapped `matches!(...) && self.at(TokenKind::Async)` onto one line in `rust_async_attribute_is_allowed`. Semantically inert. The "rustfmt-only follow-up to the rust.async decorator parser guard" rationale is accurate, and token fixture expectations legitimately need no regeneration.
+
+## Findings
+
+**No actionable findings.** Two non-blocking notes:
+
+1. *(informational, test coverage)* `mdx_frontmatter_value`'s negative branches — missing opening `---`, key absent before the closing `---`, empty value — are untested. Low value: all three degrade to the registry path, which now yields byte-identical output (`sidebarTitle` == `entry.id`, `description` == `entry.summary`). Not worth a test in a baseline-restoration PR.
+
+2. *(PR hygiene, not a code finding)* The working tree also carries `plans/issues/active/ad-hoc-class-field-mutating-receiver-place-semantics.md` (+870) and eight untracked `plans/reviews/active/*` files belonging to the other agent. Stage this PR by explicit path — a `git add -A` would sweep them in.
+
+## Verdict
+
+**Approved.** This is a valid, tightly focused prerequisite PR. All three groups are genuine root-cause corrections of validation drift on `origin/main` — a stale docs extension assumption, two real Clippy violations, and a fixture revision that disagreed with the checked-in submodule pin. There is no scope creep into rust-interop hardening, no skip/fallback/panic introduced, and no semantic change disguised as a lint or format fix. Ready for the full `scripts/run_all_tests.sh --profile create-pr` lane and PR.

--- a/plans/reviews/active/authoritative-local-validation-restoration-claude-opus-review-pass-2.md
+++ b/plans/reviews/active/authoritative-local-validation-restoration-claude-opus-review-pass-2.md
@@ -1,0 +1,19 @@
+**Verdict: APPROVED — no changes requested.**
+
+Verification of the reworded rationale against ground truth:
+
+| Claim in new rationale | Status |
+|---|---|
+| Pin `e024f2a487…` | Matches submodule HEAD (`git submodule status` → `third_party/ruff e024f2a4870568734a3b215226570aab87e396a2`) |
+| "rustfmt-only adjustment" | Confirmed. `git diff 8111415..e024f2a` = 1 file, +1/−2: `crates/ruff_python_parser/src/parser/expression.rs`, joining a two-line `matches!(…) && self.at(…)` into one line. Semantically identical; commit message is "Format rust.async attribute guard in expression parser." |
+| "to the rust.async decorator parser guard" | Accurate — the touched fn is `rust_async_attribute_is_allowed`, the guard admitting `rust.async` decorator attributes |
+| "token fixture expectations remain unchanged" | Confirmed — the 5 fixture diffs are pin-only (`ruff_fork_revision` line); `expected_token_kinds` arrays untouched |
+| Banned term removed | `grep` for `follow-up`/`followup` in the file returns nothing; `follow-up` is indeed on the banned list at `verification/areas/coverage_matrix/checks/verification_taxonomy.py:100`, and none of the replacement words hit any other banned pattern |
+
+Checks re-run locally: verification taxonomy → ok; ruff fork update rules → PASS.
+
+Two notes, neither actionable:
+- The one claim I could not re-derive from the repo is "the focused parser test passes" — that's a runtime assertion, not a file fact. It's consistent with the upstream commit being a pure reformat, so it can't have regressed.
+- Dropping "Production" and "merged" from the prior wording narrows nothing technically; the remaining sentence is strictly more precise than the version it replaces (it now names the actual nature of the commit rather than describing it as an attribute-admitting change, which was the *previous* commit `8111415`).
+
+No files modified. Ad-hoc class-field work ignored as instructed.

--- a/plans/reviews/active/diagnostic-mdx-code-coverage-claude-opus-review-pass-1.md
+++ b/plans/reviews/active/diagnostic-mdx-code-coverage-claude-opus-review-pass-1.md
@@ -1,0 +1,31 @@
+## Verdict: **Approve** — the one-line change is correct, minimal, and fixes the gate at its root.
+
+### Verification performed
+
+**Diff scope** — exactly one line, one file, as intended (`verification/areas/diagnostics/checks/code_coverage.py:174`, `.md` → `.mdx`). No other tracked change on the branch aside from the excluded parallel-work artifacts. Note: the branch has **zero commits vs `main`** — the fix is working-tree-only.
+
+**Canonical file set** — `git ls-files docs/errors` = 206: 204 per-code `.mdx` pages + `diagnostic-codes.mdx` + `diagnostic-codes.md` (the index, intentionally dual-emitted by `gen-error-docs.rs:56-60`). **Zero** per-code `.md` files exist.
+
+**Root cause, not symptom** — I reproduced the pre-fix state: with `.md`, all **204/204** active codes fail the docs-page assertion; with `.mdx`, **0** fail. The check was the stale artifact, not the docs. This is confirmed by three independent authorities:
+- `crates/sifr_diagnostics/src/bin/gen-error-docs.rs:176-180` treats `<CODE>.md` as an *"obsolete markdown stub"* and flags it as drift.
+- `crates/sifr_diagnostics/src/codes/registry.rs:626` — `docs_path: "docs/errors/<ID>.mdx"`.
+- `code_baseline_coverage.py:172-173` — `docs_link must be docs/errors/{code}.mdx`; the catalog's 204 `docs_link` entries are all `.mdx`. **Exact match** with the fixed check.
+
+**No fallback/skip** — the error path is unchanged; a missing page still hard-fails. The edit narrows nothing.
+
+**Validation run**
+- `code_coverage.py` standalone → exit 0
+- diagnostics `rules` suite (all 5 cases: schema_sync, docs_sync, code_coverage, baseline_hygiene, code_baseline_coverage) → `variants=5, failures=0`
+- `scripts/check_file_size_guardrails.py` → PASS (2821 files)
+- `scripts/check_docs_error_code_links.py` → PASS
+
+### Non-blocking observations (pre-existing on `main`, outside this diff's scope)
+
+Two sibling `.md` references survive elsewhere. Neither is a *companion mutation* this diff requires — both are independently broken/degraded on `main` and neither gates create-PR:
+
+1. `verification/areas/developer_tooling/check_diagnostic_source_canonicalization_rules.py:147,155` still asserts `docs/errors/<CODE>.md`. Running it today: `FAIL: SIFR-IMPORT-0005 docs page missing`. It is **not wired into any manifest or profile**, so it doesn't affect the gate — but `internal_docs/typescript_go_architecture_transfer_editor_corpus_snapshot_handles.md:49` claims it passes. Worth a separate PR.
+2. `crates/sifr/src/explain_cli.rs:64` — the `debug_assertions`-only source-tree lookup reads `{code}.md`, so it now always returns `None` and silently falls back to the registry summary. Cosmetic degradation, no test covers it.
+
+### Readiness
+
+Ready for create-PR validation and PR, with one mechanical prerequisite: commit the single `code_coverage.py` hunk in isolation — the working tree also holds the unrelated `ad-hoc-class-field-mutating-receiver-place-semantics` plan edit and seven untracked review artifacts that must not enter this commit.

--- a/plans/reviews/active/diagnostic-mdx-code-coverage-claude-opus-review-pass-2.md
+++ b/plans/reviews/active/diagnostic-mdx-code-coverage-claude-opus-review-pass-2.md
@@ -1,0 +1,61 @@
+## Pass 2 — diagnostic MDX migration prerequisite
+
+Reviewed the complete four-file diff (`explain_cli.rs`, `gen-error-docs.rs`, `check_diagnostic_source_canonicalization_rules.py`, `code_coverage.py`) and re-ran validation myself.
+
+### Actionable findings
+
+**1. [Low — blocking under the no-findings bar] New clippy `uninlined_format_args` warning on the rewritten `format!`** — `crates/sifr/src/explain_cli.rs:68`
+
+```
+warning: variables can be used directly in the `format!` string
+  --> crates/sifr/src/explain_cli.rs:68:10
+```
+
+This is newly introduced, not pre-existing: I reproduced both forms in an isolated crate, and only the new one lints. The old code passed `title.trim_start_matches("# ")` (a non-inlinable expression), which suppresses the lint for the whole call; now both args are plain bindings, so it fires. Fix:
+
+```rust
+    Some(format!(
+        "{title}\n\n{summary}\n\nDocs: https://docs.sifr.sh/errors/{code}"
+    ))
+```
+
+Caveat for fairness: `cargo clippy --workspace -- -D warnings` is already red on `main` (`sifr_lowering` fails it), and clippy is not wired into `scripts/run_all_tests.sh`, so this will not fail the create-PR lane. It is still a new warning in a touched line and a one-line fix.
+
+**2. [Low] Debug explain output now repeats itself and diverges from the release path** — `explain_cli.rs:66-71`
+
+`title` frontmatter is `"{id}: {summary}"` and `description` is `{summary}`, so `sifr --explain SIFR-IMPORT-0001` in debug prints:
+
+```
+SIFR-IMPORT-0001: Forbidden private sysroot declaration import.
+
+Forbidden private sysroot declaration import.
+```
+
+Previously line 2 was the body prose ("`SIFR-IMPORT-0001` belongs to the … family. It means: …"), so the second line carried new information. Release builds print bare `entry.id` on line 1. Reading `sidebarTitle: ` (which is exactly the id) instead of `title: ` would remove the duplication and make debug output match the registry fallback exactly. Cosmetic and debug-only, but it is a behavior change the diff doesn't acknowledge.
+
+### Non-blocking observations
+
+- **No YAML unescaping.** `gen-error-docs.rs:483` escapes `\` and `"` into the quoted scalar; the reader does `.trim().trim_matches('"')` with no inverse. A summary containing a quote would render with literal `\"`, and `trim_matches` strips repeated trailing quotes. I scanned all 204 generated `SIFR-*.mdx` pages with the reader's exact semantics: every one yields non-empty `title` and `description`, and none contains an escape. Zero current impact; only latent.
+- **CRLF.** `lines.next()? != "---"` and `line == "---"` would both miss `---\r`. Repo files are LF-generated, so not reachable today.
+- **Test strength.** The single assertion is a prefix check on `title` only, hardcoding registry summary text, with no `assert!` message. It does prove `description` parsed non-`None` (otherwise `source_tree_diagnostic_explanation` returns `None` and `expect` fires), but not its content, and nothing covers the frontmatter terminator (a body line `title: …` after the closing `---` must not be picked up). Adequate for the prerequisite; worth a second case if this parser grows.
+- **Fixtures no longer mirror real pages.** `seed_minimal_repo` writes `# {code}\n` into `.mdx` files with no frontmatter. Existing checks only test existence/substring, so it passes, but the fixture shape has drifted from generated output. Seeded index links use `({code}.mdx)`, which does match the real `diagnostic-codes.md:76` link style — good.
+- **`gen-error-docs.rs` scope.** Both hunks are pure whitespace/`rustfmt` output, justified because `main` fails `cargo fmt --check`. Worth one line in the PR description so it doesn't read as an unexplained touch.
+
+### Scope and stale-consumer sweep
+
+- Only the four intended files are in scope. The parallel `ad-hoc-class-field-mutating-receiver-place-semantics` plan edit and the seven review artifacts are untouched by this diff and excluded.
+- Repo-wide sweep for per-code `.md` consumers is clean. Every live reference now uses `.mdx` (`registry.rs:626`, `registry_tests.rs:60`, `code_baseline_coverage.py:172`, `code_catalog.json`, plus the two migrated checks). The only remaining `SIFR-*-NNNN.md` hits are historical prose in `plans/issues/archive/` and `plans/reviews/archive/`. The dual-emitted `docs/errors/diagnostic-codes.md` index correctly stays `.md` (`gen-error-docs.rs:56`, `registry.rs:877`, canonicalization check line 135 and the seeded index write).
+
+### Validation I ran
+
+- `cargo fmt --check` (workspace) — pass.
+- `check_diagnostic_source_canonicalization_rules.py` normal — PASS; `--self-test` — PASS.
+- `verification/areas/diagnostics/checks/code_coverage.py` — exit 0.
+- `cargo test -p sifr debug_explanation_reads_generated_mdx_frontmatter` — 1 passed.
+- Independent scan of all 204 generated pages against the reader's parsing semantics — all extract non-empty title/description.
+
+I did not run the full diagnostics area 5/5, the docs error link guard, or the file-size guard; I'm taking those from your report. `explain_cli.rs` is 108 lines, well under the cap.
+
+### Verdict
+
+**Changes requested.** One actionable fix — inline the format args at `explain_cli.rs:68`. Finding 2 is a judgment call worth a decision (keep `title:` and accept the duplicated line, or switch to `sidebarTitle:` for release parity). The migration itself is correct, complete, and root-cause: all stale per-code `.md` consumers are gone, the dual-emitted index is correctly preserved, no unwrap/panic/fallback was introduced, and scope is clean. With finding 1 applied it is ready for full create-PR validation and PR.

--- a/plans/reviews/active/diagnostic-mdx-code-coverage-claude-opus-review-pass-3.md
+++ b/plans/reviews/active/diagnostic-mdx-code-coverage-claude-opus-review-pass-3.md
@@ -1,0 +1,45 @@
+## Pass 3 — final verdict: **Approved**
+
+No actionable findings remain. Both pass-2 findings are resolved and verified empirically, not just by inspection.
+
+### Finding 1 — `uninlined_format_args`: resolved
+`explain_cli.rs:68-70` now uses fully inline captures. Verified directly rather than by reading:
+
+```
+cargo clippy -p sifr --lib --all-targets --message-format short | grep '^crates/sifr/src/explain_cli'
+→ (no output)
+```
+
+Zero clippy warnings of any kind attributable to `explain_cli.rs`, test module included. `cargo clippy -p sifr -- -D warnings` still hard-fails, but only at `crates/sifr_lowering/src/lower/ownership_diagnostics.rs:123` — `git diff origin/main` on that file is empty and its last touch is `a803b4ddc`, so it is the pre-existing failure identified in pass 2, in a dependency crate that clippy compiles before `sifr`. That is why the `-D warnings` run cannot itself reach the touched code; the `--all-targets` run above does, and is clean.
+
+### Finding 2 — debug/release divergence: resolved
+`explain_cli.rs:66-67` reads `sidebarTitle: ` + `description: `. Parity is now exact, not just structural: `registry/registry_entries/parsing_names_and_types.rs:164` holds `"Forbidden private sysroot declaration import."`, byte-identical to the page's `description`, and `sidebarTitle` is the bare id. So debug output equals the release `registry_entry` fallback string exactly, and the duplicated summary line is gone.
+
+### Exact-output test — sound
+`cargo test -p sifr debug_explanation_reads_generated_mdx_frontmatter` → 1 passed. The `assert_eq!` on the whole string now covers both extracted fields and the joining format, which the pass-2 prefix check did not. Coupling to registry summary text is intentional drift detection — `gen-error-docs`'s own drift check already enforces registry↔docs sync, so there is no new maintenance surface beyond that one string.
+
+### Fixtures — sound
+`seed_minimal_repo` writes real YAML frontmatter (`title`/`sidebarTitle`/`description`) matching generated page shape. `check_legacy_code_docs`' two substring requirements (`replacement` present, `"legacy"` case-insensitive) are satisfied by the legacy fixture's frontmatter, and the negative self-test fixture at line 588 correctly still fails. Seeded index links use `{code}.mdx`, matching `diagnostic-codes.md:76`. Both `--self-test` and the real-repo run pass, so the `.md`→`.mdx` change is exercised against actual files, not only fixtures.
+
+Independent re-scan of all 204 `docs/errors/SIFR-*.mdx` with the reader's exact semantics: every page yields non-empty `sidebarTitle` (== filename stem) and `description`, no backslash escapes in frontmatter, no CRLF. The unescaping and CRLF gaps noted in pass 2 remain latent with zero reachable impact.
+
+### `gen-error-docs.rs` scope — justified, confirmed
+Extracted origin/main's copy and ran `rustfmt --check`: it reproduces exactly these two hunks and nothing else. Pure formatting fix for a file that was unformatted on main; no logic change. Worth one line in the PR description.
+
+### Validation run this pass
+| Gate | Result |
+|---|---|
+| canonicalization normal | PASS (exit 0) |
+| canonicalization `--self-test` | PASS (exit 0) |
+| `cargo test -p sifr debug_explanation_reads_generated_mdx_frontmatter` | 1 passed |
+| diagnostics area checks | 5/5 PASS |
+| `scripts/check_docs_error_code_links.py` | PASS |
+| `cargo fmt --check` (workspace) | PASS |
+| `scripts/check_file_size_guardrails.py` | PASS (2821 files, limit 900) |
+| `cargo clippy -p sifr -- -D warnings` | fails only at pre-existing `sifr_lowering` site |
+
+Also swept the repo for stale per-code `.md` consumers: clean. The two remaining `.md` references in `gen-error-docs.rs` are both correct and untouched by this diff — `error_page_examples/{code}.md` (170 genuine `.md` source fragments) and `remove_obsolete_markdown_stubs`, which deliberately deletes leftover `SIFR-*.md` stubs and cannot match `.mdx`. Everything else is archived prose under `plans/`.
+
+Scope is clean: only the four intended files. The `ad-hoc-class-field-mutating-receiver-place-semantics` plan edit and the seven review artifacts are excluded, as instructed. I modified nothing — note that `plans/reviews/active/diagnostic-mdx-code-coverage-claude-opus-review-pass-3.md` exists but is empty (0 bytes); say the word if you want this verdict written into it.
+
+**Ready for full create-PR validation and PR.**

--- a/verification/areas/developer_tooling/check_diagnostic_source_canonicalization_rules.py
+++ b/verification/areas/developer_tooling/check_diagnostic_source_canonicalization_rules.py
@@ -144,7 +144,7 @@ def check_registry_and_docs(root: Path) -> None:
         )
         require(f'"{code}"' in entries, f"{code} missing active registry entry")
         require(
-            (root / f"docs/errors/{code}.md").is_file(),
+            (root / f"docs/errors/{code}.mdx").is_file(),
             f"{code} docs page missing",
         )
         require(f"[`{code}`]" in docs_index, f"{code} missing from diagnostic docs index")
@@ -152,7 +152,7 @@ def check_registry_and_docs(root: Path) -> None:
 
 def check_legacy_code_docs(root: Path) -> None:
     for legacy, replacement in LEGACY_WORKSPACE_IMPORT_CODES.items():
-        text = read_text(root, f"docs/errors/{legacy}.md")
+        text = read_text(root, f"docs/errors/{legacy}.mdx")
         require(
             replacement in text and "legacy" in text.lower(),
             f"{legacy} docs must name legacy replacement {replacement}",
@@ -481,10 +481,28 @@ def seed_minimal_repo(root: Path) -> None:
     )
     index_lines = []
     for code in NEW_IMPORT_CODES:
-        write(root / f"docs/errors/{code}.md", f"# {code}\n")
-        index_lines.append(f"| [`{code}`]({code}.md) | Error | seeded. |")
+        write(
+            root / f"docs/errors/{code}.mdx",
+            (
+                "---\n"
+                f'title: "{code}: seeded."\n'
+                f'sidebarTitle: "{code}"\n'
+                'description: "seeded."\n'
+                "---\n"
+            ),
+        )
+        index_lines.append(f"| [`{code}`]({code}.mdx) | Error | seeded. |")
     for legacy, replacement in LEGACY_WORKSPACE_IMPORT_CODES.items():
-        write(root / f"docs/errors/{legacy}.md", f"# {legacy}\nLegacy alias for {replacement}.\n")
+        write(
+            root / f"docs/errors/{legacy}.mdx",
+            (
+                "---\n"
+                f'title: "{legacy}: Legacy alias for {replacement}."\n'
+                f'sidebarTitle: "{legacy}"\n'
+                f'description: "Legacy alias for {replacement}."\n'
+                "---\n"
+            ),
+        )
     write(root / "docs/errors/diagnostic-codes.md", "\n".join(index_lines))
     for fixture in PARSER_FIXTURES:
         write(
@@ -567,7 +585,7 @@ def run_self_tests() -> None:
     expect_self_test_failure(
         "missing legacy migration docs",
         "docs must name legacy replacement",
-        lambda root: write(root / "docs/errors/SIFR-WORKSPACE-0104.md", "# legacy\n"),
+        lambda root: write(root / "docs/errors/SIFR-WORKSPACE-0104.mdx", "# legacy\n"),
     )
 
     spanless = CommandResult(

--- a/verification/areas/diagnostics/checks/code_coverage.py
+++ b/verification/areas/diagnostics/checks/code_coverage.py
@@ -171,7 +171,7 @@ def main() -> int:
             errors.append(f"{code} is active in the registry but missing from ACTIVE_DIAGNOSTIC_CODES")
         if not fixture_file_exists(fixture):
             errors.append(f"{code} representative fixture does not exist: {fixture}")
-        docs_page = ROOT / "docs" / "errors" / f"{code}.md"
+        docs_page = ROOT / "docs" / "errors" / f"{code}.mdx"
         if not docs_page.exists():
             errors.append(f"{code} active docs page is missing: {docs_page.relative_to(ROOT)}")
 

--- a/verification/areas/performance/ruff_fork_revalidation.json
+++ b/verification/areas/performance/ruff_fork_revalidation.json
@@ -1,6 +1,6 @@
 {
-  "ruff_fork_revision": "8111415495271a09f9ee89cb168fde669db240d8",
+  "ruff_fork_revision": "e024f2a4870568734a3b215226570aab87e396a2",
   "validated_by": "verification/areas/performance/check_ruff_fork_update_rules.py",
   "fixture_directory": "verification/areas/performance/sifr_syntax_token_fixtures",
-  "rationale": "Production formatter AST coverage revalidation for the merged Sifr Ruff decorator attribute update. Commit 8111415495271a09f9ee89cb168fde669db240d8 admits rust.async decorator attributes; representative Sifr token fixture expectations remain valid for the checked-in fork pin."
+  "rationale": "Formatter AST coverage revalidation for the checked-in Sifr Ruff fork. Commit e024f2a4870568734a3b215226570aab87e396a2 is a rustfmt-only adjustment to the rust.async decorator parser guard; the focused parser test passes and representative Sifr token fixture expectations remain unchanged."
 }

--- a/verification/areas/performance/sifr_syntax_token_fixtures/async_and_error_handling.json
+++ b/verification/areas/performance/sifr_syntax_token_fixtures/async_and_error_handling.json
@@ -1,7 +1,7 @@
 {
   "id": "async-and-error-handling",
   "source_path": "inline",
-  "ruff_fork_revision": "8111415495271a09f9ee89cb168fde669db240d8",
+  "ruff_fork_revision": "e024f2a4870568734a3b215226570aab87e396a2",
   "source": "async def fetch() -> Result[str, Error]:\n    result = await worker()\n    if result.is_err():\n        return Err(ValueError(\"failed\"))\n    return Ok(result.unwrap())\n",
   "expected_token_kinds": [
     "Async",

--- a/verification/areas/performance/sifr_syntax_token_fixtures/basic_module.json
+++ b/verification/areas/performance/sifr_syntax_token_fixtures/basic_module.json
@@ -1,7 +1,7 @@
 {
   "id": "basic-module",
   "source_path": "inline",
-  "ruff_fork_revision": "8111415495271a09f9ee89cb168fde669db240d8",
+  "ruff_fork_revision": "e024f2a4870568734a3b215226570aab87e396a2",
   "source": "from helper import value\n\ndef main():\n    reveal_type(value)\n",
   "expected_token_kinds": [
     "From",

--- a/verification/areas/performance/sifr_syntax_token_fixtures/class_and_methods.json
+++ b/verification/areas/performance/sifr_syntax_token_fixtures/class_and_methods.json
@@ -1,7 +1,7 @@
 {
   "id": "class-and-methods",
   "source_path": "inline",
-  "ruff_fork_revision": "8111415495271a09f9ee89cb168fde669db240d8",
+  "ruff_fork_revision": "e024f2a4870568734a3b215226570aab87e396a2",
   "source": "class Counter:\n    value: int\n\n    def inc(mut self, amount: int) -> int:\n        self.value = self.value + amount\n        return self.value\n",
   "expected_token_kinds": [
     "Class",

--- a/verification/areas/performance/sifr_syntax_token_fixtures/collections_and_generics.json
+++ b/verification/areas/performance/sifr_syntax_token_fixtures/collections_and_generics.json
@@ -1,7 +1,7 @@
 {
   "id": "collections-and-generics",
   "source_path": "inline",
-  "ruff_fork_revision": "8111415495271a09f9ee89cb168fde669db240d8",
+  "ruff_fork_revision": "e024f2a4870568734a3b215226570aab87e396a2",
   "source": "def total(values: list[int]) -> int:\n    acc: int = 0\n    for value in values:\n        acc = acc + value\n    return acc\n",
   "expected_token_kinds": [
     "Def",

--- a/verification/areas/performance/sifr_syntax_token_fixtures/control_flow_match.json
+++ b/verification/areas/performance/sifr_syntax_token_fixtures/control_flow_match.json
@@ -1,7 +1,7 @@
 {
   "id": "control-flow-match",
   "source_path": "inline",
-  "ruff_fork_revision": "8111415495271a09f9ee89cb168fde669db240d8",
+  "ruff_fork_revision": "e024f2a4870568734a3b215226570aab87e396a2",
   "source": "def classify(value: int) -> str:\n    if value < 0:\n        return \"negative\"\n    elif value == 0:\n        return \"zero\"\n    else:\n        match value:\n            case 1:\n                return \"one\"\n            case _:\n                return \"many\"\n",
   "expected_token_kinds": [
     "Def",


### PR DESCRIPTION
## Summary

- align diagnostic documentation consumers and canonicalization checks with the generated `.mdx` source of truth
- parse generated diagnostic frontmatter in `sifr explain` and cover it with a focused regression test
- clear existing workspace format/clippy failures without semantic changes
- refresh the checked-in Ruff fork revalidation provenance and syntax-fixture revisions to the repository gitlink

This prerequisite restores the repository authoritative local gate before the Rust interop hardening milestones are published.

## Validation

- `scripts/run_all_tests.sh --profile create-pr` — passed end to end
- 131/131 create-PR E2E fixtures passed
- all crate tests, verification areas, clippy, rustfmt, HIR maintainability, and file-size guardrails passed
- focused diagnostic, Ruff parser, frontend syntax, lowering, and driver checks passed

## Review

Claude Opus reviewed the diagnostic repair through three passes and the complete validation-restoration diff through two passes. The final reviews reported no actionable findings. Review records are included under `plans/reviews/active/`.
