### PR TITLE
Phase 40: repair qualification artifact collection

### DIFF
--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -220,6 +220,14 @@ every workflow artifact id and upload name, exact per-artifact expiry, file
 name, size, SHA-256, complete target coverage, aggregate installer/checksums,
 and VSIX evidence.
 
+Run identity is bound to the exact
+`.github/workflows/release-qualification.yml` API `path`; the API `name` is
+dynamic because the workflow uses `run-name`. The workflow contract still
+requires `retention-days: 30`. GitHub anchors expiry when upload begins but
+records `created_at` after upload completes, so the collector accepts only an
+observed API interval from 30 days minus 60 seconds through exactly 30 days.
+Longer retention or a shortfall greater than 60 seconds fails closed.
+
 The local `plan-stable-release` command in
 `scripts/distribution/release_governance.py` is non-mutating. It requires a
 clean checkout at the exact source SHA, an unexpired qualification index, the

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -196,6 +196,11 @@ Review and upstream coordination ledger:
   six-container replay, then requested an explicit over-retention mutation.
   The repair now rejects both a 61-second shortfall and one second beyond 30
   days; its error also records the observed timestamps and interval.
+- Claude Opus collector-repair review pass 2 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-4-collector-repair-claude-opus-review-pass-2.md`.
+  It independently reproduced the live API semantics and 509 MB artifact
+  replay, mutation-tested both retention bounds and the workflow-path binding,
+  found no remaining actionable issue, and approved the repair.
 
 ### milestone_40_5: Protected Sign-off and GA Activation
 

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -179,6 +179,17 @@ Review and upstream coordination ledger:
   gates all passed. Exact create-PR evidence is appended to
   `plans/phases/adhoc_performance_budget_host_variance.md` and is not a Phase
   40 prerequisite. No timeout or validation waiver was added.
+- Post-merge qualification run
+  [#30270476093](https://github.com/sifr-lang/sifr/actions/runs/30270476093)
+  bound source `3ebe27bc4095134137a5b47df7ea372aff936011` and passed all
+  four governed targets, editor qualification, and aggregate assembly. Its
+  collector exposed two real GitHub API semantics missing from the fixtures:
+  `name` contains the dynamic `run-name`, while `path` identifies the workflow;
+  and `created_at` can trail the expiry anchor by several upload seconds. The
+  repair binds the exact workflow path and permits at most 60 seconds of
+  one-sided timestamp skew while the workflow contract still requires
+  `retention-days: 30`; the real six-container replay produces and validates
+  the complete canonical 20-row index.
 
 ### milestone_40_5: Protected Sign-off and GA Activation
 

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -190,6 +190,12 @@ Review and upstream coordination ledger:
   one-sided timestamp skew while the workflow contract still requires
   `retention-days: 30`; the real six-container replay produces and validates
   the complete canonical 20-row index.
+- Claude Opus collector-repair review pass 1 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-4-collector-repair-claude-opus-review-pass-1.md`.
+  It verified the API-path binding, one-sided timestamp bound, and real
+  six-container replay, then requested an explicit over-retention mutation.
+  The repair now rejects both a 61-second shortfall and one second beyond 30
+  days; its error also records the observed timestamps and interval.
 
 ### milestone_40_5: Protected Sign-off and GA Activation
 

