### PR TITLE
Execute Rust interop area in authoritative profiles

### DIFF
--- a/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
+++ b/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
@@ -309,7 +309,7 @@ Focused commands vary by row and must be written into the item checklist before
 implementation. The minimum common gate is:
 
 ```bash
-uv run --project verification --locked python -m sifr_verify --area rust_interop
+uv run --project verification --locked python -m sifr_verify areas run --area rust_interop
 python3 verification/areas/rust_interop/checks/check_fixture_matrix.py --self-test
 python3 verification/areas/rust_interop/checks/check_compatibility_matrix.py --self-test
 python3 verification/areas/rust_interop/checks/check_tiers.py --self-test

--- a/plans/issues/active/rust-interop-verification-matrix-hardening.md
+++ b/plans/issues/active/rust-interop-verification-matrix-hardening.md
@@ -249,7 +249,7 @@ One documentation/review PR after `hardening_1` through `hardening_4`:
 Every item runs its focused self-test and the common local gates:
 
 ```bash
-uv run --project verification --locked python -m sifr_verify --area rust_interop
+uv run --project verification --locked python -m sifr_verify areas run --area rust_interop
 python3 verification/areas/rust_interop/checks/check_fixture_matrix.py --self-test
 python3 verification/areas/rust_interop/checks/check_compatibility_matrix.py --self-test
 python3 verification/areas/rust_interop/checks/check_tiers.py --self-test

