### PR TITLE
Phase 40: add protected stable publication drill

### DIFF
--- a/.github/workflows/release-publication-drill.yml
+++ b/.github/workflows/release-publication-drill.yml
@@ -1,0 +1,83 @@
+name: release-publication-drill
+
+on:
+  workflow_call:
+    inputs:
+      mode:
+        description: Exact credential-free protected drill mode
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  drill:
+    name: protected credential-free release drill
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    environment:
+      name: stable-release-drill
+    permissions:
+      contents: read
+    env:
+      DRILL_MODE: ${{ inputs.mode }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Validate drill boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${DRILL_MODE}" in
+            drill-publication) scenario=publication ;;
+            drill-rollback) scenario=rollback ;;
+            drill-first-ga) scenario=first-ga ;;
+            *)
+              echo "::error::unsupported protected drill mode"
+              exit 2
+              ;;
+          esac
+          echo "DRILL_SCENARIO=${scenario}" >>"${GITHUB_ENV}"
+          for credential in \
+            CLOUDFLARE_API_TOKEN GH_TOKEN GITHUB_TOKEN VSCE_PAT \
+            SIFR_SITE_TOKEN SIFR_WEBSITE_ACTIONS_TOKEN; do
+            test -z "${!credential:-}" || {
+              echo "::error::protected drill received production credential ${credential}"
+              exit 2
+            }
+          done
+
+      - name: Run exact shared cores with local adapters and no network
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir drill-evidence
+          sudo env \
+            -u CLOUDFLARE_API_TOKEN \
+            -u GH_TOKEN \
+            -u GITHUB_TOKEN \
+            -u VSCE_PAT \
+            -u SIFR_SITE_TOKEN \
+            -u SIFR_WEBSITE_ACTIONS_TOKEN \
+            unshare --net --mount-proc \
+              python3 -m \
+                verification.areas.distribution_release.governance.protected_drill_selftest \
+                --scenario "${DRILL_SCENARIO}" \
+                --report drill-evidence/protected-drill.json
+          python3 scripts/distribution/release_governance.py validate \
+            --kind protected-drill-evidence \
+            --input drill-evidence/protected-drill.json \
+            --expected-drill-scenario "${DRILL_SCENARIO}" \
+            --require-canonical
+
+      - name: Retain immutable drill evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: stable-release-drill-${{ github.run_id }}-${{ github.run_attempt }}
+          path: drill-evidence/protected-drill.json
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: false

--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -1,6 +1,16 @@
 name: release-publication
 
 on:
+  workflow_dispatch:
+    inputs:
+      governance_mode:
+        description: Credential-free protected drill
+        required: true
+        type: choice
+        options:
+          - drill-publication
+          - drill-rollback
+          - drill-first-ga
   workflow_call:
     inputs:
       channel:
@@ -24,7 +34,7 @@ on:
         required: true
         type: string
       governance_mode:
-        description: Ordinary preview publication or protected one-time bootstrap stage
+        description: Preview/bootstrap publication or credential-free protected drill
         required: false
         default: preview
         type: string
@@ -43,11 +53,12 @@ permissions:
   contents: write
 
 concurrency:
-  group: sifr-release-index
+  group: ${{ startsWith(inputs.governance_mode, 'drill-') && 'sifr-release-drill' || 'sifr-release-index' }}
   cancel-in-progress: false
 
 jobs:
   prepare:
+    if: ${{ !startsWith(inputs.governance_mode, 'drill-') }}
     uses: ./.github/workflows/release-publication-prepare.yml
     permissions:
       actions: read
@@ -61,6 +72,7 @@ jobs:
 
   publish:
     name: mutate governed preview release
+    if: ${{ !startsWith(inputs.governance_mode, 'drill-') }}
     needs: prepare
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -793,3 +805,11 @@ jobs:
             echo "::error::final schema-bootstrap evidence drifted after upload"
             exit 2
           }
+
+  drill:
+    if: ${{ startsWith(inputs.governance_mode, 'drill-') }}
+    uses: ./.github/workflows/release-publication-drill.yml
+    permissions:
+      contents: read
+    with:
+      mode: ${{ inputs.governance_mode }}

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -1431,6 +1431,7 @@ cargo test                                    # Run all tests (layers 1-3)
 uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite full     # Preview installer/artifact/release automation checks
 uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite incident-governance # Offline rollback/roll-forward generation, retention, and recovery
 uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite epoch-bootstrap # One-time opaque schema-v2 preview epoch bootstrap contracts
+uv run --project verification --locked python -m sifr_verify areas run --area distribution_release --suite protected-drill # Credential-free GA/normal/rollback/first-GA orchestration under local adapters
 ./verification/runner/e2e/check_report_determinism.sh --profile release # Stable e2e report signature across reruns
 uv run --project verification --locked python -m sifr_verify areas run --area fuzz_property --suite cargo-smoke --suite property --suite fuzz-smoke
 cargo test --manifest-path third_party/ruff/Cargo.toml -p ruff_python_parser # Parser snapshots

--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -579,13 +579,23 @@ closure policy is in
 Marketplace, and incident production mutations remain gated until their later
 protected-publication slices.
 
-The first protected-publication slice wires only the one-time schema-epoch
-bootstrap into `.github/workflows/release-publication.yml`. Its nested
+The first protected-publication slice wires the one-time schema-epoch
+bootstrap and credential-free protected drills into
+`.github/workflows/release-publication.yml`. Its nested
 `release-publication-prepare.yml` job has read-only permissions, no protected
 environment, and no production secret. It verifies the exact source and
 artifact bytes, the current governance-asset identity, and any staged alpha
 evidence, then uploads an immutable 30-day summary whose digest is rechecked by
 the publish job and retained in each durable bootstrap evidence record.
+
+Manual drill dispatch selects exactly publication, rollback, or first-GA
+coverage and passes that mode unchanged to `release-publication-drill.yml`;
+unknown reusable-workflow modes fail before the drill core runs. Drills use the
+isolated `sifr-release-drill` concurrency group, read-only repository
+permission, no inherited secret, an explicit production-credential scrub, and
+a blocked network namespace. They retain canonical, write-once schema-v2
+evidence for 30 days, bound to the selected scenario and the exact governed
+tests. They never acquire the production `sifr-release-index` mutation lock.
 
 `bootstrap-alpha` publishes a fresh, qualified alpha release and a write-once
 evidence record under the `channels` governance release. `bootstrap-index`
