### PR TITLE
feat(release): add stable incident recovery governance

### DIFF
--- a/demos/stable_incident_recovery_demo.sh
+++ b/demos/stable_incident_recovery_demo.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEMO_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/sifr-stable-incident-recovery.XXXXXX")"
+cleanup() {
+  rm -rf "${DEMO_ROOT}"
+}
+trap cleanup EXIT HUP INT TERM
+
+python3 - "${REPO_ROOT}" "${DEMO_ROOT}" <<'PY'
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+demo_root = Path(sys.argv[2])
+sys.path.insert(0, str(repo_root / "verification" / "areas" / "distribution_release"))
+
+from governance.common import GovernanceError, load_json_strict
+from governance.incident_fixture import plan_fixture_recovery
+from governance.incident_recovery_selftest import (
+    build_roll_forward_fixture,
+    build_rollback_fixture,
+    execute_fixture_installer,
+    run_fixture,
+    scrub_credentials,
+)
+
+print("1. Reserve a rollback generation, retain the failed attempt, and resume")
+rollback = build_rollback_fixture(demo_root / "rollback")
+with scrub_credentials():
+    failed = run_fixture(rollback, mode="initial", fail_at="after-reservation")
+    completed = run_fixture(rollback, mode="resume")
+index = load_json_strict(rollback.root / "live" / "channels.json", require_canonical=True)
+print(
+    f"burned_generation=21 failed={failed['failure']} "
+    f"realized_generation={index['generation']} stable={index['channels']['stable']}"
+)
+
+print("2. Require explicit consent before a working affected client downgrades")
+try:
+    plan_fixture_recovery(
+        fixture_root=rollback.root,
+        current_version="0.1.1",
+        entrypoint="self-update",
+        force=False,
+    )
+except GovernanceError as error:
+    print(f"refused={error}")
+working = plan_fixture_recovery(
+    fixture_root=rollback.root,
+    current_version="0.1.1",
+    entrypoint="self-update",
+    force=True,
+)
+working_state = rollback.root / "installations" / "working-client" / "version"
+execute_fixture_installer(working, working_state)
+print(f"working_client={working_state.read_text().strip()}")
+
+print("3. Recover a broken installation through the stable out-of-band entrypoint")
+broken = plan_fixture_recovery(
+    fixture_root=rollback.root,
+    current_version="0.1.1",
+    entrypoint="out-of-band",
+    force=True,
+)
+broken_state = rollback.root / "installations" / "broken-client" / "version"
+execute_fixture_installer(broken, broken_state)
+print(f"out_of_band={broken_state.read_text().strip()} signoff={completed['signoff']}")
+
+print("4. Resolve a first-GA incident by atomic roll-forward")
+forward = build_roll_forward_fixture(demo_root / "roll-forward")
+with scrub_credentials():
+    result = run_fixture(forward, mode="initial")
+forward_index = load_json_strict(
+    forward.root / "live" / "channels.json",
+    require_canonical=True,
+)
+print(
+    f"generation={result['generation']} stable={forward_index['channels']['stable']} "
+    f"withdrawn={forward_index['releases']['0.1.0']['incident_id']}"
+)
+PY

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -1429,6 +1429,7 @@ cargo test                                    # Run all tests (layers 1-3)
 ./scripts/run_all_tests.sh --profile release # Highest-confidence local qualification profile
 ./scripts/run_all_tests.sh --profile python-interop-live # Explicit opt-in container-runtime Python interop profile
 uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite full     # Preview installer/artifact/release automation checks
+uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite incident-governance # Offline rollback/roll-forward generation, retention, and recovery
 ./verification/runner/e2e/check_report_determinism.sh --profile release # Stable e2e report signature across reruns
 uv run --project verification --locked python -m sifr_verify areas run --area fuzz_property --suite cargo-smoke --suite property --suite fuzz-smoke
 cargo test --manifest-path third_party/ruff/Cargo.toml -p ruff_python_parser # Parser snapshots