--- a/plans/reviews/active/rust-interop-verification-matrix-hardening-1-claude-opus-review-pass-1.md
+++ b/plans/reviews/active/rust-interop-verification-matrix-hardening-1-claude-opus-review-pass-1.md
@@ -1,0 +1,37 @@
+## Review — `hardening_1` (Rust-interop area in authoritative profiles)
+
+**What's right.** The step is scheduled in the *same* registry execution uses: `run()` now consumes `legacy_facade_steps()` (`profile_runner.py:185,196`), and the self-test introspects that exact method, so deleting the step genuinely fails the self-test. Ordering is preserved. Staleness is handled at the source — `result_path.unlink(missing_ok=True)` before the run (`:477`), a per-profile result filename, and `--result-json` correctly plumbed through `areas.run_area` → `area_adapter.run_area`. Failure propagation is real: `blocking_failures > 0` → exit 1 → `CommandFailed`. Suite/area name typos in profile JSON are already rejected against the manifests. Budget measured at 0.43–0.60 s over three warm runs against 5000 ms blocking — appropriate headroom, no concern. `--emit-plan` confirmed to contain the selection for all four profiles; self-tests pass.
+
+### Findings
+
+**1. Medium-high — the new self-test can shell out to `cargo build` and leaks global env** (`selftest.py:293`)
+`ProfileRunner.__init__` calls `resolve_sifr_binary(...)`, which rebuilds the debug binary when it is missing *or stale* (`sifr_binary.py:36-38`; `_binary_is_stale` rglobs `crates/`, `stdlib/`, `third_party/ruff/crates`). Constructing a runner just to read a static step list drags that in. Verified by stubbing `_build_sifr_binary` and pointing `CARGO_TARGET_DIR` at an empty dir:
+
+```
+cargo build invocations triggered by self-test: ['<tmp>/debug/sifr']
+CARGO_NET_OFFLINE leaked: true
+PROBE_CACHE leaked: .../target/sifr_rust_bridge_probe_cache/release
+SIFR_GCQ_BIN leaked: <tmp>/debug/sifr
+```
+
+Failure scenario: on a clean checkout, or after editing any file under `crates/`, the mandated `uv run --project verification --locked python -m sifr_verify --self-test` turns from milliseconds into a full debug build; if that build fails it exits via `SystemExit(rc)` from `sifr_binary`, attributing a cargo failure to the runner self-test. It also permanently sets `CARGO_NET_OFFLINE=true` and pins the probe cache to the `release` profile for the rest of the process. In-lane this is masked because the parent runner already resolved the binary into `os.environ`, so it is standalone-only — but standalone is exactly how the plan's Required Validation invokes it.
+Fix: make step scheduling a pure function over profile data (it only needs `legacy_facade(profile)["generated_code_quality"]`), or make binary resolution lazy in `ProfileRunner`.
+
+**2. Medium — required suite set is hardcoded in three places, not derived from the area manifest** (`profiles.py:169-173`, `selftest.py:276-281`, four profile JSONs)
+Adding a fifth suite to `verification/areas/rust_interop/manifest.json` leaves it unexecuted in all four authoritative lanes while both the profile validator and the self-test still pass — the area would be under-executed silently, which is the failure mode this issue exists to prevent. The sibling `python_interop` path derives its required set from the capability matrix (`_compiled_evidence_suites()`). Derive the rust_interop set from the manifest's suite names the same way.
+
+**3. Medium — result-JSON mutation coverage is one-sided** (`selftest.py:311-329`)
+Only the missing-file branch is exercised. The branches that actually defend against a stale, truncated, or foreign artifact — suite-set mismatch, `area != "rust_interop"`, non-list `suites`, malformed JSON — have no test at all, so a regression that neuters them (e.g. `!=` → subset check) passes the self-test. Given the stated constraint "cannot silently accept missing or stale result artifacts", add at least the mismatch case: write a three-suite payload and assert it is rejected.
+
+**4. Low — the guard validates identity, not evidence** (`profile_runner.py:64-85`)
+`validate_rust_interop_result` never asserts `summary.blocking_failures == 0`, `suite["blocking"] is True`, or `total_variants > 0`. Today the area's nonzero exit covers real failures, so this is defense-in-depth only — but the function's name implies more than it checks, and it would not notice a zero-exit-with-failures path (e.g. anything bless-like) added later.
+
+**5. Low — one silent-skip path remains** (`profile_runner.py:466-468`)
+`validate_selected_area_suites` only enforces the four suites *if* a `rust_interop` selection exists; nothing requires a legacy-facade profile to select the area at all, and the step then prints `Skipping ...`. Only the hardcoded four-name loop in the self-test catches this, so a future legacy-facade profile would skip the area silently. Consistent with sibling steps and with the plan's literal wording, so acceptable — flagging because "no skips" was a stated constraint.
+
+**6. Low — README omits the executing profile command** (`verification/areas/rust_interop/README.md`)
+It gives the direct command and `--emit-plan`, but not `scripts/run_all_tests.sh --profile create-pr`, which is the command the exit gate names. Separately: the issue's own Required Validation line `python -m sifr_verify --area rust_interop` is not a valid CLI form — `--area` exists only under `areas run`. The README is correct; the plan text is stale and should be corrected (fine to defer to `hardening_5`).
+
+### Verdict
+
+**Not ready as-is.** Every hardening_1 bullet and exit-gate item is satisfied in substance, and the central design question — same registry for scheduling and execution, no stale-artifact acceptance — is answered correctly. But finding #1 is a genuine regression in a command the plan mandates, and #2/#3 leave the guarantee weaker than it reads. Fix #1, #2, and #3 in this PR (all small and local), then it is ready for create-PR validation. #4–#6 are optional.