--- a/plans/reviews/archive/phase-40-milestone-40-4-collector-repair-claude-opus-review-pass-1.md
+++ b/plans/reviews/archive/phase-40-milestone-40-4-collector-repair-claude-opus-review-pass-1.md
@@ -1,0 +1,44 @@
+## Review — Phase 40 milestone_40_4 qualification collector repair (`origin/main...HEAD`, commit `b9a06bda3`)
+
+Read-only. Scope: 5 files, +57/−9.
+
+### What I verified
+
+**Root cause and fix are correct.** Both repairs address real GitHub REST semantics rather than symptoms:
+
+- Binding `run_metadata["path"] == ".github/workflows/release-qualification.yml"` replaces the `name` check. `name` is the rendered `run-name` (`release-qualification.yml:2` interpolates `inputs.version`/`inputs.source_commit`), so the old equality could never hold. The repo already relied on this semantics elsewhere — `release-publication.yml:651` correlates runs on `display_title` — so the collector's `name` binding was the outlier. `path` is the immutable workflow identity, and it is a strictly stronger binding than the mutable `name:` key (which no contract test pinned anyway).
+- The one-sided retention interval matches the stated anchor asymmetry (expiry anchored at upload start, `created_at` stamped at completion), which is why the delta lands 1–9 s under 30 d.
+
+**Fail-closed behavior confirmed empirically.** I drove `collect_index` directly against the fixture with mutations:
+
+| probe | result |
+|---|---|
+| baseline (30 d − 5 s) | accepted |
+| `path` = other workflow / basename only / absent | rejected |
+| shortfall 60 s / exactly 30 d | accepted |
+| shortfall 61 s | rejected |
+| 30 d + 1 s, 31 d, 29 d | rejected |
+
+The bound is genuinely one-sided: no over-retention is tolerated, not even one second, and a missing `path` key fails closed via `.get()`. Retention inflation and truncation both abort collection.
+
+**Provenance chain intact.** `head_sha == source_commit`, `event == workflow_dispatch`, `id == GITHUB_RUN_ID`, `run_attempt`, and `repository.full_name` are still all bound, and `validate` enforces `github.sha == source_commit` before the contract case runs on that exact tree, so `path` resolves to the contract-checked workflow definition. The workflow contract still enforces `retention-days: 30` and `overwrite: false` exactly four times (`release_qualification_workflow_contract.sh:56,119`), so the loosened API-delta check remains a *derivation* backed by an independent config assertion, not a replacement for it. Permissions stay `contents: read` / `actions: read`; no mutation capability introduced.
+
+**Downstream unaffected.** `artifact_index.py:99` still requires `retention_days == 30`; per-artifact `expires_at ≥ workflow boundary` and `require_unexpired` are unchanged. The 60 s slack does not leak into any custody window, since `expires_at` (not `created_at + 30d`) is what is recorded and later compared.
+
+**Tests/docs.** `governance.qualification_selftest` passes (9 tests), plus `governance.selftest` (14), `evidence_custody`, `schema_epoch`, and the workflow contract case. Fixtures now carry realistic skew and a realistic dynamic `name`. `internal_docs/distribution_pipeline.md:223-228` and the plan ledger describe the mechanism accurately; the 6-container / 20-row replay arithmetic checks out (4×4 + 2 + 2). Touched files are all under the 900-line cap.
+
+### Actionable finding
+
+**1 · Low · test-coverage — the over-retention direction of the new bound lost its probe**
+
+- **Location:** `verification/areas/distribution_release/governance/qualification_selftest.py:210` (was `2098-12-01T00:00:00Z` = 31 d, now `2098-12-02T00:01:01Z` = 61 s shortfall); guard at `scripts/distribution/collect_qualification_artifacts.py:161-170`.
+- **Impact:** The exact-equality check previously had one negative probe, and it exercised the *long* direction — the archived pass-3 ledger credits it as "Probes: 31d, 29d, …". The repair repurposed that single probe for the shortfall direction, so `observed_retention <= ARTIFACT_RETENTION` is now asserted nowhere. Deleting the upper comparison entirely (leaving `ARTIFACT_RETENTION - SKEW <= observed_retention`) keeps the whole suite green while the collector would silently accept 60- or 90-day retention — i.e. the governance property whose loss the milestone is auditing for regresses undetected. Present behavior is correct; only the regression barrier is gone, hence low.
+- **Remediation:** Keep the 61 s case and add one more mutation in `test_artifact_collector_rejects_drift` asserting rejection of retention longer than 30 days (e.g. `created_at = "2098-12-01T23:59:59Z"`, restoring to `2098-12-02T00:00:05Z` afterward as the existing block already does). I confirmed that input rejects today, so the assertion passes as written. ~15 lines; the file lands at ~855 lines, still inside the cap.
+
+### Non-blocking observations (no change required)
+
+- `collect_qualification_artifacts.py:167-169` omits the observed interval from the error. Since this failure aborts a four-runner multi-hour qualification run, including `observed_retention` and the two timestamps would separate "GitHub upload was slow" from "retention was misconfigured" without a re-run. The 60 s ceiling is ~7× the worst observed 9 s, which I consider appropriately sized rather than over-permissive.
+- `qualification_fixture.py:556` hardcodes `0.1.0` in the cosmetic `name` while the version is otherwise carried in `prefix`; the field is unvalidated, so this is realism-only.
+- All six fixture containers share one `created_at`, so heterogeneous per-container skew (the real 1–9 s spread) is not exercised. Pre-existing fixture shape; the guard is per-artifact, so coverage is not affected.
+
+**NOT APPROVED**