@@ -1442,6 +1443,15 @@ cargo bench                                   # Run benchmarks (layer 6, generic
 ```
 
 Validation profile policy is defined in `verification/profiles/{create-pr,merge,nightly,release,python-interop-live}.json` and executed by `verification/runner/sifr_verify/profile_runner.py` through `uv run --project verification python -m sifr_verify profiles run --profile <profile>`. `scripts/run_all_tests.sh` is only the stable public facade over that runner. Verification areas are owned by schema-version-2 `verification/areas/*/manifest.json` files and executed through `uv run --project verification python -m sifr_verify areas run`. Stable-surface manifests declare owner, resource classes, pinned-corpus policy, skip policy, and baseline metadata policy. Representative `create-pr` and full-corpus `merge` e2e coverage are selected through profile data rather than hard-coded shell assumptions. The `python-interop-live` profile is selected-areas-only and explicitly opts into `container-runtime`/live-network policy for testcontainers-backed Python interop evidence; offline profiles must not select those live suites. Its live examples build native Sifr binaries for Redis, Postgres, Kafka-compatible Redpanda, and LocalStack Pub/Sub-style SNS fanout, SNS-to-SQS delivery, and direct SQS delivery. Testcontainers owns container lifecycle and endpoint discovery only; the compiled binary's hermetic declaration bridge owns every service-client operation, and broker/cloud deliveries cross a foreign-thread typed Sifr callback. Docker absence is recorded as a structured service-execution skip only after every native binary builds. When a mostly offline area has a live subset, the area can keep top-level `network_mode: offline` while the live suite declares suite-level `network_mode: live` and its resource classes. Declarative validation-suite coverage lives in area-owned validation suite manifests under `verification/areas/{core_language,project_workspace}/data/validation_suites/`; profiles select the individual suite names, and the area adapter invokes the Rust-native `tests/validation_suites.rs` harness with that exact suite filter. Fixed bug locks and unresolved crash sentinels live under `verification/areas/regression/`.
+
+Stable incident recovery is a pure extension of the governed release-index
+state machine. Canonical request and approved plan digests authorize exactly
+one rollback or incident roll-forward generation; all prior releases and
+snapshots remain immutable. The production adapter is deliberately absent
+until protected publication. The offline fixture core owns generation burning,
+exact resume, site reconciliation, range eligibility, downgrade consent, and
+incident sign-off evidence, as specified in
+`internal_docs/stable_incident_response.md`.
 
 The readiness coverage matrix is the executable registry for shipped guarantees, compiler surfaces, owners, profile assignments, and Cargo package/target/feature classification. `coverage_matrix:readiness` is selected by create-pr, merge, nightly, and release. It runs strict mode, rejects temporary statuses such as `expected-missing`, `tests:none`, and `red-blocker`, validates local-first profile policy, checks profile assignments against `profile_assignment_matrix.json`, and runs negative self-tests for the readiness enforcement claims. CI may run broader profiles, but local-vs-CI plan equivalence is checked by comparing emitted profile plans with `sifr_verify profiles compare-plans`.
 

--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -480,3 +480,67 @@ It performs a forced beta-to-stable handoff and an ordinary
 stable-to-stable update through immutable mock installers, proves receipt and
 sysroot version movement together, shows the stable no-op plan, and verifies
 that the public preview workflow still has no stable mutation input.
+
+## Stable Incident Recovery
+
+Rollback and incident roll-forward planning extend the canonical schema-v2
+release index; they do not introduce a second publication workflow.
+`plan-incident-index` in `scripts/distribution/release_governance.py` consumes
+canonical request, affected-plan, successor/target-plan, and live-index bytes,
+plus the expected generation/digest and a fresh generation number. Rollback is
+accepted only when the affected `normal` plan names that exact retained active
+predecessor and plan digest. Incident roll-forward requires a qualified
+successor plan that binds the request and affected-plan digests and records
+`rollback_target: none`. Both operations withdraw the affected stable and move
+the stable channel atomically in one validated generation.
+
+Incident requests are prepared outside the repository with exact affected
+plan, withdrawal-evidence, and—for rollback—target-plan digests. The
+evidence-commit validator permits exactly
+`plans/incidents/<incident-id>/stable-incident-request.json` and
+`withdrawal-evidence.txt` as added files. It rejects source edits, renames,
+deletions, unrelated files, noncanonical request bytes, directory/id drift, and
+evidence-digest drift.
+
+The credential-free local harness is:
+
+```bash
+scripts/distribution/run_incident_fixture.py run \
+  --fixture-root <dedicated-system-temp-directory> \
+  --live-index <temporary-channels.json> \
+  --governance-release <temporary-governance-assets> \
+  --release-assets <temporary-immutable-assets> \
+  --marketplace-stub <temporary-marketplace.json> \
+  --extension-metadata <temporary-extension-metadata.json> \
+  --site-repo <temporary-non-deploying-site-repository> \
+  --request <fixture-request> \
+  --affected-plan <fixture-affected-plan> \
+  --successor-plan <fixture-target-or-successor-plan> \
+  --mode initial \
+  --approver <fixture-reviewer>
+```
+
+It accepts only explicit temporary filesystem fixtures, rejects production
+credentials, contains no network or production adapter, and shares one
+filesystem metadata lease with preview/stable submission preflight. It
+publishes write-once request and generation evidence, burns a generation after
+reservation failure, atomically replaces only the local index, reconciles a
+non-deploying site fixture, verifies the extension/Marketplace range for
+rollback, and emits a schema-v2 incident sign-off. Resume either allocates
+after every retained snapshot or verifies the already-realized
+generation/digest and retries site reconciliation without another index
+mutation.
+
+The canonical ownership, acknowledgement, communication, retry, retention, and
+closure policy is in
+[`stable_incident_response.md`](./stable_incident_response.md). Production
+workflow inputs, write permissions, Marketplace calls, and site dispatch remain
+absent until protected publication wiring.
+
+Run the incident-specific suite and capability demo with:
+
+```bash
+uv run --project verification --locked python -m sifr_verify areas run \
+  --area distribution_release --suite incident-governance
+demos/stable_incident_recovery_demo.sh
+```

--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -497,7 +497,7 @@ the stable channel atomically in one validated generation.
 Incident requests are prepared outside the repository with exact affected
 plan, withdrawal-evidence, and—for rollback—target-plan digests. The
 evidence-commit validator permits exactly
-`plans/incidents/<incident-id>/stable-incident-request.json` and
+`plans/releases/incidents/<incident-id>/stable-incident-request.json` and
 `withdrawal-evidence.txt` as added files. It rejects source edits, renames,
 deletions, unrelated files, noncanonical request bytes, directory/id drift, and
 evidence-digest drift.

--- a/internal_docs/stable_incident_response.md
+++ b/internal_docs/stable_incident_response.md
@@ -3,7 +3,7 @@
 This runbook defines the governed response to a defect in the active stable
 Sifr release. It is authoritative for local planning and fixture drills now.
 Production workflow inputs and credentials remain intentionally absent until
-the protected publication milestone wires this tested core into the single
+the protected publication workflow wires this tested core into the single
 release-publication workflow.
 
 ## Ownership and service target
@@ -49,7 +49,7 @@ of the affected version in one new index generation.
 
 The durable incident identifier is used in all locations:
 
-1. `plans/incidents/<incident-id>/stable-incident-request.json` and
+1. `plans/releases/incidents/<incident-id>/stable-incident-request.json` and
    `withdrawal-evidence.txt` in an evidence-only PR. Repository validation
    permits exactly those two added files, checks canonical request bytes, and
    verifies the evidence digest. Source changes, renames, deletions, or
@@ -125,7 +125,7 @@ immutable installer fixtures, a Marketplace range stub, extension metadata,
 and a non-deploying site repository. It refuses production credentials, has no
 network or production adapter, and cannot invoke `gh release`, `vsce publish`,
 or repository dispatch. The production workflow still exposes neither incident
-operation and receives no incident write permissions in this milestone.
+operation and receives no incident write permissions at this boundary.
 
 Run the capability demo with:
 

--- a/internal_docs/stable_incident_response.md
+++ b/internal_docs/stable_incident_response.md
@@ -1,0 +1,134 @@
+# Stable Release Incident Response
+
+This runbook defines the governed response to a defect in the active stable
+Sifr release. It is authoritative for local planning and fixture drills now.
+Production workflow inputs and credentials remain intentionally absent until
+the protected publication milestone wires this tested core into the single
+release-publication workflow.
+
+## Ownership and service target
+
+- Release owner: `release/distribution`.
+- Incident owner: `release/distribution`.
+- Approval authority: a protected `stable-release` environment reviewer from
+  `release/distribution` who did not initiate the run. Initial and resume
+  attempts require distinct recorded approvals.
+- Acknowledgement target: 30 minutes from a qualifying trigger. This is
+  deliberately longer than the bounded 20-minute site-deployment wait, so a
+  terminal site timeout can release the metadata lease and be included in the
+  acknowledgement rather than leaving the response pending.
+
+The incident owner acknowledges by assigning the incident identifier, opening
+the evidence-only incident PR, and naming either `rollback` or
+`incident-roll-forward`. The release owner owns artifact/index verification and
+the eventual protected run. The same person may hold both roles, but may not
+approve their own protected run.
+
+## Triggers and operation choice
+
+Open a stable incident for a reproducible compiler correctness or safety
+regression, an installer or sysroot integrity failure, a supported-target
+failure, a governed dependency or security event, or a public smoke failure
+that makes the active stable release unfit for selection.
+
+Use `rollback` only when all of these conditions hold:
+
+1. the active release was produced by a `normal` stable plan;
+2. that exact plan names the requested active predecessor and approved plan
+   digest as its rollback target;
+3. the retained target is still active, its immutable installer matches the
+   governed index, and the VS Code compatibility range covers it.
+
+Use `incident-roll-forward` when no eligible rollback target exists, including
+the first GA release. The approved successor plan binds the incident-request
+digest, the affected active version and plan digest, and
+`rollback_target: none`. Activation adds the qualified successor and withdrawal
+of the affected version in one new index generation.
+
+## Evidence and communication locations
+
+The durable incident identifier is used in all locations:
+
+1. `plans/incidents/<incident-id>/stable-incident-request.json` and
+   `withdrawal-evidence.txt` in an evidence-only PR. Repository validation
+   permits exactly those two added files, checks canonical request bytes, and
+   verifies the evidence digest. Source changes, renames, deletions, or
+   unrelated incident files are rejected.
+2. Uniquely named, write-once request, release-index generation, realized site
+   facts, validation/communication/closure evidence, and incident sign-off
+   assets in the governance release.
+3. The protected workflow prepare summary and attempt history, which bind the
+   exact evidence commit, paths, digests, approver, status, and mutations.
+4. The affected GitHub release notice and the stable release documentation
+   incident notice. Public prose is landed with the GA documentation surface;
+   the governed site facts already carry the active stable version and all
+   withdrawals for deterministic reconciliation.
+
+Closure requires the public stable installer, exact pin behavior, affected
+self-update recovery, out-of-band recovery, site facts, extension range,
+release index, immutable assets, communications evidence, and sign-off to
+agree.
+
+## Mutation, retry, and retention rules
+
+All preview, stable, rollback, and incident-roll-forward operations share the
+metadata concurrency lease. A pending incident blocks a new preview or stable
+submission. A cancelled pending operation is recorded and must be explicitly
+resubmitted.
+
+The operation reserves the next unused generation by publishing
+`channels-generation-<N>.json` without overwrite before replacing
+`channels.json`. Allocation considers every retained snapshot, not only the
+live index.
+
+- Failure before reservation mutates no release state.
+- Failure after reservation retains and burns generation `N`. Resume verifies
+  the same request and plans, then reserves `N+1` or later.
+- Exact matching version/Marketplace state is verified and reused. Missing
+  planned fixture state may be supplied only before channel activation;
+  mismatched existing state fails.
+- Failure after index replacement never performs a second index mutation.
+  Resume proves the current generation/digest equals the intended snapshot and
+  starts a new correlated site attempt.
+- A site timeout is terminal and releases the lease. Rollback may then
+  supersede an outstanding site attempt; a later resume is accepted only while
+  the realized generation/digest still matches.
+
+No version tag, version asset, plan, report, evidence commit, request,
+generation snapshot, realized site facts, attempt, or sign-off is deleted or
+overwritten. Withdrawal changes selection state only.
+
+## Recovery behavior
+
+Fresh installs select the new active stable immediately. An affected
+self-update client refuses a downgrade unless the user supplies:
+
+```bash
+sifr self update --channel stable --force
+```
+
+If the affected binary cannot run self-update, the out-of-band path is:
+
+```bash
+curl -fsSL https://sifr.sh/install/stable | sh -s -- --force
+```
+
+Both paths resolve the governed active stable record, verify the immutable
+installer digest, and delegate to those exact installer bytes. A withdrawn
+version is never selectable by a channel or exact pin.
+
+## Local drill boundary
+
+`scripts/distribution/run_incident_fixture.py` accepts only a dedicated system
+temporary directory containing a filesystem index, retained governance assets,
+immutable installer fixtures, a Marketplace range stub, extension metadata,
+and a non-deploying site repository. It refuses production credentials, has no
+network or production adapter, and cannot invoke `gh release`, `vsce publish`,
+or repository dispatch. The production workflow still exposes neither incident
+operation and receives no incident write permissions in this milestone.
+
+Run the capability demo with:
+
+```bash
+demos/stable_incident_recovery_demo.sh
+```

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -94,10 +94,10 @@ Artifacts mapped to the Phase 40 exit gate:
 
 ### milestone_40_3: Rollback and Incident Governance
 
-- [ ] Implement local fail-closed incident planning, rollback, withdrawal,
+- [x] Implement local fail-closed incident planning, rollback, withdrawal,
   roll-forward, generation burning, and recovery evidence.
-- [ ] Keep production mutation adapters disabled.
-- [ ] Validate first-GA and later incident recovery.
+- [x] Keep production mutation adapters disabled.
+- [x] Validate first-GA and later incident recovery.
 - [ ] Record review rounds, PR, validation, and merge.
 
 ### milestone_40_4: Stable Documentation and VS Code Release
@@ -417,3 +417,40 @@ updating or deleting that exact tag with no bypass actors.
   exact remote head `939e69083`.
 - Main-repository [PR #3030](https://github.com/sifr-lang/sifr/pull/3030)
   merged as `db80dd35e056b9dcc9a2ac64475a198f5c36bfaa`.
+
+### milestone_40_3
+
+- Pure incident planning in
+  `verification/areas/distribution_release/governance/incident_planner.py`
+  binds canonical request, affected/target/successor plan, and expected live
+  generation/digest bytes. Rollback requires the affected `normal` plan's exact
+  active predecessor; incident roll-forward requires a request-bound qualified
+  successor with `rollback_target: none`.
+- The release-index core now preserves every unaffected channel and retained
+  release byte, withdraws only the affected stable, and either reuses exactly
+  one active retained rollback target or adds exactly one qualified successor.
+- The credential-free fixture harness takes explicit temporary index,
+  governance-asset, immutable-asset, Marketplace-stub, extension-metadata, and
+  non-deploying-site paths. It refuses production credentials and site
+  repositories without the local-only marker and has no network, GitHub
+  release, Marketplace publication, or repository-dispatch adapter.
+- Local mutation order is request retention, write-once proposed-generation
+  snapshot, atomic index replacement, exact generation/digest site recheck,
+  bounded 20-minute attempt model, site reconciliation, and schema-v2 incident
+  sign-off. Reservation failure burns the generation; post-index timeout
+  records cancellation and resumes site work without a second index mutation.
+- Fresh install, working-client self-update, and broken-client out-of-band
+  recovery all resolve the active stable and delegate to its digest-verified
+  immutable installer. Downgrades refuse without explicit `--force`.
+- Evidence-only commit validation accepts exactly the canonical incident
+  request and digest-bound withdrawal evidence under
+  `plans/incidents/<incident-id>/`; source changes or unrelated evidence fail.
+- The stable incident runbook records owner, non-initiating approval authority,
+  30-minute acknowledgement target, triggers, communication locations, retry
+  matrix, retention, first-GA roll-forward, and closure requirements.
+- Focused evidence:
+  `uv run --project verification --locked python -m sifr_verify areas run
+  --area distribution_release --suite incident-governance` passes the
+  eight-scenario recovery module; `demos/stable_incident_recovery_demo.sh`
+  demonstrates burned-generation resume, forced rollback recovery through both
+  client paths, immutable-installer execution, and first-GA roll-forward.

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -480,3 +480,9 @@ updating or deleting that exact tag with no bypass actors.
   top-level separator is restored; and custody explicitly allows the release
   README only for candidate evidence while incident evidence remains an exact
   request-plus-withdrawal-evidence commit.
+- Claude Opus review pass 3 was not approved and is archived at
+  `plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-3.md`.
+  It cleared every implementation and prior-review finding; its sole new
+  documentation finding is remediated by making the adjacent release-evidence
+  README require the digest-bound `withdrawal-evidence.txt` beside every
+  incident request.

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -90,7 +90,7 @@ Artifacts mapped to the Phase 40 exit gate:
   receipts, and `sifr self update`.
 - [x] Keep stable-changing publication mutation disabled.
 - [x] Validate all four targets and negative checksum/withdrawal/channel cases.
-- [ ] Record review rounds, PR, validation, and merge.
+- [x] Record review rounds, PR, validation, and merge.
 
 ### milestone_40_3: Rollback and Incident Governance
 
@@ -409,3 +409,11 @@ updating or deleting that exact tag with no bypass actors.
   `editor-release` 6/6, consumed Rust-interop matrix/tiers/compatibility/stale
   drafts 8/8, Rust stable-candidate 2/2, and documentation structure 1/1.
   These commands made no tracked-file changes.
+- Exact PR-head review pass 9:
+  `plans/reviews/archive/phase-40-milestone-40-2-claude-opus-review-pass-9.md`
+  reverified the complete 86-file PR diff, reproduced the milestone contract
+  counts, independently accepted the indexed `PERF-HOST` result as
+  non-prerequisite host variance, and returned `APPROVED` with no finding at
+  exact remote head `939e69083`.
+- Main-repository [PR #3030](https://github.com/sifr-lang/sifr/pull/3030)
+  merged as `db80dd35e056b9dcc9a2ac64475a198f5c36bfaa`.

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -444,7 +444,8 @@ updating or deleting that exact tag with no bypass actors.
   immutable installer. Downgrades refuse without explicit `--force`.
 - Evidence-only commit validation accepts exactly the canonical incident
   request and digest-bound withdrawal evidence under
-  `plans/incidents/<incident-id>/`; source changes or unrelated evidence fail.
+  `plans/releases/incidents/<incident-id>/`; source changes or unrelated
+  evidence fail.
 - The stable incident runbook records owner, non-initiating approval authority,
   30-minute acknowledgement target, triggers, communication locations, retry
   matrix, retention, first-GA roll-forward, and closure requirements.
@@ -454,3 +455,20 @@ updating or deleting that exact tag with no bypass actors.
   eight-scenario recovery module; `demos/stable_incident_recovery_demo.sh`
   demonstrates burned-generation resume, forced rollback recovery through both
   client paths, immutable-installer execution, and first-GA roll-forward.
+- Claude Opus review pass 1 was not approved and is archived at
+  `plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-1.md`.
+  Its five findings are remediated: canonical incident custody now uses
+  `plans/releases/incidents/` and is called by the evidence-custody repository
+  check; the sole-first-GA rollback rejection has a direct acceptance test;
+  incident index-transition cases live in the dedicated incident module rather
+  than consuming the shared governance file-size boundary; the sign-off schema
+  and validator require exactly one completed terminal attempt; and merge,
+  nightly, and release profiles select the named `incident-governance` suite,
+  with the release report requiring it and the full-suite runner de-duplicating
+  the module.
+- The authoritative create-PR profile completed all functional validation,
+  including 19/19 Python-interop variants, but exited on the host timing budget
+  after that passing step took 788.45 seconds against 600 seconds. This
+  unrelated host variance is recorded in
+  `plans/phases/adhoc_performance_budget_host_variance.md` and is not a Phase
+  40 prerequisite; no baseline or waiver changed.

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -486,3 +486,11 @@ updating or deleting that exact tag with no bypass actors.
   documentation finding is remediated by making the adjacent release-evidence
   README require the digest-bound `withdrawal-evidence.txt` beside every
   incident request.
+- Claude Opus review pass 4 is approved with no actionable findings and is
+  archived at
+  `plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-4.md`.
+  It re-ran the nine incident scenarios, combined 55-variant distribution
+  selection, coverage/profile assignment, runner self-tests, the capability
+  demo, file-size guardrails, custody-layout reproduction, stale-path sweep,
+  and a fresh full definition-of-done review against exact implementation head
+  `cc87f1e79a2d11c2f2cd1fba8b99d470741c82da`.

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -452,7 +452,7 @@ updating or deleting that exact tag with no bypass actors.
 - Focused evidence:
   `uv run --project verification --locked python -m sifr_verify areas run
   --area distribution_release --suite incident-governance` passes the
-  eight-scenario recovery module; `demos/stable_incident_recovery_demo.sh`
+  nine-scenario recovery module; `demos/stable_incident_recovery_demo.sh`
   demonstrates burned-generation resume, forced rollback recovery through both
   client paths, immutable-installer execution, and first-GA roll-forward.
 - Claude Opus review pass 1 was not approved and is archived at
@@ -472,3 +472,11 @@ updating or deleting that exact tag with no bypass actors.
   unrelated host variance is recorded in
   `plans/phases/adhoc_performance_budget_host_variance.md` and is not a Phase
   40 prerequisite; no baseline or waiver changed.
+- Claude Opus review pass 2 was not approved and is archived at
+  `plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-2.md`.
+  Its three findings are remediated: a focused incident-index mutation module
+  now directly tests atomic withdrawal, channel isolation, rollback/roll-forward
+  version sets, and retained-release byte preservation; the shared self-test's
+  top-level separator is restored; and custody explicitly allows the release
+  README only for candidate evidence while incident evidence remains an exact
+  request-plus-withdrawal-evidence commit.

--- a/plans/phases/adhoc_performance_budget_host_variance.md
+++ b/plans/phases/adhoc_performance_budget_host_variance.md
@@ -12,6 +12,10 @@ cross fixed thresholds by small and inconsistent amounts.
 This follow-up must not change performance baselines or add waivers merely to
 make one host pass.
 
+The same host also exceeded the create-PR lane's aggregate Python-interop step
+budget despite every selected case passing. That timing variance belongs to
+this follow-up rather than to stable-release governance.
+
 ## Evidence
 
 On merged main commit `56f8c41eec`:
@@ -33,11 +37,22 @@ read-only self-update receipt channel in compiled sources. The immediate parent
 comparison demonstrates that this budget failure is not introduced by the
 milestone.
 
+During the stable incident-governance work, the create-PR profile completed all
+19 Python-interop variants with zero failures, but the aggregate step took
+788.45 seconds against its 600-second budget. The slowest individual cases were
+callback examples (161.70 seconds), CPython buffer compatibility (142.55
+seconds), read-only check/doctor (126.69 seconds), and buffer examples (113.33
+seconds). The lane exited only on the elapsed-time budget after reporting every
+case as passing; the incident-governance diff does not change Python-interop or
+compiler implementation files.
+
 ## Scope
 
 - Reproduce representative measurements across controlled warm and cold runs.
 - Record host thermal state, load, CPU frequency behavior, and cache state.
 - Determine why command medians and LSP samples are bimodal.
+- Determine why cold Python-interop fixtures can exceed the aggregate
+  create-PR step budget while all functional variants pass.
 - Make sampling, warm-up, isolation, or threshold derivation robust enough that
   the merge gate is repeatable without hiding real regressions.
 - Add a deterministic self-test for the chosen stability rule.

--- a/plans/releases/README.md
+++ b/plans/releases/README.md
@@ -6,8 +6,9 @@ directories:
 - `candidates/<version>/` contains one stable candidate plan, its canonical
   release-profile report, and qualification artifact index. A later protected
   publication may add the matching sign-off.
-- `incidents/<incident-id>/` contains one incident request. A later protected
-  incident workflow may add its matching sign-off.
+- `incidents/<incident-id>/` contains one incident request and its digest-bound
+  `withdrawal-evidence.txt`. A later protected incident workflow may add the
+  matching sign-off.
 
 Changes below either directory are evidence-only: they may not be combined
 with compiler, workflow, script, documentation, or other source changes. The

--- a/plans/releases/stable_gate_inventory.json
+++ b/plans/releases/stable_gate_inventory.json
@@ -30,7 +30,7 @@
       "id": "preview-artifact-builder",
       "location": "scripts/distribution/build_release_artifacts.sh",
       "owner": "release/distribution",
-      "current_behavior": "packages alpha, beta, rc, or stable candidates without publication",
+      "current_behavior": "packages alpha, beta, or stable candidates without publication and rejects rc",
       "activation_boundary": "stable-qualification",
       "disposition": "shared target packaging moves behind stable qualification without enabling publication; milestone 40.2 removes rc acceptance from the shared public release surface"
     },
@@ -38,7 +38,7 @@
       "id": "immutable-installer-generator",
       "location": "scripts/distribution/generate_version_installer.sh",
       "owner": "release/distribution",
-      "current_behavior": "generates immutable alpha, beta, rc, or stable candidate installers without publication",
+      "current_behavior": "generates immutable alpha, beta, or stable candidate installers without publication and rejects rc",
       "activation_boundary": "stable-installation",
       "disposition": "accepts exact stable versions and derives APP_CHANNEL=stable; milestone 40.2 removes rc acceptance"
     },
@@ -46,7 +46,7 @@
       "id": "site-default-channel",
       "location": "scripts/distribution/generate_dispatchers.sh",
       "owner": "release/distribution",
-      "current_behavior": "index defaults to beta and stable is rejected",
+      "current_behavior": "index is beta-default for preview and stable-default for active GA; all four entrypoints share schema-v2 metadata",
       "activation_boundary": "stable-installation",
       "disposition": "index and stable entrypoint resolve stable; alpha and beta remain explicit"
     },
@@ -54,7 +54,7 @@
       "id": "site-version-pin",
       "location": "scripts/distribution/generate_dispatchers.sh",
       "owner": "release/distribution",
-      "current_behavior": "stable version pins are rejected",
+      "current_behavior": "exact active stable pins resolve and withdrawn or absent versions fail",
       "activation_boundary": "stable-installation",
       "disposition": "exact active stable pins resolve; withdrawn or absent pins fail"
     },
@@ -62,7 +62,7 @@
       "id": "site-release-index-preview-state",
       "location": "verification/areas/distribution_release/tools/validate_self_update_metadata.sh",
       "owner": "release/distribution",
-      "current_behavior": "requires schema-v2 preview state without stable",
+      "current_behavior": "validates preview and active schema-v2 states with GA-aware dispatcher defaults",
       "activation_boundary": "stable-installation",
       "disposition": "shared validator accepts active GA state and verifies stable dispatcher agreement"
     },
@@ -70,7 +70,7 @@
       "id": "self-update-index-state",
       "location": "crates/sifr/src/self_update_metadata.rs",
       "owner": "release/distribution",
-      "current_behavior": "requires schema-v2 preview state and rejects active GA",
+      "current_behavior": "accepts preview or active GA and resolves only active governed release records",
       "activation_boundary": "stable-installation",
       "disposition": "accepts active GA and resolves stable only from an active release record"
     },
@@ -78,7 +78,7 @@
       "id": "self-update-channel-selection",
       "location": "crates/sifr/src/self_update_metadata.rs",
       "owner": "release/distribution",
-      "current_behavior": "stable channel and exact stable versions are rejected",
+      "current_behavior": "stable channel and exact active stable versions resolve with checksum-bound installer delegation",
       "activation_boundary": "stable-installation",
       "disposition": "stable channel and exact active stable pins use the governed release index"
     },
@@ -145,6 +145,38 @@
       "current_behavior": "proves stable resolution and publication remain unavailable",
       "activation_boundary": "stable-installation",
       "disposition": "replaced by positive stable resolution plus withdrawn, checksum, and mismatch negatives"
+    },
+    {
+      "id": "stable-incident-index-planner",
+      "location": "verification/areas/distribution_release/governance/incident_planner.py",
+      "owner": "release/distribution",
+      "current_behavior": "purely validates canonical incident requests, approved plans, expected index identity, and one rollback or roll-forward generation",
+      "activation_boundary": "incident-governance",
+      "disposition": "is consumed unchanged by the protected publication adapter"
+    },
+    {
+      "id": "stable-incident-fixture-harness",
+      "location": "scripts/distribution/run_incident_fixture.py",
+      "owner": "release/distribution",
+      "current_behavior": "runs credential-free filesystem rollback, roll-forward, generation-burn, exact-resume, site-reconciliation, and recovery drills",
+      "activation_boundary": "incident-governance",
+      "disposition": "remains local-only and cannot select a production adapter"
+    },
+    {
+      "id": "stable-incident-evidence-commit",
+      "location": "verification/areas/distribution_release/governance/incident_evidence.py",
+      "owner": "release/distribution",
+      "current_behavior": "accepts only one canonical request plus its digest-bound withdrawal evidence in an additive incident commit range",
+      "activation_boundary": "incident-governance",
+      "disposition": "gates evidence-only incident PRs before protected publication"
+    },
+    {
+      "id": "stable-incident-runbook",
+      "location": "internal_docs/stable_incident_response.md",
+      "owner": "release/distribution",
+      "current_behavior": "defines trigger, ownership, 30-minute acknowledgement, approval, communication, retry, retention, and recovery policy",
+      "activation_boundary": "incident-governance",
+      "disposition": "provides the operator contract consumed by GA documentation and protected publication"
     },
     {
       "id": "release-profile-stable-gates",

--- a/plans/releases/stable_gate_inventory.json
+++ b/plans/releases/stable_gate_inventory.json
@@ -184,7 +184,7 @@
       "owner": "compiler/verification",
       "current_behavior": "executes distribution, tooling, documentation, and Rust release gates",
       "activation_boundary": "architecture-lock",
-      "disposition": "durably executes evidence-custody, editor-release expansion, and stable-candidate"
+      "disposition": "durably executes incident-governance, evidence-custody, editor-release expansion, and stable-candidate"
     }
   ]
 }

--- a/plans/reviews/archive/phase-40-milestone-40-2-claude-opus-review-pass-9.md
+++ b/plans/reviews/archive/phase-40-milestone-40-2-claude-opus-review-pass-9.md
@@ -1,0 +1,46 @@
+## Review: PR #3030 — Phase 40 / milestone 40.2, head `939e69083`
+
+### Identity
+Local `HEAD` = `939e69083e3e8d8c5cb98efe6e1d3e90bc3753e9`; `gh pr view 3030` reports `headRefOid` identical, base `main`, state OPEN, `MERGEABLE`/`CLEAN`. Working tree clean except my own untracked pass-9 placeholder (not in the PR). Reviewed the complete 86-file diff from merge-base `56f8c41ee`.
+
+**Delta since approved pass-8 head `28fe8527f`:** 2 files, +80 lines, additions only, both documentation — the archived pass-8 review and the tracker ledger entry. No functional, schema, workflow, or script byte changed. I diffed this explicitly rather than trusting the commit subjects.
+
+### Pass-7 findings — independently reverified closed
+1. **HIGH, GA-blind planner** — `create_new_version.sh:124-154` derives `site_default_channel` from index `ga_status`, requires `stable` only when `active`, validates `stable` if-present. Closed.
+2. **MEDIUM, hardcoded stable index default** — `validate_self_update_metadata.sh:157-163` now branches `expected_index_channel` on `metadata_ga_status`. Closed.
+3. **MEDIUM, unschematized artifact** — now `schema_version: 2` / `sifr-site-publication-binding-v2`, checked-in schema, rejecting validator, registered `--kind`, runner inventory at 12 schemas (confirmed: 12 files on disk). Closed.
+4. **LOW, zero digest** — rejected in producer (`:32-33`), governance, and schema (`not:{const}` on every digest). Closed.
+5. **LOW, missing evidence** — recorded at `:377-384`. Closed.
+6. **LOW, whitespace/index** — `git diff --check 56f8c41ee HEAD` exits 0; `PERF-HOST` indexed at `plans/phases/index.md:51`. Closed.
+
+### Independent verification
+**Schema/validator parity** — field-by-field match between `site_publication_facts.schema.json` and `governance/site_publication.py`, including `additionalProperties:false` ↔ `require_exact_keys` and zero-digest rejection on all seven digest fields.
+
+**Live cross-repository pinning (re-queried against GitHub, not the fixture):** tag → `07d88cc3c24707e386c5ad73fb0875c06ffd598f`; ruleset `19791667` = `target:tag`, `enforcement:active`, `bypass_actors:[]`, rules `{update,deletion}`, include exactly the one tag, exclude `[]`, `updated_at` 05:06:21.354Z; site workflow bytes at that commit hash to `7a27abaf…958`, matching `SITE_WORKFLOW_SHA256` and the fixture.
+
+**Workflow ordering / write-once** — `--clobber` appears exactly once (`:460`, `channels.json`); snapshot upload (`:452`) → index replacement (`:458`) → dispatch (`:618`); snapshot-name collision rejected (`:448`); `gh release create` targets `SOURCE_COMMIT` with no clobber. Both workflows reject `stable` input (`preview-release.yml:11-13` enum; `release-publication.yml:76-79`).
+
+**Install/self-update integrity** — `version_pin` passes the anchored SemVer regex before reaching any `sed` pattern or the installer URL, closing injection; zero installer digest rejected; SHA-256 verified before `chmod +x`; in Rust `resolve_exact()` precedes the force check (`self_update_metadata.rs:372`) and `validate_installer()` precedes `make_executable()` (`self_update_runner.rs:46-47`). Every `expect(` in the added Rust is inside test code.
+
+**Scope** — no demo filename carries phase/milestone numbering or the phase name (sole new demo: `demos/stable_self_update_demo.sh`); zero Rust-interop implementation (only the five self-update files plus a `sha2` dependency edge).
+
+**Executed here:** distribution area 104/104 variants, 0 failures; `full` + `evidence-custody` = 52 + 1 = **53/53, exactly reproducing the tracker's claim**; `developer_tooling --suite editor-release` = **6/6, exactly reproducing the tracker's claim**; 49/49 self-update tests; `cargo clippy --workspace -- -D warnings` clean; `cargo fmt --check` clean; HIR guardrails PASS; no changed non-Markdown file over 900 lines.
+
+### Assessment of the performance-budget evidence
+Sufficient, and I verified the substance rather than accepting the decision on its face:
+- **No baseline, budget, threshold, or waiver file is touched anywhere in the diff** — the only path matching that grep is the `PERF-HOST` follow-up plan itself.
+- **The milestone cannot plausibly move the failing medians.** The overruns are on check/diagnostic/LSP benchmarks. The only compiled-source changes are four self-update modules reachable solely through the `self-update` subcommand, plus a `sha2` edge — and `sha2 0.10.9` was **already in `Cargo.lock`**, so this adds no crate, only a dependency edge. Nothing in the compile/check/diagnostic/LSP hot path changed.
+- Independent parent-main reproduction is documented in `adhoc_performance_budget_host_variance.md`, the retry overruns (0.55%/0.69%) sit inside the 0.5–2.0% band that doc records for host variance, and `PERF-HOST` is indexed as a deferred non-prerequisite by explicit project/user decision.
+
+This is host variance routed to an indexed follow-up, not a milestone regression. The two tracker counts I could reproduce exactly matched, which raises my confidence in the run records I could not rerun in reasonable time.
+
+### Findings
+None. No actionable correctness, security, governance, parity, install/self-update, ordering, pinning, test, documentation, scope, or evidence defect.
+
+Two non-blocking observations, carried forward from pass 8 and still accurate — neither is a finding: the planner's post-GA precondition will require the site source to land a committed `stable` dispatcher at GA activation (unreachable today, arrives in milestone 40.5), and `cargo clippy --workspace --all-targets` fails in `sifr_lowering`, which this PR does not touch and which is not part of the AGENTS.md gate.
+
+---
+
+## Verdict
+
+**APPROVED** for merging PR #3030 at head `939e69083e3e8d8c5cb98efe6e1d3e90bc3753e9`.

--- a/plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-1.md
+++ b/plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-1.md
@@ -1,0 +1,61 @@
+I verified `HEAD = cb7567f2daa8cf721e1785844e307db4e514aebf`, merge base `db80dd35e056b9dcc9a2ac64475a198f5c36bfaa`, reviewed all 21 changed files, and ran read-only checks.
+
+## Checks run
+
+| Check | Result |
+|---|---|
+| `areas run --area distribution_release --suite incident-governance` | pass, 8/8 scenarios |
+| `areas run --area distribution_release --suite full --suite evidence-custody` | pass, 54 variants, 0 failures |
+| `demos/stable_incident_recovery_demo.sh` | pass, exit 0, all four scenes |
+| `scripts/check_file_size_guardrails.py` | PASS (2866 files, limit 900) |
+| Diff scope | no `crates/**` change; no Rust-interop implementation touched |
+| Demo filename | `stable_incident_recovery_demo.sh` — capability-based, no phase/milestone identifier ✅ |
+| Production surface | `.github/workflows/release-publication.yml` has no rollback/roll-forward input, no drill env; harness has no network/`gh`/`vsce`/dispatch adapter ✅ |
+
+What is genuinely solid: the pure planner (`incident_planner.py`), the index state machine (`release_index.py:171-313`) with byte-preservation of unaffected releases, atomic withdraw+activate, generation burning/allocation over all retained snapshots, race rejection, exact-resume without a second index mutation, site-timeout terminal/lease-releasing semantics, write-once evidence via `O_EXCL`, temp-root confinement, symlink rejection, credential refusal, downgrade consent with installer delegation, and first-GA roll-forward.
+
+## Actionable issues
+
+**1. HIGH — Incident evidence custody contract is self-contradictory and unsatisfiable; the new validator is wired into nothing.**
+
+- `verification/areas/distribution_release/governance/incident_evidence.py:38` requires `plans/incidents/<incident-id>/`.
+- The phase contract (`plans/phases/40_...md`, "New incident requests enter custody through evidence-only PRs at `plans/releases/incidents/<incident-id>/stable-incident-request.json`") and the pre-existing gate `evidence_custody.py:23-26` require `plans/releases/incidents/<incident-id>/`.
+- `evidence_custody.py:189` allows only `stable-incident-request.json` and `stable-incident-signoff.json` in an incident directory; the new validator *requires* a co-located `withdrawal-evidence.txt`.
+
+Reproduced directly:
+
+```
+changed-path-set REJECTED: invalid evidence path(s):
+  plans/releases/incidents/inc-2026-001/withdrawal-evidence.txt
+incident-directory REJECTED: .../inc-2026-001: unsupported incident evidence: withdrawal-evidence.txt
+```
+
+Failure scenario: a real incident PR at the canonical `plans/releases/incidents/<id>/` is rejected by all three checks; a PR at `plans/incidents/<id>/` passes the new validator but is silently invisible to `evidence_custody` (`validate_changed_path_set` early-returns, `validate_existing_evidence` only walks `RELEASES_ROOT/incidents`), so the canonical custody registry never validates it. Neither location works. Compounding this, `validate_incident_evidence_commit` has **no caller** outside its own selftest and the CLI subcommand — no suite, profile, or repository check invokes it, so the milestone requirement "Repository checks reject source changes, schema/digest drift, or unrelated incident files in that evidence commit" is not actually enforced by a repository check. The wrong path is propagated into `internal_docs/stable_incident_response.md:52`, `internal_docs/distribution_pipeline.md` ("Stable Incident Recovery" section), and `plans/issues/active/phase-40-stable-channel-ga-execution.md` (milestone_40_3 bullet), so the docs are inaccurate against the phase contract.
+
+**2. MEDIUM — Missing acceptance coverage explicitly named in the milestone 40.3 definition of done.**
+
+"A fixture-backed first-GA incident proves **the sole stable version cannot be withdrawn alone**." `build_roll_forward_fixture` (`incident_recovery_selftest.py:539-581`) builds the only single-stable-version index and is used solely in the happy path at line 151. No test attempts a `rollback` against that one-version first-GA index. The nearest case, `incident_recovery_selftest.py:209-213`, uses `build_rollback_fixture(..., affected_transition="ga-activation")`, which still contains **two** retained stable releases and fails on plan transition (`"rollback requires an affected normal release plan"`), not on target unavailability. The distinct guard at `release_index.py:244-251` ("must name a distinct retained active stable release") is unexercised. The DoD clause is therefore not proven.
+
+**3. MEDIUM — The 900-line file-size guardrail was satisfied by deleting PEP 8 blank separators rather than by decomposition.**
+
+`selftest.py` went 898 → 899 lines. The diff adds 3 lines and removes exactly two top-level blank separators, leaving single blank lines before `def test_release_plan_mutations` (`selftest.py:518`) and `def test_incident_mutations` (`selftest.py:563`) — the only two such spots in the file. With correct spacing the file is 901 lines, over the cap. AGENTS.md: "If a touched file exceeds the cap, refactor it by responsibility rather than adding more code to an oversized module." The guardrail passes only because of the style regression, and any further addition to this file is now blocked.
+
+**4. LOW — Schema/validator parity gap on sign-off attempt terminal state.**
+
+`incident.py:131-137` rejects duplicate/non-increasing `run_id`, any `started` attempt, and a non-`completed` final attempt. `schemas/stable_incident_signoff.schema.json:24-28,75-86` encodes none of these: `status` still enumerates `started`, and there is no uniqueness or terminal-state constraint. A consumer validating only against the checked-in schema accepts a sign-off with a dangling pending attempt. (The `operation` field and the `X.Y.Z` version patterns were correctly added to both sides.)
+
+**5. LOW — The registered `incident-governance` suite is selected by no profile.**
+
+`manifest.json:64-76` registers the suite and `runner.py:109-115,167-181` supports it, but no entry in `verification/profiles/*.json` selects it; `release.json:220-228` selects `full`/`qualification`/`evidence-custody`, and `release_report.py:41` `REQUIRED_SUITES["distribution_release"]` omits it. Coverage happens only transitively because `runner.py:128-134` appends the module to `full`, so the named suite itself is dead registration and merge/nightly/create-pr never run incident recovery.
+
+## Not issues (checked and cleared)
+
+- Sign-off completeness — request digest, per-attempt run/mode/approver/status/mutations, realized generation/digest, site reconciliation, validation, communications, closure are all recorded and cross-validated against the request (`incident_fixture.py:611-668`, `incident.py:171-176`).
+- Retention — `tree_digest` asset invariance plus retained gen-21 and gen-22 snapshots asserted (`incident_recovery_selftest.py:60,73-75`); every write path is `O_EXCL`.
+- Concurrency — shared `state/metadata-concurrency.lock` and `check_release_submission_allowed`; lease release on terminal site timeout matches the phase's GitHub-concurrency semantics.
+- Extension/Marketplace reconciliation — range check applied for `rollback`, correctly skipped for `incident-roll-forward` per the milestone (`incident_fixture.py:475-488`).
+- `generate-incident-request` correctly enforces an outside-repo clean work directory and exact affected/target plan and evidence digest binding (`release_governance.py:358-403`).
+
+## Verdict
+
+**NOT APPROVED** — issues 1 and 2 are blocking (a mutually unsatisfiable, unenforced evidence-custody contract that also contradicts the phase doc, and a missing DoD-named first-GA acceptance case); 3, 4, and 5 must also be resolved before approval.

--- a/plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-2.md
+++ b/plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-2.md
@@ -1,0 +1,64 @@
+## Review: Phase 40 · milestone_40_3 — Rollback and Incident Governance
+
+**HEAD reviewed:** `ff8c2664b795221433c1ac387849e3ee6fc8b803`
+**Range:** `db80dd35e056b9dcc9a2ac64475a198f5c36bfaa..ff8c2664b` (3 commits, 31 files, +3086/−69)
+**Pass-1 artifact inspected:** `plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-1.md`
+
+### Checks run (read-only)
+
+| Check | Result |
+|---|---|
+| `distribution_release --suite incident-governance` | pass, 8/8 scenarios |
+| `distribution_release --suite full` | pass, 53 variants, incident module runs (8 scenarios) |
+| `distribution_release --suite full --suite qualification --suite evidence-custody --suite incident-governance` | pass, 55 variants, 0 failures, **no duplicate** incident execution |
+| `coverage_matrix/runner.py` (advisory + readiness + profile-assignment) | pass, 5 variants, `profile assignment matrix ok: rows=17` |
+| `sifr_verify.selftest` | exit 0 |
+| `schema_contracts.validate_schema_contracts()` | pass (new negative sign-off cases) |
+| `demos/stable_incident_recovery_demo.sh` | exit 0, all four scenes |
+| `scripts/check_file_size_guardrails.py` | PASS (2866 files, limit 900) |
+| Diff scope | no `crates/**`, no `.github/workflows/**` change → no Rust-interop implementation, no production adapter |
+
+### Prior findings — re-check
+
+1. **Custody contract / repository enforcement — RESOLVED.** Canonical path is now `plans/releases/incidents/<id>/` on both sides (`incident_evidence.py:38-42`), `withdrawal-evidence.txt` is allowed and *required* with a digest cross-check (`evidence_custody.py:26,220-238`), and `validate_incident_evidence_commit` is wired into the suite via `validate_committed_incident_addition` (`evidence_custody.py:33,117-139`). Docs and the issue plan corrected. Verified live: suite passes and the self-test now exercises `validate_changed_path_set` + `validate_incident_directory` on a real fixture repo.
+2. **Sole-first-GA rollback rejection — RESOLVED.** Direct acceptance case at `incident_recovery_selftest.py:157-167` drives `propose_rollback` against the one-stable-version index and asserts the previously unexercised `release_index.py:245-251` guard.
+3. **900-line guardrail / decomposition — PARTIALLY RESOLVED** (see finding 1 below). `selftest.py` is 879 lines and the cap no longer depends on the style deletion, but the method was deletion, not decomposition, and one blank-separator regression remains.
+4. **Sign-off schema/runtime parity — RESOLVED.** `started` removed from the enum and `contains`/`minContains`/`maxContains` added (`stable_incident_signoff.schema.json:27-34,90`), backed by real validator support (`json_schema_202012.py:208-218`) and two negative schema-contract cases. Validator tightened to "exactly one final completed attempt" (`incident.py:136-138`). Residual (attempt ordering, `run_id` strict monotonicity) is not expressible in JSON Schema 2020-12 — not actionable.
+5. **Profile selection / no duplicate execution — RESOLVED.** `incident-governance` selected by merge, nightly, release; mirrored in `profile_assignment_matrix.json`, `release_report.py:41-46`, `qualification_fixture.py`, and the runner selftest. Duplicate execution suppressed by `runner.py:48-54,105-109,138-144`; confirmed empirically (one `incident-recovery` case in the combined run, still present when only `full` is selected).
+
+### Actionable findings
+
+**1. MEDIUM — Pass-1 finding 3 was closed by deleting the only tests of `validate_incident_index_mutation`, and the issue plan states they were relocated.**
+
+`selftest.py` lost 26 lines covering `validate_incident_index_mutation` directly: the hand-built `incident-roll-forward` mutation happy path and the rejection of a mutation that leaves the affected release `active` without an `incident_id`. They were **not** moved anywhere:
+
+```
+$ grep -rn "incident mutation|retained release bytes|reuse one retained|add exactly the qualified" \
+    verification/areas/distribution_release/governance/*selftest*.py
+(no matches)
+```
+
+`release_index.py:171-227` is now reachable only through `propose_rollback`/`propose_incident_roll_forward`, which construct correct mutations by definition, so **all ten** of its `fail()` branches — affected release removed, not withdrawn, affected bytes altered beyond withdrawal, successor not active, `stable` not pointing at the successor, rollback/roll-forward version-set mismatch, retained-release byte drift, non-stable channel drift — have zero test coverage. That validator is the atomicity/immutability guard behind two DoD clauses ("withdrawing the affected version atomically"; "add evidence without deleting or overwriting any version asset or prior generation snapshot").
+
+`plans/issues/active/phase-40-stable-channel-ga-execution.md:463` claims "incident index-transition cases live in the dedicated incident module rather than consuming the shared governance file-size boundary." No such cases exist in `incident_recovery_selftest.py`. Restoring them there (which fits its ownership boundary and keeps it at 860→~890 lines) makes both the coverage and the claim true.
+
+**2. LOW — The PEP 8 blank-separator regression pass-1 flagged is still present.**
+
+`verification/areas/distribution_release/governance/selftest.py:497` has a single blank line before `def test_release_plan_mutations` — the only such site in the file, and one of the two that pass-1 identified as introduced to buy header room. It is no longer load-bearing for the cap (879 lines; restoring the separator gives 880), so there is no reason to keep it.
+
+**3. LOW — The evidence-custody suite now contains two checks that disagree about `plans/releases/README.md`.**
+
+`evidence_custody.py:66` explicitly permits `plans/releases/README.md` to accompany an evidence change, but `validate_incident_evidence_commit` — invoked by the same `run_evidence_custody_checks()` since this commit — rejects any path in the range other than the request and withdrawal evidence (`incident_evidence.py:57-61`). An incident evidence PR that also updates that README passes `validate_changed_path_set` and then fails `validate_committed_incident_addition`. One of the two allowances should be made authoritative.
+
+### Cleared on this pass
+
+- Exact resume/race semantics: single index mutation on resume (`incident_fixture.py:154-156,195-200`), generation burning over all retained snapshots (`:422`), pre- and post-reservation staleness rechecks (`:158-189`), terminal lease-releasing site timeout (`:201-212` + `metadata_lease` finally), byte-identical realized-index assertion on resume (`incident_recovery_selftest.py:146-151`).
+- Immutable retention: every evidence write is `O_EXCL` (`_write_once_bytes`), `_write_text_evidence` refuses drift, gen-21 and gen-22 snapshots both retained, `tree_digest` proves release assets unchanged.
+- Local-only adapter boundary: temp-root confinement (`validate_fixture_root`, `require_fixture_path`), symlink rejection, credential refusal, non-deploying site marker, and `test_no_production_adapter_surface` asserting no `socket`/`urllib`/`requests`/`subprocess` in the harness and no rollback/roll-forward dispatch input in `release-publication.yml`.
+- Withdrawn-version selection: exact pins excluded via `active_installers` (`crates/sifr/src/self_update_metadata.rs:259-276`), covered by the pre-existing `install_withdrawn_stable_rejected.sh`; `validate_release_index` forbids a channel pointing at a non-active release.
+- Downgrade consent + out-of-band recovery, extension/Marketplace range check correctly skipped for `incident-roll-forward`, clean external work directory for `generate-incident-request`, demo filename is capability-based (`stable_incident_recovery_demo.sh`), no Rust-interop implementation touched.
+- The create-PR host-timing shortfall is disclosed honestly in a pre-existing follow-up (`plans/phases/adhoc_performance_budget_host_variance.md:40-47`) with no baseline or waiver change.
+
+### Verdict
+
+**NOT APPROVED** — finding 1 must be resolved (restore the `validate_incident_index_mutation` cases so the validator's rejection branches are covered and the issue-plan statement is true); findings 2 and 3 are small and should be fixed in the same change.

--- a/plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-3.md
+++ b/plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-3.md
@@ -1,0 +1,60 @@
+## Review: Phase 40 · milestone_40_3 — Rollback and Incident Governance
+
+**HEAD reviewed:** `32852b72fcbec6c3a8cd107c708656c902de8770`
+**Range:** `db80dd35e056b9dcc9a2ac64475a198f5c36bfaa..32852b72f` (3 commits, 33 files, +3344/−69)
+**Prior artifacts inspected:** `plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-1.md`, `...-pass-2.md`
+
+### Checks run (read-only)
+
+| Check | Result |
+|---|---|
+| `distribution_release --suite incident-governance` | pass, **9/9** scenarios |
+| `distribution_release --suite full` | pass, 53 variants; incident module runs once (9 scenarios) |
+| `--suite full --suite qualification --suite evidence-custody --suite incident-governance` | pass, 55 variants, 0 failures, **no duplicate** incident execution |
+| `coverage_matrix` (advisory + readiness + profile-assignment) | pass, 5 variants, `profile assignment matrix ok: rows=17` |
+| `sifr_verify` runner `selftest.run_all()` | all 11 self-tests pass (incl. release-report production) |
+| `demos/stable_incident_recovery_demo.sh` | exit 0, all four scenes |
+| `scripts/check_file_size_guardrails.py` | PASS (2867 files, limit 900) |
+| Instrumented branch trace of `test_incident_index_mutation_contract` | 12 rejections, each on a **distinct intended** `validate_incident_index_mutation` branch |
+| PEP 8 top-level separator scan (7 governance modules) | 0 violations |
+| Repro: README-described incident layout | `REJECTED: withdrawal-evidence.txt is required` (finding 1) |
+| Diff scope | no `crates/**`, no `.github/workflows/**`; workflow has **zero** occurrences of `rollback`/`incident` |
+
+### Pass-2 findings — re-check
+
+1. **`validate_incident_index_mutation` coverage — RESOLVED, genuinely.** New `incident_index_selftest.py` (168 lines) is registered in `incident_recovery_selftest.py:50` and owned by the incident module, so the issue-plan relocation claim is now true. I instrumented `assert_rejected` and confirmed the 12 cases land on 10 distinct `fail()` sites, not on the generic index validator: removed affected (`release_index.py:197`), affected not withdrawn (`:199`), affected bytes altered (`:208`), successor not active (`:212`), stable not pointing at successor (`:214`), rollback version-set drift (`:219`), roll-forward version-set drift both directions (`:222`), retained-release byte drift (`:227`), non-stable channel drift (`:194`), affected not the live stable predecessor (`:189`). Atomicity and immutability guards are exercised. The only uncovered branch is `:191` (`ga_status` regression), which is unreachable — `validate_release_index_transition:122` rejects active→preview first. Not actionable.
+2. **PEP 8 separator — RESOLVED.** `selftest.py:496-497` restored; scan of all touched governance modules shows no remaining single-blank top-level separators. `selftest.py` is 881 lines, `incident_recovery_selftest.py` 872, `incident_fixture.py` 809 — all under the cap without style debt.
+3. **README custody policy — RESOLVED in code, internally consistent, and tested.** `evidence_custody.py:63-70` now allows `plans/releases/README.md` only when every evidence path is a candidate path, so `validate_changed_path_set` and `validate_incident_evidence_commit` can no longer disagree. Positively tested at `selftest.py:831` (candidate + README accepted) and negatively at `incident_recovery_selftest.py:356-365` (incident + README rejected with `cannot mix`).
+
+### Pass-1 findings — re-check
+
+1. Custody contract/enforcement — **resolved** (canonical `plans/releases/incidents/<id>/`, `validate_incident_evidence_commit` wired through `validate_committed_incident_addition`, `evidence_custody.py:33,121-143`).
+2. Sole-first-GA rollback rejection — **resolved**, direct case at `incident_recovery_selftest.py:159-169` drives `propose_rollback` against the one-stable-version index and asserts `release_index.py:245-251`.
+3. File-size guardrail — **resolved by decomposition**, not deletion (see above).
+4. Schema/runtime parity — **resolved**; `started` gone from the attempt enum, `contains`/`minContains`/`maxContains` (schema `:28-34`) backed by real validator support (`json_schema_202012.py:208-218`) and two negative schema-contract cases. Runtime residual (`run_id` monotonicity, last-attempt-completed at `incident.py:132-138`) is not expressible in JSON Schema 2020-12.
+5. Profile selection/de-duplication — **resolved**; `incident-governance` selected by merge/nightly/release, mirrored in `profile_assignment_matrix.json`, `release_report.py:41-46`, `qualification_fixture.py`, and the runner selftest. De-dup verified empirically in both directions (`full` alone → 9 scenarios; `full` + named suite → still exactly one `incident-recovery` case).
+
+### Independently verified this pass
+
+- **Definition of done.** Fresh-install / working-client `--force` self-update / broken-client out-of-band recovery all execute the digest-verified immutable installer to `0.1.0` (`:127-130`). Sole-stable withdrawal rejected; roll-forward activates the qualified successor and withdraws atomically. Withdrawn versions unselectable by channel or pin (`validate_release_index:57-58` plus the pre-existing `install_withdrawn_stable_rejected.sh`). Racing rollback fails closed as `stale-generation` with the newer generation intact (`:259-273`). Immutable request authorizes every mutation; sign-off records digest/attempts/approvers/mutations/site/validation/communications/closure and is cross-validated against the request (`incident.py:172-177`). Retention proven by `tree_digest` invariance plus retained gen-21 **and** gen-22 (`:72-82`); every write is `O_EXCL`.
+- **Exact resume/race.** Reservation-failure burns 21 and resumes at 22; post-index site timeout resumes with byte-identical live index, **no** gen-22 snapshot, and no second index mutation (`:144-153`); pre- and post-reservation staleness rechecks (`incident_fixture.py:158-189`); terminal lease-releasing timeout via the `metadata_lease` `finally`.
+- **Local-only boundary.** Temp-root confinement, symlink rejection, credential refusal, non-deploying site marker, `run_incident_fixture.py` has no network/subprocess adapter, and `release-publication.yml` contains no incident surface at all.
+- **Scope.** No `crates/**` change; no Rust-interop implementation touched. Demo filename `stable_incident_recovery_demo.sh` is capability-based with no phase/milestone identifier. The create-PR host-timing shortfall is disclosed in the pre-existing `adhoc_performance_budget_host_variance.md` follow-up with no baseline or waiver change.
+
+### Actionable finding
+
+**1. LOW — `plans/releases/README.md` still describes the pre-milestone incident-directory contract and now contradicts an enforced check.**
+
+The README (`plans/releases/README.md:10-11`) states the incident directory "contains one incident request. A later protected incident workflow may add its matching sign-off." This milestone made `withdrawal-evidence.txt` a **required** co-located file (`evidence_custody.py:26,235-237`, `incident_evidence.py:33-36`), and the README was last modified at `dd58b9706`, before this range — so the divergence is introduced here. Both accurate descriptions live elsewhere (`internal_docs/stable_incident_response.md:52-53`, `internal_docs/distribution_pipeline.md`), but this is the file that sits next to the evidence tree and is itself the path specially allowed by `validate_changed_path_set`.
+
+Reproduced against the exact layout the README describes:
+
+```
+REJECTED: .../inc-2026-001: withdrawal-evidence.txt is required
+```
+
+Failure scenario: an incident owner follows the README, opens an evidence-only PR containing only `stable-incident-request.json`, and the `distribution_release:evidence-custody` suite fails during an active stable incident. One sentence in the README closes it.
+
+### Verdict
+
+**NOT APPROVED** — the implementation, tests, docs elsewhere, and all eight prior findings are fully resolved and independently verified; the sole remaining item is finding 1, a one-line correction to `plans/releases/README.md` so the custody documentation matches the contract this milestone now enforces.

--- a/plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-4.md
+++ b/plans/reviews/archive/phase-40-milestone-40-3-claude-opus-review-pass-4.md
@@ -1,0 +1,47 @@
+## Review: Phase 40 · milestone_40_3 — Rollback and Incident Governance
+
+**HEAD reviewed:** `cc87f1e79a2d11c2f2cd1fba8b99d470741c82da`
+**Range:** `db80dd35e056b9dcc9a2ac64475a198f5c36bfaa..cc87f1e79` (4 commits, 35 files, +3413/−71)
+**Prior artifacts read:** phase definition `plans/phases/40_...md:704-838`; archived passes 1, 2, 3.
+Read-only throughout: no file written, no git state changed.
+
+### Checks run
+
+| Check | Result |
+|---|---|
+| `distribution_release --suite incident-governance` | pass, 9/9 scenarios |
+| `--suite full --suite qualification --suite evidence-custody --suite incident-governance` | pass, 55 variants, 0 failures, incident module runs **exactly once** |
+| `coverage_matrix` (advisory + readiness + profile-assignment) | pass, 5 variants |
+| `sifr_verify` runner `selftest.run_all()` | 11/11 self-tests pass |
+| `demos/stable_incident_recovery_demo.sh` | exit 0, all four scenes (gen 21 burned → 22 realized; forced downgrade + out-of-band both land `0.1.0`; first-GA roll-forward → stable `0.1.1`, `0.1.0` withdrawn) |
+| `scripts/check_file_size_guardrails.py` | PASS (2867 files, limit 900; largest touched: `selftest.py` 881, `incident_recovery_selftest.py` 872, `incident_fixture.py` 809) |
+| Repro of README-described incident layout | request + `withdrawal-evidence.txt` **accepted** by `validate_incident_directory` and `validate_changed_path_set`; request-only rejected |
+| Stale-path sweep `plans/incidents/` outside review artifacts | 0 hits |
+| Diff scope | no `crates/**`, no `.github/workflows/**`; no Rust-interop implementation touched |
+
+### Pass-3 finding — re-check
+
+**RESOLVED.** `plans/releases/README.md:9-11` now states the incident directory contains the request *and its digest-bound `withdrawal-evidence.txt`*, with the sign-off added later by the protected workflow. That is exactly what is enforced (`evidence_custody.py:224-242` requires both files and cross-checks `withdrawal.evidence_sha256`; `incident_evidence.py:31-72` permits exactly those two added paths) and matches `internal_docs/stable_incident_response.md:52-56`, `internal_docs/distribution_pipeline.md` ("Stable Incident Recovery"), and the issue plan. Verified by direct repro above — the layout the README describes now passes; the previously-described request-only layout is the one that fails.
+
+### Pass-1 and pass-2 findings — re-check
+
+All eight remain resolved at this HEAD: canonical `plans/releases/incidents/<id>/` custody wired into `run_evidence_custody_checks` via `validate_committed_incident_addition` (`evidence_custody.py:33,121-143`); sole-first-GA rollback rejection driven directly (`incident_recovery_selftest.py:159-169` → `release_index.py:245-251`); file-size cap met by decomposition into `incident_index_selftest.py`, not blank-line deletion; sign-off schema/runtime parity (`stable_incident_signoff.schema.json:24-34,90` with real `contains`/`minContains`/`maxContains` support at `json_schema_202012.py:208-218`, plus two negative schema-contract cases; runtime `incident.py:132-138` is strictly tighter); `incident-governance` selected by merge/nightly/release and mirrored in `profile_assignment_matrix.json`, `release_report.py:41-46`, `qualification_fixture.py`, `sifr_verify/selftest.py`, with de-duplication at `runner.py:48-54,119-123,138-144` confirmed empirically in both directions.
+
+### Fresh full review
+
+- **Definition of done.** Fresh install / working-client `--force` self-update / broken-client out-of-band all resolve the governed active stable and execute the digest-verified immutable installer (`incident_recovery_selftest.py:89-130`). Sole-stable withdrawal rejected; roll-forward adds the qualified successor and withdraws atomically in one generation. Withdrawn versions unselectable by channel (`release_index.py:57-58`) or exact pin (pre-existing `install_withdrawn_stable_rejected.sh`). Racing rollback fails closed as `stale-generation` with the newer generation intact (`:259-273`). Immutable request authorizes each mutation; sign-off records request digest, per-attempt run/mode/approver/status/mutations, previous+realized generation/digest, site reconciliation, validation, communications, closure, cross-validated against the request (`incident_fixture.py:611-668`, `incident.py:172-177`). Retention proven by `tree_digest` invariance plus retained gen-21 *and* gen-22; every write is `O_EXCL`.
+- **Atomicity/immutability.** `validate_incident_index_mutation` (`release_index.py:171-227`) is the single guard for both planners and is exercised on 10 distinct rejection branches by the dedicated module.
+- **Resume/race semantics.** Pre- and post-reservation staleness rechecks around the write-once snapshot (`incident_fixture.py:158-190`); post-index site timeout is terminal and lease-releasing (`metadata_lease` `finally`), resumes with byte-identical live index, **no** gen-22 snapshot, no second index mutation, and a new correlated site attempt (`incident_recovery_selftest.py:144-153`); generation allocation burns over all retained snapshots (`:422`).
+- **Schema/runtime parity.** Request and sign-off schemas both pin `schema_version: 2`; `operation` present on both sides; the rollback-target `if/then/else` matches `require_exact_keys`.
+- **Local-only boundary.** Temp-root confinement, symlink rejection, credential refusal, non-deploying site marker, no `socket`/`urllib`/`requests`/`subprocess` in the harness, no `gh release`/`vsce publish`/`repository_dispatch` in the CLI, and `release-publication.yml` exposes neither operation (unchanged in range).
+- **Docs/demo/scope/evidence.** Runbook states owners, non-initiating approval authority, 30-minute acknowledgement target explicitly exceeding the 20-minute site wait, triggers, communication locations, retry matrix, retention, closure. Demo filename is capability-based. Issue plan and architecture/pipeline docs match the code. The create-PR host-timing shortfall is disclosed honestly in the pre-existing `adhoc_performance_budget_host_variance.md` with no baseline or waiver change.
+
+### Actionable findings
+
+None.
+
+Two non-actionable observations, recorded only for completeness: `plans/releases/README.md:13-14` describes evidence changes as never mixing with documentation changes, while `evidence_custody.py:63-70` permits the README itself alongside *candidate* evidence — the doc is stricter than the check, so following it can never fail a gate. And `incident_fixture.py:353-364` closes the lease descriptor twice (guarded by `except OSError`); no fd is live at `finally` time in this single-threaded harness, so it is latent style only.
+
+### Verdict
+
+**APPROVED**

--- a/scripts/distribution/release_governance.py
+++ b/scripts/distribution/release_governance.py
@@ -37,9 +37,12 @@ from governance.common import (  # noqa: E402
     load_json_strict,
     require_sha256,
     sha256_bytes,
+    sha256_file,
     write_canonical_json,
 )
+from governance.incident_evidence import validate_incident_evidence_commit  # noqa: E402
 from governance.release_index import propose_preview_release, validate_release_record  # noqa: E402
+from governance.incident_planner import materialize_incident_mutation  # noqa: E402
 from governance.planner import materialize_stable_plan  # noqa: E402
 
 
@@ -137,6 +140,24 @@ def parse_args() -> argparse.Namespace:
         command.add_argument("--out", required=True)
         if command_name == "generate-incident-request":
             command.add_argument("--live-index", required=True)
+            command.add_argument("--withdrawal-evidence", required=True)
+            command.add_argument("--affected-plan", required=True)
+            command.add_argument("--rollback-plan")
+    incident_index = commands.add_parser("plan-incident-index")
+    incident_index.add_argument("--request", required=True)
+    incident_index.add_argument("--live-index", required=True)
+    incident_index.add_argument("--affected-plan", required=True)
+    incident_index.add_argument("--successor-plan", required=True)
+    incident_index.add_argument("--expected-generation", required=True, type=int)
+    incident_index.add_argument("--expected-sha256", required=True)
+    incident_index.add_argument("--proposed-generation", required=True, type=int)
+    incident_index.add_argument("--out", required=True)
+    evidence_commit = commands.add_parser("validate-incident-evidence-commit")
+    evidence_commit.add_argument("--repository", default=str(REPO_ROOT))
+    evidence_commit.add_argument("--base", required=True)
+    evidence_commit.add_argument("--head", required=True)
+    evidence_commit.add_argument("--request-path", required=True)
+    evidence_commit.add_argument("--evidence-path", required=True)
     return parser.parse_args()
 
 
@@ -161,6 +182,10 @@ def main() -> int:
             generate_incident(args)
         elif args.command == "generate-incident-signoff":
             generate_incident_signoff(args)
+        elif args.command == "plan-incident-index":
+            plan_incident_index(args)
+        elif args.command == "validate-incident-evidence-commit":
+            validate_incident_evidence(args)
         else:
             raise AssertionError(args.command)
     except GovernanceError as exc:
@@ -333,15 +358,102 @@ def build_release_record(args: argparse.Namespace) -> None:
 
 
 def generate_incident(args: argparse.Namespace) -> None:
-    payload = load_json_strict(Path(args.spec))
-    validate_incident_request(payload, live_index=load_json_strict(Path(args.live_index)))
-    write_canonical_json(Path(args.out), payload, refuse_existing=True)
+    spec_path = Path(args.spec).resolve()
+    evidence_path = Path(args.withdrawal_evidence).resolve()
+    output = Path(args.out).resolve()
+    _require_clean_external_incident_directory(
+        output=output,
+        spec_path=spec_path,
+        evidence_path=evidence_path,
+    )
+    payload = validate_incident_request(
+        load_json_strict(spec_path, require_canonical=True)
+    )
+    affected_plan_path = Path(args.affected_plan)
+    affected_plan = validate_release_plan(
+        load_json_strict(affected_plan_path, require_canonical=True)
+    )
+    approved = {affected_plan["version"]: sha256_file(affected_plan_path)}
+    if payload.get("affected_release") != {
+        "version": affected_plan["version"],
+        "plan_sha256": approved[affected_plan["version"]],
+    }:
+        raise GovernanceError("incident request does not bind the exact affected plan")
+    if payload.get("withdrawal", {}).get("evidence_sha256") != sha256_file(evidence_path):
+        raise GovernanceError("incident request does not bind the withdrawal evidence bytes")
+    if payload.get("operation") == "rollback":
+        if not args.rollback_plan:
+            raise GovernanceError("rollback request generation requires --rollback-plan")
+        rollback_plan_path = Path(args.rollback_plan)
+        rollback_plan = validate_release_plan(
+            load_json_strict(rollback_plan_path, require_canonical=True)
+        )
+        approved[rollback_plan["version"]] = sha256_file(rollback_plan_path)
+    elif args.rollback_plan:
+        raise GovernanceError("incident-roll-forward request must not supply --rollback-plan")
+    validate_incident_request(
+        payload,
+        live_index=load_json_strict(Path(args.live_index), require_canonical=True),
+        approved_plan_digests=approved,
+    )
+    write_canonical_json(output, payload, refuse_existing=True)
 
 
 def generate_incident_signoff(args: argparse.Namespace) -> None:
     payload = load_json_strict(Path(args.spec))
     validate_incident_signoff(payload)
     write_canonical_json(Path(args.out), payload, refuse_existing=True)
+
+
+def plan_incident_index(args: argparse.Namespace) -> None:
+    mutation = materialize_incident_mutation(
+        request_path=Path(args.request),
+        live_index_path=Path(args.live_index),
+        affected_plan_path=Path(args.affected_plan),
+        successor_plan_path=Path(args.successor_plan),
+        expected_generation=args.expected_generation,
+        expected_sha256=args.expected_sha256,
+        proposed_generation=args.proposed_generation,
+    )
+    write_canonical_json(Path(args.out), mutation.proposed_index, refuse_existing=True)
+
+
+def validate_incident_evidence(args: argparse.Namespace) -> None:
+    request = validate_incident_evidence_commit(
+        repository=Path(args.repository),
+        base=args.base,
+        head=args.head,
+        request_path=args.request_path,
+        evidence_path=args.evidence_path,
+    )
+    print(
+        "release-governance incident evidence ok: "
+        f"incident_id={request['incident_id']} operation={request['operation']}"
+    )
+
+
+def _require_clean_external_incident_directory(
+    *,
+    output: Path,
+    spec_path: Path,
+    evidence_path: Path,
+) -> None:
+    try:
+        output.relative_to(REPO_ROOT.resolve())
+    except ValueError:
+        pass
+    else:
+        raise GovernanceError("incident request generation output must be outside the repository")
+    if not output.parent.is_dir():
+        raise GovernanceError("incident request work directory must already exist")
+    if spec_path.parent != output.parent or evidence_path.parent != output.parent:
+        raise GovernanceError("incident request spec and withdrawal evidence must be in the work directory")
+    allowed = {spec_path, evidence_path}
+    unexpected = sorted(path.name for path in output.parent.iterdir() if path.resolve() not in allowed)
+    if unexpected:
+        raise GovernanceError(
+            "incident request work directory is not clean: " + ", ".join(unexpected)
+        )
 
 
 def load_release(path: Path) -> tuple[str, dict[str, Any]]:

--- a/scripts/distribution/run_incident_fixture.py
+++ b/scripts/distribution/run_incident_fixture.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Run the credential-free stable incident recovery fixture harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AREA_ROOT = REPO_ROOT / "verification" / "areas" / "distribution_release"
+sys.path.insert(0, str(AREA_ROOT))
+
+from governance.common import GovernanceError  # noqa: E402
+from governance.incident_fixture import (  # noqa: E402
+    check_release_submission_allowed,
+    plan_fixture_recovery,
+    run_incident_fixture,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    run = commands.add_parser("run")
+    run.add_argument("--fixture-root", required=True)
+    run.add_argument("--live-index", required=True)
+    run.add_argument("--governance-release", required=True)
+    run.add_argument("--release-assets", required=True)
+    run.add_argument("--marketplace-stub", required=True)
+    run.add_argument("--extension-metadata", required=True)
+    run.add_argument("--site-repo", required=True)
+    run.add_argument("--request", required=True)
+    run.add_argument("--affected-plan", required=True)
+    run.add_argument("--successor-plan", required=True)
+    run.add_argument("--mode", required=True, choices=("initial", "resume"))
+    run.add_argument("--approver", required=True)
+    run.add_argument(
+        "--fail-at",
+        default="none",
+        choices=(
+            "none",
+            "after-reservation",
+            "race-before-index",
+            "after-index",
+            "site-timeout",
+        ),
+    )
+    check = commands.add_parser("check-submission")
+    check.add_argument("--fixture-root", required=True)
+    check.add_argument("--submission", required=True, choices=("preview", "stable"))
+    recover = commands.add_parser("recover")
+    recover.add_argument("--fixture-root", required=True)
+    recover.add_argument("--current-version")
+    recover.add_argument(
+        "--entrypoint",
+        required=True,
+        choices=("fresh-install", "self-update", "out-of-band"),
+    )
+    recover.add_argument("--force", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "run":
+            result = run_incident_fixture(
+                fixture_root=Path(args.fixture_root),
+                live_index_path=Path(args.live_index),
+                governance_root=Path(args.governance_release),
+                release_assets_root=Path(args.release_assets),
+                marketplace_path=Path(args.marketplace_stub),
+                extension_metadata_path=Path(args.extension_metadata),
+                site_root=Path(args.site_repo),
+                request_path=Path(args.request),
+                affected_plan_path=Path(args.affected_plan),
+                successor_plan_path=Path(args.successor_plan),
+                mode=args.mode,
+                approver=args.approver,
+                fail_at=args.fail_at,
+            )
+            print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+            return 3 if result["status"] == "failed" else 0
+        elif args.command == "recover":
+            result = plan_fixture_recovery(
+                fixture_root=Path(args.fixture_root),
+                current_version=args.current_version,
+                entrypoint=args.entrypoint,
+                force=args.force,
+            )
+            print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        else:
+            check_release_submission_allowed(Path(args.fixture_root), args.submission)
+            print(f"incident fixture submission allowed: {args.submission}")
+    except GovernanceError as exc:
+        print(f"incident-fixture: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/coverage_matrix/profile_assignment_matrix.json
+++ b/verification/areas/coverage_matrix/profile_assignment_matrix.json
@@ -96,9 +96,18 @@
       "surface_id": "distribution_release",
       "profiles": {
         "create-pr": [],
-        "merge": ["distribution_release:representative"],
-        "nightly": ["distribution_release:full"],
-        "release": ["distribution_release:full"]
+        "merge": [
+          "distribution_release:representative",
+          "distribution_release:incident-governance"
+        ],
+        "nightly": [
+          "distribution_release:full",
+          "distribution_release:incident-governance"
+        ],
+        "release": [
+          "distribution_release:full",
+          "distribution_release:incident-governance"
+        ]
       }
     },
     {

--- a/verification/areas/distribution_release/governance/evidence_custody.py
+++ b/verification/areas/distribution_release/governance/evidence_custody.py
@@ -60,10 +60,14 @@ def validate_changed_path_set(changed: set[str]) -> None:
     ]
     if invalid:
         raise GovernanceError(f"invalid evidence path(s): {', '.join(sorted(invalid))}")
+    readme_allowed = all(
+        CANDIDATE_PATH_RE.fullmatch(path) is not None for path in evidence_paths
+    )
     non_evidence = [
         path
         for path in changed
-        if path not in evidence_paths and path != "plans/releases/README.md"
+        if path not in evidence_paths
+        and not (readme_allowed and path == "plans/releases/README.md")
     ]
     if non_evidence:
         raise GovernanceError(

--- a/verification/areas/distribution_release/governance/evidence_custody.py
+++ b/verification/areas/distribution_release/governance/evidence_custody.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from .common import GovernanceError, load_json_strict, sha256_bytes
+from .incident_evidence import validate_incident_evidence_commit
 from .incident import validate_incident_request, validate_incident_signoff
 from .release_plan import validate_release_plan, validate_release_signoff
 from .release_report import validate_release_profile_report
@@ -22,13 +23,14 @@ CANDIDATE_PATH_RE = re.compile(
 )
 INCIDENT_PATH_RE = re.compile(
     r"^plans/releases/incidents/([a-z0-9][a-z0-9-]{2,63})/"
-    r"(stable-incident-request|stable-incident-signoff)\.json$"
+    r"((stable-incident-request|stable-incident-signoff)\.json|withdrawal-evidence\.txt)$"
 )
 
 
 def run_evidence_custody_checks() -> int:
     try:
         validate_changed_evidence_scope()
+        validate_committed_incident_addition()
         validate_existing_evidence()
     except GovernanceError as exc:
         print(f"evidence-custody: {exc}", file=sys.stderr)
@@ -79,11 +81,7 @@ def validate_changed_path_set(changed: set[str]) -> None:
 
 
 def changed_paths() -> set[str]:
-    base_ref = os.environ.get("SIFR_EVIDENCE_BASE_REF", "origin/main")
-    merge_base = git_output("merge-base", base_ref, "HEAD", allow_failure=True)
-    if not merge_base:
-        merge_base = git_output("rev-parse", "HEAD^", allow_failure=True)
-    merge_base = require_comparison_base(merge_base, base_ref=base_ref)
+    merge_base = comparison_base()
     tracked: set[str] = set()
     tracked.update(
         line
@@ -106,6 +104,39 @@ def changed_paths() -> set[str]:
         if line
     )
     return tracked
+
+
+def comparison_base() -> str:
+    base_ref = os.environ.get("SIFR_EVIDENCE_BASE_REF", "origin/main")
+    merge_base = git_output("merge-base", base_ref, "HEAD", allow_failure=True)
+    if not merge_base:
+        merge_base = git_output("rev-parse", "HEAD^", allow_failure=True)
+    return require_comparison_base(merge_base, base_ref=base_ref)
+
+
+def validate_committed_incident_addition() -> None:
+    merge_base = comparison_base()
+    committed = {
+        line
+        for line in git_output("diff", "--name-only", f"{merge_base}...HEAD").splitlines()
+        if line
+    }
+    request_paths = sorted(
+        path
+        for path in committed
+        if path.endswith("/stable-incident-request.json")
+        and path.startswith("plans/releases/incidents/")
+    )
+    for request_path in request_paths:
+        directory = request_path.rsplit("/", 1)[0]
+        evidence_path = f"{directory}/withdrawal-evidence.txt"
+        validate_incident_evidence_commit(
+            repository=REPO_ROOT,
+            base=merge_base,
+            head="HEAD",
+            request_path=request_path,
+            evidence_path=evidence_path,
+        )
 
 
 def require_comparison_base(value: str, *, base_ref: str) -> str:
@@ -186,16 +217,25 @@ def validate_candidate_directory(directory: Path) -> None:
 
 def validate_incident_directory(directory: Path) -> None:
     files = {path.name for path in directory.iterdir() if path.is_file()}
-    allowed = {"stable-incident-request.json", "stable-incident-signoff.json"}
+    allowed = {
+        "stable-incident-request.json",
+        "withdrawal-evidence.txt",
+        "stable-incident-signoff.json",
+    }
     unknown = sorted(files.difference(allowed))
     if unknown:
         raise GovernanceError(f"{directory}: unsupported incident evidence: {', '.join(unknown)}")
     request_path = directory / "stable-incident-request.json"
     if not request_path.is_file():
         raise GovernanceError(f"{directory}: stable-incident-request.json is required")
+    evidence_path = directory / "withdrawal-evidence.txt"
+    if not evidence_path.is_file():
+        raise GovernanceError(f"{directory}: withdrawal-evidence.txt is required")
     request = validate_incident_request(load_json_strict(request_path, require_canonical=True))
     if request["incident_id"] != directory.name:
         raise GovernanceError(f"{directory}: incident id does not match directory")
+    if request["withdrawal"]["evidence_sha256"] != sha256_bytes(evidence_path.read_bytes()):
+        raise GovernanceError(f"{directory}: withdrawal evidence digest mismatch")
     signoff_path = directory / "stable-incident-signoff.json"
     if signoff_path.is_file():
         signoff = validate_incident_signoff(

--- a/verification/areas/distribution_release/governance/evidence_custody.py
+++ b/verification/areas/distribution_release/governance/evidence_custody.py
@@ -198,7 +198,10 @@ def validate_incident_directory(directory: Path) -> None:
         raise GovernanceError(f"{directory}: incident id does not match directory")
     signoff_path = directory / "stable-incident-signoff.json"
     if signoff_path.is_file():
-        signoff = validate_incident_signoff(load_json_strict(signoff_path, require_canonical=True))
+        signoff = validate_incident_signoff(
+            load_json_strict(signoff_path, require_canonical=True),
+            incident_request=request,
+        )
         if signoff["incident_id"] != directory.name:
             raise GovernanceError(f"{directory}: incident sign-off identity mismatch")
         if signoff["request_sha256"] != sha256_bytes(request_path.read_bytes()):

--- a/verification/areas/distribution_release/governance/incident.py
+++ b/verification/areas/distribution_release/governance/incident.py
@@ -30,6 +30,7 @@ REQUEST_REQUIRED = {
 SIGNOFF_REQUIRED = {
     "schema_version",
     "incident_id",
+    "operation",
     "request_sha256",
     "attempts",
     "index_mutation",
@@ -110,13 +111,30 @@ def validate_incident_request(
     return request
 
 
-def validate_incident_signoff(payload: Any) -> dict[str, Any]:
+def validate_incident_signoff(
+    payload: Any,
+    *,
+    incident_request: Any | None = None,
+) -> dict[str, Any]:
     signoff = require_object(payload, "$")
     require_exact_keys(signoff, required=SIGNOFF_REQUIRED, location="$")
     require_schema_v2(signoff)
     require_incident_id(signoff["incident_id"], "$.incident_id")
+    operation = require_enum(
+        signoff["operation"],
+        {"rollback", "incident-roll-forward"},
+        "$.operation",
+    )
     require_sha256(signoff["request_sha256"], "$.request_sha256")
     validate_attempts(signoff["attempts"], "$.attempts")
+    attempts = signoff["attempts"]
+    run_ids = [attempt["run_id"] for attempt in attempts]
+    if run_ids != sorted(set(run_ids)):
+        fail("$.attempts", "run_id values must be unique and strictly increasing")
+    if any(attempt["status"] == "started" for attempt in attempts):
+        fail("$.attempts", "completed sign-off cannot contain a pending attempt")
+    if attempts[-1]["status"] != "completed":
+        fail("$.attempts", "final attempt must be completed")
 
     mutation = require_object(signoff["index_mutation"], "$.index_mutation")
     require_exact_keys(
@@ -150,6 +168,12 @@ def validate_incident_signoff(payload: Any) -> dict[str, Any]:
         if evidence["status"] != "pass":
             fail(f"$.{name}.status", "must be pass")
         require_sha256(evidence["evidence_sha256"], f"$.{name}.evidence_sha256")
+    if incident_request is not None:
+        request = validate_incident_request(incident_request)
+        if request["incident_id"] != signoff["incident_id"]:
+            fail("$.incident_id", "does not match the incident request")
+        if request["operation"] != operation:
+            fail("$.operation", "does not match the incident request")
     return signoff
 
 

--- a/verification/areas/distribution_release/governance/incident.py
+++ b/verification/areas/distribution_release/governance/incident.py
@@ -133,8 +133,9 @@ def validate_incident_signoff(
         fail("$.attempts", "run_id values must be unique and strictly increasing")
     if any(attempt["status"] == "started" for attempt in attempts):
         fail("$.attempts", "completed sign-off cannot contain a pending attempt")
-    if attempts[-1]["status"] != "completed":
-        fail("$.attempts", "final attempt must be completed")
+    completed_attempts = sum(attempt["status"] == "completed" for attempt in attempts)
+    if completed_attempts != 1 or attempts[-1]["status"] != "completed":
+        fail("$.attempts", "must contain exactly one final completed attempt")
 
     mutation = require_object(signoff["index_mutation"], "$.index_mutation")
     require_exact_keys(

--- a/verification/areas/distribution_release/governance/incident_evidence.py
+++ b/verification/areas/distribution_release/governance/incident_evidence.py
@@ -35,9 +35,11 @@ def validate_incident_evidence_commit(
     if request_relative.parent != evidence_relative.parent:
         raise GovernanceError("incident request and evidence must share one incident directory")
     parts = request_relative.parts
-    if len(parts) != 4 or parts[:2] != ("plans", "incidents"):
-        raise GovernanceError("incident evidence must use plans/incidents/<incident-id>/")
-    require_incident_id(parts[2], "incident evidence directory")
+    if len(parts) != 5 or parts[:3] != ("plans", "releases", "incidents"):
+        raise GovernanceError(
+            "incident evidence must use plans/releases/incidents/<incident-id>/"
+        )
+    require_incident_id(parts[3], "incident evidence directory")
 
     _git(repository, "merge-base", "--is-ancestor", base, head)
     changed = _git(
@@ -64,7 +66,7 @@ def validate_incident_evidence_commit(
         raise GovernanceError("withdrawal evidence must not be empty")
     request = _load_canonical_bytes(request_bytes)
     validate_incident_request(request)
-    if request["incident_id"] != parts[2]:
+    if request["incident_id"] != parts[3]:
         raise GovernanceError("incident directory does not match request incident_id")
     if request["withdrawal"]["evidence_sha256"] != sha256_bytes(evidence_bytes):
         raise GovernanceError("withdrawal evidence bytes do not match the request digest")

--- a/verification/areas/distribution_release/governance/incident_evidence.py
+++ b/verification/areas/distribution_release/governance/incident_evidence.py
@@ -1,0 +1,114 @@
+"""Evidence-only incident commit validation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .common import (
+    GovernanceError,
+    canonical_json_bytes,
+    require_incident_id,
+    sha256_bytes,
+)
+from .incident import validate_incident_request
+
+
+def validate_incident_evidence_commit(
+    *,
+    repository: Path,
+    base: str,
+    head: str,
+    request_path: str,
+    evidence_path: str,
+) -> dict[str, Any]:
+    """Require an additive commit range containing exactly request + evidence."""
+    repository = repository.resolve()
+    request_relative = _validate_relative_path(request_path)
+    evidence_relative = _validate_relative_path(evidence_path)
+    if request_relative.name != "stable-incident-request.json":
+        raise GovernanceError("incident request path must end in stable-incident-request.json")
+    if evidence_relative.name != "withdrawal-evidence.txt":
+        raise GovernanceError("incident evidence path must end in withdrawal-evidence.txt")
+    if request_relative.parent != evidence_relative.parent:
+        raise GovernanceError("incident request and evidence must share one incident directory")
+    parts = request_relative.parts
+    if len(parts) != 4 or parts[:2] != ("plans", "incidents"):
+        raise GovernanceError("incident evidence must use plans/incidents/<incident-id>/")
+    require_incident_id(parts[2], "incident evidence directory")
+
+    _git(repository, "merge-base", "--is-ancestor", base, head)
+    changed = _git(
+        repository,
+        "diff",
+        "--name-status",
+        "--no-renames",
+        base,
+        head,
+    ).decode()
+    expected = {request_relative.as_posix(), evidence_relative.as_posix()}
+    observed: set[str] = set()
+    for line in changed.splitlines():
+        fields = line.split("\t")
+        if len(fields) != 2 or fields[0] != "A":
+            raise GovernanceError("incident evidence commit may contain only added files")
+        observed.add(fields[1])
+    if observed != expected:
+        raise GovernanceError("incident evidence commit must add exactly request and withdrawal evidence")
+
+    request_bytes = _git(repository, "show", f"{head}:{request_relative.as_posix()}")
+    evidence_bytes = _git(repository, "show", f"{head}:{evidence_relative.as_posix()}")
+    if not evidence_bytes:
+        raise GovernanceError("withdrawal evidence must not be empty")
+    request = _load_canonical_bytes(request_bytes)
+    validate_incident_request(request)
+    if request["incident_id"] != parts[2]:
+        raise GovernanceError("incident directory does not match request incident_id")
+    if request["withdrawal"]["evidence_sha256"] != sha256_bytes(evidence_bytes):
+        raise GovernanceError("withdrawal evidence bytes do not match the request digest")
+    return request
+
+
+def _validate_relative_path(value: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if (
+        path.is_absolute()
+        or ".." in path.parts
+        or "." in path.parts
+        or value != path.as_posix()
+    ):
+        raise GovernanceError("incident evidence paths must be normalized repository-relative paths")
+    return path
+
+
+def _git(repository: Path, *args: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repository), *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace").strip()
+        raise GovernanceError(f"git {' '.join(args)} failed: {detail}")
+    return result.stdout
+
+
+def _load_canonical_bytes(raw: bytes) -> dict[str, Any]:
+    def pairs(items: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in items:
+            if key in result:
+                raise GovernanceError(f"incident request contains duplicate key: {key}")
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(raw, object_pairs_hook=pairs)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GovernanceError(f"incident request is invalid JSON: {exc}") from exc
+    if not isinstance(value, dict) or raw != canonical_json_bytes(value):
+        raise GovernanceError("incident request must use canonical JSON object bytes")
+    return value

--- a/verification/areas/distribution_release/governance/incident_fixture.py
+++ b/verification/areas/distribution_release/governance/incident_fixture.py
@@ -1,0 +1,809 @@
+"""Credential-free filesystem harness for stable incident recovery."""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from copy import deepcopy
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from .common import (
+    GovernanceError,
+    canonical_json_bytes,
+    fail,
+    load_json_strict,
+    require_array,
+    require_enum,
+    require_exact_keys,
+    require_nonempty_string,
+    require_object,
+    require_schema_v2,
+    sha256_bytes,
+    sha256_file,
+    version_channel,
+)
+from .incident import validate_attempts, validate_incident_request, validate_incident_signoff
+from .incident_planner import IncidentMutation, materialize_incident_mutation
+from .release_index import validate_release_index
+from .release_plan import generate_site_release_facts, validate_site_release_facts
+
+SNAPSHOT_RE = re.compile(r"^channels-generation-([1-9][0-9]*)\.json$")
+ATTEMPT_RE = re.compile(r"^attempt-([1-9][0-9]*)\.json$")
+FORBIDDEN_CREDENTIALS = {
+    "CLOUDFLARE_API_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "VSCE_PAT",
+    "SIFR_SITE_TOKEN",
+}
+SITE_WAIT_MINUTES = 20
+
+
+def run_incident_fixture(
+    *,
+    fixture_root: Path,
+    live_index_path: Path,
+    governance_root: Path,
+    release_assets_root: Path,
+    marketplace_path: Path,
+    extension_metadata_path: Path,
+    site_root: Path,
+    request_path: Path,
+    affected_plan_path: Path,
+    successor_plan_path: Path,
+    mode: str,
+    approver: str,
+    fail_at: str = "none",
+) -> dict[str, Any]:
+    """Run or resume one local-only incident operation."""
+    root = validate_fixture_root(fixture_root)
+    _reject_fixture_symlinks(root)
+    mode = require_enum(mode, {"initial", "resume"}, "mode")
+    fail_at = require_enum(
+        fail_at,
+        {
+            "none",
+            "after-reservation",
+            "race-before-index",
+            "after-index",
+            "site-timeout",
+        },
+        "fail_at",
+    )
+    require_nonempty_string(approver, "approver")
+    _reject_production_credentials()
+    request_path = require_fixture_path(root, request_path, "request")
+    affected_plan_path = require_fixture_path(root, affected_plan_path, "affected plan")
+    successor_plan_path = require_fixture_path(root, successor_plan_path, "successor plan")
+    live_index_path = require_fixture_path(root, live_index_path, "live index")
+    governance_root = require_fixture_path(
+        root,
+        governance_root,
+        "governance release",
+    )
+    release_assets_root = require_fixture_path(
+        root,
+        release_assets_root,
+        "release assets",
+    )
+    marketplace_path = require_fixture_path(root, marketplace_path, "Marketplace stub")
+    extension_metadata_path = require_fixture_path(
+        root,
+        extension_metadata_path,
+        "extension metadata",
+    )
+    site_root = require_fixture_path(root, site_root, "site repository")
+    if not (site_root / ".non-deploying-fixture").is_file():
+        fail(str(site_root), "site repository must carry the non-deploying fixture marker")
+    governance_root.mkdir(parents=True, exist_ok=True)
+    request = validate_incident_request(
+        load_json_strict(request_path, require_canonical=True)
+    )
+    request_sha256 = sha256_file(request_path)
+    incident_id = request["incident_id"]
+    request_asset = governance_root / (
+        f"stable-incident-request-{incident_id}-{request_sha256[:16]}.json"
+    )
+    completed_signoff = governance_root / (
+        f"stable-incident-signoff-{incident_id}-{request_sha256[:16]}.json"
+    )
+    if completed_signoff.exists():
+        fail(str(completed_signoff), "incident is already signed off")
+
+    with metadata_lease(root, request["operation"]):
+        attempts_root = root / "state" / request_sha256
+        attempts_root.mkdir(parents=True, exist_ok=True)
+        snapshots = load_snapshots(governance_root)
+        live_bytes = live_index_path.read_bytes()
+        live = validate_release_index(
+            load_json_strict(live_index_path, require_canonical=True)
+        )
+        _require_live_snapshot(snapshots, live, live_bytes)
+
+        previous, mutation, already_applied = _resolve_mutation(
+            request_path=request_path,
+            affected_plan_path=affected_plan_path,
+            successor_plan_path=successor_plan_path,
+            live_index_path=live_index_path,
+            request=request,
+            live=live,
+            live_bytes=live_bytes,
+            snapshots=snapshots,
+            mode=mode,
+        )
+        _verify_immutable_installer(
+            release_assets_root,
+            mutation.proposed_index,
+            mutation.successor_version,
+        )
+        _validate_extension_and_marketplace(
+            extension_metadata_path,
+            marketplace_path,
+            mutation,
+        )
+        _preserve_write_once(request_asset, request_path.read_bytes(), mode=mode)
+        run_id = _next_attempt_id(attempts_root)
+        attempt = _new_attempt(run_id, mode, approver, request_asset, request_sha256)
+        snapshot_path = governance_root / (
+            f"channels-generation-{mutation.proposed_index['generation']}.json"
+        )
+        proposed_bytes = canonical_json_bytes(mutation.proposed_index)
+        if already_applied:
+            if snapshot_path.read_bytes() != proposed_bytes:
+                fail(str(snapshot_path), "realized snapshot bytes drifted before resume")
+        else:
+            if not _previous_identity_matches(live_index_path, mutation.previous_index):
+                _add_mutation(
+                    attempt,
+                    "stale-index",
+                    "channels.json",
+                    sha256_file(live_index_path),
+                )
+                return _record_failure(attempts_root, attempt, "stale-generation")
+            _write_once_bytes(snapshot_path, proposed_bytes)
+            _add_mutation(
+                attempt,
+                "generation-reservation",
+                snapshot_path.name,
+                sha256_bytes(proposed_bytes),
+            )
+            if fail_at == "after-reservation":
+                return _record_failure(attempts_root, attempt, "after-reservation")
+            if fail_at == "race-before-index":
+                _simulate_newer_fixture_generation(
+                    live_index_path=live_index_path,
+                    governance_root=governance_root,
+                    previous=mutation.previous_index,
+                    generation=mutation.proposed_index["generation"] + 1,
+                )
+            if not _previous_identity_matches(live_index_path, mutation.previous_index):
+                _add_mutation(
+                    attempt,
+                    "stale-index",
+                    "channels.json",
+                    sha256_file(live_index_path),
+                )
+                return _record_failure(attempts_root, attempt, "stale-generation")
+            _replace_canonical(live_index_path, mutation.proposed_index)
+            _add_mutation(attempt, "release-index", "channels.json", sha256_bytes(proposed_bytes))
+            if fail_at == "after-index":
+                return _record_failure(attempts_root, attempt, "after-index")
+
+        realized = validate_release_index(
+            load_json_strict(live_index_path, require_canonical=True)
+        )
+        realized_sha256 = sha256_file(live_index_path)
+        if realized != mutation.proposed_index:
+            fail(str(live_index_path), "realized index does not equal the approved mutation")
+        if fail_at == "site-timeout":
+            site_attempt = _record_site_attempt(
+                site_root=site_root,
+                live_index_path=live_index_path,
+                request_sha256=request_sha256,
+                run_id=run_id,
+                generation=realized["generation"],
+                index_sha256=realized_sha256,
+                status="terminal-timeout",
+            )
+            _add_mutation(attempt, "site-attempt", site_attempt.name, sha256_file(site_attempt))
+            return _record_failure(attempts_root, attempt, "site-timeout")
+
+        _require_site_identity(live_index_path, realized["generation"], realized_sha256)
+        site_facts_path = _reconcile_site(
+            site_root=site_root,
+            governance_root=governance_root,
+            mutation=mutation,
+            realized_index_path=live_index_path,
+            run_id=run_id,
+        )
+        site_attempt = _record_site_attempt(
+            site_root=site_root,
+            live_index_path=live_index_path,
+            request_sha256=request_sha256,
+            run_id=run_id,
+            generation=realized["generation"],
+            index_sha256=realized_sha256,
+            status="succeeded",
+        )
+        _add_mutation(attempt, "site-attempt", site_attempt.name, sha256_file(site_attempt))
+        site_facts_sha256 = sha256_file(site_facts_path)
+        _add_mutation(attempt, "site-reconciliation", site_facts_path.name, site_facts_sha256)
+        attempt["status"] = "completed"
+        _write_attempt(attempts_root, attempt)
+        signoff_path = _write_signoff(
+            governance_root=governance_root,
+            request=request,
+            request_sha256=request_sha256,
+            previous=previous,
+            realized=realized,
+            realized_sha256=realized_sha256,
+            mutation=mutation,
+            attempts_root=attempts_root,
+            site_facts_sha256=site_facts_sha256,
+        )
+        return {
+            "status": "completed",
+            "operation": mutation.operation,
+            "generation": realized["generation"],
+            "index_sha256": realized_sha256,
+            "signoff": str(signoff_path),
+        }
+
+
+def validate_fixture_root(path: Path) -> Path:
+    root = path.resolve()
+    temporary_root = Path(tempfile.gettempdir()).resolve()
+    if root == temporary_root or temporary_root not in root.parents:
+        fail(str(path), "fixture root must be a dedicated directory under the system temp root")
+    if not root.is_dir():
+        fail(str(path), "fixture root must already exist")
+    return root
+
+
+def require_fixture_path(root: Path, path: Path, label: str) -> Path:
+    resolved = path.resolve()
+    if resolved == root or root not in resolved.parents:
+        fail(label, "must resolve inside the explicit fixture root")
+    return resolved
+
+
+def load_snapshots(governance_root: Path) -> dict[int, tuple[Path, dict[str, Any], bytes]]:
+    snapshots: dict[int, tuple[Path, dict[str, Any], bytes]] = {}
+    for path in sorted(governance_root.glob("channels-generation-*.json")):
+        match = SNAPSHOT_RE.fullmatch(path.name)
+        if match is None:
+            fail(str(path), "invalid generation snapshot name")
+        generation = int(match.group(1))
+        raw = path.read_bytes()
+        value = validate_release_index(load_json_strict(path, require_canonical=True))
+        if value["generation"] != generation:
+            fail(str(path), "snapshot name and payload generation disagree")
+        snapshots[generation] = (path, value, raw)
+    if not snapshots:
+        fail(str(governance_root), "must retain the live generation snapshot")
+    return snapshots
+
+
+def check_release_submission_allowed(fixture_root: Path, submission: str) -> None:
+    """Fail a preview/stable submission while an incident owns metadata."""
+    root = validate_fixture_root(fixture_root)
+    _reject_fixture_symlinks(root)
+    submission = require_enum(submission, {"preview", "stable"}, "submission")
+    lock_path = root / "state" / "metadata-concurrency.lock"
+    if lock_path.exists():
+        owner = lock_path.read_text(encoding="utf-8").strip()
+        if owner in {"rollback", "incident-roll-forward"}:
+            fail(submission, f"blocked while {owner} is pending")
+
+
+def plan_fixture_recovery(
+    *,
+    fixture_root: Path,
+    current_version: str | None,
+    entrypoint: str,
+    force: bool,
+) -> dict[str, Any]:
+    """Resolve fresh install or explicit incident downgrade to immutable bytes."""
+    root = validate_fixture_root(fixture_root)
+    _reject_fixture_symlinks(root)
+    entrypoint = require_enum(
+        entrypoint,
+        {"fresh-install", "self-update", "out-of-band"},
+        "entrypoint",
+    )
+    index = validate_release_index(
+        load_json_strict(root / "live" / "channels.json", require_canonical=True)
+    )
+    target_version = index["channels"]["stable"]
+    target = index["releases"][target_version]
+    if target["status"] != "active":
+        fail("stable", "governed stable target is not active")
+    if current_version is not None:
+        if version_channel(current_version, "current_version") != "stable":
+            fail("current_version", "incident recovery supports exact stable versions")
+        if _stable_tuple(target_version) < _stable_tuple(current_version) and not force:
+            command = (
+                "sifr self update --channel stable --force"
+                if entrypoint == "self-update"
+                else "curl -fsSL https://sifr.sh/install/stable | sh -s -- --force"
+            )
+            fail("force", f"downgrade requires explicit consent; recovery command: {command}")
+    installer = root / "release-assets" / target_version / f"sifr-installer-{target_version}"
+    _verify_immutable_installer(root / "release-assets", index, target_version)
+    return {
+        "status": "ready",
+        "entrypoint": entrypoint,
+        "current_version": current_version or "none",
+        "target_version": target_version,
+        "installer": str(installer),
+        "installer_sha256": sha256_file(installer),
+        "force": force,
+        "action": "delegate-to-immutable-installer",
+    }
+
+
+@contextmanager
+def metadata_lease(root: Path, operation: str) -> Iterator[None]:
+    lock_path = root / "state" / "metadata-concurrency.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        descriptor = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError as exc:
+        raise GovernanceError("metadata concurrency lease is already held") from exc
+    try:
+        os.write(descriptor, f"{operation}\n".encode())
+        os.close(descriptor)
+        yield
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        lock_path.unlink(missing_ok=True)
+
+
+def _resolve_mutation(
+    *,
+    request_path: Path,
+    affected_plan_path: Path,
+    successor_plan_path: Path,
+    live_index_path: Path,
+    request: dict[str, Any],
+    live: dict[str, Any],
+    live_bytes: bytes,
+    snapshots: dict[int, tuple[Path, dict[str, Any], bytes]],
+    mode: str,
+) -> tuple[tuple[dict[str, Any], str], IncidentMutation, bool]:
+    affected_version = request["affected_release"]["version"]
+    live_affected = live["releases"].get(affected_version)
+    already_applied = (
+        isinstance(live_affected, dict)
+        and live_affected.get("status") == "withdrawn"
+        and live_affected.get("incident_id") == request["incident_id"]
+    )
+    if already_applied:
+        if mode != "resume":
+            fail("mode", "an already-realized incident requires resume")
+        previous_candidates = [
+            (value, raw)
+            for generation, (_, value, raw) in snapshots.items()
+            if generation < live["generation"]
+            and value["channels"].get("stable") == affected_version
+            and value["releases"].get(affected_version, {}).get("status") == "active"
+        ]
+        if not previous_candidates:
+            fail("resume", "cannot recover the exact pre-incident generation")
+        previous, previous_bytes = max(previous_candidates, key=lambda item: item[0]["generation"])
+        with tempfile.NamedTemporaryFile(
+            dir=live_index_path.parent,
+            prefix=".incident-previous-",
+            suffix=".json",
+            delete=False,
+        ) as stream:
+            stream.write(previous_bytes)
+            temporary = Path(stream.name)
+        try:
+            mutation = materialize_incident_mutation(
+                request_path=request_path,
+                live_index_path=temporary,
+                affected_plan_path=affected_plan_path,
+                successor_plan_path=successor_plan_path,
+                expected_generation=previous["generation"],
+                expected_sha256=sha256_bytes(previous_bytes),
+                proposed_generation=live["generation"],
+            )
+        finally:
+            temporary.unlink(missing_ok=True)
+        return (previous, sha256_bytes(previous_bytes)), mutation, True
+
+    proposed_generation = max(snapshots) + 1
+    mutation = materialize_incident_mutation(
+        request_path=request_path,
+        live_index_path=live_index_path,
+        affected_plan_path=affected_plan_path,
+        successor_plan_path=successor_plan_path,
+        expected_generation=live["generation"],
+        expected_sha256=sha256_bytes(live_bytes),
+        proposed_generation=proposed_generation,
+    )
+    return (live, sha256_bytes(live_bytes)), mutation, False
+
+
+def _require_live_snapshot(
+    snapshots: dict[int, tuple[Path, dict[str, Any], bytes]],
+    live: dict[str, Any],
+    live_bytes: bytes,
+) -> None:
+    snapshot = snapshots.get(live["generation"])
+    if snapshot is None or snapshot[2] != live_bytes:
+        fail("live index", "must equal its retained immutable generation snapshot")
+
+
+def _previous_identity_matches(
+    live_index_path: Path,
+    expected: dict[str, Any],
+) -> bool:
+    try:
+        live = validate_release_index(
+            load_json_strict(live_index_path, require_canonical=True)
+        )
+    except GovernanceError:
+        return False
+    return live == expected
+
+
+def _simulate_newer_fixture_generation(
+    *,
+    live_index_path: Path,
+    governance_root: Path,
+    previous: dict[str, Any],
+    generation: int,
+) -> None:
+    raced = deepcopy(previous)
+    raced["generation"] = generation
+    validate_release_index(raced)
+    _replace_canonical(live_index_path, raced)
+    _write_once_bytes(
+        governance_root / f"channels-generation-{generation}.json",
+        canonical_json_bytes(raced),
+    )
+
+
+def _validate_extension_and_marketplace(
+    extension_metadata_path: Path,
+    marketplace_path: Path,
+    mutation: IncidentMutation,
+) -> None:
+    extension = _load_range_fixture(extension_metadata_path, "extension metadata")
+    marketplace = _load_range_fixture(marketplace_path, "Marketplace stub")
+    if mutation.operation == "rollback":
+        for label, value in (("extension metadata", extension), ("Marketplace stub", marketplace)):
+            if not _version_in_range(mutation.successor_version, value["compiler_compatibility"]):
+                fail(label, "compiler compatibility range excludes the rollback target")
+    published = require_array(marketplace["published_versions"], "$.published_versions")
+    if mutation.successor_version not in published:
+        fail("Marketplace stub", "does not contain the successor version")
+
+
+def _load_range_fixture(path: Path, label: str) -> dict[str, Any]:
+    value = require_object(load_json_strict(path, require_canonical=True), label)
+    require_exact_keys(
+        value,
+        required={"schema_version", "compiler_compatibility", "published_versions"},
+        location=label,
+    )
+    require_schema_v2(value, label)
+    require_nonempty_string(value["compiler_compatibility"], f"{label}.compiler_compatibility")
+    versions = require_array(value["published_versions"], f"{label}.published_versions")
+    if not versions or any(not isinstance(item, str) for item in versions):
+        fail(f"{label}.published_versions", "must contain exact stable versions")
+    return value
+
+
+def _version_in_range(version: str, expression: str) -> bool:
+    match = re.fullmatch(
+        r">=([0-9]+\.[0-9]+\.[0-9]+),<([0-9]+\.[0-9]+\.[0-9]+)",
+        expression,
+    )
+    if match is None:
+        fail("compiler_compatibility", "must use >=X.Y.Z,<X.Y.Z")
+    parsed = tuple(int(part) for part in version.split("."))
+    lower = tuple(int(part) for part in match.group(1).split("."))
+    upper = tuple(int(part) for part in match.group(2).split("."))
+    return lower <= parsed < upper
+
+
+def _stable_tuple(version: str) -> tuple[int, int, int]:
+    version_channel(version, "version")
+    major, minor, patch = (int(part) for part in version.split("."))
+    return major, minor, patch
+
+
+def _verify_immutable_installer(
+    release_assets_root: Path,
+    index: dict[str, Any],
+    version: str,
+) -> None:
+    installer = release_assets_root / version / f"sifr-installer-{version}"
+    if not installer.is_file():
+        fail(str(installer), "immutable installer fixture is missing")
+    if sha256_file(installer) != index["releases"][version]["installer_sha256"]:
+        fail(str(installer), "immutable installer digest does not match the governed index")
+
+
+def _reconcile_site(
+    *,
+    site_root: Path,
+    governance_root: Path,
+    mutation: IncidentMutation,
+    realized_index_path: Path,
+    run_id: int,
+) -> Path:
+    install_root = site_root / "install"
+    dispatchers = {
+        name: sha256_file(install_root / name)
+        for name in ("index", "stable", "alpha", "beta")
+    }
+    realized = load_json_strict(realized_index_path, require_canonical=True)
+    facts = generate_site_release_facts(
+        realized,
+        source_plan_sha256=mutation.successor_plan_sha256,
+        release_index_sha256=sha256_file(realized_index_path),
+        dispatchers=dispatchers,
+    )
+    deployed_path = site_root / "release-facts.json"
+    _replace_canonical(deployed_path, facts)
+    validate_site_release_facts(
+        load_json_strict(deployed_path, require_canonical=True),
+        governed_index=realized,
+    )
+    retained = governance_root / (
+        f"site-release-facts-generation-{realized['generation']}-attempt-{run_id}.json"
+    )
+    _write_once_bytes(retained, deployed_path.read_bytes())
+    return retained
+
+
+def _record_site_attempt(
+    *,
+    site_root: Path,
+    live_index_path: Path,
+    request_sha256: str,
+    run_id: int,
+    generation: int,
+    index_sha256: str,
+    status: str,
+) -> Path:
+    status = require_enum(status, {"succeeded", "terminal-timeout"}, "site status")
+    _require_site_identity(live_index_path, generation, index_sha256)
+    cancellation = "not-required" if status == "succeeded" else "requested"
+    value = (
+        f"request_sha256={request_sha256}\n"
+        f"run_id={run_id}\n"
+        f"generation={generation}\n"
+        f"index_sha256={index_sha256}\n"
+        f"deadline_minutes={SITE_WAIT_MINUTES}\n"
+        f"status={status}\n"
+        f"cancellation={cancellation}\n"
+    )
+    path = site_root / "attempts" / (
+        f"{request_sha256[:16]}-attempt-{run_id}.txt"
+    )
+    _write_once_bytes(path, value.encode())
+    return path
+
+
+def _require_site_identity(
+    live_index_path: Path,
+    generation: int,
+    index_sha256: str,
+) -> None:
+    live = validate_release_index(
+        load_json_strict(live_index_path, require_canonical=True)
+    )
+    if live["generation"] != generation or sha256_file(live_index_path) != index_sha256:
+        fail("site attempt", "live generation/digest changed before dispatch")
+
+
+def _write_signoff(
+    *,
+    governance_root: Path,
+    request: dict[str, Any],
+    request_sha256: str,
+    previous: tuple[dict[str, Any], str],
+    realized: dict[str, Any],
+    realized_sha256: str,
+    mutation: IncidentMutation,
+    attempts_root: Path,
+    site_facts_sha256: str,
+) -> Path:
+    evidence_digests = {
+        name: _write_text_evidence(
+            governance_root / f"incident-{name}-{request['incident_id']}.txt",
+            _evidence_text(name, request, realized, mutation),
+        )
+        for name in ("validation", "communications", "closure")
+    }
+    attempts = [
+        load_json_strict(path, require_canonical=True)
+        for path in sorted(
+            attempts_root.glob("attempt-*.json"),
+            key=_attempt_id,
+        )
+    ]
+    validate_attempts(attempts, "$.attempts")
+    signoff = {
+        "schema_version": 2,
+        "incident_id": request["incident_id"],
+        "operation": mutation.operation,
+        "request_sha256": request_sha256,
+        "attempts": attempts,
+        "index_mutation": {
+            "previous_generation": previous[0]["generation"],
+            "previous_sha256": previous[1],
+            "realized_generation": realized["generation"],
+            "realized_sha256": realized_sha256,
+            "affected_version": mutation.affected_version,
+            "successor_version": mutation.successor_version,
+        },
+        "site_reconciliation": {
+            "status": "pass",
+            "evidence_sha256": site_facts_sha256,
+        },
+        "validation": {"status": "pass", "evidence_sha256": evidence_digests["validation"]},
+        "communications": {
+            "status": "pass",
+            "evidence_sha256": evidence_digests["communications"],
+        },
+        "closure": {"status": "pass", "evidence_sha256": evidence_digests["closure"]},
+    }
+    validate_incident_signoff(signoff, incident_request=request)
+    path = governance_root / (
+        f"stable-incident-signoff-{request['incident_id']}-{request_sha256[:16]}.json"
+    )
+    _write_once_bytes(path, canonical_json_bytes(signoff))
+    return path
+
+
+def _evidence_text(
+    name: str,
+    request: dict[str, Any],
+    realized: dict[str, Any],
+    mutation: IncidentMutation,
+) -> str:
+    return (
+        f"kind={name}\n"
+        f"incident={request['incident_id']}\n"
+        f"operation={mutation.operation}\n"
+        f"generation={realized['generation']}\n"
+        f"stable={mutation.successor_version}\n"
+    )
+
+
+def _new_attempt(
+    run_id: int,
+    mode: str,
+    approver: str,
+    request_asset: Path,
+    request_sha256: str,
+) -> dict[str, Any]:
+    attempt = {
+        "run_id": run_id,
+        "mode": mode,
+        "approver": approver,
+        "status": "started",
+        "mutations": [],
+    }
+    _add_mutation(attempt, "incident-request", request_asset.name, request_sha256)
+    return attempt
+
+
+def _add_mutation(attempt: dict[str, Any], kind: str, identity: str, digest: str) -> None:
+    attempt["mutations"].append({"kind": kind, "identity": identity, "sha256": digest})
+
+
+def _record_failure(
+    attempts_root: Path,
+    attempt: dict[str, Any],
+    failure: str,
+) -> dict[str, Any]:
+    attempt["status"] = "failed"
+    _add_mutation(
+        attempt,
+        "failure",
+        failure,
+        sha256_bytes(f"{failure}\n".encode()),
+    )
+    _write_attempt(attempts_root, attempt)
+    return {"status": "failed", "failure": failure, "run_id": attempt["run_id"]}
+
+
+def _write_attempt(root: Path, attempt: dict[str, Any]) -> None:
+    validate_attempts([attempt], "$.attempts")
+    _write_once_bytes(
+        root / f"attempt-{attempt['run_id']}.json",
+        canonical_json_bytes(attempt),
+    )
+
+
+def _next_attempt_id(root: Path) -> int:
+    ids = []
+    for path in root.glob("attempt-*.json"):
+        match = ATTEMPT_RE.fullmatch(path.name)
+        if match is None:
+            fail(str(path), "invalid attempt evidence name")
+        ids.append(int(match.group(1)))
+    return max(ids, default=0) + 1
+
+
+def _preserve_write_once(path: Path, expected: bytes, *, mode: str) -> None:
+    if path.exists():
+        if mode != "resume" or path.read_bytes() != expected:
+            fail(str(path), "existing request evidence requires exact resume")
+        return
+    if mode != "initial":
+        fail(str(path), "resume requires retained request evidence")
+    _write_once_bytes(path, expected)
+
+
+def _write_once_bytes(path: Path, value: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        fail(str(path), "refusing to overwrite retained evidence")
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(value)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def _replace_canonical(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = canonical_json_bytes(value)
+    with tempfile.NamedTemporaryFile(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".next",
+        delete=False,
+    ) as stream:
+        stream.write(encoded)
+        stream.flush()
+        os.fsync(stream.fileno())
+        temporary = Path(stream.name)
+    try:
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _write_text_evidence(path: Path, value: str) -> str:
+    encoded = value.encode()
+    if path.exists():
+        if path.read_bytes() != encoded:
+            fail(str(path), "retained evidence bytes drifted")
+    else:
+        _write_once_bytes(path, encoded)
+    return sha256_bytes(encoded)
+
+
+def _reject_production_credentials() -> None:
+    present = sorted(name for name in FORBIDDEN_CREDENTIALS if os.environ.get(name))
+    if present:
+        fail("environment", f"fixture harness refuses production credential(s): {', '.join(present)}")
+
+
+def _reject_fixture_symlinks(root: Path) -> None:
+    symlinks = sorted(path for path in root.rglob("*") if path.is_symlink())
+    if symlinks:
+        fail(str(symlinks[0]), "fixture tree must not contain symbolic links")
+
+
+def _attempt_id(path: Path) -> int:
+    match = ATTEMPT_RE.fullmatch(path.name)
+    if match is None:
+        fail(str(path), "invalid attempt evidence name")
+    return int(match.group(1))

--- a/verification/areas/distribution_release/governance/incident_index_selftest.py
+++ b/verification/areas/distribution_release/governance/incident_index_selftest.py
@@ -1,0 +1,168 @@
+"""Mutation coverage for the atomic stable incident-index contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable
+
+from .common import GovernanceError
+from .release_index import validate_incident_index_mutation
+from .selftest import active_index, release_record
+
+INCIDENT_ID = "inc-index-001"
+
+
+def test_incident_index_mutation_contract() -> None:
+    previous = active_index()
+    previous["releases"]["0.0.8"] = release_record("stable")
+    previous["releases"]["0.0.9"] = release_record("stable")
+
+    rollback = deepcopy(previous)
+    rollback["generation"] = 9
+    rollback["channels"]["stable"] = "0.0.9"
+    withdraw(rollback, "0.1.0")
+    validate(previous, rollback, operation="rollback", successor="0.0.9")
+
+    invalid_rollbacks = (
+        changed(rollback, lambda value: value["releases"].pop("0.1.0")),
+        changed(rollback, lambda value: reactivate(value, "0.1.0")),
+        changed(
+            rollback,
+            lambda value: value["releases"]["0.1.0"].update(
+                {"installer_sha256": "f" * 64}
+            ),
+        ),
+        changed(rollback, deactivate_successor),
+        changed(
+            rollback,
+            lambda value: value["channels"].update({"stable": "0.0.8"}),
+        ),
+        changed(
+            rollback,
+            lambda value: value["releases"].update(
+                {"0.0.7": release_record("stable")}
+            ),
+        ),
+        changed(
+            rollback,
+            lambda value: value["releases"]["0.0.8"].update(
+                {"installer_sha256": "f" * 64}
+            ),
+        ),
+        changed(rollback, move_alpha_channel),
+    )
+    for candidate in invalid_rollbacks:
+        assert_rejected(
+            lambda candidate=candidate: validate(
+                previous,
+                candidate,
+                operation="rollback",
+                successor="0.0.9",
+            )
+        )
+
+    forward = deepcopy(previous)
+    forward["generation"] = 9
+    forward["channels"]["stable"] = "0.1.1"
+    withdraw(forward, "0.1.0")
+    forward["releases"]["0.1.1"] = release_record("stable")
+    validate(
+        previous,
+        forward,
+        operation="incident-roll-forward",
+        successor="0.1.1",
+    )
+    assert_rejected(
+        lambda: validate(
+            previous,
+            rollback,
+            operation="incident-roll-forward",
+            successor="0.0.9",
+        )
+    )
+    assert_rejected(
+        lambda: validate(
+            previous,
+            forward,
+            operation="rollback",
+            successor="0.1.1",
+        )
+    )
+    extra_forward = changed(
+        forward,
+        lambda value: value["releases"].update(
+            {"0.1.2": release_record("stable")}
+        ),
+    )
+    assert_rejected(
+        lambda: validate(
+            previous,
+            extra_forward,
+            operation="incident-roll-forward",
+            successor="0.1.1",
+        )
+    )
+    assert_rejected(
+        lambda: validate(
+            previous,
+            rollback,
+            operation="rollback",
+            affected="0.0.9",
+            successor="0.0.8",
+        )
+    )
+
+
+def validate(
+    previous: dict[str, Any],
+    proposed: dict[str, Any],
+    *,
+    operation: str,
+    successor: str,
+    affected: str = "0.1.0",
+) -> None:
+    validate_incident_index_mutation(
+        previous,
+        proposed,
+        operation=operation,
+        incident_id=INCIDENT_ID,
+        affected_version=affected,
+        successor_version=successor,
+    )
+
+
+def withdraw(index: dict[str, Any], version: str) -> None:
+    index["releases"][version]["status"] = "withdrawn"
+    index["releases"][version]["incident_id"] = INCIDENT_ID
+
+
+def reactivate(index: dict[str, Any], version: str) -> None:
+    index["releases"][version]["status"] = "active"
+    index["releases"][version].pop("incident_id")
+
+
+def deactivate_successor(index: dict[str, Any]) -> None:
+    withdraw(index, "0.0.9")
+    index["channels"]["stable"] = "0.0.8"
+
+
+def move_alpha_channel(index: dict[str, Any]) -> None:
+    index["releases"]["0.1.0-alpha.3"] = release_record("alpha")
+    index["channels"]["alpha"] = "0.1.0-alpha.3"
+
+
+def changed(
+    value: dict[str, Any],
+    mutation: Callable[[dict[str, Any]], Any],
+) -> dict[str, Any]:
+    candidate = deepcopy(value)
+    mutation(candidate)
+    return candidate
+
+
+def assert_rejected(callback: Callable[[], None]) -> None:
+    try:
+        callback()
+    except GovernanceError:
+        return
+    raise AssertionError("invalid incident index mutation unexpectedly passed")

--- a/verification/areas/distribution_release/governance/incident_planner.py
+++ b/verification/areas/distribution_release/governance/incident_planner.py
@@ -1,0 +1,197 @@
+"""Pure rollback and incident roll-forward planning over governed index bytes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .common import (
+    GovernanceError,
+    load_json_strict,
+    require_positive_int,
+    require_sha256,
+    sha256_file,
+)
+from .incident import validate_incident_request
+from .release_index import (
+    propose_incident_roll_forward,
+    propose_rollback,
+    validate_release_index,
+)
+from .release_plan import validate_release_plan
+
+
+@dataclass(frozen=True)
+class IncidentMutation:
+    """Validated inputs and the one proposed immutable index generation."""
+
+    operation: str
+    request: dict[str, Any]
+    request_sha256: str
+    affected_plan_sha256: str
+    successor_plan_sha256: str
+    previous_index: dict[str, Any]
+    proposed_index: dict[str, Any]
+    affected_version: str
+    successor_version: str
+
+
+def materialize_incident_mutation(
+    *,
+    request_path: Path,
+    live_index_path: Path,
+    affected_plan_path: Path,
+    successor_plan_path: Path,
+    expected_generation: int,
+    expected_sha256: str,
+    proposed_generation: int,
+) -> IncidentMutation:
+    """Validate exact canonical evidence and return a deterministic mutation."""
+    request = validate_incident_request(_load_canonical(request_path))
+    live_index = validate_release_index(_load_canonical(live_index_path))
+    affected_plan = validate_release_plan(_load_canonical(affected_plan_path))
+    successor_plan = validate_release_plan(_load_canonical(successor_plan_path))
+    request_sha256 = sha256_file(request_path)
+    live_sha256 = sha256_file(live_index_path)
+    affected_plan_sha256 = sha256_file(affected_plan_path)
+    successor_plan_sha256 = sha256_file(successor_plan_path)
+    require_positive_int(expected_generation, "expected_generation")
+    require_sha256(expected_sha256, "expected_sha256")
+    if live_index["generation"] != expected_generation:
+        raise GovernanceError("live index generation does not match expected_generation")
+    if live_sha256 != expected_sha256:
+        raise GovernanceError("live index bytes do not match expected_sha256")
+
+    affected_ref = request.get("affected_release")
+    affected_version = affected_ref.get("version") if isinstance(affected_ref, dict) else ""
+    if affected_plan.get("version") != affected_version:
+        raise GovernanceError("affected plan version does not match the incident request")
+    if affected_plan_sha256 != affected_ref.get("plan_sha256"):
+        raise GovernanceError("affected plan bytes do not match the incident request")
+    live_release = live_index["releases"].get(affected_version)
+    if live_release != affected_plan.get("desired_release"):
+        raise GovernanceError("affected plan release bytes do not match the live index")
+
+    operation = request.get("operation")
+    approved = {affected_version: affected_plan_sha256}
+    if operation == "rollback":
+        target_ref = request.get("rollback_target")
+        target_version = target_ref.get("version") if isinstance(target_ref, dict) else ""
+        approved[target_version] = successor_plan_sha256
+        validate_incident_request(
+            request,
+            live_index=live_index,
+            approved_plan_digests=approved,
+        )
+        _validate_rollback_plans(
+            affected_plan=affected_plan,
+            target_plan=successor_plan,
+            target_version=target_version,
+            target_plan_sha256=successor_plan_sha256,
+            live_index=live_index,
+        )
+        proposed = propose_rollback(
+            live_index,
+            incident_id=request["incident_id"],
+            affected_version=affected_version,
+            target_version=target_version,
+            proposed_generation=proposed_generation,
+        )
+        successor_version = target_version
+    elif operation == "incident-roll-forward":
+        validate_incident_request(
+            request,
+            live_index=live_index,
+            approved_plan_digests=approved,
+        )
+        _validate_roll_forward_plan(
+            plan=successor_plan,
+            request_sha256=request_sha256,
+            affected_version=affected_version,
+            affected_plan_sha256=affected_plan_sha256,
+            live_index=live_index,
+        )
+        successor_version = successor_plan["version"]
+        proposed = propose_incident_roll_forward(
+            live_index,
+            incident_id=request["incident_id"],
+            affected_version=affected_version,
+            successor_version=successor_version,
+            successor_release=successor_plan["desired_release"],
+            proposed_generation=proposed_generation,
+        )
+    else:
+        validate_incident_request(request)
+        raise AssertionError("validated incident operation was not handled")
+
+    return IncidentMutation(
+        operation=operation,
+        request=request,
+        request_sha256=request_sha256,
+        affected_plan_sha256=affected_plan_sha256,
+        successor_plan_sha256=successor_plan_sha256,
+        previous_index=live_index,
+        proposed_index=proposed,
+        affected_version=affected_version,
+        successor_version=successor_version,
+    )
+
+
+def _validate_rollback_plans(
+    *,
+    affected_plan: dict[str, Any],
+    target_plan: dict[str, Any],
+    target_version: str,
+    target_plan_sha256: str,
+    live_index: dict[str, Any],
+) -> None:
+    if affected_plan["transition"] != "normal":
+        raise GovernanceError("rollback requires an affected normal release plan")
+    expected = {"version": target_version, "plan_sha256": target_plan_sha256}
+    if affected_plan["rollback_target"] != expected:
+        raise GovernanceError("affected plan does not authorize the requested rollback target")
+    predecessor = affected_plan["expected_stable_predecessor"]
+    if (
+        not isinstance(predecessor, dict)
+        or predecessor.get("version") != target_version
+        or predecessor.get("plan_sha256") != target_plan_sha256
+    ):
+        raise GovernanceError("affected plan predecessor does not authorize rollback")
+    if target_plan["version"] != target_version:
+        raise GovernanceError("rollback target plan version does not match the request")
+    if live_index["releases"].get(target_version) != target_plan["desired_release"]:
+        raise GovernanceError("rollback target plan release bytes do not match the retained index")
+
+
+def _validate_roll_forward_plan(
+    *,
+    plan: dict[str, Any],
+    request_sha256: str,
+    affected_version: str,
+    affected_plan_sha256: str,
+    live_index: dict[str, Any],
+) -> None:
+    validate_release_plan(
+        plan,
+        active_index=live_index,
+        incident_request_sha256=request_sha256,
+    )
+    if plan["transition"] != "incident-roll-forward":
+        raise GovernanceError("successor plan must use incident-roll-forward")
+    if plan["rollback_target"] != "none":
+        raise GovernanceError("incident roll-forward successor must have rollback_target none")
+    expected = plan["expected_stable_predecessor"]
+    if (
+        not isinstance(expected, dict)
+        or expected.get("version") != affected_version
+        or expected.get("plan_sha256") != affected_plan_sha256
+    ):
+        raise GovernanceError("successor plan does not bind the affected release plan")
+
+
+def _load_canonical(path: Path) -> dict[str, Any]:
+    value = load_json_strict(path, require_canonical=True)
+    if not isinstance(value, dict):
+        raise GovernanceError(f"{path}: expected a JSON object")
+    return value

--- a/verification/areas/distribution_release/governance/incident_recovery_selftest.py
+++ b/verification/areas/distribution_release/governance/incident_recovery_selftest.py
@@ -19,6 +19,7 @@ from .common import (
     sha256_file,
     write_canonical_json,
 )
+from .evidence_custody import validate_changed_path_set, validate_incident_directory
 from .incident import validate_incident_signoff
 from .incident_evidence import validate_incident_evidence_commit
 from .incident_fixture import (
@@ -28,7 +29,11 @@ from .incident_fixture import (
     run_incident_fixture,
 )
 from .incident_planner import materialize_incident_mutation
-from .release_index import propose_incident_roll_forward, validate_release_index
+from .release_index import (
+    propose_incident_roll_forward,
+    propose_rollback,
+    validate_release_index,
+)
 from .release_plan import validate_release_plan, validate_site_release_facts
 from .selftest import release_record as base_release_record
 from .selftest import valid_plan as base_plan
@@ -149,6 +154,17 @@ def test_site_timeout_resumes_without_second_index_mutation() -> None:
 def test_first_ga_incident_roll_forward() -> None:
     with tempfile.TemporaryDirectory(prefix="sifr-incident-forward-") as temporary:
         fixture = build_roll_forward_fixture(Path(temporary))
+        sole_stable = read_index(fixture.root)
+        expect_rejected(
+            lambda: propose_rollback(
+                sole_stable,
+                incident_id="inc-first-ga-rollback",
+                affected_version="0.1.0",
+                target_version="0.1.0",
+                proposed_generation=21,
+            ),
+            "distinct retained active stable release",
+        )
         write_range_fixture(
             fixture.root / "extension-metadata.json",
             ">=9.0.0,<10.0.0",
@@ -316,23 +332,37 @@ def test_evidence_only_commit_validator() -> None:
                 "evidence_sha256": sha256_bytes(evidence),
             },
         }
-        incident_root = repository / "plans" / "incidents" / request["incident_id"]
+        incident_root = (
+            repository / "plans" / "releases" / "incidents" / request["incident_id"]
+        )
         incident_root.mkdir(parents=True)
         (incident_root / "stable-incident-request.json").write_bytes(canonical_json_bytes(request))
         (incident_root / "withdrawal-evidence.txt").write_bytes(evidence)
         git(repository, "add", "plans")
         git(repository, "commit", "-qm", "incident evidence")
         head = git(repository, "rev-parse", "HEAD").strip()
+        request_relative = (
+            "plans/releases/incidents/"
+            f"{request['incident_id']}/stable-incident-request.json"
+        )
+        evidence_relative = (
+            "plans/releases/incidents/"
+            f"{request['incident_id']}/withdrawal-evidence.txt"
+        )
+        validate_changed_path_set({request_relative, evidence_relative})
+        validate_incident_directory(incident_root)
+        expect_rejected(
+            lambda: validate_changed_path_set(
+                {request_relative, evidence_relative, "crates/sifr/src/main.rs"}
+            ),
+            "cannot mix with source changes",
+        )
         validated = validate_incident_evidence_commit(
             repository=repository,
             base=base,
             head=head,
-            request_path=(
-                f"plans/incidents/{request['incident_id']}/stable-incident-request.json"
-            ),
-            evidence_path=(
-                f"plans/incidents/{request['incident_id']}/withdrawal-evidence.txt"
-            ),
+            request_path=request_relative,
+            evidence_path=evidence_relative,
         )
         assert validated == request
 
@@ -345,12 +375,8 @@ def test_evidence_only_commit_validator() -> None:
                 repository=repository,
                 base=base,
                 head=bad_head,
-                request_path=(
-                    f"plans/incidents/{request['incident_id']}/stable-incident-request.json"
-                ),
-                evidence_path=(
-                    f"plans/incidents/{request['incident_id']}/withdrawal-evidence.txt"
-                ),
+                request_path=request_relative,
+                evidence_path=evidence_relative,
             ),
             "exactly request",
         )

--- a/verification/areas/distribution_release/governance/incident_recovery_selftest.py
+++ b/verification/areas/distribution_release/governance/incident_recovery_selftest.py
@@ -1,0 +1,834 @@
+"""End-to-end mutation tests for local-only stable incident recovery."""
+
+from __future__ import annotations
+
+import copy
+import os
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from .common import (
+    GovernanceError,
+    TARGETS,
+    canonical_json_bytes,
+    load_json_strict,
+    sha256_bytes,
+    sha256_file,
+    write_canonical_json,
+)
+from .incident import validate_incident_signoff
+from .incident_evidence import validate_incident_evidence_commit
+from .incident_fixture import (
+    FORBIDDEN_CREDENTIALS,
+    check_release_submission_allowed,
+    plan_fixture_recovery,
+    run_incident_fixture,
+)
+from .incident_planner import materialize_incident_mutation
+from .release_index import propose_incident_roll_forward, validate_release_index
+from .release_plan import validate_release_plan, validate_site_release_facts
+from .selftest import release_record as base_release_record
+from .selftest import valid_plan as base_plan
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def run_self_tests() -> int:
+    tests = (
+        test_rollback_burns_generation_and_resumes,
+        test_site_timeout_resumes_without_second_index_mutation,
+        test_first_ga_incident_roll_forward,
+        test_fail_closed_preconditions,
+        test_concurrency_and_credential_boundaries,
+        test_evidence_only_commit_validator,
+        test_cli_surfaces,
+        test_no_production_adapter_surface,
+    )
+    for test in tests:
+        test()
+        print(f"incident-recovery-self-test pass: {test.__name__}")
+    print(f"incident recovery self-tests ok: tests={len(tests)}")
+    return 0
+
+
+def test_rollback_burns_generation_and_resumes() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-rollback-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary))
+        assets_before = tree_digest(fixture.root / "release-assets")
+        with scrub_credentials():
+            failed = run_fixture(fixture, mode="initial", fail_at="after-reservation")
+            assert failed == {"status": "failed", "failure": "after-reservation", "run_id": 1}
+            assert read_index(fixture.root)["generation"] == 20
+            assert (fixture.root / "governance-release" / "channels-generation-21.json").is_file()
+            completed = run_fixture(fixture, mode="resume")
+        assert completed["status"] == "completed"
+        index = read_index(fixture.root)
+        assert index["generation"] == 22
+        assert index["channels"]["stable"] == "0.1.0"
+        assert index["releases"]["0.1.1"]["status"] == "withdrawn"
+        assert index["releases"]["0.1.1"]["incident_id"] == "inc-rollback-001"
+        assert (fixture.root / "governance-release" / "channels-generation-21.json").is_file()
+        assert (fixture.root / "governance-release" / "channels-generation-22.json").is_file()
+        assert tree_digest(fixture.root / "release-assets") == assets_before
+        assert_signoff_and_site(fixture, completed)
+        with scrub_credentials():
+            expect_rejected(
+                lambda: run_fixture(fixture, mode="resume"),
+                "already signed off",
+            )
+        fresh = plan_fixture_recovery(
+            fixture_root=fixture.root,
+            current_version=None,
+            entrypoint="fresh-install",
+            force=False,
+        )
+        assert fresh["target_version"] == "0.1.0"
+        expect_rejected(
+            lambda: plan_fixture_recovery(
+                fixture_root=fixture.root,
+                current_version="0.1.1",
+                entrypoint="self-update",
+                force=False,
+            ),
+            "sifr self update --channel stable --force",
+        )
+        working = plan_fixture_recovery(
+            fixture_root=fixture.root,
+            current_version="0.1.1",
+            entrypoint="self-update",
+            force=True,
+        )
+        expect_rejected(
+            lambda: plan_fixture_recovery(
+                fixture_root=fixture.root,
+                current_version="0.1.1",
+                entrypoint="out-of-band",
+                force=False,
+            ),
+            "https://sifr.sh/install/stable",
+        )
+        broken = plan_fixture_recovery(
+            fixture_root=fixture.root,
+            current_version="0.1.1",
+            entrypoint="out-of-band",
+            force=True,
+        )
+        assert working["action"] == broken["action"] == "delegate-to-immutable-installer"
+        for name, recovery in (("fresh", fresh), ("working", working), ("broken", broken)):
+            state = fixture.root / "installations" / name / "version"
+            execute_fixture_installer(recovery, state)
+            assert state.read_text(encoding="utf-8") == "0.1.0\n"
+
+
+def test_site_timeout_resumes_without_second_index_mutation() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-timeout-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary))
+        with scrub_credentials():
+            failed = run_fixture(fixture, mode="initial", fail_at="site-timeout")
+            assert failed["status"] == "failed"
+            timeout_evidence = next((fixture.root / "site" / "attempts").glob("*.txt"))
+            timeout_text = timeout_evidence.read_text(encoding="utf-8")
+            assert "deadline_minutes=20" in timeout_text
+            assert "status=terminal-timeout" in timeout_text
+            assert "cancellation=requested" in timeout_text
+            realized_bytes = (fixture.root / "live" / "channels.json").read_bytes()
+            realized = read_index(fixture.root)
+            assert realized["generation"] == 21
+            completed = run_fixture(fixture, mode="resume")
+        assert (fixture.root / "live" / "channels.json").read_bytes() == realized_bytes
+        assert not (fixture.root / "governance-release" / "channels-generation-22.json").exists()
+        assert_signoff_and_site(fixture, completed)
+        attempts = sorted((fixture.root / "state").glob("*/attempt-*.json"))
+        assert [load_json_strict(path)["status"] for path in attempts] == ["failed", "completed"]
+        assert len(list((fixture.root / "site" / "attempts").glob("*.txt"))) == 2
+
+
+def test_first_ga_incident_roll_forward() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-forward-") as temporary:
+        fixture = build_roll_forward_fixture(Path(temporary))
+        write_range_fixture(
+            fixture.root / "extension-metadata.json",
+            ">=9.0.0,<10.0.0",
+            ["0.1.0"],
+        )
+        with scrub_credentials():
+            completed = run_fixture(fixture, mode="initial")
+        index = read_index(fixture.root)
+        assert index["generation"] == 21
+        assert index["channels"]["stable"] == "0.1.1"
+        assert index["releases"]["0.1.0"]["status"] == "withdrawn"
+        assert index["releases"]["0.1.1"]["status"] == "active"
+        assert_signoff_and_site(fixture, completed)
+
+
+def test_fail_closed_preconditions() -> None:
+    current = active_fixture_index(
+        generation=20,
+        stable_version="0.1.0",
+        stable_records={"0.1.0": base_release_record("stable")},
+    )
+    expect_rejected(
+        lambda: propose_incident_roll_forward(
+            current,
+            incident_id="inc-forward-old",
+            affected_version="0.1.0",
+            successor_version="0.0.9",
+            successor_release=base_release_record("stable"),
+            proposed_generation=21,
+        ),
+        "newer stable",
+    )
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-negative-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary))
+        live = fixture.root / "live" / "channels.json"
+        expect_rejected(
+            lambda: materialize_incident_mutation(
+                request_path=fixture.request,
+                live_index_path=live,
+                affected_plan_path=fixture.affected_plan,
+                successor_plan_path=fixture.successor_plan,
+                expected_generation=19,
+                expected_sha256=sha256_file(live),
+                proposed_generation=21,
+            ),
+            "expected_generation",
+        )
+        write_range_fixture(
+            fixture.root / "extension-metadata.json",
+            ">=0.1.1,<0.2.0",
+            ["0.1.0", "0.1.1"],
+        )
+        with scrub_credentials():
+            expect_rejected(lambda: run_fixture(fixture, mode="initial"), "excludes")
+        assert read_index(fixture.root)["generation"] == 20
+        assert not (fixture.root / "governance-release" / "channels-generation-21.json").exists()
+
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-ga-rollback-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary), affected_transition="ga-activation")
+        with scrub_credentials():
+            expect_rejected(lambda: run_fixture(fixture, mode="initial"), "normal release plan")
+        assert read_index(fixture.root)["generation"] == 20
+
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-marketplace-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary))
+        write_range_fixture(
+            fixture.root / "marketplace.json",
+            ">=0.1.0,<0.2.0",
+            ["0.1.1"],
+        )
+        with scrub_credentials():
+            expect_rejected(lambda: run_fixture(fixture, mode="initial"), "successor version")
+        assert read_index(fixture.root)["generation"] == 20
+
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-assets-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary))
+        installer = fixture.root / "release-assets" / "0.1.0" / "sifr-installer-0.1.0"
+        installer.write_bytes(installer.read_bytes() + b"drift\n")
+        with scrub_credentials():
+            expect_rejected(lambda: run_fixture(fixture, mode="initial"), "digest")
+        assert read_index(fixture.root)["generation"] == 20
+
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-site-marker-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary))
+        (fixture.root / "site" / ".non-deploying-fixture").unlink()
+        with scrub_credentials():
+            expect_rejected(lambda: run_fixture(fixture, mode="initial"), "non-deploying")
+        assert read_index(fixture.root)["generation"] == 20
+
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-race-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary))
+        with scrub_credentials():
+            failed = run_fixture(
+                fixture,
+                mode="initial",
+                fail_at="race-before-index",
+            )
+        assert failed["failure"] == "stale-generation"
+        raced = read_index(fixture.root)
+        assert raced["generation"] == 22
+        assert raced["channels"]["stable"] == "0.1.1"
+        assert raced["releases"]["0.1.1"]["status"] == "active"
+        assert (fixture.root / "governance-release" / "channels-generation-21.json").is_file()
+        assert (fixture.root / "governance-release" / "channels-generation-22.json").is_file()
+
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-symlink-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary))
+        (fixture.root / "site" / "escape").symlink_to(Path(temporary).parent)
+        with scrub_credentials():
+            expect_rejected(lambda: run_fixture(fixture, mode="initial"), "symbolic links")
+        assert read_index(fixture.root)["generation"] == 20
+
+
+def test_concurrency_and_credential_boundaries() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-boundary-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary))
+        lock = fixture.root / "state" / "metadata-concurrency.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.write_text("rollback\n", encoding="utf-8")
+        expect_rejected(
+            lambda: check_release_submission_allowed(fixture.root, "stable"),
+            "blocked",
+        )
+        lock.unlink()
+        check_release_submission_allowed(fixture.root, "preview")
+
+        original = os.environ.get("GH_TOKEN")
+        os.environ["GH_TOKEN"] = "fixture-must-refuse"
+        try:
+            expect_rejected(
+                lambda: run_fixture(fixture, mode="initial"),
+                "production credential",
+            )
+        finally:
+            if original is None:
+                os.environ.pop("GH_TOKEN", None)
+            else:
+                os.environ["GH_TOKEN"] = original
+        assert not list((fixture.root / "governance-release").glob("stable-incident-request-*"))
+
+
+def test_evidence_only_commit_validator() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-evidence-") as temporary:
+        repository = Path(temporary)
+        git(repository, "init", "-q")
+        git(repository, "config", "user.email", "release-fixture@sifr.test")
+        git(repository, "config", "user.name", "Release Fixture")
+        (repository / "README.md").write_text("fixture\n", encoding="utf-8")
+        git(repository, "add", "README.md")
+        git(repository, "commit", "-qm", "base")
+        base = git(repository, "rev-parse", "HEAD").strip()
+
+        evidence = b"stable smoke regression evidence\n"
+        request = {
+            "schema_version": 2,
+            "incident_id": "inc-evidence-001",
+            "operation": "incident-roll-forward",
+            "trigger": "stable smoke regression",
+            "affected_release": {
+                "version": "0.1.0",
+                "plan_sha256": "a" * 64,
+            },
+            "withdrawal": {
+                "reason": "confirmed regression",
+                "evidence_sha256": sha256_bytes(evidence),
+            },
+        }
+        incident_root = repository / "plans" / "incidents" / request["incident_id"]
+        incident_root.mkdir(parents=True)
+        (incident_root / "stable-incident-request.json").write_bytes(canonical_json_bytes(request))
+        (incident_root / "withdrawal-evidence.txt").write_bytes(evidence)
+        git(repository, "add", "plans")
+        git(repository, "commit", "-qm", "incident evidence")
+        head = git(repository, "rev-parse", "HEAD").strip()
+        validated = validate_incident_evidence_commit(
+            repository=repository,
+            base=base,
+            head=head,
+            request_path=(
+                f"plans/incidents/{request['incident_id']}/stable-incident-request.json"
+            ),
+            evidence_path=(
+                f"plans/incidents/{request['incident_id']}/withdrawal-evidence.txt"
+            ),
+        )
+        assert validated == request
+
+        (repository / "source.py").write_text("unexpected = True\n", encoding="utf-8")
+        git(repository, "add", "source.py")
+        git(repository, "commit", "-qm", "unrelated source")
+        bad_head = git(repository, "rev-parse", "HEAD").strip()
+        expect_rejected(
+            lambda: validate_incident_evidence_commit(
+                repository=repository,
+                base=base,
+                head=bad_head,
+                request_path=(
+                    f"plans/incidents/{request['incident_id']}/stable-incident-request.json"
+                ),
+                evidence_path=(
+                    f"plans/incidents/{request['incident_id']}/withdrawal-evidence.txt"
+                ),
+            ),
+            "exactly request",
+        )
+
+
+def test_no_production_adapter_surface() -> None:
+    root = REPO_ROOT
+    harness = (Path(__file__).with_name("incident_fixture.py")).read_text(encoding="utf-8")
+    for forbidden in ("import socket", "import urllib", "import requests", "import subprocess"):
+        assert forbidden not in harness
+    workflow = (root / ".github" / "workflows" / "release-publication.yml").read_text(
+        encoding="utf-8"
+    )
+    dispatch = workflow.split("jobs:", 1)[0]
+    assert "rollback" not in dispatch
+    assert "incident-roll-forward" not in dispatch
+    assert "stable-release-drill" not in workflow
+    script = (root / "scripts" / "distribution" / "run_incident_fixture.py").read_text(
+        encoding="utf-8"
+    )
+    assert "gh release" not in script
+    assert "vsce publish" not in script
+    assert "repository_dispatch" not in script
+
+
+def test_cli_surfaces() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-incident-cli-") as temporary:
+        fixture = build_rollback_fixture(Path(temporary) / "fixture")
+        live = fixture.root / "live" / "channels.json"
+        planned = fixture.root / "planned-index.json"
+        run_cli(
+            REPO_ROOT / "scripts" / "distribution" / "release_governance.py",
+            "plan-incident-index",
+            "--request",
+            str(fixture.request),
+            "--live-index",
+            str(live),
+            "--affected-plan",
+            str(fixture.affected_plan),
+            "--successor-plan",
+            str(fixture.successor_plan),
+            "--expected-generation",
+            "20",
+            "--expected-sha256",
+            sha256_file(live),
+            "--proposed-generation",
+            "21",
+            "--out",
+            str(planned),
+        )
+        proposed = validate_release_index(
+            load_json_strict(planned, require_canonical=True)
+        )
+        assert proposed["generation"] == 21
+        assert proposed["channels"]["stable"] == "0.1.0"
+
+        work = Path(temporary) / "request-work"
+        work.mkdir()
+        spec = work / "request-spec.json"
+        evidence = work / "withdrawal-evidence.txt"
+        spec.write_bytes(fixture.request.read_bytes())
+        evidence.write_bytes(
+            (fixture.root / "evidence" / "withdrawal-evidence.txt").read_bytes()
+        )
+        generated = work / "stable-incident-request.json"
+        run_cli(
+            REPO_ROOT / "scripts" / "distribution" / "release_governance.py",
+            "generate-incident-request",
+            "--spec",
+            str(spec),
+            "--out",
+            str(generated),
+            "--live-index",
+            str(live),
+            "--withdrawal-evidence",
+            str(evidence),
+            "--affected-plan",
+            str(fixture.affected_plan),
+            "--rollback-plan",
+            str(fixture.successor_plan),
+        )
+        assert generated.read_bytes() == fixture.request.read_bytes()
+
+        with scrub_credentials():
+            result = run_cli(
+                REPO_ROOT / "scripts" / "distribution" / "run_incident_fixture.py",
+                "run",
+                "--fixture-root",
+                str(fixture.root),
+                "--live-index",
+                str(fixture.root / "live" / "channels.json"),
+                "--governance-release",
+                str(fixture.root / "governance-release"),
+                "--release-assets",
+                str(fixture.root / "release-assets"),
+                "--marketplace-stub",
+                str(fixture.root / "marketplace.json"),
+                "--extension-metadata",
+                str(fixture.root / "extension-metadata.json"),
+                "--site-repo",
+                str(fixture.root / "site"),
+                "--request",
+                str(fixture.request),
+                "--affected-plan",
+                str(fixture.affected_plan),
+                "--successor-plan",
+                str(fixture.successor_plan),
+                "--mode",
+                "initial",
+                "--approver",
+                "fixture-cli-reviewer",
+            )
+        assert '"status":"completed"' in result
+
+
+class Fixture:
+    def __init__(
+        self,
+        root: Path,
+        request: Path,
+        affected_plan: Path,
+        successor_plan: Path,
+    ) -> None:
+        self.root = root
+        self.request = request
+        self.affected_plan = affected_plan
+        self.successor_plan = successor_plan
+
+
+def build_rollback_fixture(
+    root: Path,
+    *,
+    affected_transition: str = "normal",
+) -> Fixture:
+    root.mkdir(parents=True, exist_ok=True)
+    target_record = make_release(root, "0.1.0", "d")
+    affected_record = make_release(root, "0.1.1", "e")
+    target_plan = make_plan("0.1.0", target_record, "ga-activation")
+    target_path = root / "evidence" / "target-plan.json"
+    write_json(target_path, target_plan)
+    target_digest = sha256_file(target_path)
+    affected_plan = make_plan(
+        "0.1.1",
+        affected_record,
+        affected_transition,
+        predecessor=(
+            ("0.1.0", target_digest)
+            if affected_transition == "normal"
+            else None
+        ),
+    )
+    affected_path = root / "evidence" / "affected-plan.json"
+    write_json(affected_path, affected_plan)
+    affected_digest = sha256_file(affected_path)
+    withdrawal = b"rollback regression evidence\n"
+    request = {
+        "schema_version": 2,
+        "incident_id": "inc-rollback-001",
+        "operation": "rollback",
+        "trigger": "stable target smoke regression",
+        "affected_release": {
+            "version": "0.1.1",
+            "plan_sha256": affected_digest,
+        },
+        "withdrawal": {
+            "reason": "confirmed stable regression",
+            "evidence_sha256": sha256_bytes(withdrawal),
+        },
+        "rollback_target": {
+            "version": "0.1.0",
+            "plan_sha256": target_digest,
+        },
+    }
+    request_path = root / "evidence" / "stable-incident-request.json"
+    write_json(request_path, request)
+    (root / "evidence" / "withdrawal-evidence.txt").write_bytes(withdrawal)
+    index = active_fixture_index(
+        generation=20,
+        stable_version="0.1.1",
+        stable_records={"0.1.0": target_record, "0.1.1": affected_record},
+    )
+    initialize_fixture_surface(root, index, published=["0.1.0", "0.1.1"])
+    return Fixture(root, request_path, affected_path, target_path)
+
+
+def build_roll_forward_fixture(root: Path) -> Fixture:
+    root.mkdir(parents=True, exist_ok=True)
+    affected_record = make_release(root, "0.1.0", "d")
+    successor_record = make_release(root, "0.1.1", "e")
+    affected_plan = make_plan("0.1.0", affected_record, "ga-activation")
+    affected_path = root / "evidence" / "affected-plan.json"
+    write_json(affected_path, affected_plan)
+    affected_digest = sha256_file(affected_path)
+    withdrawal = b"first GA incident evidence\n"
+    request = {
+        "schema_version": 2,
+        "incident_id": "inc-forward-001",
+        "operation": "incident-roll-forward",
+        "trigger": "first GA stable regression",
+        "affected_release": {
+            "version": "0.1.0",
+            "plan_sha256": affected_digest,
+        },
+        "withdrawal": {
+            "reason": "first GA must roll forward",
+            "evidence_sha256": sha256_bytes(withdrawal),
+        },
+    }
+    request_path = root / "evidence" / "stable-incident-request.json"
+    write_json(request_path, request)
+    request_digest = sha256_file(request_path)
+    successor_plan = make_plan(
+        "0.1.1",
+        successor_record,
+        "incident-roll-forward",
+        predecessor=("0.1.0", affected_digest),
+        incident_request_sha256=request_digest,
+    )
+    successor_path = root / "evidence" / "successor-plan.json"
+    write_json(successor_path, successor_plan)
+    (root / "evidence" / "withdrawal-evidence.txt").write_bytes(withdrawal)
+    index = active_fixture_index(
+        generation=20,
+        stable_version="0.1.0",
+        stable_records={"0.1.0": affected_record},
+    )
+    initialize_fixture_surface(root, index, published=["0.1.0", "0.1.1"])
+    return Fixture(root, request_path, affected_path, successor_path)
+
+
+def make_release(root: Path, version: str, commit_character: str) -> dict[str, Any]:
+    installer = (
+        b"#!/bin/sh\nset -eu\n"
+        + b': "${SIFR_FIXTURE_INSTALL_STATE:?missing fixture state path}"\n'
+        + f"mkdir -p \"$(dirname \"${{SIFR_FIXTURE_INSTALL_STATE}}\")\"\n".encode()
+        + f"printf '%s\\n' '{version}' >\"${{SIFR_FIXTURE_INSTALL_STATE}}\"\n".encode()
+        + f"# immutable fixture installer for {version}\n".encode()
+        + b"# padding-000000000000000000000000000000000000000000000000000000000000\n"
+    )
+    installer_path = root / "release-assets" / version / f"sifr-installer-{version}"
+    installer_path.parent.mkdir(parents=True, exist_ok=True)
+    installer_path.write_bytes(installer)
+    installer_path.chmod(0o755)
+    record = base_release_record("stable")
+    record["source_commit"] = commit_character * 40
+    record["installer_sha256"] = sha256_bytes(installer)
+    return record
+
+
+def make_plan(
+    version: str,
+    release: dict[str, Any],
+    transition: str,
+    *,
+    predecessor: tuple[str, str] | None = None,
+    incident_request_sha256: str | None = None,
+) -> dict[str, Any]:
+    plan = copy.deepcopy(base_plan())
+    plan["version"] = version
+    plan["transition"] = transition
+    plan["source_commit"] = release["source_commit"]
+    plan["plan_id"] = f"stable-{version}-{release['source_commit'][:12]}"
+    plan["desired_release"] = copy.deepcopy(release)
+    plan["installer_sha256"] = release["installer_sha256"]
+    plan["vscode"]["version"] = version
+    for row in plan["targets"]:
+        row["sifr_version"] = version
+        row["installer_version"] = version
+        row["sysroot_version"] = version
+    if predecessor is None:
+        plan["expected_stable_predecessor"] = "none"
+        plan["rollback_target"] = "none"
+    else:
+        predecessor_value = {
+            "version": predecessor[0],
+            "status": "active",
+            "plan_sha256": predecessor[1],
+        }
+        plan["expected_stable_predecessor"] = predecessor_value
+        plan["rollback_target"] = {
+            "version": predecessor[0],
+            "plan_sha256": predecessor[1],
+        }
+    if transition == "incident-roll-forward":
+        assert incident_request_sha256 is not None
+        plan["rollback_target"] = "none"
+        plan["incident_request_sha256"] = incident_request_sha256
+    validate_release_plan(plan)
+    return plan
+
+
+def active_fixture_index(
+    *,
+    generation: int,
+    stable_version: str,
+    stable_records: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    alpha = base_release_record("alpha")
+    beta = base_release_record("beta")
+    index = {
+        "schema_version": 2,
+        "generation": generation,
+        "ga_status": "active",
+        "channels": {
+            "alpha": "0.1.0-alpha.2",
+            "beta": "0.1.0-beta.2",
+            "stable": stable_version,
+        },
+        "releases": {
+            "0.1.0-alpha.2": alpha,
+            "0.1.0-beta.2": beta,
+            **stable_records,
+        },
+    }
+    validate_release_index(index)
+    return index
+
+
+def initialize_fixture_surface(
+    root: Path,
+    index: dict[str, Any],
+    *,
+    published: list[str],
+) -> None:
+    write_json(root / "live" / "channels.json", index)
+    write_json(
+        root / "governance-release" / f"channels-generation-{index['generation']}.json",
+        index,
+    )
+    write_range_fixture(
+        root / "extension-metadata.json",
+        ">=0.1.0,<0.2.0",
+        published,
+    )
+    write_range_fixture(root / "marketplace.json", ">=0.1.0,<0.2.0", published)
+    install_root = root / "site" / "install"
+    install_root.mkdir(parents=True, exist_ok=True)
+    (root / "site" / ".non-deploying-fixture").write_text(
+        "local-only\n",
+        encoding="utf-8",
+    )
+    for name in ("index", "stable", "alpha", "beta"):
+        (install_root / name).write_text(
+            f"#!/bin/sh\n# local non-deploying {name} dispatcher\n",
+            encoding="utf-8",
+        )
+
+
+def write_range_fixture(path: Path, expression: str, versions: list[str]) -> None:
+    write_json(
+        path,
+        {
+            "schema_version": 2,
+            "compiler_compatibility": expression,
+            "published_versions": versions,
+        },
+        replace=True,
+    )
+
+
+def run_fixture(
+    fixture: Fixture,
+    *,
+    mode: str,
+    fail_at: str = "none",
+) -> dict[str, Any]:
+    return run_incident_fixture(
+        fixture_root=fixture.root,
+        live_index_path=fixture.root / "live" / "channels.json",
+        governance_root=fixture.root / "governance-release",
+        release_assets_root=fixture.root / "release-assets",
+        marketplace_path=fixture.root / "marketplace.json",
+        extension_metadata_path=fixture.root / "extension-metadata.json",
+        site_root=fixture.root / "site",
+        request_path=fixture.request,
+        affected_plan_path=fixture.affected_plan,
+        successor_plan_path=fixture.successor_plan,
+        mode=mode,
+        approver="fixture-release-reviewer",
+        fail_at=fail_at,
+    )
+
+
+def assert_signoff_and_site(fixture: Fixture, result: dict[str, Any]) -> None:
+    signoff = validate_incident_signoff(
+        load_json_strict(Path(result["signoff"]), require_canonical=True),
+        incident_request=load_json_strict(
+            fixture.request,
+            require_canonical=True,
+        ),
+    )
+    index = read_index(fixture.root)
+    facts_paths = sorted(
+        (fixture.root / "governance-release").glob("site-release-facts-generation-*.json")
+    )
+    assert len(facts_paths) == 1
+    facts = validate_site_release_facts(
+        load_json_strict(facts_paths[0], require_canonical=True),
+        governed_index=index,
+    )
+    assert facts["stable_version"] == index["channels"]["stable"]
+    assert facts["withdrawals"]
+    assert signoff["index_mutation"]["realized_generation"] == index["generation"]
+
+
+def read_index(root: Path) -> dict[str, Any]:
+    return validate_release_index(
+        load_json_strict(root / "live" / "channels.json", require_canonical=True)
+    )
+
+
+def write_json(path: Path, value: dict[str, Any], *, replace: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if replace:
+        path.unlink(missing_ok=True)
+    write_canonical_json(path, value, refuse_existing=True)
+
+
+def tree_digest(root: Path) -> str:
+    payload = b"".join(
+        path.relative_to(root).as_posix().encode()
+        + b"\0"
+        + path.read_bytes()
+        + b"\0"
+        for path in sorted(item for item in root.rglob("*") if item.is_file())
+    )
+    return sha256_bytes(payload)
+
+
+def execute_fixture_installer(recovery: dict[str, Any], state: Path) -> None:
+    environment = os.environ.copy()
+    environment["SIFR_FIXTURE_INSTALL_STATE"] = str(state)
+    subprocess.run(
+        [recovery["installer"]],
+        check=True,
+        env=environment,
+        stdout=subprocess.DEVNULL,
+    )
+
+
+def git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def run_cli(script: Path, *args: str) -> str:
+    result = subprocess.run(
+        [str(script), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def expect_rejected(callback: Any, contains: str) -> None:
+    try:
+        callback()
+    except GovernanceError as exc:
+        if contains not in str(exc):
+            raise AssertionError(f"expected {contains!r} in {exc!r}") from exc
+        return
+    raise AssertionError("invalid incident operation unexpectedly passed")
+
+
+@contextmanager
+def scrub_credentials() -> Iterator[None]:
+    saved = {name: os.environ.pop(name) for name in FORBIDDEN_CREDENTIALS if name in os.environ}
+    try:
+        yield
+    finally:
+        os.environ.update(saved)
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_self_tests())

--- a/verification/areas/distribution_release/governance/incident_recovery_selftest.py
+++ b/verification/areas/distribution_release/governance/incident_recovery_selftest.py
@@ -22,6 +22,7 @@ from .common import (
 from .evidence_custody import validate_changed_path_set, validate_incident_directory
 from .incident import validate_incident_signoff
 from .incident_evidence import validate_incident_evidence_commit
+from .incident_index_selftest import test_incident_index_mutation_contract
 from .incident_fixture import (
     FORBIDDEN_CREDENTIALS,
     check_release_submission_allowed,
@@ -46,6 +47,7 @@ def run_self_tests() -> int:
         test_rollback_burns_generation_and_resumes,
         test_site_timeout_resumes_without_second_index_mutation,
         test_first_ga_incident_roll_forward,
+        test_incident_index_mutation_contract,
         test_fail_closed_preconditions,
         test_concurrency_and_credential_boundaries,
         test_evidence_only_commit_validator,
@@ -351,6 +353,16 @@ def test_evidence_only_commit_validator() -> None:
         )
         validate_changed_path_set({request_relative, evidence_relative})
         validate_incident_directory(incident_root)
+        expect_rejected(
+            lambda: validate_changed_path_set(
+                {
+                    request_relative,
+                    evidence_relative,
+                    "plans/releases/README.md",
+                }
+            ),
+            "cannot mix",
+        )
         expect_rejected(
             lambda: validate_changed_path_set(
                 {request_relative, evidence_relative, "crates/sifr/src/main.rs"}

--- a/verification/areas/distribution_release/governance/qualification_fixture.py
+++ b/verification/areas/distribution_release/governance/qualification_fixture.py
@@ -105,7 +105,12 @@ def write_source_contracts(source_root: Path) -> None:
             {"area": "documentation", "suites": ["structure"]},
             {
                 "area": "distribution_release",
-                "suites": ["full", "qualification", "evidence-custody"],
+                "suites": [
+                    "full",
+                    "qualification",
+                    "evidence-custody",
+                    "incident-governance",
+                ],
             },
         ],
     }

--- a/verification/areas/distribution_release/governance/release_index.py
+++ b/verification/areas/distribution_release/governance/release_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 from .common import (
@@ -171,6 +172,7 @@ def validate_incident_index_mutation(
     previous_value: Any,
     proposed_value: Any,
     *,
+    operation: str,
     incident_id: str,
     affected_version: str,
     successor_version: str,
@@ -178,15 +180,147 @@ def validate_incident_index_mutation(
     previous = validate_release_index(previous_value)
     proposed = validate_release_index(proposed_value)
     validate_release_index_transition(previous, proposed)
+    operation = require_enum(
+        operation,
+        {"rollback", "incident-roll-forward"},
+        "operation",
+    )
     if previous["ga_status"] != "active" or previous["channels"].get("stable") != affected_version:
         fail("$.channels.stable", "affected version is not the live stable predecessor")
+    if proposed["ga_status"] != "active":
+        fail("$.ga_status", "incident mutation must preserve active GA status")
+    for channel, version in previous["channels"].items():
+        if channel != "stable" and proposed["channels"].get(channel) != version:
+            fail(f"$.channels.{channel}", "incident mutation may change only stable")
     affected = proposed["releases"].get(affected_version)
     if not isinstance(affected, dict):
         fail("$.releases", "incident mutation removed the affected release")
     if affected.get("status") != "withdrawn" or affected.get("incident_id") != incident_id:
         fail("$.releases", "incident mutation must withdraw the affected version atomically")
+    expected_affected = {
+        **previous["releases"][affected_version],
+        "status": "withdrawn",
+        "incident_id": incident_id,
+    }
+    if affected != expected_affected:
+        fail(
+            f"$.releases.{affected_version}",
+            "incident mutation may only add withdrawal status and incident identity",
+        )
     successor = proposed["releases"].get(successor_version)
     if not isinstance(successor, dict) or successor.get("status") != "active":
         fail("$.releases", "incident mutation must activate the successor atomically")
     if proposed["channels"].get("stable") != successor_version:
         fail("$.channels.stable", "incident mutation must point stable at the successor")
+    prior_versions = set(previous["releases"])
+    proposed_versions = set(proposed["releases"])
+    if operation == "rollback":
+        if successor_version not in prior_versions or proposed_versions != prior_versions:
+            fail("$.releases", "rollback must reuse one retained active release")
+    else:
+        if successor_version in prior_versions or proposed_versions != prior_versions | {successor_version}:
+            fail("$.releases", "incident roll-forward must add exactly the qualified successor")
+    for version, release in previous["releases"].items():
+        if version == affected_version:
+            continue
+        if proposed["releases"].get(version) != release:
+            fail(f"$.releases.{version}", "incident mutation must preserve retained release bytes")
+
+
+def propose_rollback(
+    current_value: Any,
+    *,
+    incident_id: str,
+    affected_version: str,
+    target_version: str,
+    proposed_generation: int,
+) -> dict[str, Any]:
+    """Return the immutable-index rollback mutation for an approved request."""
+    current = validate_release_index(current_value)
+    require_incident_id(incident_id, "incident_id")
+    _require_incident_generation(current, proposed_generation)
+    if current["ga_status"] != "active" or current["channels"].get("stable") != affected_version:
+        fail("affected_version", "must equal the live active stable version")
+    target = current["releases"].get(target_version)
+    if (
+        target_version == affected_version
+        or not isinstance(target, dict)
+        or target.get("channel") != "stable"
+        or target.get("status") != "active"
+    ):
+        fail("target_version", "must name a distinct retained active stable release")
+    proposed = deepcopy(current)
+    proposed["generation"] = proposed_generation
+    proposed["channels"]["stable"] = target_version
+    proposed["releases"][affected_version]["status"] = "withdrawn"
+    proposed["releases"][affected_version]["incident_id"] = incident_id
+    proposed["releases"] = dict(sorted(proposed["releases"].items()))
+    validate_incident_index_mutation(
+        current,
+        proposed,
+        operation="rollback",
+        incident_id=incident_id,
+        affected_version=affected_version,
+        successor_version=target_version,
+    )
+    return proposed
+
+
+def propose_incident_roll_forward(
+    current_value: Any,
+    *,
+    incident_id: str,
+    affected_version: str,
+    successor_version: str,
+    successor_release: Any,
+    proposed_generation: int,
+) -> dict[str, Any]:
+    """Return the atomic withdrawal plus qualified-successor index mutation."""
+    current = validate_release_index(current_value)
+    require_incident_id(incident_id, "incident_id")
+    _require_incident_generation(current, proposed_generation)
+    if current["ga_status"] != "active" or current["channels"].get("stable") != affected_version:
+        fail("affected_version", "must equal the live active stable version")
+    if successor_version in current["releases"]:
+        fail("successor_version", "must be a new immutable stable release")
+    if _stable_order(successor_version, "successor_version") <= _stable_order(
+        affected_version,
+        "affected_version",
+    ):
+        fail("successor_version", "incident roll-forward must move to a newer stable version")
+    successor = validate_release_record(
+        successor_release,
+        version=successor_version,
+        expected_channel="stable",
+    )
+    if successor["status"] != "active" or "incident_id" in successor:
+        fail("successor_release", "must be an active qualified release")
+    proposed = deepcopy(current)
+    proposed["generation"] = proposed_generation
+    proposed["channels"]["stable"] = successor_version
+    proposed["releases"][affected_version]["status"] = "withdrawn"
+    proposed["releases"][affected_version]["incident_id"] = incident_id
+    proposed["releases"][successor_version] = deepcopy(successor)
+    proposed["releases"] = dict(sorted(proposed["releases"].items()))
+    validate_incident_index_mutation(
+        current,
+        proposed,
+        operation="incident-roll-forward",
+        incident_id=incident_id,
+        affected_version=affected_version,
+        successor_version=successor_version,
+    )
+    return proposed
+
+
+def _require_incident_generation(current: dict[str, Any], proposed_generation: int) -> None:
+    if type(proposed_generation) is not int or proposed_generation <= current["generation"]:
+        fail("proposed_generation", "must be an integer greater than the live generation")
+
+
+def _stable_order(version: Any, location: str) -> tuple[int, int, int]:
+    if version_channel(version, location) != "stable":
+        fail(location, "must be an exact stable version")
+    assert isinstance(version, str)
+    major, minor, patch = (int(part) for part in version.split("."))
+    return major, minor, patch

--- a/verification/areas/distribution_release/governance/release_report.py
+++ b/verification/areas/distribution_release/governance/release_report.py
@@ -38,7 +38,12 @@ REQUIRED_SUITES = {
     },
     "developer_tooling": {"full", "editor-release"},
     "documentation": {"structure"},
-    "distribution_release": {"full", "qualification", "evidence-custody"},
+    "distribution_release": {
+        "full",
+        "qualification",
+        "evidence-custody",
+        "incident-governance",
+    },
 }
 
 

--- a/verification/areas/distribution_release/governance/schema_contracts.py
+++ b/verification/areas/distribution_release/governance/schema_contracts.py
@@ -41,6 +41,22 @@ def validate_schema_contracts() -> None:
             raise ValueError(
                 f"qualification schema accepted invalid expiry: {expires_at}"
             )
+    incident_schema = SCHEMA_ROOT / "stable_incident_signoff.schema.json"
+    no_completed = copy.deepcopy(fixtures["stable_incident_signoff.schema.json"])
+    no_completed["attempts"][0]["status"] = "failed"
+    duplicate_completed = copy.deepcopy(fixtures["stable_incident_signoff.schema.json"])
+    duplicate_completed["attempts"].append(
+        {**copy.deepcopy(duplicate_completed["attempts"][0]), "run_id": 2}
+    )
+    for invalid_signoff in (no_completed, duplicate_completed):
+        try:
+            validate_instance(invalid_signoff, incident_schema)
+        except JsonSchemaError:
+            pass
+        else:
+            raise ValueError(
+                "incident sign-off schema accepted an invalid completed-attempt count"
+            )
 
 
 def schema_fixtures() -> dict[str, Any]:
@@ -300,6 +316,7 @@ def release_report() -> dict[str, Any]:
             ("distribution_release", "full"),
             ("distribution_release", "qualification"),
             ("distribution_release", "evidence-custody"),
+            ("distribution_release", "incident-governance"),
         ],
     }
     return {
@@ -334,7 +351,12 @@ def release_report() -> dict[str, Any]:
                     ("documentation", ["structure"]),
                     (
                         "distribution_release",
-                        ["full", "qualification", "evidence-custody"],
+                        [
+                            "full",
+                            "qualification",
+                            "evidence-custody",
+                            "incident-governance",
+                        ],
                     ),
                 )
             ],

--- a/verification/areas/distribution_release/governance/schema_contracts.py
+++ b/verification/areas/distribution_release/governance/schema_contracts.py
@@ -422,6 +422,7 @@ def incident_signoff() -> dict[str, Any]:
     return {
         "schema_version": 2,
         "incident_id": "inc-2026-001",
+        "operation": "rollback",
         "request_sha256": SHA_A,
         "attempts": [attempt()],
         "index_mutation": {

--- a/verification/areas/distribution_release/governance/selftest.py
+++ b/verification/areas/distribution_release/governance/selftest.py
@@ -496,6 +496,7 @@ def test_release_index_transitions() -> None:
     validate_incident_index_mutation(
         active_index(),
         incident,
+        operation="incident-roll-forward",
         incident_id="inc-2026-001",
         affected_version="0.1.0",
         successor_version="0.1.1",
@@ -506,13 +507,13 @@ def test_release_index_transitions() -> None:
         lambda value: validate_incident_index_mutation(
             active_index(),
             value,
+            operation="incident-roll-forward",
             incident_id="inc-2026-001",
             affected_version="0.1.0",
             successor_version="0.1.1",
         ),
         invalid,
     )
-
 
 def test_release_plan_mutations() -> None:
     ga = valid_plan()
@@ -558,7 +559,6 @@ def test_release_plan_mutations() -> None:
         lambda value: validate_release_plan(value, incident_request_sha256=SHA_B),
         incident,
     )
-
 
 def test_incident_mutations() -> None:
     request = valid_incident_request()
@@ -639,6 +639,7 @@ def test_signoff_mutations() -> None:
     incident_signoff = {
         "schema_version": 2,
         "incident_id": "inc-2026-001",
+        "operation": "rollback",
         "request_sha256": SHA_A,
         "attempts": [valid_attempt()],
         "index_mutation": {

--- a/verification/areas/distribution_release/governance/selftest.py
+++ b/verification/areas/distribution_release/governance/selftest.py
@@ -25,7 +25,6 @@ from .evidence_custody import (
 from .incident import validate_incident_request, validate_incident_signoff
 from .release_index import (
     propose_preview_release,
-    validate_incident_index_mutation,
     validate_release_index,
     validate_release_index_transition,
 )
@@ -237,6 +236,7 @@ def valid_report() -> dict[str, Any]:
             ("distribution_release", "full"),
             ("distribution_release", "qualification"),
             ("distribution_release", "evidence-custody"),
+            ("distribution_release", "incident-governance"),
         ],
     }
     steps = []
@@ -288,7 +288,12 @@ def valid_report() -> dict[str, Any]:
                     ("documentation", {"structure"}),
                     (
                         "distribution_release",
-                        {"full", "qualification", "evidence-custody"},
+                        {
+                            "full",
+                            "qualification",
+                            "evidence-custody",
+                            "incident-governance",
+                        },
                     ),
                 )
             ],
@@ -488,32 +493,6 @@ def test_release_index_transitions() -> None:
         ),
         preview_index(),
     )
-    incident = mutate(active_index(), lambda item: item.update({"generation": 9}))
-    incident["releases"]["0.1.0"]["status"] = "withdrawn"
-    incident["releases"]["0.1.0"]["incident_id"] = "inc-2026-001"
-    incident["releases"]["0.1.1"] = release_record("stable")
-    incident["channels"]["stable"] = "0.1.1"
-    validate_incident_index_mutation(
-        active_index(),
-        incident,
-        operation="incident-roll-forward",
-        incident_id="inc-2026-001",
-        affected_version="0.1.0",
-        successor_version="0.1.1",
-    )
-    invalid = mutate(incident, lambda item: item["releases"]["0.1.0"].update({"status": "active"}))
-    invalid["releases"]["0.1.0"].pop("incident_id")
-    expect_rejected(
-        lambda value: validate_incident_index_mutation(
-            active_index(),
-            value,
-            operation="incident-roll-forward",
-            incident_id="inc-2026-001",
-            affected_version="0.1.0",
-            successor_version="0.1.1",
-        ),
-        invalid,
-    )
 
 def test_release_plan_mutations() -> None:
     ga = valid_plan()
@@ -559,6 +538,7 @@ def test_release_plan_mutations() -> None:
         lambda value: validate_release_plan(value, incident_request_sha256=SHA_B),
         incident,
     )
