### PR TITLE
release: bootstrap schema-v2 preview epoch

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -20,6 +20,20 @@ on:
         required: false
         default: main
         type: string
+      governance_mode:
+        description: Ordinary preview publication or one-time protected schema bootstrap stage
+        required: false
+        default: preview
+        type: choice
+        options:
+          - preview
+          - bootstrap-alpha
+          - bootstrap-index
+      bootstrap_alpha_version:
+        description: Fresh protected alpha version required only by bootstrap-index
+        required: false
+        default: ""
+        type: string
 
 permissions:
   actions: read
@@ -37,6 +51,8 @@ jobs:
       base_ref: ${{ steps.validate.outputs.base_ref }}
       source_sha: ${{ steps.validate.outputs.source_sha }}
       site_base_commit: ${{ steps.validate.outputs.site_base_commit }}
+      governance_mode: ${{ steps.validate.outputs.governance_mode }}
+      bootstrap_alpha_version: ${{ steps.validate.outputs.bootstrap_alpha_version }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -52,6 +68,8 @@ jobs:
           INPUT_CHANNEL: ${{ inputs.channel }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_BASE_REF: ${{ inputs.base_ref }}
+          GOVERNANCE_MODE: ${{ inputs.governance_mode }}
+          BOOTSTRAP_ALPHA_VERSION: ${{ inputs.bootstrap_alpha_version }}
           SITE_BASE_COMMIT: 07d88cc3c24707e386c5ad73fb0875c06ffd598f
         run: |
           set -euo pipefail
@@ -67,6 +85,38 @@ jobs:
             echo "::error::version ${INPUT_VERSION} belongs to ${BASH_REMATCH[1]}, not ${INPUT_CHANNEL}"
             exit 2
           fi
+          case "${GOVERNANCE_MODE}" in
+            preview)
+              test -z "${BOOTSTRAP_ALPHA_VERSION}" || {
+                echo "::error::ordinary preview publication cannot name a bootstrap alpha"
+                exit 2
+              }
+              ;;
+            bootstrap-alpha)
+              test "${INPUT_CHANNEL}" = "alpha" || {
+                echo "::error::bootstrap-alpha requires an alpha release"
+                exit 2
+              }
+              test -z "${BOOTSTRAP_ALPHA_VERSION}" || {
+                echo "::error::bootstrap-alpha does not accept bootstrap_alpha_version"
+                exit 2
+              }
+              ;;
+            bootstrap-index)
+              test "${INPUT_CHANNEL}" = "beta" || {
+                echo "::error::bootstrap-index requires a beta release"
+                exit 2
+              }
+              [[ "${BOOTSTRAP_ALPHA_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]] || {
+                echo "::error::bootstrap-index requires a fresh alpha version"
+                exit 2
+              }
+              ;;
+            *)
+              echo "::error::unsupported governance_mode"
+              exit 2
+              ;;
+          esac
           if [[ ! "${SITE_BASE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::preview release must pin an exact merged website commit"
             exit 2
@@ -77,6 +127,8 @@ jobs:
             echo "base_ref=${INPUT_BASE_REF:-main}"
             echo "source_sha=$(git rev-parse HEAD)"
             echo "site_base_commit=${SITE_BASE_COMMIT}"
+            echo "governance_mode=${GOVERNANCE_MODE}"
+            echo "bootstrap_alpha_version=${BOOTSTRAP_ALPHA_VERSION}"
           } >>"${GITHUB_OUTPUT}"
 
   build-artifacts:
@@ -144,5 +196,7 @@ jobs:
       base_ref: ${{ needs.validate.outputs.base_ref }}
       source_commit: ${{ needs.validate.outputs.source_sha }}
       site_base_commit: ${{ needs.validate.outputs.site_base_commit }}
+      governance_mode: ${{ needs.validate.outputs.governance_mode }}
+      bootstrap_alpha_version: ${{ needs.validate.outputs.bootstrap_alpha_version }}
     secrets:
       SIFR_WEBSITE_ACTIONS_TOKEN: ${{ secrets.SIFR_WEBSITE_ACTIONS_TOKEN }}

--- a/.github/workflows/release-publication-prepare.yml
+++ b/.github/workflows/release-publication-prepare.yml
@@ -1,0 +1,219 @@
+name: release-publication-prepare
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      source_commit:
+        required: true
+        type: string
+      governance_mode:
+        required: true
+        type: string
+      bootstrap_alpha_version:
+        required: false
+        default: ""
+        type: string
+    outputs:
+      summary_sha256:
+        value: ${{ jobs.prepare.outputs.summary_sha256 }}
+      summary_artifact_name:
+        value: ${{ jobs.prepare.outputs.summary_artifact_name }}
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  prepare:
+    name: prepare governed publication
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      summary_sha256: ${{ steps.summary.outputs.summary_sha256 }}
+      summary_artifact_name: ${{ steps.summary.outputs.summary_artifact_name }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      CHANNEL: ${{ inputs.channel }}
+      VERSION: ${{ inputs.version }}
+      SOURCE_COMMIT: ${{ inputs.source_commit }}
+      GOVERNANCE_MODE: ${{ inputs.governance_mode }}
+      BOOTSTRAP_ALPHA_VERSION: ${{ inputs.bootstrap_alpha_version }}
+      LEGACY_INDEX_SHA256: 71b3243925670f56dc510b8f45b6614a622f58097a0fea9492f61d20dc4bf9ef
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: sifr-${{ inputs.version }}-*
+          path: prepare-assets
+          merge-multiple: true
+
+      - name: Validate read-only prepare inputs and artifact bytes
+        id: summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${GOVERNANCE_MODE}" in
+            preview)
+              test -z "${BOOTSTRAP_ALPHA_VERSION}" || {
+                echo "::error::preview mode cannot name a bootstrap alpha"
+                exit 2
+              }
+              ;;
+            bootstrap-alpha)
+              test "${CHANNEL}" = "alpha" && test -z "${BOOTSTRAP_ALPHA_VERSION}" || {
+                echo "::error::bootstrap-alpha input mismatch"
+                exit 2
+              }
+              ;;
+            bootstrap-index)
+              test "${CHANNEL}" = "beta" || {
+                echo "::error::bootstrap-index requires beta"
+                exit 2
+              }
+              [[ "${BOOTSTRAP_ALPHA_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]] || {
+                echo "::error::bootstrap-index requires a fresh alpha version"
+                exit 2
+              }
+              ;;
+            *) echo "::error::unsupported governance_mode"; exit 2 ;;
+          esac
+          if [[ ! "${SOURCE_COMMIT}" =~ ^[0-9a-f]{40}$ ||
+                "$(git rev-parse HEAD)" != "${SOURCE_COMMIT}" ]]; then
+            echo "::error::prepare source identity mismatch"
+            exit 2
+          fi
+          for target in \
+            aarch64-apple-darwin \
+            x86_64-apple-darwin \
+            x86_64-unknown-linux-gnu \
+            aarch64-unknown-linux-gnu
+          do
+            archive="prepare-assets/sifr-${VERSION}-${target}.tar.gz"
+            checksum="${archive}.sha256"
+            test -f "${archive}" && test -f "${checksum}" || {
+              echo "::error::prepare artifact set is incomplete"
+              exit 2
+            }
+            test "$(tr -d '[:space:]' <"${checksum}")" = \
+              "$(sha256sum "${archive}" | awk '{print $1}')" || {
+                echo "::error::prepare checksum mismatch for ${archive}"
+                exit 2
+              }
+            scripts/distribution/verify_release_archive.py \
+              "${archive}" \
+              --version "${VERSION}" \
+              --target "${target}"
+          done
+          scripts/distribution/generate_version_installer.sh \
+            --version "${VERSION}" \
+            --artifact-dir prepare-assets \
+            --out "prepare-assets/sifr-installer-${VERSION}"
+          mkdir -p prepare
+          gh release download channels \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern channels.json \
+            --dir prepare
+          mv prepare/channels.json prepare/current-channels.json
+          current_sha256="$(
+            sha256sum prepare/current-channels.json | awk '{print $1}'
+          )"
+          if [[ "${GOVERNANCE_MODE}" == bootstrap-* ]]; then
+            test "${current_sha256}" = "${LEGACY_INDEX_SHA256}" &&
+              test "$(wc -c <prepare/current-channels.json | tr -d '[:space:]')" = "105" || {
+                echo "::error::one-time bootstrap source is not the exact opaque v1 asset"
+                exit 2
+              }
+          else
+            scripts/distribution/release_governance.py validate \
+              --kind release-index \
+              --input prepare/current-channels.json \
+              --require-canonical
+          fi
+          bootstrap_alpha_evidence_sha256=""
+          if [[ "${GOVERNANCE_MODE}" == "bootstrap-index" ]]; then
+            gh release download channels \
+              --repo "${GITHUB_REPOSITORY}" \
+              --pattern "schema-v2-bootstrap-alpha-${BOOTSTRAP_ALPHA_VERSION}.json" \
+              --dir prepare
+            scripts/distribution/release_governance.py validate \
+              --kind schema-bootstrap-evidence \
+              --input "prepare/schema-v2-bootstrap-alpha-${BOOTSTRAP_ALPHA_VERSION}.json" \
+              --require-canonical
+            test "$(
+              jq -r '.stage + ":" + .alpha.version' \
+                "prepare/schema-v2-bootstrap-alpha-${BOOTSTRAP_ALPHA_VERSION}.json"
+            )" = "alpha-assets:${BOOTSTRAP_ALPHA_VERSION}" || {
+              echo "::error::staged alpha evidence identity mismatch"
+              exit 2
+            }
+            bootstrap_alpha_evidence_sha256="$(
+              sha256sum \
+                "prepare/schema-v2-bootstrap-alpha-${BOOTSTRAP_ALPHA_VERSION}.json" |
+                awk '{print $1}'
+            )"
+          fi
+          asset_digests="$(
+            find prepare-assets -mindepth 1 -maxdepth 1 -type f -print0 |
+              LC_ALL=C sort -z |
+              xargs -0 sha256sum |
+              jq -Rn '
+                [inputs | capture("^(?<sha>[0-9a-f]{64})  prepare-assets/(?<name>.+)$")]
+                | map({key:.name, value:.sha})
+                | from_entries
+              '
+          )"
+          jq -cnS \
+            --arg mode "${GOVERNANCE_MODE}" \
+            --arg channel "${CHANNEL}" \
+            --arg version "${VERSION}" \
+            --arg source "${SOURCE_COMMIT}" \
+            --arg alpha "${BOOTSTRAP_ALPHA_VERSION}" \
+            --arg alpha_evidence "${bootstrap_alpha_evidence_sha256}" \
+            --arg current "${current_sha256}" \
+            --argjson assets "${asset_digests}" \
+            '{
+              schema_version: 2,
+              operation: $mode,
+              channel: $channel,
+              version: $version,
+              source_commit: $source,
+              bootstrap_alpha_version: $alpha,
+              bootstrap_alpha_evidence_sha256: $alpha_evidence,
+              current_index_sha256: $current,
+              assets: $assets
+            }' >prepare/summary.json
+          summary_sha256="$(sha256sum prepare/summary.json | awk '{print $1}')"
+          summary_artifact_name="publication-prepare-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "summary_sha256=${summary_sha256}" >>"${GITHUB_OUTPUT}"
+          echo "summary_artifact_name=${summary_artifact_name}" >>"${GITHUB_OUTPUT}"
+          {
+            echo "## Governed publication prepare"
+            echo
+            echo "- operation: \`${GOVERNANCE_MODE}\`"
+            echo "- channel/version: \`${CHANNEL}\` / \`${VERSION}\`"
+            echo "- source commit: \`${SOURCE_COMMIT}\`"
+            echo "- current index SHA-256: \`${current_sha256}\`"
+            echo "- prepare summary SHA-256: \`${summary_sha256}\`"
+            if [[ -n "${BOOTSTRAP_ALPHA_VERSION}" ]]; then
+              echo "- staged alpha: \`${BOOTSTRAP_ALPHA_VERSION}\`"
+            fi
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ steps.summary.outputs.summary_artifact_name }}
+          path: prepare/summary.json
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: false

--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -23,6 +23,16 @@ on:
         description: Exact sifr-website workflow and deployment base
         required: true
         type: string
+      governance_mode:
+        description: Ordinary preview publication or protected one-time bootstrap stage
+        required: false
+        default: preview
+        type: string
+      bootstrap_alpha_version:
+        description: Fresh staged alpha version for bootstrap-index
+        required: false
+        default: ""
+        type: string
     secrets:
       SIFR_WEBSITE_ACTIONS_TOKEN:
         description: Fine-grained token limited to sifr-website Actions
@@ -37,10 +47,28 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  prepare:
+    uses: ./.github/workflows/release-publication-prepare.yml
+    permissions:
+      actions: read
+      contents: read
+    with:
+      channel: ${{ inputs.channel }}
+      version: ${{ inputs.version }}
+      source_commit: ${{ inputs.source_commit }}
+      governance_mode: ${{ inputs.governance_mode }}
+      bootstrap_alpha_version: ${{ inputs.bootstrap_alpha_version }}
+
   publish:
     name: mutate governed preview release
+    needs: prepare
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    environment:
+      name: ${{ inputs.governance_mode == 'preview' && 'preview-release' || 'stable-release' }}
+    permissions:
+      actions: read
+      contents: write
     env:
       GH_TOKEN: ${{ github.token }}
       CHANNEL: ${{ inputs.channel }}
@@ -48,6 +76,10 @@ jobs:
       BASE_REF: ${{ inputs.base_ref }}
       SOURCE_COMMIT: ${{ inputs.source_commit }}
       SITE_BASE_COMMIT: ${{ inputs.site_base_commit }}
+      GOVERNANCE_MODE: ${{ inputs.governance_mode }}
+      BOOTSTRAP_ALPHA_VERSION: ${{ inputs.bootstrap_alpha_version }}
+      PREPARE_SUMMARY_SHA256: ${{ needs.prepare.outputs.summary_sha256 }}
+      LEGACY_INDEX_SHA256: 71b3243925670f56dc510b8f45b6614a622f58097a0fea9492f61d20dc4bf9ef
       PUBLICATION_ATTEMPT: ${{ github.run_id }}-${{ github.run_attempt }}
       SITE_REPOSITORY: sifr-lang/sifr-website
       SITE_WORKFLOW: release-site.yml
@@ -64,8 +96,63 @@ jobs:
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
+          pattern: sifr-${{ inputs.version }}-*
           path: release-assets
           merge-multiple: true
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ needs.prepare.outputs.summary_artifact_name }}
+          path: protected-prepare
+
+      - name: Revalidate prepare summary and protected approver
+        id: approval
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(sha256sum protected-prepare/summary.json | awk '{print $1}')" = \
+            "${PREPARE_SUMMARY_SHA256}" || {
+              echo "::error::protected job received different prepare-summary bytes"
+              exit 2
+            }
+          jq -e \
+            --arg mode "${GOVERNANCE_MODE}" \
+            --arg channel "${CHANNEL}" \
+            --arg version "${VERSION}" \
+            --arg source "${SOURCE_COMMIT}" \
+            --arg alpha "${BOOTSTRAP_ALPHA_VERSION}" \
+            '.schema_version == 2
+             and .operation == $mode
+             and .channel == $channel
+             and .version == $version
+             and .source_commit == $source
+             and .bootstrap_alpha_version == $alpha
+             and (
+               if $mode == "bootstrap-index"
+               then (.bootstrap_alpha_evidence_sha256 | test("^[0-9a-f]{64}$"))
+               else .bootstrap_alpha_evidence_sha256 == ""
+               end
+             )
+             and (.current_index_sha256 | test("^[0-9a-f]{64}$"))
+             and (.assets | type == "object")' \
+            protected-prepare/summary.json >/dev/null || {
+            echo "::error::prepare summary outputs do not match protected job inputs"
+            exit 2
+          }
+          if [[ "${GOVERNANCE_MODE}" == bootstrap-* ]]; then
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" \
+              >protected-prepare/approvals.json
+            approvers_json="$(
+              scripts/distribution/release_governance.py resolve-publication-approvers \
+                --approvals protected-prepare/approvals.json \
+                --initiator "${GITHUB_TRIGGERING_ACTOR}" \
+                --environment stable-release
+            )"
+            echo "approvers_json=${approvers_json}" >>"${GITHUB_OUTPUT}"
+          else
+            echo 'approvers_json=[]' >>"${GITHUB_OUTPUT}"
+          fi
 
       - name: Validate protected publication inputs
         shell: bash
@@ -76,6 +163,31 @@ jobs:
           case "${CHANNEL}" in
             alpha|beta) ;;
             *) echo "::error::release-publication accepts only alpha or beta"; exit 2 ;;
+          esac
+          case "${GOVERNANCE_MODE}" in
+            preview)
+              test -z "${BOOTSTRAP_ALPHA_VERSION}" || {
+                echo "::error::preview mode cannot name a bootstrap alpha"
+                exit 2
+              }
+              ;;
+            bootstrap-alpha)
+              test "${CHANNEL}" = "alpha" && test -z "${BOOTSTRAP_ALPHA_VERSION}" || {
+                echo "::error::bootstrap-alpha input mismatch"
+                exit 2
+              }
+              ;;
+            bootstrap-index)
+              test "${CHANNEL}" = "beta" || {
+                echo "::error::bootstrap-index requires beta"
+                exit 2
+              }
+              [[ "${BOOTSTRAP_ALPHA_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]] || {
+                echo "::error::bootstrap-index requires a fresh alpha version"
+                exit 2
+              }
+              ;;
+            *) echo "::error::unsupported governance_mode"; exit 2 ;;
           esac
           if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta)\.[0-9]+$ ||
                 "${BASH_REMATCH[1]}" != "${CHANNEL}" ]]; then
@@ -97,38 +209,15 @@ jobs:
             echo "::error::site_base_commit must be an exact commit"
             exit 2
           fi
-          site_ruleset="$(
-            GH_TOKEN="${SITE_TOKEN}" gh api \
-              -H "Time-Zone: UTC" \
-              "repos/${SITE_REPOSITORY}/rulesets/${SITE_WORKFLOW_RULESET_ID}"
-          )"
-          if ! jq -e \
-            --arg ref "refs/tags/${SITE_WORKFLOW_REF}" \
-            --arg updated_at "${SITE_WORKFLOW_RULESET_UPDATED_AT}" \
-            --argjson id "${SITE_WORKFLOW_RULESET_ID}" \
-            '.id == $id
-             and .target == "tag"
-             and .enforcement == "active"
-             and .updated_at == $updated_at
-             and .conditions.ref_name.include == [$ref]
-             and .conditions.ref_name.exclude == []
-             and (.bypass_actors // []) == []
-             and (.current_user_can_bypass // "never") == "never"
-             and ([.rules[].type] | sort) == ["deletion", "update"]' \
-            <<<"${site_ruleset}" >/dev/null
-          then
-            echo "::error::site workflow tag immutability ruleset is not active and exact"
-            exit 2
-          fi
-          site_dispatch_sha="$(
-            GH_TOKEN="${SITE_TOKEN}" gh api \
-              "repos/${SITE_REPOSITORY}/git/ref/tags/${SITE_WORKFLOW_REF}" \
-              --jq '.object.sha'
-          )"
-          if [[ "${site_dispatch_sha}" != "${SITE_BASE_COMMIT}" ]]; then
-            echo "::error::protected site workflow tag does not resolve to site_base_commit"
-            exit 2
-          fi
+          GH_TOKEN="${SITE_TOKEN}" \
+            scripts/distribution/verify_site_workflow_identity.sh \
+              --repository "${SITE_REPOSITORY}" \
+              --ruleset-id "${SITE_WORKFLOW_RULESET_ID}" \
+              --ruleset-updated-at "${SITE_WORKFLOW_RULESET_UPDATED_AT}" \
+              --workflow-ref "${SITE_WORKFLOW_REF}" \
+              --site-commit "${SITE_BASE_COMMIT}" \
+              --workflow "${SITE_WORKFLOW}" \
+              --workflow-sha256 "${SITE_WORKFLOW_SHA256}"
           existing_release_count="$(
             gh api \
               --method GET \
@@ -153,69 +242,15 @@ jobs:
             echo "::error::version tag already exists; release source identity is write-once"
             exit 2
           fi
-          site_workflow="$(mktemp)"
-          GH_TOKEN="${SITE_TOKEN}" gh api \
-            -H "Accept: application/vnd.github.raw+json" \
-            "repos/${SITE_REPOSITORY}/contents/.github/workflows/${SITE_WORKFLOW}?ref=${SITE_BASE_COMMIT}" \
-            >"${site_workflow}"
-          actual_site_workflow_sha256="$(sha256sum "${site_workflow}" | awk '{print $1}')"
-          if [[ "${actual_site_workflow_sha256}" != "${SITE_WORKFLOW_SHA256}" ]]; then
-            echo "::error::pinned site workflow bytes do not match the reviewed contract"
-            exit 2
-          fi
 
       - name: Verify complete immutable asset set
         shell: bash
         run: |
           set -euo pipefail
-          for target in \
-            aarch64-apple-darwin \
-            x86_64-apple-darwin \
-            x86_64-unknown-linux-gnu \
-            aarch64-unknown-linux-gnu
-          do
-            archive="release-assets/sifr-${VERSION}-${target}.tar.gz"
-            checksum="${archive}.sha256"
-            test -f "${archive}" || { echo "::error::missing ${archive}"; exit 2; }
-            test -f "${checksum}" || { echo "::error::missing ${checksum}"; exit 2; }
-            expected="$(tr -d '[:space:]' <"${checksum}")"
-            actual="$(sha256sum "${archive}" | awk '{print $1}')"
-            test "${expected}" = "${actual}" || {
-              echo "::error::checksum mismatch for ${archive}"
-              exit 2
-            }
-            scripts/distribution/verify_release_archive.py \
-              "${archive}" \
-              --version "${VERSION}" \
-              --target "${target}"
-          done
-          scripts/distribution/generate_version_installer.sh \
+          scripts/distribution/verify_release_publication_assets.sh \
             --version "${VERSION}" \
-            --artifact-dir release-assets \
-            --out "release-assets/sifr-installer-${VERSION}"
-          expected_names="$(
-            {
-              for target in \
-                aarch64-apple-darwin \
-                x86_64-apple-darwin \
-                x86_64-unknown-linux-gnu \
-                aarch64-unknown-linux-gnu
-              do
-                echo "sifr-${VERSION}-${target}.tar.gz"
-                echo "sifr-${VERSION}-${target}.tar.gz.sha256"
-              done
-              echo "sifr-installer-${VERSION}"
-            } | LC_ALL=C sort
-          )"
-          actual_names="$(
-            find release-assets -mindepth 1 -maxdepth 1 -type f -exec basename {} \; |
-              LC_ALL=C sort
-          )"
-          if [[ "${actual_names}" != "${expected_names}" ]]; then
-            echo "::error::release asset set contains missing or unexpected files"
-            diff -u <(printf '%s\n' "${expected_names}") <(printf '%s\n' "${actual_names}") || true
-            exit 2
-          fi
+            --assets release-assets \
+            --prepare-summary protected-prepare/summary.json
 
       - name: Fetch governed index and allocate max generation
         id: index
@@ -228,6 +263,46 @@ jobs:
             --pattern channels.json \
             --dir publication
           mv publication/channels.json publication/current-channels.json
+          current_sha256="$(sha256sum publication/current-channels.json | awk '{print $1}')"
+          test "$(
+            jq -r '.current_index_sha256' protected-prepare/summary.json
+          )" = "${current_sha256}" || {
+            echo "::error::governed index changed after read-only prepare"
+            exit 2
+          }
+          if [[ "${GOVERNANCE_MODE}" == bootstrap-* ]]; then
+            test "${current_sha256}" = "${LEGACY_INDEX_SHA256}" &&
+              test "$(wc -c <publication/current-channels.json | tr -d '[:space:]')" = "105" || {
+                echo "::error::one-time bootstrap source is not the exact opaque v1 asset"
+                exit 2
+              }
+            if [[ "${GOVERNANCE_MODE}" == "bootstrap-index" ]]; then
+              stage_evidence="publication/schema-v2-bootstrap-alpha-${BOOTSTRAP_ALPHA_VERSION}.json"
+              gh release download channels \
+                --repo "${GITHUB_REPOSITORY}" \
+                --pattern "$(basename "${stage_evidence}")" \
+                --dir publication
+              test "$(sha256sum "${stage_evidence}" | awk '{print $1}')" = "$(
+                jq -r '.bootstrap_alpha_evidence_sha256' \
+                  protected-prepare/summary.json
+              )" || {
+                echo "::error::staged alpha evidence changed after read-only prepare"
+                exit 2
+              }
+              scripts/distribution/fetch_schema_bootstrap_alpha.sh \
+                --repository "${GITHUB_REPOSITORY}" \
+                --version "${BOOTSTRAP_ALPHA_VERSION}" \
+                --evidence "${stage_evidence}" \
+                --assets publication/bootstrap-alpha-assets \
+                --record publication/alpha-release.json
+            fi
+            {
+              echo "current_generation=0"
+              echo "current_sha256=${current_sha256}"
+              echo "proposed_generation=1"
+            } >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
           scripts/distribution/release_governance.py validate \
             --kind release-index \
             --input publication/current-channels.json \
@@ -236,7 +311,6 @@ jobs:
             python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["generation"])' \
               publication/current-channels.json
           )"
-          current_sha256="$(sha256sum publication/current-channels.json | awk '{print $1}')"
           max_generation="${current_generation}"
           while IFS= read -r snapshot; do
             [[ -n "${snapshot}" ]] || continue
@@ -290,14 +364,45 @@ jobs:
             --installer "release-assets/sifr-installer-${VERSION}" \
             --artifact-dir release-assets \
             --out publication/new-release.json
-          scripts/distribution/release_governance.py update-preview-index \
-            --current publication/current-channels.json \
-            --out publication/channels.json \
-            --channel "${CHANNEL}" \
-            --release publication/new-release.json \
-            --expected-generation "${CURRENT_GENERATION}" \
-            --expected-sha256 "${CURRENT_SHA256}" \
-            --proposed-generation "${PROPOSED_GENERATION}"
+          release_record_sha256="$(
+            sha256sum publication/new-release.json | awk '{print $1}'
+          )"
+          echo "release_record_sha256=${release_record_sha256}" >>"${GITHUB_OUTPUT}"
+          if [[ "${GOVERNANCE_MODE}" == "bootstrap-alpha" ]]; then
+            jq -cnS \
+              --arg version "${VERSION}" \
+              --arg source "${SOURCE_COMMIT}" \
+              --arg current "${CURRENT_SHA256}" \
+              --arg attempt "${PUBLICATION_ATTEMPT}" \
+              '{
+                schema_version: 2,
+                operation: "schema-epoch-bootstrap-alpha-assets",
+                version: $version,
+                source_commit: $source,
+                current_index_sha256: $current,
+                publication_attempt: $attempt
+              }' >publication/publication-plan.json
+            echo "release_plan_sha256=$(
+              sha256sum publication/publication-plan.json | awk '{print $1}'
+            )" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if [[ "${GOVERNANCE_MODE}" == "bootstrap-index" ]]; then
+            scripts/distribution/release_governance.py generate-schema-bootstrap-index \
+              --current publication/current-channels.json \
+              --alpha-release publication/alpha-release.json \
+              --beta-release publication/new-release.json \
+              --out publication/channels.json
+          else
+            scripts/distribution/release_governance.py update-preview-index \
+              --current publication/current-channels.json \
+              --out publication/channels.json \
+              --channel "${CHANNEL}" \
+              --release publication/new-release.json \
+              --expected-generation "${CURRENT_GENERATION}" \
+              --expected-sha256 "${CURRENT_SHA256}" \
+              --proposed-generation "${PROPOSED_GENERATION}"
+          fi
           ga_status="$(
             python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["ga_status"])' \
               publication/channels.json
@@ -310,39 +415,42 @@ jobs:
           scripts/distribution/generate_dispatchers.sh \
             --install-root dispatchers \
             --default-channel "${site_default_channel}"
-          python3 - \
-            publication/publication-plan.json \
-            "${CHANNEL}" \
-            "${VERSION}" \
-            "${SOURCE_COMMIT}" \
-            "${SITE_BASE_COMMIT}" \
-            "${CURRENT_GENERATION}" \
-            "${CURRENT_SHA256}" \
-            "${PROPOSED_GENERATION}" \
-            "${PUBLICATION_ATTEMPT}" \
-            "${site_default_channel}" <<'PY'
-          import json
-          import pathlib
-          import sys
-
-          out, channel, version, source, site, current_gen, current_sha, proposed_gen, attempt, site_default = sys.argv[1:]
-          value = {
-              "schema_version": 2,
-              "operation": "preview-publication",
-              "channel": channel,
-              "version": version,
-              "source_commit": source,
-              "site_base_commit": site,
-              "current_index": {"generation": int(current_gen), "sha256": current_sha},
-              "proposed_generation": int(proposed_gen),
-              "publication_attempt": attempt,
-              "site_default_channel": site_default,
-          }
-          pathlib.Path(out).write_text(
-              json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n",
-              encoding="utf-8",
-          )
-          PY
+          jq -cnS \
+            --arg mode "${GOVERNANCE_MODE}" \
+            --arg channel "${CHANNEL}" \
+            --arg version "${VERSION}" \
+            --arg source "${SOURCE_COMMIT}" \
+            --arg site "${SITE_BASE_COMMIT}" \
+            --arg current_sha "${CURRENT_SHA256}" \
+            --argjson current_generation "${CURRENT_GENERATION}" \
+            --argjson proposed_generation "${PROPOSED_GENERATION}" \
+            --arg attempt "${PUBLICATION_ATTEMPT}" \
+            --arg site_default "${site_default_channel}" \
+            --arg alpha "${BOOTSTRAP_ALPHA_VERSION}" \
+            '{
+              schema_version: 2,
+              operation: (
+                if $mode == "bootstrap-index"
+                then "schema-epoch-bootstrap"
+                else "preview-publication"
+                end
+              ),
+              channel: $channel,
+              version: $version,
+              source_commit: $source,
+              site_base_commit: $site,
+              current_index: {
+                generation: $current_generation,
+                sha256: $current_sha
+              },
+              proposed_generation: $proposed_generation,
+              publication_attempt: $attempt,
+              site_default_channel: $site_default
+            }
+            + if $mode == "bootstrap-index"
+              then {bootstrap_alpha_version: $alpha}
+              else {}
+              end' >publication/publication-plan.json
           release_plan_sha256="$(
             sha256sum publication/publication-plan.json | awk '{print $1}'
           )"
@@ -409,7 +517,40 @@ jobs:
             }
           done < <(find release-assets -mindepth 1 -maxdepth 1 -type f | LC_ALL=C sort)
 
+      - name: Retain protected alpha bootstrap evidence
+        if: inputs.governance_mode == 'bootstrap-alpha'
+        shell: bash
+        env:
+          APPROVERS_JSON: ${{ steps.approval.outputs.approvers_json }}
+        run: |
+          set -euo pipefail
+          evidence="publication/schema-v2-bootstrap-alpha-${VERSION}.json"
+          scripts/distribution/materialize_schema_bootstrap_evidence.py \
+            --stage alpha-assets \
+            --run-id "${GITHUB_RUN_ID}" \
+            --run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --initiator "${GITHUB_TRIGGERING_ACTOR}" \
+            --approvers-json "${APPROVERS_JSON}" \
+            --prepare-summary protected-prepare/summary.json \
+            --legacy-index publication/current-channels.json \
+            --alpha-version "${VERSION}" \
+            --alpha-source-commit "${SOURCE_COMMIT}" \
+            --alpha-record publication/new-release.json \
+            --alpha-assets publication/published-assets \
+            --out "${evidence}"
+          gh release upload channels "${evidence}" --repo "${GITHUB_REPOSITORY}"
+          verify_dir="$(mktemp -d)"
+          gh release download channels \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "$(basename "${evidence}")" \
+            --dir "${verify_dir}"
+          cmp "${evidence}" "${verify_dir}/$(basename "${evidence}")" || {
+            echo "::error::protected alpha bootstrap evidence drifted after upload"
+            exit 2
+          }
+
       - name: Revalidate lease and publish write-once generation snapshot
+        if: inputs.governance_mode != 'bootstrap-alpha'
         shell: bash
         env:
           EXPECTED_GENERATION: ${{ steps.index.outputs.current_generation }}
@@ -423,15 +564,24 @@ jobs:
             --pattern channels.json \
             --dir "${live_dir}"
           live_index="${live_dir}/channels.json"
-          scripts/distribution/release_governance.py validate \
-            --kind release-index \
-            --input "${live_index}" \
-            --require-canonical
-          live_generation="$(
-            python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["generation"])' \
-              "${live_index}"
-          )"
           live_sha256="$(sha256sum "${live_index}" | awk '{print $1}')"