--- a/plans/reviews/archive/phase-40-milestone-40-4-collector-repair-claude-opus-review-pass-2.md
+++ b/plans/reviews/archive/phase-40-milestone-40-4-collector-repair-claude-opus-review-pass-2.md
@@ -1,0 +1,49 @@
+## Review — Phase 40 milestone_40_4 collector repair, pass 2 (`origin/main...HEAD`, `aeb3b7144`)
+
+Read-only; working tree untouched. Scope: 6 files, +127/−10.
+
+### Pass-1 finding closed
+
+**Low · test-coverage — upper retention bound lacked a mutation → resolved.** `qualification_selftest.py:210` now restores the long-direction probe (`created_at = 2098-12-01T23:59:59Z` = 30 d + 1 s) *in addition to* the 61 s shortfall probe (`2098-12-02T00:01:01Z`), then restores the realistic baseline `2098-12-02T00:00:05Z`.
+
+I mutation-tested the guard by loading source-mutated collectors through `load_collector` — all four mutants are killed by `test_artifact_collector_rejects_drift`:
+
+| mutant | result |
+|---|---|
+| drop `<= ARTIFACT_RETENTION` | KILLED — "collector accepted retention longer than 30 days" |
+| drop `ARTIFACT_RETENTION - SKEW <=` | KILLED — "collector accepted excessive retention shortfall" |
+| drop the `path` identity clause | KILLED — "collector accepted another workflow path" |
+| widen skew 60 s → 1 day | KILLED — "collector accepted excessive retention shortfall" |
+
+Boundary probes against the fixture: `exactly 30 d`, `30 d − 59 s`, `30 d − 60 s` accepted (20 rows each); `30 d − 61 s`, `30 d + 1 s`, `31 d`, `29 d`, `90 d` rejected. The bound is exactly as documented and strictly one-sided.
+
+**Improved error confirmed:** `… artifact retention is outside the governed 30-day API timestamp bound (created_at=2098-12-01T23:59:59Z, expires_at=2099-01-01T00:00:00Z, observed=30 days, 0:00:01)` — pass-1 observation 1 closed.
+
+### Root cause verified against the live GitHub API
+
+Both semantics are real, not inferred. `gh api …/runs/30270476093` returns `name = "Qualify stable candidate 0.1.0 at 3ebe27bc…"`, `path = ".github/workflows/release-qualification.yml"` — the old `name == "release-qualification"` equality could never hold. Real per-artifact deltas are `−1 s, −1 s, −4 s, −4 s, −6 s, −9 s` (expiry anchored at upload start), all one-sided and ≤ 9 s against the 60 s ceiling. I ran `origin/main`'s collector against the real metadata: it fails at the `name` clause; patching only that clause, it then fails at `retention is not exactly 30 days`. Both repairs are necessary and sufficient.
+
+### Real six-container / 20-row replay reproduced
+
+I downloaded the run's 509 MB of artifacts plus raw `gh api` run/artifact JSON and ran the branch collector end to end: `artifacts=20` across exactly 6 containers (4 targets × 4 files, assemble 2, editor 2), and `validate_qualification_artifact_index` accepts the output. Rows carry the API `expires_at` verbatim (not `created_at + 30 d`), so the 60 s slack cannot widen any custody window. Ledger claim is truthful; job list confirms four targets, editor, and assemble succeeded and only the collect job failed.
+
+### Contract, provenance, security
+
+- Workflow contract still asserts `retention-days: 30` and `overwrite: false` exactly four times each (`release_qualification_workflow_contract.sh:56,119`), so the loosened API-delta check remains a derivation backed by an independent config assertion.
+- `path` binding matches the real file; `run-name` interpolation at `release-qualification.yml:2` explains the dynamic `name`. The workflow writes the full raw `gh api` run object, so `path` is present in production input.
+- Provenance clauses intact: `id`, `run_attempt`, `head_sha == source_commit`, `event == workflow_dispatch`, `repository.full_name`. Missing `path` fails closed via `.get()`. Permissions remain `contents: read` / `actions: read`; no mutation surface added. `artifact_index.py:99` still pins `retention_days == 30`.
+- Docs (`distribution_pipeline.md:223-230`) and the ledger describe the mechanism accurately; the archived pass-1 report's stated scope (5 files, +57/−9) matches `b9a06bda3` exactly.
+
+### Gates run
+
+`distribution_release --suite full`: 54 variants, 0 failures. `--suite qualification`: 9 tests pass. `scripts/check_file_size_guardrails.py`: PASS (touched files 312 / 855 / 829 lines).
+
+### Non-blocking observations (no change required)
+
+- 60 s ceiling is ~7× the worst observed 9 s upload for 124 MB containers. A future much larger artifact could exceed it and abort a run — but that fails closed with a now-precise diagnostic, which is the intended governance posture.
+- `qualification_fixture.py:544` still hardcodes `0.1.0` in the cosmetic `name`; the field is unvalidated, realism-only.
+- All fixture containers still share one `created_at`, so heterogeneous per-container skew isn't exercised; the guard is per-artifact and the drift test mutates only `artifacts[0]`, so coverage is unaffected.
+
+No actionable finding remains.
+
+**APPROVED**