--- a/plans/reviews/active/rust-interop-verification-matrix-hardening-1-claude-opus-review-pass-2.md
+++ b/plans/reviews/active/rust-interop-verification-matrix-hardening-1-claude-opus-review-pass-2.md
@@ -1,0 +1,39 @@
+## Review pass 2 — `hardening_1` (Rust-interop area in authoritative profiles)
+
+Reviewed the complete intended diff (10 files, +340/−30) — the paths listed match exactly; no stray files. Ad-hoc class-field review artifacts ignored.
+
+### Pass-1 findings: all six resolved
+
+| # | Pass-1 finding | Status | Evidence |
+|---|---|---|---|
+| 1 | Self-test shells out to `cargo build`, leaks env | **Fixed** | Step registry is now pure data (`profile_runner.py:64-92`, `legacy_facade_step_methods`); `selftest.py` imports only `legacy_facade_step_names` / `validate_rust_interop_result` — no `ProfileRunner`, no `resolve_sifr_binary`, no `os.environ` touch. Standalone `--self-test` runs in **0.157 s** total. `run()` consumes the same registry via `getattr` (`:257-262`), so scheduling and execution still share one source. |
+| 2 | Required suite set hardcoded | **Fixed** | `required_rust_interop_suites()` (`profiles.py:186-199`) derives from `verification/areas/rust_interop/manifest.json`, with empty/invalid/duplicate rejection. Verified live: injecting a 5th manifest suite fails all four profiles (`profile create-pr omits required Rust interop verification suites: runtime-ecosystem`); a duplicate name yields `manifest has invalid or duplicate suites`. |
+| 3 | One-sided mutation coverage | **Fixed** | `selftest.py:326-385` covers missing file, foreign `area`, incomplete suite set, non-list `suites`, `blocking_failures: 1`, and malformed JSON, plus a positive payload. |
+| 4 | Guard validated identity, not evidence | **Fixed** | `validate_rust_interop_result` now requires per-suite `blocking is True`, `total_variants > 0`, `total_failures == 0`, plus `summary.blocking_failures == 0` and `summary.total_variants > 0`. Field names verified against the real emitter (`area_adapter.py:71-89,151-159`). |
+| 5 | Silent-skip path if a profile omits the area | **Fixed** | `profiles.py:177-185` requires `rust_interop` in `selected_areas` for every non-`selected-areas-only` profile; `python-interop-live.json` (the only `selected-areas-only` profile) remains exempt. Self-test asserts both the missing-area and missing-suite rejections. |
+| 6 | README/plan commands | **Fixed** | README adds direct, `--profile create-pr`, and `--emit-plan` commands; all three verified to exist (`run_all_tests.sh:23-24`, `areas run --result-json` at `areas.py:126`). Both issue plans corrected to `python -m sifr_verify areas run --area rust_interop`, which I ran successfully. |
+
+Registry-deletion still fails loudly: removing the step entry in-memory made the self-test raise `create-pr omits the executable Rust interop step`.
+
+### Validation re-run locally
+
+- `py_compile` on all three runner modules: pass
+- `python -m sifr_verify --self-test`: 8/8 pass, incl. the new *Rust interop profile execution self-test*
+- Profile validation: `load_all_profiles()` clean; coverage-matrix profile-policy area passes (5 variants, 0 failures)
+- Direct area: `variants=4, failures=0, blocking_failures=0` (all four suites)
+- Focused step via the real code path: `[sifr-lane-step] name=rust_interop_checks elapsed_ms=504 status=pass` against a 5000 ms blocking budget (≈10× headroom)
+- `--emit-plan` for create-pr/merge/nightly/release: each contains the four-suite `rust_interop` selection
+- `git diff --check` clean; file-size guardrail PASS (2821 files)
+- Not run here: the full `scripts/run_all_tests.sh --profile create-pr` lane and `cargo clippy`/`fmt` (untouched by this diff) — run the create-PR lane before opening the PR, as the exit gate requires.
+
+### Findings
+
+No actionable findings. Three optional observations, none affecting the shipped guarantee:
+
+1. **Optional (test-coverage)** — `profile_runner.py:74-84`: the per-suite evidence branch added for pass-1 #4 has no mutation case; a regression deleting it still passes the self-test (the summary mutation only covers `summary.blocking_failures`). Two more entries in `invalid_payloads` (`blocking: False`, `total_failures: 1`) would close it. Beyond the mandated mutation set.
+2. **Optional (dead branch)** — `profile_runner.py:503-506`: the `Skipping Rust interop checks` path is now unreachable for any validated legacy-facade profile, since `profiles.py` requires the area *and* all manifest suites. Raising instead of printing would remove the last skip-shaped fallback.
+3. **Forward note** — requiring *every* manifest suite makes any future rust_interop suite (e.g. the external-crate runtime suites planned in `rust-interop-runtime-ecosystem-certification.md`) mandatory in create-PR, and the step executes selected suites without resource-class filtering. The failure is loud, not silent, so this is the correct default — just expect that issue to have to either scope such suites into create-PR or introduce an explicit profile-tier split.
+
+### Verdict
+
+**Approved.** All pass-1 findings are resolved at the root, not papered over; the scheduling/execution registry is single-sourced and pure, required suites are manifest-derived with invalid/duplicate rejection, result-JSON evidence is checked in substance with six mutation cases, and no silent-skip path remains for legacy-facade profiles. Ready for full create-PR validation and the PR.