+          if [[ "${GOVERNANCE_MODE}" == "bootstrap-index" ]]; then
+            test "${live_sha256}" = "${LEGACY_INDEX_SHA256}" &&
+              test "$(wc -c <"${live_index}" | tr -d '[:space:]')" = "105" || {
+                echo "::error::opaque bootstrap lease changed before reservation"
+                exit 2
+              }
+            live_generation=0
+          else
+            scripts/distribution/release_governance.py validate \
+              --kind release-index \
+              --input "${live_index}" \
+              --require-canonical
+            live_generation="$(
+              python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["generation"])' \
+                "${live_index}"
+            )"
+          fi
           if [[ "${live_generation}" != "${EXPECTED_GENERATION}" ||
                 "${live_sha256}" != "${EXPECTED_SHA256}" ]]; then
             echo "::error::release index changed after proposal generation"
@@ -452,6 +602,7 @@ jobs:
           gh release upload channels "${snapshot}" --repo "${GITHUB_REPOSITORY}"
 
       - name: Replace only canonical channels.json
+        if: inputs.governance_mode != 'bootstrap-alpha'
         shell: bash
         run: |
           set -euo pipefail
@@ -471,6 +622,7 @@ jobs:
             }
 
       - name: Build correlated site publication facts
+        if: inputs.governance_mode != 'bootstrap-alpha'
         id: site
         shell: bash
         env:
@@ -506,6 +658,7 @@ jobs:
           )" >>"${GITHUB_OUTPUT}"
 
       - name: Dispatch exact site workflow
+        if: inputs.governance_mode != 'bootstrap-alpha'
         id: dispatch
         shell: bash
         env:
@@ -522,38 +675,15 @@ jobs:
         run: |
           set -euo pipefail
           dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          site_ruleset="$(
-            GH_TOKEN="${SITE_TOKEN}" gh api \
-              -H "Time-Zone: UTC" \
-              "repos/${SITE_REPOSITORY}/rulesets/${SITE_WORKFLOW_RULESET_ID}"
-          )"
-          if ! jq -e \
-            --arg ref "refs/tags/${SITE_WORKFLOW_REF}" \
-            --arg updated_at "${SITE_WORKFLOW_RULESET_UPDATED_AT}" \
-            --argjson id "${SITE_WORKFLOW_RULESET_ID}" \
-            '.id == $id
-             and .target == "tag"
-             and .enforcement == "active"
-             and .updated_at == $updated_at
-             and .conditions.ref_name.include == [$ref]
-             and .conditions.ref_name.exclude == []
-             and (.bypass_actors // []) == []
-             and (.current_user_can_bypass // "never") == "never"
-             and ([.rules[].type] | sort) == ["deletion", "update"]' \
-            <<<"${site_ruleset}" >/dev/null
-          then
-            echo "::error::site workflow tag lost immutable protection before dispatch"
-            exit 2
-          fi
-          site_dispatch_sha="$(
-            GH_TOKEN="${SITE_TOKEN}" gh api \
-              "repos/${SITE_REPOSITORY}/git/ref/tags/${SITE_WORKFLOW_REF}" \
-              --jq '.object.sha'
-          )"
-          if [[ "${site_dispatch_sha}" != "${SITE_BASE_COMMIT}" ]]; then
-            echo "::error::protected site workflow tag moved before dispatch"
-            exit 2
-          fi
+          GH_TOKEN="${SITE_TOKEN}" \
+            scripts/distribution/verify_site_workflow_identity.sh \
+              --repository "${SITE_REPOSITORY}" \
+              --ruleset-id "${SITE_WORKFLOW_RULESET_ID}" \
+              --ruleset-updated-at "${SITE_WORKFLOW_RULESET_UPDATED_AT}" \
+              --workflow-ref "${SITE_WORKFLOW_REF}" \
+              --site-commit "${SITE_BASE_COMMIT}" \
+              --workflow "${SITE_WORKFLOW}" \
+              --workflow-sha256 "${SITE_WORKFLOW_SHA256}"
           jq -n \
             --arg ref "${SITE_WORKFLOW_REF}" \
             --arg source "${SOURCE_COMMIT}" \
@@ -592,98 +722,74 @@ jobs:
           echo "dispatched_at=${dispatched_at}" >>"${GITHUB_OUTPUT}"
 
       - name: Poll exact site run with 20-minute deadline
+        if: inputs.governance_mode != 'bootstrap-alpha'
         shell: bash
         env:
           SITE_TOKEN: ${{ secrets.SIFR_WEBSITE_ACTIONS_TOKEN }}
           DISPATCHED_AT: ${{ steps.dispatch.outputs.dispatched_at }}
         run: |
           set -euo pipefail
-          expected_title="Sifr site release ${PUBLICATION_ATTEMPT}"
-          site_run_id=""
-          poll_error=""
-          poll_query_failures=0
-          poll_deadline=$((SECONDS + 1200))
-          while (( SECONDS < poll_deadline )); do
-            remaining_seconds=$((poll_deadline - SECONDS))
-            if (( remaining_seconds <= 0 )); then
-              break
-            fi
-            set +e
-            runs="$(
-              GH_TOKEN="${SITE_TOKEN}" timeout --foreground "${remaining_seconds}s" gh api \
-                --method GET \
-                --paginate \
-                --slurp \
-                "repos/${SITE_REPOSITORY}/actions/workflows/${SITE_WORKFLOW}/runs" \
-                -f event=workflow_dispatch \
-                -f created="${DISPATCHED_AT}..*" \
-                -f per_page=100
-            )"
-            poll_status=$?
-            set -e
-            if [[ ${poll_status} -eq 124 ]]; then
-              break
-            fi
-            if [[ ${poll_status} -ne 0 ]]; then
-              poll_query_failures=$((poll_query_failures + 1))
-              if (( poll_query_failures >= 3 )); then
-                poll_error="could not query the correlated site run after three attempts"
-                break
-              fi
-              remaining_seconds=$((poll_deadline - SECONDS))
-              if (( remaining_seconds > 0 )); then
-                sleep_seconds=10
-                if (( remaining_seconds < sleep_seconds )); then
-                  sleep_seconds="${remaining_seconds}"
-                fi
-                sleep "${sleep_seconds}"
-              fi
-              continue
-            fi
-            poll_query_failures=0
-            matched="$(
-              jq -r \
-                --arg title "${expected_title}" \
-                --arg sha "${SITE_BASE_COMMIT}" \
-                --arg since "${DISPATCHED_AT}" \
-                'first(
-                   .[].workflow_runs[]
-                   | select(.display_title == $title)
-                   | select(.head_sha == $sha)
-                   | select(.event == "workflow_dispatch")
-                   | select(.created_at >= $since)
-                   | [.id, .status, (.conclusion // "")]
-                   | @tsv
-                 ) // empty' <<<"${runs}"
-            )"
-            if [[ -n "${matched}" ]]; then
-              IFS=$'\t' read -r site_run_id status conclusion <<<"${matched}"
-              if [[ "${status}" == "completed" ]]; then
-                if [[ "${conclusion}" == "success" ]]; then
-                  echo "Correlated site run ${site_run_id} completed successfully"
-                  exit 0
-                fi
-                echo "::error::correlated site run ${site_run_id} concluded ${conclusion}"
-                exit 2
-              fi
-            fi
-            remaining_seconds=$((poll_deadline - SECONDS))
-            if (( remaining_seconds > 0 )); then
-              sleep_seconds=10
-              if (( remaining_seconds < sleep_seconds )); then
-                sleep_seconds="${remaining_seconds}"
-              fi
-              sleep "${sleep_seconds}"
-            fi
-          done
-          if [[ -n "${site_run_id}" ]]; then
-            GH_TOKEN="${SITE_TOKEN}" gh api \
-              --method POST \
-              "repos/${SITE_REPOSITORY}/actions/runs/${site_run_id}/cancel" || true
-          fi
-          if [[ -n "${poll_error}" ]]; then
-            echo "::error::${poll_error}"
+          GH_TOKEN="${SITE_TOKEN}" \
+            scripts/distribution/poll_site_release_run.sh \
+              --repository "${SITE_REPOSITORY}" \
+              --workflow "${SITE_WORKFLOW}" \
+              --title "Sifr site release ${PUBLICATION_ATTEMPT}" \
+              --sha "${SITE_BASE_COMMIT}" \
+              --dispatched-at "${DISPATCHED_AT}" \
+              --deadline-seconds 1200
+
+      - name: Run protected public schema-bootstrap smoke
+        if: inputs.governance_mode == 'bootstrap-index'
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/distribution/run_schema_bootstrap_public_smoke.sh \
+            --repository "${GITHUB_REPOSITORY}" \
+            --version "${VERSION}" \
+            --index publication/channels.json \
+            --dispatchers dispatchers \
+            --out publication/bootstrap-smoke
+
+      - name: Retain final protected schema-bootstrap evidence
+        if: inputs.governance_mode == 'bootstrap-index'
+        shell: bash
+        env:
+          APPROVERS_JSON: ${{ steps.approval.outputs.approvers_json }}
+        run: |
+          set -euo pipefail
+          alpha_source="$(
+            jq -r '.alpha.source_commit' \
+              "publication/schema-v2-bootstrap-alpha-${BOOTSTRAP_ALPHA_VERSION}.json"
+          )"
+          evidence="publication/schema-v2-bootstrap-generation-1.json"
+          scripts/distribution/materialize_schema_bootstrap_evidence.py \
+            --stage preview-index \
+            --run-id "${GITHUB_RUN_ID}" \
+            --run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --initiator "${GITHUB_TRIGGERING_ACTOR}" \
+            --approvers-json "${APPROVERS_JSON}" \
+            --prepare-summary protected-prepare/summary.json \
+            --legacy-index publication/current-channels.json \
+            --alpha-version "${BOOTSTRAP_ALPHA_VERSION}" \
+            --alpha-source-commit "${alpha_source}" \
+            --alpha-record publication/alpha-release.json \
+            --alpha-assets publication/bootstrap-alpha-assets \
+            --beta-version "${VERSION}" \
+            --beta-source-commit "${SOURCE_COMMIT}" \
+            --beta-record publication/new-release.json \
+            --beta-assets publication/published-assets \
+            --index publication/channels.json \
+            --smoke-dir publication/bootstrap-smoke \
+            --alpha-evidence \
+              "publication/schema-v2-bootstrap-alpha-${BOOTSTRAP_ALPHA_VERSION}.json" \
+            --out "${evidence}"
+          gh release upload channels "${evidence}" --repo "${GITHUB_REPOSITORY}"
+          verify_dir="$(mktemp -d)"
+          gh release download channels \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "$(basename "${evidence}")" \
+            --dir "${verify_dir}"
+          cmp "${evidence}" "${verify_dir}/$(basename "${evidence}")" || {
+            echo "::error::final schema-bootstrap evidence drifted after upload"
             exit 2
-          fi
-          echo "::error::correlated site deployment exceeded the 20-minute deadline"
-          exit 2
+          }

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -1430,6 +1430,7 @@ cargo test                                    # Run all tests (layers 1-3)
 ./scripts/run_all_tests.sh --profile python-interop-live # Explicit opt-in container-runtime Python interop profile
 uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite full     # Preview installer/artifact/release automation checks
 uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite incident-governance # Offline rollback/roll-forward generation, retention, and recovery
+uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite epoch-bootstrap # One-time opaque schema-v2 preview epoch bootstrap contracts
 ./verification/runner/e2e/check_report_determinism.sh --profile release # Stable e2e report signature across reruns
 uv run --project verification --locked python -m sifr_verify areas run --area fuzz_property --suite cargo-smoke --suite property --suite fuzz-smoke
 cargo test --manifest-path third_party/ruff/Cargo.toml -p ruff_python_parser # Parser snapshots
@@ -1447,8 +1448,10 @@ Validation profile policy is defined in `verification/profiles/{create-pr,merge,
 Stable incident recovery is a pure extension of the governed release-index
 state machine. Canonical request and approved plan digests authorize exactly
 one rollback or incident roll-forward generation; all prior releases and
-snapshots remain immutable. The production adapter is deliberately absent
-until protected publication. The offline fixture core owns generation burning,
+snapshots remain immutable. Stable and incident production adapters remain
+deliberately absent until their protected-publication slices; the one-time
+schema-epoch bootstrap adapter is separately fail-closed on the exact opaque
+pre-epoch asset identity and protected approval. The offline fixture core owns generation burning,
 exact resume, site reconciliation, range eligibility, downgrade consent, and
 incident sign-off evidence, as specified in
 `internal_docs/stable_incident_response.md`.

--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -575,13 +575,46 @@ mutation.
 
 The canonical ownership, acknowledgement, communication, retry, retention, and
 closure policy is in
-[`stable_incident_response.md`](./stable_incident_response.md). Production
-workflow inputs, write permissions, Marketplace calls, and site dispatch remain
-absent until protected publication wiring.
+[`stable_incident_response.md`](./stable_incident_response.md). Stable,
+Marketplace, and incident production mutations remain gated until their later
+protected-publication slices.
 
-Run the incident-specific suite and capability demo with:
+The first protected-publication slice wires only the one-time schema-epoch
+bootstrap into `.github/workflows/release-publication.yml`. Its nested
+`release-publication-prepare.yml` job has read-only permissions, no protected
+environment, and no production secret. It verifies the exact source and
+artifact bytes, the current governance-asset identity, and any staged alpha
+evidence, then uploads an immutable 30-day summary whose digest is rechecked by
+the publish job and retained in each durable bootstrap evidence record.
+
+`bootstrap-alpha` publishes a fresh, qualified alpha release and a write-once
+evidence record under the `channels` governance release. `bootstrap-index`
+re-downloads and hashes every staged alpha asset, publishes a fresh qualified
+beta release, and builds generation 1 from those two release records. The
+discarded pre-epoch asset is accepted only by its observed SHA-256
+`71b3243925670f56dc510b8f45b6614a622f58097a0fea9492f61d20dc4bf9ef`
+and 105-byte size; no code parses its fields and no pre-epoch fixture,
+migration, or fallback is retained.
+
+Both bootstrap stages run in the `stable-release` environment. Publish reads
+the workflow run's GitHub approval history and fails unless the recorded
+environment approvers include at least one login distinct from
+`GITHUB_TRIGGERING_ACTOR`. The final evidence binds the alpha-stage evidence
+digest, run/attempt, initiator, approvers, and prepare-summary digest as well as
+the final stage's own prepare-summary digest. The final stage
+reserves `channels-generation-1.json`, replaces only `channels.json`,
+reconciles the pinned site workflow, and then verifies the real governance
+asset, beta-default dispatcher, stable preview rejection, fresh public install,
+and installed `self update --dry-run` without
+`SIFR_TEST_CHANNEL_METADATA_PATH`. Only after those checks does it upload the
+write-once generation-1 bootstrap evidence.
+
+Run the protected bootstrap and incident-specific suites, plus the capability
+demo, with:
 
 ```bash