--- a/scripts/distribution/collect_qualification_artifacts.py
+++ b/scripts/distribution/collect_qualification_artifacts.py
@@ -26,6 +26,9 @@ from governance.common import (  # noqa: E402
     write_canonical_json,
 )
 
+ARTIFACT_RETENTION = timedelta(days=30)
+ARTIFACT_TIMESTAMP_SKEW = timedelta(seconds=60)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -95,7 +98,7 @@ def collect_index(
         or run_metadata.get("run_attempt") != run_attempt
         or run_metadata.get("head_sha") != source_commit
         or run_metadata.get("event") != "workflow_dispatch"
-        or run_metadata.get("name") != "release-qualification"
+        or run_metadata.get("path") != ".github/workflows/release-qualification.yml"
         or repository.get("full_name") != "sifr-lang/sifr"
     ):
         raise GovernanceError(
@@ -155,9 +158,15 @@ def collect_index(
             raise GovernanceError(
                 f"{workflow_name}: artifact timestamps need timezones"
             )
-        if parsed_expiry - parsed_creation != timedelta(days=30):
+        observed_retention = parsed_expiry - parsed_creation
+        if not (
+            ARTIFACT_RETENTION - ARTIFACT_TIMESTAMP_SKEW
+            <= observed_retention
+            <= ARTIFACT_RETENTION
+        ):
             raise GovernanceError(
-                f"{workflow_name}: artifact retention is not exactly 30 days"
+                f"{workflow_name}: artifact retention is outside the governed "
+                "30-day API timestamp bound"
             )
         expiries.append((parsed_expiry, expires_at))
         workflow_run = require_object(

--- a/scripts/distribution/collect_qualification_artifacts.py
+++ b/scripts/distribution/collect_qualification_artifacts.py
@@ -166,7 +166,9 @@ def collect_index(
         ):
             raise GovernanceError(
                 f"{workflow_name}: artifact retention is outside the governed "
-                "30-day API timestamp bound"
+                "30-day API timestamp bound "
+                f"(created_at={created_at}, expires_at={expires_at}, "
+                f"observed={observed_retention})"
             )
         expiries.append((parsed_expiry, expires_at))
         workflow_run = require_object(

--- a/verification/areas/distribution_release/governance/qualification_fixture.py
+++ b/verification/areas/distribution_release/governance/qualification_fixture.py
@@ -541,7 +541,8 @@ def write_workflow_metadata(
             "run_attempt": 1,
             "head_sha": source_commit,
             "event": "workflow_dispatch",
-            "name": "release-qualification",
+            "name": f"Qualify stable candidate 0.1.0 at {source_commit}",
+            "path": ".github/workflows/release-qualification.yml",
             "repository": {"full_name": "sifr-lang/sifr"},
         },
     )
@@ -552,7 +553,7 @@ def write_workflow_metadata(
                 "id": artifact_id,
                 "name": f"{prefix}{suffix}",
                 "expired": False,
-                "created_at": "2098-12-02T00:00:00Z",
+                "created_at": "2098-12-02T00:00:05Z",
                 "expires_at": "2099-01-01T00:00:00Z",
                 "workflow_run": {"id": 42},
             }

--- a/verification/areas/distribution_release/governance/qualification_selftest.py
+++ b/verification/areas/distribution_release/governance/qualification_selftest.py
@@ -91,7 +91,7 @@ def create_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
                 "id": artifact_id,
                 "name": workflow_name,
                 "expired": False,
-                "created_at": "2098-12-02T00:00:00Z",
+                "created_at": "2098-12-02T00:00:05Z",
                 "expires_at": "2099-01-01T00:00:00Z",
                 "workflow_run": {"id": 42, "head_sha": COMMIT},
             }
@@ -106,7 +106,8 @@ def create_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
                 "run_attempt": 1,
                 "head_sha": COMMIT,
                 "event": "workflow_dispatch",
-                "name": "release-qualification",
+                "name": f"Qualify stable candidate {VERSION} at {COMMIT}",
+                "path": ".github/workflows/release-qualification.yml",
                 "repository": {"full_name": "sifr-lang/sifr"},
             }
         )