--- a/verification/areas/rust_interop/README.md
+++ b/verification/areas/rust_interop/README.md
@@ -60,6 +60,26 @@ fixture evidence; they must not silently degrade to compile-only coverage.
 - `stale-drafts`: scans active planning and documentation paths for accepted
   examples of abandoned Rust interop syntax.
 
+Run the complete area directly with:
+
+```bash
+uv run --project verification --locked python -m sifr_verify areas run --area rust_interop
+```
+
+The authoritative create-PR, merge, nightly, and release profiles select all
+four suites and execute them through the `rust_interop_checks` legacy-facade
+step. Execute the create-PR profile with:
+
+```bash
+scripts/run_all_tests.sh --profile create-pr
+```
+
+Inspect the same profile's plan without executing it:
+
+```bash
+scripts/run_all_tests.sh --profile create-pr --emit-plan
+```
+
 ## Compatibility Categories
 
 - `supported`: positive and negative fixture evidence both pass for the stated

--- a/verification/profiles/create-pr.json
+++ b/verification/profiles/create-pr.json
@@ -12,6 +12,7 @@
     "diagnostic_rules": {"budget_ms": 90000, "enforcement": "blocking"},
     "cpython_differential": {"budget_ms": 30000, "enforcement": "blocking"},
     "python_interop": {"budget_ms": 600000, "enforcement": "blocking"},
+    "rust_interop_checks": {"budget_ms": 5000, "enforcement": "blocking"},
     "frontend_syntax_guardrails": {"budget_ms": 60000, "enforcement": "blocking"},
     "developer_tooling_checks": {"budget_ms": 180000, "enforcement": "blocking"},
     "performance_budget_checks": {"budget_ms": 120000, "enforcement": "blocking"},