+uv run --project verification --locked python -m sifr_verify areas run \
+  --area distribution_release --suite epoch-bootstrap
 uv run --project verification --locked python -m sifr_verify areas run \
   --area distribution_release --suite incident-governance
 demos/stable_incident_recovery_demo.sh

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -465,6 +465,11 @@ Review and upstream coordination ledger:
   baseline or waiver changed, and it is not a Phase 40 prerequisite.
 - Schema-v2 preview epoch bootstrap implementation is under review in
   [PR #3040](https://github.com/sifr-lang/sifr/pull/3040).
+- Exact PR-head bootstrap review pass 13 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-13-exact-pr-head-satisfied.md`.
+  It independently matched local, remote-branch, and PR head at
+  `e51491338e396e6b8f2d19345c9df68242e2b029`, re-ran the complete focused
+  gate set, found no actionable issue, and returned `VERDICT: SATISFIED`.
 - [x] Add the single protected publication workflow and production site adapter.
 - [ ] Publish or verify write-once assets, Marketplace version, governed index
   activation, site facts, and post-publication smoke.

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -346,6 +346,123 @@ Review and upstream coordination ledger:
   to commit and push that remediation and refresh PR #3039's review summary;
   both are release-mechanics requirements completed before the final exact-head
   round.
+- Exact pushed-head review pass 6 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-qualification-isolation-review-pass-6-final-pr-head.md`.
+  It matched local, remote branch, and PR head
+  `36e20eeb166a7a241b9f71c5b2080dd9b01e8703`, re-ran every gate affected by
+  the final documentation commit, found no actionable issue, and returned
+  `VERDICT: SATISFIED`.
+- Qualification isolation merged through
+  [PR #3039](https://github.com/sifr-lang/sifr/pull/3039) as
+  `d8dd28a8013447365e3b1fab5a7422de5509ac3b`.
+- The schema-epoch bootstrap wave now has a read-only prepare workflow, a
+  `stable-release` environment boundary, immutable workflow-approval-history
+  validation that rejects the initiator, exact opaque pre-epoch digest/size
+  custody, fresh alpha staging, fresh beta plus generation-1 preview
+  activation, write-once bootstrap evidence, site reconciliation, and real
+  public install/self-update smoke. No pre-epoch payload fixture, parser,
+  migration, compatibility reader, or fallback is present.
+- Bootstrap review pass 1 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-1.md`.
+  Its `VERDICT: NOT SATISFIED` findings were remediated by making prepare
+  artifact selection rerun-safe, retaining prepare and alpha-stage
+  correlations in durable evidence, accepting and recording all distinct
+  non-initiating approvers, adding producer and schema mutation coverage,
+  failing on any public-smoke override, preserving site-run cancellation after
+  query failure, enforcing numeric ruleset identity, reducing the publication
+  workflow to 795 lines, and extending the 900-line guardrail to workflow YAML.
+- Bootstrap review pass 2 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-2.md`.
+  Its `VERDICT: NOT SATISFIED` findings were remediated by freezing all four
+  public-smoke output filenames and their shared workflow directory in the
+  contract test, directly testing wrong-stage and wrong-alpha staged evidence,
+  and checking the opaque pre-epoch digest and byte size agree across both
+  workflows, the semantic validator, and the JSON Schema.
+- Bootstrap review pass 3 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-3.md`.
+  Its `VERDICT: NOT SATISFIED` findings were remediated by proving both
+  site-workflow identity checks surround publication and dispatch, deduplicating
+  the named bootstrap self-test from the default full-area run, removing an
+  unused evidence serializer, using the installer's actual sysroot-isolation
+  variable, validating a positive alpha-stage instance against the JSON Schema,
+  and consolidating the bootstrap module's common imports.
+- Bootstrap review pass 4 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-4.md`.
+  Its `VERDICT: NOT SATISFIED` findings were remediated by assigning
+  `epoch-bootstrap` to merge, nightly, and release profiles and release-report
+  custody, documenting the named suite, and adding load-bearing negatives for
+  duplicate smoke IDs with distinct digests and forbidden beta data in an
+  alpha-stage record.
+- The review's live query-string preflight succeeded against the public
+  governance endpoint: the cache-busted URL returned the exact opaque
+  `channels.json` identity
+  `71b3243925670f56dc510b8f45b6614a622f58097a0fea9492f61d20dc4bf9ef`
+  at 105 bytes.
+- Bootstrap review pass 5 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-5.md`.
+  Its `VERDICT: NOT SATISFIED` findings were remediated with independent
+  semantic mutations for smoke length, duplicate and unknown smoke IDs,
+  evidence and prepare digests, case-folded approver uniqueness, and active
+  release status, plus a validly named tenth asset that makes the JSON Schema's
+  exact-nine bound load-bearing.
+- Bootstrap review pass 6 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-6.md`.
+  Its `VERDICT: NOT SATISFIED` findings were remediated by isolating the
+  short-smoke and valid-withdrawn-release cases and expanding the semantic
+  mutation matrix across run identity, approval presence/uniqueness, prepare,
+  alpha-stage and index digests, release-record custody, smoke membership and
+  exact object shapes.
+- Bootstrap review pass 7 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-7.md`.
+  Its `VERDICT: NOT SATISFIED` full-validator mutation sweep was remediated with
+  producer-path isolation for withdrawn records, source-commit disagreement,
+  and record-version disagreement, plus direct guards for opaque byte size,
+  wrapper shape, channel/version evidence, approver container/value types, and
+  empty approval initiator/login identities.
+- Bootstrap review pass 8 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-8.md`.
+  Its `VERDICT: NOT SATISFIED` full-validator sweep found one remaining masked
+  case: the scalar approver test repeated characters and hit uniqueness before
+  the array-container guard. The scalar is now `abc`, whose distinct characters
+  isolate and pin the container requirement; this also makes pass 7's ledgered
+  container/value claim accurate.
+- Bootstrap review pass 9 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-9.md`.
+  Its `VERDICT: NOT SATISFIED` widened whole-call mutation sweep found the beta
+  evidence validator was not independently pinned. The complete alpha mutation
+  set is now mirrored for beta: object shape, channel/version, source commit,
+  release-record digest, exact asset membership, and individual asset digests.
+- Bootstrap review pass 10 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-10-satisfied.md`.
+  Its widened 88-mutant whole-wave sweep independently re-ran every guard and
+  validator deletion, confirmed all 33 survivors are structurally masked by
+  pinned sibling guards, found no fail-open path, and returned
+  `VERDICT: SATISFIED` with no actionable findings.
+- The first authoritative create-PR run reached one unrelated transient LSP
+  transcript timeout; the exact replay passed immediately in 7.6 seconds and
+  the second full run passed it in 6 seconds. That second run then exposed two
+  real bootstrap-registration gaps: the verification runner still expected 12
+  governed release schemas and its production release-report fixture omitted
+  the newly required `epoch-bootstrap` suite. Both fixtures now include the
+  schema and suite, and the complete runner self-test passes.
+- Bootstrap review pass 11 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-11.md`.
+  Its `VERDICT: NOT SATISFIED` whole-wave registration sweep confirmed both
+  runner remediations, then found the new read-only prepare workflow was
+  omitted from the no-v1-residue contract. The forbidden reader, migration,
+  and fallback sweep now covers prepare, publication, and bootstrap workflows.
+- Bootstrap review pass 12 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-12-satisfied.md`.
+  It re-ran the full distribution area (110/110, with the bootstrap exactly
+  once), found no remaining actionable issue, and returned
+  `VERDICT: SATISFIED`.
+- The final create-PR profile completed all 19 Python-interop variants with
+  zero failures but exited on the host timing budget after that passing step
+  took 690.10 seconds against 600 seconds. Two preceding wave runs completed
+  the same functional step within budget at 456.79 and 455.79 seconds. This
+  unrelated host variance is recorded in
+  `plans/phases/adhoc_performance_budget_host_variance.md`; no performance
+  baseline or waiver changed, and it is not a Phase 40 prerequisite.
 - [ ] Add the single protected publication workflow and production site adapter.
 - [ ] Publish or verify write-once assets, Marketplace version, governed index
   activation, site facts, and post-publication smoke.

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -463,7 +463,9 @@ Review and upstream coordination ledger:
   unrelated host variance is recorded in
   `plans/phases/adhoc_performance_budget_host_variance.md`; no performance
   baseline or waiver changed, and it is not a Phase 40 prerequisite.
-- [ ] Add the single protected publication workflow and production site adapter.
+- Schema-v2 preview epoch bootstrap implementation is under review in
+  [PR #3040](https://github.com/sifr-lang/sifr/pull/3040).
+- [x] Add the single protected publication workflow and production site adapter.
 - [ ] Publish or verify write-once assets, Marketplace version, governed index
   activation, site facts, and post-publication smoke.
 - [ ] Exercise resume, stale generation, burned generation, rollback, and

--- a/plans/phases/adhoc_performance_budget_host_variance.md
+++ b/plans/phases/adhoc_performance_budget_host_variance.md
@@ -46,6 +46,17 @@ seconds). The lane exited only on the elapsed-time budget after reporting every
 case as passing; the incident-governance diff does not change Python-interop or
 compiler implementation files.
 
+During the schema-v2 preview epoch bootstrap wave, the final create-PR profile
+again completed all 19 Python-interop variants with zero failures, but the
+aggregate step took 690.10 seconds against the same 600-second budget. The
+slowest cases were callback examples (145.16 seconds), read-only check/doctor
+(121.95 seconds), CPython buffer compatibility (106.41 seconds), buffer
+examples (102.67 seconds), and DLPack examples (80.62 seconds); Cargo also
+reported package-cache file-lock waits. Two preceding runs of the same wave
+completed that functional step within budget at 456.79 and 455.79 seconds.
+The bootstrap diff does not change Python-interop or compiler implementation
+files, and no threshold, baseline, or waiver was changed.
+
 During stable documentation/editor qualification on source head `147296fb0`,
 the create-PR profile passed coverage, core, diagnostics, and 18 of 19 selected
 Python-interop variants. `readonly-check-doctor` alone exceeded its internal

--- a/plans/releases/stable_gate_inventory.json
+++ b/plans/releases/stable_gate_inventory.json
@@ -107,6 +107,38 @@
       "disposition": "remains build/upload-only and never gains release, package, Marketplace, site, environment, or metadata mutation authority"
     },
     {
+      "id": "protected-publication-prepare",
+      "location": ".github/workflows/release-publication-prepare.yml",
+      "owner": "release/distribution",
+      "current_behavior": "revalidates exact source, release artifacts, current index identity, and staged alpha evidence with read-only permissions and emits a digest-bound 30-day summary",
+      "activation_boundary": "protected-publication",
+      "disposition": "remains read-only, has no protected environment or production secret, and supplies the reviewer-visible bytes consumed by publish"
+    },
+    {
+      "id": "schema-v2-preview-epoch-bootstrap",
+      "location": "verification/areas/distribution_release/governance/schema_bootstrap.py",
+      "owner": "release/distribution",
+      "current_behavior": "builds generation 1 preview metadata only from the exact opaque pre-epoch asset identity and fresh alpha/beta release records",
+      "activation_boundary": "protected-publication",
+      "disposition": "executes once under stable-release approval without parsing, migrating, or retaining the discarded schema-v1 data model"
+    },
+    {
+      "id": "protected-publication-approval",
+      "location": ".github/workflows/release-publication.yml",
+      "owner": "release/distribution",
+      "current_behavior": "queries immutable workflow approval history and requires at least one stable-release approver distinct from the workflow initiator before mutation",
+      "activation_boundary": "protected-publication",
+      "disposition": "records all actual distinct environment reviewers in bootstrap and later stable sign-off evidence"
+    },
+    {
+      "id": "schema-bootstrap-public-smoke",
+      "location": "scripts/distribution/run_schema_bootstrap_public_smoke.sh",
+      "owner": "release/distribution",
+      "current_behavior": "verifies the real governance asset, beta-default and stable-rejection dispatchers, a fresh public install, and installed self-update without the qualification override",
+      "activation_boundary": "protected-publication",
+      "disposition": "remains the mutable-public-endpoint proof separate from isolated local qualification"
+    },
+    {
       "id": "canonical-stable-planner",
       "location": "scripts/distribution/release_governance.py",
       "owner": "release/distribution",

--- a/plans/reviews/archive/phase-40-milestone-40-5-qualification-isolation-review-pass-6-final-pr-head.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-qualification-isolation-review-pass-6-final-pr-head.md
@@ -1,0 +1,59 @@
+# Pass 6 — Final Exact-Pushed-Head Review, PR #3039
+
+## Identity (all three agree)
+
+| Source | SHA |
+|---|---|
+| local `git rev-parse HEAD` | `36e20eeb166a7a241b9f71c5b2080dd9b01e8703` |
+| `git ls-remote origin refs/heads/codex/phase-40-milestone-40-5-bootstrap` | `36e20eeb166a7a241b9f71c5b2080dd9b01e8703` |
+| `git ls-remote origin refs/pull/3039/head` | `36e20eeb166a7a241b9f71c5b2080dd9b01e8703` |
+| `gh pr view 3039 → headRefOid` | `36e20eeb166a7a241b9f71c5b2080dd9b01e8703` |
+
+Remote identity: `origin` = `https://github.com/sifr-lang/sifr.git`, PR #3039 OPEN, base `main`, head branch `codex/phase-40-milestone-40-5-bootstrap`. Merge-base = `origin/main` = `21bd64d7c4cd83a45da274519ed0fdd3ac8d63f7`; two commits (`d78cfb756`, `36e20eeb1`), 16 files, +681/−111. Working tree carries only the 0-byte `plans/reviews/active/…pass-6-final-pr-head.md` placeholder — this review's own slot, not written per instruction. **No files edited by this review.**
+
+## Pass-5 findings — both fully closed at the exact remote head
+
+**Finding 1 (MEDIUM, remediation uncommitted) → CLOSED.** The delta `d78cfb756..HEAD` is exactly the five files pass 5 reviewed out of the working tree: `internal_docs/typescript_go_architecture_transfer_guardrails.md` (+1), the ledger (+30/−2), and the pass-3/pass-4/pass-5 archives. Nothing under `crates/**` or `verification/**` changed after pass 5, so its green full profile applies to this head's code byte-for-byte. The guardrail row is at `internal_docs/typescript_go_architecture_transfer_guardrails.md:73` and covers exactly `self_update_metadata_source.rs:37` (`.is_file()`) and `:42` (`fs::read_to_string`) — the two sites `DIRECT_FS_PATTERN` emits, neither more nor fewer. Gate now green **at the pushed commit**: `check_typescript_go_transfer_guardrails.py` → `PASS`, exit 0; `--self-test` → `PASS`, exit 0.
+
+**Finding 2 (LOW, stale PR description) → CLOSED.** `gh pr view 3039 --json body` now names the direct-read inventory in the Summary ("inventory both the release trust boundary and the two non-semantic direct filesystem sites used only by dry-run qualification"), records the full chain including the superseded pass-3 approval and pass-4's remediated finding, and states that a final exact-head review is required before merge. Validation list matches what I reproduced.
+
+## Independent verification at `36e20eeb1`
+
+| Check | Result |
+|---|---|
+| `cargo test -p sifr --bin sifr self_update` | **53 passed**, 0 failed |
+| `cargo clippy --workspace -- -D warnings` | exit 0 |
+| `cargo fmt --check` | clean |
+| `check_typescript_go_transfer_guardrails.py` / `--self-test` | PASS / PASS |
+| `stable_gate_inventory_selftest.py` | exit 0 |
+| `scripts/check_file_size_guardrails.py` | PASS (2890 files, cap 900) |
+| `python3 verification/areas/sysroot_release/runner.py --help` | exit 0 — direct-runner execution intact |
+| `check_no_path_leakage.py --self-test` | PASS |
+| `git diff --check origin/main...HEAD` | clean |
+| `py_compile` both area modules | clean |
+| Inventory integrity | 27 gates, all `location` paths exist; `self-update-metadata-source` uses the pre-existing `stable-qualification` boundary (5 gates share it) |
+| File sizes | runner.py 826, self_update_certification.py 190, self_update_metadata_source.rs 130, self_update_metadata.rs 869, self_update_cli.rs 531 |
+
+**Security / trust containment.** `fetch_channel_metadata` has exactly one call site (`self_update_cli.rs:89`); `args.dry_run` originates solely from the clap flag. `resolve_test_fixture` (`self_update_metadata_source.rs:19-23`) rejects the override before any path handling, so rejection precedes `resolve_update_plan` (`:95`), `installer_sha256` pinning, and `SelfUpdateRunner::production().run` (`:122`); `--dry-run` returns at `:106-110`, acquiring no lock and mutating nothing. Fixture inputs fail closed: non-absolute (empty string included, since `PathBuf::from("")` is not absolute), symlink and directory via `fs::symlink_metadata` + `file_type().is_file()` (`:34-41`), non-UTF-8 via `read_to_string`. Repo-wide, `SIFR_TEST_CHANNEL_METADATA_PATH` appears only in the module constant, the doc paragraph, `runner.py:748` (popped in `installed_env()`, the builder for every installed-binary call site), and `self_update_certification.py:68` (a per-command copy). No `.github/**` reference. `self_update_runner.rs` / `self_update_receipt.rs` untouched; installer URLs still derive from `GITHUB_RELEASE_DOWNLOAD_BASE_URL`. Fixture path is under a `tempfile.TemporaryDirectory` root, hence absolute.
+
+**No schema-v1 fallback.** `schema_version != 2` is still hard-rejected (`self_update_metadata.rs:185`), the new module is schema-agnostic, and every added `schema_version` line is either `2` or the unrelated pre-existing `sysroot_schema_version: 1` in the moved receipt writer / a prohibition or observation of external live state in archived prose. I re-derived that the committed fixture satisfies `ChannelMetadata::parse` and `validate_release_record` by construction: 5 top-level keys, `generation: 1`, `ga_status: "preview"` with exactly alpha+beta and no `stable`, two active records with exactly the 5 required keys and no `incident_id`, 40/64-char lowercase hex, exactly the four supported targets with 2 digest keys each.
+
+**Chronology.** Log slots 01:01 / 01:22 / 01:31 / 01:42 / 01:50 (pass 6 at 02:16) against archives written 01:15 / 01:30 / 01:49 / 01:49 / 02:15, commit `36e20eeb1` at 02:15:47. The pass-3 archive's 01:49 mtime is consistent with pass 4 (01:42) finding it missing and pass 5 disclosing it as restored. The ledger reads in true order — pass 3 SATISFIED at exact head, explicitly "superseded when the later authoritative create-PR profile found the inventory omission", then the omission, pass 4, pass 5 — with no retro-editing of earlier verdicts.
+
+**Milestone-wave readiness.** All `milestone_40_5` checkboxes correctly remain `[ ]`, including the isolation item whose second clause (separate protected public-endpoint smoke) depends on the undelivered publication workflow. No stable mapping, GA activation, baseline/threshold/waiver, profile-manifest, or interop change in the diff.
+
+## Actionable findings
+
+None.
+
+## Non-blocking observations
+
+- The PR Summary calls the pre-split runner "oversized": `origin/main:verification/areas/sysroot_release/runner.py` is 896 lines, i.e. under the 900 cap but four lines from it — the wave's additions (~+27) would have breached it, so the split was genuinely required; only the adjective is loose. No validation claim is affected.
+- `internal_docs/distribution_pipeline.md:388-389` describes "protected publication smoke" in the present tense while that smoke is still an unchecked 40.5 item. Vacuously true today (nothing outside the certification module sets the var). Already recorded by pass 3.
+- Still nothing automated asserts the dry-run artifact's `installer_url` carries the trusted GitHub prefix while fixture metadata is in play; the property is code-derived (`self_update_metadata.rs:88-90`) plus doc- and inventory-asserted. A prefix assertion in `validate_self_update_dry_run_json` would make it test-enforced. Carried from pass 3, not a defect in this wave.
+- `fs::symlink_metadata` at `self_update_metadata_source.rs:34` remains outside `DIRECT_FS_PATTERN` — a pre-existing scanner scope limitation, and the row covers exactly what the gate demands.
+- The area manifest declares `network_mode: "offline"`; this wave is what makes that declaration truthful for the self-update leg.
+- `plans/reviews/archive/phase-40-milestone-40-4-evidence-closure-review-pass-5-final-pr-head.md` plus its ledger bullet ride along in this 40.5 PR. It is the prior milestone's final-head record that #3038 merged without; pass 3 verified it against `b09845a86`, and the accompanying text claims no closure. Correct carry-over, not scope creep.
+- I did not re-run `sysroot_release --suite host-installed-smoke` or the full create-PR profile: `crates/**` and `verification/**` at this head are byte-identical to `d78cfb756`, which passes 1–3 each ran green, and pass 5's green full profile covered a tree differing from this head only in documentation. I re-ran every gate the post-pass-5 delta can affect. "Ruff" in the PR validation list refers to the Ruff-fork parser lane, not a Python linter — the repo has no `ruff check` lane.
+
+VERDICT: SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-1.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-1.md
@@ -1,0 +1,71 @@
+## Review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 1)
+
+I read the phase and issue docs, the full `git diff`, all nine untracked files, and the surrounding governance/runner/contract surfaces. The core design is sound: the epoch is genuinely opaque (no v1 parser, fixture, migration, or fallback anywhere — the `forbidden` sweep in `schema_epoch_bootstrap_workflow_contract.sh:104-110` plus `build_preview_epoch` accepting only a digest+size holds up), `prepare` is truly read-only and unprotected, the digest chain prepare→publish→live is checked at three points, `fetch_schema_bootstrap_alpha.sh` reproduces the alpha release record byte-for-byte rather than trusting it, and the public smoke exercises real endpoints. The `.sha256` files contain a bare digest (`build_release_artifacts.sh:275`), so the `tr -d '[:space:]'` comparisons are correct; `site_default_channel` resolves to `beta` under `preview`, so the smoke's `${version}:beta:false` expectation is consistent.
+
+The following are actionable.
+
+### 1. Prepare→publish artifact handoff breaks on any job re-run — High
+
+`release-publication-prepare.yml:210` names the artifact `publication-prepare-${{ github.run_id }}-${{ github.run_attempt }}`; `release-publication.yml:169-172` downloads that exact name. "Re-run failed jobs" increments `run_attempt` for the run but does **not** re-execute the already-succeeded `prepare` job (its outputs are reused via `needs.prepare.outputs.summary_sha256`). So on attempt 2 the publish job looks for `publication-prepare-<id>-2`, which was never uploaded, and dies at `download-artifact` before emitting any governed diagnostic. Every transient failure in the protected job — approvals API hiccup, site poll timeout, upload flake — becomes unrecoverable-by-rerun. Drop `run_attempt` from the name (`overwrite: false` already gives write-once semantics within the run).
+
+### 2. Two distinct approvers hard-fail the protected mutation — Medium-High
+
+`verification/areas/distribution_release/governance/schema_bootstrap.py:121-122`:
+
+```python
+if len(approved) != 1:
+    fail("approval history", "contains ambiguous distinct approvers")
+```
+
+The frozen policy is "at least one non-initiating `release/distribution` reviewer" and "initial and resume attempts each require a fresh approval." The `/approvals` endpoint returns the whole run's review history with no attempt discriminator, so a resume approved by a second reviewer yields two distinct logins → permanent hard fail. Same outcome if the `stable-release` environment is configured with two required reviewers. This should accept ≥1 distinct non-initiator and record all of them, not reject.
+
+### 3. Generation-1 evidence does not bind the alpha stage or the prepare summary — Medium
+
+`schema_bootstrap.py:223-292` records `alpha.{version,source_commit,release_record_sha256,published_assets}` but not the alpha stage's own evidence-asset digest, run id, or approver; and no evidence field carries `prepare_summary_sha256`. Those two correlations live only in `protected-prepare/summary.json`, which exists solely as a 30-day workflow artifact (`release-publication-prepare.yml:213`). The phase doc (`plans/phases/40_…md:952-955`) requires "Its prepare summary, protected approval, immutable snapshot, exact asset digests, and public smoke are retained as publication evidence." After retention expiry, nothing durable ties generation 1 back to the read-only prepare or to who approved the alpha stage. Add `prepare_summary_sha256` and `alpha_evidence_sha256` (plus the alpha run id/approver) to the `preview-index` payload and schema.
+
+### 4. New JSON Schema is materially weaker than the validator, with no negative coverage — Medium
+
+Given this repo's history (40.0 passes 4–6 were entirely schema/validator-parity findings):
+
+- `schema_epoch_bootstrap_evidence.schema.json` `public_smoke` has `minItems`/`maxItems: 4` but no uniqueness constraint, so four identical `"dispatcher-default"` entries validate; `schema_bootstrap.py:185-187` rejects them.
+- `$defs/assets` only requires `minProperties: 9` with arbitrary keys; `schema_bootstrap.py:419-424` requires exactly `expected_asset_names(version)`. The schema accepts an asset map for the wrong version.
+- `schema_contracts.py:27-65` registers only a positive fixture for the new schema, unlike the qualification-index and incident-signoff schemas which each carry explicit negatives.
+
+### 5. `materialize_bootstrap_evidence` — the actual producer — is untested — Medium
+
+`schema_bootstrap_selftest.py` covers `build_preview_epoch`, `validate_bootstrap_evidence`, and one happy/one self-approval case of `resolve_distinct_approver`. Nothing exercises the producer: `_require_exact_bootstrap_membership` (`schema_bootstrap.py:298-338`, index/record disagreement), the exact-asset-set check at `:367-370`, a missing smoke file, `write_canonical_json(refuse_existing=True)`, or the preview-index required-argument guard at `:243-255`. Also untested in `resolve_distinct_approver`: empty history, non-`approved` state, wrong environment name, and — notably — the `len(approved) != 1` branch that carries finding 2.
+
+### 6. Public-smoke override scrub is too late and covers only the last check — Medium-Low
+
+`run_schema_bootstrap_public_smoke.sh:93` unsets `SIFR_TEST_CHANNEL_METADATA_PATH` *after* the stable-rejection run (`:74-86`) and the fresh public install (`:88-92`). `internal_docs/distribution_pipeline.md` and the new `schema-bootstrap-public-smoke` inventory entry both claim the smoke runs "without the qualification override," and `schema_epoch_bootstrap_workflow_contract.sh:97` asserts the `unset` literal is present — but the guarantee only holds for the final `self update` invocation. Move it above line 31, and prefer a hard `test -z "${SIFR_TEST_CHANNEL_METADATA_PATH:-}"` failure over a silent unset: a set override means the smoke was mis-invoked.
+
+### 7. Poller extraction abandons a live site run on repeated query failure — Low-Medium
+
+`poll_site_release_run.sh:51-56` now `exit 2`s from inside the loop on the third consecutive query failure. The replaced inline code set `poll_error` and `break`, reaching the cancellation call (now `:93-95`). An already-matched, still-running site deployment is now left in flight after the protected job fails. Use `break` with a sticky error flag so the cancel path still runs.
+
+### 8. Empty review artifact — Low
+
+`plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-1.md` is 0 bytes and is not referenced from the issue ledger. Populate or remove before commit.
+
+### 9. `release-publication.yml` is at 851/900 lines with no automated cap — Low
+
+`scripts/check_file_size_guardrails.py:112-126` categorizes only `crates/**/*.rs`, `scripts/**/*.py`, `verification/**/*.py`, and `demos/**/*.sifr`, so this file's 586-line growth is unenforced even though AGENTS.md's 900-line rule lists no YAML exclusion. The rest of 40.5 (`ga-activation`, `normal`, `rollback`, `incident-roll-forward`, the `drill` job, Marketplace) must land in this same file under the phase's "do not add a second mutation workflow" constraint. Extract the bootstrap stages into a called workflow or step scripts now, and/or extend the guardrail to `.github/workflows/*.yml`.
+
+### 10. Unrelated reformatting inflates the reviewable diff — Low
+
+`scripts/distribution/release_governance.py` carries ~20 pure line-wrapping hunks in untouched functions (`generate_release_index`, `plan_stable_release`, `generate_incident`, `_require_clean_external_incident_directory`); `runner.py` carries ~15 more; `schema_contracts.py:490-492` converts an unrelated lambda to a def. `validate_bootstrap_evidence` is also inserted out of alphabetical order at `release_governance.py:28` and `governance/__init__.py:15,34` — the same class of nit pass 2 of 40.4 asked to be fixed.
+
+### 11. `--ruleset-id` is unvalidated before `jq --argjson` — Low
+
+`verify_site_workflow_identity.sh:30-33` checks `--ruleset-id` only for non-emptiness, then feeds it to `jq --argjson id`, which aborts with a raw jq parse error instead of a governed message for any non-numeric value. Add `"${ruleset_id}" =~ ^[0-9]+$` to the guard.
+
+---
+
+### External execution requirements (not implementation prerequisites)
+
+- `stable-release` environment must exist with ≥1 required reviewer from `release/distribution`; enable GitHub's "prevent self-review" so the in-workflow check at `release-publication.yml:208-218` is a second layer, not the only one. With no reviewers configured the approvals list is empty and the job fails closed — correct, but it fails late, after `prepare`.
+- `release-publication.yml:67-68` now routes *ordinary* preview publication through a `preview-release` environment. GitHub auto-creates it rule-free on first use, so behavior is unchanged today; confirm no reviewers are attached unless routine previews are meant to require approval.
+- The live `channels.json` must still be exactly 105 bytes / `71b3243925…4bf9ef` when `bootstrap-index` runs; any intervening mutation permanently disables this path (by design, and correctly so).
+- `sifr.sh/install` and `/install/stable` must serve the new dispatcher bytes within the 180-second convergence budget at `run_schema_bootstrap_public_smoke.sh:37`.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-10-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-10-satisfied.md
@@ -1,0 +1,53 @@
+# Review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 10 — satisfied)
+
+I read the full tracked `git diff` (21 files, 862/300), all 21 untracked files, the phase/issue ledger, and archived passes 1–9, then regenerated the widened mutant grammar from scratch off `schema_bootstrap.py`'s AST.
+
+### Pass-9 remediation confirmed dead
+
+The beta half of the release attestation now carries the complete seven-case alpha set (`schema_bootstrap_selftest.py:236-254`): unexpected key, wrong-channel version with matching asset shape (`release_evidence("0.1.0-alpha.7")`), invalid `source_commit`, invalid `release_record_sha256`, invalid asset digest, popped asset, and foreign same-channel asset set (`0.1.0-beta.99`).
+
+Measured, not asserted — dropping the sole beta call at `schema_bootstrap.py:198`:
+
+```
+[30] drop-stmt L198: _validate_release_evidence
+     rc=1 :: AssertionError: evidence mutation 32 unexpectedly passed
+```
+
+It is now killed, symmetric with its alpha twin at `:163` (killed by mutation 25). Both `_validate_approvers` calls (`:148`, `:189`) and `_require_exact_bootstrap_membership` (`:314`) are likewise killed by governed `AssertionError`s, not by crashes.
+
+### Widened mutation sweep re-run
+
+**88 mutants — one per `or`-clause of every `if …: fail(…)`, one per dropped `require_*`/`_validate_*`/`_require_*` statement, one per bypassed `x = require_*(y, …)` — 33 survive.** All 88 were verified to compile, so every "killed" result is a real behavioral kill rather than a syntax error. Every mutation ran in a `/tmp` copy; the working tree was never touched (diffstat identical before and after).
+
+The 33 survivors are exactly the structurally masked set carried forward from passes 8–9: the 13 container/type-guard bypasses, the 4 `require_nonempty_string` bypasses (`:93`, `:216`, `:461`, `:486`), `:268`, `:310`, `:429`, `:462`, the five membership clauses (`:389`, `:390`, `:397`×2, `:406`), and the seven `:294` `is None` clauses. Pass 9's prose enumerated these as "32" while listing 33 — a bookkeeping slip in the report, not a change in the code. I re-probed the ones that could plausibly be coverage gaps rather than masking; the sharpest, `index["ga_status"] != "preview"` at `:397`, is genuinely pinned by its live sibling: `validate_release_index` (`release_index.py:33-39`) requires a `stable` channel key whenever `ga_status == "active"`, so any non-preview index fails the `index["channels"] != expected_channels` clause in the same guard. The seven `is None` clauses are masked by each other within one `or` under the single missing-inputs negative. No survivor is a fail-open path.
+
+### Gates
+
+`governance.schema_bootstrap_selftest` PASS · named `epoch-bootstrap` suite PASS (variants=1, failures=0) · full `distribution_release` area PASS (**variants=110, failures=0**, `schema-v2-preview-epoch-bootstrap` appearing exactly once — the pass-3 dedup holds) · `governance.selftest` PASS (tests=14) · `ruff check` **rc=0** on all 11 changed/new Python files (pyenv 3.10.12, ruff 0.1.4) · file-size guardrail PASS (2898 files, limit 900) · `git diff --check` PASS. All earlier gates and remediations remain green.
+
+### Ledger
+
+Pass 9 is archived at `plans/reviews/archive/…-pass-9.md` and ledgered at `plans/issues/active/phase-40-stable-channel-ga-execution.md:427-432`; the entry describes the beta mirror accurately (object shape, channel/version, source commit, release-record digest, exact asset membership, individual asset digests). Passes 1–9 are all present and consistent.
+
+## Actionable findings
+
+None.
+
+## Not findings
+
+- 33 surviving mutants, each re-probed and confirmed masked by a pinned sibling on its real entry path. Correctly ordered defense-in-depth, not fail-open.
+- `ruff format --check` would still reformat several files in the package; wired into no repo gate, pre-existing baseline.
+- `release_governance.py --kind schema-bootstrap-evidence` routes to the semantic validator and not the JSON Schema. Now that both channel halves of `_validate_release_evidence` are independently pinned, the durable path is fully guarded; the schema remains the stricter redundant contract exercised by `schema_contracts`.
+- Post-`gh release create` failures remain unrecoverable by re-run; fail-loud stays correct.
+- Whether `actions/download-artifact@v4` resolves an attempt-1 artifact during "Re-run failed jobs" is still not locally reproducible.
+
+## Commit mechanics and downstream execution requirements (not implementation defects)
+
+- `plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-10.md` is a 0-byte untracked file. It must receive this report, be archived, and be ledgered. I did not modify it, per instruction.
+- Downstream, not implementation prerequisites: `stable-release` environment with ≥1 `release/distribution` reviewer and "prevent self-review" enabled; no reviewers on the auto-created `preview-release` environment; live `channels.json` still exactly 105 bytes / `71b3243925…4bf9ef` at `bootstrap-index` time; `sifr.sh` serving new dispatcher bytes inside the 180-second budget; the `SIFR_WEBSITE_ACTIONS_TOKEN` secret.
+
+## Whole-wave verdict
+
+Every structural, workflow, profile, schema, producer-path, and coverage finding from passes 1–9 is closed and independently re-measured. The last-standing defect — an unpinned beta release-evidence validator, surfaced only when the mutant grammar widened to whole-call deletions — is dead, killed by a seven-case set that mirrors alpha exactly. Re-running that same widened grammar from scratch produced no new survivor outside the structurally masked set, and no fail-open path remains in the bootstrap validator, producer, or workflow contract.
+
+VERDICT: SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-11.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-11.md
@@ -1,0 +1,41 @@
+## Archived review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 11)
+
+Read: phase plan, `plans/issues/active/phase-40-stable-channel-ga-execution.md`, the full working-tree diff vs `d8dd28a80` (22 tracked files + 22 untracked), and archived bootstrap passes 1–10.
+
+### Verification of the two-line remediation
+
+| Item | Result |
+|---|---|
+| `verification/runner/sifr_verify/selftest.py:89` `len(governed) != 13` | Correct — `schemas/` holds exactly 13 `*.schema.json` files including `schema_epoch_bootstrap_evidence.schema.json` |
+| `selftest.py:684` adds `epoch-bootstrap` to the release-report production fixture | Correct and load-bearing — `release_report.REQUIRED_SUITES["distribution_release"]` (`release_report.py:41-46`) now requires it and `validate_profile` (`:160-166`) enforces it; the fixture passes `validate_release_profile_report` without `source_root`, so `REQUIRED_SUITES` is the only gate it must satisfy |
+
+### Whole-wave registration sweep (the class of gap that broke pass 10)
+
+Every surface that must know about the new suite/schema is registered and consistent: `manifest.json` (epoch-bootstrap adapter), `runner.py:51,134,195,205,214` (execution + `validate_suite_case` command/entry maps + `full`-suite dedup), `merge/nightly/release.json`, `profile_assignment_matrix.json`, `release_report.REQUIRED_SUITES`, `governance/selftest.py:244,301`, `qualification_fixture.py:123`, `schema_contracts.py:106,409,449`, `sifr_verify/selftest.py:89,684`, `internal_docs/architecture.md:1433`, `distribution_pipeline.md`. `schema_contracts.validate_schema_contracts:29-31` and the assignment-matrix `validate_row_membership` are name-derived, so `epoch-bootstrap`/the new schema are pinned rather than merely listed. No stale exact-count or exact-list fixture remains anywhere in `verification/` or `scripts/`.
+
+Independently cross-checked `REQUIRED_SUITES` against the **real** `verification/profiles/release.json` (not the fixture): all four areas satisfied, `validate_profile` passes.
+
+### Gates re-run in this worktree
+
+`sifr_verify --self-test` (all 11 sections) PASS · `coverage_matrix` 5/5 PASS (`rows=17`) · `distribution_release` full area **110 variants, 0 failures**, `schema-v2-preview-epoch-bootstrap` appearing exactly once · merge-selection simulation (`representative`+`qualification`+`incident-governance`+`epoch-bootstrap`) 55/55 PASS · named `epoch-bootstrap` suite PASS · `documentation --suite structure` PASS · file-size guardrail PASS (2898 files) and its self-test PASS (`release-publication.yml` 795/900) · `git diff --check` clean · `compileall` + `bash -n` clean on all new/changed sources · asset-set arity confirmed 9, matching the schema's `minProperties: 9` / `not minProperties: 10`.
+
+*(Note: the full-area run initially aborted on host `ENOSPC`, not a test failure; it was re-run to completion after space freed.)*
+
+## Actionable findings
+
+**1. MEDIUM — the execution ledger stops at pass 10 and now overstates the wave's state.**
+`plans/issues/active/phase-40-stable-channel-ga-execution.md:435-440` records pass 10 as `VERDICT: SATISFIED` "with no actionable findings" and nothing follows it. The authoritative create-PR gate subsequently found two real verification-runner integration defects (stale governed-schema count; release-report production fixture missing `epoch-bootstrap`), both now fixed in the tree, and neither the gate run nor the remediation is recorded. Every comparable event in this issue is ledgered — including this milestone's own qualification-isolation wave, where the same situation is written up at `:332-335` ("The first authoritative create-PR profile found that…"). As it stands, a reader of the issue file concludes the wave was clean at pass 10. Add the create-PR discovery, the two fixture repairs, and the pass-11 artifact/link, consistent with `:299-302` and `:332-341`.
+
+**2. LOW — the new `release-publication-prepare.yml` is outside both v1-residue guards.**
+`verification/areas/distribution_release/cases/schema_epoch_bootstrap_workflow_contract.sh:145-151` sweeps for the forbidden `bootstrap_channel_metadata.py` / `migrate` / `fallback` fragments over `publication` and `bootstrap` only — `prepare` is read at `:14-16` and asserted against a positive fragment list at `:90-99`, but is never subjected to the forbidden sweep. Independently, `verification/areas/distribution_release/governance/schema_epoch.py:12-16` lists only `preview-release.yml` among workflows in `GOVERNED_FILES`, so neither publication workflow is scanned for `V1_PATTERNS`. The prepare job is precisely the surface that downloads the pre-epoch `channels.json` (`release-publication-prepare.yml:123-142`), i.e. the most likely place for a v1 reader/fallback to reappear against the milestone's "no v1 reader, writer, fixture, migration, negotiation, or fallback survives" invariant. I confirmed the file is currently clean, so this is a guard-coverage gap rather than a live defect; adding `prepare` to the loop at `:150-151` closes it.
+
+## Not findings
+
+- `profile_assignment_matrix.json` omits `distribution_release:qualification` and `:evidence-custody` while `REQUIRED_SUITES` mandates them, so those two are not statically pinned to `release.json`. Pre-existing (predates this wave); `epoch-bootstrap` *is* pinned by the matrix, so the new suite is fully guarded.
+- `_release_report_production_self_test` hardcodes the suite selection instead of deriving it from `release.json`. This is what made the defect visible rather than silent, and the matrix row supplies the missing direction of the constraint.
+- `test_materializer` patches `sha256_bytes` module-wide (`schema_bootstrap_selftest.py:435-439`); that symbol is used only for the opaque legacy identity in this module, so the fixture is sound.
+- `run_schema_bootstrap_public_smoke.sh` leaves `stable-dispatcher.sh` in the smoke directory; `materialize_bootstrap_evidence` reads the four `<id>.txt` files by name and does not require an exact directory listing.
+- 0-byte `plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-11.md`: commit mechanics for this report; not modified, per instruction.
+- Downstream live setup (`stable-release` environment reviewers/prevent-self-review, live 105-byte pre-epoch asset at bootstrap time, `SIFR_WEBSITE_ACTIONS_TOKEN`) treated as non-prerequisite per scope.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-12-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-12-satisfied.md
@@ -1,0 +1,5 @@
+# Archived review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 12 — satisfied)
+
+The remaining background wait-loop finished; it was the poller for the full `distribution_release` area run whose result I already reported (110 variants, 0 failures, `schema-v2-preview-epoch-bootstrap` once). No new information, and no change to the review.
+
+VERDICT: SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-13-exact-pr-head-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-13-exact-pr-head-satisfied.md
@@ -1,0 +1,47 @@
+## Archived pass 13 — exact-PR-head review, PR #3040
+
+### Identity (verified independently)
+| Source | SHA |
+|---|---|
+| local `HEAD` | `e51491338e396e6b8f2d19345c9df68242e2b029` |
+| `origin/codex/phase-40-milestone-40-5-preview-bootstrap` | `e51491338e396e6b8f2d19345c9df68242e2b029` |
+| PR #3040 `headRefOid` | `e51491338e396e6b8f2d19345c9df68242e2b029` |
+
+Base `d8dd28a80` is the merge-base; PR is `MERGEABLE`, 47 files, 2 commits (`e7fc93efd` implementation, `e51491338` docs link) — matches the local diff exactly. Working tree is clean except the untracked, zero-byte pass-13 report slot (not modified).
+
+### Prior findings — all closed
+- **Pass 11 / finding 1 (ledger)** — `plans/issues/active/phase-40-stable-channel-ga-execution.md:346-471` now ledgers passes 1–12, the create-PR transient LSP timeout and its replay, both runner-registration remediations, the pass-11 prepare-workflow gap and its fix, the host-variance run, and the PR link.
+- **Pass 11 / finding 2 (prepare outside the no-v1-residue sweep)** — `cases/schema_epoch_bootstrap_workflow_contract.sh:145-151` now runs the `bootstrap_channel_metadata.py` / `migrate` / `fallback` sweep over `(prepare, publication, bootstrap)`.
+- **Pass-10 runner-registration repairs** — `sifr_verify/selftest.py:89` (`13` schemas) and `:684` (`epoch-bootstrap` in the release-report production fixture) both present and load-bearing against `release_report.REQUIRED_SUITES`.
+
+### What I re-verified in the implementation
+- **Approval/security**: `release-publication.yml:67-71` binds the publish job to `stable-release` for both bootstrap modes; `:108-156` revalidates the prepare-summary digest against the prepare job's output, cross-checks every field against the protected job's own inputs, then resolves approvers from the run's immutable approval history. `resolve_distinct_approvers` fails closed on an empty history and case-folds self-approval — exercised live: `["Bob"]`/`["alice"]` on valid histories, exit 2 with `requires a stable-release approval by someone other than alice` on `[]`. Preview mode is unchanged (`approvers_json=[]`).
+- **Rerun-safe prepare**: artifact name `publication-prepare-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` with `overwrite: false`, `retention-days: 30`, read-only permissions, no environment, no secret. Publish's `download-artifact` now carries `pattern: sifr-${version}-*` so the summary artifact can't leak into `release-assets`. `verify_release_publication_assets.sh:81-99` re-digests the publish-side set and requires `.assets` equality with prepare; `generate_version_installer.sh` is deterministic (its `date`/`mktemp`/`uname` are escaped into the emitted script, not evaluated at generation).
+- **Opaque legacy identity**: the `71b3243…f9ef` / 105-byte pair is pinned identically in prepare (`:236-241`), publish index fetch (`:273-278`), lease revalidation (`:568-574`), `schema_bootstrap.py:28-29`, and the JSON Schema (`:33-34`) — cross-asserted by the contract case. No field of the pre-epoch asset is parsed anywhere.
+- **Staged alpha → generation 1**: `fetch_schema_bootstrap_alpha.sh` re-validates staged evidence canonically, pins tag→source, re-downloads all 9 assets, checks the exact name set and per-asset digests, and proves the release record is byte-reproducible. `_require_exact_bootstrap_membership` forces generation 1 / `ga_status: preview` / exactly the two evidenced channels and records; `"stable"` is asserted absent.
+- **Write-once ordering**: snapshot reservation (with a pre-existence guard) → single `--clobber` on `channels.json` → activated-digest recheck → site identity revalidation → dispatch → poll → smoke → final evidence upload with post-upload `cmp`. `bootstrap-alpha` correctly short-circuits before any index mutation.
+- **Site reconciliation**: the extracted `verify_site_workflow_identity.sh` is called twice (pre-publication and pre-dispatch) and is *stronger* than the previous inline code — the dispatch-time check now also verifies the pinned workflow bytes, which it did not before.
+- **Public smoke**: `run_schema_bootstrap_public_smoke.sh` refuses to run with `SIFR_TEST_CHANNEL_METADATA_PATH` set, byte-matches the live index and both dispatchers, requires the stable dispatcher to fail with the governed GA-metadata message, installs from the real endpoint, and pins `${version}:beta:false`. All four `<id>.txt` filenames match the `SMOKE_IDS` the materializer reads.
+
+### Gates re-run at this exact head
+| Gate | Result |
+|---|---|
+| `distribution_release --suite epoch-bootstrap` | PASS (1/1) |
+| `distribution_release --suite representative` | PASS (52/52), new `schema_epoch_bootstrap_workflow_contract` discovered and passing |
+| `distribution_release` full+qualification+evidence-custody+incident-governance+epoch-bootstrap | PASS (58/58: full 54, +4) |
+| Combined with representative | 52 + 58 = **110**, reconciling the prior 110/110 and merge-selection 55/55 figures exactly |
+| `sifr_verify --self-test` | PASS (all 11 sections) |
+| `coverage_matrix` | PASS (5/5) |
+| `documentation --suite structure` | PASS |
+| file-size guardrail + self-test | PASS (2898 files); `release-publication.yml` 795/900, `schema_bootstrap.py` 498, selftest 574, prepare 219 |
+| `git diff --check`, `bash -n` on all changed shell, `compileall` | clean |
+| `resolve-publication-approvers` behavioral probe | fail-closed as specified |
+
+### Notes (not findings)
+- `- [x] Add the single protected publication workflow and production site adapter.` is checked while `ga-activation`/`normal`/`rollback`/`incident-roll-forward` and the `stable-release-drill` job remain unimplemented. The surrounding ledger prose and `distribution_pipeline.md` both state explicitly that those mutations are gated to later slices, and the next two checklist items are unchecked, so no reader is misled — bookkeeping granularity, not a false claim.
+- `expect_failure` in `schema_bootstrap_selftest.py:568` catches `OSError` alongside `GovernanceError`; for the missing-smoke case the rejection is in fact an `OSError` from `sha256_file`. Still fail-closed, and the producer path is the one under test.
+- Downstream live configuration (`stable-release` reviewers with prevent-self-review, `preview-release` environment creation, `SIFR_WEBSITE_ACTIONS_TOKEN`, confirming the live 105-byte asset at dispatch time) is post-merge operational, per scope.
+
+No actionable finding at this head.
+
+VERDICT: SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-2.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-2.md
@@ -1,0 +1,52 @@
+# Review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 2)
+
+I read the full `git diff`, all 14 untracked files, the phase/issue docs, and the archived pass-1 report, and independently re-ran the gates.
+
+## Pass-1 re-audit
+
+| # | Pass-1 finding | Status |
+|---|---|---|
+| 1 | Prepare→publish artifact handoff breaks on re-run | **Resolved.** `release-publication-prepare.yml:197,215` emits and uploads under the same computed name, exported at `:25-26,39`; publish downloads `needs.prepare.outputs.summary_artifact_name` (`release-publication.yml:105`). Rerun-failed reuses the succeeded job's attempt-1 name (artifact still present under the unchanged `run_id`); rerun-all re-uploads at attempt 2. `overwrite: false` retained. |
+| 2 | Two distinct approvers hard-fail | **Resolved.** `resolve_distinct_approvers` (`schema_bootstrap.py:87-121`) collects all distinct non-initiating `stable-release` approvers case-insensitively and fails only on an empty set; evidence stores arrays (`_validate_approvers`, `:227-243`). |
+| 3 | Generation-1 evidence unbound to alpha stage / prepare | **Resolved.** `prepare_summary_sha256` is required at both stages, and `alpha_evidence.{sha256,run_id,run_attempt,initiator,approvers,prepare_summary_sha256}` at `preview-index` (`:167-198,337-348`). |
+| 4 | Schema weaker than validator, no negatives | **Substantially resolved.** `uniqueItems` + per-id `minContains/maxContains` (schema `:68-112`), exact-9 channel-shaped asset maps via `minProperties`/`not minProperties` + `propertyNames` (`:140-157`), stage `if/then/else` with `not required` (`:114-127`), and two negatives in `schema_contracts.py:66-81`. I verified the repo's schema engine actually supports `contains/minContains/maxContains/propertyNames/if/then/else/not` (`verification/json_schema_202012.py:11-42`). I probed 14 instances against both surfaces: all structural cases agree; the only divergences are the four cross-field semantics 2020-12 cannot express (asset map vs sibling `version`, approver vs sibling `initiator` incl. case-folded uniqueness). Those are validator-only by necessity and are covered semantically (`schema_bootstrap_selftest.py:132,139-141`). |
+| 5 | Producer untested | **Mostly resolved** — see finding 2 below. |
+| 6 | Public-smoke override scrub too late | **Resolved.** Hard `test -z` before any request (`run_schema_bootstrap_public_smoke.sh:31-34`), gated by an ordering assert (`schema_epoch_bootstrap_workflow_contract.sh:113-116`). |
+| 7 | Poller abandons a matched run | **Resolved.** Sticky `poll_error` + `break` reaches cancel (`poll_site_release_run.sh:54-56,94-96`), gated at `preview_release_workflow_yaml_parses.sh:110-114`. |
+| 8 | Empty review artifact | **Recurs** — see finding 4. |
+| 9 | `release-publication.yml` at 851 lines, unenforced | **Resolved.** 795 lines; guardrail covers `.github/workflows/*.{yml,yaml}` with a self-test (`check_file_size_guardrails.py:123,133-134,262,273-276`). |
+| 10 | Reformatting noise | **Resolved.** `release_governance.py`/`runner.py` diffs are additions plus alphabetical insertion only; the one E731 conversion is explained. |
+| 11 | Unvalidated `--ruleset-id` | **Resolved.** `verify_site_workflow_identity.sh:31`, gated at `site_release_workflow_contract.sh:87`. |
+
+No schema-v1 parser, fixture, migration, or fallback exists: the only `schema-v1` hit is the pre-existing `schema_version: 1` *rejection* fixture at `cases/site_publication_facts_generated.sh:42`. Digest-chain, write-once, ordering, and approval behavior all check out, and `--clobber` count is pinned at 1.
+
+Gates I re-ran here: epoch-bootstrap suite PASS; full distribution suite PASS, **variants=56**; the three touched/new contract cases PASS; file-size self-test + repository gate PASS; `bash -n` over all `scripts/distribution/*.sh` PASS. (Ruff is not installed under the active interpreter, so I could not independently reproduce that one.)
+
+## Actionable findings
+
+### 1. The smoke-output filename contract between bash and Python is ungated, and drift lands *after* the irreversible mutation — Medium
+
+`schema_bootstrap.py:360-367` hashes `smoke_dir / f"{smoke_id}.txt"` for each of the four frozen `SMOKE_IDS` (`:33-38`). The producing side spells those four paths literally and independently in bash — `run_schema_bootstrap_public_smoke.sh:57` (`governance-index.txt`), `:67` (`dispatcher-default.txt`), `:77` (`dispatcher-stable-rejection.txt`), `:97-98` (`installed-self-update.txt`) — and the directory is coupled only by `--out publication/bootstrap-smoke` / `--smoke-dir publication/bootstrap-smoke` at `release-publication.yml:751,782`.
+
+`schema_epoch_bootstrap_workflow_contract.sh:104-116` asserts six URL/message fragments in the smoke script but none of the four output paths. So renaming, relocating, or dropping one output keeps every gate green: the smoke script still exits 0, and the first failure is `FileNotFoundError` inside `materialize_schema_bootstrap_evidence.py` — at which point the version release is published, `channels-generation-1.json` is reserved, `channels.json` is replaced, and the site has deployed. The epoch is live, permanently un-evidenced, and the run cannot be re-run (`release-publication.yml:231-233` is write-once by design). Assert each `SMOKE_IDS` member appears as its `${out}/<id>.txt` literal, and that the workflow's `--out` and `--smoke-dir` are the same path.
+
+### 2. The staged-alpha binding branch — the fix for pass-1 finding 3 — is unreached by the self-test — Low-Medium
+
+`schema_bootstrap.py:326-336` is the invariant that makes generation-1 evidence trustworthy: the staged evidence must be `stage == "alpha-assets"` and its `alpha` block must equal the alpha block this run reproduced. `test_materializer` (`schema_bootstrap_selftest.py:288-358`) always passes the single matching `alpha_evidence_path`; the "unexpected alpha asset" case (`:330-335`) fails earlier inside `_materialize_release_evidence`, so the comparison never executes. Deleting lines 329-336 leaves the suite green. Add two cases: a second alpha evidence materialized from a different alpha version/assets, and the final evidence itself passed as `--alpha-evidence` (exercising the `stage` check).
+
+### 3. The opaque pre-epoch identity is duplicated across four enforcement surfaces with no cross-surface equality gate — Low
+
+`71b3243925…4bf9ef`/`105` is asserted independently at `release-publication-prepare.yml:47,133`, `release-publication.yml:82,275,570`, `schema_bootstrap.py:29-30`, and `schemas/schema_epoch_bootstrap_evidence.schema.json:33-34`. `schema_epoch_bootstrap_workflow_contract.sh:94-96` checks only that the *identifier* `LEGACY_INDEX_SHA256` is present, never that the four values agree. Drift fails closed (the Python constant rejects before mutation), but it is undetectable until a bootstrap attempt. Assert the literal digest and `105` in all four files from the contract case.
+
+### 4. `plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-2.md` is a 0-byte untracked file — Low
+
+Same class as pass-1 finding 8. Populate it with this report and add the ledger entry in `plans/issues/active/phase-40-stable-channel-ga-execution.md` (the pass-1 archive is referenced at `:361-373`; pass 2 is not), or remove it before commit.
+
+## Not findings
+
+- The four schema/validator divergences above are inherent to JSON Schema 2020-12 sibling-value comparison and are covered by semantic tests; no parity regression.
+- Post-`gh release create` failures are unrecoverable by re-run in every mode. That is the pre-existing write-once contract, not new to this slice.
+- `prepare` checks artifact *presence* per target rather than the exact set; publish's `verify_release_publication_assets.sh:56-79` enforces exactness before any mutation, so the asymmetry only changes which job reports it.
+- The external execution requirements from pass 1 (environment + reviewer configuration, prevent-self-review, live `channels.json` identity at bootstrap time, `sifr.sh` convergence budget) still stand and remain outside the implementation.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-3.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-3.md
@@ -1,0 +1,64 @@
+# Review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 3)
+
+I read the full diff, all 15 untracked files, the phase/issue docs, and the archived pass-1 and pass-2 reports, and independently re-ran the gates plus a schema/validator parity probe.
+
+## Pass-2 re-audit
+
+| # | Pass-2 finding | Status |
+|---|---|---|
+| 1 | Smoke-output filename contract ungated, drift lands after irreversible mutation | **Resolved.** `schema_epoch_bootstrap_workflow_contract.sh:117-120` now freezes all four `${out}/<id>.txt` literals, and `:57-58` proves `--out publication/bootstrap-smoke` equals `--smoke-dir publication/bootstrap-smoke`. I confirmed all four literals exist at `run_schema_bootstrap_public_smoke.sh:57,67,77,98` and that the ids match `SMOKE_IDS` (`schema_bootstrap.py:33-38`) exactly. |
+| 2 | Staged-alpha binding branch unreached by the self-test | **Resolved.** `schema_bootstrap_selftest.py:331-337` passes the final `preview-index` evidence as `--alpha-evidence` (exercises the `stage != "alpha-assets"` half of `schema_bootstrap.py:329-336`), and `:338-370` materializes a genuinely different alpha (`0.1.0-alpha.3`, own record + assets + run 44) to exercise the exact alpha-block equality half. Both raise before the earlier asset checks. |
+| 3 | Opaque pre-epoch identity duplicated across four surfaces with no cross-surface gate | **Resolved.** `schema_epoch_bootstrap_workflow_contract.sh:127-136` asserts the literal digest in all four surfaces and the size in each surface's own idiom (`= "105"`, `LEGACY_INDEX_SIZE_BYTES = 105`, `"size_bytes": {"const": 105}`). |
+| 4 | Empty pass-2 review artifact | **Resolved.** Populated, archived, and ledgered at `plans/issues/active/phase-40-stable-channel-ga-execution.md:370-376`. |
+
+All eleven pass-1 remediations remain in place. Parity probe (18 instances against both the JSON Schema and `validate_bootstrap_evidence`): every structural case agrees in both directions, including the `alpha-assets` positive and all four stray-key rejections; the only divergences are the three cross-field semantics 2020-12 cannot express (asset map vs sibling `version`, approver vs sibling `initiator`, case-folded approver uniqueness), all validator-stricter and covered semantically. No schema-v1 parser, fixture, migration, or fallback exists.
+
+Gates re-run here: `governance.schema_bootstrap_selftest` PASS; epoch-bootstrap suite PASS; full distribution area PASS (**variants=111, failures=0**); `schema_epoch_bootstrap_workflow_contract.sh`, `preview_release_workflow_yaml_parses.sh`, `site_release_workflow_contract.sh` PASS; file-size self-test + repository gate PASS (2898 files); `git diff --check` PASS; `bash -n` over all `scripts/distribution/*.sh` PASS; `ruff check` clean on every changed Python file (the 8 remaining diagnostics are all in untouched files). `generate_version_installer.sh` output depends only on version + archive digests, so the new prepare→publish installer-digest equality in `verify_release_publication_assets.sh:94-99` is sound.
+
+## Actionable findings
+
+### 1. The pre-dispatch site-workflow re-verification is no longer gated — Medium-Low
+
+Before the pass-1 extraction, `site_release_workflow_contract.sh` asserted two *distinct* diagnostics — `"site workflow tag immutability ruleset is not active and exact"` (input validation) and `"site workflow tag lost immutable protection before dispatch"` (pre-dispatch) — which proved two independent call sites. Both were replaced by one shared script emitting one message set, and the contract now only asserts membership plus one ordering relation:
+
+- `site_release_workflow_contract.sh:77` — `"scripts/distribution/verify_site_workflow_identity.sh"` appears somewhere
+- `:96` — its first index precedes `"Publish write-once version release and verify assets"`
+
+`release-publication.yml` invokes it twice (`:212-220` and `:678-686`), but nothing asserts `count == 2`, and nothing asserts an invocation occurs at or after `"Dispatch exact site workflow"`. Deleting `:678-686` keeps `site_release_workflow_contract.sh`, `preview_release_workflow_yaml_parses.sh`, and `schema_epoch_bootstrap_workflow_contract.sh` all green — and reopens exactly the TOCTOU window that second check exists to close: the site workflow tag could be moved or its ruleset weakened between input validation and dispatch, and the protected job would dispatch to unreviewed bytes. This is the same class as pass-2 finding 1 (a gate that a refactor silently stopped covering). Assert `publication.count("verify_site_workflow_identity.sh") == 2` and that the second index falls between `"Dispatch exact site workflow"` and `"Poll exact site run"`.
+
+### 2. `governance.schema_bootstrap_selftest` executes twice per default full-area run — Low
+
+`runner.py:126-133` runs the module for the `epoch-bootstrap` suite, and `:143-149` appends it unconditionally to the `full` suite. Because `select_suites` selects every manifest suite when unfiltered, both fire. Measured: `case=schema-v2-preview-epoch-bootstrap` appears **2** times, while `case=incident-recovery` appears **1** — the adjacent `include_incident=not incident_suite_selected` dedup (`runner.py:47-50,105-108,151`) exists for precisely this reason and was not mirrored. The duplicate is also double-counted in the reported `total_variants` (111 includes it twice), which is the number used as merge evidence. Mirror the incident pattern with an `include_epoch_bootstrap` flag.
+
+### 3. `bootstrap_evidence_bytes` is dead code — Low
+
+`schema_bootstrap.py:246-247` defines it; a repo-wide grep finds no caller in any script, workflow, test, or module. It is also the only consumer of the `canonical_json_bytes` import at `:10`. AGENTS.md's "no fallback paths or solutions unless explicitly requested" and the pass-1 finding-10 posture argue for deleting both.
+
+### 4. The public smoke sets a variable nothing reads — Low
+
+`run_schema_bootstrap_public_smoke.sh:80,94` set `SIFR_SYSROOT_DIR`. No code in the repo reads that name: the generated installer reads `SIFR_SYSROOT_INSTALL_DIR` (`generate_version_installer.sh`, `sysroot_dir="${SIFR_SYSROOT_INSTALL_DIR:-${default_sysroot_dir}}"`), and the compiler reads `SIFR_SYSROOT` (`crates/sifr_sysroot/src/resolve.rs:6`). The intended temp-root isolation holds today only by accident — `install_dir` ends in `/bin`, so `default_sysroot_dir` resolves to the same path. If that default ever changes, the smoke silently writes its toolchain outside the sandbox on the protected runner, and the intent expressed in the code would not be what is enforced. Use `SIFR_SYSROOT_INSTALL_DIR`.
+
+### 5. The `alpha-assets` stage is never validated against the new JSON Schema — Low
+
+`schema_contracts.py:30-33` enforces exactly one fixture per schema file, and `schema_bootstrap_evidence()` returns a `preview-index` instance. So the newly added `if/then/else` else-branch (`schema_epoch_bootstrap_evidence.schema.json:114-127`) — the branch governing the durable alpha-stage evidence that `bootstrap-index` consumes — has no positive coverage: a schema bug there would reject valid alpha evidence with no gate noticing (the runtime path uses only the semantic validator, so it would not break, but the schema/validator parity contract this area maintains would be silently false). I confirmed manually that the branch is correct today. Register the alpha-stage instance as a second checked instance, or add it to the negative/positive probes alongside the two existing bootstrap negatives at `:66-81`.
+
+### 6. Duplicate import statement — Nit
+
+`schema_bootstrap.py:8-25` and `:26` are two separate `from .common import` statements; fold `load_json_strict` into the first.
+
+## Not findings
+
+- Post-`gh release create` failures remain unrecoverable by re-run in every mode; for `bootstrap-index` the durable evidence upload is necessarily last (it must bind the smoke digests), so a `sifr.sh` convergence flake leaves generation 1 live and un-evidenced. That is the correct fail-loud choice over recording an unverified pass, and it is the pre-existing write-once contract.
+- The smoke writes a fifth file, `${out}/stable-dispatcher.sh`, into the evidence directory; the materializer hashes only the four `SMOKE_IDS` files, so this is harmless (unlike the asset directories, an exact-set check would be wrong here).
+- `poll_site_release_run.sh` does not guard `GH_TOKEN` non-emptiness the way `verify_site_workflow_identity.sh:30` does, but an empty token yields three governed query failures and a governed exit 2.
+- Prepare checks artifact presence per target while publish enforces exactness; publish's `.assets` equality against the prepare summary now makes any prepare-side extra file fail closed before mutation.
+- Nested reusable-workflow depth (preview-release → release-publication → prepare) is 3, within GitHub's limit of 4; `prepare` declares no `concurrency`, so it cannot deadlock against `group: sifr-release-index`.
+- The `.github/workflows` guardrail extension does not cover `.github/actions/**/action.yml`; out of scope for this slice.
+
+## Commit mechanics and execution requirements (not implementation defects)
+
+- `plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-3.md` is a 0-byte untracked file. It must receive this report, be archived, and be ledgered in `plans/issues/active/phase-40-stable-channel-ga-execution.md` before commit. I did not modify it, per instruction.
+- Pass-1's external requirements still stand: `stable-release` environment with ≥1 `release/distribution` reviewer and GitHub "prevent self-review" enabled; confirmation that no reviewers are attached to the auto-created `preview-release` environment; the live `channels.json` still being exactly 105 bytes / `71b3243925…4bf9ef` at `bootstrap-index` time; and `sifr.sh` serving new dispatcher bytes inside the 180-second budget.
+- One behavior I cannot reproduce locally: whether `actions/download-artifact@v4` resolves an attempt-1 artifact during "Re-run failed jobs". Pass 2 adjudicated this resolved and the naming is correct on both re-run paths; validate it on the first live re-run rather than treating it as settled.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-4.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-4.md
@@ -1,0 +1,73 @@
+# Review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 4)
+
+I read the full `git diff`, all 16 untracked files, the phase doc (`plans/phases/40_stable_channel_ga_promotion_and_release_governance.md:938-1010`), the issue ledger, and the archived pass-1/2/3 reports, and independently re-ran the gates plus schema-weakening probes.
+
+### Pass-3 re-audit
+
+| # | Pass-3 finding | Status |
+|---|---|---|
+| 1 | Pre-dispatch site-workflow re-verification ungated | **Resolved.** `site_release_workflow_contract.sh:96-104` asserts `count == 2`, `first < "Publish write-once version release and verify assets"`, and `"Dispatch exact site workflow" < second < "Poll exact site run"`. I confirmed the two call sites at `release-publication.yml:212-220,678-686`, and that the extracted helper's own diagnostics are now asserted against `verify_site_workflow_identity.sh` directly (`:77-84`) rather than the caller. |
+| 2 | Bootstrap self-test ran twice per default full-area run | **Resolved.** `runner.py:51-57,113-118,153-159` mirrors the incident dedup exactly. Measured: default run = **110 variants, 0 failures**, `case=schema-v2-preview-epoch-bootstrap` appears **1** time (same as `case=incident-recovery`). |
+| 3 | `bootstrap_evidence_bytes` dead code | **Resolved.** Both it and the `canonical_json_bytes` import are gone; `sha256_bytes`/`sha256_file` are the only serializers used. |
+| 4 | Smoke set unread `SIFR_SYSROOT_DIR` | **Resolved.** `run_schema_bootstrap_public_smoke.sh:80,94` use `SIFR_SYSROOT_INSTALL_DIR`, and `schema_epoch_bootstrap_workflow_contract.sh:114,125` both require the correct spelling and forbid the dead one. |
+| 5 | `alpha-assets` stage never validated against the JSON Schema | **Resolved** for the positive case: `schema_contracts.py:66-73` deletes the four conditional keys and validates the alpha-stage instance. See finding 2 for the negative half. |
+| 6 | Duplicate `from .common import` | **Resolved.** Single import block, `schema_bootstrap.py:8-25`. |
+
+All pass-1 and pass-2 remediations remain in place. I re-verified: no schema-v1 parser/fixture/migration/fallback exists (the `forbidden` sweep at `:145-151` plus `build_preview_epoch` taking only digest+size); the digest chain prepare→publish→live holds at `release-publication.yml:80-84,285-290,303-309,568-573`; `--clobber` count is pinned at 1; `bootstrap-alpha` never touches `channels.json`; site publication facts carry no `operation` field, so the `schema-epoch-bootstrap` plan operation cannot fail that step post-mutation.
+
+Gates re-run here: default distribution area PASS (110 variants, 0 failures); `governance.schema_bootstrap_selftest` PASS; the three touched/new contract cases PASS; `bash -n` over all `scripts/distribution/*.sh` PASS; file-size gate PASS (`release-publication.yml` at 795/900); `git diff --check` PASS. Ruff is not installed under the active interpreter, so I could not reproduce that one.
+
+## Actionable findings
+
+### 1. The new `epoch-bootstrap` suite is assigned to no validation profile, so the merge gate never executes the bootstrap validator or producer — Low-Medium
+
+`verification/areas/distribution_release/manifest.json:79-88` registers the suite and `runner.py:194-215` validates its command/entry, but the name appears in **none** of `verification/profiles/{create-pr,merge,nightly,release}.json` nor `verification/areas/coverage_matrix/profile_assignment_matrix.json`. Consequently the module runs only via the `full` suite's unconditional append (`runner.py:153-159`), and `full` is selected by `nightly` and `release` only.
+
+Measured, using the merge profile's exact selection:
+
+```
+runner.py --suite representative --suite qualification --suite incident-governance
+  → variants=54, failures=0   # no schema-v2-preview-epoch-bootstrap, no governance-contracts
+```
+
+`scripts/run_all_tests.sh` with no arguments is the merge gate and AGENTS.md's authoritative pre-PR check. Under it, the three new shell contract cases *do* run (they live in `cases/`, so `representative` picks them up — I confirmed `schema_epoch_bootstrap_workflow_contract`, `site_release_workflow_contract`, and `preview_release_workflow_yaml_parses` all execute there). What does **not** run is `governance.schema_bootstrap_selftest` — the only coverage for `validate_bootstrap_evidence`, `resolve_distinct_approvers`, `build_preview_epoch`, and `materialize_bootstrap_evidence`, i.e. the code that authorizes the irreversible one-time mutation. The two comparable named governance suites, `qualification` and `incident-governance`, are both in `merge.json:distribution_release`.
+
+The self-reported "default distribution run PASS: 110 variants" is a bare `runner.py` invocation, which selects every manifest suite including `full`; it is not what the merge gate or CI runs. Add `epoch-bootstrap` to `merge.json` (and, following `incident-governance`, to `nightly.json`/`release.json` plus `profile_assignment_matrix.json` and `release_report.py:REQUIRED_SUITES`), or drop the named suite and document the module as `full`-only like `governance.selftest`. As it stands the suite is selectable by no profile and is not listed among the suite commands in `internal_docs/architecture.md:1432` or the new `distribution_pipeline.md` section either.
+
+(`governance-contracts` being merge-absent is pre-existing and not new to this slice; it is noted only because it means `validate_schema_contracts` — including finding 2's coverage — is also nightly/release-only.)
+
+### 2. The pass-2 `public_smoke` `contains`/`maxContains` blocks and the stage `if/then/else` have no negative coverage — Low
+
+`schema_contracts.py:74-88` registers two bootstrap negatives. I probed which schema constraints they are actually load-bearing for:
+
+- `duplicate_smoke` sets `public_smoke[1].id = public_smoke[0].id`. Since the fixture's four records differ *only* by `id`, the mutation makes two records byte-identical, so `uniqueItems: true` (`schema_epoch_bootstrap_evidence.schema.json:72`) rejects it on its own.
+- `extra_asset` is rejected by `$defs/alpha_assets`'s `not: {minProperties: 10}` (`:143`).
+
+Measured against weakened copies of the schema:
+
+```
+delete properties.public_smoke.allOf   → duplicate_smoke=REJECT, extra_asset=REJECT   (gate stays green)
+delete top-level allOf                 → duplicate_smoke=REJECT, extra_asset=REJECT,
+                                          alpha-assets instance retaining "beta"=ACCEPT (gate stays green)
+```
+
+So deleting either pass-2 remediation leaves `validate_schema_contracts` passing. With `properties.public_smoke.allOf` gone, `[{id:A,sha:1},{id:A,sha:2},{id:B,…},{id:C,…}]` validates against the JSON Schema while `validate_bootstrap_evidence:217-219` rejects it (`smoke_id in seen`) — exactly the schema/validator parity break this area has spent passes 40.0/4–6, 2/#1 and 3/#5 closing. The schema is correct today (I verified all four cases reject); only the gate is blind. Add a duplicate-id-with-distinct-digest negative and an `alpha-assets`-instance-retaining-`beta` negative.
+
+## Not findings
+
+- The four cross-field semantics 2020-12 cannot express (asset map vs sibling `version`, exact asset-set membership vs the 9-property bound, approver vs sibling `initiator`, case-folded approver uniqueness) remain validator-stricter and semantically covered at `schema_bootstrap_selftest.py:132,139-141`.
+- `release-publication.yml` at 795/900 with the remaining 40.5 scope (`ga-activation`, `normal`, `rollback`, `incident-roll-forward`, `drill`, Marketplace) to land in the same file leaves 105 lines. Pass 1 adjudicated this resolved once the guardrail was extended; I have no new evidence to reopen it, but the extraction discipline established here needs to continue.
+- Post-`gh release create` failures are unrecoverable by re-run in every mode; for `bootstrap-index` the evidence upload is necessarily last. Fail-loud over recording an unverified pass remains correct.
+- `poll_site_release_run.sh` preserves the sticky-`poll_error`-then-cancel ordering, gated at `preview_release_workflow_yaml_parses.sh:110-114`.
+- `verify_release_publication_assets.sh:81-99` and `release-publication-prepare.yml:166-175` compute basename-keyed digest maps from the same `sha256sum`/`capture` idiom, so the prepare↔publish `.assets` equality is sound.
+- `materialize_schema_bootstrap_evidence.py:74` catches `GovernanceError`, `OSError`, and `json.JSONDecodeError`; every failure path in `schema_bootstrap.py` routes through `fail()`.
+- The fifth smoke output `${out}/stable-dispatcher.sh` is not in `SMOKE_IDS` and is correctly not exact-set-checked.
+
+## Commit mechanics and execution requirements (not implementation defects)
+
+- `plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-4.md` is a 0-byte untracked file. It must receive this report, be archived, and be ledgered in `plans/issues/active/phase-40-stable-channel-ga-execution.md` (passes 1–3 are at `:361-386`; pass 4 is absent). I did not modify it, per instruction.
+- **New pre-flight item:** `run_schema_bootstrap_public_smoke.sh:45` appends `?sifr_publication_smoke=${RANDOM}-${SECONDS}` to every polled URL, including `https://github.com/${repository}/releases/download/channels/channels.json`. There is no precedent for this pattern anywhere else in `scripts/`. If GitHub's release-download redirect or Cloudflare rejects the unknown query parameter, the `governance-index` check can never converge and the run fails *after* `channels.json` has been replaced and the site deployed. Verify one `curl` against the live endpoint with the parameter before the bootstrap run, not during it.
+- Pass-1's external requirements stand: `stable-release` environment with ≥1 `release/distribution` reviewer and GitHub "prevent self-review" enabled; confirmation that no reviewers are attached to the auto-created `preview-release` environment; live `channels.json` still exactly 105 bytes / `71b3243925…4bf9ef` at `bootstrap-index` time; `sifr.sh` serving new dispatcher bytes inside the 180-second budget.
+- Still not locally reproducible: whether `actions/download-artifact@v4` resolves an attempt-1 artifact during "Re-run failed jobs". Validate on the first live re-run.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-5.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-5.md
@@ -1,0 +1,56 @@
+# Review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 5)
+
+I read the full diff, all 16 untracked files, the phase spec (`plans/phases/40_stable_channel_ga_promotion_and_release_governance.md:938-1010`), the issue ledger, and archived passes 1–4, then independently re-ran the gates plus mutation probes against both the JSON Schema and the semantic validator.
+
+## Pass-4 re-audit
+
+| # | Pass-4 finding | Status |
+|---|---|---|
+| 1 | `epoch-bootstrap` assigned to no profile; merge gate never runs the bootstrap validator/producer | **Resolved.** Present in `merge.json:247`, `nightly.json:226`, `release.json:225`, `profile_assignment_matrix.json:99-113`, `release_report.py:46`, `selftest.py:244,301`, `qualification_fixture.py:123`, `schema_contracts.py:407,447`, `architecture.md:1433`, `distribution_pipeline.md:614-616`. Measured with the merge profile's exact selection: **variants=55, failures=0**, `case=schema-v2-preview-epoch-bootstrap` present. Nightly selection (`full`+`epoch-bootstrap`) yields exactly **1** occurrence — pass-3's dedup still holds. Release selection: **58 variants, 0 failures**. `coverage_matrix` area PASS (`profile assignment matrix ok: rows=17`). |
+| 2 | `duplicate_smoke` / `extra_asset` negatives not load-bearing; no `alpha-assets`-else negative | **Resolved** for both remediations. Measured against weakened schema copies: baseline rejects all three negatives; `delete properties.public_smoke.allOf` → `duplicate_smoke=ACCEPT` (now load-bearing via the distinct `SHA_A` digest at `schema_contracts.py:78`); `delete top-level allOf` → `alpha_with_beta=ACCEPT` (else branch now load-bearing). |
+
+All pass-1/2/3 remediations remain. Re-verified: no schema-v1 parser/fixture/migration/fallback (`schema_epoch_bootstrap_workflow_contract.sh:145-151`); digest chain prepare→publish→live at `release-publication.yml:113-117,267-272,285-291,568-573`; `--clobber` pinned at 1; `bootstrap-alpha` never reaches the snapshot/replace/site steps; both `verify_site_workflow_identity.sh` call sites gated by count and ordering; `verify_release_publication_assets.sh:85-96` and `release-publication-prepare.yml:166-174` use matching prefix-stripped digest maps.
+
+Gates re-run: three contract cases PASS; file-size gate PASS (2898 files, `release-publication.yml` 795/900) and self-test PASS; `git diff --check` PASS; `stable_gate_inventory_selftest` exit 0; `ruff check` clean on every changed Python file (the 8 diagnostics are all in untouched files — reproduced under pyenv 3.10.12). Pass-4's cache-busting preflight item is closed by the ledger entry.
+
+## Actionable findings
+
+### 1. The bootstrap validator's guards are not pinned by the suite that now gates them — Low
+
+Pass 4 moved `epoch-bootstrap` into `merge.json` so the merge gate would cover `validate_bootstrap_evidence`/`materialize_bootstrap_evidence`. It now runs, but it does not *pin* them. Applying pass-4's own methodology to the validator, these single-line deletions each leave `governance.schema_bootstrap_selftest` green (rc=0):
+
+| `schema_bootstrap.py` | guard removed |
+|---|---|
+| `:217` | `or smoke_id in seen` (duplicate smoke id) |
+| `:217` | `smoke_id not in SMOKE_IDS` (unknown smoke id) |
+| `:209-210` | exactly-four `public_smoke` length check |
+| `:179` | `require_sha256(alpha_evidence["sha256"], …)` |
+| `:149-152` | `require_sha256(evidence["prepare_summary_sha256"], …)` |
+| `:238-239` | approver `normalized in seen` uniqueness |
+| `:469-470` | `release["status"] != "active"` |
+
+For contrast, these *are* detected: index generation, legacy `size_bytes`, both exact-asset-set checks, approver≠initiator, the staged-alpha stage/identity binding, and index↔record equality. The three `public_smoke` guards mask each other — `schema_bootstrap_selftest.py:142-144` appends a 5th duplicate, so removing both the length and dedup checks *is* caught; only a single-guard regression is invisible.
+
+This is the semantic half of the parity pair passes 2/#1, 3/#5 and 4/#2 spent three rounds closing, and it is the half that matters at publication time: the protected path calls only `release_governance.py validate --kind schema-bootstrap-evidence` and `materialize_bootstrap_evidence`; the JSON Schema is never consulted. A regression here is schema-stricter/validator-looser — the dangerous direction. Add to the `mutations` tuple at `schema_bootstrap_selftest.py:129-146`: a four-item `public_smoke` with a duplicated id and distinct digest; a four-item list with an unknown id; non-digest `alpha_evidence.sha256`; non-digest `prepare_summary_sha256`; `approvers: ["r", "R"]`; and a wrapper whose `release.status` is not `active`.
+
+### 2. `$defs/alpha_assets`'s `not: {minProperties: 10}` still has no isolating negative — Low
+
+`schema_contracts.py:80` adds the key `"unexpected"`, which `propertyNames` (`schema_epoch_bootstrap_evidence.schema.json:144-146`) rejects on its own. Measured: `delete $defs.alpha_assets.not` leaves `validate_schema_contracts` green, and the weakened schema then **accepts** an alpha block carrying a tenth *validly named* asset (`sifr-0.9.9-alpha.1-x86_64-apple-darwin.tar.gz`) that `validate_bootstrap_evidence:493-496` rejects. Exactly the shape of pass-4 finding 2, one constraint over. Use a validly named tenth asset for that negative, or add one beside it.
+
+## Not findings
+
+- `ruff format --check` would reformat `schema_bootstrap.py`, `schema_bootstrap_selftest.py`, `schema_contracts.py`, and `runner.py` — but it would also reformat 19 of 29 files in that package and is wired into no repo gate. Pre-existing style baseline, not this slice.
+- `iter_source_files` (`check_file_size_guardrails.py:133-134`) now walks `.yml`/`.yaml` under `crates`/`scripts`/`verification`/`demos` too, but `category_for_path` returns `None` for them — extra traversal only, no behavior change.
+- `distribution_release` is absent from `create-pr` entirely (`profile_assignment_matrix.json:98`), so `--profile create-pr` not running `epoch-bootstrap` matches `incident-governance` and is pre-existing.
+- `extra_asset`'s redundancy aside, the four cross-field semantics 2020-12 cannot express remain validator-stricter and semantically covered.
+- The fifth smoke output `${out}/stable-dispatcher.sh` is correctly outside `SMOKE_IDS`.
+- Post-`gh release create` failures remain unrecoverable by re-run; for `bootstrap-index` the evidence upload is necessarily last. Fail-loud stays correct.
+- `A && B || C` at `release-publication.yml:175` and `release-publication-prepare.yml:72` is correct for both false branches.
+
+## Commit mechanics and execution requirements (not implementation defects)
+
+- `plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-5.md` is a 0-byte untracked file. It must receive this report, be archived, and be ledgered in `plans/issues/active/phase-40-stable-channel-ga-execution.md` (passes 1–4 are at `:361-399`; pass 5 is absent). I did not modify it, per instruction.
+- Pass-1's external requirements stand: `stable-release` environment with ≥1 `release/distribution` reviewer and GitHub "prevent self-review" enabled; confirmation that no reviewers are attached to the auto-created `preview-release` environment; live `channels.json` still exactly 105 bytes / `71b3243925…4bf9ef` at `bootstrap-index` time; `sifr.sh` serving new dispatcher bytes inside the 180-second budget.
+- Still not locally reproducible: whether `actions/download-artifact@v4` resolves an attempt-1 artifact during "Re-run failed jobs". Validate on the first live re-run.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-6.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-6.md
@@ -1,0 +1,64 @@
+# Review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 6)
+
+I read the full `git diff`, all 16 untracked files, the phase/issue ledger, and archived passes 1–5, then independently re-ran the gates and re-ran pass-5's own mutation methodology against both the JSON Schema and the semantic validator. I did not modify any file.
+
+## Pass-5 re-audit
+
+| # | Pass-5 finding | Status |
+|---|---|---|
+| 1 | Bootstrap validator guards not pinned by the suite that gates them | **Partially resolved — 5 of 7 pinned.** See findings 1 and 2. |
+| 2 | `$defs/alpha_assets`'s `not: {minProperties: 10}` had no isolating negative | **Resolved.** `schema_contracts.py:79-81` now adds the validly named `sifr-0.9.9-alpha.1-x86_64-apple-darwin.tar.gz`, so `propertyNames` no longer masks the bound. Measured: `delete $defs.alpha_assets.not` now makes `validate_schema_contracts` **fail** (it was green in pass 5). `delete properties.public_smoke.allOf` and `delete top-level allOf` also still fail, so pass-4's two negatives remain load-bearing. |
+
+Re-verified as still in place: all pass-1/2/3/4 remediations; profile assignment across `merge`/`nightly`/`release` + matrix + `release_report.REQUIRED_SUITES` + `selftest.py` + `qualification_fixture.py`; the `full`-suite dedup; no schema-v1 parser/fixture/migration/fallback; digest chain prepare→publish→live; `--clobber` pinned at 1; both `verify_site_workflow_identity.sh` call sites gated by count and ordering; smoke-output filename freeze; the four-surface legacy-identity equality gate; pass-5 report archived and ledgered at `:401-407`.
+
+Gates re-run here: `governance.schema_bootstrap_selftest` PASS; `epoch-bootstrap` suite PASS (variants=1); merge-profile distribution selection PASS (**variants=55, failures=0**); the three contract cases PASS; `profile_assignment_matrix` PASS (rows=17); file-size gate PASS (2898 files, `release-publication.yml` 795/900); `git diff --check` clean; `ruff check` rc=0 on all changed Python (under pyenv 3.10.12).
+
+## Actionable findings
+
+### 1. The exactly-four `public_smoke` length guard — pass-5 item 3 — is still not pinned; the retained mutation is masked by the guard the same round made load-bearing — Low
+
+Measured: deleting `schema_bootstrap.py:209-210` leaves `governance.schema_bootstrap_selftest` at **rc=0**.
+
+The mutation retained for this (`schema_bootstrap_selftest.py:156-158`) appends a copy of `public_smoke[0]`, producing a *five*-item list with a duplicate id. Pass 5 already diagnosed the masking; this round pinned the dedup branch (`:159-166`) but kept the same length mutation, so the append is now caught by `smoke_id in seen` whether or not `:209-210` exists. Because `SMOKE_IDS` has exactly four members, no over-length list can isolate the guard — only a *short* one can. With `:209-210` deleted I confirmed a three-record `public_smoke` (all unique, all known ids) is **accepted** by `validate_bootstrap_evidence`, i.e. `release_governance.py validate --kind schema-bootstrap-evidence` would admit generation-1 evidence recording only three of the four public smokes. Add `lambda value: value["public_smoke"].pop()` to the `mutations` tuple.
+
+### 2. The `release["status"] != "active"` guard — pass-5 item 7 — is still not pinned; the new withdrawn case is rejected upstream — Low
+
+Measured: deleting `schema_bootstrap.py:469-470` leaves the self-test at **rc=0**.
+
+The added case (`schema_bootstrap_selftest.py:86-96`) sets `status = "withdrawn"` but leaves `incident_id` absent, so `validate_release_record` (`release_index.py:88-91`) rejects it first — I reproduced the actual diagnostic: `release[0.1.0-alpha.2].incident_id: must be a lowercase incident identifier`. The bootstrap-local guard is never reached. The isolating input is a withdrawn wrapper carrying a *valid* `incident_id`; with that, and only that, the guard fires (`alpha release.release.status: must be active`). Without it, `build_preview_epoch` would seat a withdrawn alpha or beta release as a generation-1 preview channel head. Set `withdrawn_alpha["release"]["incident_id"] = "inc-2026-001"` alongside the status change.
+
+### 3. The pass-5 ledger entry asserts both of the above are remediated — Low
+
+`plans/issues/active/phase-40-stable-channel-ga-execution.md:403-406` records "independent semantic mutations for smoke length … and active release status". Neither mutation is independent, as measured above. This is the durable record future rounds re-audit against; correct it with the remediation rather than leaving a claim the suite does not support.
+
+### 4. Five further guards in the same load-bearing function are unpinned — Low
+
+Applying pass-5's methodology beyond its own list, these single-edit deletions also leave `governance.schema_bootstrap_selftest` green:
+
+| `schema_bootstrap.py` | guard | behavior once removed (confirmed) |
+|---|---|---|
+| `:228-229` | `_validate_approvers` empty-list rejection | `"approvers": []` **accepted** |
+| `:146` | `require_positive_int(run_attempt)` | `run_attempt: 0` accepted |
+| `:207` | `require_sha256(index["sha256"])` | non-digest index digest accepted |
+| `:194-197` | `require_sha256(alpha_evidence["prepare_summary_sha256"])` | non-digest accepted |
+| `:490` | `require_sha256(release_record_sha256)` | non-digest accepted |
+
+The first is the consequential one: it is what makes the durable evidence prove a protected, non-initiating approval happened. Every guard is correct today — I verified each rejects on the current code — but the merge gate would not notice their removal, and the protected path consults only this validator, never the JSON Schema. Six mutations of the same shape as the ones already in the tuple close all five.
+
+## Not findings
+
+- Schema-side constraints `public_smoke.uniqueItems`/`minItems`/`maxItems`, `$defs/alpha_assets.propertyNames`, `$defs/approvers.{minItems,uniqueItems}`, and `$defs/beta_assets.not` are individually deletable without failing `validate_schema_contracts` — but each is redundantly covered by a sibling constraint that *is* pinned, and the schema is the secondary surface. Not worth chasing past finding 4.
+- The four cross-field semantics 2020-12 cannot express remain validator-stricter and semantically covered.
+- `profile_assignment_matrix.json` omitting `distribution_release:qualification` under `merge` is correct: `validate_row_membership` treats rows as a declared subset of the profile's selection, and the omission predates this slice.
+- `A && B || C` at `release-publication.yml:175` and `release-publication-prepare.yml:74` is correct for both false branches.
+- Post-`gh release create` failures remain unrecoverable by re-run; for `bootstrap-index` the evidence upload is necessarily last. Fail-loud stays correct.
+- The fifth smoke output `${out}/stable-dispatcher.sh` is correctly outside `SMOKE_IDS`.
+- `release-publication.yml` at 795/900 with the rest of 40.5 still to land; extraction discipline needs to continue, but no new evidence to reopen.
+
+## Commit mechanics and execution requirements (not implementation defects)
+
+- `plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-6.md` is a 0-byte untracked file. It must receive this report, be archived, and be ledgered (passes 1–5 are at `:361-407`). I did not modify it, per instruction.
+- Pass-1's external requirements stand: `stable-release` environment with ≥1 `release/distribution` reviewer and GitHub "prevent self-review" enabled; no reviewers attached to the auto-created `preview-release` environment; live `channels.json` still exactly 105 bytes / `71b3243925…4bf9ef` at `bootstrap-index` time; `sifr.sh` serving new dispatcher bytes inside the 180-second budget.
+- Still not locally reproducible: whether `actions/download-artifact@v4` resolves an attempt-1 artifact during "Re-run failed jobs". Validate on the first live re-run.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-7.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-7.md
@@ -1,0 +1,89 @@
+# Review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 7)
+
+I read the full diff, all 20 untracked files, the phase/issue ledger, and archived passes 1–6, then ran the requested single-guard deletion sweep **across the entire semantic bootstrap validator** rather than the seven guards pass 5 happened to name.
+
+## Method
+
+I generated 83 single-edit mutants of `schema_bootstrap.py` mechanically from its AST — one per boolean clause of every `if …: fail(…)`, one per dropped `require_*` statement, one per bypassed `x = require_*(y, …)` → `x = y` — ran `governance.schema_bootstrap_selftest` against each, and for every mutant the suite failed to kill, re-ran a 29-case bad-input battery against both entry paths (`validate_bootstrap_evidence`, and `materialize_bootstrap_evidence` at *both* the `alpha-assets` and `preview-index` stages) to separate genuinely load-bearing guards from ones masked by a sibling surface.
+
+**Result: 42 of 83 mutants survive the gate; 10 of those are load-bearing.** Every guard is correct today — all 29 bad inputs are rejected on the current code. The gap is entirely in what the merge-gated suite pins.
+
+## Pass-6 re-audit
+
+| # | Pass-6 finding | Status |
+|---|---|---|
+| 1 | Exactly-four `public_smoke` length guard unpinned | **Resolved.** `schema_bootstrap_selftest.py:198` adds the short-list `pop()`; deleting `schema_bootstrap.py:209-210` now kills the suite. |
+| 2 | `release["status"] != "active"` unpinned; withdrawn case rejected upstream | **Not resolved** — see finding 1. |
+| 3 | Ledger asserts an isolation the suite does not support | **Resolved for pass 5's entry, recurs in pass 6's** — see finding 4. |
+| 4 | Five further guards unpinned (`approvers: []`, `run_attempt`, index digest, alpha-stage prepare digest, `release_record_sha256`) | **Resolved.** All five mutants are now killed (`:160,158,167,175-177,181-183`). |
+
+All pass-1/2/3/4/5 remediations remain: `--clobber` pinned at 1; two `verify_site_workflow_identity.sh` call sites; `release-publication.yml` at 795/900; `epoch-bootstrap` in merge/nightly/release + matrix + `release_report`; no schema-v1 parser/fixture/migration/fallback; the four-surface legacy-identity gate; smoke-filename freeze.
+
+**Gates re-run:** `schema_bootstrap_selftest` PASS; `epoch-bootstrap` suite PASS (variants=1); merge-profile distribution selection PASS (**variants=55, failures=0**); `governance.selftest` PASS; all three contract cases PASS; file-size gate PASS (2898 files) and self-test PASS; `git diff --check` clean; `bash -n` over all `scripts/distribution/*.sh` clean. Two I could not reproduce: `ruff` is not resolvable under the active pyenv shim, and `coverage_matrix` needs the `uv` project env (`ModuleNotFoundError: sifr_verify`) — I verified `profile_assignment_matrix.json`'s three added rows by inspection instead. The working tree is unmodified; every mutant was reverted.
+
+## Findings
+
+### 1. The `release.status != "active"` guard is still unpinned — pass-6 finding 2 recurs, and the guard *is* load-bearing — Low-Medium
+
+`schema_bootstrap.py:469-470`. Measured: deleting both lines leaves `governance.schema_bootstrap_selftest` at **rc=0**.
+
+Pass 6 diagnosed the missing `incident_id`; that was added (`schema_bootstrap_selftest.py:100`), but the case still runs through `build_preview_epoch`, and with the guard deleted the input is caught one layer down by `validate_release_index`:
+
+```
+$.channels.alpha: must point at an active matching release
+```
+
+So the retained mutation exercises `release_index.py`, not the bootstrap-local guard — the same masking shape as the length/dedup pair pass 6 called out, one surface over. Because `validate_release_index` always re-checks channel heads, **no input routed through `build_preview_epoch` can ever isolate this guard.**
+
+The guard is not redundant, though. `_validate_release_wrapper` is also reached from `_materialize_release_evidence`, where no index validation follows. With `:469-470` deleted I confirmed:
+
+```
+alpha-assets producer, withdrawn alpha record + incident_id "inc-2026-001"
+  baseline → rejected: alpha release.release.status: must be active
+  guard deleted → ACCEPTED, durable evidence written
+```
+
+i.e. `bootstrap-alpha` would materialize write-once generation-1 alpha evidence attesting a withdrawn release. The isolating case must call `materialize_bootstrap_evidence(stage="alpha-assets", …)` with a withdrawn-but-valid alpha record, not `build_preview_epoch`.
+
+### 2. The producer's source-commit binding is unpinned — Low-Medium
+
+`schema_bootstrap.py:437-438`. Deleting leaves the suite green, and the alpha-assets producer then **accepts** a release record whose `source_commit` contradicts the workflow-supplied `--alpha-source-commit`, recording the supplied value in durable evidence. Nothing downstream catches it: `require_commit` at `:429` and `:489` only check the 40-hex *format*, and `_validate_release_evidence` never sees the record. This is the field that makes generation-1 evidence attributable to a reviewed commit.
+
+### 3. Eight more load-bearing guards in the same function set are unpinned — Low
+
+Each of these single-edit deletions leaves `governance.schema_bootstrap_selftest` green, and each admits a concrete bad input I confirmed is rejected today:
+
+| `schema_bootstrap.py` | guard | admitted once removed |
+|---|---|---|
+| `:435-436` | `record_version != version` | producer accepts a record whose `version` differs from the evidenced one |
+| `:487-488` | `version_channel(version) != channel` | `$.alpha` carrying a beta version and `$.beta` carrying an alpha version both accepted |
+| `:460` | `require_exact_keys(wrapper, {"version","release"})` | release wrapper with an arbitrary extra top-level key accepted |
+| `:42` (size clause) | `size_bytes != LEGACY_INDEX_SIZE_BYTES` | 104-byte legacy index with the correct digest accepted (the digest clause *is* pinned) |
+| `:227` | `require_array(payload, location)` in `_validate_approvers` | `"approvers": "x"` accepted |
+| `:234` | `require_nonempty_string(raw, …)` | `"approvers": [""]` accepted |
+| `:92` | `require_nonempty_string(initiator, …)` | `resolve_distinct_approvers(…, initiator="")` accepted — self-approval can no longer be excluded |
+| `:111` | `require_nonempty_string(user.get("login"), …)` | an approval whose `user.login` is `""` counted as a distinct approver |
+
+The last two matter most: they are what makes "a protected, non-initiating human approved this" a checkable claim rather than a formatting convention. Eight mutations of the same shape as the tuple entries already at `:153-211` close all of these; findings 1 and 2 need producer-path cases instead.
+
+### 4. The pass-6 ledger entry again asserts an isolation the suite does not support — Low
+
+`plans/issues/active/phase-40-stable-channel-ga-execution.md:408-415` records pass 6 as "remediated by isolating the short-smoke and valid-withdrawn-release cases." The short-smoke half is true (verified). The withdrawn half is not, per finding 1. Pass 6 raised exactly this against pass 5's entry and it was corrected; the correction re-introduced the same overclaim one entry down. This is the durable record future rounds re-audit against.
+
+## Not findings
+
+- **32 surviving mutants whose removal I could not make observable.** `:268` (producer legacy-identity custody — masked by `$.legacy_index.sha256` in the final `validate_bootstrap_evidence`), `:310` (producer generation-1 — masked by `$.index.generation`), `:388`/`:397` clauses (masked by the pinned `index["releases"]` equality and by `validate_release_index`), `:429` (`require_commit` — re-checked at `:489`), `:462` (masked by `validate_release_record`'s own channel check), and the seven `:294` `is None` clauses (each masked by its six siblings in the all-omitted test). Defense-in-depth, correctly ordered; not worth mutation cases.
+- The 14 `require_object`/`require_array` type guards fail closed when removed, but via an uncaught `TypeError` rather than a governed diagnostic. Structural typing is covered by the JSON Schema, which the protected path never consults — worth knowing, not worth a finding.
+- Schema-side: `duplicate_smoke`, `extra_asset` (validly named tenth asset), and `alpha_with_beta` remain the three load-bearing negatives pass 6 measured; `schema_contracts.py:66-95` is unchanged.
+- The four cross-field semantics 2020-12 cannot express remain validator-stricter and semantically covered.
+- Post-`gh release create` failures remain unrecoverable by re-run; the `bootstrap-index` evidence upload is necessarily last. Fail-loud stays correct.
+- The fifth smoke output `${out}/stable-dispatcher.sh` is correctly outside `SMOKE_IDS`.
+
+## Commit mechanics and execution requirements (not implementation defects)
+
+- `plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-7.md` is a 0-byte untracked file. It must receive this report, be archived, and be ledgered (passes 1–6 are at `:361-415`). I did not modify it, per instruction.
+- Pass-1's external requirements stand: `stable-release` environment with ≥1 `release/distribution` reviewer and "prevent self-review" enabled; no reviewers on the auto-created `preview-release` environment; live `channels.json` still exactly 105 bytes / `71b3243925…4bf9ef` at `bootstrap-index` time; `sifr.sh` serving new dispatcher bytes inside the 180-second budget.
+- Still not locally reproducible: `actions/download-artifact@v4` resolving an attempt-1 artifact during "Re-run failed jobs". Validate on the first live re-run.
+- `ruff` and the `coverage_matrix` area could not be executed in this environment (see above); both were green in pass 6 and the relevant files are unchanged, but I am not vouching for them independently this round.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-8.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-8.md
@@ -1,0 +1,71 @@
+# Review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 8)
+
+I read the full `git diff`, all 20 untracked files, the phase/issue ledger, and archived passes 1–7, then re-ran pass-7's full-validator mutant methodology from scratch. I generated **83** single-edit mutants of `schema_bootstrap.py` mechanically from its AST (one per `or`-clause of every `if …: fail(…)`, one per dropped `require_*` statement, one per bypassed `x = require_*(y, …)`) and ran `governance.schema_bootstrap_selftest` against each, then probed every survivor at its real entry path (`validate_bootstrap_evidence`, `build_preview_epoch`, `resolve_distinct_approvers`, and `materialize_bootstrap_evidence` at both stages).
+
+**Result: 33 of 83 survive (was 42); exactly 1 is load-bearing (was 10).**
+
+### Pass-7 re-audit — 9 of 10 load-bearing guards now killed
+
+| `schema_bootstrap.py` | pass-7 item | mutant | status |
+|---|---|---|---|
+| `:469-470` `status != "active"` | F1 | 73 | **killed** — `schema_bootstrap_selftest.py:424-439` now calls the `alpha-assets` producer with a withdrawn-but-valid record, the entry path pass 7 identified |
+| `:437-438` `source_commit` binding | F2 | 67 | **killed** (`:440-446`) |
+| `:435-436` `record_version != version` | F3 | 66 | **killed** (`:487-493`) |
+| `:487-488` `version_channel != channel` | F3 | 77 | **killed** (`:218-220`) |
+| `:460` `require_exact_keys(wrapper)` | F3 | 70 | **killed** (`:107-117`) |
+| `:42` size clause | F3 | 0 | **killed** (`:89-97`) |
+| `:234` `require_nonempty_string(raw)` | F3 | 46 | **killed** (`:198`) |
+| `:92` `require_nonempty_string(initiator)` | F3 | 3 | **killed** (`:143-149`) |
+| `:111` `user.login` | F3 | 9 | **killed** (`:150-158`) |
+| `:227` `require_array` in `_validate_approvers` | F3 | 44 | **not killed** — finding 1 |
+
+Pass-7 F4 (ledger) is addressed for pass 6's entry; pass 7's own entry carries a narrower version of the same overclaim — finding 2.
+
+The 32 other survivors are all in pass-7's declared not-findings set and I re-confirmed they fail closed via a pinned sibling: `:268`, `:310`, the `:388`/`:397` clauses, `:429`, `:462`, the seven `:294` `is None` clauses, and the type guards. I additionally probed the four `require_nonempty_string` bypasses pass 7 did not enumerate individually (mutants 4, 39, 71, 76 at `:93`, `:216`, `:461`, `:486`) — all still reject their bad input via a sibling (`smoke_id not in SMOKE_IDS`, `version_channel`, the `environment` default constant). Not findings.
+
+**Gates re-run:** `schema_bootstrap_selftest` PASS; `epoch-bootstrap` suite PASS (variants=1); merge-profile distribution selection PASS (**variants=56, failures=0**); `governance.selftest` PASS (tests=14); `validate_schema_contracts` PASS; all three contract cases PASS; file-size gate PASS (2898 files, `release-publication.yml` 795/900); `ruff check` **rc=0** on all 11 changed/new Python files (resolved under pyenv 3.10.12 — pass 7 could not run this); `bash -n` clean over `scripts/distribution/*.sh`; `git diff --check` PASS. Pass-6's three schema-side negatives re-measured as still load-bearing (deleting `properties.public_smoke.allOf`, the top-level `allOf`, or `$defs.alpha_assets.not` each fails `validate_schema_contracts`). Structural remediations intact: `--clobber` at 1, two `verify_site_workflow_identity.sh` call sites, no schema-v1 surface, `epoch-bootstrap` in merge/nightly/release + matrix rows 102/107/112 + `release_report.py:46`.
+
+Mutation testing required temporarily rewriting `schema_bootstrap.py` and the evidence JSON Schema. Both were restored and verified byte-identical (`schema_bootstrap.py` sha `90cb386a…`; schema `diff` clean). The working tree is unmodified; I wrote nothing to `plans/`.
+
+## Actionable findings
+
+### 1. `_validate_approvers`' array-container guard (`:227`) is still unpinned — pass-7 finding 3 recurs — Low
+
+`schema_bootstrap.py:227`. Deleting it (`values = payload` instead of `require_array(payload, location)`) leaves `governance.schema_bootstrap_selftest` at **rc=0**.
+
+The mutation added for it (`schema_bootstrap_selftest.py:197`, `"approvers": "release-reviewer"`) does not isolate the guard. Measured with `:227` bypassed:
+
+```
+"approvers": "release-reviewer"  → rejected: $.approvers[3]: must be a unique GitHub login
+"approvers": "abc"               → ACCEPTED   (approvers a, b, c)
+"approvers": "x"                 → ACCEPTED
+"approvers": {"a": 1}            → ACCEPTED
+```
+
+The chosen string happens to repeat the character `e`, so the per-character walk trips the `normalized in seen` dedup at `:238-239` — the guard passes 5, 6 and 7 each spent a round making load-bearing. Any string of distinct characters, or a mapping, slips through. Baseline rejects all four with `$.approvers: must be an array`, so the guard is correct today and genuinely load-bearing: with it gone, `release_governance.py validate --kind schema-bootstrap-evidence` would admit durable generation-1 evidence whose `approvers` is a bare scalar rather than the list of protected-environment logins it is supposed to attest — and the protected path never consults the JSON Schema that would otherwise catch the type. Replace or supplement `:197` with `"approvers": "abc"` (or `{"a": 1}`).
+
+### 2. The pass-7 ledger entry asserts an isolation the suite does not support — Low
+
+`plans/issues/active/phase-40-stable-channel-ga-execution.md:418-424` records pass 7 as remediated with "direct guards for … approver container/value types". The *value* half is true (`:234`, mutant 46, killed). The *container* half is not, per finding 1. This is the third consecutive round in which the ledger entry claims an isolation one guard broader than the suite delivers (pass-6 F3 against pass 5, pass-7 F4 against pass 6). Correct it alongside the remediation rather than leaving the durable record ahead of the gate.
+
+## Not findings
+
+- 32 surviving mutants re-confirmed masked by a pinned sibling, as enumerated above. Correctly ordered defense-in-depth.
+- Merge-profile selection is 56 variants this round vs pass-7's 55; the delta is an added case in the area manifest, and failures remain 0 with `schema-v2-preview-epoch-bootstrap` appearing exactly once (the `full`+`epoch-bootstrap` dedup from pass 3 still holds).
+- `ruff format --check` would still reformat several files in the package; wired into no repo gate, pre-existing baseline.
+- The four cross-field semantics 2020-12 cannot express remain validator-stricter and semantically covered.
+- Post-`gh release create` failures remain unrecoverable by re-run; the `bootstrap-index` evidence upload is necessarily last. Fail-loud stays correct.
+- The fifth smoke output `${out}/stable-dispatcher.sh` is correctly outside `SMOKE_IDS`.
+- `A && B || C` at `release-publication.yml:175` and `release-publication-prepare.yml:74` is correct for both false branches.
+
+## Commit mechanics and downstream execution requirements (not implementation defects)
+
+- `plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-8.md` is a 0-byte untracked file. It must receive this report, be archived, and be ledgered (passes 1–7 are at `:361-424`). I did not modify it, per instruction.
+- Downstream, not implementation prerequisites: `stable-release` environment with ≥1 `release/distribution` reviewer and "prevent self-review" enabled; no reviewers on the auto-created `preview-release` environment; live `channels.json` still exactly 105 bytes / `71b3243925…4bf9ef` at `bootstrap-index` time; `sifr.sh` serving new dispatcher bytes inside the 180-second budget.
+- Still not locally reproducible: whether `actions/download-artifact@v4` resolves an attempt-1 artifact during "Re-run failed jobs". Validate on the first live re-run.
+
+## Whole-wave verdict
+
+The wave is one mutation case from done. Every structural, workflow, profile, schema, and producer-path finding from passes 1–7 is closed and re-measured green here, and the pass-7 sweep's load-bearing gap has gone from 10 guards to 1. The remaining defect is a test-coverage gap in the merge-gated suite, not a behavior defect — all guards are correct on the current code — but it is the same masking pattern that has now survived four consecutive rounds, and it sits on the guard that makes the approver attestation structurally checkable.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-9.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-9.md
@@ -1,0 +1,59 @@
+# Review: Phase 40 M40.5 schema-v2 preview epoch bootstrap (pass 9)
+
+I read the full `git diff`, all 20 untracked files, the phase/issue ledger, and archived passes 1–8, then regenerated pass-8's full-validator mutant sweep from scratch off `schema_bootstrap.py`'s AST (one mutant per `or`-clause of every `if …: fail(…)`, one per dropped `require_*`/`_validate_*`/`_require_*` statement, one per bypassed `x = require_*(y, …)`). **88 mutants; 33 survive.** Every mutation ran in a `/tmp` copy — the working tree was never touched (diffstat identical before and after: 21 files, 856/300).
+
+### Pass-8 remediation confirmed
+
+`_validate_approvers`' container guard (`schema_bootstrap.py:227`) is now **killed**. With `values = payload` substituted for `require_array(payload, location)`, the merge-gated selftest fails at `evidence mutation 7 unexpectedly passed` — the distinct-character scalar at `schema_bootstrap_selftest.py:197` (`"approvers": "abc"`) walks past the `normalized in seen` dedup that masked `"release-reviewer"` and lands on the container requirement. Pass-8 finding 2 is also closed: the ledger entry at `plans/issues/active/phase-40-stable-channel-ga-execution.md:423-429` now states the container/value isolation accurately and records pass 7's claim as retroactively made true.
+
+### Survivor audit
+
+32 of the 33 survivors are exactly pass-8's re-confirmed masked set — `:268`, `:310`, the `:388`/`:397` clauses, `:429`, `:462`, the seven `:294` `is None` clauses, the type-guard bypasses, and the four `require_nonempty_string` bypasses at `:93`, `:216`, `:461`, `:486`. I re-probed each at its real entry path; all still fail closed via a pinned sibling. Not findings.
+
+The 33rd is new — my generator emitted `_validate_*` drop-statements, a class pass 8's `require_*`-only generator did not produce.
+
+### Gates re-run
+
+`schema_bootstrap_selftest` PASS · named `epoch-bootstrap` suite PASS (variants=1) · full `distribution_release` area PASS (**variants=110, failures=0**, covering `validate_schema_contracts` and all contract cases) · `governance.selftest` PASS (tests=14) · `ruff check` **rc=0** on all 11 changed/new Python files (pyenv 3.10.12) · file-size gate PASS (2898 files) · `git diff --check` PASS. All earlier gates and remediations remain green.
+
+## Actionable findings
+
+### 1. `$.beta` release evidence is validated by exactly one unpinned call — Medium
+
+`verification/areas/distribution_release/governance/schema_bootstrap.py:198`. Replacing `_validate_release_evidence(evidence["beta"], "beta", "$.beta")` with `pass` leaves `governance.schema_bootstrap_selftest` at **rc=0**. Its alpha counterpart at `:163` (same mutant class, index 26) is killed — the asymmetry is the whole defect.
+
+The selftest's semantic mutation table (`schema_bootstrap_selftest.py:189-249`) carries seven mutations against `$.alpha` (`unexpected` key, wrong-channel version, bad `source_commit`, bad `release_record_sha256`, bad and popped `published_assets` entries, foreign asset set) and **zero** against `$.beta`. Measured with `:198` dropped:
+
+```
+beta.source_commit = "not-a-commit"             → ACCEPTED
+beta.release_record_sha256 = "not-a-digest"     → ACCEPTED
+beta = release_evidence("0.1.0-alpha.7")        → ACCEPTED
+beta.published_assets: one entry popped         → ACCEPTED
+beta.published_assets: one digest not-a-digest  → ACCEPTED
+beta.unexpected = True                          → ACCEPTED
+beta = "nope"                                   → ACCEPTED
+```
+
+Baseline rejects all seven, so the guard is correct today and genuinely load-bearing. It is also the sole gate on the durable path: `scripts/distribution/release_governance.py:221` maps `--kind schema-bootstrap-evidence` straight to `validate_bootstrap_evidence` and never consults `schema_epoch_bootstrap_evidence.schema.json`, whose `$defs.beta` (`:169`) would otherwise catch the shape. The merge-gated schema contracts only exercise `beta`'s presence/absence (`schema_contracts.py:71,88`), never its content. With `:198` gone, generation-1 evidence could durably attest a beta release whose version, source commit, record digest, or published asset set is unrelated to what was actually published — the same attestation the alpha half is pinned seven ways against.
+
+Add `$.beta` counterparts to the alpha mutations at `schema_bootstrap_selftest.py:215-234`. One wrong-channel case (`{"beta": release_evidence("0.1.0-alpha.7")}`) isolates the call on its own; mirroring the full alpha set restores symmetry.
+
+## Not findings
+
+- 32 surviving mutants re-confirmed masked by a pinned sibling. Correctly ordered defense-in-depth.
+- Full-area selection is 110 variants with `schema-v2-preview-epoch-bootstrap` appearing exactly once — the `full`+`epoch-bootstrap` dedup from pass 3 holds.
+- `ruff format --check` would still reformat several files in the package; wired into no repo gate, pre-existing baseline.
+- The four cross-field semantics 2020-12 cannot express remain validator-stricter and semantically covered.
+- Post-`gh release create` failures remain unrecoverable by re-run; fail-loud stays correct.
+
+## Commit mechanics and downstream execution requirements (not implementation defects)
+
+- `plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-9.md` is a 0-byte untracked file. It must receive this report, be archived, and be ledgered (passes 1–8 are at `:361-429`). I did not modify it, per instruction.
+- Downstream, not implementation prerequisites: `stable-release` environment with ≥1 `release/distribution` reviewer and "prevent self-review" enabled; no reviewers on the auto-created `preview-release` environment; live `channels.json` still exactly 105 bytes / `71b3243925…4bf9ef` at `bootstrap-index` time; `sifr.sh` serving new dispatcher bytes inside the 180-second budget.
+- Still not locally reproducible: whether `actions/download-artifact@v4` resolves an attempt-1 artifact during "Re-run failed jobs".
+
+## Whole-wave verdict
+
+Every structural, workflow, profile, schema, and producer-path finding from passes 1–8 is closed and re-measured green, and the approver-container guard that survived four rounds is now dead. The remaining defect is one more instance of the same masking pattern, surfaced only because this pass widened the mutant grammar to whole-validator-call deletions: the beta half of the release attestation carries none of the seven negatives its alpha twin does. It is a test-coverage gap, not a behavior defect — but it sits on the evidence field that binds generation 1 to a real published beta release, and it is a mechanical fix.
+
+VERDICT: NOT SATISFIED

--- a/scripts/check_file_size_guardrails.py
+++ b/scripts/check_file_size_guardrails.py
@@ -120,6 +120,8 @@ def category_for_path(rel_path: Path) -> str | None:
         return "python-tooling"
     if rel.startswith("verification/") and rel.endswith(".py"):
         return "python-verification"
+    if rel.startswith(".github/workflows/") and rel.endswith((".yml", ".yaml")):
+        return "github-workflow"
     if rel.startswith("demos/") and rel.endswith(".sifr"):
         return "sifr-demo"
     if rel.startswith("crates/sifr/tests/") and rel.endswith(".sifr"):
@@ -128,8 +130,8 @@ def category_for_path(rel_path: Path) -> str | None:
 
 
 def iter_source_files(repo_root: Path) -> Iterable[SourceFile]:
-    roots = ("crates", "scripts", "verification", "demos")
-    suffixes = (".rs", ".py", ".sifr")
+    roots = ("crates", "scripts", "verification", "demos", ".github/workflows")
+    suffixes = (".rs", ".py", ".sifr", ".yml", ".yaml")
     for root_name in roots:
         root = repo_root / root_name
         if not root.exists():
@@ -257,6 +259,7 @@ def run_self_test() -> None:
             "verification/areas/developer_tooling/check.py",
             "demos/sample.sifr",
             "crates/sifr/tests/e2e/pass/sample.sifr",
+            ".github/workflows/release.yml",
         )
         for rel in passing_included:
             write_lines(repo_root / rel, MAX_SOURCE_LINES)
@@ -266,6 +269,12 @@ def run_self_test() -> None:
         repo_root = Path(temp_dir)
         write_lines(repo_root / "scripts/oversized.py", MAX_SOURCE_LINES + 1)
         assert_violation(repo_root, "scripts/oversized.py", "python-tooling")
+
+    with tempfile.TemporaryDirectory(prefix="sifr-file-size-guardrail-") as temp_dir:
+        repo_root = Path(temp_dir)
+        workflow = ".github/workflows/oversized.yml"
+        write_lines(repo_root / workflow, MAX_SOURCE_LINES + 1)
+        assert_violation(repo_root, workflow, "github-workflow")
 
     excluded_oversized = (
         "target/generated.rs",

--- a/scripts/distribution/fetch_schema_bootstrap_alpha.sh
+++ b/scripts/distribution/fetch_schema_bootstrap_alpha.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "usage: fetch_schema_bootstrap_alpha.sh --repository OWNER/REPO --version X.Y.Z-alpha.N --evidence PATH --assets DIR --record PATH" >&2
+  exit 2
+}
+
+repository=""
+version=""
+evidence=""
+assets=""
+record=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repository) repository="${2:-}"; shift 2 ;;
+    --version) version="${2:-}"; shift 2 ;;
+    --evidence) evidence="${2:-}"; shift 2 ;;
+    --assets) assets="${2:-}"; shift 2 ;;
+    --record) record="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "${repository}" && -n "${version}" && -n "${evidence}" &&
+  -n "${assets}" && -n "${record}" ]] || usage
+[[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]] || usage
+test -f "${evidence}" || {
+  echo "schema-bootstrap-alpha: missing evidence: ${evidence}" >&2
+  exit 2
+}
+scripts/distribution/release_governance.py validate \
+  --kind schema-bootstrap-evidence \
+  --input "${evidence}" \
+  --require-canonical
+test "$(
+  jq -r '.stage + ":" + .alpha.version' "${evidence}"
+)" = "alpha-assets:${version}" || {
+  echo "schema-bootstrap-alpha: evidence identity mismatch" >&2
+  exit 2
+}
+alpha_source="$(jq -r '.alpha.source_commit' "${evidence}")"
+test "$(
+  gh api "repos/${repository}/git/ref/tags/${version}" --jq '.object.sha'
+)" = "${alpha_source}" || {
+  echo "schema-bootstrap-alpha: tag source mismatch" >&2
+  exit 2
+}
+mkdir -p "${assets}"
+gh release download "${version}" --repo "${repository}" --dir "${assets}"
+actual_names="$(
+  find "${assets}" -mindepth 1 -maxdepth 1 -type f -exec basename {} \; |
+    LC_ALL=C sort
+)"
+expected_names="$(jq -r '.alpha.published_assets | keys[]' "${evidence}" | LC_ALL=C sort)"
+test "${actual_names}" = "${expected_names}" || {
+  echo "schema-bootstrap-alpha: immutable asset set drifted" >&2
+  exit 2
+}
+while IFS=$'\t' read -r name expected; do
+  test "$(sha256sum "${assets}/${name}" | awk '{print $1}')" = "${expected}" || {
+    echo "schema-bootstrap-alpha: asset digest drifted: ${name}" >&2
+    exit 2
+  }
+done < <(
+  jq -r '.alpha.published_assets | to_entries[] | [.key, .value] | @tsv' \
+    "${evidence}"
+)
+scripts/distribution/release_governance.py build-release-record \
+  --version "${version}" \
+  --channel alpha \
+  --source-commit "${alpha_source}" \
+  --installer "${assets}/sifr-installer-${version}" \
+  --artifact-dir "${assets}" \
+  --out "${record}"
+test "$(sha256sum "${record}" | awk '{print $1}')" = "$(
+  jq -r '.alpha.release_record_sha256' "${evidence}"
+)" || {
+  echo "schema-bootstrap-alpha: release record is not reproducible" >&2
+  exit 2
+}