@@ -615,6 +625,8 @@ demo, with:
 ```bash
 uv run --project verification --locked python -m sifr_verify areas run \
   --area distribution_release --suite epoch-bootstrap
+uv run --project verification --locked python -m sifr_verify areas run \
+  --area distribution_release --suite protected-drill
 uv run --project verification --locked python -m sifr_verify areas run \
   --area distribution_release --suite incident-governance
 demos/stable_incident_recovery_demo.sh

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -511,6 +511,8 @@ Review and upstream coordination ledger:
   131/131, and every crate, runtime, tooling, performance, and guardrail step.
   Its 1058.85-second cold-cache wall time produced only the declared warm-target
   advisory; every enforced per-step budget passed.
+- Protected credential-free drill and stable index planning are under review
+  in [PR #3041](https://github.com/sifr-lang/sifr/pull/3041).
 - [ ] Publish or verify write-once assets, Marketplace version, governed index
   activation, site facts, and post-publication smoke.
 - [ ] Exercise resume, stale generation, burned generation, rollback, and

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -470,7 +470,47 @@ Review and upstream coordination ledger:
   It independently matched local, remote-branch, and PR head at
   `e51491338e396e6b8f2d19345c9df68242e2b029`, re-ran the complete focused
   gate set, found no actionable issue, and returned `VERDICT: SATISFIED`.
+- Frozen-head bootstrap review pass 14 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-14-final-pr-head-satisfied.md`.
+  It matched local, remote-branch, and PR head at
+  `7236ce5f773979ec6d56c8942785f25be04a60d9`, verified the pass-13 archive
+  delta was documentation-only and truthful, re-ran the focused gates, and
+  returned `VERDICT: SATISFIED` with no actionable finding.
+- [PR #3040](https://github.com/sifr-lang/sifr/pull/3040) merged the schema-v2
+  preview epoch bootstrap implementation as
+  `e22a8cfbf058f9657b285370d7d075f9ff0209b3`.
 - [x] Add the single protected publication workflow and production site adapter.
+- The protected-drill wave adds the deterministic `ga-activation` and `normal`
+  index-planning core, a named `protected-drill` suite, and a
+  `stable-release-drill` job whose dispatch selects exactly publication,
+  rollback, or first-GA coverage through temporary local adapters inside a
+  network namespace. The local suite runs all scenarios, including normal,
+  site-timeout resume, and stale/credential boundaries. The reusable drill
+  accepts no secrets, grants read-only repository permission, and retains
+  write-once schema-v2 evidence for 30 days.
+- Protected-drill review pass 1 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-1-not-satisfied.md`.
+  Its six findings are remediated: drill concurrency is isolated, unknown
+  modes fail closed, the production site secret remains required, credential
+  names share one Python contract checked against the workflow, transition
+  defenses have direct tests, and emitted mutation evidence binds the exact
+  plan, previous index identity, and proposed index bytes.
+- Protected-drill review pass 2 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-2-not-satisfied.md`.
+  Both findings are remediated: mutation evidence now accepts intentional
+  burned-generation gaps while requiring strict monotonicity and validating
+  before write, and the durable distribution reference documents the exact
+  drill dispatch, concurrency, credential, network, and retention boundaries.
+- Protected-drill review pass 3 is satisfied and archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-3-satisfied.md`.
+  It re-ran the focused and combined 60-variant gates, confirmed every prior
+  finding remains closed, found no actionable issue, and returned
+  `SATISFIED`.
+- The authoritative create-PR profile passed with zero blocking failures:
+  Python interop 19/19 in 414.69 seconds, consumed Rust interop 10/10, e2e
+  131/131, and every crate, runtime, tooling, performance, and guardrail step.
+  Its 1058.85-second cold-cache wall time produced only the declared warm-target
+  advisory; every enforced per-step budget passed.
 - [ ] Publish or verify write-once assets, Marketplace version, governed index
   activation, site facts, and post-publication smoke.
 - [ ] Exercise resume, stale generation, burned generation, rollback, and

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -513,6 +513,11 @@ Review and upstream coordination ledger:
   advisory; every enforced per-step budget passed.
 - Protected credential-free drill and stable index planning are under review
   in [PR #3041](https://github.com/sifr-lang/sifr/pull/3041).
+- Exact PR-head review pass 4 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-4-exact-pr-head-satisfied.md`.
+  It matched local, remote branch, and PR head at
+  `774592acd140747c068bfe6f4752b34006e9664a`, rechecked the complete wave,
+  found no actionable issue, and returned `SATISFIED`.
 - [ ] Publish or verify write-once assets, Marketplace version, governed index
   activation, site facts, and post-publication smoke.
 - [ ] Exercise resume, stale generation, burned generation, rollback, and

--- a/plans/releases/stable_gate_inventory.json
+++ b/plans/releases/stable_gate_inventory.json
@@ -131,6 +131,22 @@
       "disposition": "records all actual distinct environment reviewers in bootstrap and later stable sign-off evidence"
     },
     {
+      "id": "protected-publication-stable-index-planner",
+      "location": "verification/areas/distribution_release/governance/stable_planner.py",
+      "owner": "release/distribution",
+      "current_behavior": "materializes deterministic ga-activation and normal stable index mutations from an exact canonical plan and live generation/digest",
+      "activation_boundary": "protected-publication",
+      "disposition": "is shared by the credential-free drill and protected production adapter without providing a local mutation path"
+    },
+    {
+      "id": "protected-publication-drill",
+      "location": ".github/workflows/release-publication-drill.yml",
+      "owner": "release/distribution",
+      "current_behavior": "runs an exactly selected publication, rollback, or first-GA scenario through shared cores and temporary adapters in a network namespace with no production credential",
+      "activation_boundary": "protected-publication",
+      "disposition": "remains read-only in stable-release-drill and retains immutable bounded-lifetime drill evidence"
+    },
+    {
       "id": "schema-bootstrap-public-smoke",
       "location": "scripts/distribution/run_schema_bootstrap_public_smoke.sh",
       "owner": "release/distribution",

--- a/plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-1-not-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-1-not-satisfied.md
@@ -1,0 +1,72 @@
+## Review — Phase 40 / Milestone 40.5 protected credential-free drill + stable index planner
+
+**Scope check (clean).** No `crates/`, no `demos/`, no Rust interop implementation. The wave is confined to release governance, workflow plumbing, verification suites, and planning docs. Schema/suite/profile registration is complete and self-enforcing (`schema_contracts.py:29-31` set-equality on fixture names; `sifr_verify/selftest.py:89` bumped 13→14; merge/nightly/release profiles + `profile_assignment_matrix.json` all updated consistently). The new case script is auto-discovered by `runner.py:248` glob and is `0755`. The zero-byte `plans/reviews/active/…pass-1.md` matches the repo's existing handoff-slot convention (pass 14 did the same) — not a finding.
+
+Findings below, most severe first.
+
+---
+
+### 1. The drill occupies the production release-index concurrency lock — `.github/workflows/release-publication.yml:55-57`
+
+```yaml
+concurrency:
+  group: sifr-release-index
+  cancel-in-progress: false
+```
+
+This is workflow-level, so it applies to the `drill:` job path too. A read-only, credential-free drill (up to 20 min) now holds the same mutual-exclusion group as real preview/bootstrap index mutation. Worse: with `cancel-in-progress: false`, GitHub keeps only **one** pending run per group and cancels earlier pending ones — so dispatching two drills while a real publication is queued evicts the queued production run.
+
+The drill is precisely the kind of job that must not contend with the production lock. Suggest keying the group on mode, e.g.
+`group: ${{ startsWith(inputs.governance_mode, 'drill-') && 'sifr-release-drill' || 'sifr-release-index' }}`.
+
+### 2. Scenario mapping fails open on unrecognized `drill-*` modes — `.github/workflows/release-publication.yml:810,815`
+
+```yaml
+if: ${{ startsWith(inputs.governance_mode, 'drill-') }}
+...
+scenario: ${{ ... == 'drill-first-ga' && 'first-ga' || ... == 'drill-rollback' && 'rollback' || 'publication' }}
+```
+
+The `workflow_call` `governance_mode` input is an unvalidated `type: string` (`:36-40`). Any value starting with `drill-` — including a typo or an unintended value — now (a) skips `prepare` and `publish` via the two `!startsWith(...)` guards at `:61` and `:75`, and (b) is silently normalized to `publication` by the trailing `|| 'publication'` fallback. The run then reports **success** having published nothing.
+
+Before this change, an unsupported `governance_mode` was rejected by the publish job's `*) echo "::error::unsupported governance_mode"; exit 2` (`:202`). The drill's own boundary validator (`release-publication-drill.yml:34-40`) cannot compensate, because the ternary has already erased the bogus value. Map exactly the three modes and fail on anything else (or pass `inputs.governance_mode` through verbatim and let the boundary step reject it).
+
+### 3. `SIFR_WEBSITE_ACTIONS_TOKEN` downgraded to `required: false` unnecessarily — `.github/workflows/release-publication.yml:46-49`
+
+`secrets:` under `workflow_call` is only evaluated for `workflow_call` invocations; `workflow_dispatch` (the only way to reach the drill) never consults it, and the sole caller `preview-release.yml:201-202` always passes the token. So the drill did not require this relaxation, and the change removes a call-site fail-closed guarantee on the production publication path: a future caller that omits the secret now passes call validation and runs `publish` with an empty `SITE_TOKEN`.
+
+Blast radius is bounded — `verify_site_workflow_identity.sh:29` requires `-n "${GH_TOKEN:-}"` and exits 2 at the first validation step, before any mutation — but the guarantee has moved from the interface contract to a downstream script with no test pinning it. Restore `required: true`, or add an explicit non-empty assertion in the publish job's validate step.
+
+### 4. Credential deny-list is forked three ways and the Python guard misses the site token — `governance/incident_fixture.py:35-41`
+
+`FORBIDDEN_CREDENTIALS` contains 5 names and **omits `SIFR_WEBSITE_ACTIONS_TOKEN`**, yet it is the only in-process refusal used by the drill (`protected_drill_selftest.py:104`). The other two lists — `runner.py:719-727` (scrub) and `release-publication-drill.yml:41-48` (boundary) — both carry 6 names including the site token.
+
+Consequence: `run_drill` will happily execute with the production site token live in the environment (local invocation, or any future job that maps it), which is exactly the boundary the drill exists to assert. Hoist one shared constant and have all three sites consume it.
+
+### 5. The transition negative tests don't reach the code they name — `governance/stable_planner_selftest.py:111-125`
+
+Both cases assert on `"active live stable predecessor"`, which is emitted by `release_plan.py:126` (plan↔index consistency), not by the stable-planner transition logic. As a result:
+
+- `stable_planner.py:56-57` (`"stable publication accepts ga-activation or normal"`) is **never exercised**. The case that would reach it is an `incident-roll-forward` plan carrying a well-formed `expected_stable_predecessor` against an active index — `valid_plan(transition="incident-roll-forward")` leaves the predecessor as `"none"`, so it short-circuits earlier.
+- `release_index.py:205-206`, `:207-208`, and `:202-203` are unreachable via `materialize_stable_mutation` (all three are already enforced by `release_plan.py:94-96` and `:121-131`) and untested via the direct `propose_stable_release` entry point.
+
+The guards are correct defense-in-depth; the issue is that a test named `test_fail_closed_identity_and_transition` currently certifies the transition guard without touching it. The `expected_generation` / `expected_sha256` / `proposed_generation` assertions in the same test (`:80-103`) *are* load-bearing.
+
+### 6. `plan-stable-index` discards the plan digest it computes — `scripts/distribution/release_governance.py:481-493`, `governance/stable_planner.py:73-76`
+
+`materialize_stable_mutation` computes `plan_sha256` (a second full-file hash) and `transition`, but `plan_stable_index` writes only `mutation.proposed_index`. Nothing in the emitted artifact binds the proposed index to the exact plan bytes that produced it — which is the identity property the planner exists to provide for the future protected adapter. Today the hash is dead work; emitting the mutation record (or at minimum `plan_sha256` + `transition` alongside the index) would make it load-bearing.
+
+---
+
+### Optional observations (no action required)
+
+- **TOCTOU on the live index** — `stable_planner.py:43-49` reads the file once via `load_json_strict` and again via `sha256_file`. A concurrent rewrite between the two reads means the validated bytes and the digested bytes differ. Single read + hash-in-memory would close it. (Irrelevant in the drill; matters if the protected adapter reuses this path against a shared working tree.)
+- **The drill's boundary env loop is vacuous today** — `release-publication-drill.yml:41-48` checks names that are never in the job environment (`GITHUB_TOKEN` is not exported by default; no `env:` maps secrets). It is useful defense-in-depth against a future edit, but it does not verify the `stable-release-drill` GitHub environment is secret-free. The real protection is the absence of a `secrets:` block on the `uses:` call plus `sudo env -u` at `:55-61`, which is correct.
+- **Doc overstatement** — `plans/releases/stable_gate_inventory.json:140` and `plans/issues/active/phase-40-stable-channel-ga-execution.md:481-485` describe the drill as running GA, normal, rollback, site-timeout resume, and first-GA together. Only the local suite does (`--scenario` defaults to `all`); a single `workflow_dispatch` runs exactly one scenario and no dispatch option selects `all`. `internal_docs/architecture.md:1434` is accurate as written since it documents the local suite.
+- **Duplicate scenario execution under `all`** — `test_concurrency_and_credential_boundaries` is listed in both `rollback` and `first-ga` (`protected_drill_evidence.py:26,29`) so it runs twice. It mutates `os.environ["GH_TOKEN"]` (`incident_recovery_selftest.py:296`); `run_drill`'s credential gate runs once up front, so a failed restore would not be re-caught.
+- **Overlapping workflow contracts** — `cases/preview_release_workflow_yaml_parses.sh:110-111` and the new `cases/protected_release_drill_workflow_contract.sh` both YAML-parse and textually assert the drill file.
+- **`release_index.py:378-384`** — replacing `type(x) is not int` with `isinstance` + explicit bool exclusion is behaviour-preserving for `bool` but now admits `int` subclasses (`IntEnum`); the previous form was strictly tighter, and the change is incidental to this wave.
+
+---
+
+**Not SATISFIED** — findings 1–3 (production workflow safety) and 4 are actionable; 5–6 are test/evidence integrity gaps worth closing in this wave. Everything else I checked — schema-v2-only behaviour, canonical/`refuse_existing` evidence writes, retained-release and preview-channel preservation in `propose_stable_release` (`release_index.py:212-229`), the import-time `SCENARIOS`↔`GOVERNED_SCENARIO_TESTS` cross-check (`protected_drill_selftest.py:94-98`), read-only drill permissions, write-once bounded-retention artifact, and file sizes (all new files ≤ 226 lines) — is correct.

--- a/plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-2-not-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-2-not-satisfied.md
@@ -1,0 +1,78 @@
+All listed validations re-run locally. Here is the second-pass audit.
+
+---
+
+## Re-audit of the six pass-1 findings — all remediated
+
+| # | Pass-1 finding | Status |
+|---|---|---|
+| 1 | Drill occupies `sifr-release-index` lock | **Fixed** — `.github/workflows/release-publication.yml:56` now keys the group `${{ startsWith(inputs.governance_mode, 'drill-') && 'sifr-release-drill' \|\| 'sifr-release-index' }}`. `inputs` is a valid context for workflow-level `concurrency` on both `workflow_call` and `workflow_dispatch`, and `workflow_call` supplies `default: preview` (`:38`), so the non-drill branch is total. Pinned by `preview_release_workflow_yaml_parses.sh:55` and `protected_release_drill_workflow_contract.sh:42`. |
+| 2 | Unknown `drill-*` modes fail open to `publication` | **Fixed** — the ternary is gone; `release-publication.yml:815` passes `mode: ${{ inputs.governance_mode }}` verbatim, and `release-publication-drill.yml:34-42` maps exactly the three modes with `*) exit 2`. The dispatch surface is additionally narrowed to `type: choice` with three options (`:8-12`). A `workflow_call` with `drill-typo` now skips prepare/publish and fails the run at the boundary step. Fail-closed confirmed. |
+| 3 | `SIFR_WEBSITE_ACTIONS_TOKEN` downgraded | **Fixed** — `release-publication.yml:45-48` is back to `required: true` (no diff hunk against base), and `protected_release_drill_workflow_contract.sh:47-50` slices the secrets block and asserts it, so a future downgrade fails the suite. |
+| 4 | Credential deny-list forked three ways, Python guard missing the site token | **Fixed** — `governance/common.py:18-25` defines the 6-name `PRODUCTION_CREDENTIAL_NAMES`; `incident_fixture.py:36`, `runner.py:14-16,285-288`, and `protected_drill_selftest.py:106-112` all consume it, and `protected_release_drill_workflow_contract.sh:75-79` contract-checks both the workflow's boundary loop and its `sudo env -u` scrub list against that tuple name-for-name. Verified live: the local run aborted with `refuses production credential(s): VSCE_PAT` before executing anything. |
+| 5 | Transition negative tests never reached the guards they named | **Fixed** — `stable_planner_selftest.py:139-206` (`test_direct_transition_defenses`) drives `propose_stable_release` directly and reaches all five guards (`release_index.py:196-197`, `:199-200`, `:194`, `:205-206`, `:207-208`), and `:126-136` adds the `incident-roll-forward`-plan case that finally reaches `stable_planner.py:95-96`. Confirmed load-bearing by inverting each guard. |
+| 6 | `plan-stable-index` discarded the plan digest | **Fixed** — `StableMutation.evidence()` (`stable_planner.py:40-55`) emits transition, version, exact `plan_sha256`, previous generation+digest, the full proposed index, and `proposed_index_sha256`; `release_governance.py:484-494` writes it canonically with `refuse_existing=True`. Also fixes the pass-1 TOCTOU observation: `stable_planner.py:69-70` reads each file once and both parses and hashes those same bytes. |
+
+Registration is complete: `sifr_verify/selftest.py:89` 13→15, both new schemas lint-clean, `protected-drill` present in the manifest, all three profiles, `profile_assignment_matrix.json`, `release_report.REQUIRED_SUITES`, `selftest.valid_report`, and `qualification_fixture`.
+
+---
+
+## Actionable findings
+
+### 1. The mutation-evidence validator rejects generation gaps the planner deliberately allows — `governance/stable_planner.py:157-158`
+
+```python
+if proposed["generation"] != previous_generation + 1:
+    fail("$.proposed_index.generation", "must immediately follow the previous index")
+```
+
+The producer side imposes no such rule. `propose_stable_release` gates only through `_require_incident_generation` (`release_index.py:378-384`), which requires `proposed_generation > current["generation"]`, and `validate_release_index_transition` (`release_index.py:344-345`) only requires monotonic increase. Generation gaps are not hypothetical here — they are the documented resume behaviour of this exact governance model (`internal_docs/distribution_pipeline.md:568`, "burns a generation after reservation failure"; `test_rollback_burns_generation_and_resumes`).
+
+The wave's own fixtures already straddle the disagreement: `stable_planner_selftest.py:68-81` certifies a `normal` mutation from generation **8 → 12** as valid planning, but that test never runs the validator, and `test_cli_producer` only exercises 7 → 8. Reproduced:
+
+```
+planner accepted gap; proposed generation: 12 previous: 8
+validator REJECTED: $.proposed_index.generation: must immediately follow the previous index
+```
+
+Failure scenario: a GA activation whose generation reservation fails once, burning generation 8. The retry plans 7 → 9, `plan-stable-index` writes the artifact (`release_governance.py:484-494` does **not** validate before writing), and `release_governance.py validate --kind stable-index-mutation-evidence` then rejects the very artifact the wave just produced — with no way to represent the resume-after-burn case the milestone is required to exercise. The direction is fail-closed, so this is not a safety hole, but the two halves of the wave's identity contract disagree and the gap-tolerant path is unrepresentable.
+
+Either relax to `proposed["generation"] > previous_generation` (matching the producer and the incident model), or tighten `propose_stable_release` to reject gaps — but not both as they stand. If the strict form is intentional, `test_normal_successor` should not use a 4-generation gap, and the CLI should validate before writing.
+
+### 2. The durable protected-publication doc still describes `release-publication.yml` as bootstrap-only — `internal_docs/distribution_pipeline.md:582-583`
+
+> "The first protected-publication slice wires **only** the one-time schema-epoch bootstrap into `.github/workflows/release-publication.yml`."
+
+That file now also carries a `workflow_dispatch` entry point (`:4-12`) and a nested `release-publication-drill.yml` job (`:809-815`). The wave documents this only in `plans/issues/active/phase-40-stable-channel-ga-execution.md:481-495`; `internal_docs/` gained just two suite-command lines (`architecture.md:1434`, `distribution_pipeline.md:618-619`) and `architecture.md` never mentions `release-publication.yml` at all. Per AGENTS.md, `internal_docs/` is the durable reference. The paragraph should record the drill dispatch surface, the isolated concurrency group, the read-only/no-secret/no-network guarantees, the exact-mode fail-closed mapping, and the write-once 30-day evidence.
+
+The one-scenario-per-dispatch precision fix itself is correct and consistent across `stable_gate_inventory.json:140-147` and the plan issue.
+
+---
+
+## Optional observations (no action required)
+
+- **The external evidence check doesn't bind the dispatched scenario.** `release-publication-drill.yml:70-73` validates with `--kind protected-drill-evidence` but no expected-scenario argument, so only the in-process `validate_drill_evidence(report, expected_scenarios=selected)` (`protected_drill_selftest.py:137`) ties the report to `DRILL_SCENARIO`. Producer and checker are the same process. A `jq`-free grep of `"name":"${DRILL_SCENARIO}"` in the workflow would close the loop cheaply.
+- **`stable_index_mutation_evidence.schema.json` has no negative fixture** in `schema_contracts.py`, unlike the drill schema (`:98-115`), and its `proposed_index` is `{"type": "object"}` (`:49-51`) — all structure lives in the Python validator. Consistent with how `release_index` is handled elsewhere, but the asymmetry with the sibling schema added in the same wave is worth a note.
+- **`sudo env -u …` is belt-and-braces.** `sudo` runs with `env_reset` by default, so the six `-u` flags in `release-publication-drill.yml:58-64` are already redundant; they are useful as a contract-checkable artifact, which is exactly how the case script uses them.
+- **`test_concurrency_and_credential_boundaries` still runs twice under `--scenario all`** (`protected_drill_evidence.py:26,29`) — carried over from pass 1, unchanged and harmless.
+- **Ruff on new files matches the repo baseline, not clean.** `protected_drill_selftest.py:3` (I001, `.protected_drill_evidence` imported after `.stable_planner_selftest`) and `stable_planner_selftest.py:9` (UP035, `typing.Callable`) — both mirror existing files (`selftest.py:3,10`). There is no ruff config or CI ruff step in this repo, and `verification/` has 551 baseline hits, so this is not a regression.
+- **`_require_incident_generation` style change** (`release_index.py:378-384`) uses `isinstance` + bool exclusion while `common.py:81,98` kept `type(x) is not int` with a new `# noqa: E721`. Two idioms for the same intent, both correct; incidental to this wave.
+
+---
+
+## Validation re-run
+
+| Gate | Result |
+|---|---|
+| `stable_planner_selftest` | **5/5 pass** |
+| `protected_drill_selftest` (all scenarios) | **11 tests pass**, plus credential gate verified live |
+| `validate_schema_contracts` | pass |
+| `sifr_verify --self-test` (incl. 15-schema epoch) | pass |
+| `protected_release_drill_workflow_contract.sh` | pass |
+| `preview_release_workflow_yaml_parses.sh` (4 workflows YAML-parse) | pass |
+| `coverage_matrix` readiness | **4/4**, 5 variants, 0 failures |
+| distribution_release full+qualification+evidence-custody+incident-governance+epoch-bootstrap+protected-drill | **variants=60, failures=0** |
+| File-size guardrail | largest touched file 882 lines; all new files ≤ 318 |
+| Scope | no `crates/`, no `demos/`, no Rust interop, no phase-numbered demos, no production mutation |
+
+**Not SATISFIED** — finding 1 is a genuine producer/validator contradiction in the evidence contract this wave exists to establish, and finding 2 is a durable-docs gap. Everything from pass 1 is correctly closed, and no new workflow-safety, credential-boundary, fail-closed, or planner-correctness defect surfaced.

--- a/plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-3-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-3-satisfied.md
@@ -1,0 +1,52 @@
+All listed validations re-run locally and reproduce. Third-pass audit below.
+
+---
+
+## Re-audit of the pass-2 findings — both remediated
+
+**Pass-2 #1 (producer/validator generation contradiction)** — **Fixed.** `stable_planner.py:157-158` is now `if proposed["generation"] <= previous_generation: fail(..., "must follow the previous index")`, which matches `_require_incident_generation` (`release_index.py:379-384`) and `validate_release_index_transition` exactly. The burned-generation resume case is now representable: `test_normal_successor` plans 8→12 and calls `validate_stable_mutation_evidence(mutation.evidence())` (`stable_planner_selftest.py:87,95`) — the validator is now on that path, which it was not in pass 2. The strict direction is still pinned by a negative: `test_ga_activation` builds a same-generation `stale` artifact, re-digests it so only the generation rule can fire, and asserts `"must follow the previous index"` (`:70-78`). The CLI validates before writing (`release_governance.py:498-499` → `write_canonical_json(..., refuse_existing=True)`), so the artifact the wave produces can no longer be one the validator rejects. Verified 5/5 green.
+
+**Pass-2 #2 (durable doc described `release-publication.yml` as bootstrap-only)** — **Fixed.** `internal_docs/distribution_pipeline.md:582-598` now says the slice wires "the one-time schema-epoch bootstrap **and credential-free protected drills**", followed by a paragraph covering every boundary I checked, and each claim is true against the tree: exact one-scenario dispatch (`release-publication.yml:4-12`, `release-publication-drill.yml:34-42`), verbatim mode pass-through (`release-publication.yml:815`), fail-closed on unknown modes (`*) exit 2`, and non-`drill-` typos still hit the publish job's existing `*) exit 2`), isolated `sifr-release-drill` group (`:56`), `contents: read` (`:812`, drill `:11-12,21-22`), no inherited secret (no `secrets:` on the `uses:`, contract-asserted), production-credential scrub (`drill:44-51,58-64`), blocked network (`unshare --net`), scenario-bound write-once schema-v2 evidence with 30-day retention (`:70-83`), and never taking the production lock.
+
+**Also verified as claimed:** the external CLI check now binds the scenario — `--expected-drill-scenario "${DRILL_SCENARIO}"` (`release-publication-drill.yml:73`) reaches `validate_drill_evidence(payload, expected_scenarios=(...))` (`release_governance.py:255-259`), and the case script pins that exact fragment (`protected_release_drill_workflow_contract.sh:59`). I confirmed the guard is load-bearing by feeding a `rollback` report with `expected_scenarios=("first-ga",)`: rejected at `protected_drill_evidence.py:80-81`. The new mutation schema has two negative fixtures (`schema_contracts.py:117-133`, bad `transition`, `previous_index.generation: 0`).
+
+**All six pass-1 findings remain closed** — I re-checked each against the current tree, not the pass-2 write-up: concurrency ternary, verbatim mode + `type: choice`, `SIFR_WEBSITE_ACTIONS_TOKEN: required: true` (sliced and asserted at `protected_release_drill_workflow_contract.sh:47-50`), single `PRODUCTION_CREDENTIAL_NAMES` consumed by all four sites, direct transition tests reaching all five guards, and plan-bound mutation evidence.
+
+---
+
+## Actionable findings
+
+None.
+
+**SATISFIED.**
+
+---
+
+## Optional observations (no action required)
+
+- **`expected_scenarios` mismatch has no negative test** — `protected_drill_selftest.py:53` exercises the binding positively and the seven mutations at `:54-64` never vary `expected_scenarios` (they call `validate_drill_evidence(changed)` with no binding). The workflow's new scenario gate therefore rests on a branch (`protected_drill_evidence.py:80-81`) that no test asserts rejects. I verified it manually; a one-line addition to the mutation loop would pin it.
+- **`--expected-drill-scenario` is silently ignored for other kinds** — `release_governance.py:255` gates on `args.kind == "protected-drill-evidence" and args.expected_drill_scenario`; passing it with `--kind release-index` is a no-op rather than an error. Identical laxity to the pre-existing `--previous` / `--live-index` flags, so this is consistent, not a regression.
+- **No `--live-index` re-binding for `stable-index-mutation-evidence`** — the evidence records `previous_index.sha256` (`stable_planner.py:47-50`) but the CLI has no path to re-verify it against a live index, unlike `release-plan`, `incident-request`, and `site-facts` (`release_governance.py:260-266`). The artifact is self-consistent (`proposed_index_sha256` is recomputed at `:165-166`) but externally unanchored until the protected adapter lands.
+- **`test_no_production_adapter_surface` assertion narrowed** — `incident_recovery_selftest.py:405` went from `"rollback" not in dispatch` to `"\n          - rollback\n" not in dispatch`. Necessary now that `- drill-rollback` is a legitimate option, but it no longer catches an arbitrary future `rollback`-bearing dispatch option at other indentation. `"incident-roll-forward" not in dispatch` is unweakened.
+- **`proposed_index` remains `{"type": "object"}`** in `stable_index_mutation_evidence.schema.json:49-51`; all structure lives in `validate_release_index`. The pass-2 asymmetry note is now half-closed (negative fixtures exist); the loose subschema is unchanged and consistent with how `release_index` is handled elsewhere.
+- **The drill core runs as root** — `sudo env … unshare` (`release-publication-drill.yml:58-65`) executes `python3` as root, leaving `drill-evidence/protected-drill.json` root-owned in the workspace. Harmless here: umask 022 makes it readable by the non-root validate and upload steps, and none of the 11 governed tests run `git` inside the checkout (`git()` at `incident_recovery_selftest.py:843` is used only by `test_evidence_only_commit_validator`, which is not in any drill scenario), so there is no dubious-ownership exposure.
+- **`sudo env -u` is belt-and-braces** — `env_reset` already applies; the flags earn their place as the contract-checkable artifact consumed by `protected_release_drill_workflow_contract.sh:77-80`.
+- **`test_concurrency_and_credential_boundaries` still runs twice under `--scenario all`** (`protected_drill_evidence.py:26,30`) — carried from pass 1, unchanged, harmless; it restores `GH_TOKEN` in a `finally` (`incident_recovery_selftest.py:301-306`).
+- **Ruff I001/UP035 on the new files** matches the existing `verification/` baseline; no ruff config or CI ruff step exists in this repo.
+
+---
+
+## Validation re-run
+
+| Gate | Result |
+|---|---|
+| `stable_planner_selftest` | **5/5 pass** |
+| `protected-drill` suite via `sifr_verify` | **11 tests, variants=1, failures=0** |
+| Credential gate, live | aborts with `refuses production credential(s): VSCE_PAT` |
+| `protected_release_drill_workflow_contract.sh` | pass |
+| `preview_release_workflow_yaml_parses.sh` (4 workflows) | pass |
+| `sifr_verify --self-test` (incl. 15-schema epoch) | pass |
+| distribution_release full+qualification+evidence-custody+incident-governance+epoch-bootstrap+protected-drill | **variants=60, failures=0** |
+| Stock `python3` import of the drill module (no `uv`) | ok — pure stdlib chain, so the CI `python3 -m` invocation resolves |
+| File-size guardrail | largest touched 882 (`incident_recovery_selftest.py`); all new files ≤ 333 |
+| Scope | no `crates/`, no `demos/`, no Rust interop, no phase-numbered demos, no live production mutation |

--- a/plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-4-exact-pr-head-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-4-exact-pr-head-satisfied.md
@@ -1,0 +1,40 @@
+All identity, diff, archive, and gate checks are done. Independent re-verification results below.
+
+## Identity evidence (exact, independently verified)
+
+| Ref | SHA |
+|---|---|
+| local `HEAD` | `774592acd140747c068bfe6f4752b34006e9664a` |
+| `origin/codex/phase-40-milestone-40-5-bootstrap-execution` | `774592acd140747c068bfe6f4752b34006e9664a` |
+| GitHub PR #3041 `headRefOid` (`gh pr view`) | `774592acd140747c068bfe6f4752b34006e9664a` |
+| base | `e22a8cfbf058f9657b285370d7d075f9ff0209b3` |
+
+PR #3041 is OPEN, base `main`. Diff vs base: 2 commits, 35 files, +1721/−38.
+
+**Post-review delta is documentation-only and truthful.** `774592acd` is a 2-line addition to `plans/issues/active/phase-40-stable-channel-ga-execution.md:514-515` stating the wave is "under review in [PR #3041]". It links the correct PR number and URL, adds no claim of merge or completion, and touches no code. All implementation is in `e7423c840`, the tree pass 3 reviewed.
+
+## Re-verification at exact head
+
+**Archives.** Passes 1 (6 findings) and 2 (2 findings) archived NOT SATISFIED; pass 3 SATISFIED. I re-checked each closure against the tree rather than the write-ups: isolated `sifr-release-drill` concurrency group (`release-publication.yml:56`), verbatim `mode: ${{ inputs.governance_mode }}` with no fail-open ternary (`:815`), `SIFR_WEBSITE_ACTIONS_TOKEN: required: true` (unchanged from base, sliced and asserted at `protected_release_drill_workflow_contract.sh:47-50`), single `PRODUCTION_CREDENTIAL_NAMES` in `common.py:18-25` consumed by `incident_fixture.py:36`, `runner.py:14-16,284-287`, `protected_drill_selftest.py:12,105`, and contract-checked name-for-name against both the workflow boundary loop and the `sudo env -u` scrub, `test_direct_transition_defenses` reaching all six `propose_stable_release` guards directly, plan-bound `StableMutation.evidence()`, `proposed["generation"] <= previous_generation` matching `_require_incident_generation` and `validate_release_index_transition`, and `distribution_pipeline.md:582-598` documenting the drill surface. All closed.
+
+**Fail-closed modes.** `workflow_dispatch` exposes only `drill-publication`/`drill-rollback`/`drill-first-ga` as `type: choice`, so no dispatch can reach production mutation. A `workflow_call` with any other `drill-*` value skips `prepare`/`publish` and dies at the drill boundary `*) exit 2` (`release-publication-drill.yml:38-41`); non-`drill-` typos still hit the publish job's existing `*) exit 2`. GitHub's `startsWith` is case-insensitive while the bash `case` is not, so `Drill-publication` also fails closed rather than running anything.
+
+**Credential/network/permission boundary.** No `${{ secrets.` reference anywhere in the drill file (contract-forbidden alongside `contents: write`, `gh release`, `vsce publish`, `/dispatches`), no `secrets:` on the `uses:` call, `contents: read` at both workflow and job level, `persist-credentials: false`, six-name env scrub, `unshare --net`. Live-verified: the drill aborts with `protected drill refuses production credential(s): VSCE_PAT` when a real token is present, and passes 11/11 across all three scenarios when scrubbed.
+
+**Planner rules.** `propose_stable_release` (`release_index.py:171-231`) enforces active-qualified non-incident release, no pre-existing record, strictly-increasing generation, exact ga-activation vs. normal preconditions, forward-only stable ordering, alpha/beta channel preservation, and byte-exact retained-release preservation — all six reached by direct negative tests. `validate_stable_mutation_evidence` re-validates the index, generation ordering, bound stable activation, and recomputes `proposed_index_sha256` from canonical bytes; the CLI validates *before* `write_canonical_json(..., refuse_existing=True)`.
+
+**Schema-v2 / external binding / registration.** Both new schemas are `const 2` with negative fixtures; `--expected-drill-scenario "${DRILL_SCENARIO}"` reaches `validate_drill_evidence(expected_scenarios=…)`, closing the producer/checker loop externally. Schema count is exactly 15, matching `sifr_verify/selftest.py:89`. `protected-drill` is registered consistently in the manifest, area runner allow-list/command/entry map, all three profiles, `profile_assignment_matrix.json`, `release_report.REQUIRED_SUITES`, `selftest.valid_report`, `schema_contracts.release_report`, and `qualification_fixture`.
+
+**Gates re-run locally at this head:** drill selftest 11/11 credential-free (and correctly refusing when credentialed), `protected-drill` via `sifr_verify` variants=1/failures=0, `validate_schema_contracts` pass, `sifr_verify --self-test` pass, both workflow-contract case scripts pass. Largest touched file 882 lines; all new files ≤ 333. No `crates/`, no `demos/`, no Rust-interop implementation, no phase-numbered demos, no live production mutation.
+
+## Findings
+
+None actionable.
+
+Two non-actionable observations, both carried or incidental:
+- `verification/areas/distribution_release/runner.py:14` is now the only one of 20 area runners with a top-level absolute `verification.*` import, so `python3 verification/areas/distribution_release/runner.py` no longer resolves. The supported path (`sifr_verify areas run`, which `exec_module`s it with repo root as cwd) works, nothing invokes it directly, and the cwd dependency already exists repo-wide (`sifr_verify/selftest.py:44`, `schema_contracts.py:9`). Relative imports are unavailable here because the runner is loaded as a standalone module.
+- Environment secrets attached to `stable-release-drill` would be reachable in the called workflow regardless of the absent `secrets:` block; the actual protection is that the drill file contains no `${{ secrets.` reference, which `protected_release_drill_workflow_contract.sh:63` and `incident_recovery_selftest.py:414` both pin. Pass 1 noted this; the runtime env-var loop remains defense-in-depth only.
+
+## SATISFIED
+
+No files were modified.

--- a/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-14-final-pr-head-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-schema-bootstrap-review-pass-14-final-pr-head-satisfied.md
@@ -1,0 +1,31 @@
+## Archived pass 14 — frozen-head review, PR #3040
+
+### Identity (verified independently)
+| Source | SHA |
+|---|---|
+| local `HEAD` | `7236ce5f773979ec6d56c8942785f25be04a60d9` |
+| `origin/codex/phase-40-milestone-40-5-preview-bootstrap` (`git ls-remote`) | `7236ce5f773979ec6d56c8942785f25be04a60d9` |
+| PR #3040 `headRefOid` | `7236ce5f773979ec6d56c8942785f25be04a60d9` |
+
+All three match. Working tree is clean except the untracked, zero-byte pass-14 handoff slot (`plans/reviews/active/phase-40-milestone-40-5-schema-bootstrap-review-pass-14-final-pr-head.md`, 0 bytes) — no file modified during this review. PR is `OPEN`, base `main`, `MERGEABLE` / `CLEAN`, 48 changed files, 3 commits; `origin/main` is still `d8dd28a80` and is an ancestor of HEAD, so no rebase drift. (`gh pr checks` reports no checks configured on this branch — validation is the local gate per AGENTS.md, not a finding.)
+
+### The two-file delta `e51491338..7236ce5f7`
+`git diff --stat` confirms exactly `plans/issues/active/phase-40-stable-channel-ga-execution.md` (+5) and the new `plans/reviews/archive/…-pass-13-exact-pr-head-satisfied.md` (+47). Zero implementation, workflow, verification, or prior-evidence bytes changed — the 47-file implementation diff `d8dd28a80..e51491338` is byte-identical to what pass 13 reviewed.
+
+- **Archived report is complete**: 47 lines, self-contained, with identity table, prior-finding closure, per-area implementation verification, a gate results table, three explicit non-findings, and the terminal `VERDICT: SATISFIED`. Nothing truncated.
+- **Ledger entry is truthful** (`phase-40-stable-channel-ga-execution.md:468-472`): the cited archive path exists at exactly that location; it does record matching local/remote/PR head at `e51391…` — `e51491338e396e6b8f2d19345c9df68242e2b029`, the actual parent commit and the then-PR-head; and it does return `VERDICT: SATISFIED` with no actionable finding. No overstatement.
+- **Archive's own claims re-spot-checked at this head**: `sifr_verify/selftest.py:89` (`if len(governed) != 13:`) and `:684` (`"epoch-bootstrap"`) present; the no-v1-residue sweep over `(prepare, publication, bootstrap)` present at `schema_epoch_bootstrap_workflow_contract.sh:145-151`; `release-publication.yml:67-68` binds `preview-release`/`stable-release`, `:108-120` re-digests the prepare summary and exits 2 on mismatch; sizes `release-publication.yml` 795, `schema_bootstrap.py` 498, `schema_bootstrap_selftest.py` 574 all as stated. The report's "47 files, 2 commits" is correct as of the head it reviewed; 48/3 now simply reflects this archival commit.
+
+### Gates re-run at exact head `7236ce5f7`
+| Gate | Result |
+|---|---|
+| `distribution_release --suite epoch-bootstrap` | PASS (1/1, bootstrap self-test PASS) |
+| `distribution_release --suite representative` | PASS (52/52, 0 failures) |
+| `sifr_verify --self-test` | PASS (all sections) |
+| `documentation --suite structure` | PASS (1/1) — covers the newly added archive doc |
+| `scripts/check_file_size_guardrails.py` | PASS (2898 files, limit 900) |
+| `git status` after all runs | unchanged; only the zero-byte pass-14 slot |
+
+No actionable finding. The delta is docs-only, accurate, and self-consistent; the implementation carried forward unchanged from a SATISFIED review, and the focused gates still pass at this exact head.
+
+VERDICT: SATISFIED

--- a/scripts/distribution/release_governance.py
+++ b/scripts/distribution/release_governance.py
@@ -20,6 +20,7 @@ from governance import (  # noqa: E402
     GovernanceError,
     generate_site_release_facts,
     validate_bootstrap_evidence,
+    validate_drill_evidence,
     validate_incident_request,
     validate_incident_signoff,
     validate_install_receipt,
@@ -33,6 +34,7 @@ from governance import (  # noqa: E402
     validate_self_version,
     validate_site_publication_facts,
     validate_site_release_facts,
+    validate_stable_mutation_evidence,
 )
 from governance.common import (  # noqa: E402
     load_json_strict,
@@ -49,6 +51,7 @@ from governance.schema_bootstrap import (  # noqa: E402
     build_preview_epoch,
     resolve_distinct_approvers,
 )
+from governance.stable_planner import materialize_stable_mutation  # noqa: E402
 
 
 def parse_args() -> argparse.Namespace:
@@ -61,6 +64,7 @@ def parse_args() -> argparse.Namespace:
         required=True,
         choices=(
             "release-index",
+            "protected-drill-evidence",
             "schema-bootstrap-evidence",
             "release-plan",
             "release-signoff",
@@ -73,11 +77,16 @@ def parse_args() -> argparse.Namespace:
             "self-update-plan",
             "self-version",
             "site-publication-facts",
+            "stable-index-mutation-evidence",
         ),
     )
     validate.add_argument("--input", required=True)
     validate.add_argument("--previous")
     validate.add_argument("--live-index")
+    validate.add_argument(
+        "--expected-drill-scenario",
+        choices=("publication", "rollback", "first-ga"),
+    )
     validate.add_argument("--require-canonical", action="store_true")
 
     generate_index = commands.add_parser("generate-release-index")
@@ -169,6 +178,13 @@ def parse_args() -> argparse.Namespace:
     bootstrap_index.add_argument("--alpha-release", required=True)
     bootstrap_index.add_argument("--beta-release", required=True)
     bootstrap_index.add_argument("--out", required=True)
+    stable_index = commands.add_parser("plan-stable-index")
+    stable_index.add_argument("--plan", required=True)
+    stable_index.add_argument("--live-index", required=True)
+    stable_index.add_argument("--expected-generation", required=True, type=int)
+    stable_index.add_argument("--expected-sha256", required=True)
+    stable_index.add_argument("--proposed-generation", required=True, type=int)
+    stable_index.add_argument("--out", required=True)
     approvers = commands.add_parser("resolve-publication-approvers")
     approvers.add_argument("--approvals", required=True)
     approvers.add_argument("--initiator", required=True)
@@ -203,6 +219,8 @@ def main() -> int:
             validate_incident_evidence(args)
         elif args.command == "generate-schema-bootstrap-index":
             generate_schema_bootstrap_index(args)
+        elif args.command == "plan-stable-index":
+            plan_stable_index(args)
         elif args.command == "resolve-publication-approvers":
             resolve_publication_approvers(args)
         else:
@@ -218,6 +236,7 @@ def validate_command(args: argparse.Namespace) -> None:
     payload = load_json_strict(path, require_canonical=args.require_canonical)
     validators: dict[str, Callable[[Any], Any]] = {
         "release-index": validate_release_index,
+        "protected-drill-evidence": validate_drill_evidence,
         "schema-bootstrap-evidence": validate_bootstrap_evidence,
         "release-plan": validate_release_plan,
         "release-signoff": validate_release_signoff,
@@ -230,8 +249,14 @@ def validate_command(args: argparse.Namespace) -> None:
         "self-update-plan": validate_self_update_plan,
         "self-version": validate_self_version,
         "site-publication-facts": validate_site_publication_facts,
+        "stable-index-mutation-evidence": validate_stable_mutation_evidence,
     }
-    if args.kind == "release-index" and args.previous:
+    if args.kind == "protected-drill-evidence" and args.expected_drill_scenario:
+        validate_drill_evidence(
+            payload,
+            expected_scenarios=(args.expected_drill_scenario,),
+        )
+    elif args.kind == "release-index" and args.previous:
         validate_release_index_transition(load_json_strict(Path(args.previous)), payload)
     elif args.kind == "incident-request" and args.live_index:
         validate_incident_request(payload, live_index=load_json_strict(Path(args.live_index)))
@@ -463,6 +488,23 @@ def generate_schema_bootstrap_index(args: argparse.Namespace) -> None:
         beta_wrapper=load_json_strict(Path(args.beta_release), require_canonical=True),
     )
     write_canonical_json(Path(args.out), payload, refuse_existing=True)
+
+
+def plan_stable_index(args: argparse.Namespace) -> None:
+    mutation = materialize_stable_mutation(
+        plan_path=Path(args.plan),
+        live_index_path=Path(args.live_index),
+        expected_generation=args.expected_generation,
+        expected_sha256=args.expected_sha256,
+        proposed_generation=args.proposed_generation,
+    )
+    evidence = mutation.evidence()
+    validate_stable_mutation_evidence(evidence)
+    write_canonical_json(
+        Path(args.out),
+        evidence,
+        refuse_existing=True,
+    )
 
 
 def resolve_publication_approvers(args: argparse.Namespace) -> None:

--- a/verification/areas/coverage_matrix/profile_assignment_matrix.json
+++ b/verification/areas/coverage_matrix/profile_assignment_matrix.json
@@ -99,17 +99,20 @@
         "merge": [
           "distribution_release:representative",
           "distribution_release:incident-governance",
-          "distribution_release:epoch-bootstrap"
+          "distribution_release:epoch-bootstrap",
+          "distribution_release:protected-drill"
         ],
         "nightly": [
           "distribution_release:full",
           "distribution_release:incident-governance",
-          "distribution_release:epoch-bootstrap"
+          "distribution_release:epoch-bootstrap",
+          "distribution_release:protected-drill"
         ],
         "release": [
           "distribution_release:full",
           "distribution_release:incident-governance",
-          "distribution_release:epoch-bootstrap"
+          "distribution_release:epoch-bootstrap",
+          "distribution_release:protected-drill"
         ]
       }
     },