@@ -186,9 +187,27 @@ def test_artifact_collector_rejects_drift() -> None:
                 "collector accepted another workflow definition commit"
             )
         run_metadata["head_sha"] = COMMIT
+        run_metadata["path"] = ".github/workflows/not-release-qualification.yml"
+        rewrite_canonical(run_metadata_path, run_metadata)
+        try:
+            load_collector().collect_index(
+                version=VERSION,
+                source_commit=COMMIT,
+                submodules_path=submodules_path,
+                run_id=42,
+                run_attempt=1,
+                run_metadata_path=run_metadata_path,
+                metadata_path=metadata_path,
+                artifact_root=artifact_root,
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("collector accepted another workflow path")
+        run_metadata["path"] = ".github/workflows/release-qualification.yml"
         rewrite_canonical(run_metadata_path, run_metadata)
         metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-        metadata["artifacts"][0]["created_at"] = "2098-12-01T00:00:00Z"
+        metadata["artifacts"][0]["created_at"] = "2098-12-02T00:01:01Z"
         rewrite_canonical(metadata_path, metadata)
         try:
             load_collector().collect_index(
@@ -205,7 +224,7 @@ def test_artifact_collector_rejects_drift() -> None:
             pass
         else:
             raise AssertionError("collector accepted non-governed artifact retention")
-        metadata["artifacts"][0]["created_at"] = "2098-12-02T00:00:00Z"
+        metadata["artifacts"][0]["created_at"] = "2098-12-02T00:00:05Z"
         rewrite_canonical(metadata_path, metadata)
         target_dir = (
             artifact_root / f"sifr-stable-candidate-{VERSION}-{COMMIT}-{TARGETS[0]}"

--- a/verification/areas/distribution_release/governance/qualification_selftest.py
+++ b/verification/areas/distribution_release/governance/qualification_selftest.py
@@ -223,7 +223,24 @@ def test_artifact_collector_rejects_drift() -> None:
         except ValueError:
             pass
         else:
-            raise AssertionError("collector accepted non-governed artifact retention")
+            raise AssertionError("collector accepted excessive retention shortfall")
+        metadata["artifacts"][0]["created_at"] = "2098-12-01T23:59:59Z"
+        rewrite_canonical(metadata_path, metadata)
+        try:
+            load_collector().collect_index(
+                version=VERSION,
+                source_commit=COMMIT,
+                submodules_path=submodules_path,
+                run_id=42,
+                run_attempt=1,
+                run_metadata_path=run_metadata_path,
+                metadata_path=metadata_path,
+                artifact_root=artifact_root,
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("collector accepted retention longer than 30 days")
         metadata["artifacts"][0]["created_at"] = "2098-12-02T00:00:05Z"
         rewrite_canonical(metadata_path, metadata)
         target_dir = (


### PR DESCRIPTION
## Summary

- bind qualification run identity to GitHub API workflow `path`, not dynamic `run-name`
- preserve exact 30-day workflow retention while accepting only 0-60 seconds of one-sided API timestamp skew
- add negative mutations for wrong workflow path, >60-second shortfall, and any over-retention
- document and replay qualification run 30270476093 across six real artifact containers / 20 canonical rows

## Validation

- distribution_release qualification/full: 55/55 passed
- qualification self-tests: 9/9 passed
- real run artifact collector replay: 20 rows, canonical validation passed, byte-deterministic
- file-size guardrails: PASS
- Claude Opus repair review pass 2: APPROVED