--- a/scripts/distribution/materialize_schema_bootstrap_evidence.py
+++ b/scripts/distribution/materialize_schema_bootstrap_evidence.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Materialize canonical evidence for one protected schema bootstrap stage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AREA_ROOT = REPO_ROOT / "verification" / "areas" / "distribution_release"
+sys.path.insert(0, str(AREA_ROOT))
+
+from governance.common import GovernanceError  # noqa: E402
+from governance.schema_bootstrap import materialize_bootstrap_evidence  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--stage", required=True, choices=("alpha-assets", "preview-index")
+    )
+    parser.add_argument("--run-id", required=True, type=int)
+    parser.add_argument("--run-attempt", required=True, type=int)
+    parser.add_argument("--initiator", required=True)
+    parser.add_argument("--approvers-json", required=True)
+    parser.add_argument("--prepare-summary", required=True)
+    parser.add_argument("--legacy-index", required=True)
+    parser.add_argument("--alpha-version", required=True)
+    parser.add_argument("--alpha-source-commit", required=True)
+    parser.add_argument("--alpha-record", required=True)
+    parser.add_argument("--alpha-assets", required=True)
+    parser.add_argument("--beta-version")
+    parser.add_argument("--beta-source-commit")
+    parser.add_argument("--beta-record")
+    parser.add_argument("--beta-assets")
+    parser.add_argument("--index")
+    parser.add_argument("--smoke-dir")
+    parser.add_argument("--alpha-evidence")
+    parser.add_argument("--out", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        approvers = json.loads(args.approvers_json)
+        if not isinstance(approvers, list):
+            raise GovernanceError("--approvers-json must be a JSON array")
+        materialize_bootstrap_evidence(
+            stage=args.stage,
+            run_id=args.run_id,
+            run_attempt=args.run_attempt,
+            initiator=args.initiator,
+            approvers=approvers,
+            prepare_summary_path=Path(args.prepare_summary),
+            legacy_index_path=Path(args.legacy_index),
+            alpha_version=args.alpha_version,
+            alpha_source_commit=args.alpha_source_commit,
+            alpha_record_path=Path(args.alpha_record),
+            alpha_assets_dir=Path(args.alpha_assets),
+            out=Path(args.out),
+            beta_version=args.beta_version,
+            beta_source_commit=args.beta_source_commit,
+            beta_record_path=Path(args.beta_record) if args.beta_record else None,
+            beta_assets_dir=Path(args.beta_assets) if args.beta_assets else None,
+            index_path=Path(args.index) if args.index else None,
+            smoke_dir=Path(args.smoke_dir) if args.smoke_dir else None,
+            alpha_evidence_path=(
+                Path(args.alpha_evidence) if args.alpha_evidence else None
+            ),
+        )
+    except (GovernanceError, OSError, json.JSONDecodeError) as exc:
+        print(f"schema-bootstrap-evidence: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/distribution/poll_site_release_run.sh
+++ b/scripts/distribution/poll_site_release_run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "usage: poll_site_release_run.sh --repository OWNER/REPO --workflow FILE --title TEXT --sha COMMIT --dispatched-at TIMESTAMP [--deadline-seconds N]" >&2
+  exit 2
+}
+
+repository=""
+workflow=""
+title=""
+sha=""
+dispatched_at=""
+deadline_seconds=1200
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repository) repository="${2:-}"; shift 2 ;;
+    --workflow) workflow="${2:-}"; shift 2 ;;
+    --title) title="${2:-}"; shift 2 ;;
+    --sha) sha="${2:-}"; shift 2 ;;
+    --dispatched-at) dispatched_at="${2:-}"; shift 2 ;;
+    --deadline-seconds) deadline_seconds="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+[[ -n "${repository}" && -n "${workflow}" && -n "${title}" &&
+  "${sha}" =~ ^[0-9a-f]{40}$ && -n "${dispatched_at}" &&
+  "${deadline_seconds}" =~ ^[1-9][0-9]*$ ]] || usage
+
+run_id=""
+query_failures=0
+poll_error=""
+poll_deadline=$((SECONDS + deadline_seconds))
+while (( SECONDS < poll_deadline )); do
+  remaining_seconds=$((poll_deadline - SECONDS))
+  (( remaining_seconds > 0 )) || break
+  set +e
+  runs="$(
+    timeout --foreground "${remaining_seconds}s" gh api \
+      --method GET \
+      --paginate \
+      --slurp \
+      "repos/${repository}/actions/workflows/${workflow}/runs" \
+      -f event=workflow_dispatch \
+      -f created="${dispatched_at}..*" \
+      -f per_page=100
+  )"
+  query_status=$?
+  set -e
+  [[ ${query_status} -ne 124 ]] || break
+  if [[ ${query_status} -ne 0 ]]; then
+    query_failures=$((query_failures + 1))
+    if (( query_failures >= 3 )); then
+      poll_error="could not query the correlated run after three attempts"
+      break
+    fi
+  else
+    query_failures=0
+    matched="$(
+      jq -r \
+        --arg title "${title}" \
+        --arg sha "${sha}" \
+        --arg since "${dispatched_at}" \
+        'first(
+           .[].workflow_runs[]
+           | select(.display_title == $title)
+           | select(.head_sha == $sha)
+           | select(.event == "workflow_dispatch")
+           | select(.created_at >= $since)
+           | [.id, .status, (.conclusion // "")]
+           | @tsv
+         ) // empty' <<<"${runs}"
+    )"
+    if [[ -n "${matched}" ]]; then
+      IFS=$'\t' read -r run_id status conclusion <<<"${matched}"
+      if [[ "${status}" == "completed" ]]; then
+        if [[ "${conclusion}" == "success" ]]; then
+          echo "Correlated site run ${run_id} completed successfully"
+          exit 0
+        fi
+        echo "site-release-poll: correlated run ${run_id} concluded ${conclusion}" >&2
+        exit 2
+      fi
+    fi
+  fi
+  remaining_seconds=$((poll_deadline - SECONDS))
+  if (( remaining_seconds > 0 )); then
+    sleep_seconds=10
+    (( remaining_seconds >= sleep_seconds )) || sleep_seconds="${remaining_seconds}"
+    sleep "${sleep_seconds}"
+  fi
+done
+if [[ -n "${run_id}" ]]; then
+  gh api --method POST "repos/${repository}/actions/runs/${run_id}/cancel" || true
+fi
+if [[ -n "${poll_error}" ]]; then
+  echo "site-release-poll: ${poll_error}" >&2
+  exit 2
+fi
+echo "site-release-poll: correlated deployment exceeded the deadline" >&2
+exit 2