--- a/verification/areas/distribution_release/cases/preview_release_workflow_yaml_parses.sh
+++ b/verification/areas/distribution_release/cases/preview_release_workflow_yaml_parses.sh
@@ -7,19 +7,22 @@ source "$(dirname "$0")/common.sh"
 preview="${REPO_ROOT}/.github/workflows/preview-release.yml"
 publication="${REPO_ROOT}/.github/workflows/release-publication.yml"
 prepare="${REPO_ROOT}/.github/workflows/release-publication-prepare.yml"
+drill="${REPO_ROOT}/.github/workflows/release-publication-drill.yml"
 poller="${REPO_ROOT}/scripts/distribution/poll_site_release_run.sh"
 ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "${preview}" >/dev/null
 ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "${publication}" >/dev/null
 ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "${prepare}" >/dev/null
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "${drill}" >/dev/null
 
-python3 - "${preview}" "${publication}" "${prepare}" "${poller}" <<'PY'
+python3 - "${preview}" "${publication}" "${prepare}" "${drill}" "${poller}" <<'PY'
 import pathlib
 import sys
 
 preview = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 publication = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
 prepare = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
-poller = pathlib.Path(sys.argv[4]).read_text(encoding="utf-8")
+drill = pathlib.Path(sys.argv[4]).read_text(encoding="utf-8")
+poller = pathlib.Path(sys.argv[5]).read_text(encoding="utf-8")
 
 preview_required = (
     "options:\n          - alpha\n          - beta",
@@ -49,7 +52,7 @@ for forbidden in ("-rc.", "alpha|beta|rc", "stable\n          -"):
         raise SystemExit(f"preview workflow retained forbidden release input: {forbidden}")
 
 publication_required = (
-    "group: sifr-release-index",
+    "'sifr-release-drill' || 'sifr-release-index'",
     "uses: ./.github/workflows/release-publication-prepare.yml",
     "name: ${{ inputs.governance_mode == 'preview' && 'preview-release' || 'stable-release' }}",
     "actions/runs/${GITHUB_RUN_ID}/approvals",
@@ -104,6 +107,8 @@ for fragment in prepare_required:
         raise SystemExit(f"prepare workflow omitted governed fragment: {fragment}")
 if "contents: write" in prepare or "environment:" in prepare:
     raise SystemExit("prepare workflow must remain read-only and unprotected")
+if "name: stable-release-drill" not in drill or "unshare --net --mount-proc" not in drill:
+    raise SystemExit("protected drill must use its credential-free environment and network namespace")
 
 poll_required = (
     "poll_deadline=$((SECONDS + deadline_seconds))",

--- a/verification/areas/distribution_release/cases/protected_release_drill_workflow_contract.sh
+++ b/verification/areas/distribution_release/cases/protected_release_drill_workflow_contract.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+publication="${REPO_ROOT}/.github/workflows/release-publication.yml"
+drill="${REPO_ROOT}/.github/workflows/release-publication-drill.yml"
+
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "${publication}" >/dev/null
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "${drill}" >/dev/null
+
+python3 - "${publication}" "${drill}" "${REPO_ROOT}" <<'PY'
+import pathlib
+import sys
+
+publication = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+drill = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+root = pathlib.Path(sys.argv[3])
+sys.path.insert(0, str(root))
+from verification.areas.distribution_release.governance.common import (
+    PRODUCTION_CREDENTIAL_NAMES,
+)
+planner = (
+    root
+    / "verification/areas/distribution_release/governance/stable_planner.py"
+).read_text(encoding="utf-8")
+drill_selftest = (
+    root
+    / "verification/areas/distribution_release/governance/protected_drill_selftest.py"
+).read_text(encoding="utf-8")
+
+for fragment in (
+    "workflow_dispatch:",
+    "- drill-publication",
+    "if: ${{ !startsWith(inputs.governance_mode, 'drill-') }}",
+    "if: ${{ startsWith(inputs.governance_mode, 'drill-') }}",
+    "uses: ./.github/workflows/release-publication-drill.yml",
+    "drill-first-ga",
+    "drill-rollback",
+    "permissions:\n      contents: read",
+    "'sifr-release-drill' || 'sifr-release-index'",
+    "mode: ${{ inputs.governance_mode }}",
+):
+    assert fragment in publication, fragment
+assert "secrets: inherit" not in publication
+site_secret = publication.split("SIFR_WEBSITE_ACTIONS_TOKEN:", 1)[1].split(
+    "\n\npermissions:", 1
+)[0]
+assert "required: true" in site_secret
+
+for fragment in (
+    "name: stable-release-drill",
+    "permissions:\n  contents: read",
+    "persist-credentials: false",
+    "unshare --net --mount-proc",
+    "governance.protected_drill_selftest",
+    "--kind protected-drill-evidence",
+    '--expected-drill-scenario "${DRILL_SCENARIO}"',
+    "stable-release-drill-${{ github.run_id }}-${{ github.run_attempt }}",
+    "retention-days: 30",
+    "overwrite: false",
+    "drill-publication) scenario=publication",
+    "drill-rollback) scenario=rollback",
+    "drill-first-ga) scenario=first-ga",
+):
+    assert fragment in drill, fragment
+for forbidden in (
+    "${{ secrets.",
+    "gh release",
+    "vsce publish",
+    "/dispatches",
+    "contents: write",
+):
+    assert forbidden not in drill, forbidden
+credential_boundary = drill.split("for credential in", 1)[1].split("; do", 1)[0]
+credential_scrub = drill.split("sudo env", 1)[1].split("unshare --net", 1)[0]
+for credential in PRODUCTION_CREDENTIAL_NAMES:
+    assert credential in credential_boundary, credential
+    assert f"-u {credential}" in credential_scrub, credential
+
+for fragment in (
+    "materialize_stable_mutation",
+    "validate_release_plan",
+    "propose_stable_release",
+    "expected_generation",
+    "expected_sha256",
+):
+    assert fragment in planner, fragment
+for fragment in (
+    "test_ga_activation",
+    "test_normal_successor",
+    "test_rollback_burns_generation_and_resumes",
+    "test_site_timeout_resumes_without_second_index_mutation",
+    "test_first_ga_incident_roll_forward",
+    "PRODUCTION_CREDENTIAL_NAMES",
+    '"external_network": "blocked"',
+    "validate_drill_evidence",
+):
+    assert fragment in drill_selftest, fragment
+PY

--- a/verification/areas/distribution_release/governance/__init__.py
+++ b/verification/areas/distribution_release/governance/__init__.py
@@ -4,7 +4,12 @@ from .common import GovernanceError
 from .artifact_index import validate_qualification_artifact_index
 from .incident import validate_incident_request, validate_incident_signoff
 from .planner import materialize_stable_plan
-from .release_index import validate_release_index, validate_release_index_transition
+from .protected_drill_evidence import validate_drill_evidence
+from .release_index import (
+    propose_stable_release,
+    validate_release_index,
+    validate_release_index_transition,
+)
 from .release_plan import (
     generate_site_release_facts,
     validate_release_plan,
@@ -13,6 +18,10 @@ from .release_plan import (
 )
 from .release_report import validate_release_profile_report
 from .schema_bootstrap import validate_bootstrap_evidence
+from .stable_planner import (
+    materialize_stable_mutation,
+    validate_stable_mutation_evidence,
+)
 from .surface_contracts import (
     validate_install_receipt,
     validate_self_update_plan,
@@ -24,7 +33,10 @@ __all__ = [
     "GovernanceError",
     "generate_site_release_facts",
     "materialize_stable_plan",
+    "materialize_stable_mutation",
+    "propose_stable_release",
     "validate_bootstrap_evidence",
+    "validate_drill_evidence",
     "validate_incident_request",
     "validate_incident_signoff",
     "validate_qualification_artifact_index",
@@ -38,4 +50,5 @@ __all__ = [
     "validate_self_version",
     "validate_site_publication_facts",
     "validate_site_release_facts",
+    "validate_stable_mutation_evidence",
 ]

--- a/verification/areas/distribution_release/governance/common.py
+++ b/verification/areas/distribution_release/governance/common.py
@@ -15,6 +15,14 @@ TARGETS = (
     "aarch64-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
 )
+PRODUCTION_CREDENTIAL_NAMES = (
+    "CLOUDFLARE_API_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "VSCE_PAT",
+    "SIFR_SITE_TOKEN",
+    "SIFR_WEBSITE_ACTIONS_TOKEN",
+)
 BUILDERS = {
     "aarch64-apple-darwin": "macos-15",
     "x86_64-apple-darwin": "macos-15-intel",
@@ -70,7 +78,7 @@ def require_exact_keys(
 
 def require_schema_v2(value: dict[str, Any], location: str = "$") -> None:
     schema_version = value.get("schema_version")
-    if type(schema_version) is not int or schema_version != SCHEMA_VERSION:
+    if type(schema_version) is not int or schema_version != SCHEMA_VERSION:  # noqa: E721
         fail(location, "schema_version must be integer 2")
 
 
@@ -87,7 +95,7 @@ def require_enum(value: Any, allowed: set[str] | frozenset[str], location: str) 
 
 
 def require_positive_int(value: Any, location: str) -> int:
-    if type(value) is not int or value < 1:
+    if type(value) is not int or value < 1:  # noqa: E721
         fail(location, "must be a positive integer")
     return value
 
@@ -180,20 +188,36 @@ def write_canonical_json(path: Path, value: Any, *, refuse_existing: bool = Fals
     path.write_bytes(canonical_json_bytes(value))
 
 
-def load_json_strict(path: Path, *, require_canonical: bool = False) -> Any:
+def load_json_bytes_strict(
+    raw: bytes,
+    *,
+    source: str,
+    require_canonical: bool = False,
+) -> Any:
     def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
         result: dict[str, Any] = {}
         for key, value in pairs:
             if key in result:
-                fail(str(path), f"duplicate object key: {key}")
+                fail(source, f"duplicate object key: {key}")
             result[key] = value
         return result
 
     try:
-        raw = path.read_bytes()
         value = json.loads(raw, object_pairs_hook=object_pairs)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise GovernanceError(f"{path}: invalid JSON: {exc}") from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GovernanceError(f"{source}: invalid JSON: {exc}") from exc
     if require_canonical and raw != canonical_json_bytes(value):
-        fail(str(path), "must use canonical JSON bytes")
+        fail(source, "must use canonical JSON bytes")
     return value
+
+
+def load_json_strict(path: Path, *, require_canonical: bool = False) -> Any:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise GovernanceError(f"{path}: invalid JSON: {exc}") from exc
+    return load_json_bytes_strict(
+        raw,
+        source=str(path),
+        require_canonical=require_canonical,
+    )

--- a/verification/areas/distribution_release/governance/incident_fixture.py
+++ b/verification/areas/distribution_release/governance/incident_fixture.py
@@ -12,6 +12,7 @@ from typing import Any, Iterator
 
 from .common import (
     GovernanceError,
+    PRODUCTION_CREDENTIAL_NAMES,
     canonical_json_bytes,
     fail,
     load_json_strict,
@@ -32,13 +33,7 @@ from .release_plan import generate_site_release_facts, validate_site_release_fac
 
 SNAPSHOT_RE = re.compile(r"^channels-generation-([1-9][0-9]*)\.json$")
 ATTEMPT_RE = re.compile(r"^attempt-([1-9][0-9]*)\.json$")
-FORBIDDEN_CREDENTIALS = {
-    "CLOUDFLARE_API_TOKEN",
-    "GH_TOKEN",
-    "GITHUB_TOKEN",
-    "VSCE_PAT",
-    "SIFR_SITE_TOKEN",
-}
+FORBIDDEN_CREDENTIALS = set(PRODUCTION_CREDENTIAL_NAMES)
 SITE_WAIT_MINUTES = 20
 
 

--- a/verification/areas/distribution_release/governance/incident_recovery_selftest.py
+++ b/verification/areas/distribution_release/governance/incident_recovery_selftest.py
@@ -12,7 +12,6 @@ from typing import Any, Iterator
 
 from .common import (
     GovernanceError,
-    TARGETS,
     canonical_json_bytes,
     load_json_strict,
     sha256_bytes,
@@ -403,9 +402,20 @@ def test_no_production_adapter_surface() -> None:
         encoding="utf-8"
     )
     dispatch = workflow.split("jobs:", 1)[0]
-    assert "rollback" not in dispatch
+    assert "\n          - rollback\n" not in dispatch
     assert "incident-roll-forward" not in dispatch
-    assert "stable-release-drill" not in workflow
+    assert "- drill-rollback" in dispatch
+    assert "uses: ./.github/workflows/release-publication-drill.yml" in workflow
+    drill = (
+        root / ".github" / "workflows" / "release-publication-drill.yml"
+    ).read_text(encoding="utf-8")
+    assert "name: stable-release-drill" in drill
+    assert "unshare --net --mount-proc" in drill
+    assert "${{ secrets." not in drill
+    assert "contents: write" not in drill
+    assert "gh release" not in drill
+    assert "vsce publish" not in drill
+    assert "/dispatches" not in drill
     script = (root / "scripts" / "distribution" / "run_incident_fixture.py").read_text(
         encoding="utf-8"
     )
@@ -623,7 +633,7 @@ def make_release(root: Path, version: str, commit_character: str) -> dict[str, A
     installer = (
         b"#!/bin/sh\nset -eu\n"
         + b': "${SIFR_FIXTURE_INSTALL_STATE:?missing fixture state path}"\n'
-        + f"mkdir -p \"$(dirname \"${{SIFR_FIXTURE_INSTALL_STATE}}\")\"\n".encode()
+        + "mkdir -p \"$(dirname \"${SIFR_FIXTURE_INSTALL_STATE}\")\"\n".encode()
         + f"printf '%s\\n' '{version}' >\"${{SIFR_FIXTURE_INSTALL_STATE}}\"\n".encode()
         + f"# immutable fixture installer for {version}\n".encode()
         + b"# padding-000000000000000000000000000000000000000000000000000000000000\n"

--- a/verification/areas/distribution_release/governance/protected_drill_evidence.py
+++ b/verification/areas/distribution_release/governance/protected_drill_evidence.py
@@ -1,0 +1,82 @@
+"""Semantic contract for credential-free protected release-drill evidence."""
+
+from __future__ import annotations
+
+from .common import (
+    fail,
+    require_array,
+    require_exact_keys,
+    require_nonempty_string,
+    require_object,
+    require_schema_v2,
+)
+
+GOVERNED_SCENARIO_TESTS: dict[str, tuple[str, ...]] = {
+    "publication": (
+        "test_ga_activation",
+        "test_normal_successor",
+        "test_fail_closed_identity_and_transition",
+        "test_direct_transition_defenses",
+        "test_cli_producer",
+        "test_evidence_contract",
+    ),
+    "rollback": (
+        "test_rollback_burns_generation_and_resumes",
+        "test_site_timeout_resumes_without_second_index_mutation",
+        "test_concurrency_and_credential_boundaries",
+    ),
+    "first-ga": (
+        "test_first_ga_incident_roll_forward",
+        "test_concurrency_and_credential_boundaries",
+    ),
+}
+
+
+def validate_drill_evidence(
+    payload: object,
+    *,
+    expected_scenarios: tuple[str, ...] | None = None,
+) -> dict[str, object]:
+    """Validate semantic invariants beyond the checked-in JSON Schema."""
+    evidence = require_object(payload, "$")
+    require_exact_keys(
+        evidence,
+        required={
+            "schema_version",
+            "environment",
+            "external_network",
+            "production_credentials",
+            "scenarios",
+            "status",
+        },
+        location="$",
+    )
+    require_schema_v2(evidence)
+    if evidence["environment"] != "stable-release-drill":
+        fail("$.environment", "must be stable-release-drill")
+    if evidence["external_network"] != "blocked":
+        fail("$.external_network", "must record the blocked network boundary")
+    if evidence["production_credentials"] != "absent":
+        fail("$.production_credentials", "must record absent production credentials")
+    if evidence["status"] != "pass":
+        fail("$.status", "completed drill evidence must pass")
+    rows = require_array(evidence["scenarios"], "$.scenarios")
+    if not rows:
+        fail("$.scenarios", "must contain at least one drill scenario")
+    names: list[str] = []
+    for index, value in enumerate(rows):
+        location = f"$.scenarios[{index}]"
+        row = require_object(value, location)
+        require_exact_keys(row, required={"name", "tests"}, location=location)
+        name = require_nonempty_string(row["name"], f"{location}.name")
+        if name not in GOVERNED_SCENARIO_TESTS or name in names:
+            fail(f"{location}.name", "must be a unique governed drill scenario")
+        tests = require_array(row["tests"], f"{location}.tests")
+        for test_index, test in enumerate(tests):
+            require_nonempty_string(test, f"{location}.tests[{test_index}]")
+        if tests != list(GOVERNED_SCENARIO_TESTS[name]):
+            fail(f"{location}.tests", "must equal the governed scenario test order")
+        names.append(name)
+    if expected_scenarios is not None and names != list(expected_scenarios):
+        fail("$.scenarios", "does not equal the requested drill scenarios")
+    return evidence

--- a/verification/areas/distribution_release/governance/protected_drill_selftest.py
+++ b/verification/areas/distribution_release/governance/protected_drill_selftest.py
@@ -1,0 +1,164 @@
+"""Credential-free protected stable-publication and incident drill."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+from .common import (
+    GovernanceError,
+    PRODUCTION_CREDENTIAL_NAMES,
+    write_canonical_json,
+)
+from .incident_recovery_selftest import (
+    test_concurrency_and_credential_boundaries,
+    test_first_ga_incident_roll_forward,
+    test_rollback_burns_generation_and_resumes,
+    test_site_timeout_resumes_without_second_index_mutation,
+)
+from .protected_drill_evidence import (
+    GOVERNED_SCENARIO_TESTS,
+    validate_drill_evidence,
+)
+from .stable_planner_selftest import (
+    test_cli_producer,
+    test_direct_transition_defenses,
+    test_fail_closed_identity_and_transition,
+    test_ga_activation,
+    test_normal_successor,
+)
+
+
+def test_evidence_contract() -> None:
+    evidence: dict[str, object] = {
+        "schema_version": 2,
+        "environment": "stable-release-drill",
+        "external_network": "blocked",
+        "production_credentials": "absent",
+        "scenarios": [
+            {
+                "name": "rollback",
+                "tests": [
+                    test_rollback_burns_generation_and_resumes.__name__,
+                    test_site_timeout_resumes_without_second_index_mutation.__name__,
+                    test_concurrency_and_credential_boundaries.__name__,
+                ],
+            }
+        ],
+        "status": "pass",
+    }
+    validate_drill_evidence(evidence, expected_scenarios=("rollback",))
+    mutations = (
+        lambda value: value.update(
+            {"schema_version": value["schema_version"] - 1}
+        ),
+        lambda value: value.update({"environment": "stable-release"}),
+        lambda value: value.update({"external_network": "available"}),
+        lambda value: value.update({"production_credentials": "present"}),
+        lambda value: value.update({"status": "failed"}),
+        lambda value: value["scenarios"].append(copy.deepcopy(value["scenarios"][0])),
+        lambda value: value["scenarios"][0]["tests"].pop(),
+    )
+    for mutate in mutations:
+        changed = copy.deepcopy(evidence)
+        mutate(changed)
+        try:
+            validate_drill_evidence(changed)
+        except GovernanceError:
+            pass
+        else:
+            raise AssertionError("protected drill evidence mutation passed")
+
+
+SCENARIOS: dict[str, tuple[Callable[[], None], ...]] = {
+    "publication": (
+        test_ga_activation,
+        test_normal_successor,
+        test_fail_closed_identity_and_transition,
+        test_direct_transition_defenses,
+        test_cli_producer,
+        test_evidence_contract,
+    ),
+    "rollback": (
+        test_rollback_burns_generation_and_resumes,
+        test_site_timeout_resumes_without_second_index_mutation,
+        test_concurrency_and_credential_boundaries,
+    ),
+    "first-ga": (
+        test_first_ga_incident_roll_forward,
+        test_concurrency_and_credential_boundaries,
+    ),
+}
+
+if {
+    name: tuple(test.__name__ for test in tests)
+    for name, tests in SCENARIOS.items()
+} != GOVERNED_SCENARIO_TESTS:
+    raise AssertionError("protected drill runner drifted from its evidence contract")
+
+
+def run_drill(scenario: str, *, report_path: Path | None = None) -> int:
+    if scenario not in {*SCENARIOS, "all"}:
+        raise GovernanceError(f"unsupported protected drill scenario: {scenario}")
+    present = sorted(
+        name for name in PRODUCTION_CREDENTIAL_NAMES if os.environ.get(name)
+    )
+    if present:
+        raise GovernanceError(
+            "protected drill refuses production credential(s): " + ", ".join(present)
+        )
+    selected = (
+        tuple(SCENARIOS)
+        if scenario == "all"
+        else (scenario,)
+    )
+    for name in selected:
+        for test in SCENARIOS[name]:
+            test()
+            print(f"protected-drill pass: scenario={name} test={test.__name__}")
+    if report_path is not None:
+        report = {
+            "schema_version": 2,
+            "environment": "stable-release-drill",
+            "external_network": "blocked",
+            "production_credentials": "absent",
+            "scenarios": [
+                {
+                    "name": name,
+                    "tests": [test.__name__ for test in SCENARIOS[name]],
+                }
+                for name in selected
+            ],
+            "status": "pass",
+        }
+        validate_drill_evidence(report, expected_scenarios=selected)
+        write_canonical_json(
+            report_path,
+            report,
+            refuse_existing=True,
+        )
+    print(f"protected stable release drill ok: scenarios={','.join(selected)}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scenario",
+        choices=(*SCENARIOS, "all"),
+        default="all",
+    )
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    try:
+        return run_drill(args.scenario, report_path=args.report)
+    except GovernanceError as exc:
+        print(f"protected stable release drill: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/distribution_release/governance/qualification_fixture.py
+++ b/verification/areas/distribution_release/governance/qualification_fixture.py
@@ -121,6 +121,7 @@ def write_source_contracts(source_root: Path) -> None:
                     "evidence-custody",
                     "incident-governance",
                     "epoch-bootstrap",
+                    "protected-drill",
                 ],
             },
         ],

--- a/verification/areas/distribution_release/governance/release_index.py
+++ b/verification/areas/distribution_release/governance/release_index.py
@@ -168,6 +168,68 @@ def propose_preview_release(
     return proposed
 
 
+def propose_stable_release(
+    current_value: Any,
+    *,
+    transition: str,
+    version: str,
+    release_value: Any,
+    expected_predecessor: str | None,
+    proposed_generation: int,
+) -> dict[str, Any]:
+    """Return a GA activation or normal stable release-index mutation."""
+    current = validate_release_index(current_value)
+    transition = require_enum(
+        transition,
+        {"ga-activation", "normal"},
+        "transition",
+    )
+    release = validate_release_record(
+        release_value,
+        version=version,
+        expected_channel="stable",
+    )
+    if release["status"] != "active" or "incident_id" in release:
+        fail("release", "stable publication requires an active qualified release")
+    if version in current["releases"]:
+        fail("$.releases", f"release record already exists: {version}")
+    _require_incident_generation(current, proposed_generation)
+
+    live_stable = current["channels"].get("stable")
+    if transition == "ga-activation":
+        if current["ga_status"] != "preview" or live_stable is not None:
+            fail("transition", "ga-activation requires preview metadata without stable")
+        if expected_predecessor is not None:
+            fail("expected_predecessor", "ga-activation cannot name a predecessor")
+    else:
+        if current["ga_status"] != "active" or live_stable is None:
+            fail("transition", "normal requires an active stable predecessor")
+        if expected_predecessor != live_stable:
+            fail("expected_predecessor", "does not equal the live stable version")
+        if _stable_order(version, "version") <= _stable_order(live_stable, "live stable"):
+            fail("version", "normal stable publication must move forward")
+
+    proposed = deepcopy(current)
+    proposed["generation"] = proposed_generation
+    proposed["ga_status"] = "active"
+    proposed["channels"]["stable"] = version
+    proposed["channels"] = dict(sorted(proposed["channels"].items()))
+    proposed["releases"][version] = deepcopy(release)
+    proposed["releases"] = dict(sorted(proposed["releases"].items()))
+    validate_release_index_transition(current, proposed)
+
+    for channel in ("alpha", "beta"):
+        if proposed["channels"][channel] != current["channels"][channel]:
+            fail(f"$.channels.{channel}", "stable publication must preserve preview channels")
+    for retained_version, retained_release in current["releases"].items():
+        if proposed["releases"].get(retained_version) != retained_release:
+            fail(
+                f"$.releases.{retained_version}",
+                "stable publication must preserve retained release bytes",
+            )
+    return proposed
+
+
 def validate_incident_index_mutation(
     previous_value: Any,
     proposed_value: Any,
@@ -314,7 +376,11 @@ def propose_incident_roll_forward(
 
 
 def _require_incident_generation(current: dict[str, Any], proposed_generation: int) -> None:
-    if type(proposed_generation) is not int or proposed_generation <= current["generation"]:
+    if (
+        not isinstance(proposed_generation, int)
+        or isinstance(proposed_generation, bool)
+        or proposed_generation <= current["generation"]
+    ):
         fail("proposed_generation", "must be an integer greater than the live generation")
 
 

--- a/verification/areas/distribution_release/governance/release_report.py
+++ b/verification/areas/distribution_release/governance/release_report.py
@@ -44,6 +44,7 @@ REQUIRED_SUITES = {
         "evidence-custody",
         "incident-governance",
         "epoch-bootstrap",
+        "protected-drill",
     },
 }
 

--- a/verification/areas/distribution_release/governance/schema_contracts.py
+++ b/verification/areas/distribution_release/governance/schema_contracts.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from verification.json_schema_202012 import JsonSchemaError, validate_instance
 
-from .common import TARGETS
+from .common import TARGETS, canonical_json_bytes, sha256_bytes
 from .schema_bootstrap import (
     BOOTSTRAP_GENERATION,
     LEGACY_INDEX_SHA256,
@@ -95,12 +95,51 @@ def validate_schema_contracts() -> None:
             raise ValueError(
                 "bootstrap evidence schema accepted an invalid governed collection"
             )
+    drill_schema = SCHEMA_ROOT / "protected_release_drill_evidence.schema.json"
+    unknown_scenario = copy.deepcopy(
+        fixtures["protected_release_drill_evidence.schema.json"]
+    )
+    unknown_scenario["scenarios"][0]["name"] = "production"
+    duplicate_test = copy.deepcopy(
+        fixtures["protected_release_drill_evidence.schema.json"]
+    )
+    duplicate_test["scenarios"][0]["tests"].append(
+        duplicate_test["scenarios"][0]["tests"][0]
+    )
+    for invalid_drill in (unknown_scenario, duplicate_test):
+        try:
+            validate_instance(invalid_drill, drill_schema)
+        except JsonSchemaError:
+            pass
+        else:
+            raise ValueError(
+                "protected drill schema accepted an invalid governed collection"
+            )
+    mutation_schema = SCHEMA_ROOT / "stable_index_mutation_evidence.schema.json"
+    invalid_transition = copy.deepcopy(
+        fixtures["stable_index_mutation_evidence.schema.json"]
+    )
+    invalid_transition["transition"] = "rollback"
+    invalid_previous_generation = copy.deepcopy(
+        fixtures["stable_index_mutation_evidence.schema.json"]
+    )
+    invalid_previous_generation["previous_index"]["generation"] = 0
+    for invalid_mutation in (invalid_transition, invalid_previous_generation):
+        try:
+            validate_instance(invalid_mutation, mutation_schema)
+        except JsonSchemaError:
+            pass
+        else:
+            raise ValueError(
+                "stable mutation evidence schema accepted an invalid binding"
+            )
 
 
 def schema_fixtures() -> dict[str, Any]:
     index = preview_index()
     return {
         "qualification_artifact_index.schema.json": qualification_index(),
+        "protected_release_drill_evidence.schema.json": protected_drill_evidence(),
         "release_index.schema.json": index,
         "release_profile_report.schema.json": release_report(),
         "schema_epoch_bootstrap_evidence.schema.json": schema_bootstrap_evidence(),
@@ -110,9 +149,52 @@ def schema_fixtures() -> dict[str, Any]:
         "site_publication_facts.schema.json": site_publication_facts(),
         "stable_incident_request.schema.json": incident_request(),
         "stable_incident_signoff.schema.json": incident_signoff(),
+        "stable_index_mutation_evidence.schema.json": stable_index_mutation_evidence(),
         "stable_release_plan.schema.json": release_plan(),
         "stable_release_signoff.schema.json": release_signoff(),
         "stable_site_release_facts.schema.json": site_facts(),
+    }
+
+
+def protected_drill_evidence() -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "environment": "stable-release-drill",
+        "external_network": "blocked",
+        "production_credentials": "absent",
+        "scenarios": [
+            {
+                "name": "publication",
+                "tests": [
+                    "test_ga_activation",
+                    "test_normal_successor",
+                    "test_fail_closed_identity_and_transition",
+                    "test_direct_transition_defenses",
+                    "test_cli_producer",
+                    "test_evidence_contract",
+                ],
+            }
+        ],
+        "status": "pass",
+    }
+
+
+def stable_index_mutation_evidence() -> dict[str, Any]:
+    proposed = preview_index()
+    proposed["generation"] = 8
+    proposed["ga_status"] = "active"
+    proposed["channels"]["stable"] = "0.1.0"
+    proposed["channels"] = dict(sorted(proposed["channels"].items()))
+    proposed["releases"]["0.1.0"] = release_record("stable")
+    proposed["releases"] = dict(sorted(proposed["releases"].items()))
+    return {
+        "schema_version": 2,
+        "transition": "ga-activation",
+        "version": "0.1.0",
+        "plan_sha256": SHA_A,
+        "previous_index": {"generation": 7, "sha256": SHA_B},
+        "proposed_index": proposed,
+        "proposed_index_sha256": sha256_bytes(canonical_json_bytes(proposed)),
     }
 
 
@@ -407,6 +489,7 @@ def release_report() -> dict[str, Any]:
             ("distribution_release", "evidence-custody"),
             ("distribution_release", "incident-governance"),
             ("distribution_release", "epoch-bootstrap"),
+            ("distribution_release", "protected-drill"),
         ],
     }
     return {
@@ -447,6 +530,7 @@ def release_report() -> dict[str, Any]:
                             "evidence-custody",
                             "incident-governance",
                             "epoch-bootstrap",
+                            "protected-drill",
                         ],
                     ),
                 )

--- a/verification/areas/distribution_release/governance/selftest.py
+++ b/verification/areas/distribution_release/governance/selftest.py
@@ -242,6 +242,7 @@ def valid_report() -> dict[str, Any]:
             ("distribution_release", "evidence-custody"),
             ("distribution_release", "incident-governance"),
             ("distribution_release", "epoch-bootstrap"),
+            ("distribution_release", "protected-drill"),
         ],
     }
     steps = []
@@ -299,6 +300,7 @@ def valid_report() -> dict[str, Any]:
                             "evidence-custody",
                             "incident-governance",
                             "epoch-bootstrap",
+                            "protected-drill",
                         },
                     ),
                 )

--- a/verification/areas/distribution_release/governance/stable_planner.py
+++ b/verification/areas/distribution_release/governance/stable_planner.py
@@ -1,0 +1,167 @@
+"""Plan deterministic GA-activation and normal stable index mutations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .common import (
+    canonical_json_bytes,
+    fail,
+    load_json_bytes_strict,
+    require_enum,
+    require_exact_keys,
+    require_object,
+    require_positive_int,
+    require_schema_v2,
+    require_sha256,
+    sha256_bytes,
+    version_channel,
+)
+from .release_index import (
+    propose_stable_release,
+    validate_release_index,
+)
+from .release_plan import validate_release_plan
+
+
+@dataclass(frozen=True)
+class StableMutation:
+    """One approved stable release-index proposal."""
+
+    transition: str
+    version: str
+    plan_sha256: str
+    previous_index_sha256: str
+    previous_index: dict[str, Any]
+    proposed_index: dict[str, Any]
+
+    def evidence(self) -> dict[str, Any]:
+        """Return a canonicalizable plan-to-index binding."""
+        return {
+            "schema_version": 2,
+            "transition": self.transition,
+            "version": self.version,
+            "plan_sha256": self.plan_sha256,
+            "previous_index": {
+                "generation": self.previous_index["generation"],
+                "sha256": self.previous_index_sha256,
+            },
+            "proposed_index": self.proposed_index,
+            "proposed_index_sha256": sha256_bytes(
+                canonical_json_bytes(self.proposed_index)
+            ),
+        }
+
+
+def materialize_stable_mutation(
+    *,
+    plan_path: Path,
+    live_index_path: Path,
+    expected_generation: int,
+    expected_sha256: str,
+    proposed_generation: int,
+) -> StableMutation:
+    """Validate exact inputs and return a stable index mutation without writing."""
+    require_sha256(expected_sha256, "expected_sha256")
+    try:
+        live_bytes = live_index_path.read_bytes()
+        plan_bytes = plan_path.read_bytes()
+    except OSError as exc:
+        fail("stable publication input", str(exc))
+    current = validate_release_index(
+        load_json_bytes_strict(
+            live_bytes,
+            source=str(live_index_path),
+            require_canonical=True,
+        )
+    )
+    if current["generation"] != expected_generation:
+        fail("expected_generation", "does not equal the live release index")
+    live_sha256 = sha256_bytes(live_bytes)
+    if live_sha256 != expected_sha256:
+        fail("expected_sha256", "does not equal the live release index")
+
+    plan = validate_release_plan(
+        load_json_bytes_strict(
+            plan_bytes,
+            source=str(plan_path),
+            require_canonical=True,
+        ),
+        active_index=current,
+    )
+    transition = plan["transition"]
+    if transition not in {"ga-activation", "normal"}:
+        fail("$.transition", "stable publication accepts ga-activation or normal")
+    predecessor = plan["expected_stable_predecessor"]
+    expected_predecessor = (
+        None if predecessor == "none" else predecessor["version"]
+    )
+    proposed = propose_stable_release(
+        current,
+        transition=transition,
+        version=plan["version"],
+        release_value=plan["desired_release"],
+        expected_predecessor=expected_predecessor,
+        proposed_generation=proposed_generation,
+    )
+    return StableMutation(
+        transition=transition,
+        version=plan["version"],
+        plan_sha256=sha256_bytes(plan_bytes),
+        previous_index_sha256=live_sha256,
+        previous_index=current,
+        proposed_index=proposed,
+    )
+
+
+def validate_stable_mutation_evidence(payload: object) -> dict[str, Any]:
+    """Validate an emitted stable plan-to-index binding."""
+    evidence = require_object(payload, "$")
+    require_exact_keys(
+        evidence,
+        required={
+            "schema_version",
+            "transition",
+            "version",
+            "plan_sha256",
+            "previous_index",
+            "proposed_index",
+            "proposed_index_sha256",
+        },
+        location="$",
+    )
+    require_schema_v2(evidence)
+    require_enum(
+        evidence["transition"],
+        {"ga-activation", "normal"},
+        "$.transition",
+    )
+    version = evidence["version"]
+    if version_channel(version, "$.version") != "stable":
+        fail("$.version", "must be an exact stable version")
+    require_sha256(evidence["plan_sha256"], "$.plan_sha256")
+    previous = require_object(evidence["previous_index"], "$.previous_index")
+    require_exact_keys(
+        previous,
+        required={"generation", "sha256"},
+        location="$.previous_index",
+    )
+    previous_generation = require_positive_int(
+        previous["generation"],
+        "$.previous_index.generation",
+    )
+    require_sha256(previous["sha256"], "$.previous_index.sha256")
+    proposed = validate_release_index(evidence["proposed_index"])
+    if proposed["generation"] <= previous_generation:
+        fail("$.proposed_index.generation", "must follow the previous index")
+    if proposed["ga_status"] != "active" or proposed["channels"].get("stable") != version:
+        fail("$.proposed_index", "must activate the bound stable version")
+    proposed_sha256 = require_sha256(
+        evidence["proposed_index_sha256"],
+        "$.proposed_index_sha256",
+    )
+    if proposed_sha256 != sha256_bytes(canonical_json_bytes(proposed)):
+        fail("$.proposed_index_sha256", "does not match the proposed index bytes")
+    return evidence

--- a/verification/areas/distribution_release/governance/stable_planner_selftest.py
+++ b/verification/areas/distribution_release/governance/stable_planner_selftest.py
@@ -1,0 +1,332 @@
+"""Mutation tests for stable GA-activation and normal index planning."""
+
+from __future__ import annotations
+
+import copy
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .common import (
+    GovernanceError,
+    canonical_json_bytes,
+    load_json_strict,
+    sha256_bytes,
+    sha256_file,
+    write_canonical_json,
+)
+from .release_index import propose_stable_release
+from .selftest import (
+    SHA_A,
+    active_index,
+    preview_index,
+    release_record,
+    valid_plan,
+)
+from .stable_planner import (
+    materialize_stable_mutation,
+    validate_stable_mutation_evidence,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CLI = REPO_ROOT / "scripts" / "distribution" / "release_governance.py"
+
+
+def run_self_tests() -> int:
+    tests = (
+        test_ga_activation,
+        test_normal_successor,
+        test_fail_closed_identity_and_transition,
+        test_direct_transition_defenses,
+        test_cli_producer,
+    )
+    for test in tests:
+        test()
+        print(f"stable-planner-self-test pass: {test.__name__}")
+    print(f"stable planner self-tests ok: tests={len(tests)}")
+    return 0
+
+
+def test_ga_activation() -> None:
+    with fixture_files(preview_index(), valid_plan()) as fixture:
+        mutation = plan_fixture(fixture, proposed_generation=8)
+        proposed = mutation.proposed_index
+        assert mutation.transition == "ga-activation"
+        assert mutation.version == "0.1.0"
+        assert proposed["generation"] == 8
+        assert proposed["ga_status"] == "active"
+        assert proposed["channels"] == {
+            "alpha": "0.1.0-alpha.2",
+            "beta": "0.1.0-beta.2",
+            "stable": "0.1.0",
+        }
+        assert proposed["releases"]["0.1.0"] == release_record("stable")
+        assert_retained_bytes(mutation.previous_index, proposed)
+        evidence = mutation.evidence()
+        validate_stable_mutation_evidence(evidence)
+        stale = copy.deepcopy(evidence)
+        stale["proposed_index"]["generation"] = mutation.previous_index["generation"]
+        stale["proposed_index_sha256"] = sha256_bytes(
+            canonical_json_bytes(stale["proposed_index"])
+        )
+        expect_rejected(
+            lambda: validate_stable_mutation_evidence(stale),
+            "must follow the previous index",
+        )
+
+
+def test_normal_successor() -> None:
+    live = active_index()
+    live["channels"]["stable"] = "0.0.9"
+    live["releases"].pop("0.1.0")
+    live["releases"]["0.0.9"] = release_record("stable")
+    with fixture_files(live, valid_plan(transition="normal")) as fixture:
+        mutation = plan_fixture(fixture, proposed_generation=12)
+        proposed = mutation.proposed_index
+        assert mutation.transition == "normal"
+        assert proposed["generation"] == 12
+        assert proposed["channels"]["stable"] == "0.1.0"
+        assert proposed["releases"]["0.0.9"] == live["releases"]["0.0.9"]
+        assert proposed["releases"]["0.1.0"] == release_record("stable")
+        assert_retained_bytes(live, proposed)
+        validate_stable_mutation_evidence(mutation.evidence())
+
+
+def test_fail_closed_identity_and_transition() -> None:
+    with fixture_files(preview_index(), valid_plan()) as fixture:
+        expect_rejected(
+            lambda: materialize_stable_mutation(
+                plan_path=fixture.plan,
+                live_index_path=fixture.index,
+                expected_generation=6,
+                expected_sha256=sha256_file(fixture.index),
+                proposed_generation=8,
+            ),
+            "expected_generation",
+        )
+        expect_rejected(
+            lambda: materialize_stable_mutation(
+                plan_path=fixture.plan,
+                live_index_path=fixture.index,
+                expected_generation=7,
+                expected_sha256=SHA_A,
+                proposed_generation=8,
+            ),
+            "expected_sha256",
+        )
+        expect_rejected(
+            lambda: plan_fixture(fixture, proposed_generation=7),
+            "proposed_generation",
+        )
+
+    with fixture_files(active_index(), valid_plan()) as fixture:
+        expect_rejected(
+            lambda: plan_fixture(fixture, proposed_generation=9),
+            "ga-activation",
+        )
+
+    with fixture_files(
+        preview_index(),
+        valid_plan(transition="normal"),
+    ) as fixture:
+        expect_rejected(
+            lambda: plan_fixture(fixture, proposed_generation=8),
+            "active live stable predecessor",
+        )
+
+    incident = valid_plan(transition="incident-roll-forward")
+    incident["expected_stable_predecessor"] = {
+        "version": "0.1.0",
+        "status": "active",
+        "plan_sha256": "d" * 64,
+    }
+    with fixture_files(active_index(), incident) as fixture:
+        expect_rejected(
+            lambda: plan_fixture(fixture, proposed_generation=9),
+            "stable publication accepts ga-activation or normal",
+        )
+
+
+def test_direct_transition_defenses() -> None:
+    candidate = release_record("stable")
+    expect_rejected(
+        lambda: propose_stable_release(
+            preview_index(),
+            transition="incident-roll-forward",
+            version="0.1.0",
+            release_value=candidate,
+            expected_predecessor=None,
+            proposed_generation=8,
+        ),
+        "transition",
+    )
+    expect_rejected(
+        lambda: propose_stable_release(
+            preview_index(),
+            transition="ga-activation",
+            version="0.1.0",
+            release_value=candidate,
+            expected_predecessor="0.0.9",
+            proposed_generation=8,
+        ),
+        "cannot name a predecessor",
+    )
+    expect_rejected(
+        lambda: propose_stable_release(
+            preview_index(),
+            transition="ga-activation",
+            version="0.1.0",
+            release_value=candidate,
+            expected_predecessor=None,
+            proposed_generation=7,
+        ),
+        "proposed_generation",
+    )
+    expect_rejected(
+        lambda: propose_stable_release(
+            active_index(),
+            transition="normal",
+            version="0.2.0",
+            release_value=candidate,
+            expected_predecessor="0.0.9",
+            proposed_generation=9,
+        ),
+        "does not equal the live stable version",
+    )
+    expect_rejected(
+        lambda: propose_stable_release(
+            active_index(),
+            transition="normal",
+            version="0.0.9",
+            release_value=candidate,
+            expected_predecessor="0.1.0",
+            proposed_generation=9,
+        ),
+        "must move forward",
+    )
+    expect_rejected(
+        lambda: propose_stable_release(
+            active_index(),
+            transition="normal",
+            version="0.1.0",
+            release_value=candidate,
+            expected_predecessor="0.1.0",
+            proposed_generation=9,
+        ),
+        "already exists",
+    )
+
+
+def test_cli_producer() -> None:
+    with fixture_files(preview_index(), valid_plan()) as fixture:
+        output = fixture.root / "proposed.json"
+        command = [
+            sys.executable,
+            str(CLI),
+            "plan-stable-index",
+            "--plan",
+            str(fixture.plan),
+            "--live-index",
+            str(fixture.index),
+            "--expected-generation",
+            "7",
+            "--expected-sha256",
+            sha256_file(fixture.index),
+            "--proposed-generation",
+            "8",
+            "--out",
+            str(output),
+        ]
+        subprocess.run(command, cwd=REPO_ROOT, check=True)
+        evidence = validate_stable_mutation_evidence(
+            load_json_strict(output, require_canonical=True),
+        )
+        proposed = evidence["proposed_index"]
+        assert evidence["transition"] == "ga-activation"
+        assert evidence["version"] == "0.1.0"
+        assert evidence["plan_sha256"] == sha256_file(fixture.plan)
+        assert evidence["previous_index"] == {
+            "generation": 7,
+            "sha256": sha256_file(fixture.index),
+        }
+        assert evidence["proposed_index_sha256"] == sha256_bytes(
+            canonical_json_bytes(proposed)
+        )
+        assert proposed["channels"]["stable"] == "0.1.0"
+        repeated = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert repeated.returncode == 2
+        assert "refusing to overwrite" in repeated.stderr
+
+
+class FixtureFiles:
+    def __init__(self, root: Path, index: Path, plan: Path) -> None:
+        self.root = root
+        self.index = index
+        self.plan = plan
+
+
+class fixture_files:
+    def __init__(self, index: dict[str, Any], plan: dict[str, Any]) -> None:
+        self.index_value = index
+        self.plan_value = plan
+        self.temporary: tempfile.TemporaryDirectory[str] | None = None
+
+    def __enter__(self) -> FixtureFiles:
+        self.temporary = tempfile.TemporaryDirectory(prefix="sifr-stable-planner-")
+        root = Path(self.temporary.name)
+        index = root / "channels.json"
+        plan = root / "stable-release-plan.json"
+        write_canonical_json(index, self.index_value)
+        write_canonical_json(plan, self.plan_value)
+        return FixtureFiles(root, index, plan)
+
+    def __exit__(self, *_: object) -> None:
+        assert self.temporary is not None
+        self.temporary.cleanup()
+
+
+def plan_fixture(
+    fixture: FixtureFiles,
+    *,
+    proposed_generation: int,
+):
+    current = load_json_strict(fixture.index, require_canonical=True)
+    return materialize_stable_mutation(
+        plan_path=fixture.plan,
+        live_index_path=fixture.index,
+        expected_generation=current["generation"],
+        expected_sha256=sha256_file(fixture.index),
+        proposed_generation=proposed_generation,
+    )
+
+
+def assert_retained_bytes(
+    previous: dict[str, Any],
+    proposed: dict[str, Any],
+) -> None:
+    for channel in ("alpha", "beta"):
+        assert proposed["channels"][channel] == previous["channels"][channel]
+    for version, release in previous["releases"].items():
+        assert proposed["releases"][version] == release
+
+
+def expect_rejected(action: Callable[[], Any], message: str) -> None:
+    try:
+        action()
+    except GovernanceError as exc:
+        assert message in str(exc), exc
+    else:
+        raise AssertionError(f"expected rejection containing {message!r}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_self_tests())

--- a/verification/areas/distribution_release/manifest.json
+++ b/verification/areas/distribution_release/manifest.json
@@ -87,6 +87,19 @@
           "diagnostic_formats": []
         }
       ]
+    },
+    {
+      "name": "protected-drill",
+      "kind": "adapter",
+      "cases": [
+        {
+          "id": "protected-stable-release-drill",
+          "entry": "verification/areas/distribution_release/governance/protected_drill_selftest.py",
+          "command": "distribution-protected-drill",
+          "expect_exit_code": 0,
+          "diagnostic_formats": []
+        }
+      ]
     }
   ],
   "network_mode": "offline",

--- a/verification/areas/distribution_release/runner.py
+++ b/verification/areas/distribution_release/runner.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import time
 from pathlib import Path
 from typing import Any
+
+from verification.areas.distribution_release.governance.common import (
+    PRODUCTION_CREDENTIAL_NAMES,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 AREA_ROOT = Path(__file__).resolve().parent
@@ -51,11 +56,15 @@ def main(argv: list[str] | None = None) -> int:
     epoch_suite_selected = any(
         str(suite["name"]) == "epoch-bootstrap" for suite in selected
     )
+    drill_suite_selected = any(
+        str(suite["name"]) == "protected-drill" for suite in selected
+    )
     suite_results = [
         run_suite(
             suite,
             include_incident=not incident_suite_selected,
             include_epoch_bootstrap=not epoch_suite_selected,
+            include_protected_drill=not drill_suite_selected,
         )
         for suite in selected
     ]
@@ -114,6 +123,7 @@ def run_suite(
     *,
     include_incident: bool = True,
     include_epoch_bootstrap: bool = True,
+    include_protected_drill: bool = True,
 ) -> dict[str, Any]:
     suite_name = str(suite["name"])
     case = validate_suite_case(suite)
@@ -136,6 +146,14 @@ def run_suite(
             run_python_module(
                 "governance.schema_bootstrap_selftest",
                 "schema-v2-preview-epoch-bootstrap",
+            )
+        ]
+    elif suite_name == "protected-drill":
+        variants = [
+            run_python_module(
+                "governance.protected_drill_selftest",
+                "protected-stable-release-drill",
+                scrub_credentials=True,
             )
         ]
     elif suite_name == "qualification":
@@ -162,6 +180,14 @@ def run_suite(
                     run_python_module(
                         "governance.incident_recovery_selftest",
                         "incident-recovery",
+                    )
+                )
+            if include_protected_drill:
+                variants.append(
+                    run_python_module(
+                        "governance.protected_drill_selftest",
+                        "protected-stable-release-drill",
+                        scrub_credentials=True,
                     )
                 )
     failures = sum(1 for variant in variants if variant["status"] == "fail")
@@ -193,6 +219,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
         "evidence-custody",
         "incident-governance",
         "epoch-bootstrap",
+        "protected-drill",
     }:
         raise SystemExit(f"unsupported distribution_release suite: {suite_name}")
     cases = suite.get("cases", [])
@@ -203,6 +230,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
         "evidence-custody": "distribution-evidence-custody",
         "incident-governance": "distribution-incident-recovery",
         "epoch-bootstrap": "distribution-schema-bootstrap",
+        "protected-drill": "distribution-protected-drill",
         "qualification": "distribution-stable-qualification",
     }.get(suite_name, "distribution-case-directory")
     if str(case.get("command")) != expected_command:
@@ -212,6 +240,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
         "evidence-custody": AREA_ROOT / "governance" / "evidence_custody.py",
         "incident-governance": AREA_ROOT / "governance" / "incident_recovery_selftest.py",
         "epoch-bootstrap": AREA_ROOT / "governance" / "schema_bootstrap_selftest.py",
+        "protected-drill": AREA_ROOT / "governance" / "protected_drill_selftest.py",
         "qualification": AREA_ROOT / "governance" / "qualification_selftest.py",
     }.get(suite_name, CASES_ROOT)
     if entry != expected_entry or not entry.exists():
@@ -245,13 +274,23 @@ def run_distribution_case(script: Path) -> dict[str, Any]:
     }
 
 
-def run_python_module(module: str, label: str) -> dict[str, Any]:
+def run_python_module(
+    module: str,
+    label: str,
+    *,
+    scrub_credentials: bool = False,
+) -> dict[str, Any]:
     print(f"Running distribution governance module {module}", flush=True)
     started = time.perf_counter()
     qualified_module = f"verification.areas.distribution_release.{module}"
+    environment = os.environ.copy()
+    if scrub_credentials:
+        for name in PRODUCTION_CREDENTIAL_NAMES:
+            environment.pop(name, None)
     result = subprocess.run(
         [sys.executable, "-m", qualified_module],
         cwd=REPO_ROOT,
+        env=environment,
         check=False,
     )
     elapsed_ms = (time.perf_counter() - started) * 1000.0

--- a/verification/areas/distribution_release/schemas/protected_release_drill_evidence.schema.json
+++ b/verification/areas/distribution_release/schemas/protected_release_drill_evidence.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Protected stable release drill evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "environment",
+    "external_network",
+    "production_credentials",
+    "scenarios",
+    "status"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 2
+    },
+    "environment": {
+      "const": "stable-release-drill"
+    },
+    "external_network": {
+      "const": "blocked"
+    },
+    "production_credentials": {
+      "const": "absent"
+    },
+    "scenarios": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 3,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "tests"
+        ],
+        "properties": {
+          "name": {
+            "enum": [
+              "publication",
+              "rollback",
+              "first-ga"
+            ]
+          },
+          "tests": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "const": "pass"
+    }
+  }
+}

--- a/verification/areas/distribution_release/schemas/stable_index_mutation_evidence.schema.json
+++ b/verification/areas/distribution_release/schemas/stable_index_mutation_evidence.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Stable index mutation evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "transition",
+    "version",
+    "plan_sha256",
+    "previous_index",
+    "proposed_index",
+    "proposed_index_sha256"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 2
+    },
+    "transition": {
+      "enum": [
+        "ga-activation",
+        "normal"
+      ]
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+    },
+    "plan_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "previous_index": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "generation",
+        "sha256"
+      ],
+      "properties": {
+        "generation": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "proposed_index": {
+      "type": "object"
+    },
+    "proposed_index_sha256": {
+      "$ref": "#/$defs/sha256"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "not": {
+        "const": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    }
+  }
+}

--- a/verification/profiles/merge.json
+++ b/verification/profiles/merge.json
@@ -244,7 +244,8 @@
         "representative",
         "qualification",
         "incident-governance",
-        "epoch-bootstrap"
+        "epoch-bootstrap",
+        "protected-drill"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/profiles/nightly.json
+++ b/verification/profiles/nightly.json
@@ -223,7 +223,8 @@
         "full",
         "qualification",
         "incident-governance",
-        "epoch-bootstrap"
+        "epoch-bootstrap",
+        "protected-drill"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/profiles/release.json
+++ b/verification/profiles/release.json
@@ -222,7 +222,8 @@
         "qualification",
         "evidence-custody",
         "incident-governance",
-        "epoch-bootstrap"
+        "epoch-bootstrap",
+        "protected-drill"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -86,7 +86,7 @@ def _schema_self_test() -> None:
         / "schemas"
     )
     governed = [lint_schema(path) for path in sorted(governance_schemas.glob("*.schema.json"))]
