### PR TITLE
Track pre-existing algorithmic corpus failures

### DIFF
--- a/plans/issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md
+++ b/plans/issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md
@@ -1,0 +1,79 @@
+# Ad Hoc Issue: Algorithmic Full-Corpus Pre-Existing Failures
+
+## Status
+
+Active non-blocking follow-up created from the Rust-interop
+`certification_0` validation on 2026-07-26. The failures predate that
+milestone, are outside its Rust-interop scope, and do not block
+`certification_0`, Phase 40, or stable-channel Rust-interop certification.
+
+No failure is suppressed or reclassified by the Rust-interop work. Remediation
+belongs in separate focused PRs owned by this issue.
+
+## Preserved Evidence
+
+The exact-state nightly and release profiles both passed their complete
+Rust-interop steps and then independently reported the same 20 blocking
+failures in the 412-variant algorithmic-compatibility lane:
+
+- `target/validation_lane_reports/nightly.latest.json` and its adjacent log:
+  Rust interop passed in 4,161 ms; the algorithmic lane reported 20 failures.
+- `target/validation_lane_reports/release.latest.json` and its adjacent log:
+  Rust interop passed in 3,880 ms; the algorithmic lane reported the same 20
+  failures.
+- `target/verification/areas/algorithmic_compatibility/leetcode-full-taxonomy.json`
+  records 20 failures among 411 corpus fixtures: 15
+  `other_type_surface_and_api_mismatch`, 4
+  `any_unknown_typing_and_container_specialization_gap`, and 1
+  `signature_invalid_fixture_surface`.
+
+The failing fixture slugs are:
+
+- `0002_add_two_numbers`
+- `0036_valid_sudoku`
+- `0056_merge_intervals`
+- `0086_partition_list`
+- `0094_binary_tree_inorder_traversal`
+- `0144_binary_tree_preorder_traversal`
+- `0145_binary_tree_postorder_traversal`
+- `0252_meeting_rooms`
+- `0350_intersection_of_two_arrays_ii`
+- `0377_combination_sum_iv`
+- `0435_non_overlapping_intervals`
+- `0442_find_all_duplicates_in_an_array`
+- `0452_minimum_number_of_arrows_to_burst_balloons`
+- `0621_task_scheduler`
+- `0767_reorganize_string`
+- `1203_sort_items_by_groups_respecting_dependencies`
+- `1383_maximum_performance_of_a_team`
+- `1481_least_number_of_unique_integers_after_k_removals`
+- `1489_find_critical_and_pseudo_critical_edges_in_minimum_spanning_tree`
+- `2402_meeting_rooms_iii`
+
+Representative diagnostics include unknown `Any` hash/equality capability,
+mutable-borrow representation changes, unavailable generated total `Ord`, and
+structural-equality mismatches between concrete and `Any` containers. The
+taxonomy artifact and profile logs remain the detailed ephemeral evidence;
+this issue is the durable repository record.
+
+## Scope
+
+- Diagnose each failure against the current language contract.
+- Group fixes by compiler concern and ownership boundary.
+- Implement root-cause compiler or fixture corrections in focused PRs.
+- Preserve the full-corpus gate as blocking; do not add baselines, exclusions,
+  fallback behavior, or Rust-interop-specific exceptions.
+- Name any associated demo after the capability it demonstrates. Demo names
+  must not contain a phase number or phase name.
+- Do not modify Rust-interop matrices, stable claims, crate pins, or profile
+  registration unless a separately reviewed cross-area requirement is proven.
+
+## Acceptance Criteria
+
+- [ ] Every listed fixture passes the canonical full-corpus algorithmic suite.
+- [ ] The current canonical corpus count passes without a baseline,
+  suppression, exclusion, or non-blocking reclassification.
+- [ ] Both nightly and release profiles pass their complete algorithmic-
+  compatibility lane locally.
+- [ ] Focused compiler tests cover each corrected root-cause category.
+- [ ] Review rounds are satisfied and all remediation PRs are merged.