--- a/scripts/distribution/release_governance.py
+++ b/scripts/distribution/release_governance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import re
 import subprocess
 import sys
@@ -18,22 +19,22 @@ sys.path.insert(0, str(AREA_ROOT))
 from governance import (  # noqa: E402
     GovernanceError,
     generate_site_release_facts,
+    validate_bootstrap_evidence,
     validate_incident_request,
     validate_incident_signoff,
+    validate_install_receipt,
+    validate_qualification_artifact_index,
     validate_release_index,
     validate_release_index_transition,
     validate_release_plan,
     validate_release_profile_report,
     validate_release_signoff,
-    validate_qualification_artifact_index,
-    validate_install_receipt,
     validate_self_update_plan,
     validate_self_version,
     validate_site_publication_facts,
     validate_site_release_facts,
 )
 from governance.common import (  # noqa: E402
-    canonical_json_bytes,
     load_json_strict,
     require_sha256,
     sha256_bytes,
@@ -41,9 +42,13 @@ from governance.common import (  # noqa: E402
     write_canonical_json,
 )
 from governance.incident_evidence import validate_incident_evidence_commit  # noqa: E402
-from governance.release_index import propose_preview_release, validate_release_record  # noqa: E402
 from governance.incident_planner import materialize_incident_mutation  # noqa: E402
 from governance.planner import materialize_stable_plan  # noqa: E402
+from governance.release_index import propose_preview_release, validate_release_record  # noqa: E402
+from governance.schema_bootstrap import (  # noqa: E402
+    build_preview_epoch,
+    resolve_distinct_approvers,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -56,6 +61,7 @@ def parse_args() -> argparse.Namespace:
         required=True,
         choices=(
             "release-index",
+            "schema-bootstrap-evidence",
             "release-plan",
             "release-signoff",
             "site-facts",
@@ -158,6 +164,15 @@ def parse_args() -> argparse.Namespace:
     evidence_commit.add_argument("--head", required=True)
     evidence_commit.add_argument("--request-path", required=True)
     evidence_commit.add_argument("--evidence-path", required=True)
+    bootstrap_index = commands.add_parser("generate-schema-bootstrap-index")
+    bootstrap_index.add_argument("--current", required=True)
+    bootstrap_index.add_argument("--alpha-release", required=True)
+    bootstrap_index.add_argument("--beta-release", required=True)
+    bootstrap_index.add_argument("--out", required=True)
+    approvers = commands.add_parser("resolve-publication-approvers")
+    approvers.add_argument("--approvals", required=True)
+    approvers.add_argument("--initiator", required=True)
+    approvers.add_argument("--environment", default="stable-release")
     return parser.parse_args()
 
 
@@ -186,6 +201,10 @@ def main() -> int:
             plan_incident_index(args)
         elif args.command == "validate-incident-evidence-commit":
             validate_incident_evidence(args)
+        elif args.command == "generate-schema-bootstrap-index":
+            generate_schema_bootstrap_index(args)
+        elif args.command == "resolve-publication-approvers":
+            resolve_publication_approvers(args)
         else:
             raise AssertionError(args.command)
     except GovernanceError as exc:
@@ -199,6 +218,7 @@ def validate_command(args: argparse.Namespace) -> None:
     payload = load_json_strict(path, require_canonical=args.require_canonical)
     validators: dict[str, Callable[[Any], Any]] = {
         "release-index": validate_release_index,
+        "schema-bootstrap-evidence": validate_bootstrap_evidence,
         "release-plan": validate_release_plan,
         "release-signoff": validate_release_signoff,
         "site-facts": validate_site_release_facts,
@@ -430,6 +450,28 @@ def validate_incident_evidence(args: argparse.Namespace) -> None:
         "release-governance incident evidence ok: "
         f"incident_id={request['incident_id']} operation={request['operation']}"
     )
+
+
+def generate_schema_bootstrap_index(args: argparse.Namespace) -> None:
+    legacy_bytes = Path(args.current).read_bytes()
+    payload = build_preview_epoch(
+        legacy_index_sha256=sha256_bytes(legacy_bytes),
+        legacy_index_size_bytes=len(legacy_bytes),
+        alpha_wrapper=load_json_strict(
+            Path(args.alpha_release), require_canonical=True
+        ),
+        beta_wrapper=load_json_strict(Path(args.beta_release), require_canonical=True),
+    )
+    write_canonical_json(Path(args.out), payload, refuse_existing=True)
+
+
+def resolve_publication_approvers(args: argparse.Namespace) -> None:
+    approvers = resolve_distinct_approvers(
+        load_json_strict(Path(args.approvals)),
+        initiator=args.initiator,
+        environment=args.environment,
+    )
+    print(json.dumps(approvers, separators=(",", ":")))
 
 
 def _require_clean_external_incident_directory(

--- a/scripts/distribution/run_schema_bootstrap_public_smoke.sh
+++ b/scripts/distribution/run_schema_bootstrap_public_smoke.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "usage: run_schema_bootstrap_public_smoke.sh --repository OWNER/REPO --version X.Y.Z-beta.N --index PATH --dispatchers DIR --out DIR" >&2
+  exit 2
+}
+
+repository=""
+version=""
+index=""
+dispatchers=""
+out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repository) repository="${2:-}"; shift 2 ;;
+    --version) version="${2:-}"; shift 2 ;;
+    --index) index="${2:-}"; shift 2 ;;
+    --dispatchers) dispatchers="${2:-}"; shift 2 ;;
+    --out) out="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "${repository}" && -n "${version}" && -n "${index}" &&
+  -n "${dispatchers}" && -n "${out}" ]] || usage
+[[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]] || usage
+test -f "${index}" && test -f "${dispatchers}/index" &&
+  test -f "${dispatchers}/stable" || usage
+test -z "${SIFR_TEST_CHANNEL_METADATA_PATH:-}" || {
+  echo "schema-bootstrap-smoke: qualification metadata override must be absent" >&2
+  exit 2
+}
+mkdir -p "${out}"
+
+download_until_matches() {
+  local url="$1"
+  local expected="$2"
+  local destination="$3"
+  local deadline=$((SECONDS + 180))
+  while (( SECONDS < deadline )); do
+    if curl -fsSL \
+      -H "Cache-Control: no-cache" \
+      "${url}?sifr_publication_smoke=${RANDOM}-${SECONDS}" \
+      -o "${destination}" &&
+      cmp "${expected}" "${destination}"
+    then
+      return 0
+    fi
+    sleep 5
+  done
+  echo "schema-bootstrap-smoke: public bytes did not converge: ${url}" >&2
+  return 2
+}
+
+live_index="${out}/governance-index.txt"
+download_until_matches \
+  "https://github.com/${repository}/releases/download/channels/channels.json" \
+  "${index}" \
+  "${live_index}"
+scripts/distribution/release_governance.py validate \
+  --kind release-index \
+  --input "${live_index}" \
+  --require-canonical
+
+default_dispatcher="${out}/dispatcher-default.txt"
+stable_dispatcher="${out}/stable-dispatcher.sh"
+download_until_matches https://sifr.sh/install "${dispatchers}/index" "${default_dispatcher}"
+download_until_matches \
+  https://sifr.sh/install/stable \
+  "${dispatchers}/stable" \
+  "${stable_dispatcher}"
+
+install_root="$(mktemp -d)"
+stable_root="$(mktemp -d)"
+stable_log="${out}/dispatcher-stable-rejection.txt"
+if HOME="${stable_root}" \
+  SIFR_INSTALL_DIR="${stable_root}/bin" \
+  SIFR_SYSROOT_INSTALL_DIR="${stable_root}" \
+  SIFR_NO_MODIFY_PATH=1 \
+  sh "${stable_dispatcher}" >"${stable_log}" 2>&1
+then
+  echo "schema-bootstrap-smoke: stable dispatcher activated during preview" >&2
+  exit 2
+fi
+grep -F "stable channel installs require active GA metadata" "${stable_log}" >/dev/null || {
+  echo "schema-bootstrap-smoke: stable rejection was not the governed preview result" >&2
+  exit 2
+}
+
+HOME="${install_root}" \
+SIFR_INSTALL_DIR="${install_root}/bin" \
+SIFR_SYSROOT_INSTALL_DIR="${install_root}" \
+  SIFR_NO_MODIFY_PATH=1 \
+  sh "${default_dispatcher}"
+"${install_root}/bin/sifr" self update --dry-run --format json \
+  >"${out}/installed-self-update.txt"
+scripts/distribution/release_governance.py validate \
+  --kind self-update-plan \
+  --input "${out}/installed-self-update.txt"
+test "$(
+  jq -r '.target_version + ":" + .resolved_channel + ":" + (.would_run_installer | tostring)' \
+    "${out}/installed-self-update.txt"
+)" = "${version}:beta:false" || {
+  echo "schema-bootstrap-smoke: installed beta did not resolve a public no-op plan" >&2
+  exit 2
+}