-    if len(governed) != 13:
+    if len(governed) != 15:
         raise AssertionError("release-governance schema lint registration drifted")
     try:
         validate_schema_requirement({"type": "object", "oneOf": []}, Path("bad.schema.json"))
@@ -682,6 +682,7 @@ def _release_report_production_self_test() -> None:
             "evidence-custody",
             "incident-governance",
             "epoch-bootstrap",
+            "protected-drill",
         ],
     }
     with tempfile.TemporaryDirectory(prefix="sifr-release-report-production-") as directory:


### PR DESCRIPTION
## Summary
- add deterministic GA-activation and normal stable index planning with schema-v2 plan-to-index evidence
- add a protected credential-free, no-network release drill with exact scenario binding and isolated concurrency
- register the drill in release profiles, release reporting, coverage, durable docs, and governance inventory

## Validation
- `scripts/run_all_tests.sh --profile create-pr` (pass; Python interop 19/19, Rust interop 10/10, e2e 131/131)
- combined distribution release suites: 60/60
- coverage readiness: 4/4
- file-size, schema epoch/contracts, workflow YAML/contracts, runner self-tests
- Claude Opus review passes 1-3; pass 3 SATISFIED

No live production mutation is included in this wave. This is Phase 40 release governance only and does not implement Rust interop.