--- a/plans/issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md
+++ b/plans/issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md
@@ -27,6 +27,11 @@ failures in the 412-variant algorithmic-compatibility lane:
   `any_unknown_typing_and_container_specialization_gap`, and 1
   `signature_invalid_fixture_surface`.
 
+The taxonomy artifact was generated on 2026-06-16 and contains 411 fixture
+records. The later profile lanes report 412 area variants because their count
+also includes the area-level policy/runner variant. The 20 failing fixture
+slugs are set-identical across all three evidence sources.
+
 The failing fixture slugs are:
 
 - `0002_add_two_numbers`
@@ -65,8 +70,18 @@ this issue is the durable repository record.
   fallback behavior, or Rust-interop-specific exceptions.
 - Name any associated demo after the capability it demonstrates. Demo names
   must not contain a phase number or phase name.
+- This user-directed naming rule supersedes the project-workflow skill's
+  generic `<milestone>_demo` example for every demo owned by this issue.
 - Do not modify Rust-interop matrices, stable claims, crate pins, or profile
   registration unless a separately reviewed cross-area requirement is proven.
+
+## Implementation Progress
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Failure diagnosis and root-cause grouping | pending | all 20 failures remain preserved above |
+| Focused remediation PR waves | blocked | starts after diagnosis groups establish reviewable compiler ownership boundaries |
+| Full-corpus closeout | blocked | starts after every remediation wave merges |
 
 ## Acceptance Criteria
 
@@ -76,4 +91,8 @@ this issue is the durable repository record.
 - [ ] Both nightly and release profiles pass their complete algorithmic-
   compatibility lane locally.
 - [ ] Focused compiler tests cover each corrected root-cause category.
+- [ ] Every associated demo uses a capability-based name containing no phase
+  number or phase name.
+- [ ] The authoritative create-PR and merge profiles, Clippy, rustfmt,
+  maintainability, file-size, and diff-hygiene gates pass locally.
 - [ ] Review rounds are satisfied and all remediation PRs are merged.

--- a/plans/issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md
+++ b/plans/issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md
@@ -29,8 +29,9 @@ failures in the 412-variant algorithmic-compatibility lane:
 
 The taxonomy artifact was generated on 2026-06-16 and contains 411 fixture
 records. The later profile lanes report 412 area variants because their count
-also includes the area-level policy/runner variant. The 20 failing fixture
-slugs are set-identical across all three evidence sources.
+also includes the area-level `full-corpus-taxonomy-smoke` policy/runner
+variant. The 20 failing fixture slugs are set-identical across all three
+evidence sources.
 
 The failing fixture slugs are:
 

--- a/plans/issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md
+++ b/plans/issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md
@@ -6,6 +6,8 @@ Active non-blocking follow-up created from the Rust-interop
 `certification_0` validation on 2026-07-26. The failures predate that
 milestone, are outside its Rust-interop scope, and do not block
 `certification_0`, Phase 40, or stable-channel Rust-interop certification.