--- a/scripts/distribution/verify_release_publication_assets.sh
+++ b/scripts/distribution/verify_release_publication_assets.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "usage: verify_release_publication_assets.sh --version X.Y.Z-CHANNEL.N --assets DIR --prepare-summary PATH" >&2
+  exit 2
+}
+
+version=""
+assets=""
+prepare_summary=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) version="${2:-}"; shift 2 ;;
+    --assets) assets="${2:-}"; shift 2 ;;
+    --prepare-summary) prepare_summary="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+[[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta)\.[0-9]+$ &&
+  -d "${assets}" && -f "${prepare_summary}" ]] || usage
+
+for target in \
+  aarch64-apple-darwin \
+  x86_64-apple-darwin \
+  x86_64-unknown-linux-gnu \
+  aarch64-unknown-linux-gnu
+do
+  archive="${assets}/sifr-${version}-${target}.tar.gz"
+  checksum="${archive}.sha256"
+  test -f "${archive}" || {
+    echo "release-publication-assets: missing ${archive}" >&2
+    exit 2
+  }
+  test -f "${checksum}" || {
+    echo "release-publication-assets: missing ${checksum}" >&2
+    exit 2
+  }
+  expected="$(tr -d '[:space:]' <"${checksum}")"
+  actual="$(sha256sum "${archive}" | awk '{print $1}')"
+  test "${expected}" = "${actual}" || {
+    echo "release-publication-assets: checksum mismatch for ${archive}" >&2
+    exit 2
+  }
+  scripts/distribution/verify_release_archive.py \
+    "${archive}" \
+    --version "${version}" \
+    --target "${target}"
+done
+
+scripts/distribution/generate_version_installer.sh \
+  --version "${version}" \
+  --artifact-dir "${assets}" \
+  --out "${assets}/sifr-installer-${version}"
+expected_names="$(
+  {
+    for target in \
+      aarch64-apple-darwin \
+      x86_64-apple-darwin \
+      x86_64-unknown-linux-gnu \
+      aarch64-unknown-linux-gnu
+    do
+      echo "sifr-${version}-${target}.tar.gz"
+      echo "sifr-${version}-${target}.tar.gz.sha256"
+    done
+    echo "sifr-installer-${version}"
+  } | LC_ALL=C sort
+)"
+actual_names="$(
+  find "${assets}" -mindepth 1 -maxdepth 1 -type f -exec basename {} \; |
+    LC_ALL=C sort
+)"
+if [[ "${actual_names}" != "${expected_names}" ]]; then
+  echo "release-publication-assets: asset set is incomplete or unexpected" >&2
+  diff -u <(printf '%s\n' "${expected_names}") \
+    <(printf '%s\n' "${actual_names}") || true
+  exit 2
+fi
+
+publish_asset_digests="$(
+  find "${assets}" -mindepth 1 -maxdepth 1 -type f -print0 |
+    LC_ALL=C sort -z |
+    xargs -0 sha256sum |
+    jq -Rn --arg prefix "${assets}/" '
+      [
+        inputs
+        | capture("^(?<sha>[0-9a-f]{64})  (?<path>.+)$")
+        | {key:(.path | ltrimstr($prefix)), value:.sha}
+      ]
+      | from_entries
+    '
+)"
+jq -e \
+  --argjson assets "${publish_asset_digests}" \
+  '.assets == $assets' "${prepare_summary}" >/dev/null || {
+  echo "release-publication-assets: bytes differ from read-only prepare" >&2
+  exit 2
+}

--- a/scripts/distribution/verify_site_workflow_identity.sh
+++ b/scripts/distribution/verify_site_workflow_identity.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "usage: verify_site_workflow_identity.sh --repository OWNER/REPO --ruleset-id ID --ruleset-updated-at TIMESTAMP --workflow-ref REF --site-commit SHA --workflow PATH --workflow-sha256 SHA256" >&2
+  exit 2
+}
+
+repository=""
+ruleset_id=""
+ruleset_updated_at=""
+workflow_ref=""
+site_commit=""
+workflow=""
+workflow_sha256=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repository) repository="${2:-}"; shift 2 ;;
+    --ruleset-id) ruleset_id="${2:-}"; shift 2 ;;
+    --ruleset-updated-at) ruleset_updated_at="${2:-}"; shift 2 ;;
+    --workflow-ref) workflow_ref="${2:-}"; shift 2 ;;
+    --site-commit) site_commit="${2:-}"; shift 2 ;;
+    --workflow) workflow="${2:-}"; shift 2 ;;
+    --workflow-sha256) workflow_sha256="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "${GH_TOKEN:-}" && -n "${repository}" &&
+  "${ruleset_id}" =~ ^[1-9][0-9]*$ &&
+  -n "${ruleset_updated_at}" && -n "${workflow_ref}" &&
+  "${site_commit}" =~ ^[0-9a-f]{40}$ && -n "${workflow}" &&
+  "${workflow_sha256}" =~ ^[0-9a-f]{64}$ ]] || usage
+
+site_ruleset="$(
+  gh api \
+    -H "Time-Zone: UTC" \
+    "repos/${repository}/rulesets/${ruleset_id}"
+)"
+if ! jq -e \
+  --arg ref "refs/tags/${workflow_ref}" \
+  --arg updated_at "${ruleset_updated_at}" \
+  --argjson id "${ruleset_id}" \
+  '.id == $id
+   and .target == "tag"
+   and .enforcement == "active"
+   and .updated_at == $updated_at
+   and .conditions.ref_name.include == [$ref]
+   and .conditions.ref_name.exclude == []
+   and (.bypass_actors // []) == []
+   and (.current_user_can_bypass // "never") == "never"
+   and ([.rules[].type] | sort) == ["deletion", "update"]' \
+  <<<"${site_ruleset}" >/dev/null
+then
+  echo "site-workflow-identity: immutable tag ruleset is not active and exact" >&2
+  exit 2
+fi
+
+site_dispatch_sha="$(
+  gh api \
+    "repos/${repository}/git/ref/tags/${workflow_ref}" \
+    --jq '.object.sha'
+)"
+if [[ "${site_dispatch_sha}" != "${site_commit}" ]]; then
+  echo "site-workflow-identity: protected workflow tag moved" >&2
+  exit 2
+fi
+
+site_workflow="$(mktemp)"
+gh api \
+  -H "Accept: application/vnd.github.raw+json" \
+  "repos/${repository}/contents/.github/workflows/${workflow}?ref=${site_commit}" \
+  >"${site_workflow}"
+actual_sha256="$(sha256sum "${site_workflow}" | awk '{print $1}')"
+if [[ "${actual_sha256}" != "${workflow_sha256}" ]]; then
+  echo "site-workflow-identity: pinned workflow bytes do not match the reviewed contract" >&2
+  exit 2
+fi

--- a/verification/areas/coverage_matrix/profile_assignment_matrix.json
+++ b/verification/areas/coverage_matrix/profile_assignment_matrix.json
@@ -98,15 +98,18 @@
         "create-pr": [],
         "merge": [
           "distribution_release:representative",
-          "distribution_release:incident-governance"
+          "distribution_release:incident-governance",
+          "distribution_release:epoch-bootstrap"
         ],
         "nightly": [
           "distribution_release:full",
-          "distribution_release:incident-governance"
+          "distribution_release:incident-governance",
+          "distribution_release:epoch-bootstrap"
         ],
         "release": [
           "distribution_release:full",
-          "distribution_release:incident-governance"
+          "distribution_release:incident-governance",
+          "distribution_release:epoch-bootstrap"
         ]
       }
     },

--- a/verification/areas/distribution_release/cases/preview_release_workflow_yaml_parses.sh
+++ b/verification/areas/distribution_release/cases/preview_release_workflow_yaml_parses.sh
@@ -6,15 +6,20 @@ source "$(dirname "$0")/common.sh"
 
 preview="${REPO_ROOT}/.github/workflows/preview-release.yml"
 publication="${REPO_ROOT}/.github/workflows/release-publication.yml"
+prepare="${REPO_ROOT}/.github/workflows/release-publication-prepare.yml"
+poller="${REPO_ROOT}/scripts/distribution/poll_site_release_run.sh"
 ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "${preview}" >/dev/null
 ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "${publication}" >/dev/null
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "${prepare}" >/dev/null
 
-python3 - "${preview}" "${publication}" <<'PY'
+python3 - "${preview}" "${publication}" "${prepare}" "${poller}" <<'PY'
 import pathlib
 import sys
 
 preview = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 publication = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+prepare = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