+
 
 def test_incident_mutations() -> None:
     request = valid_incident_request()

--- a/verification/areas/distribution_release/governance/selftest.py
+++ b/verification/areas/distribution_release/governance/selftest.py
@@ -494,6 +494,7 @@ def test_release_index_transitions() -> None:
         preview_index(),
     )
 
+
 def test_release_plan_mutations() -> None:
     ga = valid_plan()
     validate_release_plan(ga, active_index=preview_index())
@@ -827,6 +828,7 @@ def test_evidence_custody_mutations() -> None:
     )
     candidate = "plans/releases/candidates/0.1.0/stable-release-plan.json"
     validate_changed_path_set({candidate})
+    validate_changed_path_set({candidate, "plans/releases/README.md"})
     path_mutations = [
         {candidate, "crates/sifr/src/main.rs"},
         {candidate, "plans/releases/candidates/0.1.1/stable-release-plan.json"},

--- a/verification/areas/distribution_release/manifest.json
+++ b/verification/areas/distribution_release/manifest.json
@@ -61,6 +61,19 @@
           "diagnostic_formats": []
         }
       ]
+    },
+    {
+      "name": "incident-governance",
+      "kind": "adapter",
+      "cases": [
+        {
+          "id": "incident-recovery",
+          "entry": "verification/areas/distribution_release/governance/incident_recovery_selftest.py",
+          "command": "distribution-incident-recovery",
+          "expect_exit_code": 0,
+          "diagnostic_formats": []
+        }
+      ]
     }
   ],
   "network_mode": "offline",