@@ -90,6 +91,18 @@
     ]
   },
   "selected_areas": [
+    {
+      "area": "rust_interop",
+      "suites": [
+        "matrix",
+        "tiers",
+        "compatibility-matrix",
+        "stale-drafts"
+      ],
+      "resource_classes": [
+        "default-local"
+      ]
+    },
     {
       "area": "coverage_matrix",
       "suites": [

--- a/verification/profiles/merge.json
+++ b/verification/profiles/merge.json
@@ -70,6 +70,18 @@
   },
   "selected_areas": [
     {
+      "area": "rust_interop",
+      "suites": [
+        "matrix",
+        "tiers",
+        "compatibility-matrix",
+        "stale-drafts"
+      ],
+      "resource_classes": [
+        "default-local"
+      ]
+    },
+    {
       "area": "coverage_matrix",
       "suites": [
         "readiness"

--- a/verification/profiles/nightly.json
+++ b/verification/profiles/nightly.json
@@ -72,6 +72,18 @@
   },
   "selected_areas": [
     {
+      "area": "rust_interop",
+      "suites": [
+        "matrix",
+        "tiers",
+        "compatibility-matrix",
+        "stale-drafts"
+      ],
+      "resource_classes": [
+        "default-local"
+      ]
+    },
+    {
       "area": "coverage_matrix",
       "suites": [
         "readiness"

--- a/verification/profiles/release.json
+++ b/verification/profiles/release.json
@@ -71,6 +71,18 @@
   },
   "selected_areas": [
     {
+      "area": "rust_interop",
+      "suites": [
+        "matrix",
+        "tiers",
+        "compatibility-matrix",
+        "stale-drafts"
+      ],
+      "resource_classes": [
+        "default-local"
+      ]
+    },
+    {
       "area": "coverage_matrix",
       "suites": [
         "readiness"

--- a/verification/runner/sifr_verify/profile_runner.py
+++ b/verification/runner/sifr_verify/profile_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import json
 import os
 import resource
 import shutil
@@ -58,6 +59,94 @@ class Tee:
     def flush(self) -> None:
         for stream in self._streams:
             stream.flush()
+
+
+LEGACY_FACADE_STEPS_BEFORE_GENERATED = (
+    ("coverage_matrix_checks", "run_coverage_matrix_checks"),
+    ("core_guardrails", "run_core_guardrails"),
+    ("diagnostic_rules", "run_diagnostic_rules"),
+    ("cpython_differential", "run_cpython_differential_suites"),
+    ("python_interop", "run_python_interop_suites"),
+    ("rust_interop_checks", "run_rust_interop_checks"),
+    ("frontend_syntax_guardrails", "run_frontend_syntax_guardrails"),
+    ("developer_tooling_checks", "run_developer_tooling_checks"),
+    ("performance_budget_checks", "run_performance_budget_checks"),
+    ("verification_hardening_self_tests", "run_verification_hardening_self_tests"),
+    ("verification_runner_foundation", "run_verification_runner_foundation_checks"),
+    ("fuzz_property_checks", "run_fuzz_property_suites"),
+    ("algorithmic_compatibility_checks", "run_algorithmic_compatibility_suites"),
+    ("distribution_validation", "run_distribution_checks"),
+    ("sysroot_release_certification", "run_sysroot_release_checks"),
+)
+GENERATED_CODE_QUALITY_STEP = (
+    "generated_code_quality_checks",
+    "run_generated_code_quality_checks",
+)
+LEGACY_FACADE_STEPS_AFTER_GENERATED = (
+    ("crate_tests", "run_crate_tests"),
+    ("validation_suite_matrix", "run_validation_suites"),
+    ("runtime_platform_suites", "run_runtime_platform_suites"),
+    ("e2e_pass_suite", "run_e2e_pass_suite"),
+    ("verification_hardening_suites", "run_hardening_suites"),
+    ("extra_e2e_checks", "run_extra_e2e_checks"),
+)
+
+
+def legacy_facade_step_methods(profile: dict[str, Any]) -> list[tuple[str, str]]:
+    steps = list(LEGACY_FACADE_STEPS_BEFORE_GENERATED)
+    if legacy_facade(profile)["generated_code_quality"] != "none":
+        steps.append(GENERATED_CODE_QUALITY_STEP)
+    steps.extend(LEGACY_FACADE_STEPS_AFTER_GENERATED)
+    return steps
+
+
+def legacy_facade_step_names(profile: dict[str, Any]) -> set[str]:
+    return {name for name, _method_name in legacy_facade_step_methods(profile)}
+
+
+def validate_rust_interop_result(result_path: Path, expected_suites: list[str]) -> None:
+    if not result_path.is_file():
+        raise ProfileRunnerError(f"Rust interop area emitted no result JSON: {result_path}")
+    try:
+        payload = json.loads(result_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProfileRunnerError(f"Rust interop area emitted invalid result JSON: {result_path}") from exc
+    if not isinstance(payload, dict) or payload.get("area") != "rust_interop":
+        raise ProfileRunnerError(f"Rust interop area emitted an invalid result document: {result_path}")
+    raw_suites = payload.get("suites")
+    if not isinstance(raw_suites, list):
+        raise ProfileRunnerError(f"Rust interop result JSON has no suite results: {result_path}")
+    for suite in raw_suites:
+        if (
+            not isinstance(suite, dict)
+            or suite.get("blocking") is not True
+            or not isinstance(suite.get("total_variants"), int)
+            or int(suite["total_variants"]) <= 0
+            or suite.get("total_failures") != 0
+        ):
+            raise ProfileRunnerError(
+                f"Rust interop result JSON contains invalid suite evidence: {result_path}"
+            )
+    actual_suites = {
+        str(suite.get("name"))
+        for suite in raw_suites
+        if isinstance(suite, dict) and isinstance(suite.get("name"), str)
+    }
+    if actual_suites != set(expected_suites):
+        raise ProfileRunnerError(
+            "Rust interop result JSON suite mismatch: "
+            f"expected={sorted(expected_suites)} actual={sorted(actual_suites)}"
+        )
+    summary = payload.get("summary")
+    if (
+        not isinstance(summary, dict)
+        or summary.get("blocking_failures") != 0
+        or not isinstance(summary.get("total_variants"), int)
+        or int(summary["total_variants"]) <= 0
+    ):
+        raise ProfileRunnerError(
+            f"Rust interop result JSON contains invalid blocking summary: {result_path}"
+        )
 
 
 def run_command(command: list[str], *, env: dict[str, str] | None = None) -> None:
@@ -157,34 +246,7 @@ class ProfileRunner:
         if self.execution_mode == "selected-areas-only":
             return self.run_selected_areas_only()
 
-        steps: list[tuple[str, Callable[[], None]]] = [
-            ("coverage_matrix_checks", self.run_coverage_matrix_checks),
-            ("core_guardrails", self.run_core_guardrails),
-            ("diagnostic_rules", self.run_diagnostic_rules),
-            ("cpython_differential", self.run_cpython_differential_suites),
-            ("python_interop", self.run_python_interop_suites),
-            ("frontend_syntax_guardrails", self.run_frontend_syntax_guardrails),
-            ("developer_tooling_checks", self.run_developer_tooling_checks),
-            ("performance_budget_checks", self.run_performance_budget_checks),
-            ("verification_hardening_self_tests", self.run_verification_hardening_self_tests),
-            ("verification_runner_foundation", self.run_verification_runner_foundation_checks),
-            ("fuzz_property_checks", self.run_fuzz_property_suites),
-            ("algorithmic_compatibility_checks", self.run_algorithmic_compatibility_suites),
-            ("distribution_validation", self.run_distribution_checks),
-            ("sysroot_release_certification", self.run_sysroot_release_checks),
-        ]
-        if self.generated_code_quality_mode != "none":
-            steps.append(("generated_code_quality_checks", self.run_generated_code_quality_checks))
-        steps.extend(
-            [
-                ("crate_tests", self.run_crate_tests),
-                ("validation_suite_matrix", self.run_validation_suites),
-                ("runtime_platform_suites", self.run_runtime_platform_suites),
-                ("e2e_pass_suite", self.run_e2e_pass_suite),
-                ("verification_hardening_suites", self.run_hardening_suites),
-                ("extra_e2e_checks", self.run_extra_e2e_checks),
-            ]
-        )
+        steps = self.legacy_facade_steps()
 
         for name, callback in steps:
             result = timed_step(name, callback)
@@ -194,6 +256,12 @@ class ProfileRunner:
             if budget_status != 0:
                 return budget_status
         return 0
+
+    def legacy_facade_steps(self) -> list[tuple[str, Callable[[], None]]]:
+        return [
+            (name, getattr(self, method_name))
+            for name, method_name in legacy_facade_step_methods(self.profile)
+        ]
 
     @property
     def execution_mode(self) -> str:
@@ -430,6 +498,27 @@ class ProfileRunner:
         for suite in suites:
             args.extend(["--suite", suite])
         run_command(uv_area_command(*args))
+
+    def run_rust_interop_checks(self) -> None:
+        suites = self.selected_suites_for_area("rust_interop")
+        if not suites:
+            print(f"Skipping Rust interop checks for lane {self.profile_name}")
+            return
+        print("Running Rust interop checks")
+        result_path = (
+            REPO_ROOT
+            / "target"
+            / "verification"
+            / "areas"
+            / f"rust-interop-{self.profile_name}-results.json"
+        )
+        result_path.unlink(missing_ok=True)
+        args = ["--area", "rust_interop"]
+        for suite in suites:
+            args.extend(["--suite", suite])
+        args.extend(["--result-json", str(result_path.relative_to(REPO_ROOT))])
+        run_command(uv_area_command(*args))
+        validate_rust_interop_result(result_path, suites)
 
     def run_frontend_syntax_guardrails(self) -> None:
         print("Running frontend and syntax guardrails")

--- a/verification/runner/sifr_verify/profiles.py
+++ b/verification/runner/sifr_verify/profiles.py
@@ -27,6 +27,7 @@ PROFILE_STEP_NAMES = {
     "diagnostic_rules",
     "cpython_differential",
     "python_interop",
+    "rust_interop_checks",
     "frontend_syntax_guardrails",
     "developer_tooling_checks",
     "performance_budget_checks",
@@ -45,6 +46,9 @@ PROFILE_STEP_NAMES = {
 }
 PYTHON_INTEROP_CAPABILITY_MATRIX = (
     REPO_ROOT / "verification" / "areas" / "python_interop" / "declaration_capabilities.json"
+)
+RUST_INTEROP_MANIFEST = (
+    REPO_ROOT / "verification" / "areas" / "rust_interop" / "manifest.json"
 )
 
 
@@ -164,6 +168,39 @@ def validate_selected_area_suites(profile: dict[str, Any]) -> None:
                     f"profile {profile.get('name')} omits required Python interop "
                     f"certification suites: {', '.join(missing)}"
                 )
+        if area == "rust_interop" and profile.get("execution_mode") != "selected-areas-only":
+            required_suites = required_rust_interop_suites()
+            missing = sorted(required_suites.difference(selected_suites))
+            if missing:
+                raise ProfileError(
+                    f"profile {profile.get('name')} omits required Rust interop "
+                    f"verification suites: {', '.join(missing)}"
+                )
+    if profile.get("execution_mode") != "selected-areas-only":
+        selected_area_names = {
+            selection.get("area")
+            for selection in profile.get("selected_areas", [])
+            if isinstance(selection, dict)
+        }
+        if "rust_interop" not in selected_area_names:
+            raise ProfileError(
+                f"profile {profile.get('name')} omits the required Rust interop area"
+            )
+
+
+def required_rust_interop_suites() -> set[str]:
+    manifest = load_json(RUST_INTEROP_MANIFEST)
+    suites = manifest.get("suites") if isinstance(manifest, dict) else None
+    if not isinstance(suites, list) or not suites:
+        raise ProfileError("Rust interop area manifest has no suites")
+    names = {
+        str(suite["name"])
+        for suite in suites
+        if isinstance(suite, dict) and isinstance(suite.get("name"), str)
+    }
+    if len(names) != len(suites):
+        raise ProfileError("Rust interop area manifest has invalid or duplicate suites")
+    return names
 
 
 def _compiled_evidence_suites() -> set[str]:

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import tempfile
 from pathlib import Path
 
@@ -13,8 +14,14 @@ from .profiles import (
     legacy_facade,
     load_all_profiles,
     selected_resource_classes,
+    required_rust_interop_suites,
     validate_crate_test_membership,
     validate_selected_area_suites,
+)
+from .profile_runner import (
+    ProfileRunnerError,
+    legacy_facade_step_names,
+    validate_rust_interop_result,
 )
 from .results import build_result
 from .schemas import load_schema, validate_all_committed_schemas, validate_data, validate_schema_requirement
@@ -25,6 +32,7 @@ def run_all() -> list[str]:
         ("schema self-tests", _schema_self_test),
         ("profile schema self-test", _profile_schema_self_test),
         ("crate membership self-test", _crate_membership_self_test),
+        ("Rust interop profile execution self-test", _rust_interop_profile_self_test),
         ("e2e profile self-test", _e2e_profile_self_test),
         ("runner discovery self-test", _discovery_self_test),
         ("resource class selection self-test", _resource_class_self_test),
@@ -87,6 +95,7 @@ def _profile_schema_self_test() -> None:
     create_pr_step_budgets = profiles["create-pr"].get("step_budgets", {})
     required_blocking_steps = {
         "generated_code_quality_checks",
+        "rust_interop_checks",
         "crate_tests",
         "runtime_platform_suites",
         "e2e_pass_suite",
@@ -266,6 +275,112 @@ def _crate_membership_self_test() -> None:
             raise
     else:
         raise AssertionError("incomplete Python interop certification profile was accepted")
+
+
+def _rust_interop_profile_self_test() -> None:
+    profiles = load_all_profiles()
+    required_suites = required_rust_interop_suites()
+    for profile_name in ("create-pr", "merge", "nightly", "release"):
+        profile = profiles[profile_name]
+        selected = {
+            str(suite)
+            for selection in profile["selected_areas"]
+            if selection.get("area") == "rust_interop"
+            for suite in selection.get("suites", [])
+        }
+        if selected != required_suites:
+            raise AssertionError(
+                f"{profile_name} Rust interop plan mismatch: "
+                f"expected={sorted(required_suites)} actual={sorted(selected)}"
+            )
+        step_names = legacy_facade_step_names(profile)
+        if "rust_interop_checks" not in step_names:
+            raise AssertionError(f"{profile_name} omits the executable Rust interop step")
+
+    incomplete_profile = {
+        "name": "self-test",
+        "selected_areas": [
+            {
+                "area": "rust_interop",
+                "suites": ["matrix", "tiers", "compatibility-matrix"],
+            }
+        ],
+    }
+    try:
+        validate_selected_area_suites(incomplete_profile)
+    except ProfileError as exc:
+        if "omits required Rust interop verification suites: stale-drafts" not in str(exc):
+            raise
+    else:
+        raise AssertionError("incomplete Rust interop profile was accepted")
+
+    missing_area_profile = {
+        "name": "self-test",
+        "selected_areas": [],
+    }
+    try:
+        validate_selected_area_suites(missing_area_profile)
+    except ProfileError as exc:
+        if "omits the required Rust interop area" not in str(exc):
+            raise
+    else:
+        raise AssertionError("legacy profile without the Rust interop area was accepted")
+
+    with tempfile.TemporaryDirectory(prefix="sifr-rust-interop-result-self-test-") as temp_dir:
+        result_path = Path(temp_dir) / "result.json"
+        try:
+            validate_rust_interop_result(result_path, sorted(required_suites))
+        except ProfileRunnerError as exc:
+            if "emitted no result JSON" not in str(exc):
+                raise
+        else:
+            raise AssertionError("missing Rust interop result JSON was accepted")
+
+        valid_payload = {
+            "area": "rust_interop",
+            "suites": [
+                {
+                    "name": suite,
+                    "blocking": True,
+                    "total_variants": 1,
+                    "total_failures": 0,
+                }
+                for suite in sorted(required_suites)
+            ],
+            "summary": {
+                "blocking_failures": 0,
+                "total_variants": len(required_suites),
+            },
+        }
+        result_path.write_text(json.dumps(valid_payload), encoding="utf-8")
+        validate_rust_interop_result(result_path, sorted(required_suites))
+
+        invalid_payloads = [
+            {**valid_payload, "area": "python_interop"},
+            {**valid_payload, "suites": valid_payload["suites"][:-1]},
+            {**valid_payload, "suites": "not-a-list"},
+            {
+                **valid_payload,
+                "summary": {"blocking_failures": 1, "total_variants": len(required_suites)},
+            },
+        ]
+        for index, payload in enumerate(invalid_payloads):
+            result_path.write_text(json.dumps(payload), encoding="utf-8")
+            try:
+                validate_rust_interop_result(result_path, sorted(required_suites))
+            except ProfileRunnerError:
+                pass
+            else:
+                raise AssertionError(
+                    f"invalid Rust interop result JSON mutation {index} was accepted"
+                )
+        result_path.write_text("{not-json", encoding="utf-8")
+        try:
+            validate_rust_interop_result(result_path, sorted(required_suites))
+        except ProfileRunnerError:
+            pass
+        else:
+            raise AssertionError("malformed Rust interop result JSON was accepted")
 
 
 def _e2e_profile_self_test() -> None:


### PR DESCRIPTION
## Summary

- select all manifest-defined Rust interop suites in create-PR, merge, nightly, and release profiles
- add a single-sourced `rust_interop_checks` facade step that executes the selected area suites and validates substantive result evidence
- require normal legacy-facade profiles to schedule the area and every manifest suite
- add mutation self-tests for missing scheduling, suite drift, missing/malformed/foreign/incomplete/failing results, and update direct/profile documentation

This is `hardening_1` from `plans/issues/active/rust-interop-verification-matrix-hardening.md`.

## Validation

- direct Rust interop area: 4/4 suites passed, 34 fixture rows
- fixture, compatibility, tier, and stale-draft self-tests passed
- verification runner self-test passed, including Rust interop profile execution mutations
- create-PR emitted plan contains all four suites and a blocking 5,000 ms budget
- `scripts/run_all_tests.sh --profile create-pr` passed end to end
- real lane output: `name=rust_interop_checks elapsed_ms=605 status=pass`
- 131/131 create-PR E2E fixtures passed; zero blocking failures

## Review

Claude Opus reviewed the milestone in two rounds. The first round produced six actionable findings; all were fixed at the root. The second round approved the complete diff with no actionable findings. Both review records are included under `plans/reviews/active/`.