+poller = pathlib.Path(sys.argv[4]).read_text(encoding="utf-8")
 
 preview_required = (
     "options:\n          - alpha\n          - beta",
@@ -23,6 +28,9 @@ preview_required = (
     "preview release must pin an exact merged website commit",
     "cargo build --release --locked",
     "uses: ./.github/workflows/release-publication.yml",
+    "bootstrap-alpha",
+    "bootstrap-index",
+    "bootstrap_alpha_version",
     "permissions:\n      actions: read\n      contents: write",
     "SIFR_WEBSITE_ACTIONS_TOKEN: ${{ secrets.SIFR_WEBSITE_ACTIONS_TOKEN }}",
 )
@@ -42,6 +50,15 @@ for forbidden in ("-rc.", "alpha|beta|rc", "stable\n          -"):
 
 publication_required = (
     "group: sifr-release-index",
+    "uses: ./.github/workflows/release-publication-prepare.yml",
+    "name: ${{ inputs.governance_mode == 'preview' && 'preview-release' || 'stable-release' }}",
+    "actions/runs/${GITHUB_RUN_ID}/approvals",
+    "resolve-publication-approvers",
+    "--initiator \"${GITHUB_TRIGGERING_ACTOR}\"",
+    "generate-schema-bootstrap-index",
+    "schema-v2-bootstrap-generation-1.json",
+    "run_schema_bootstrap_public_smoke.sh",
+    "materialize_schema_bootstrap_evidence.py",
     "release-publication accepts only alpha or beta",
     "version release already exists; preview assets are write-once",
     "version tag already exists; release source identity is write-once",
@@ -54,13 +71,8 @@ publication_required = (
     "--clobber",
     "site_base_commit must be an exact commit",
     "repos/${SITE_REPOSITORY}/actions/workflows/${SITE_WORKFLOW}/dispatches",
-    "select(.head_sha == $sha)",
-    "select(.created_at >= $since)",
     "timeout-minutes: 60",
-    "poll_deadline=$((SECONDS + 1200))",
-    "poll_query_failures >= 3",
-    'timeout --foreground "${remaining_seconds}s" gh api',
-    "actions/runs/${site_run_id}/cancel",
+    "poll_site_release_run.sh",
 )
 for fragment in publication_required:
     if fragment not in publication:
@@ -70,10 +82,42 @@ if publication.count("--clobber") != 1:
 if "gh release upload \"${VERSION}\"" in publication:
     raise SystemExit("version assets must not use a mutable upload path")
 if "stable|alpha|beta" in publication or "choices=(\"stable\"" in publication:
-    raise SystemExit("stable mutation must remain absent from milestone 40.2")
+    raise SystemExit("stable mutation must remain absent from the preview/bootstrap workflow")
 snapshot = publication.index('gh release upload channels "${snapshot}"')
 replacement = publication.index("Replace only canonical channels.json")
 dispatch = publication.index("Dispatch exact site workflow")
 if not snapshot < replacement < dispatch:
     raise SystemExit("snapshot, index replacement, and site dispatch are misordered")
+
+prepare_required = (
+    "permissions:\n  actions: read\n  contents: read",
+    "prepare governed publication",
+    'summary_artifact_name="publication-prepare-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+    "name: ${{ steps.summary.outputs.summary_artifact_name }}",
+    "one-time bootstrap source is not the exact opaque v1 asset",
+    "--kind schema-bootstrap-evidence",
+    "retention-days: 30",
+    "overwrite: false",
+)
+for fragment in prepare_required:
+    if fragment not in prepare:
+        raise SystemExit(f"prepare workflow omitted governed fragment: {fragment}")
+if "contents: write" in prepare or "environment:" in prepare:
+    raise SystemExit("prepare workflow must remain read-only and unprotected")
+
+poll_required = (
+    "poll_deadline=$((SECONDS + deadline_seconds))",
+    "query_failures >= 3",
+    'timeout --foreground "${remaining_seconds}s" gh api',
+    "select(.head_sha == $sha)",
+    "select(.created_at >= $since)",
+    'actions/runs/${run_id}/cancel',
+)
+for fragment in poll_required:
+    if fragment not in poller:
+        raise SystemExit(f"site poller omitted governed fragment: {fragment}")
+if not poller.index('poll_error="could not query') < poller.index(
+    'actions/runs/${run_id}/cancel'
+):
+    raise SystemExit("site poller must cancel a matched run after repeated query failure")
 PY

--- a/verification/areas/distribution_release/cases/schema_epoch_bootstrap_workflow_contract.sh
+++ b/verification/areas/distribution_release/cases/schema_epoch_bootstrap_workflow_contract.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+python3 - "${REPO_ROOT}" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+caller = (root / ".github/workflows/preview-release.yml").read_text(encoding="utf-8")
+publication = (root / ".github/workflows/release-publication.yml").read_text(encoding="utf-8")
+prepare = (root / ".github/workflows/release-publication-prepare.yml").read_text(
+    encoding="utf-8"
+)
+bootstrap = (
+    root
+    / "verification/areas/distribution_release/governance/schema_bootstrap.py"
+).read_text(encoding="utf-8")
+evidence_schema = (
+    root
+    / "verification/areas/distribution_release/schemas/schema_epoch_bootstrap_evidence.schema.json"
+).read_text(encoding="utf-8")
+smoke = (
+    root / "scripts/distribution/run_schema_bootstrap_public_smoke.sh"
+).read_text(encoding="utf-8")
+alpha = (
+    root / "scripts/distribution/fetch_schema_bootstrap_alpha.sh"
+).read_text(encoding="utf-8")
+assets = (
+    root / "scripts/distribution/verify_release_publication_assets.sh"
+).read_text(encoding="utf-8")
+
+for fragment in (
+    "bootstrap-alpha",
+    "bootstrap-index",
+    "bootstrap_alpha_version",
+    "test \"${INPUT_CHANNEL}\" = \"alpha\"",
+    "test \"${INPUT_CHANNEL}\" = \"beta\"",
+):
+    assert fragment in caller, fragment
+for fragment in (
+    "uses: ./.github/workflows/release-publication-prepare.yml",
+    "name: ${{ needs.prepare.outputs.summary_artifact_name }}",
+    "name: ${{ inputs.governance_mode == 'preview' && 'preview-release' || 'stable-release' }}",
+    "actions/runs/${GITHUB_RUN_ID}/approvals",
+    "--initiator \"${GITHUB_TRIGGERING_ACTOR}\"",
+    "governed index changed after read-only prepare",
+    "staged alpha evidence changed after read-only prepare",
+    "generate-schema-bootstrap-index",
+    "channels-generation-${PROPOSED_GENERATION}.json",
+    "Retain protected alpha bootstrap evidence",
+    "Run protected public schema-bootstrap smoke",
+    "Retain final protected schema-bootstrap evidence",
+    "schema-v2-bootstrap-generation-1.json",
+    "--out publication/bootstrap-smoke",
+    "--smoke-dir publication/bootstrap-smoke",
+):
+    assert fragment in publication, fragment
+for fragment in (
+    "verify_release_publication_assets.sh",
+    "protected-prepare/summary.json",
+):
+    assert fragment in publication, fragment
+for fragment in (
+    "generate_version_installer.sh",
+    "asset set is incomplete or unexpected",
+    "bytes differ from read-only prepare",
+):
+    assert fragment in assets, fragment
+assert publication.index("Publish write-once version release and verify assets") < publication.index(
+    "Retain protected alpha bootstrap evidence"
+)
+assert publication.index('gh release upload channels "${snapshot}"') < publication.index(
+    "Replace only canonical channels.json"
+)
+assert publication.index("Replace only canonical channels.json") < publication.index(
+    "Dispatch exact site workflow"
+)
+assert publication.index("Dispatch exact site workflow") < publication.index(
+    "Run protected public schema-bootstrap smoke"
+)
+assert publication.index("Run protected public schema-bootstrap smoke") < publication.index(
+    "Retain final protected schema-bootstrap evidence"
+)
+assert publication.count("--clobber") == 1
+assert "contents: write" not in prepare
+assert "environment:" not in prepare
+for fragment in (
+    "actions: read",
+    "contents: read",
+    "one-time bootstrap source is not the exact opaque v1 asset",
+    'summary_artifact_name="publication-prepare-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+    "name: ${{ steps.summary.outputs.summary_artifact_name }}",
+    "retention-days: 30",
+    "overwrite: false",
+):
+    assert fragment in prepare, fragment
+for fragment in (
+    "LEGACY_INDEX_SHA256",
+    "LEGACY_INDEX_SIZE_BYTES",
+    "BOOTSTRAP_GENERATION = 1",
+    "approval by someone other than",
+    '"ga_status": "preview"',
+    '"channels": {',
+):
+    assert fragment in bootstrap, fragment
+assert '"stable":' not in bootstrap
+for fragment in (
+    "https://sifr.sh/install",
+    "https://sifr.sh/install/stable",
+    "SIFR_TEST_CHANNEL_METADATA_PATH",
+    "SIFR_SYSROOT_INSTALL_DIR",
+    'test -z "${SIFR_TEST_CHANNEL_METADATA_PATH:-}"',
+    "self update --dry-run --format json",
+    "stable channel installs require active GA metadata",
+    '${out}/governance-index.txt',
+    '${out}/dispatcher-default.txt',
+    '${out}/dispatcher-stable-rejection.txt',
+    '${out}/installed-self-update.txt',
+):
+    assert fragment in smoke, fragment
+assert "unset SIFR_TEST_CHANNEL_METADATA_PATH" not in smoke
+assert "SIFR_SYSROOT_DIR" not in smoke
+assert smoke.index('test -z "${SIFR_TEST_CHANNEL_METADATA_PATH:-}"') < smoke.index(
+    "download_until_matches()"
+)
+legacy_digest = "71b3243925670f56dc510b8f45b6614a622f58097a0fea9492f61d20dc4bf9ef"
+for surface in (prepare, publication, bootstrap, evidence_schema):
+    assert legacy_digest in surface
+for surface, size_fragment in (
+    (prepare, '= "105"'),
+    (publication, '= "105"'),
+    (bootstrap, "LEGACY_INDEX_SIZE_BYTES = 105"),
+    (evidence_schema, '"size_bytes": {"const": 105}'),
+):
+    assert size_fragment in surface
+for fragment in (
+    "immutable asset set drifted",
+    "asset digest drifted",
+    "release record is not reproducible",
+):
+    assert fragment in alpha, fragment
+for forbidden in (
+    "bootstrap_channel_metadata.py",
+    "migrate",
+    "fallback",
+):
+    for surface in (prepare, publication, bootstrap):
+        assert forbidden not in surface.lower()
+PY

--- a/verification/areas/distribution_release/cases/site_release_workflow_contract.sh
+++ b/verification/areas/distribution_release/cases/site_release_workflow_contract.sh
@@ -6,7 +6,8 @@ source "$(dirname "$0")/common.sh"
 
 fixture="${REPO_ROOT}/verification/areas/distribution_release/fixtures/site_release_contract.json"
 publication_workflow="${REPO_ROOT}/.github/workflows/release-publication.yml"
-python3 - "${fixture}" "${publication_workflow}" <<'PY'
+identity_helper="${REPO_ROOT}/scripts/distribution/verify_site_workflow_identity.sh"
+python3 - "${fixture}" "${publication_workflow}" "${identity_helper}" <<'PY'
 import copy
 import json
 import pathlib
@@ -15,6 +16,7 @@ import sys
 
 fixture = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 publication = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+identity = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
 sha = re.compile(r"^[0-9a-f]{64}$")
 commit = re.compile(r"^[0-9a-f]{40}$")
 attempt = re.compile(r"^[A-Za-z0-9._-]{1,80}$")
@@ -71,24 +73,35 @@ for fragment in (
     "SITE_WORKFLOW_REF: sifr-release-site-stable-distribution",
     'SITE_WORKFLOW_RULESET_ID: "19791667"',
     'SITE_WORKFLOW_RULESET_UPDATED_AT: "2026-07-27T05:06:21.354Z"',
-    '-H "Time-Zone: UTC"',
     "SITE_WORKFLOW_SHA256: 7a27abaf9d7e67298ea3033abf19f1c504c68bf50bdcd4e3cc5577330456a958",
-    ".updated_at == $updated_at",
-    "(.bypass_actors // []) == []",
-    '(.current_user_can_bypass // "never") == "never"',
-    "site workflow tag immutability ruleset is not active and exact",
-    "site workflow tag lost immutable protection before dispatch",
-    "protected site workflow tag does not resolve to site_base_commit",
-    "protected site workflow tag moved before dispatch",
-    "pinned site workflow bytes do not match the reviewed contract",
+    "scripts/distribution/verify_site_workflow_identity.sh",
+    '--workflow-sha256 "${SITE_WORKFLOW_SHA256}"',
     '--arg ref "${SITE_WORKFLOW_REF}"',
     "scripts/distribution/generate_dispatchers.sh \\\n"
     "            --install-root dispatchers \\\n"
     '            --default-channel "${site_default_channel}"',
 ):
     assert fragment in publication, fragment
-assert publication.index("pinned site workflow bytes do not match") < publication.index(
-    "Publish write-once version release and verify assets"
+for fragment in (
+    '"${ruleset_id}" =~ ^[1-9][0-9]*$',
+    '-H "Time-Zone: UTC"',
+    ".updated_at == $updated_at",
+    "(.bypass_actors // []) == []",
+    '(.current_user_can_bypass // "never") == "never"',
+    "immutable tag ruleset is not active and exact",
+    "protected workflow tag moved",
+    "pinned workflow bytes do not match the reviewed contract",
+):
+    assert fragment in identity, fragment
+identity_call = "scripts/distribution/verify_site_workflow_identity.sh"
+assert publication.count(identity_call) == 2
+first_identity = publication.index(identity_call)
+second_identity = publication.index(identity_call, first_identity + 1)
+assert first_identity < publication.index("Publish write-once version release and verify assets")
+assert (
+    publication.index("Dispatch exact site workflow")
+    < second_identity
+    < publication.index("Poll exact site run")
 )
 
 payload = {

--- a/verification/areas/distribution_release/governance/__init__.py
+++ b/verification/areas/distribution_release/governance/__init__.py
@@ -12,6 +12,7 @@ from .release_plan import (
     validate_site_release_facts,
 )
 from .release_report import validate_release_profile_report
+from .schema_bootstrap import validate_bootstrap_evidence
 from .surface_contracts import (
     validate_install_receipt,
     validate_self_update_plan,
@@ -23,6 +24,7 @@ __all__ = [
     "GovernanceError",
     "generate_site_release_facts",
     "materialize_stable_plan",
+    "validate_bootstrap_evidence",
     "validate_incident_request",
     "validate_incident_signoff",
     "validate_qualification_artifact_index",

--- a/verification/areas/distribution_release/governance/qualification_fixture.py
+++ b/verification/areas/distribution_release/governance/qualification_fixture.py
@@ -120,6 +120,7 @@ def write_source_contracts(source_root: Path) -> None:
                     "qualification",
                     "evidence-custody",
                     "incident-governance",
+                    "epoch-bootstrap",
                 ],
             },
         ],

--- a/verification/areas/distribution_release/governance/release_report.py
+++ b/verification/areas/distribution_release/governance/release_report.py
@@ -43,6 +43,7 @@ REQUIRED_SUITES = {
         "qualification",
         "evidence-custody",
         "incident-governance",
+        "epoch-bootstrap",
     },
 }
 

--- a/verification/areas/distribution_release/governance/schema_bootstrap.py
+++ b/verification/areas/distribution_release/governance/schema_bootstrap.py
@@ -1,0 +1,498 @@
+"""One-time, fail-closed schema-v2 preview epoch bootstrap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .common import (
+    TARGETS,
+    fail,
+    load_json_strict,
+    require_array,
+    require_commit,
+    require_enum,
+    require_exact_keys,
+    require_nonempty_string,
+    require_object,
+    require_positive_int,
+    require_schema_v2,
+    require_sha256,
+    sha256_bytes,
+    sha256_file,
+    version_channel,
+    write_canonical_json,
+)
+from .release_index import validate_release_index, validate_release_record
+
+LEGACY_INDEX_SHA256 = "71b3243925670f56dc510b8f45b6614a622f58097a0fea9492f61d20dc4bf9ef"
+LEGACY_INDEX_SIZE_BYTES = 105
+BOOTSTRAP_GENERATION = 1
+PROTECTED_ENVIRONMENT = "stable-release"
+SMOKE_IDS = {
+    "dispatcher-default",
+    "dispatcher-stable-rejection",
+    "governance-index",
+    "installed-self-update",
+}
+
+
+def require_opaque_legacy_identity(*, sha256: str, size_bytes: int) -> None:
+    """Accept only the observed pre-epoch asset identity, never its data model."""
+    if size_bytes != LEGACY_INDEX_SIZE_BYTES or sha256 != LEGACY_INDEX_SHA256:
+        fail(
+            "legacy channels.json",
+            "does not match the one-time opaque bootstrap identity",
+        )
+
+
+def build_preview_epoch(
+    *,
+    legacy_index_sha256: str,
+    legacy_index_size_bytes: int,
+    alpha_wrapper: Any,
+    beta_wrapper: Any,
+) -> dict[str, Any]:
+    require_opaque_legacy_identity(
+        sha256=legacy_index_sha256,
+        size_bytes=legacy_index_size_bytes,
+    )
+    alpha_version, alpha_release = _validate_release_wrapper(
+        alpha_wrapper,
+        expected_channel="alpha",
+        location="alpha release",
+    )
+    beta_version, beta_release = _validate_release_wrapper(
+        beta_wrapper,
+        expected_channel="beta",
+        location="beta release",
+    )
+    payload = {
+        "schema_version": 2,
+        "generation": BOOTSTRAP_GENERATION,
+        "ga_status": "preview",
+        "channels": {
+            "alpha": alpha_version,
+            "beta": beta_version,
+        },
+        "releases": {
+            alpha_version: alpha_release,
+            beta_version: beta_release,
+        },
+    }
+    return validate_release_index(payload)
+
+
+def resolve_distinct_approvers(
+    approvals: Any,
+    *,
+    initiator: str,
+    environment: str = PROTECTED_ENVIRONMENT,
+) -> list[str]:
+    require_nonempty_string(initiator, "initiator")
+    require_nonempty_string(environment, "environment")
+    normalized_initiator = initiator.casefold()
+    values = require_array(approvals, "approval history")
+    approved: dict[str, str] = {}
+    for index, raw in enumerate(values):
+        location = f"approval history[{index}]"
+        review = require_object(raw, location)
+        if review.get("state") != "approved":
+            continue
+        environments = require_array(
+            review.get("environments"), f"{location}.environments"
+        )
+        if not any(
+            isinstance(item, dict) and item.get("name") == environment
+            for item in environments
+        ):
+            continue
+        user = require_object(review.get("user"), f"{location}.user")
+        login = require_nonempty_string(user.get("login"), f"{location}.user.login")
+        normalized_login = login.casefold()
+        if normalized_login != normalized_initiator:
+            approved.setdefault(normalized_login, login)
+    if not approved:
+        fail(
+            "approval history",
+            f"requires a {environment} approval by someone other than {initiator}",
+        )
+    return [approved[key] for key in sorted(approved)]
+
+
+def validate_bootstrap_evidence(payload: Any) -> dict[str, Any]:
+    evidence = require_object(payload, "$")
+    stage = evidence.get("stage")
+    required = {
+        "schema_version",
+        "operation",
+        "stage",
+        "run_id",
+        "run_attempt",
+        "initiator",
+        "approvers",
+        "prepare_summary_sha256",
+        "legacy_index",
+        "alpha",
+    }
+    if stage == "preview-index":
+        required.update({"alpha_evidence", "beta", "index", "public_smoke"})
+    require_exact_keys(evidence, required=required, location="$")
+    require_schema_v2(evidence)
+    if evidence["operation"] != "schema-epoch-bootstrap":
+        fail("$.operation", "must be schema-epoch-bootstrap")
+    stage = require_enum(stage, {"alpha-assets", "preview-index"}, "$.stage")
+    require_positive_int(evidence["run_id"], "$.run_id")
+    require_positive_int(evidence["run_attempt"], "$.run_attempt")
+    initiator = require_nonempty_string(evidence["initiator"], "$.initiator")
+    _validate_approvers(evidence["approvers"], initiator, "$.approvers")
+    require_sha256(
+        evidence["prepare_summary_sha256"],
+        "$.prepare_summary_sha256",
+    )
+    legacy = require_object(evidence["legacy_index"], "$.legacy_index")
+    require_exact_keys(
+        legacy,
+        required={"sha256", "size_bytes"},
+        location="$.legacy_index",
+    )
+    if legacy["sha256"] != LEGACY_INDEX_SHA256:
+        fail("$.legacy_index.sha256", "does not match the opaque bootstrap asset")
+    if legacy["size_bytes"] != LEGACY_INDEX_SIZE_BYTES:
+        fail("$.legacy_index.size_bytes", "does not match the opaque bootstrap asset")
+    _validate_release_evidence(evidence["alpha"], "alpha", "$.alpha")
+    if stage == "alpha-assets":
+        return evidence
+    alpha_evidence = require_object(evidence["alpha_evidence"], "$.alpha_evidence")
+    require_exact_keys(
+        alpha_evidence,
+        required={
+            "sha256",
+            "run_id",
+            "run_attempt",
+            "initiator",
+            "approvers",
+            "prepare_summary_sha256",
+        },
+        location="$.alpha_evidence",
+    )
+    require_sha256(alpha_evidence["sha256"], "$.alpha_evidence.sha256")
+    require_positive_int(alpha_evidence["run_id"], "$.alpha_evidence.run_id")
+    require_positive_int(
+        alpha_evidence["run_attempt"],
+        "$.alpha_evidence.run_attempt",
+    )
+    alpha_initiator = require_nonempty_string(
+        alpha_evidence["initiator"],
+        "$.alpha_evidence.initiator",
+    )
+    _validate_approvers(
+        alpha_evidence["approvers"],
+        alpha_initiator,
+        "$.alpha_evidence.approvers",
+    )
+    require_sha256(
+        alpha_evidence["prepare_summary_sha256"],
+        "$.alpha_evidence.prepare_summary_sha256",
+    )
+    _validate_release_evidence(evidence["beta"], "beta", "$.beta")
+    index = require_object(evidence["index"], "$.index")
+    require_exact_keys(
+        index,
+        required={"generation", "sha256"},
+        location="$.index",
+    )
+    if index["generation"] != BOOTSTRAP_GENERATION:
+        fail("$.index.generation", "must start the canonical epoch at generation 1")
+    require_sha256(index["sha256"], "$.index.sha256")
+    smoke = require_array(evidence["public_smoke"], "$.public_smoke")
+    if len(smoke) != len(SMOKE_IDS):
+        fail("$.public_smoke", "must contain exactly four bootstrap smoke records")
+    seen: set[str] = set()
+    for index_value, raw in enumerate(smoke):
+        location = f"$.public_smoke[{index_value}]"
+        item = require_object(raw, location)
+        require_exact_keys(item, required={"id", "status", "sha256"}, location=location)
+        smoke_id = require_nonempty_string(item["id"], f"{location}.id")
+        if smoke_id not in SMOKE_IDS or smoke_id in seen:
+            fail(f"{location}.id", "must be a unique governed bootstrap smoke id")
+        seen.add(smoke_id)
+        if item["status"] != "pass":
+            fail(f"{location}.status", "must be pass")
+        require_sha256(item["sha256"], f"{location}.sha256")
+    return evidence
+
+
+def _validate_approvers(payload: Any, initiator: str, location: str) -> list[str]:
+    values = require_array(payload, location)
+    if not values:
+        fail(location, "must contain at least one protected-environment approver")
+    normalized_initiator = initiator.casefold()
+    seen: set[str] = set()
+    approvers: list[str] = []
+    for index, raw in enumerate(values):
+        approver = require_nonempty_string(raw, f"{location}[{index}]")
+        normalized = approver.casefold()
+        if normalized == normalized_initiator:
+            fail(f"{location}[{index}]", "must differ from the workflow initiator")
+        if normalized in seen:
+            fail(f"{location}[{index}]", "must be a unique GitHub login")
+        seen.add(normalized)
+        approvers.append(approver)
+    return approvers
+
+
+def materialize_bootstrap_evidence(
+    *,
+    stage: str,
+    run_id: int,
+    run_attempt: int,
+    initiator: str,
+    approvers: list[str],
+    prepare_summary_path: Path,
+    legacy_index_path: Path,
+    alpha_version: str,
+    alpha_source_commit: str,
+    alpha_record_path: Path,
+    alpha_assets_dir: Path,
+    out: Path,
+    beta_version: str | None = None,
+    beta_source_commit: str | None = None,
+    beta_record_path: Path | None = None,
+    beta_assets_dir: Path | None = None,
+    index_path: Path | None = None,
+    smoke_dir: Path | None = None,
+    alpha_evidence_path: Path | None = None,
+) -> dict[str, Any]:
+    legacy_bytes = legacy_index_path.read_bytes()
+    require_opaque_legacy_identity(
+        sha256=sha256_bytes(legacy_bytes),
+        size_bytes=len(legacy_bytes),
+    )
+    payload: dict[str, Any] = {
+        "schema_version": 2,
+        "operation": "schema-epoch-bootstrap",
+        "stage": stage,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "initiator": initiator,
+        "approvers": approvers,
+        "prepare_summary_sha256": sha256_file(prepare_summary_path),
+        "legacy_index": {
+            "sha256": sha256_bytes(legacy_bytes),
+            "size_bytes": len(legacy_bytes),
+        },
+        "alpha": _materialize_release_evidence(
+            version=alpha_version,
+            channel="alpha",
+            source_commit=alpha_source_commit,
+            record_path=alpha_record_path,
+            assets_dir=alpha_assets_dir,
+        ),
+    }
+    if stage == "preview-index":
+        if (
+            beta_version is None
+            or beta_source_commit is None
+            or beta_record_path is None
+            or beta_assets_dir is None
+            or index_path is None
+            or smoke_dir is None
+            or alpha_evidence_path is None
+        ):
+            fail(
+                "bootstrap evidence",
+                "preview-index stage requires beta, index, and smoke inputs",
+            )
+        index = validate_release_index(
+            load_json_strict(index_path, require_canonical=True)
+        )
+        if index["generation"] != BOOTSTRAP_GENERATION:
+            fail("bootstrap index", "must be generation 1")
+        alpha_wrapper = load_json_strict(alpha_record_path, require_canonical=True)
+        beta_wrapper = load_json_strict(beta_record_path, require_canonical=True)
+        _require_exact_bootstrap_membership(
+            index=index,
+            alpha_version=alpha_version,
+            alpha_wrapper=alpha_wrapper,
+            beta_version=beta_version,
+            beta_wrapper=beta_wrapper,
+        )
+        staged_alpha = validate_bootstrap_evidence(
+            load_json_strict(alpha_evidence_path, require_canonical=True)
+        )
+        if (
+            staged_alpha["stage"] != "alpha-assets"
+            or staged_alpha["alpha"] != payload["alpha"]
+        ):
+            fail(
+                "alpha bootstrap evidence",
+                "must bind the exact alpha release used by generation 1",
+            )
+        payload.update(
+            {
+                "alpha_evidence": {
+                    "sha256": sha256_file(alpha_evidence_path),
+                    "run_id": staged_alpha["run_id"],
+                    "run_attempt": staged_alpha["run_attempt"],
+                    "initiator": staged_alpha["initiator"],
+                    "approvers": staged_alpha["approvers"],
+                    "prepare_summary_sha256": staged_alpha[
+                        "prepare_summary_sha256"
+                    ],
+                },
+                "beta": _materialize_release_evidence(
+                    version=beta_version,
+                    channel="beta",
+                    source_commit=beta_source_commit,
+                    record_path=beta_record_path,
+                    assets_dir=beta_assets_dir,
+                ),
+                "index": {
+                    "generation": index["generation"],
+                    "sha256": sha256_file(index_path),
+                },
+                "public_smoke": [
+                    {
+                        "id": smoke_id,
+                        "status": "pass",
+                        "sha256": sha256_file(smoke_dir / f"{smoke_id}.txt"),
+                    }
+                    for smoke_id in sorted(SMOKE_IDS)
+                ],
+            }
+        )
+    evidence = validate_bootstrap_evidence(payload)
+    write_canonical_json(out, evidence, refuse_existing=True)
+    return evidence
+
+
+def _require_exact_bootstrap_membership(
+    *,
+    index: dict[str, Any],
+    alpha_version: str,
+    alpha_wrapper: Any,
+    beta_version: str,
+    beta_wrapper: Any,
+) -> None:
+    alpha_record_version, alpha_release = _validate_release_wrapper(
+        alpha_wrapper,
+        expected_channel="alpha",
+        location="alpha release",
+    )
+    beta_record_version, beta_release = _validate_release_wrapper(
+        beta_wrapper,
+        expected_channel="beta",
+        location="beta release",
+    )
+    if (
+        alpha_record_version != alpha_version
+        or beta_record_version != beta_version
+    ):
+        fail(
+            "bootstrap index",
+            "evidenced versions must match their exact release records",
+        )
+    expected_channels = {"alpha": alpha_version, "beta": beta_version}
+    if index["ga_status"] != "preview" or index["channels"] != expected_channels:
+        fail(
+            "bootstrap index",
+            "must expose exactly the evidenced alpha and beta preview channels",
+        )
+    expected_releases = {
+        alpha_version: alpha_release,
+        beta_version: beta_release,
+    }
+    if index["releases"] != expected_releases:
+        fail(
+            "bootstrap index",
+            "must contain exactly the evidenced alpha and beta release records",
+        )
+
+
+def expected_asset_names(version: str) -> set[str]:
+    names = {f"sifr-installer-{version}"}
+    for target in TARGETS:
+        archive = f"sifr-{version}-{target}.tar.gz"
+        names.update({archive, f"{archive}.sha256"})
+    return names
+
+
+def _materialize_release_evidence(
+    *,
+    version: str,
+    channel: str,
+    source_commit: str,
+    record_path: Path,
+    assets_dir: Path,
+) -> dict[str, Any]:
+    require_commit(source_commit, f"{channel} source commit")
+    record_version, record = _validate_release_wrapper(
+        load_json_strict(record_path, require_canonical=True),
+        expected_channel=channel,
+        location=f"{channel} release",
+    )
+    if record_version != version:
+        fail(f"{channel} release.version", "does not match the evidence version")
+    if record["source_commit"] != source_commit:
+        fail(f"{channel} release.source_commit", "does not match the evidence source")
+    names = expected_asset_names(version)
+    actual = {path.name for path in assets_dir.iterdir() if path.is_file()}
+    if actual != names:
+        fail(f"{channel} assets", "must contain the exact immutable asset set")
+    return {
+        "version": version,
+        "source_commit": source_commit,
+        "release_record_sha256": sha256_file(record_path),
+        "published_assets": {
+            name: sha256_file(assets_dir / name) for name in sorted(names)
+        },
+    }
+
+
+def _validate_release_wrapper(
+    payload: Any,
+    *,
+    expected_channel: str,
+    location: str,
+) -> tuple[str, dict[str, Any]]:
+    wrapper = require_object(payload, location)
+    require_exact_keys(wrapper, required={"version", "release"}, location=location)
+    version = require_nonempty_string(wrapper["version"], f"{location}.version")
+    if version_channel(version, f"{location}.version") != expected_channel:
+        fail(f"{location}.version", f"must be a {expected_channel} version")
+    release = validate_release_record(
+        wrapper["release"],
+        version=version,
+        expected_channel=expected_channel,
+    )
+    if release["status"] != "active":
+        fail(f"{location}.release.status", "must be active")
+    return version, release
+
+
+def _validate_release_evidence(payload: Any, channel: str, location: str) -> None:
+    value = require_object(payload, location)
+    require_exact_keys(
+        value,
+        required={
+            "version",
+            "source_commit",
+            "release_record_sha256",
+            "published_assets",
+        },
+        location=location,
+    )
+    version = require_nonempty_string(value["version"], f"{location}.version")
+    if version_channel(version, f"{location}.version") != channel:
+        fail(f"{location}.version", f"must be a {channel} version")
+    require_commit(value["source_commit"], f"{location}.source_commit")
+    require_sha256(value["release_record_sha256"], f"{location}.release_record_sha256")
+    assets = require_object(value["published_assets"], f"{location}.published_assets")
+    expected = expected_asset_names(version)
+    if set(assets) != expected:
+        fail(
+            f"{location}.published_assets", "must contain the exact immutable asset set"
+        )
+    for name, digest in assets.items():
+        require_sha256(digest, f"{location}.published_assets.{name}")

--- a/verification/areas/distribution_release/governance/schema_bootstrap_selftest.py
+++ b/verification/areas/distribution_release/governance/schema_bootstrap_selftest.py
@@ -1,0 +1,574 @@
+"""Mutation tests for the one-time schema-v2 preview epoch bootstrap."""
+
+from __future__ import annotations
+
+import copy
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from . import schema_bootstrap as bootstrap_module
+from .common import GovernanceError
+from .common import write_canonical_json
+from .schema_bootstrap import (
+    BOOTSTRAP_GENERATION,
+    LEGACY_INDEX_SHA256,
+    LEGACY_INDEX_SIZE_BYTES,
+    build_preview_epoch,
+    expected_asset_names,
+    materialize_bootstrap_evidence,
+    resolve_distinct_approvers,
+    validate_bootstrap_evidence,
+)
+from .schema_contracts import COMMIT, SHA_A, SHA_B, SHA_C, SHA_D, release_record
+
+
+def main() -> int:
+    alpha = wrapper("0.1.0-alpha.2", "alpha")
+    beta = wrapper("0.1.0-beta.15", "beta")
+    index = build_preview_epoch(
+        legacy_index_sha256=LEGACY_INDEX_SHA256,
+        legacy_index_size_bytes=LEGACY_INDEX_SIZE_BYTES,
+        alpha_wrapper=alpha,
+        beta_wrapper=beta,
+    )
+    assert index["generation"] == BOOTSTRAP_GENERATION
+    assert index["ga_status"] == "preview"
+    assert set(index["channels"]) == {"alpha", "beta"}
+    assert "stable" not in index["channels"]
+    evidence = valid_evidence()
+    assert validate_bootstrap_evidence(evidence) == evidence
+    stage = copy.deepcopy(evidence)
+    stage["stage"] = "alpha-assets"
+    for key in ("alpha_evidence", "beta", "index", "public_smoke"):
+        del stage[key]
+    assert validate_bootstrap_evidence(stage) == stage
+    stage_with_beta = copy.deepcopy(stage)
+    stage_with_beta["beta"] = release_evidence("0.1.0-beta.15")
+    expect_failure(
+        lambda: validate_bootstrap_evidence(stage_with_beta),
+        "alpha stage with beta evidence",
+    )
+    invalid_stage = copy.deepcopy(stage)
+    invalid_stage["stage"] = "unknown-stage"
+    expect_failure(
+        lambda: validate_bootstrap_evidence(invalid_stage),
+        "unknown bootstrap evidence stage",
+    )
+    approvals = [
+        {
+            "state": "approved",
+            "environments": [{"name": "stable-release"}],
+            "user": {"login": "release-reviewer"},
+        }
+    ]
+    assert (
+        resolve_distinct_approvers(approvals, initiator="release-initiator")
+        == ["release-reviewer"]
+    )
+    multi_approvals = approvals + [
+        {
+            "state": "approved",
+            "environments": [{"name": "stable-release"}],
+            "user": {"login": "second-reviewer"},
+        }
+    ]
+    assert resolve_distinct_approvers(
+        multi_approvals,
+        initiator="release-initiator",
+    ) == ["release-reviewer", "second-reviewer"]
+    expect_failure(
+        lambda: build_preview_epoch(
+            legacy_index_sha256="f" * 64,
+            legacy_index_size_bytes=LEGACY_INDEX_SIZE_BYTES,
+            alpha_wrapper=alpha,
+            beta_wrapper=beta,
+        ),
+        "opaque legacy drift",
+    )
+    expect_failure(
+        lambda: build_preview_epoch(
+            legacy_index_sha256=LEGACY_INDEX_SHA256,
+            legacy_index_size_bytes=LEGACY_INDEX_SIZE_BYTES - 1,
+            alpha_wrapper=alpha,
+            beta_wrapper=beta,
+        ),
+        "opaque legacy size drift",
+    )
+    expect_failure(
+        lambda: build_preview_epoch(
+            legacy_index_sha256=LEGACY_INDEX_SHA256,
+            legacy_index_size_bytes=LEGACY_INDEX_SIZE_BYTES,
+            alpha_wrapper=beta,
+            beta_wrapper=beta,
+        ),
+        "channel swap",
+    )
+    extra_wrapper_key = copy.deepcopy(alpha)
+    extra_wrapper_key["unexpected"] = True
+    expect_failure(
+        lambda: build_preview_epoch(
+            legacy_index_sha256=LEGACY_INDEX_SHA256,
+            legacy_index_size_bytes=LEGACY_INDEX_SIZE_BYTES,
+            alpha_wrapper=extra_wrapper_key,
+            beta_wrapper=beta,
+        ),
+        "release wrapper extra key",
+    )
+    withdrawn_alpha = copy.deepcopy(alpha)
+    withdrawn_alpha["release"]["status"] = "withdrawn"
+    withdrawn_alpha["release"]["incident_id"] = "inc-2026-001"
+    expect_failure(
+        lambda: build_preview_epoch(
+            legacy_index_sha256=LEGACY_INDEX_SHA256,
+            legacy_index_size_bytes=LEGACY_INDEX_SIZE_BYTES,
+            alpha_wrapper=withdrawn_alpha,
+            beta_wrapper=beta,
+        ),
+        "withdrawn bootstrap release",
+    )
+    expect_failure(
+        lambda: resolve_distinct_approvers(
+            [
+                {
+                    "state": "approved",
+                    "environments": [{"name": "stable-release"}],
+                    "user": {"login": "Release-Initiator"},
+                }
+            ],
+            initiator="release-initiator",
+        ),
+        "case-insensitive self approval",
+    )
+    expect_failure(
+        lambda: resolve_distinct_approvers(
+            approvals,
+            initiator="",
+        ),
+        "empty approval initiator",
+    )
+    empty_login_approval = copy.deepcopy(approvals)
+    empty_login_approval[0]["user"]["login"] = ""
+    expect_failure(
+        lambda: resolve_distinct_approvers(
+            empty_login_approval,
+            initiator="release-initiator",
+        ),
+        "empty approval login",
+    )
+    for rejected, label in (
+        ([], "empty approval history"),
+        (
+            [
+                {
+                    "state": "rejected",
+                    "environments": [{"name": "stable-release"}],
+                    "user": {"login": "release-reviewer"},
+                }
+            ],
+            "non-approved review",
+        ),
+        (
+            [
+                {
+                    "state": "approved",
+                    "environments": [{"name": "preview-release"}],
+                    "user": {"login": "release-reviewer"},
+                }
+            ],
+            "wrong approval environment",
+        ),
+    ):
+        expect_failure(
+            lambda rejected=rejected: resolve_distinct_approvers(
+                rejected,
+                initiator="release-initiator",
+            ),
+            label,
+        )
+    mutations = (
+        lambda value: value.update({"unexpected": True}),
+        lambda value: value.update({"schema_version": 0}),
+        lambda value: value.update({"operation": "preview-publication"}),
+        lambda value: value.update({"run_id": 0}),
+        lambda value: value.update({"run_attempt": 0}),
+        lambda value: value.update({"initiator": ""}),
+        lambda value: value.update({"approvers": []}),
+        lambda value: value.update({"approvers": "abc"}),
+        lambda value: value.update({"approvers": [""]}),
+        lambda value: value.update({"approvers": [value["initiator"]]}),
+        lambda value: value["legacy_index"].update({"unexpected": True}),
+        lambda value: value["legacy_index"].update({"sha256": SHA_A}),
+        lambda value: value["legacy_index"].update({"size_bytes": 104}),
+        lambda value: value["index"].update({"unexpected": True}),
+        lambda value: value["index"].update({"generation": 2}),
+        lambda value: value["index"].update({"sha256": "not-a-digest"}),
+        lambda value: value.update({"prepare_summary_sha256": "not-a-digest"}),
+        lambda value: value["alpha_evidence"].update({"sha256": "not-a-digest"}),
+        lambda value: value["alpha_evidence"].update({"unexpected": True}),
+        lambda value: value["alpha_evidence"].update({"run_id": 0}),
+        lambda value: value["alpha_evidence"].update({"run_attempt": 0}),
+        lambda value: value["alpha_evidence"].update({"initiator": ""}),
+        lambda value: value["alpha_evidence"].update({"approvers": []}),
+        lambda value: value["alpha_evidence"].update(
+            {"prepare_summary_sha256": "not-a-digest"}
+        ),
+        lambda value: value.update({"approvers": ["Release-Reviewer", "release-reviewer"]}),
+        lambda value: value["alpha"].update({"unexpected": True}),
+        lambda value: value.update(
+            {"alpha": release_evidence("0.1.0-beta.15")}
+        ),
+        lambda value: value["alpha"].update({"source_commit": "not-a-commit"}),
+        lambda value: value["alpha"].update(
+            {"release_record_sha256": "not-a-digest"}
+        ),
+        lambda value: value["alpha"]["published_assets"].update(
+            {
+                next(iter(value["alpha"]["published_assets"])): "not-a-digest",
+            }
+        ),
+        lambda value: value["alpha"]["published_assets"].pop(
+            next(iter(value["alpha"]["published_assets"]))
+        ),
+        lambda value: value["alpha"].update(
+            {"published_assets": release_evidence("0.1.0-alpha.99")["published_assets"]}
+        ),
+        lambda value: value["beta"].update({"unexpected": True}),
+        lambda value: value.update(
+            {"beta": release_evidence("0.1.0-alpha.7")}
+        ),
+        lambda value: value["beta"].update({"source_commit": "not-a-commit"}),
+        lambda value: value["beta"].update(
+            {"release_record_sha256": "not-a-digest"}
+        ),
+        lambda value: value["beta"]["published_assets"].update(
+            {
+                next(iter(value["beta"]["published_assets"])): "not-a-digest",
+            }
+        ),
+        lambda value: value["beta"]["published_assets"].pop(
+            next(iter(value["beta"]["published_assets"]))
+        ),
+        lambda value: value["beta"].update(
+            {"published_assets": release_evidence("0.1.0-beta.99")["published_assets"]}
+        ),
+        lambda value: value["public_smoke"].append(
+            copy.deepcopy(value["public_smoke"][0])
+        ),
+        lambda value: value["public_smoke"].pop(),
+        lambda value: (
+            value["public_smoke"][1].update(
+                {
+                    "id": value["public_smoke"][0]["id"],
+                    "sha256": SHA_A,
+                }
+            )
+        ),
+        lambda value: value["public_smoke"][0].update({"id": "unknown-smoke"}),
+        lambda value: value["public_smoke"][0].update({"unexpected": True}),
+        lambda value: value["public_smoke"][0].update({"status": "fail"}),
+        lambda value: value["public_smoke"][0].update({"sha256": "not-a-digest"}),
+    )
+    for index_value, mutation in enumerate(mutations):
+        changed = copy.deepcopy(evidence)
+        mutation(changed)
+        expect_failure(
+            lambda changed=changed: validate_bootstrap_evidence(changed),
+            f"evidence mutation {index_value}",
+        )
+    test_materializer()
+    print("schema-v2 preview epoch bootstrap self-test: PASS")
+    return 0
+
+
+def wrapper(version: str, channel: str) -> dict[str, object]:
+    record = release_record(channel)
+    record["source_commit"] = COMMIT
+    return {"version": version, "release": record}
+
+
+def valid_evidence() -> dict[str, object]:
+    return {
+        "schema_version": 2,
+        "operation": "schema-epoch-bootstrap",
+        "stage": "preview-index",
+        "run_id": 42,
+        "run_attempt": 1,
+        "initiator": "release-initiator",
+        "approvers": ["release-reviewer"],
+        "prepare_summary_sha256": SHA_A,
+        "legacy_index": {
+            "sha256": LEGACY_INDEX_SHA256,
+            "size_bytes": LEGACY_INDEX_SIZE_BYTES,
+        },
+        "alpha": release_evidence("0.1.0-alpha.2"),
+        "alpha_evidence": {
+            "sha256": SHA_A,
+            "run_id": 41,
+            "run_attempt": 1,
+            "initiator": "alpha-initiator",
+            "approvers": ["alpha-reviewer"],
+            "prepare_summary_sha256": SHA_B,
+        },
+        "beta": release_evidence("0.1.0-beta.15"),
+        "index": {"generation": BOOTSTRAP_GENERATION, "sha256": SHA_D},
+        "public_smoke": [
+            {"id": smoke_id, "status": "pass", "sha256": SHA_C}
+            for smoke_id in (
+                "dispatcher-default",
+                "dispatcher-stable-rejection",
+                "governance-index",
+                "installed-self-update",
+            )
+        ],
+    }
+
+
+def release_evidence(version: str) -> dict[str, object]:
+    return {
+        "version": version,
+        "source_commit": COMMIT,
+        "release_record_sha256": SHA_A,
+        "published_assets": {
+            name: SHA_B for name in sorted(expected_asset_names(version))
+        },
+    }
+
+
+def test_materializer() -> None:
+    alpha_version = "0.1.0-alpha.2"
+    beta_version = "0.1.0-beta.15"
+    alpha_record = wrapper(alpha_version, "alpha")
+    beta_record = wrapper(beta_version, "beta")
+    index = build_preview_epoch(
+        legacy_index_sha256=LEGACY_INDEX_SHA256,
+        legacy_index_size_bytes=LEGACY_INDEX_SIZE_BYTES,
+        alpha_wrapper=alpha_record,
+        beta_wrapper=beta_record,
+    )
+    with tempfile.TemporaryDirectory() as raw_root:
+        root = Path(raw_root)
+        legacy_path = root / "legacy.json"
+        prepare_summary = root / "prepare-summary.json"
+        alpha_record_path = root / "alpha-record.json"
+        beta_record_path = root / "beta-record.json"
+        index_path = root / "channels.json"
+        alpha_assets = root / "alpha-assets"
+        beta_assets = root / "beta-assets"
+        smoke_dir = root / "smoke"
+        legacy_path.write_bytes(b"x" * LEGACY_INDEX_SIZE_BYTES)
+        prepare_summary.write_bytes(b'{"schema_version":2}\n')
+        write_canonical_json(alpha_record_path, alpha_record, refuse_existing=True)
+        write_canonical_json(beta_record_path, beta_record, refuse_existing=True)
+        write_canonical_json(index_path, index, refuse_existing=True)
+        for directory, version in (
+            (alpha_assets, alpha_version),
+            (beta_assets, beta_version),
+        ):
+            directory.mkdir()
+            for name in expected_asset_names(version):
+                (directory / name).write_bytes(name.encode())
+        smoke_dir.mkdir()
+        for smoke_id in (
+            "dispatcher-default",
+            "dispatcher-stable-rejection",
+            "governance-index",
+            "installed-self-update",
+        ):
+            (smoke_dir / f"{smoke_id}.txt").write_text(
+                f"{smoke_id}: pass\n",
+                encoding="utf-8",
+            )
+        alpha_evidence_path = root / "alpha-evidence.json"
+        final_evidence_path = root / "final-evidence.json"
+
+        def materialize_alpha(
+            out: Path,
+            *,
+            final_alpha_record: Path = alpha_record_path,
+            final_alpha_source: str = COMMIT,
+        ) -> dict[str, object]:
+            return materialize_bootstrap_evidence(
+                stage="alpha-assets",
+                run_id=41,
+                run_attempt=1,
+                initiator="alpha-initiator",
+                approvers=["alpha-reviewer"],
+                prepare_summary_path=prepare_summary,
+                legacy_index_path=legacy_path,
+                alpha_version=alpha_version,
+                alpha_source_commit=final_alpha_source,
+                alpha_record_path=final_alpha_record,
+                alpha_assets_dir=alpha_assets,
+                out=out,
+            )
+
+        def materialize_final(
+            out: Path,
+            *,
+            final_beta_record: Path = beta_record_path,
+            final_smoke_dir: Path = smoke_dir,
+            final_alpha_evidence: Path = alpha_evidence_path,
+        ) -> dict[str, object]:
+            return materialize_bootstrap_evidence(
+                stage="preview-index",
+                run_id=42,
+                run_attempt=1,
+                initiator="beta-initiator",
+                approvers=["beta-reviewer", "second-reviewer"],
+                prepare_summary_path=prepare_summary,
+                legacy_index_path=legacy_path,
+                alpha_version=alpha_version,
+                alpha_source_commit=COMMIT,
+                alpha_record_path=alpha_record_path,
+                alpha_assets_dir=alpha_assets,
+                out=out,
+                beta_version=beta_version,
+                beta_source_commit=COMMIT,
+                beta_record_path=final_beta_record,
+                beta_assets_dir=beta_assets,
+                index_path=index_path,
+                smoke_dir=final_smoke_dir,
+                alpha_evidence_path=final_alpha_evidence,
+            )
+
+        with patch.object(
+            bootstrap_module,
+            "sha256_bytes",
+            return_value=LEGACY_INDEX_SHA256,
+        ):
+            materialize_alpha(alpha_evidence_path)
+            final = materialize_final(final_evidence_path)
+            assert final["alpha_evidence"]["run_id"] == 41
+            withdrawn_record = copy.deepcopy(alpha_record)
+            withdrawn_record["release"]["status"] = "withdrawn"
+            withdrawn_record["release"]["incident_id"] = "inc-2026-001"
+            withdrawn_record_path = root / "withdrawn-alpha-record.json"
+            write_canonical_json(
+                withdrawn_record_path,
+                withdrawn_record,
+                refuse_existing=True,
+            )
+            expect_failure(
+                lambda: materialize_alpha(
+                    root / "withdrawn-alpha-evidence.json",
+                    final_alpha_record=withdrawn_record_path,
+                ),
+                "producer rejects withdrawn alpha release",
+            )
+            expect_failure(
+                lambda: materialize_alpha(
+                    root / "source-mismatch-alpha-evidence.json",
+                    final_alpha_source="f" * 40,
+                ),
+                "producer rejects record and source-commit disagreement",
+            )
+            expect_failure(
+                lambda: materialize_bootstrap_evidence(
+                    stage="preview-index",
+                    run_id=43,
+                    run_attempt=1,
+                    initiator="beta-initiator",
+                    approvers=["beta-reviewer"],
+                    prepare_summary_path=prepare_summary,
+                    legacy_index_path=legacy_path,
+                    alpha_version=alpha_version,
+                    alpha_source_commit=COMMIT,
+                    alpha_record_path=alpha_record_path,
+                    alpha_assets_dir=alpha_assets,
+                    out=final_evidence_path,
+                ),
+                "preview producer missing required inputs",
+            )
+            expect_failure(
+                lambda: materialize_final(final_evidence_path),
+                "producer refuses existing evidence",
+            )
+            expect_failure(
+                lambda: materialize_final(
+                    root / "wrong-alpha-stage-evidence.json",
+                    final_alpha_evidence=final_evidence_path,
+                ),
+                "producer rejects preview-index evidence as the alpha stage",
+            )
+            other_alpha_version = "0.1.0-alpha.3"
+            other_alpha_record_path = root / "other-alpha-record.json"
+            other_alpha_assets = root / "other-alpha-assets"
+            other_alpha_evidence = root / "other-alpha-evidence.json"
+            write_canonical_json(
+                other_alpha_record_path,
+                wrapper(other_alpha_version, "alpha"),
+                refuse_existing=True,
+            )
+            other_alpha_assets.mkdir()
+            for name in expected_asset_names(other_alpha_version):
+                (other_alpha_assets / name).write_bytes(name.encode())
+            expect_failure(
+                lambda: materialize_alpha(
+                    root / "version-mismatch-alpha-evidence.json",
+                    final_alpha_record=other_alpha_record_path,
+                ),
+                "producer rejects record and evidence version disagreement",
+            )
+            materialize_bootstrap_evidence(
+                stage="alpha-assets",
+                run_id=44,
+                run_attempt=1,
+                initiator="other-alpha-initiator",
+                approvers=["other-alpha-reviewer"],
+                prepare_summary_path=prepare_summary,
+                legacy_index_path=legacy_path,
+                alpha_version=other_alpha_version,
+                alpha_source_commit=COMMIT,
+                alpha_record_path=other_alpha_record_path,
+                alpha_assets_dir=other_alpha_assets,
+                out=other_alpha_evidence,
+            )
+            expect_failure(
+                lambda: materialize_final(
+                    root / "wrong-alpha-release-evidence.json",
+                    final_alpha_evidence=other_alpha_evidence,
+                ),
+                "producer rejects evidence for a different alpha release",
+            )
+            unexpected_asset = alpha_assets / "unexpected"
+            unexpected_asset.write_bytes(b"unexpected")
+            expect_failure(
+                lambda: materialize_final(root / "unexpected-asset-evidence.json"),
+                "producer rejects unexpected alpha asset",
+            )
+            unexpected_asset.unlink()
+            missing_smoke = smoke_dir / "governance-index.txt"
+            missing_smoke.unlink()
+            expect_failure(
+                lambda: materialize_final(root / "missing-smoke-evidence.json"),
+                "producer rejects missing smoke record",
+            )
+            missing_smoke.write_text("governance-index: pass\n", encoding="utf-8")
+            changed_beta = copy.deepcopy(beta_record)
+            changed_beta["release"]["installer_sha256"] = SHA_D
+            changed_beta_path = root / "changed-beta-record.json"
+            write_canonical_json(
+                changed_beta_path,
+                changed_beta,
+                refuse_existing=True,
+            )
+            expect_failure(
+                lambda: materialize_final(
+                    root / "mismatched-index-evidence.json",
+                    final_beta_record=changed_beta_path,
+                ),
+                "producer rejects index and record disagreement",
+            )
+
+
+def expect_failure(callback: object, label: str) -> None:
+    try:
+        callback()  # type: ignore[operator]
+    except (GovernanceError, OSError):
+        return
+    raise AssertionError(f"{label} unexpectedly passed")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/distribution_release/governance/schema_contracts.py
+++ b/verification/areas/distribution_release/governance/schema_contracts.py
@@ -9,6 +9,12 @@ from typing import Any
 from verification.json_schema_202012 import JsonSchemaError, validate_instance
 
 from .common import TARGETS
+from .schema_bootstrap import (
+    BOOTSTRAP_GENERATION,
+    LEGACY_INDEX_SHA256,
+    LEGACY_INDEX_SIZE_BYTES,
+    expected_asset_names,
+)
 
 SCHEMA_ROOT = Path(__file__).resolve().parents[1] / "schemas"
 SHA_A = "a" * 64
@@ -57,6 +63,38 @@ def validate_schema_contracts() -> None:
             raise ValueError(
                 "incident sign-off schema accepted an invalid completed-attempt count"
             )
+    bootstrap_schema = SCHEMA_ROOT / "schema_epoch_bootstrap_evidence.schema.json"
+    alpha_stage = copy.deepcopy(
+        fixtures["schema_epoch_bootstrap_evidence.schema.json"]
+    )
+    alpha_stage["stage"] = "alpha-assets"
+    for key in ("alpha_evidence", "beta", "index", "public_smoke"):
+        del alpha_stage[key]
+    validate_instance(alpha_stage, bootstrap_schema)
+    duplicate_smoke = copy.deepcopy(
+        fixtures["schema_epoch_bootstrap_evidence.schema.json"]
+    )
+    duplicate_smoke["public_smoke"][1]["id"] = duplicate_smoke["public_smoke"][0]["id"]
+    duplicate_smoke["public_smoke"][1]["sha256"] = SHA_A
+    extra_asset = copy.deepcopy(fixtures["schema_epoch_bootstrap_evidence.schema.json"])
+    extra_asset["alpha"]["published_assets"][
+        "sifr-0.9.9-alpha.1-x86_64-apple-darwin.tar.gz"
+    ] = SHA_A
+    alpha_with_beta = copy.deepcopy(
+        fixtures["schema_epoch_bootstrap_evidence.schema.json"]
+    )
+    alpha_with_beta["stage"] = "alpha-assets"
+    for key in ("alpha_evidence", "index", "public_smoke"):
+        del alpha_with_beta[key]
+    for invalid_bootstrap in (duplicate_smoke, extra_asset, alpha_with_beta):
+        try:
+            validate_instance(invalid_bootstrap, bootstrap_schema)
+        except JsonSchemaError:
+            pass
+        else:
+            raise ValueError(
+                "bootstrap evidence schema accepted an invalid governed collection"
+            )
 
 
 def schema_fixtures() -> dict[str, Any]:
@@ -65,6 +103,7 @@ def schema_fixtures() -> dict[str, Any]:
         "qualification_artifact_index.schema.json": qualification_index(),
         "release_index.schema.json": index,
         "release_profile_report.schema.json": release_report(),
+        "schema_epoch_bootstrap_evidence.schema.json": schema_bootstrap_evidence(),
         "self_update_install_receipt.schema.json": install_receipt(),
         "self_update_plan.schema.json": self_update_plan(),
         "self_version.schema.json": self_version(),
@@ -74,6 +113,53 @@ def schema_fixtures() -> dict[str, Any]:
         "stable_release_plan.schema.json": release_plan(),
         "stable_release_signoff.schema.json": release_signoff(),
         "stable_site_release_facts.schema.json": site_facts(),
+    }
+
+
+def schema_bootstrap_evidence() -> dict[str, Any]:
+    def release(version: str) -> dict[str, Any]:
+        return {
+            "version": version,
+            "source_commit": COMMIT,
+            "release_record_sha256": SHA_A,
+            "published_assets": {
+                name: SHA_B for name in sorted(expected_asset_names(version))
+            },
+        }
+
+    return {
+        "schema_version": 2,
+        "operation": "schema-epoch-bootstrap",
+        "stage": "preview-index",
+        "run_id": 42,
+        "run_attempt": 1,
+        "initiator": "release-initiator",
+        "approvers": ["release-reviewer"],
+        "prepare_summary_sha256": SHA_A,
+        "legacy_index": {
+            "sha256": LEGACY_INDEX_SHA256,
+            "size_bytes": LEGACY_INDEX_SIZE_BYTES,
+        },
+        "alpha": release("0.1.0-alpha.2"),
+        "alpha_evidence": {
+            "sha256": SHA_B,
+            "run_id": 41,
+            "run_attempt": 1,
+            "initiator": "alpha-initiator",
+            "approvers": ["alpha-reviewer"],
+            "prepare_summary_sha256": SHA_C,
+        },
+        "beta": release("0.1.0-beta.15"),
+        "index": {"generation": BOOTSTRAP_GENERATION, "sha256": SHA_C},
+        "public_smoke": [
+            {"id": smoke_id, "status": "pass", "sha256": SHA_D}
+            for smoke_id in (
+                "dispatcher-default",
+                "dispatcher-stable-rejection",
+                "governance-index",
+                "installed-self-update",
+            )
+        ],
     }
 
 
@@ -320,6 +406,7 @@ def release_report() -> dict[str, Any]:
             ("distribution_release", "qualification"),
             ("distribution_release", "evidence-custody"),
             ("distribution_release", "incident-governance"),
+            ("distribution_release", "epoch-bootstrap"),
         ],
     }
     return {
@@ -359,6 +446,7 @@ def release_report() -> dict[str, Any]:
                             "qualification",
                             "evidence-custody",
                             "incident-governance",
+                            "epoch-bootstrap",
                         ],
                     ),
                 )
@@ -443,7 +531,9 @@ def release_signoff() -> dict[str, Any]:
 
 
 def incident_signoff() -> dict[str, Any]:
-    evidence = lambda digest: {"status": "pass", "evidence_sha256": digest}
+    def evidence(digest: str) -> dict[str, str]:
+        return {"status": "pass", "evidence_sha256": digest}
+
     return {
         "schema_version": 2,
         "incident_id": "inc-2026-001",

--- a/verification/areas/distribution_release/governance/selftest.py
+++ b/verification/areas/distribution_release/governance/selftest.py
@@ -241,6 +241,7 @@ def valid_report() -> dict[str, Any]:
             ("distribution_release", "qualification"),
             ("distribution_release", "evidence-custody"),
             ("distribution_release", "incident-governance"),
+            ("distribution_release", "epoch-bootstrap"),
         ],
     }
     steps = []
@@ -297,6 +298,7 @@ def valid_report() -> dict[str, Any]:
                             "qualification",
                             "evidence-custody",
                             "incident-governance",
+                            "epoch-bootstrap",
                         },
                     ),
                 )

--- a/verification/areas/distribution_release/manifest.json
+++ b/verification/areas/distribution_release/manifest.json
@@ -74,6 +74,19 @@
           "diagnostic_formats": []
         }
       ]
+    },
+    {
+      "name": "epoch-bootstrap",
+      "kind": "adapter",
+      "cases": [
+        {
+          "id": "schema-v2-preview-epoch-bootstrap",
+          "entry": "verification/areas/distribution_release/governance/schema_bootstrap_selftest.py",
+          "command": "distribution-schema-bootstrap",
+          "expect_exit_code": 0,
+          "diagnostic_formats": []
+        }
+      ]
     }
   ],
   "network_mode": "offline",

--- a/verification/areas/distribution_release/runner.py
+++ b/verification/areas/distribution_release/runner.py
@@ -48,8 +48,15 @@ def main(argv: list[str] | None = None) -> int:
     incident_suite_selected = any(
         str(suite["name"]) == "incident-governance" for suite in selected
     )
+    epoch_suite_selected = any(
+        str(suite["name"]) == "epoch-bootstrap" for suite in selected
+    )
     suite_results = [
-        run_suite(suite, include_incident=not incident_suite_selected)
+        run_suite(
+            suite,
+            include_incident=not incident_suite_selected,
+            include_epoch_bootstrap=not epoch_suite_selected,
+        )
         for suite in selected
     ]
     total_variants = sum(int(result["total_variants"]) for result in suite_results)
@@ -106,6 +113,7 @@ def run_suite(
     suite: dict[str, Any],
     *,
     include_incident: bool = True,
+    include_epoch_bootstrap: bool = True,
 ) -> dict[str, Any]:
     suite_name = str(suite["name"])
     case = validate_suite_case(suite)
@@ -123,6 +131,13 @@ def run_suite(
                 "incident-recovery",
             )
         ]
+    elif suite_name == "epoch-bootstrap":
+        variants = [
+            run_python_module(
+                "governance.schema_bootstrap_selftest",
+                "schema-v2-preview-epoch-bootstrap",
+            )
+        ]
     elif suite_name == "qualification":
         variants = [
             run_python_module(
@@ -135,6 +150,13 @@ def run_suite(
         if suite_name == "full":
             variants.append(run_python_module("governance.selftest", "governance-contracts"))
             variants.append(run_python_module("governance.schema_epoch", "schema-epoch"))
+            if include_epoch_bootstrap:
+                variants.append(
+                    run_python_module(
+                        "governance.schema_bootstrap_selftest",
+                        "schema-v2-preview-epoch-bootstrap",
+                    )
+                )
             if include_incident:
                 variants.append(
                     run_python_module(
@@ -170,6 +192,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
         "qualification",
         "evidence-custody",
         "incident-governance",
+        "epoch-bootstrap",
     }:
         raise SystemExit(f"unsupported distribution_release suite: {suite_name}")
     cases = suite.get("cases", [])
@@ -179,6 +202,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
     expected_command = {
         "evidence-custody": "distribution-evidence-custody",
         "incident-governance": "distribution-incident-recovery",
+        "epoch-bootstrap": "distribution-schema-bootstrap",
         "qualification": "distribution-stable-qualification",
     }.get(suite_name, "distribution-case-directory")
     if str(case.get("command")) != expected_command:
@@ -187,6 +211,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
     expected_entry = {
         "evidence-custody": AREA_ROOT / "governance" / "evidence_custody.py",
         "incident-governance": AREA_ROOT / "governance" / "incident_recovery_selftest.py",
+        "epoch-bootstrap": AREA_ROOT / "governance" / "schema_bootstrap_selftest.py",
         "qualification": AREA_ROOT / "governance" / "qualification_selftest.py",
     }.get(suite_name, CASES_ROOT)
     if entry != expected_entry or not entry.exists():

--- a/verification/areas/distribution_release/schemas/schema_epoch_bootstrap_evidence.schema.json
+++ b/verification/areas/distribution_release/schemas/schema_epoch_bootstrap_evidence.schema.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sifr.sh/schemas/schema-epoch-bootstrap-evidence-v2.json",
+  "title": "Sifr one-time schema epoch bootstrap evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "operation",
+    "stage",
+    "run_id",
+    "run_attempt",
+    "initiator",
+    "approvers",
+    "prepare_summary_sha256",
+    "legacy_index",
+    "alpha"
+  ],
+  "properties": {
+    "schema_version": {"const": 2},
+    "operation": {"const": "schema-epoch-bootstrap"},
+    "stage": {"enum": ["alpha-assets", "preview-index"]},
+    "run_id": {"type": "integer", "minimum": 1},
+    "run_attempt": {"type": "integer", "minimum": 1},
+    "initiator": {"type": "string", "minLength": 1},
+    "approvers": {"$ref": "#/$defs/approvers"},
+    "prepare_summary_sha256": {"$ref": "#/$defs/sha256"},
+    "legacy_index": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha256", "size_bytes"],
+      "properties": {
+        "sha256": {"const": "71b3243925670f56dc510b8f45b6614a622f58097a0fea9492f61d20dc4bf9ef"},
+        "size_bytes": {"const": 105}
+      }
+    },
+    "alpha": {"$ref": "#/$defs/alpha"},
+    "alpha_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sha256",
+        "run_id",
+        "run_attempt",
+        "initiator",
+        "approvers",
+        "prepare_summary_sha256"
+      ],
+      "properties": {
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "run_id": {"type": "integer", "minimum": 1},
+        "run_attempt": {"type": "integer", "minimum": 1},
+        "initiator": {"type": "string", "minLength": 1},
+        "approvers": {"$ref": "#/$defs/approvers"},
+        "prepare_summary_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "beta": {"$ref": "#/$defs/beta"},
+    "index": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generation", "sha256"],
+      "properties": {
+        "generation": {"const": 1},
+        "sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "public_smoke": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "status", "sha256"],
+        "properties": {
+          "id": {
+            "enum": [
+              "dispatcher-default",
+              "dispatcher-stable-rejection",
+              "governance-index",
+              "installed-self-update"
+            ]
+          },
+          "status": {"const": "pass"},
+          "sha256": {"$ref": "#/$defs/sha256"}
+        }
+      },
+      "allOf": [
+        {
+          "contains": {"properties": {"id": {"const": "dispatcher-default"}}},
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {"properties": {"id": {"const": "dispatcher-stable-rejection"}}},
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {"properties": {"id": {"const": "governance-index"}}},
+          "minContains": 1,
+          "maxContains": 1
+        },
+        {
+          "contains": {"properties": {"id": {"const": "installed-self-update"}}},
+          "minContains": 1,
+          "maxContains": 1
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"stage": {"const": "preview-index"}}},
+      "then": {"required": ["alpha_evidence", "beta", "index", "public_smoke"]},
+      "else": {
+        "allOf": [
+          {"not": {"required": ["alpha_evidence"]}},
+          {"not": {"required": ["beta"]}},
+          {"not": {"required": ["index"]}},
+          {"not": {"required": ["public_smoke"]}}
+        ]
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "not": {"const": "0000000000000000000000000000000000000000000000000000000000000000"}
+    },
+    "approvers": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "alpha_assets": {
+      "type": "object",
+      "minProperties": 9,
+      "not": {"minProperties": 10},
+      "propertyNames": {
+        "pattern": "^sifr-(installer-[0-9]+\\.[0-9]+\\.[0-9]+-alpha\\.[0-9]+|[0-9]+\\.[0-9]+\\.[0-9]+-alpha\\.[0-9]+-(aarch64-apple-darwin|x86_64-apple-darwin|x86_64-unknown-linux-gnu|aarch64-unknown-linux-gnu)\\.tar\\.gz(\\.sha256)?)$"
+      },
+      "additionalProperties": {"$ref": "#/$defs/sha256"}
+    },
+    "beta_assets": {
+      "type": "object",
+      "minProperties": 9,
+      "not": {"minProperties": 10},
+      "propertyNames": {
+        "pattern": "^sifr-(installer-[0-9]+\\.[0-9]+\\.[0-9]+-beta\\.[0-9]+|[0-9]+\\.[0-9]+\\.[0-9]+-beta\\.[0-9]+-(aarch64-apple-darwin|x86_64-apple-darwin|x86_64-unknown-linux-gnu|aarch64-unknown-linux-gnu)\\.tar\\.gz(\\.sha256)?)$"
+      },
+      "additionalProperties": {"$ref": "#/$defs/sha256"}
+    },
+    "alpha": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "source_commit", "release_record_sha256", "published_assets"],
+      "properties": {
+        "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+-alpha\\.[0-9]+$"},
+        "source_commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "release_record_sha256": {"$ref": "#/$defs/sha256"},
+        "published_assets": {"$ref": "#/$defs/alpha_assets"}
+      }
+    },
+    "beta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "source_commit", "release_record_sha256", "published_assets"],
+      "properties": {
+        "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+-beta\\.[0-9]+$"},
+        "source_commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "release_record_sha256": {"$ref": "#/$defs/sha256"},
+        "published_assets": {"$ref": "#/$defs/beta_assets"}
+      }
+    }
+  }
+}

--- a/verification/profiles/merge.json
+++ b/verification/profiles/merge.json
@@ -243,7 +243,8 @@
       "suites": [
         "representative",
         "qualification",
-        "incident-governance"
+        "incident-governance",
+        "epoch-bootstrap"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/profiles/nightly.json
+++ b/verification/profiles/nightly.json
@@ -222,7 +222,8 @@
       "suites": [
         "full",
         "qualification",
-        "incident-governance"
+        "incident-governance",
+        "epoch-bootstrap"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/profiles/release.json
+++ b/verification/profiles/release.json
@@ -221,7 +221,8 @@
         "full",
         "qualification",
         "evidence-custody",
-        "incident-governance"
+        "incident-governance",
+        "epoch-bootstrap"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -86,7 +86,7 @@ def _schema_self_test() -> None:
         / "schemas"
     )
     governed = [lint_schema(path) for path in sorted(governance_schemas.glob("*.schema.json"))]
-    if len(governed) != 12:
+    if len(governed) != 13:
         raise AssertionError("release-governance schema lint registration drifted")
     try:
         validate_schema_requirement({"type": "object", "oneOf": []}, Path("bad.schema.json"))
@@ -681,6 +681,7 @@ def _release_report_production_self_test() -> None:
             "qualification",
             "evidence-custody",
             "incident-governance",
+            "epoch-bootstrap",
         ],
     }
     with tempfile.TemporaryDirectory(prefix="sifr-release-report-production-") as directory:


### PR DESCRIPTION
## Summary

- add a read-only prepare workflow and protected publication path for the one-time schema-v2 preview epoch bootstrap
- bind fresh alpha and beta release evidence, exact opaque pre-epoch identity, generation-1 preview activation, site reconciliation, and real public install/self-update smoke
- add strict schema, semantic validator, producer, workflow contract, profile registration, release-report custody, guardrails, documentation, and archived Opus review evidence

## Validation

- `uv run --project verification --locked python -m sifr_verify --self-test`
- `uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite epoch-bootstrap`
- full `distribution_release`: 110/110 (reviewer reproduction)
- merge distribution selection: 55/55 (reviewer reproduction)
- coverage/profile assignment, documentation structure, file-size guard + self-test, compileall, bash syntax, and `git diff --check`
- Claude Opus passes 1–12; pass 12: `VERDICT: SATISFIED`
- create-PR profile completed all 19 Python-interop variants; final run exceeded only the known host timing budget (690.10s vs 600s), indexed in `plans/phases/adhoc_performance_budget_host_variance.md`; no threshold or waiver changed

## Downstream execution

The implementation PR is independently reviewable and mergeable. Actual protected bootstrap execution remains intentionally downstream: configure the `stable-release` environment with a distinct non-initiating release reviewer and prevent-self-review, provide the website Actions token, and confirm the live opaque schema-v1 asset still matches the pinned 105-byte digest immediately before dispatch.