+The durable issue was established in
+[PR #3029](https://github.com/sifr-lang/sifr/pull/3029).
 
 No failure is suppressed or reclassified by the Rust-interop work. Remediation
 belongs in separate focused PRs owned by this issue.

--- a/plans/reviews/active/ad-hoc-algorithmic-full-corpus-preexisting-failures-claude-opus-review-pass-1.md
+++ b/plans/reviews/active/ad-hoc-algorithmic-full-corpus-preexisting-failures-claude-opus-review-pass-1.md
@@ -1,4 +1,4 @@
-# Algorithmic Full-Corpus Follow-Up Review — Round 1
+# Algorithmic Full-Corpus Follow-Up Claude Opus Review — Pass 1
 
 Commit `f9487cfaf` was reviewed read-only. No files, Git, or GitHub state were
 modified, and no Cargo or test command was run.

--- a/plans/reviews/active/ad-hoc-algorithmic-full-corpus-preexisting-failures-claude-opus-review-pass-2.md
+++ b/plans/reviews/active/ad-hoc-algorithmic-full-corpus-preexisting-failures-claude-opus-review-pass-2.md
@@ -1,0 +1,57 @@
+# Algorithmic Full-Corpus Follow-Up Claude Opus Review — Pass 2
+
+Exact head `50ba828f6` was reviewed read-only against merged base
+`53fa84b708`. No files, Git, or GitHub state were modified, and no Cargo or
+test command was run.
+
+## Scope Isolation
+
+The committed range contains exactly two new files:
+
+- `plans/issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md`
+- the pass-1 review artifact
+
+The parallel-agent edits to the Rust interop certification tracker, codegen,
+and panic-wrapper module are outside the commit range and were ignored.
+
+## Round-1 Findings
+
+All four pass-1 findings are resolved:
+
+1. The user-directed capability demo naming rule explicitly supersedes the
+   project-workflow skill's generic milestone-demo example.
+2. Acceptance criteria include capability naming plus the authoritative
+   profiles, Clippy, rustfmt, maintainability, file-size, and diff-hygiene
+   gates.
+3. The issue records the taxonomy's 2026-06-16 generation date and reconciles
+   411 fixtures with the profile lanes' 412 area variants.
+4. The issue includes an implementation-progress table for future focused PR
+   waves and merged links.
+
+## Evidence Re-verification
+
+- 411 taxonomy fixtures and exactly 20 failures.
+- Category split: 15 type-surface/API mismatches, 4 `Any`/container
+  specialization gaps, and 1 invalid fixture signature.
+- The document's 20 slugs are set-identical across taxonomy, nightly, and
+  release evidence.
+- Rust interop passed in 4,161 ms and 3,880 ms while the two 412-variant
+  algorithmic lanes each reported 392 passes and 20 failures.
+- All four representative diagnostic families are present in the preserved
+  records.
+- Rust interop certification and Phase 40 remain explicitly non-blocked, while
+  the algorithmic full-corpus gate remains blocking and forbids suppression,
+  fallback behavior, exclusions, or reclassification.
+- The scope is documentation-only.
+
+## Remaining Findings
+
+1. **Low** — Rename the pass-1 review artifact to the established full
+   issue-slug/model/pass convention so future review rounds sort with their
+   owning issue.
+2. **Low** — Name the extra `full-corpus-taxonomy-smoke` area variant directly
+   in the 411-versus-412 provenance explanation.
+
+Neither finding affects evidence fidelity, scope framing, or gate strength.
+
+## SATISFIED

--- a/plans/reviews/active/ad-hoc-algorithmic-full-corpus-preexisting-failures-claude-opus-review-pass-3.md
+++ b/plans/reviews/active/ad-hoc-algorithmic-full-corpus-preexisting-failures-claude-opus-review-pass-3.md
@@ -1,0 +1,47 @@
+# Algorithmic Full-Corpus Follow-Up Claude Opus Review — Pass 3
+
+Exact committed head `52cd5d48a` was reviewed read-only against base
+`53fa84b708`. No files, Git, or GitHub state were modified, and no Cargo or
+test command was run.
+
+## Scope Isolation
+
+The committed range contains exactly three Markdown files under `plans/`:
+
+- the active algorithmic full-corpus follow-up issue;
+- the Claude Opus pass-1 review;
+- the Claude Opus pass-2 review.
+
+The parallel-agent certification-2 code and tracker edits were absent from the
+commit range and ignored.
+
+## Round-2 Findings
+
+Both low findings are resolved:
+
+1. The pass-1 artifact now uses the full issue slug and the established
+   `claude-opus-review-pass-N` convention.
+2. The 411-versus-412 provenance paragraph names the extra
+   `full-corpus-taxonomy-smoke` area policy/runner variant directly.
+
+## Final Re-verification
+
+- The taxonomy records its 2026-06-16 generation date, 411 fixtures, 20
+  failures, and the exact 15/4/1 category split.
+- The issue's 20 slugs are set-identical to taxonomy, nightly, and release
+  failure records.
+- Both profile lanes contain 412 algorithmic cases with 392 passes and 20
+  failures, while their Rust interop steps pass in 4,161 ms and 3,880 ms.
+- All four representative diagnostic families are present in the preserved
+  taxonomy evidence.
+- The issue forbids baselines, exclusions, suppression, fallback paths, and
+  Rust-interop-specific exceptions. Its acceptance criteria preserve the
+  blocking canonical full-corpus requirement and authoritative local gates.
+- Demo names are capability-based, contain no phase number or phase name, and
+  explicitly supersede the workflow skill's generic milestone-demo example.
+- The failures remain honestly non-blocking for Rust interop certification and
+  Phase 40 without weakening their owning algorithmic gate.
+
+Remaining actionable findings: none.
+
+## SATISFIED

--- a/plans/reviews/active/algorithmic-corpus-review-r1.md
+++ b/plans/reviews/active/algorithmic-corpus-review-r1.md
@@ -1,0 +1,44 @@
+# Algorithmic Full-Corpus Follow-Up Review — Round 1
+
+Commit `f9487cfaf` was reviewed read-only. No files, Git, or GitHub state were
+modified, and no Cargo or test command was run.
+
+## Verified Against Evidence
+
+- Scope is one documentation issue only. No matrix, claim, fixture, crate pin,
+  or compiler change is included.
+- The 20 listed slugs are set-identical to the failure records in
+  `leetcode-full-taxonomy.json`, `nightly.latest.json`, and
+  `release.latest.json`.
+- The taxonomy counts are exact: 411 fixtures, 20 failures, with category
+  counts 15, 4, and 1.
+- Both profile lanes ran 412 algorithmic variants. Their Rust interop steps
+  passed in 4,161 ms and 3,880 ms while their algorithmic compatibility steps
+  failed.
+- The representative unknown-`Any` hash/equality diagnostic is present in the
+  taxonomy evidence.
+- The non-blocking Rust-interop framing matches the merged certification issue,
+  while the algorithmic full-corpus gate remains blocking and cannot be
+  weakened with baselines, exclusions, fallback behavior, or reclassification.
+- The capability-based demo naming requirement is explicit and forbids phase
+  numbers and phase names.
+
+## Findings
+
+1. **Low-Medium** — The capability-based demo naming rule contradicts the
+   workflow skill's generic `<milestone>_demo` example without explicitly
+   stating which rule wins. State that this issue's user-directed convention
+   supersedes that example.
+2. **Low** — Acceptance criteria do not repeat the demo-naming requirement or
+   the required local facade, Clippy, formatting, file-size, and HIR gates.
+3. **Low** — The taxonomy artifact's 2026-06-16 generation date and the
+   411-fixture versus 412-lane-variant distinction should be explicit.
+4. **Low** — Add an implementation-progress table so future focused PRs and
+   merged links can be recorded without retrofitting the issue.
+
+None of these findings blocks the issue from landing; the evidence is
+faithful, the algorithmic gate stays blocking, the failures stay outside and
+non-blocking for Rust interop certification and Phase 40, and no unrelated
+work is present. Findings 1 and 2 are worth folding in before merge.
+
+## SATISFIED


### PR DESCRIPTION
## Summary

- preserve the exact 20 pre-existing full-corpus algorithmic failures observed during Rust interop certification validation
- keep those failures non-blocking for Rust interop certification and Phase 40 while retaining their own blocking canonical gate
- require capability-based demo names with no phase number or phase name
- record three Claude Opus review passes through final `SATISFIED`

## Validation

- exact slug/count/category/timing evidence rechecked against nightly, release, and taxonomy artifacts
- `git diff --check origin/main...HEAD`
- final Claude Opus review: `SATISFIED`, no remaining findings
- authoritative merge profile on the unchanged code base: all 24 lane steps passed; this PR changes Markdown only

## Scope

The issue does not fix, suppress, baseline, exclude, or reclassify any algorithmic failure and does not modify Rust interop implementation, matrices, claims, fixtures, or crate pins.