--- a/verification/areas/distribution_release/runner.py
+++ b/verification/areas/distribution_release/runner.py
@@ -106,6 +106,13 @@ def run_suite(suite: dict[str, Any]) -> dict[str, Any]:
                 "evidence-custody",
             )
         ]
+    elif suite_name == "incident-governance":
+        variants = [
+            run_python_module(
+                "governance.incident_recovery_selftest",
+                "incident-recovery",
+            )
+        ]
     elif suite_name == "qualification":
         variants = [
             run_python_module(
@@ -118,6 +125,12 @@ def run_suite(suite: dict[str, Any]) -> dict[str, Any]:
         if suite_name == "full":
             variants.append(run_python_module("governance.selftest", "governance-contracts"))
             variants.append(run_python_module("governance.schema_epoch", "schema-epoch"))
+            variants.append(
+                run_python_module(
+                    "governance.incident_recovery_selftest",
+                    "incident-recovery",
+                )
+            )
     failures = sum(1 for variant in variants if variant["status"] == "fail")
     return {
         "name": suite_name,
@@ -140,7 +153,13 @@ def run_suite(suite: dict[str, Any]) -> dict[str, Any]:
 
 def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
     suite_name = str(suite["name"])
-    if suite_name not in {"representative", "full", "qualification", "evidence-custody"}:
+    if suite_name not in {
+        "representative",
+        "full",
+        "qualification",
+        "evidence-custody",
+        "incident-governance",
+    }:
         raise SystemExit(f"unsupported distribution_release suite: {suite_name}")
     cases = suite.get("cases", [])
     if not isinstance(cases, list) or len(cases) != 1:
@@ -148,6 +167,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
     case = cases[0]
     expected_command = {
         "evidence-custody": "distribution-evidence-custody",
+        "incident-governance": "distribution-incident-recovery",
         "qualification": "distribution-stable-qualification",
     }.get(suite_name, "distribution-case-directory")
     if str(case.get("command")) != expected_command:
@@ -155,6 +175,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
     entry = REPO_ROOT / str(case.get("entry"))
     expected_entry = {
         "evidence-custody": AREA_ROOT / "governance" / "evidence_custody.py",
+        "incident-governance": AREA_ROOT / "governance" / "incident_recovery_selftest.py",
         "qualification": AREA_ROOT / "governance" / "qualification_selftest.py",
     }.get(suite_name, CASES_ROOT)
     if entry != expected_entry or not entry.exists():

--- a/verification/areas/distribution_release/runner.py
+++ b/verification/areas/distribution_release/runner.py
@@ -45,7 +45,13 @@ def main(argv: list[str] | None = None) -> int:
     print(f"  manifest={MANIFEST_PATH.relative_to(REPO_ROOT)}", flush=True)
     print("  bless=no", flush=True)
 
-    suite_results = [run_suite(suite) for suite in selected]
+    incident_suite_selected = any(
+        str(suite["name"]) == "incident-governance" for suite in selected
+    )
+    suite_results = [
+        run_suite(suite, include_incident=not incident_suite_selected)
+        for suite in selected
+    ]
     total_variants = sum(int(result["total_variants"]) for result in suite_results)
     total_failures = sum(int(result["total_failures"]) for result in suite_results)
     payload = {
@@ -96,7 +102,11 @@ def select_suites(manifest: dict[str, Any], requested: set[str]) -> list[dict[st
     return selected
 
 
-def run_suite(suite: dict[str, Any]) -> dict[str, Any]:
+def run_suite(
+    suite: dict[str, Any],
+    *,
+    include_incident: bool = True,
+) -> dict[str, Any]:
     suite_name = str(suite["name"])
     case = validate_suite_case(suite)
     if suite_name == "evidence-custody":
@@ -125,12 +135,13 @@ def run_suite(suite: dict[str, Any]) -> dict[str, Any]:
         if suite_name == "full":
             variants.append(run_python_module("governance.selftest", "governance-contracts"))
             variants.append(run_python_module("governance.schema_epoch", "schema-epoch"))
-            variants.append(
-                run_python_module(
-                    "governance.incident_recovery_selftest",
-                    "incident-recovery",
+            if include_incident:
+                variants.append(
+                    run_python_module(
+                        "governance.incident_recovery_selftest",
+                        "incident-recovery",
+                    )
                 )
-            )
     failures = sum(1 for variant in variants if variant["status"] == "fail")
     return {
         "name": suite_name,

--- a/verification/areas/distribution_release/schemas/stable_incident_signoff.schema.json
+++ b/verification/areas/distribution_release/schemas/stable_incident_signoff.schema.json
@@ -7,6 +7,7 @@
   "required": [
     "schema_version",
     "incident_id",
+    "operation",
     "request_sha256",
     "attempts",
     "index_mutation",
@@ -18,6 +19,7 @@
   "properties": {
     "schema_version": {"const": 2},
     "incident_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{2,63}$"},
+    "operation": {"enum": ["rollback", "incident-roll-forward"]},
     "request_sha256": {"$ref": "#/$defs/sha256"},
     "attempts": {
       "type": "array",
@@ -40,8 +42,8 @@
         "previous_sha256": {"$ref": "#/$defs/sha256"},
         "realized_generation": {"type": "integer", "minimum": 1},
         "realized_sha256": {"$ref": "#/$defs/sha256"},
-        "affected_version": {"type": "string"},
-        "successor_version": {"type": "string"}
+        "affected_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "successor_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"}
       }
     },
     "site_reconciliation": {"$ref": "#/$defs/evidence"},

--- a/verification/areas/distribution_release/schemas/stable_incident_signoff.schema.json
+++ b/verification/areas/distribution_release/schemas/stable_incident_signoff.schema.json
@@ -24,7 +24,14 @@
     "attempts": {
       "type": "array",
       "minItems": 1,
-      "items": {"$ref": "#/$defs/attempt"}
+      "items": {"$ref": "#/$defs/attempt"},
+      "contains": {
+        "type": "object",
+        "required": ["status"],
+        "properties": {"status": {"const": "completed"}}
+      },
+      "minContains": 1,
+      "maxContains": 1
     },
     "index_mutation": {
       "type": "object",
@@ -80,7 +87,7 @@
         "run_id": {"type": "integer", "minimum": 1},
         "mode": {"enum": ["initial", "resume"]},
         "approver": {"type": "string", "minLength": 1},
-        "status": {"enum": ["started", "failed", "completed"]},
+        "status": {"enum": ["failed", "completed"]},
         "mutations": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/mutation"}}
       }
     }

--- a/verification/json_schema_202012.py
+++ b/verification/json_schema_202012.py
@@ -23,8 +23,11 @@ SCHEMA_KEYS = {
     "propertyNames",
     "additionalProperties",
     "items",
+    "contains",
     "minItems",
     "maxItems",
+    "minContains",
+    "maxContains",
     "uniqueItems",
     "minProperties",
     "minimum",
@@ -73,7 +76,16 @@ def _lint_node(node: Any, path: Path, location: str) -> None:
             raise JsonSchemaError(f"{path}:{location}.{keyword}: must be an object")
         for name, child in children.items():
             _lint_node(child, path, f"{location}.{keyword}.{name}")
-    for keyword in ("items", "propertyNames", "additionalProperties", "if", "then", "else", "not"):
+    for keyword in (
+        "items",
+        "contains",
+        "propertyNames",
+        "additionalProperties",
+        "if",
+        "then",
+        "else",
+        "not",
+    ):
         child = node.get(keyword)
         if child is not None and isinstance(child, (dict, bool)):
             _lint_node(child, path, f"{location}.{keyword}")
@@ -193,6 +205,17 @@ def _validate_array(
         raise JsonSchemaError(f"{location}: has too many items")
     if schema.get("uniqueItems") and len({canonical(item) for item in value}) != len(value):
         raise JsonSchemaError(f"{location}: items must be unique")
+    if "contains" in schema:
+        matches = sum(
+            _matches(item, schema["contains"], root_path, current_path, f"{location}[{index}]")
+            for index, item in enumerate(value)
+        )
+        minimum = schema.get("minContains", 1)
+        maximum = schema.get("maxContains")
+        if matches < minimum:
+            raise JsonSchemaError(f"{location}: has too few matching items")
+        if maximum is not None and matches > maximum:
+            raise JsonSchemaError(f"{location}: has too many matching items")
     if "items" in schema:
         for index, item in enumerate(value):
             _validate(item, schema["items"], root_path, current_path, f"{location}[{index}]")

--- a/verification/profiles/merge.json
+++ b/verification/profiles/merge.json
@@ -242,7 +242,8 @@
       "area": "distribution_release",
       "suites": [
         "representative",
-        "qualification"
+        "qualification",
+        "incident-governance"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/profiles/nightly.json
+++ b/verification/profiles/nightly.json
@@ -221,7 +221,8 @@
       "area": "distribution_release",
       "suites": [
         "full",
-        "qualification"
+        "qualification",
+        "incident-governance"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/profiles/release.json
+++ b/verification/profiles/release.json
@@ -221,7 +221,8 @@
       "suites": [
         "full",
         "qualification",
-        "evidence-custody"
+        "evidence-custody",
+        "incident-governance"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -667,7 +667,12 @@ def _release_report_production_self_test() -> None:
         ],
         "developer_tooling": ["full"],
         "documentation": ["structure"],
-        "distribution_release": ["full", "qualification", "evidence-custody"],
+        "distribution_release": [
+            "full",
+            "qualification",
+            "evidence-custody",
+            "incident-governance",
+        ],
     }
     with tempfile.TemporaryDirectory(prefix="sifr-release-report-production-") as directory:
         root = Path(directory)


### PR DESCRIPTION
## What changed

- add governed rollback and first-GA incident roll-forward planning with atomic release-index mutation checks
- add a credential-free, network-free local incident fixture covering generation burning, exact resume, races, site timeout/cancellation, immutable evidence retention, installer recovery, extension/Marketplace reconciliation, and sign-off
- wire canonical incident evidence custody at `plans/releases/incidents/<incident-id>/` into repository validation
- add schema-v2 incident request/sign-off contracts and exact terminal-attempt validation
- register and select the named `distribution_release:incident-governance` suite in merge, nightly, and release profiles without duplicate execution
- add the capability demo `demos/stable_incident_recovery_demo.sh` and stable incident-response documentation

## Why

Phase 40 requires stable-channel incident handling to be mechanically safe before production publication wiring: affected releases must be withdrawn atomically, retained artifacts must remain immutable, rollback must use an approved retained target, and the first GA must roll forward rather than disappear.

## Validation

- `distribution_release --suite full --suite qualification --suite evidence-custody --suite incident-governance`: 55 variants, 0 failures, incident module exactly once
- incident governance: 9/9 scenarios
- coverage/readiness and profile assignment: pass
- runner self-tests: pass
- documentation structure: pass
- `demos/stable_incident_recovery_demo.sh`: pass
- file-size and HIR maintainability guardrails: pass
- Claude Opus full review pass 4: APPROVED, no actionable findings

The authoritative create-PR profile completed every functional check, including 19/19 Python-interop variants, but the host exceeded that step's aggregate timing budget (788.45s vs 600s). This unrelated host variance is recorded in `plans/phases/adhoc_performance_budget_host_variance.md`; no baseline or waiver changed, and it is not a Phase 40 prerequisite.
