### PR TITLE
Phase 40: add protected stable publication prepare

### DIFF
--- a/.github/workflows/release-publication-prepare.yml
+++ b/.github/workflows/release-publication-prepare.yml
@@ -19,11 +19,41 @@ on:
         required: false
         default: ""
         type: string
+      evidence_commit:
+        required: false
+        default: ""
+        type: string
+      candidate_path:
+        required: false
+        default: ""
+        type: string
+      expected_plan_sha256:
+        required: false
+        default: ""
+        type: string
+      publication_mode:
+        required: false
+        default: ""
+        type: string
+      proposed_generation:
+        required: false
+        default: ""
+        type: string
     outputs:
       summary_sha256:
         value: ${{ jobs.prepare.outputs.summary_sha256 }}
       summary_artifact_name:
         value: ${{ jobs.prepare.outputs.summary_artifact_name }}
+      plan_sha256:
+        value: ${{ jobs.prepare.outputs.plan_sha256 }}
+      release_report_sha256:
+        value: ${{ jobs.prepare.outputs.release_report_sha256 }}
+      qualification_sha256:
+        value: ${{ jobs.prepare.outputs.qualification_sha256 }}
+      live_index_sha256:
+        value: ${{ jobs.prepare.outputs.live_index_sha256 }}
+      proposed_index_sha256:
+        value: ${{ jobs.prepare.outputs.proposed_index_sha256 }}
 
 permissions:
   actions: read
@@ -35,8 +65,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:
-      summary_sha256: ${{ steps.summary.outputs.summary_sha256 }}
-      summary_artifact_name: ${{ steps.summary.outputs.summary_artifact_name }}
+      summary_sha256: ${{ steps.outputs.outputs.summary_sha256 }}
+      summary_artifact_name: ${{ steps.outputs.outputs.summary_artifact_name }}
+      plan_sha256: ${{ steps.outputs.outputs.plan_sha256 }}
+      release_report_sha256: ${{ steps.outputs.outputs.release_report_sha256 }}
+      qualification_sha256: ${{ steps.outputs.outputs.qualification_sha256 }}
+      live_index_sha256: ${{ steps.outputs.outputs.live_index_sha256 }}
+      proposed_index_sha256: ${{ steps.outputs.outputs.proposed_index_sha256 }}
     env:
       GH_TOKEN: ${{ github.token }}
       CHANNEL: ${{ inputs.channel }}
@@ -44,25 +79,36 @@ jobs:
       SOURCE_COMMIT: ${{ inputs.source_commit }}
       GOVERNANCE_MODE: ${{ inputs.governance_mode }}
       BOOTSTRAP_ALPHA_VERSION: ${{ inputs.bootstrap_alpha_version }}
+      EVIDENCE_COMMIT: ${{ inputs.evidence_commit }}
+      CANDIDATE_PATH: ${{ inputs.candidate_path }}
+      EXPECTED_PLAN_SHA256: ${{ inputs.expected_plan_sha256 }}
+      PUBLICATION_MODE: ${{ inputs.publication_mode }}
+      PROPOSED_GENERATION: ${{ inputs.proposed_generation }}
       LEGACY_INDEX_SHA256: 71b3243925670f56dc510b8f45b6614a622f58097a0fea9492f61d20dc4bf9ef
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        if: ${{ inputs.governance_mode != 'ga-activation' && inputs.governance_mode != 'normal' }}
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        if: ${{ inputs.governance_mode != 'ga-activation' && inputs.governance_mode != 'normal' }}
         with:
           pattern: sifr-${{ inputs.version }}-*
           path: prepare-assets
           merge-multiple: true
 
       - name: Validate read-only prepare inputs and artifact bytes
-        id: summary
+        if: ${{ inputs.governance_mode != 'ga-activation' && inputs.governance_mode != 'normal' }}
         shell: bash
         run: |
           set -euo pipefail
+          if [[ -n "${EVIDENCE_COMMIT}${CANDIDATE_PATH}${EXPECTED_PLAN_SHA256}${PUBLICATION_MODE}${PROPOSED_GENERATION}" ]]; then
+            echo "::error::preview/bootstrap prepare cannot receive stable inputs"
+            exit 2
+          fi
           case "${GOVERNANCE_MODE}" in
             preview)
               test -z "${BOOTSTRAP_ALPHA_VERSION}" || {
@@ -194,9 +240,6 @@ jobs:
               assets: $assets
             }' >prepare/summary.json
           summary_sha256="$(sha256sum prepare/summary.json | awk '{print $1}')"
-          summary_artifact_name="publication-prepare-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          echo "summary_sha256=${summary_sha256}" >>"${GITHUB_OUTPUT}"
-          echo "summary_artifact_name=${summary_artifact_name}" >>"${GITHUB_OUTPUT}"
           {
             echo "## Governed publication prepare"
             echo
@@ -210,9 +253,173 @@ jobs:
             fi
           } >>"${GITHUB_STEP_SUMMARY}"
 
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        if: ${{ inputs.governance_mode == 'ga-activation' || inputs.governance_mode == 'normal' }}
+        with:
+          ref: ${{ inputs.evidence_commit }}
+          fetch-depth: 0
+          path: stable-evidence
+          persist-credentials: false
+
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        if: ${{ inputs.governance_mode == 'ga-activation' || inputs.governance_mode == 'normal' }}
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 0
+          path: stable-source
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Prepare exact stable publication inputs
+        if: ${{ inputs.governance_mode == 'ga-activation' || inputs.governance_mode == 'normal' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${CHANNEL}" = "stable" &&
+            [[ "${EVIDENCE_COMMIT}" =~ ^[0-9a-f]{40}$ ]] &&
+            [[ "${CANDIDATE_PATH}" =~ ^plans/releases/candidates/[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
+            [[ "${EXPECTED_PLAN_SHA256}" =~ ^[0-9a-f]{64}$ ]] &&
+            [[ "${PUBLICATION_MODE}" =~ ^(initial|resume)$ ]] &&
+            [[ "${PROPOSED_GENERATION}" =~ ^[1-9][0-9]*$ ]] || {
+              echo "::error::stable prepare inputs are incomplete or malformed"
+              exit 2
+            }
+          test -z "${BOOTSTRAP_ALPHA_VERSION}" || {
+            echo "::error::stable publication cannot name a bootstrap alpha"
+            exit 2
+          }
+          candidate_version="${CANDIDATE_PATH##*/}"
+          test "${VERSION}" = "${candidate_version}" || {
+            echo "::error::stable candidate path/version mismatch"
+            exit 2
+          }
+          candidate="stable-evidence/${CANDIDATE_PATH}"
+          qualification="${candidate}/qualification-artifact-index.json"
+          test -f "${qualification}" || {
+            echo "::error::candidate qualification index is missing"
+            exit 2
+          }
+          (
+            cd stable-source
+            python3 scripts/distribution/release_governance.py validate \
+              --kind qualification-artifact-index \
+              --input "../${qualification}" \
+              --require-canonical
+          )
+          run_id="$(jq -er '.workflow.run_id' "${qualification}")"
+          run_attempt="$(jq -er '.workflow.run_attempt' "${qualification}")"
+          test "$(jq -er '.workflow.repository' "${qualification}")" = "${GITHUB_REPOSITORY}" || {
+            echo "::error::qualification repository identity mismatch"
+            exit 2
+          }
+          run_metadata="$(
+            gh api \
+              "/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/attempts/${run_attempt}"
+          )"
+          test "$(jq -er '.id' <<<"${run_metadata}")" = "${run_id}" &&
+            test "$(jq -er '.run_attempt' <<<"${run_metadata}")" = "${run_attempt}" &&
+            test "$(jq -er '.head_sha' <<<"${run_metadata}")" = "${SOURCE_COMMIT}" &&
+            test "$(jq -er '.conclusion' <<<"${run_metadata}")" = "success" || {
+              echo "::error::qualification workflow-run provenance mismatch"
+              exit 2
+            }
+          mkdir -p stable-assets prepare
+          while IFS=$'\t' read -r artifact_id artifact_name artifact_size_bytes; do
+            artifact_metadata="$(
+              gh api \
+                "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}"
+            )"
+            test "$(jq -er '.id' <<<"${artifact_metadata}")" = "${artifact_id}" &&
+              test "$(jq -er '.name' <<<"${artifact_metadata}")" = "${artifact_name}" &&
+              test "$(jq -r '.expired' <<<"${artifact_metadata}")" = "false" &&
+              test "$(jq -er '.workflow_run.id' <<<"${artifact_metadata}")" = "${run_id}" || {
+                echo "::error::qualification artifact provenance mismatch"
+                exit 2
+              }
+            mkdir -p "stable-assets/${artifact_name}"
+            archive="stable-assets/${artifact_name}.zip"
+            gh api \
+              "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" \
+              >"${archive}"
+            python3 stable-source/scripts/distribution/extract_github_artifact.py \
+              "${archive}" \
+              "stable-assets/${artifact_name}" \
+              --expected-uncompressed-bytes "${artifact_size_bytes}"
+            rm "${archive}"
+          done < <(
+            jq -er \
+              '[.artifacts[] | {
+                id: .workflow_artifact_id,
+                name: .workflow_artifact_name,
+                size: .size_bytes
+              }]
+              | group_by(.id)
+              | .[]
+              | [.[0].id, .[0].name, (map(.size) | add)]
+              | @tsv' \
+              "${qualification}"
+          )
+          gh release download channels \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern channels.json \
+            --dir prepare
+          mv prepare/channels.json prepare/current-channels.json
+          (
+            cd stable-source
+            python3 scripts/distribution/release_governance.py \
+              prepare-stable-publication \
+              --operation "${GOVERNANCE_MODE}" \
+              --mode "${PUBLICATION_MODE}" \
+              --evidence-root ../stable-evidence \
+              --evidence-commit "${EVIDENCE_COMMIT}" \
+              --candidate-path "${CANDIDATE_PATH}" \
+              --expected-plan-sha256 "${EXPECTED_PLAN_SHA256}" \
+              --source-root . \
+              --live-index ../prepare/current-channels.json \
+              --artifact-root ../stable-assets \
+              --proposed-generation "${PROPOSED_GENERATION}" \
+              --out ../prepare/summary.json
+          )
+          test "$(jq -er '.qualification.run_id' prepare/summary.json)" = "${run_id}" &&
+            test "$(jq -er '.qualification.run_attempt' prepare/summary.json)" = "${run_attempt}" &&
+            test "$(jq -er '.version' prepare/summary.json)" = "${VERSION}" || {
+              echo "::error::stable prepare summary lost candidate identity"
+              exit 2
+            }
+          summary_sha256="$(sha256sum prepare/summary.json | awk '{print $1}')"
+          {
+            echo "## Governed stable publication prepare"
+            echo
+            echo "- operation/mode: \`${GOVERNANCE_MODE}\` / \`${PUBLICATION_MODE}\`"
+            echo "- candidate: \`${VERSION}\` at \`${SOURCE_COMMIT}\`"
+            echo "- evidence: \`${EVIDENCE_COMMIT}:${CANDIDATE_PATH}\`"
+            echo "- qualification run: \`${run_id}/${run_attempt}\`"
+            echo "- live index: generation \`$(jq -r '.live_index.generation' prepare/summary.json)\`"
+            echo "- proposed generation: \`$(jq -r '.mutation.proposed_index.generation' prepare/summary.json)\`"
+            echo "- prepare summary SHA-256: \`${summary_sha256}\`"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+      - name: Bind prepare outputs
+        id: outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f prepare/summary.json
+          summary_sha256="$(sha256sum prepare/summary.json | awk '{print $1}')"
+          summary_artifact_name="publication-prepare-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "summary_sha256=${summary_sha256}" >>"${GITHUB_OUTPUT}"
+          echo "summary_artifact_name=${summary_artifact_name}" >>"${GITHUB_OUTPUT}"
+          {
+            echo "plan_sha256=$(jq -r '.evidence.plan_sha256 // ""' prepare/summary.json)"
+            echo "release_report_sha256=$(jq -r '.release_report.sha256 // ""' prepare/summary.json)"
+            echo "qualification_sha256=$(jq -r '.qualification.sha256 // ""' prepare/summary.json)"
+            echo "live_index_sha256=$(jq -r '.live_index.sha256 // ""' prepare/summary.json)"
+            echo "proposed_index_sha256=$(jq -r '.mutation.proposed_index_sha256 // ""' prepare/summary.json)"
+          } >>"${GITHUB_OUTPUT}"
+
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ${{ steps.summary.outputs.summary_artifact_name }}
+          name: ${{ steps.outputs.outputs.summary_artifact_name }}
           path: prepare/summary.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/release-publication-prepare.yml
+++ b/.github/workflows/release-publication-prepare.yml
@@ -324,7 +324,7 @@ jobs:
               exit 2
             }
           mkdir -p stable-assets prepare
-          while IFS=$'\t' read -r artifact_id artifact_name artifact_size_bytes; do
+          while IFS=$'\t' read -r artifact_id artifact_name artifact_size_bytes artifact_expires_at; do
             artifact_metadata="$(
               gh api \
                 "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}"
@@ -332,6 +332,7 @@ jobs:
             test "$(jq -er '.id' <<<"${artifact_metadata}")" = "${artifact_id}" &&
               test "$(jq -er '.name' <<<"${artifact_metadata}")" = "${artifact_name}" &&
               test "$(jq -r '.expired' <<<"${artifact_metadata}")" = "false" &&
+              test "$(jq -er '.expires_at' <<<"${artifact_metadata}")" = "${artifact_expires_at}" &&
               test "$(jq -er '.workflow_run.id' <<<"${artifact_metadata}")" = "${run_id}" || {
                 echo "::error::qualification artifact provenance mismatch"
                 exit 2
@@ -351,11 +352,12 @@ jobs:
               '[.artifacts[] | {
                 id: .workflow_artifact_id,
                 name: .workflow_artifact_name,
-                size: .size_bytes
+                size: .size_bytes,
+                expires_at: .expires_at
               }]
               | group_by(.id)
               | .[]
-              | [.[0].id, .[0].name, (map(.size) | add)]
+              | [.[0].id, .[0].name, (map(.size) | add), .[0].expires_at]
               | @tsv' \
               "${qualification}"
           )

--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -588,6 +588,22 @@ artifact bytes, the current governance-asset identity, and any staged alpha
 evidence, then uploads an immutable 30-day summary whose digest is rechecked by
 the publish job and retained in each durable bootstrap evidence record.
 
+The same reusable prepare workflow now has a stable-publication path for
+`ga-activation` and `normal`. It separately checks out the exact evidence
+commit and candidate source commit without persisted credentials, reads the
+qualification run identity from the canonical candidate directory, and
+downloads the six exact write-once workflow uploads named by that
+qualification index. The `stable-prepare` validator rejects a dirty or
+mismatched checkout, an expired qualification window shorter than seven full
+days, source/profile/toolchain/submodule drift, any changed transported byte,
+supporting report or release-note drift, and a stale live index identity. It
+then emits—without mutation—the exact proposed generation/index, 20 artifact
+identities, Marketplace VSIX binding, site base commit, and evidence/source
+identities for protected-environment review. The summary is immutable for 30
+days; its plan, release-report, qualification, live-index, and proposed-index
+digests are explicit reusable-workflow outputs, and the later publish job must
+consume the exact summary digest.
+
 Manual drill dispatch selects exactly publication, rollback, or first-GA
 coverage and passes that mode unchanged to `release-publication-drill.yml`;
 unknown reusable-workflow modes fail before the drill core runs. Drills use the
@@ -627,6 +643,8 @@ uv run --project verification --locked python -m sifr_verify areas run \
   --area distribution_release --suite epoch-bootstrap
 uv run --project verification --locked python -m sifr_verify areas run \
   --area distribution_release --suite protected-drill
+uv run --project verification --locked python -m sifr_verify areas run \
+  --area distribution_release --suite stable-prepare
 uv run --project verification --locked python -m sifr_verify areas run \
   --area distribution_release --suite incident-governance
 demos/stable_incident_recovery_demo.sh

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -518,6 +518,39 @@ Review and upstream coordination ledger:
   It matched local, remote branch, and PR head at
   `774592acd140747c068bfe6f4752b34006e9664a`, rechecked the complete wave,
   found no actionable issue, and returned `SATISFIED`.
+- Frozen-head review pass 5 is archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-5-frozen-pr-head-satisfied.md`.
+  It matched local, remote branch, and PR head at
+  `a5ffe3704bbdf71616f5edee6f08c9de34c3ac76`, confirmed the pass-4 archive
+  delta was documentation-only and truthful, and returned `SATISFIED`.
+- [PR #3041](https://github.com/sifr-lang/sifr/pull/3041) merged the protected
+  credential-free drill and stable index planning wave as
+  `f9837adb105f048ed56624c148ee83ecbd2a3d03`.
+- The next protected-publication wave adds a credential-free stable prepare
+  path for `ga-activation` and `normal`. It binds an exact evidence commit,
+  canonical candidate directory and plan digest, a separate clean exact source
+  checkout, at least seven full days of qualification lifetime, all 20
+  transported artifact identities from six write-once qualification uploads,
+  Rust/documentation/release-note evidence, Marketplace VSIX bytes, live index
+  identity, site base commit, and a deterministic proposed stable mutation.
+  The reusable workflow remains read-only and secret-free and retains the
+  reviewer-visible summary for 30 days. The named `stable-prepare` suite is
+  selected by merge, nightly, and release profiles and required by the release
+  report.
+- Stable-prepare review pass 1 is satisfied and archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-stable-prepare-review-pass-1-satisfied.md`.
+  Opus re-read every file after the in-review hardening, reproduced the
+  stable-prepare, governance, runner, combined 60-variant distribution,
+  coverage, workflow-contract, diff, and file-size gates, and found no
+  actionable correctness, provenance, extraction, schema, permission, or
+  compatibility issue. Its verdict binds the final reviewed workflow,
+  extractor, artifact-index, and prepare-core byte identities recorded in the
+  archive.
+- The authoritative `scripts/run_all_tests.sh --profile create-pr` gate passed
+  for the stable-prepare implementation, including every blocking lane and
+  131/131 E2E fixtures (`report_signature=7c39b8c1dd4fec7c`). The only
+  advisory was the already-indexed non-blocking warm wall-time variance; every
+  enforced step budget passed.
 - [ ] Publish or verify write-once assets, Marketplace version, governed index
   activation, site facts, and post-publication smoke.
 - [ ] Exercise resume, stale generation, burned generation, rollback, and

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -551,6 +551,19 @@ Review and upstream coordination ledger:
   131/131 E2E fixtures (`report_signature=7c39b8c1dd4fec7c`). The only
   advisory was the already-indexed non-blocking warm wall-time variance; every
   enforced step budget passed.
+- Exact PR-head stable-prepare review pass 2 is satisfied and archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-stable-prepare-review-pass-2-exact-pr-head-satisfied.md`.
+  It independently matched local, remote, and [PR #3043](https://github.com/sifr-lang/sifr/pull/3043)
+  at `a671c913116e6fa30073d6220abe639154b51e72`, reproduced the focused
+  gates, found no actionable issue, and returned `SATISFIED`.
+- Its non-blocking observations were hardened before the frozen-head review:
+  each governed upload now has one canonical expiry shared by all transported
+  entries and matched exactly to the authoritative GitHub artifact API,
+  the stable-prepare schema fixture passes the semantic validator, and the
+  extraction self-test pins pre-write rejection of uncompressed byte-count
+  drift. The focused 60-variant distribution run, stable-prepare 6/6,
+  governance 14/14, runner foundation, coverage readiness, schema/workflow
+  contracts, Ruff, diff, and file-size guardrails pass after these changes.
 - [ ] Publish or verify write-once assets, Marketplace version, governed index
   activation, site facts, and post-publication smoke.
 - [ ] Exercise resume, stale generation, burned generation, rollback, and

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -564,6 +564,12 @@ Review and upstream coordination ledger:
   drift. The focused 60-variant distribution run, stable-prepare 6/6,
   governance 14/14, runner foundation, coverage readiness, schema/workflow
   contracts, Ruff, diff, and file-size guardrails pass after these changes.
+- Frozen PR-head stable-prepare review pass 3 is satisfied and archived at
+  `plans/reviews/archive/phase-40-milestone-40-5-stable-prepare-review-pass-3-frozen-pr-head-satisfied.md`.
+  It matched local, remote, and PR #3043 at
+  `55c6d960c4ea29b7b945df88d72573a6008c9651`, independently rechecked the
+  complete wave and all post-pass-2 hardening, reproduced the focused gates,
+  found no actionable issue, and returned `SATISFIED`.
 - [ ] Publish or verify write-once assets, Marketplace version, governed index
   activation, site facts, and post-publication smoke.
 - [ ] Exercise resume, stale generation, burned generation, rollback, and

--- a/plans/releases/README.md
+++ b/plans/releases/README.md
@@ -3,9 +3,10 @@
 Phase 40 keeps reviewed, immutable release evidence under two controlled
 directories:
 
-- `candidates/<version>/` contains one stable candidate plan, its canonical
-  release-profile report, and qualification artifact index. A later protected
-  publication may add the matching sign-off.
+- `candidates/<version>/` contains the stable plan, canonical release-profile
+  report, qualification artifact index, stable support claims, Rust validation
+  report, documentation report, and release notes reviewed for that exact
+  candidate. A later protected publication may add the matching sign-off.
 - `incidents/<incident-id>/` contains one incident request and its digest-bound
   `withdrawal-evidence.txt`. A later protected incident workflow may add the
   matching sign-off.

--- a/plans/releases/stable_gate_inventory.json
+++ b/plans/releases/stable_gate_inventory.json
@@ -110,9 +110,9 @@
       "id": "protected-publication-prepare",
       "location": ".github/workflows/release-publication-prepare.yml",
       "owner": "release/distribution",
-      "current_behavior": "revalidates exact source, release artifacts, current index identity, and staged alpha evidence with read-only permissions and emits a digest-bound 30-day summary",
+      "current_behavior": "revalidates exact preview/bootstrap inputs or the exact stable candidate evidence commit, clean source/submodules, unexpired qualification uploads, supporting reports, current index identity, Marketplace bytes, and site base with read-only permissions and emits a digest-bound 30-day summary",
       "activation_boundary": "protected-publication",
-      "disposition": "remains read-only, has no protected environment or production secret, and supplies the reviewer-visible bytes consumed by publish"
+      "disposition": "remains read-only, has no protected environment or production secret, and supplies the exact reviewer-visible stable mutation proposal and transported bytes consumed by publish"
     },
     {
       "id": "schema-v2-preview-epoch-bootstrap",
@@ -262,9 +262,9 @@
       "id": "release-profile-stable-gates",
       "location": "verification/profiles/release.json",
       "owner": "compiler/verification",
-      "current_behavior": "executes distribution, tooling, documentation, and Rust release gates",
+      "current_behavior": "executes distribution, stable prepare, tooling, documentation, and Rust release gates",
       "activation_boundary": "architecture-lock",
-      "disposition": "durably executes incident-governance, evidence-custody, editor-release expansion, documentation ga-release, and Rust stable-candidate"
+      "disposition": "durably executes incident-governance, evidence-custody, protected-drill, stable-prepare, editor-release expansion, documentation ga-release, and Rust stable-candidate"
     }
   ]
 }

--- a/plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-5-frozen-pr-head-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-protected-drill-review-pass-5-frozen-pr-head-satisfied.md
@@ -1,0 +1,34 @@
+All checks complete. No files modified.
+
+## Identity evidence (independently verified)
+
+| Ref | SHA |
+|---|---|
+| local `HEAD` | `a5ffe3704bbdf71616f5edee6f08c9de34c3ac76` |
+| `origin/codex/phase-40-milestone-40-5-bootstrap-execution` (after fetch) | `a5ffe3704bbdf71616f5edee6f08c9de34c3ac76` |
+| PR #3041 `headRefOid` (`gh pr view`) | `a5ffe3704bbdf71616f5edee6f08c9de34c3ac76` |
+| base | `e22a8cfbf058f9657b285370d7d075f9ff0209b3` |
+
+All three equal. PR #3041 OPEN, base `main`, "Phase 40: add protected stable publication drill". Diff vs base: 3 commits, 36 files, +1766/−38. Working tree carries only the untracked pass-5 slot file that pre-existed this session.
+
+## Delta since pass 4 (`774592acd`)
+
+Documentation-only, 2 files, +45/−0: the archived pass-4 artifact and a 5-line tracking entry in `plans/issues/active/phase-40-stable-channel-ga-execution.md:516-520`. No code, workflow, schema, or registration byte changed. The tracking text is truthful — it states the pass matched all three refs at `774592acd`, found no actionable issue, and returned `SATISFIED`, with no merge or completion claim.
+
+**Pass-4 artifact accuracy.** Its identity table (`774592acd` on all three refs, base `e22a8cfbf`) and its diff figures ("2 commits, 35 files, +1721/−38") reconcile exactly with the frozen head minus this 1-new-file/45-line delta. Spot-checked technical claims all hold at HEAD: schema count exactly 15 (`ls` = 15, `sifr_verify/selftest.py:89` = 15), largest touched file 882 lines (`incident_recovery_selftest.py`), largest new file 332 (`stable_planner_selftest.py`), `release-publication.yml` = 815 lines, `PRODUCTION_CREDENTIAL_NAMES` at `common.py:18-25`. Its two carried non-actionable observations remain accurate. The earlier "13→14" in the pass-1 archive is historically correct for that tree (the second schema landed in pass-1 remediation); pass 2 records 13→15.
+
+## Frozen-head audit vs base
+
+- **Workflow safety / fail-closed.** `workflow_dispatch` exposes only `drill-publication|drill-rollback|drill-first-ga` as `type: choice`. `prepare` and `publish` are gated `!startsWith(..., 'drill-')`; `drill` is gated `startsWith(...)`. Any other `drill-*` value arriving via `workflow_call` skips both mutation jobs and dies at the drill's `*) exit 2` boundary; non-`drill-` typos hit the publish job's existing `*) exit 2`. Case-mismatched `Drill-*` passes GitHub's case-insensitive `startsWith` into the case-sensitive bash `case`, which also exits 2 — fail-closed both ways. Isolated `sifr-release-drill` concurrency group, so the drill never takes the production `sifr-release-index` lock.
+- **Credential / network isolation.** No `${{ secrets.` anywhere in the drill file, no `secrets:` on the `uses:` call, `contents: read` at workflow and job level, `persist-credentials: false`, explicit six-name pre-check, `sudo env -u` scrub of the same six, `unshare --net --mount-proc`. Contract script pins the credential list name-for-name against both the boundary loop and the scrub, and forbids `contents: write`, `gh release`, `vsce publish`, `/dispatches`. Verified live: with a real `VSCE_PAT` in my environment the drill aborts `protected drill refuses production credential(s): VSCE_PAT`; scrubbed it passes 11/11 across all three scenarios.
+- **Planner / evidence correctness.** `propose_stable_release` enforces active non-incident release, no pre-existing record, strictly-increasing generation, exact ga-activation vs. normal preconditions, forward-only stable ordering, alpha/beta preservation, and byte-exact retained-release preservation — all six reached by direct negative tests in `test_direct_transition_defenses`. `validate_stable_mutation_evidence` re-validates the proposed index, requires strict generation advance, checks the bound stable activation, and recomputes `proposed_index_sha256` from canonical bytes; the CLI validates *before* `write_canonical_json(..., refuse_existing=True)`, and the double-run test pins the refusal.
+- **Schema / suite registration.** Both new schemas are `const 2` with negative fixtures in `validate_schema_contracts`. `--expected-drill-scenario` closes the producer/checker loop externally. `protected-drill` is registered consistently in the manifest, runner allow-list + command map + entry map, all three profiles, `profile_assignment_matrix.json`, `release_report.REQUIRED_SUITES`, `selftest.valid_report`, `schema_contracts.release_report`, and `qualification_fixture`.
+- **Scope.** No `crates/`, no `demos/`, no Rust-interop implementation, no phase-numbered demos, no live production mutation path. Durable docs updated in `internal_docs/architecture.md` and `distribution_pipeline.md:582-598`, plus `stable_gate_inventory.json` entries for both new surfaces.
+
+**Gates re-run locally at this head:** drill selftest 11/11 credential-free (and correctly refusing when credentialed), `sifr_verify areas run --suite protected-drill` variants=1/failures=0, `validate_schema_contracts` pass, `sifr_verify --self-test` pass, both workflow-contract case scripts pass, file-size guardrails PASS (2903 files, limit 900).
+
+## Findings
+
+None actionable. Residual non-actionable notes, all carried or incidental: `--expected-drill-scenario` is accepted-and-ignored for non-drill `--kind` values (the workflow always pairs them); `_require_incident_generation` moved from `type() is not int` to `isinstance` with an explicit `bool` exclusion, which is behaviorally equivalent for any real input; `test_no_production_adapter_surface` narrowed `"rollback" not in dispatch` to the line-anchored `"\n          - rollback\n"`, necessary now that `drill-rollback` is a dispatch option and still pinning the absence of a bare production `rollback` choice; and `runner.py:14`'s absolute `verification.*` import (pass-4 observation) remains, with the supported `sifr_verify` path verified working.
+
+## SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-stable-prepare-review-pass-1-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-stable-prepare-review-pass-1-satisfied.md
@@ -1,0 +1,40 @@
+# Phase 40 / Milestone 40.5 — stable-publication prepare wave review
+
+**Important process note first:** the working tree changed **three times underneath me during this review** (`release-publication-prepare.yml` went 182 → 188 → 192 → 199 insertions; `extract_github_artifact.py` gained `--expected-uncompressed-bytes`; `artifact_index.py` was not modified at review start and is now modified). I re-read every volatile file and re-ran every test against the **final** state. This verdict applies to exactly these bytes:
+
+```
+7006d9655df2c2d9  .github/workflows/release-publication-prepare.yml
+97330224cdc7247c  scripts/distribution/extract_github_artifact.py
+b258fe353e3470ae  verification/areas/.../governance/artifact_index.py
+15f08d91ca9219fe  verification/areas/.../governance/stable_prepare.py
+```
+
+## What I verified (not just "tests pass")
+
+**Fail-closed shell/expression correctness.** Anchored regexes on all five new inputs, `set -euo pipefail`, `exit 2` inside `while … done < <(…)` correctly terminates the step (process substitution, not a pipe, so the loop body runs in the current shell). Unknown `governance_mode` still falls into the preview branch's `*) unsupported governance_mode; exit 2`. The un-`if`'d "Bind prepare outputs" step is safe because `test -f prepare/summary.json` fails closed if neither branch ran.
+
+One thing I specifically checked because it is a classic inverted-guard bug: `expired` uses `jq -r`, not `jq -er` (`.github/workflows/release-publication-prepare.yml:317`). With `-e`, a `false` value exits 1 and would have short-circuited the whole `&&` chain into the error path on every healthy artifact. It is correct as written; every other field that is a nonzero int or non-empty string correctly uses `-er`.
+
+**Injection / provenance.** `run_id`, `run_attempt`, `workflow_artifact_id`, `workflow_artifact_name` are all validated by `validate --kind qualification-artifact-index --require-canonical` **before** interpolation into API URLs and filesystem paths (`artifact_index.py:97-100,155-208`: positive ints; name must have no `/` and must equal `sifr-stable-candidate-<version>-<source_commit>-<suffix>`). Run-attempt binding checks `.id`, `.run_attempt`, `.head_sha == SOURCE_COMMIT`, `.conclusion == success`; artifact binding checks `.id`, `.name`, `.expired`, `.workflow_run.id`. The new one-to-one `workflow_id ↔ workflow_name` map plus `len(...) != 6` (`artifact_index.py:171-178,254-255`) closes the ambiguity `group_by(.id) | .[0].name` would otherwise have had.
+
+**Archive extraction.** Rejects absolute paths, `..`, backslashes, symlink/device members, duplicates, overwrites, and non-empty or symlinked destinations; resolves each target and confirms containment. The `--expected-uncompressed-bytes` total is sound and *also* rejects undeclared content, because each of the six uploads contains exactly the declared artifacts: `path: qualification/*` globs to the zip root and `qualify_stable_target.py` writes only the 4 declared files (install/receipt/smoke all live in a `TemporaryDirectory`), giving 4×4 + 2 (editor) + 2 (assemble) = the 20 governed ids.
+
+**Submodule binding — I initially flagged this as a gap and it is not one.** `_require_checkout` does not compare gitlinks, unlike the sibling `planner.validate_source_identity:232`. But the binding is anchored transitively: `validate_release_profile_report(..., source_root=source_root)` → `validate_source` → `collect_submodules(source_root) != submodules` (`release_report.py:127-128`), and `stable_prepare.py:139` then requires `report["source"]["submodules"] == plan["submodules"]`. Recursive submodule identity *is* re-derived from the real checkout.
+
+**Mutation non-authority.** `materialize_stable_mutation` returns a proposal without writing; the only artifact produced is `prepare/summary.json` via `write_canonical_json(refuse_existing=True)` (proven by the CLI test's second-invocation assertion). Read-only permissions, no secrets, and the contract case forbids `contents: write`, `${{ secrets.`, `gh release upload`, `vsce publish`, `unzip`.
+
+**Backward compatibility.** The reusable workflow's *outputs* are unchanged; only the internal step id moved `summary` → `outputs`, and both existing contract cases were updated. No workflow references `steps.summary`. All five new inputs default to `""`, and the sole caller (`release-publication.yml`) cannot reach the stable branch — its dispatch choices are `drill-*` and its call default is `preview`; if it ever did, empty inputs fail closed at the regex gate.
+
+**Profile registration and de-duplication**, verified empirically rather than by reading: `--suite full --suite stable-prepare` → `variants=60, failures=0` with `stable-publication-prepare` executing exactly once.
+
+**Re-run against final bytes:** stable_prepare 6/6 · governance 14/14 · runner `run_all` 11/11 · distribution `full`+`stable-prepare` 60/60 · coverage matrix 5/5 · all three workflow contract cases · `check_file_size_guardrails.py` PASS (largest new file 603 lines) · `git diff --check` clean.
+
+## Non-blocking observations (no change required)
+
+- The candidate-evidence file contract is now hard-coded in three independent places — `stable_prepare.py:48-58`, `evidence_custody.py:25-29`, and `evidence_custody.py:186-208` — with no test binding them. Drift fails closed in both directions, so this is maintainability, not correctness; a shared constant would remove the hazard when the next evidence file is added.
+- `mode` (`initial`/`resume`) is recorded in the summary but has no behavioral effect in `materialize_stable_prepare`. Defensible for a read-only prepare (`validate_release_plan(active_index=…)` already rejects a plan whose index flip has happened), but the resume distinction only becomes load-bearing in the publish job.
+- `plans/reviews/active/phase-40-milestone-40-5-stable-prepare-review-pass-1.md` is a 0-byte placeholder; it should not be committed empty.
+
+I found no fail-open path, no expression/shell defect, no provenance or extraction weakness, no canonical/schema contract gap, no mutation authority, and no guardrail violation.
+
+VERDICT: SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-stable-prepare-review-pass-2-exact-pr-head-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-stable-prepare-review-pass-2-exact-pr-head-satisfied.md
@@ -1,0 +1,44 @@
+Verification and review complete. No files modified.
+
+## Identity (independently verified)
+
+| Ref | SHA |
+|---|---|
+| local `HEAD` | `a671c913116e6fa30073d6220abe639154b51e72` |
+| `origin/codex/phase-40-milestone-40-5-stable-publication` (after fetch) | `a671c913116e6fa30073d6220abe639154b51e72` |
+| PR #3043 `headRefOid` | `a671c913116e6fa30073d6220abe639154b51e72` |
+| merge base / base | `f9837adb105f048ed56624c148ee83ecbd2a3d03` (`main`) |
+
+All three identical. PR #3043 OPEN, base `main`. Diff: 1 commit, 31 files, +2270/−218. Working tree carries only the pre-existing untracked pass-2 slot file.
+
+## What I confirmed at this exact head
+
+**Fail-closed provenance chain.** `SOURCE_COMMIT` has no explicit regex in the stable step, but it is transitively pinned: `run_metadata.head_sha == SOURCE_COMMIT` (a real SHA) forces `SOURCE_COMMIT` to be a 40-hex, and `_require_checkout(source_root, plan["source_commit"])` (`stable_prepare.py:399-405`) forces the `ref: source_commit` checkout HEAD to equal the plan's commit — so `head_sha == SOURCE_COMMIT == plan.source_commit == qualification.source_commit` (the last checked at `stable_prepare.py:164-169`). Run/attempt binding checks `.id`, `.run_attempt`, `.head_sha`, `.conclusion == success`; artifact binding checks `.id`, `.name`, `.expired`, `.workflow_run.id`. `.expired` correctly uses `jq -r` not `-er` (`:334`) — with `-e` a healthy `false` would have exited 1 and inverted the guard.
+
+**No injection.** `run_id`, `run_attempt`, `workflow_artifact_id/name` are validated by `validate --kind qualification-artifact-index --require-canonical` **before** interpolation into API URLs and paths. Names are fully pinned to `sifr-stable-candidate-<version>-<source_commit>-<suffix>` and rejected if they contain `/` (`artifact_index.py:166-206`), and file names are pinned per artifact id and must be single components (`:245`).
+
+**`group_by(.id)` ambiguity is closed.** The workflow's jq takes `.[0].name` for a group; the new one-to-one id↔name map plus `len(...) != 6` in both `artifact_index.py:171-178,254-255` and `stable_prepare.py:433-446` make that safe, and it runs before the jq read.
+
+**ZIP safety — exercised, not just read.** Rejects `..`, absolute, backslash, symlink/device members, duplicates, overwrite, non-empty/symlinked destination. I built adversarial archives: byte-count mismatch rejected *before any write* (`d2` left empty after a 10 MB highly-compressible member declared as 5 bytes); `zipfile` bounds decompression by the declared `file_size`, so the sum check is a real decompression bound, and `verify_transported_artifacts` (`planner.py:255-264`) then re-checks each file's actual size and SHA-256. Nested-directory content extracts but would break the exact byte sum, so undeclared content fails closed.
+
+**Submodule binding is real** (I re-derived it rather than trusting pass 1): `validate_release_profile_report(..., source_root=…)` → `collect_submodules` uses `git submodule status --recursive` and rejects `-`/`+`/`U` (`release_report.py:354-366`), then `stable_prepare.py:139` requires report submodules == plan submodules.
+
+**Mutation-free / credential-free.** `actions: read` + `contents: read` only; no `secrets:`; the sole caller (`release-publication.yml:62-70`) omits all five new inputs, and if `governance_mode=normal` ever reached it, prepare fails at the regex gate and `publish` (`needs: prepare`) is skipped. Only output is `prepare/summary.json` via `write_canonical_json(refuse_existing=True)`, pinned by the CLI double-run test. Preview/bootstrap behavior preserved: outputs unchanged, the new outputs degrade to `""` via `// ""` on absent keys (no jq error — indexing `null` is legal), and stable inputs are rejected outright (`:107-110`).
+
+**Reproduced locally at this head:** stable-prepare selftest 6/6 · `--suite stable-prepare` variants=1/failures=0 · `full`+`stable-prepare` **60/60** with both `stable_publication_prepare_workflow_contract` and `stable-publication-prepare` present exactly once · evidence-custody 1/1 · coverage matrix 5/5 · `sifr_verify --self-test` all pass (schema count 16) · `validate_schema_contracts` pass · all three workflow-contract cases pass · file-size guardrails PASS (2908 files, largest new file 621) · `git diff --check` clean. Schema enum ↔ `EXPECTED_ARTIFACT_IDS` verified equal (20). No circular import from evidence_custody's new top-level `.planner`/`.artifact_index` imports.
+
+**Pass-1 SATISFIED still holds.** Its byte-identity claims, the 6-upload/one-to-one closure, the submodule-transitivity correction, and the `jq -er` observation all reconcile with this head; the 0-byte placeholder it flagged is **not** committed. Ledger and doc text are truthful — `internal_docs/distribution_pipeline.md:591-606` describes only what exists, and "the later publish job must consume the exact summary digest" is stated as an obligation with the publish checklist item still unchecked.
+
+**Scope.** No `crates/`, no `demos/`, no Rust interop implementation, no phase-numbered demo names, no wait thread, no production mutation path.
+
+## Findings
+
+None actionable.
+
+**Nonblocking (no change required):**
+- `.github/workflows/release-publication-prepare.yml:334` consults the live artifact's `.expired` but not its `.expires_at`; the seven-full-day window (`stable_prepare.py:_require_publication_window`) derives from the evidence's absolute timestamp. Correct as written for truthful evidence (absolute, with `retention_days == 30` pinned), but comparing the API's authoritative `expires_at` would close the forged-evidence case for free.
+- `schema_contracts.stable_publication_prepare()` is schema-valid but would be *rejected* by `validate_stable_prepare_summary` (20 distinct workflow ids vs the required 6; `vsix_sha256` = `SHA_D` ≠ `artifacts.vsix.sha256`). Harmless — only the Python validator is authoritative — but the fixture no longer doubles as a realistic example.
+- `stable_prepare_selftest.test_safe_artifact_extractor` covers traversal and symlink but not the byte-count mismatch branch. I verified that branch manually; a third fixture would pin it.
+- Carried from pass 1 and still true: the candidate-evidence file set is hard-coded in three places (`stable_prepare.py:48-58`, `evidence_custody.py:26-30`, `:190-215`) with no shared constant, and `mode` (`initial`/`resume`) is recorded but has no behavioral effect until the publish job exists.
+
+VERDICT: SATISFIED

--- a/plans/reviews/archive/phase-40-milestone-40-5-stable-prepare-review-pass-3-frozen-pr-head-satisfied.md
+++ b/plans/reviews/archive/phase-40-milestone-40-5-stable-prepare-review-pass-3-frozen-pr-head-satisfied.md
@@ -1,0 +1,39 @@
+All three heads match the frozen SHA. I reviewed the complete `origin/main...HEAD` diff (2 commits, 32 files) and reproduced the validation set locally.
+
+## Head verification
+
+| Location | SHA |
+|---|---|
+| local `HEAD` | `55c6d960c4ea29b7b945df88d72573a6008c9651` |
+| `refs/heads/codex/phase-40-milestone-40-5-stable-publication` (origin) | same |
+| PR #3043 `headRefOid` (state OPEN, MERGEABLE, base `main`) | same |
+
+Working tree clean except one untracked file (`plans/reviews/active/…pass-3-frozen-pr-head.md`), which is not part of the PR. No files modified.
+
+## Post-pass-2 hardening — each item confirmed
+
+- **One canonical expiry per governed upload** — `artifact_index.py:199-206` adds `workflow_id_to_expiry` and rejects any second entry of the same `workflow_artifact_id` with a differing `expires_at`; pinned by a new mutation case (`selftest.py:659-674`, artifacts[1] expiry drift, plus artifacts[4] id-collision). Combined with the pre-existing "must not expire before the workflow qualification boundary" check, `workflow.expires_at` is a lower bound on API-verified per-artifact expiries — so the seven-day window (`stable_prepare.py:566-577`) can no longer be forged forward.
+- **Exact API expiry comparison before download** — `release-publication-prepare.yml:334` now compares `.expires_at` from the authoritative `/actions/artifacts/{id}` response against the index value, alongside `.id`, `.name`, `.expired == false`, `.workflow_run.id`, and only then fetches `/zip` (`:342-345`). Contract-pinned (`stable_publication_prepare_workflow_contract.sh:26-27`).
+- **Schema fixture** — `schema_contracts.stable_publication_prepare()` is now derived from `qualification_index()` (real names/digests/6 upload ids, `vsix_sha256` = transported VSIX). I verified it passes both `validate_instance(..., stable_publication_prepare.schema.json)` and `validate_stable_prepare_summary` (checked directly). I also confirmed the relative `$ref` to `stable_index_mutation_evidence.schema.json` genuinely resolves (an empty `mutation` is rejected) and the 20-identity `propertyNames`+`minProperties: 20` pair is enforced.
+- **ZIP byte-count mismatch rejects before writing** — `extract_github_artifact.py:29-44` plans every member, then sums `file_size` and compares to `--expected-uncompressed-bytes` *before* the write loop at `:45`. New self-test fixture (`stable_prepare_selftest.py:306-324`) asserts non-zero exit **and** `not any(destination.iterdir())`.
+
+## Requirement recheck (spot-verified, not carried over)
+
+Credential-free/mutation-free (`permissions: actions: read, contents: read`; no `secrets:`; `persist-credentials: false` on both checkouts; `materialize_stable_mutation` returns without writing — `stable_planner.py:58-116`); exact evidence + source commits with `submodules: recursive` and clean-checkout enforcement (`stable_prepare.py:451-457`); exact successful run/attempt (`/attempts/{n}` with `id`/`run_attempt`/`head_sha`/`conclusion == success`); 6 uploads × 20 artifacts (`artifact_index.py:263-264`, `EXPECTED_ARTIFACT_IDS` = 4 singletons + 4 kinds × 4 targets); write-once (`retention_days == 30`, `overwrite is not False`); ≥7 full days; deterministic schema-v2 summary via `write_canonical_json(refuse_existing=True)` (double-run test at `stable_prepare_selftest.py:241-249`); exact Marketplace binding through `validate_marketplace_publish_plan` (`editor_qualification.py:95-130`) plus `vsix_sha256 == artifacts["vsix"].sha256`; site pinned to `sifr-lang/sifr-website`; 30-day `overwrite: false` summary upload (`:428`). Scope is Phase 40 release/distribution only — no `crates/`, no demos, no Rust-interop implementation.
+
+**No preview/bootstrap regression:** the sole caller (`release-publication.yml:62-71`) passes none of the five new inputs, and the preview path rejects them outright (`:107-110`). The `Bind prepare outputs` step is unconditional and uses `// ""`, which is safe on the preview summary (missing keys index to `null`, not an error) — I confirmed the preview summary shape at `:220-241`. `ga-activation`/`normal` were previously rejected by the `case` default and now fail-closed at the stable regex gate, with `publish` (`needs: prepare`) skipped either way.
+
+## Validation reproduced at this head
+
+stable-prepare selftest **6/6** · governance **14/14** · combined `full`+`stable-prepare` **60/60**, 0 failures · all three workflow-contract cases exit 0 · `sifr_verify --self-test` all lanes pass (schema lint count 16) · coverage matrix 5/5 (`profile assignment matrix ok: rows=17`) · file-size guardrails PASS (2908 files, limit 900; largest new file 621) · `git diff --check` clean. Python lint is not a repo lane (no first-party `ruff` config; `ruff` here is the parser submodule) — I checked the refactored modules for orphaned imports instead and found none.
+
+## Findings
+
+None actionable.
+
+Nonblocking, no change required:
+- `release-publication-prepare.yml:415-421` — a `jq` failure inside `echo "k=$(jq …)"` cannot fail the step under `set -e`, so a malformed summary would silently yield an empty output rather than aborting. Unreachable in practice: `validate_stable_prepare_summary` already ran inside the producer, and the gating identity checks at `:387-392` use assignment/`test` forms that do abort.
+- The artifact API exposes no attempt number, so attempt-granular artifact provenance rests on the index binding plus commit-qualified write-once upload names — the strongest available given the API.
+- Carried from pass 2 and still open: the candidate-evidence file set is duplicated across `stable_prepare.py:49-58` and `evidence_custody.py:180-200`, and `mode` (`initial`/`resume`) is recorded without behavioral effect until the publish job lands (the corresponding checklist items in `plans/issues/active/phase-40-stable-channel-ga-execution.md` remain unchecked, so the docs are truthful).
+
+VERDICT: SATISFIED

--- a/scripts/distribution/extract_github_artifact.py
+++ b/scripts/distribution/extract_github_artifact.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Extract one GitHub Actions artifact ZIP without path or link traversal."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import stat
+import zipfile
+from pathlib import Path, PurePosixPath
+
+
+def extract_artifact(
+    archive_path: Path,
+    destination: Path,
+    *,
+    expected_uncompressed_bytes: int,
+) -> None:
+    if expected_uncompressed_bytes < 1:
+        raise ValueError("expected uncompressed size must be positive")
+    if destination.is_symlink() or not destination.is_dir():
+        raise ValueError("destination must be an existing non-symlink directory")
+    if any(destination.iterdir()):
+        raise ValueError("destination must be empty")
+    destination = destination.resolve()
+    seen: set[str] = set()
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            planned: list[tuple[zipfile.ZipInfo, PurePosixPath, Path]] = []
+            for member in archive.infolist():
+                relative = _safe_member_path(member)
+                normalized = relative.as_posix()
+                if normalized in seen:
+                    raise ValueError(f"duplicate artifact member: {normalized}")
+                seen.add(normalized)
+                target = destination.joinpath(*relative.parts)
+                if not target.resolve().is_relative_to(destination):
+                    raise ValueError(f"artifact member escapes destination: {normalized}")
+                planned.append((member, relative, target))
+            files = [member for member, _, _ in planned if not member.is_dir()]
+            if not files:
+                raise ValueError("artifact ZIP contains no files")
+            if sum(member.file_size for member in files) != expected_uncompressed_bytes:
+                raise ValueError("artifact ZIP uncompressed size does not match evidence")
+            for member, relative, target in planned:
+                if member.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if target.exists() or target.is_symlink():
+                    raise ValueError(
+                        f"artifact member would overwrite: {relative.as_posix()}"
+                    )
+                with archive.open(member) as source, target.open("xb") as output:
+                    shutil.copyfileobj(source, output)
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise ValueError(f"invalid artifact ZIP: {exc}") from exc
+
+
+def _safe_member_path(member: zipfile.ZipInfo) -> PurePosixPath:
+    name = member.filename
+    relative = PurePosixPath(name)
+    if (
+        not name
+        or "\\" in name
+        or relative.is_absolute()
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
+        raise ValueError(f"unsafe artifact member path: {name!r}")
+    mode = member.external_attr >> 16
+    file_type = stat.S_IFMT(mode)
+    if file_type not in {0, stat.S_IFREG, stat.S_IFDIR}:
+        raise ValueError(f"artifact member is not a regular file/directory: {name}")
+    if member.is_dir() != (file_type == stat.S_IFDIR) and file_type != 0:
+        raise ValueError(f"artifact member type is inconsistent: {name}")
+    return relative
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("destination", type=Path)
+    parser.add_argument("--expected-uncompressed-bytes", required=True, type=int)
+    args = parser.parse_args()
+    try:
+        extract_artifact(
+            args.archive,
+            args.destination,
+            expected_uncompressed_bytes=args.expected_uncompressed_bytes,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/distribution/release_governance.py
+++ b/scripts/distribution/release_governance.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(AREA_ROOT))
 from governance import (  # noqa: E402
     GovernanceError,
     generate_site_release_facts,
+    materialize_stable_prepare,
     validate_bootstrap_evidence,
     validate_drill_evidence,
     validate_incident_request,
@@ -35,6 +36,7 @@ from governance import (  # noqa: E402
     validate_site_publication_facts,
     validate_site_release_facts,
     validate_stable_mutation_evidence,
+    validate_stable_prepare_summary,
 )
 from governance.common import (  # noqa: E402
     load_json_strict,
@@ -78,6 +80,7 @@ def parse_args() -> argparse.Namespace:
             "self-version",
             "site-publication-facts",
             "stable-index-mutation-evidence",
+            "stable-publication-prepare",
         ),
     )
     validate.add_argument("--input", required=True)
@@ -185,6 +188,22 @@ def parse_args() -> argparse.Namespace:
     stable_index.add_argument("--expected-sha256", required=True)
     stable_index.add_argument("--proposed-generation", required=True, type=int)
     stable_index.add_argument("--out", required=True)
+    stable_prepare = commands.add_parser("prepare-stable-publication")
+    stable_prepare.add_argument(
+        "--operation",
+        required=True,
+        choices=("ga-activation", "normal"),
+    )
+    stable_prepare.add_argument("--mode", required=True, choices=("initial", "resume"))
+    stable_prepare.add_argument("--evidence-root", required=True)
+    stable_prepare.add_argument("--evidence-commit", required=True)
+    stable_prepare.add_argument("--candidate-path", required=True)
+    stable_prepare.add_argument("--expected-plan-sha256", required=True)
+    stable_prepare.add_argument("--source-root", required=True)
+    stable_prepare.add_argument("--live-index", required=True)
+    stable_prepare.add_argument("--artifact-root", required=True)
+    stable_prepare.add_argument("--proposed-generation", required=True, type=int)
+    stable_prepare.add_argument("--out", required=True)
     approvers = commands.add_parser("resolve-publication-approvers")
     approvers.add_argument("--approvals", required=True)
     approvers.add_argument("--initiator", required=True)
@@ -221,6 +240,8 @@ def main() -> int:
             generate_schema_bootstrap_index(args)
         elif args.command == "plan-stable-index":
             plan_stable_index(args)
+        elif args.command == "prepare-stable-publication":
+            prepare_stable_publication(args)
         elif args.command == "resolve-publication-approvers":
             resolve_publication_approvers(args)
         else:
@@ -250,6 +271,7 @@ def validate_command(args: argparse.Namespace) -> None:
         "self-version": validate_self_version,
         "site-publication-facts": validate_site_publication_facts,
         "stable-index-mutation-evidence": validate_stable_mutation_evidence,
+        "stable-publication-prepare": validate_stable_prepare_summary,
     }
     if args.kind == "protected-drill-evidence" and args.expected_drill_scenario:
         validate_drill_evidence(
@@ -505,6 +527,22 @@ def plan_stable_index(args: argparse.Namespace) -> None:
         evidence,
         refuse_existing=True,
     )
+
+
+def prepare_stable_publication(args: argparse.Namespace) -> None:
+    summary = materialize_stable_prepare(
+        operation=args.operation,
+        mode=args.mode,
+        evidence_root=Path(args.evidence_root),
+        evidence_commit=args.evidence_commit,
+        candidate_path=args.candidate_path,
+        expected_plan_sha256=args.expected_plan_sha256,
+        source_root=Path(args.source_root),
+        live_index_path=Path(args.live_index),
+        artifact_root=Path(args.artifact_root),
+        proposed_generation=args.proposed_generation,
+    )
+    write_canonical_json(Path(args.out), summary, refuse_existing=True)
 
 
 def resolve_publication_approvers(args: argparse.Namespace) -> None:

--- a/verification/areas/coverage_matrix/profile_assignment_matrix.json
+++ b/verification/areas/coverage_matrix/profile_assignment_matrix.json
@@ -100,19 +100,22 @@
           "distribution_release:representative",
           "distribution_release:incident-governance",
           "distribution_release:epoch-bootstrap",
-          "distribution_release:protected-drill"
+          "distribution_release:protected-drill",
+          "distribution_release:stable-prepare"
         ],
         "nightly": [
           "distribution_release:full",
           "distribution_release:incident-governance",
           "distribution_release:epoch-bootstrap",
-          "distribution_release:protected-drill"
+          "distribution_release:protected-drill",
+          "distribution_release:stable-prepare"
         ],
         "release": [
           "distribution_release:full",
           "distribution_release:incident-governance",
           "distribution_release:epoch-bootstrap",
-          "distribution_release:protected-drill"
+          "distribution_release:protected-drill",
+          "distribution_release:stable-prepare"
         ]
       }
     },

--- a/verification/areas/distribution_release/cases/preview_release_workflow_yaml_parses.sh
+++ b/verification/areas/distribution_release/cases/preview_release_workflow_yaml_parses.sh
@@ -96,7 +96,7 @@ prepare_required = (
     "permissions:\n  actions: read\n  contents: read",
     "prepare governed publication",
     'summary_artifact_name="publication-prepare-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
-    "name: ${{ steps.summary.outputs.summary_artifact_name }}",
+    "name: ${{ steps.outputs.outputs.summary_artifact_name }}",
     "one-time bootstrap source is not the exact opaque v1 asset",
     "--kind schema-bootstrap-evidence",
     "retention-days: 30",

--- a/verification/areas/distribution_release/cases/schema_epoch_bootstrap_workflow_contract.sh
+++ b/verification/areas/distribution_release/cases/schema_epoch_bootstrap_workflow_contract.sh
@@ -92,7 +92,7 @@ for fragment in (
     "contents: read",
     "one-time bootstrap source is not the exact opaque v1 asset",
     'summary_artifact_name="publication-prepare-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
-    "name: ${{ steps.summary.outputs.summary_artifact_name }}",
+    "name: ${{ steps.outputs.outputs.summary_artifact_name }}",
     "retention-days: 30",
     "overwrite: false",
 ):

--- a/verification/areas/distribution_release/cases/stable_publication_prepare_workflow_contract.sh
+++ b/verification/areas/distribution_release/cases/stable_publication_prepare_workflow_contract.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+workflow="${REPO_ROOT}/.github/workflows/release-publication-prepare.yml"
+
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "${workflow}" >/dev/null
+
+python3 - "${workflow}" <<'PY'
+import pathlib
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+
+for fragment in (
+    "permissions:\n  actions: read\n  contents: read",
+    "evidence_commit:",
+    "candidate_path:",
+    "expected_plan_sha256:",
+    "publication_mode:",
+    "proposed_generation:",
+    "ref: ${{ inputs.evidence_commit }}",
+    "path: stable-evidence",
+    "path: stable-source",
+    "submodules: recursive",
+    "persist-credentials: false",
+    "/actions/runs/${run_id}/attempts/${run_attempt}",
+    "/actions/artifacts/${artifact_id}",
+    "group_by(.id)",
+    "extract_github_artifact.py",
+    "--expected-uncompressed-bytes",
+    "qualification-artifact-index.json",
+    'candidate_version="${CANDIDATE_PATH##*/}"',
+    "workflow_artifact_name",
+    "prepare-stable-publication",
+    '--operation "${GOVERNANCE_MODE}"',
+    '--evidence-commit "${EVIDENCE_COMMIT}"',
+    '--expected-plan-sha256 "${EXPECTED_PLAN_SHA256}"',
+    '--proposed-generation "${PROPOSED_GENERATION}"',
+    "prepare/summary.json",
+    "release_report_sha256:",
+    "qualification_sha256:",
+    "live_index_sha256:",
+    "proposed_index_sha256:",
+    "retention-days: 30",
+    "overwrite: false",
+):
+    assert fragment in workflow, fragment
+
+for forbidden in (
+    "contents: write",
+    "packages: write",
+    "id-token: write",
+    "${{ secrets.",
+    "vsce publish",
+    "gh release upload",
+    "gh run download",
+    "unzip ",
+):
+    assert forbidden not in workflow, forbidden
+
+stable_step = workflow.split(
+    "- name: Prepare exact stable publication inputs",
+    1,
+)[1].split("- name: Bind prepare outputs", 1)[0]
+assert "ga-activation" in stable_step
+assert "normal" in stable_step
+assert "bootstrap-alpha" not in stable_step
+assert "stable-source/scripts/distribution/release_governance.py" not in stable_step
+PY

--- a/verification/areas/distribution_release/cases/stable_publication_prepare_workflow_contract.sh
+++ b/verification/areas/distribution_release/cases/stable_publication_prepare_workflow_contract.sh
@@ -28,6 +28,8 @@ for fragment in (
     "persist-credentials: false",
     "/actions/runs/${run_id}/attempts/${run_attempt}",
     "/actions/artifacts/${artifact_id}",
+    "artifact_expires_at",
+    "'.expires_at'",
     "group_by(.id)",
     "extract_github_artifact.py",
     "--expected-uncompressed-bytes",

--- a/verification/areas/distribution_release/governance/__init__.py
+++ b/verification/areas/distribution_release/governance/__init__.py
@@ -22,6 +22,10 @@ from .stable_planner import (
     materialize_stable_mutation,
     validate_stable_mutation_evidence,
 )
+from .stable_prepare import (
+    materialize_stable_prepare,
+    validate_stable_prepare_summary,
+)
 from .surface_contracts import (
     validate_install_receipt,
     validate_self_update_plan,
@@ -34,6 +38,7 @@ __all__ = [
     "generate_site_release_facts",
     "materialize_stable_plan",
     "materialize_stable_mutation",
+    "materialize_stable_prepare",
     "propose_stable_release",
     "validate_bootstrap_evidence",
     "validate_drill_evidence",
@@ -51,4 +56,5 @@ __all__ = [
     "validate_site_publication_facts",
     "validate_site_release_facts",
     "validate_stable_mutation_evidence",
+    "validate_stable_prepare_summary",
 ]

--- a/verification/areas/distribution_release/governance/artifact_index.py
+++ b/verification/areas/distribution_release/governance/artifact_index.py
@@ -125,6 +125,7 @@ def validate_qualification_artifact_index(
     report_ids: set[str] = set()
     workflow_id_to_name: dict[int, str] = {}
     workflow_name_to_id: dict[str, int] = {}
+    workflow_id_to_expiry: dict[int, str] = {}
     for position, value in enumerate(artifacts):
         location = f"$.artifacts[{position}]"
         artifact = require_object(value, location)
@@ -194,6 +195,14 @@ def validate_qualification_artifact_index(
             fail(
                 f"{location}.expires_at",
                 "must not expire before the workflow qualification boundary",
+            )
+        if (
+            workflow_id_to_expiry.setdefault(workflow_artifact_id, artifact_expiry)
+            != artifact_expiry
+        ):
+            fail(
+                f"{location}.expires_at",
+                "must equal the expiry of its governed workflow upload",
             )
         expected_prefix = (
             f"sifr-stable-candidate-{index['candidate_version']}-"

--- a/verification/areas/distribution_release/governance/artifact_index.py
+++ b/verification/areas/distribution_release/governance/artifact_index.py
@@ -123,6 +123,8 @@ def validate_qualification_artifact_index(
     target_coverage = {kind: set() for kind in TARGET_KINDS}
     singleton_counts = {kind: 0 for kind in SINGLETON_KINDS}
     report_ids: set[str] = set()
+    workflow_id_to_name: dict[int, str] = {}
+    workflow_name_to_id: dict[str, int] = {}
     for position, value in enumerate(artifacts):
         location = f"$.artifacts[{position}]"
         artifact = require_object(value, location)
@@ -153,7 +155,7 @@ def validate_qualification_artifact_index(
         name = require_nonempty_string(artifact["name"], f"{location}.name")
         require_sha256(artifact["sha256"], f"{location}.sha256")
         require_positive_int(artifact["size_bytes"], f"{location}.size_bytes")
-        require_positive_int(
+        workflow_artifact_id = require_positive_int(
             artifact["workflow_artifact_id"],
             f"{location}.workflow_artifact_id",
         )
@@ -165,6 +167,16 @@ def validate_qualification_artifact_index(
             fail(
                 f"{location}.workflow_artifact_name",
                 "must be a single governed upload name",
+            )
+        if (
+            workflow_id_to_name.setdefault(workflow_artifact_id, workflow_name)
+            != workflow_name
+            or workflow_name_to_id.setdefault(workflow_name, workflow_artifact_id)
+            != workflow_artifact_id
+        ):
+            fail(
+                location,
+                "workflow artifact id/name mapping must be one-to-one",
             )
         artifact_expiry = require_nonempty_string(
             artifact["expires_at"],
@@ -239,6 +251,8 @@ def validate_qualification_artifact_index(
             "$.artifacts",
             "must contain the exact governed qualification artifact identifiers",
         )
+    if len(workflow_id_to_name) != 6:
+        fail("$.artifacts", "must bind exactly six workflow artifact uploads")
     for kind, observed in target_coverage.items():
         if observed != set(TARGETS):
             missing = sorted(set(TARGETS).difference(observed))

--- a/verification/areas/distribution_release/governance/evidence_custody.py
+++ b/verification/areas/distribution_release/governance/evidence_custody.py
@@ -9,8 +9,14 @@ import sys
 from pathlib import Path
 
 from .common import GovernanceError, load_json_strict, sha256_bytes
+from .artifact_index import validate_qualification_artifact_index
 from .incident_evidence import validate_incident_evidence_commit
 from .incident import validate_incident_request, validate_incident_signoff
+from .planner import (
+    stable_claim_ids,
+    validate_documentation_report,
+    validate_rust_candidate_result,
+)
 from .release_plan import validate_release_plan, validate_release_signoff
 from .release_report import validate_release_profile_report
 
@@ -18,8 +24,9 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 RELEASES_ROOT = REPO_ROOT / "plans" / "releases"
 CANDIDATE_PATH_RE = re.compile(
     r"^plans/releases/candidates/([0-9]+\.[0-9]+\.[0-9]+)/"
-    r"(stable-release-plan|release-profile-report|qualification-artifact-index|"
-    r"stable-release-signoff)\.json$"
+    r"((stable-release-plan|release-profile-report|qualification-artifact-index|"
+    r"stable-support-claims|rust-validation-report|documentation-report|"
+    r"stable-release-signoff)\.json|release-notes\.md)$"
 )
 INCIDENT_PATH_RE = re.compile(
     r"^plans/releases/incidents/([a-z0-9][a-z0-9-]{2,63})/"
@@ -164,24 +171,46 @@ def validate_existing_evidence() -> None:
 
 def validate_candidate_directory(directory: Path) -> None:
     expected_version = directory.name
-    files = {path.name for path in directory.iterdir() if path.is_file()}
+    if directory.is_symlink() or not directory.is_dir():
+        raise GovernanceError(f"{directory}: candidate evidence must be a directory")
+    entries = list(directory.iterdir())
+    unsafe = sorted(
+        path.name for path in entries if path.is_symlink() or not path.is_file()
+    )
+    if unsafe:
+        raise GovernanceError(
+            f"{directory}: unsupported candidate evidence entries: {', '.join(unsafe)}"
+        )
+    files = {path.name for path in entries}
     allowed = {
         "stable-release-plan.json",
         "release-profile-report.json",
         "qualification-artifact-index.json",
+        "stable-support-claims.json",
+        "rust-validation-report.json",
+        "documentation-report.json",
+        "release-notes.md",
         "stable-release-signoff.json",
     }
     unknown = sorted(files.difference(allowed))
     if unknown:
-        raise GovernanceError(f"{directory}: unsupported evidence files: {', '.join(unknown)}")
+        raise GovernanceError(
+            f"{directory}: unsupported evidence files: {', '.join(unknown)}"
+        )
     required = {
         "stable-release-plan.json",
         "release-profile-report.json",
         "qualification-artifact-index.json",
+        "stable-support-claims.json",
+        "rust-validation-report.json",
+        "documentation-report.json",
+        "release-notes.md",
     }
     missing = sorted(required.difference(files))
     if missing:
-        raise GovernanceError(f"{directory}: missing candidate evidence: {', '.join(missing)}")
+        raise GovernanceError(
+            f"{directory}: missing candidate evidence: {', '.join(missing)}"
+        )
 
     plan_path = directory / "stable-release-plan.json"
     report_path = directory / "release-profile-report.json"
@@ -191,12 +220,13 @@ def validate_candidate_directory(directory: Path) -> None:
         load_json_strict(report_path, require_canonical=True),
         canonical_bytes=report_path.read_bytes(),
     )
-    from .artifact_index import validate_qualification_artifact_index
-
     qualification = validate_qualification_artifact_index(
         load_json_strict(qualification_path, require_canonical=True)
     )
-    if plan["version"] != expected_version or report["source"]["commit"] != plan["source_commit"]:
+    if (
+        plan["version"] != expected_version
+        or report["source"]["commit"] != plan["source_commit"]
+    ):
         raise GovernanceError(f"{directory}: candidate identity/source mismatch")
     if qualification["candidate_version"] != expected_version:
         raise GovernanceError(f"{directory}: qualification candidate version mismatch")
@@ -204,18 +234,57 @@ def validate_candidate_directory(directory: Path) -> None:
         raise GovernanceError(f"{directory}: qualification source mismatch")
     if qualification["submodules"] != plan["submodules"]:
         raise GovernanceError(f"{directory}: qualification submodule mismatch")
-    if plan["release_profile_report"]["sha256"] != sha256_bytes(report_path.read_bytes()):
+    if plan["release_profile_report"]["sha256"] != sha256_bytes(
+        report_path.read_bytes()
+    ):
         raise GovernanceError(f"{directory}: release report digest mismatch")
     if plan["qualification_artifact_index"]["sha256"] != sha256_bytes(
         qualification_path.read_bytes()
     ):
-        raise GovernanceError(f"{directory}: qualification artifact index digest mismatch")
+        raise GovernanceError(
+            f"{directory}: qualification artifact index digest mismatch"
+        )
+    claims_path = directory / "stable-support-claims.json"
+    if plan["rust_interop"]["stable_support_claims_sha256"] != sha256_bytes(
+        claims_path.read_bytes()
+    ):
+        raise GovernanceError(f"{directory}: stable support claims digest mismatch")
+    claims = load_json_strict(claims_path, require_canonical=True)
+    if plan["rust_interop"]["advertised_claim_ids"] != stable_claim_ids(claims):
+        raise GovernanceError(f"{directory}: stable support claim ids drifted")
+    rust_report_path = directory / "rust-validation-report.json"
+    if plan["rust_interop"]["validation_report_sha256"] != sha256_bytes(
+        rust_report_path.read_bytes()
+    ):
+        raise GovernanceError(f"{directory}: Rust validation report digest mismatch")
+    validate_rust_candidate_result(
+        load_json_strict(rust_report_path, require_canonical=True),
+        expected_digest=plan["rust_interop"]["validation_report_sha256"],
+        release_report=report,
+    )
+    documentation_path = directory / "documentation-report.json"
+    if plan["documentation_report"]["sha256"] != sha256_bytes(
+        documentation_path.read_bytes()
+    ):
+        raise GovernanceError(f"{directory}: documentation report digest mismatch")
+    documentation = validate_documentation_report(
+        load_json_strict(documentation_path, require_canonical=True),
+        source_commit=plan["source_commit"],
+    )
+    if documentation["report_id"] != plan["documentation_report"]["id"]:
+        raise GovernanceError(f"{directory}: documentation report id mismatch")
+    if plan["release_notes_sha256"] != sha256_bytes(
+        (directory / "release-notes.md").read_bytes()
+    ):
+        raise GovernanceError(f"{directory}: release notes digest mismatch")
     signoff_path = directory / "stable-release-signoff.json"
     if signoff_path.is_file():
-        signoff = validate_release_signoff(load_json_strict(signoff_path, require_canonical=True))
-        if signoff["version"] != expected_version or signoff["plan_sha256"] != sha256_bytes(
-            plan_path.read_bytes()
-        ):
+        signoff = validate_release_signoff(
+            load_json_strict(signoff_path, require_canonical=True)
+        )
+        if signoff["version"] != expected_version or signoff[
+            "plan_sha256"
+        ] != sha256_bytes(plan_path.read_bytes()):
             raise GovernanceError(f"{directory}: stable sign-off provenance mismatch")
 
 

--- a/verification/areas/distribution_release/governance/evidence_custody_selftest.py
+++ b/verification/areas/distribution_release/governance/evidence_custody_selftest.py
@@ -1,0 +1,133 @@
+"""Focused mutation tests for candidate evidence-directory custody."""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .common import GovernanceError, canonical_json_bytes, sha256_bytes
+from .evidence_custody import (
+    require_comparison_base,
+    validate_candidate_directory,
+    validate_changed_path_set,
+)
+from .qualification_fixture import stable_claims
+from .qualification_rust_fixture import rust_candidate_result
+from .schema_contracts import qualification_index
+
+
+def run_evidence_custody_mutations(
+    *,
+    valid_plan: Callable[[], dict[str, Any]],
+    valid_report: Callable[[], dict[str, Any]],
+    source_commit: str,
+    retained_digest: str,
+) -> None:
+    _test_changed_paths()
+    with tempfile.TemporaryDirectory() as directory:
+        candidate_dir = Path(directory) / "0.1.0"
+        candidate_dir.mkdir()
+        report = valid_report()
+        qualification_bytes = canonical_json_bytes(qualification_index())
+        claims_bytes = canonical_json_bytes(stable_claims(variant="baseline"))
+        rust_bytes = canonical_json_bytes(rust_candidate_result())
+        rust_sha256 = sha256_bytes(rust_bytes)
+        documentation_bytes = canonical_json_bytes(
+            {
+                "schema_version": 2,
+                "kind": "stable-documentation-qualification",
+                "report_id": "docs-a",
+                "source_commit": source_commit,
+                "suites": [
+                    {"name": "structure", "status": "pass", "total_variants": 1},
+                    {"name": "ga-release", "status": "pass", "total_variants": 1},
+                ],
+                "result_sha256": retained_digest,
+                "status": "pass",
+            }
+        )
+        release_notes_bytes = b"# Stable release notes\n"
+        report["result_artifacts"] = [
+            {
+                "path": "target/verification/example.json",
+                "sha256": retained_digest,
+            },
+            {
+                "path": "target/verification/rust-interop-release-results.json",
+                "sha256": rust_sha256,
+            },
+        ]
+        for step in report["steps"]:
+            for suite in step["suite_results"]:
+                if suite["area"] == "rust_interop":
+                    suite["result_artifact_sha256"] = rust_sha256
+        report_bytes = canonical_json_bytes(report)
+        plan = valid_plan()
+        plan["release_profile_report"]["sha256"] = sha256_bytes(report_bytes)
+        plan["qualification_artifact_index"]["sha256"] = sha256_bytes(
+            qualification_bytes
+        )
+        plan["rust_interop"]["stable_support_claims_sha256"] = sha256_bytes(
+            claims_bytes
+        )
+        plan["rust_interop"]["advertised_claim_ids"] = [
+            "direct_crate_fixture",
+            "bridge_fixture",
+        ]
+        plan["rust_interop"]["validation_report_sha256"] = rust_sha256
+        plan["documentation_report"]["sha256"] = sha256_bytes(documentation_bytes)
+        plan["release_notes_sha256"] = sha256_bytes(release_notes_bytes)
+        files = {
+            "stable-release-plan.json": canonical_json_bytes(plan),
+            "release-profile-report.json": report_bytes,
+            "qualification-artifact-index.json": qualification_bytes,
+            "stable-support-claims.json": claims_bytes,
+            "rust-validation-report.json": rust_bytes,
+            "documentation-report.json": documentation_bytes,
+            "release-notes.md": release_notes_bytes,
+        }
+        for name, contents in files.items():
+            (candidate_dir / name).write_bytes(contents)
+        validate_candidate_directory(candidate_dir)
+        unexpected = candidate_dir / "nested"
+        unexpected.mkdir()
+        try:
+            validate_candidate_directory(candidate_dir)
+        except GovernanceError:
+            pass
+        else:
+            raise AssertionError("nested candidate evidence passed custody")
+        unexpected.rmdir()
+        (candidate_dir / "release-profile-report.json").write_bytes(
+            canonical_json_bytes({**report, "report_id": "tampered"})
+        )
+        try:
+            validate_candidate_directory(candidate_dir)
+        except GovernanceError:
+            pass
+        else:
+            raise AssertionError("candidate report digest mismatch passed custody")
+
+
+def _test_changed_paths() -> None:
+    try:
+        require_comparison_base("", base_ref="missing")
+    except GovernanceError:
+        pass
+    else:
+        raise AssertionError("missing evidence comparison base passed")
+    candidate = "plans/releases/candidates/0.1.0/stable-release-plan.json"
+    validate_changed_path_set({candidate})
+    validate_changed_path_set({candidate, "plans/releases/README.md"})
+    for paths in (
+        {candidate, "crates/sifr/src/main.rs"},
+        {candidate, "plans/releases/candidates/0.1.1/stable-release-plan.json"},
+        {"plans/releases/candidates/0.1.0/unexpected.json"},
+    ):
+        try:
+            validate_changed_path_set(paths)
+        except GovernanceError:
+            continue
+        raise AssertionError(f"invalid evidence custody paths passed: {paths}")

--- a/verification/areas/distribution_release/governance/qualification_fixture.py
+++ b/verification/areas/distribution_release/governance/qualification_fixture.py
@@ -122,6 +122,7 @@ def write_source_contracts(source_root: Path) -> None:
                     "incident-governance",
                     "epoch-bootstrap",
                     "protected-drill",
+                    "stable-prepare",
                 ],
             },
         ],

--- a/verification/areas/distribution_release/governance/release_report.py
+++ b/verification/areas/distribution_release/governance/release_report.py
@@ -45,6 +45,7 @@ REQUIRED_SUITES = {
         "incident-governance",
         "epoch-bootstrap",
         "protected-drill",
+        "stable-prepare",
     },
 }
 

--- a/verification/areas/distribution_release/governance/schema_contracts.py
+++ b/verification/areas/distribution_release/governance/schema_contracts.py
@@ -133,6 +133,19 @@ def validate_schema_contracts() -> None:
             raise ValueError(
                 "stable mutation evidence schema accepted an invalid binding"
             )
+    prepare_schema = SCHEMA_ROOT / "stable_publication_prepare.schema.json"
+    unknown_artifact = copy.deepcopy(
+        fixtures["stable_publication_prepare.schema.json"]
+    )
+    unknown_artifact["artifacts"]["unknown"] = unknown_artifact["artifacts"].pop(
+        "installer"
+    )
+    try:
+        validate_instance(unknown_artifact, prepare_schema)
+    except JsonSchemaError:
+        pass
+    else:
+        raise ValueError("stable prepare schema accepted an unknown artifact identity")
 
 
 def schema_fixtures() -> dict[str, Any]:
@@ -150,6 +163,7 @@ def schema_fixtures() -> dict[str, Any]:
         "stable_incident_request.schema.json": incident_request(),
         "stable_incident_signoff.schema.json": incident_signoff(),
         "stable_index_mutation_evidence.schema.json": stable_index_mutation_evidence(),
+        "stable_publication_prepare.schema.json": stable_publication_prepare(),
         "stable_release_plan.schema.json": release_plan(),
         "stable_release_signoff.schema.json": release_signoff(),
         "stable_site_release_facts.schema.json": site_facts(),
@@ -195,6 +209,73 @@ def stable_index_mutation_evidence() -> dict[str, Any]:
         "previous_index": {"generation": 7, "sha256": SHA_B},
         "proposed_index": proposed,
         "proposed_index_sha256": sha256_bytes(canonical_json_bytes(proposed)),
+    }
+
+
+def stable_publication_prepare() -> dict[str, Any]:
+    mutation = stable_index_mutation_evidence()
+    artifact_ids = sorted(
+        {
+            "installer",
+            "checksums",
+            "vsix",
+            "editor-qualification-report",
+            *{
+                f"{kind}-{target}"
+                for target in TARGETS
+                for kind in (
+                    "binary-archive",
+                    "checksum",
+                    "sysroot",
+                    "qualification-report",
+                )
+            },
+        }
+    )
+    return {
+        "schema_version": 2,
+        "operation": "ga-activation",
+        "mode": "initial",
+        "version": "0.1.0",
+        "evidence": {
+            "commit": COMMIT,
+            "candidate_path": "plans/releases/candidates/0.1.0",
+            "plan_sha256": SHA_A,
+        },
+        "source": {
+            "commit": COMMIT,
+            "submodules": {"editor_integrations": "f" * 40},
+        },
+        "release_report": {"id": "release-report-a", "sha256": SHA_B},
+        "qualification": {
+            "id": "qualification-42-1",
+            "sha256": SHA_C,
+            "run_id": 42,
+            "run_attempt": 1,
+            "expires_at": "2026-08-20T00:00:00Z",
+        },
+        "live_index": {"generation": 7, "sha256": SHA_B},
+        "mutation": mutation,
+        "artifacts": {
+            artifact_id: {
+                "name": f"{artifact_id}.bin",
+                "sha256": SHA_A,
+                "size_bytes": 1,
+                "workflow_artifact_id": index,
+                "workflow_artifact_name": f"candidate-artifact-{index}",
+            }
+            for index, artifact_id in enumerate(artifact_ids, start=1)
+        },
+        "marketplace": {
+            "publisher": "sifr",
+            "extension": "sifr-vscode",
+            "version": "0.2.0",
+            "vsix_sha256": SHA_D,
+        },
+        "site": {
+            "repository": "sifr-lang/sifr-website",
+            "base_commit": "1" * 40,
+        },
     }
 
 
@@ -490,6 +571,7 @@ def release_report() -> dict[str, Any]:
             ("distribution_release", "incident-governance"),
             ("distribution_release", "epoch-bootstrap"),
             ("distribution_release", "protected-drill"),
+            ("distribution_release", "stable-prepare"),
         ],
     }
     return {
@@ -531,6 +613,7 @@ def release_report() -> dict[str, Any]:
                             "incident-governance",
                             "epoch-bootstrap",
                             "protected-drill",
+                            "stable-prepare",
                         ],
                     ),
                 )

--- a/verification/areas/distribution_release/governance/schema_contracts.py
+++ b/verification/areas/distribution_release/governance/schema_contracts.py
@@ -214,24 +214,10 @@ def stable_index_mutation_evidence() -> dict[str, Any]:
 
 def stable_publication_prepare() -> dict[str, Any]:
     mutation = stable_index_mutation_evidence()
-    artifact_ids = sorted(
-        {
-            "installer",
-            "checksums",
-            "vsix",
-            "editor-qualification-report",
-            *{
-                f"{kind}-{target}"
-                for target in TARGETS
-                for kind in (
-                    "binary-archive",
-                    "checksum",
-                    "sysroot",
-                    "qualification-report",
-                )
-            },
-        }
-    )
+    qualification = qualification_index()
+    transported = {
+        artifact["id"]: artifact for artifact in qualification["artifacts"]
+    }
     return {
         "schema_version": 2,
         "operation": "ga-activation",
@@ -258,19 +244,19 @@ def stable_publication_prepare() -> dict[str, Any]:
         "mutation": mutation,
         "artifacts": {
             artifact_id: {
-                "name": f"{artifact_id}.bin",
-                "sha256": SHA_A,
-                "size_bytes": 1,
-                "workflow_artifact_id": index,
-                "workflow_artifact_name": f"candidate-artifact-{index}",
+                "name": artifact["name"],
+                "sha256": artifact["sha256"],
+                "size_bytes": artifact["size_bytes"],
+                "workflow_artifact_id": artifact["workflow_artifact_id"],
+                "workflow_artifact_name": artifact["workflow_artifact_name"],
             }
-            for index, artifact_id in enumerate(artifact_ids, start=1)
+            for artifact_id, artifact in sorted(transported.items())
         },
         "marketplace": {
             "publisher": "sifr",
             "extension": "sifr-vscode",
             "version": "0.2.0",
-            "vsix_sha256": SHA_D,
+            "vsix_sha256": transported["vsix"]["sha256"],
         },
         "site": {
             "repository": "sifr-lang/sifr-website",

--- a/verification/areas/distribution_release/governance/selftest.py
+++ b/verification/areas/distribution_release/governance/selftest.py
@@ -670,6 +670,15 @@ def test_artifact_index_mutations() -> None:
         validate_qualification_artifact_index,
         mutate(
             payload,
+            lambda item: item["artifacts"][1].update(
+                {"expires_at": "2026-08-21T00:00:00Z"}
+            ),
+        ),
+    )
+    expect_rejected(
+        validate_qualification_artifact_index,
+        mutate(
+            payload,
             lambda item: item["artifacts"].__setitem__(
                 slice(None),
                 [

--- a/verification/areas/distribution_release/governance/selftest.py
+++ b/verification/areas/distribution_release/governance/selftest.py
@@ -13,15 +13,9 @@ from .artifact_index import validate_qualification_artifact_index
 from .common import (
     GovernanceError,
     TARGETS,
-    canonical_json_bytes,
     load_json_strict,
-    sha256_bytes,
 )
-from .evidence_custody import (
-    require_comparison_base,
-    validate_candidate_directory,
-    validate_changed_path_set,
-)
+from .evidence_custody_selftest import run_evidence_custody_mutations
 from .incident import validate_incident_request, validate_incident_signoff
 from .release_index import (
     propose_preview_release,
@@ -243,6 +237,7 @@ def valid_report() -> dict[str, Any]:
             ("distribution_release", "incident-governance"),
             ("distribution_release", "epoch-bootstrap"),
             ("distribution_release", "protected-drill"),
+            ("distribution_release", "stable-prepare"),
         ],
     }
     steps = []
@@ -301,6 +296,7 @@ def valid_report() -> dict[str, Any]:
                             "incident-governance",
                             "epoch-bootstrap",
                             "protected-drill",
+                            "stable-prepare",
                         },
                     ),
                 )
@@ -667,6 +663,13 @@ def test_artifact_index_mutations() -> None:
         validate_qualification_artifact_index,
         mutate(
             payload,
+            lambda item: item["artifacts"][4].update({"workflow_artifact_id": 1}),
+        ),
+    )
+    expect_rejected(
+        validate_qualification_artifact_index,
+        mutate(
+            payload,
             lambda item: item["artifacts"].__setitem__(
                 slice(None),
                 [
@@ -799,48 +802,12 @@ def test_release_report_mutations() -> None:
 
 
 def test_evidence_custody_mutations() -> None:
-    expect_rejected(
-        lambda value: require_comparison_base(value, base_ref="missing"),
-        "",
+    run_evidence_custody_mutations(
+        valid_plan=valid_plan,
+        valid_report=valid_report,
+        source_commit=COMMIT,
+        retained_digest=SHA_A,
     )
-    candidate = "plans/releases/candidates/0.1.0/stable-release-plan.json"
-    validate_changed_path_set({candidate})
-    validate_changed_path_set({candidate, "plans/releases/README.md"})
-    path_mutations = [
-        {candidate, "crates/sifr/src/main.rs"},
-        {candidate, "plans/releases/candidates/0.1.1/stable-release-plan.json"},
-        {"plans/releases/candidates/0.1.0/unexpected.json"},
-    ]
-    for paths in path_mutations:
-        try:
-            validate_changed_path_set(paths)
-        except GovernanceError:
-            continue
-        raise AssertionError(f"invalid evidence custody paths passed: {paths}")
-
-    with tempfile.TemporaryDirectory() as directory:
-        candidate_dir = Path(directory) / "0.1.0"
-        candidate_dir.mkdir()
-        report = valid_report()
-        report_bytes = canonical_json_bytes(report)
-        qualification = qualification_index()
-        qualification_bytes = canonical_json_bytes(qualification)
-        plan = valid_plan()
-        plan["release_profile_report"]["sha256"] = sha256_bytes(report_bytes)
-        plan["qualification_artifact_index"]["sha256"] = sha256_bytes(qualification_bytes)
-        (candidate_dir / "stable-release-plan.json").write_bytes(canonical_json_bytes(plan))
-        (candidate_dir / "release-profile-report.json").write_bytes(report_bytes)
-        (candidate_dir / "qualification-artifact-index.json").write_bytes(qualification_bytes)
-        validate_candidate_directory(candidate_dir)
-        (candidate_dir / "release-profile-report.json").write_bytes(
-            canonical_json_bytes({**report, "report_id": "tampered"})
-        )
-        try:
-            validate_candidate_directory(candidate_dir)
-        except GovernanceError:
-            pass
-        else:
-            raise AssertionError("candidate report digest mismatch passed custody")
 
 
 def test_strict_loader_rejects_duplicate_keys() -> None:

--- a/verification/areas/distribution_release/governance/stable_prepare.py
+++ b/verification/areas/distribution_release/governance/stable_prepare.py
@@ -1,0 +1,621 @@
+"""Read-only protected preparation for GA and normal stable publication."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .artifact_index import (
+    EXPECTED_ARTIFACT_IDS,
+    validate_qualification_artifact_index,
+)
+from .common import (
+    GovernanceError,
+    fail,
+    load_json_strict,
+    require_commit,
+    require_enum,
+    require_exact_keys,
+    require_nonempty_string,
+    require_object,
+    require_positive_int,
+    require_schema_v2,
+    require_sha256,
+    sha256_file,
+    version_channel,
+)
+from .planner import (
+    bind_aggregate_artifacts,
+    bind_target_reports,
+    stable_claim_ids,
+    validate_documentation_report,
+    validate_rust_candidate_result,
+    verify_transported_artifacts,
+)
+from .release_plan import validate_release_plan, validate_release_signoff
+from .release_report import (
+    canonical_profile_digest,
+    validate_release_profile_report,
+)
+from .stable_planner import (
+    materialize_stable_mutation,
+    validate_stable_mutation_evidence,
+)
+
+CANDIDATE_PATH_RE = re.compile(r"^plans/releases/candidates/([0-9]+\.[0-9]+\.[0-9]+)$")
+REQUIRED_CANDIDATE_FILES = {
+    "stable-release-plan.json",
+    "release-profile-report.json",
+    "qualification-artifact-index.json",
+    "stable-support-claims.json",
+    "rust-validation-report.json",
+    "documentation-report.json",
+    "release-notes.md",
+}
+OPTIONAL_CANDIDATE_FILES = {"stable-release-signoff.json"}
+MINIMUM_PUBLICATION_WINDOW = timedelta(days=7)
+
+
+def materialize_stable_prepare(
+    *,
+    operation: str,
+    mode: str,
+    evidence_root: Path,
+    evidence_commit: str,
+    candidate_path: str,
+    expected_plan_sha256: str,
+    source_root: Path,
+    live_index_path: Path,
+    artifact_root: Path,
+    proposed_generation: int,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Revalidate exact reviewer-visible inputs and return a read-only summary."""
+    operation = require_enum(
+        operation,
+        {"ga-activation", "normal"},
+        "operation",
+    )
+    mode = require_enum(mode, {"initial", "resume"}, "mode")
+    evidence_commit = require_commit(evidence_commit, "evidence_commit")
+    require_sha256(expected_plan_sha256, "expected_plan_sha256")
+    require_positive_int(proposed_generation, "proposed_generation")
+    match = CANDIDATE_PATH_RE.fullmatch(candidate_path)
+    if match is None:
+        fail("candidate_path", "must be a normalized candidate evidence directory")
+
+    evidence_root = evidence_root.resolve()
+    source_root = source_root.resolve()
+    _require_checkout(evidence_root, evidence_commit, "evidence")
+    candidate_root = evidence_root / candidate_path
+    if (
+        candidate_root.is_symlink()
+        or not candidate_root.is_dir()
+        or not candidate_root.resolve().is_relative_to(evidence_root)
+    ):
+        fail("candidate_path", "must remain inside the evidence checkout")
+    _require_candidate_files(candidate_root)
+
+    plan_path = candidate_root / "stable-release-plan.json"
+    report_path = candidate_root / "release-profile-report.json"
+    qualification_path = candidate_root / "qualification-artifact-index.json"
+    claims_path = candidate_root / "stable-support-claims.json"
+    rust_report_path = candidate_root / "rust-validation-report.json"
+    documentation_path = candidate_root / "documentation-report.json"
+    release_notes_path = candidate_root / "release-notes.md"
+    signoff_path = candidate_root / "stable-release-signoff.json"
+    if sha256_file(plan_path) != expected_plan_sha256:
+        fail("expected_plan_sha256", "does not match candidate evidence")
+
+    plan = validate_release_plan(
+        load_json_strict(plan_path, require_canonical=True),
+        active_index=load_json_strict(live_index_path, require_canonical=True),
+    )
+    if plan["transition"] != operation or plan["version"] != match.group(1):
+        fail("candidate_path", "does not match the requested plan operation/version")
+    if signoff_path.is_file():
+        signoff = validate_release_signoff(
+            load_json_strict(signoff_path, require_canonical=True)
+        )
+        if (
+            signoff["version"] != plan["version"]
+            or signoff["plan_sha256"] != expected_plan_sha256
+        ):
+            fail("stable-release-signoff.json", "does not bind the candidate plan")
+    _require_checkout(source_root, plan["source_commit"], "source")
+    _validate_source_contracts(plan, source_root)
+
+    report_bytes = report_path.read_bytes()
+    profile_sha256 = canonical_profile_digest(
+        source_root / "verification/profiles/release.json"
+    )
+    report = validate_release_profile_report(
+        load_json_strict(report_path, require_canonical=True),
+        canonical_bytes=report_bytes,
+        source_root=source_root,
+        expected_profile_sha256=profile_sha256,
+    )
+    _require_reference(
+        plan["release_profile_report"],
+        identifier=report["report_id"],
+        path=report_path,
+        location="$.release_profile_report",
+    )
+    if (
+        report["source"]["commit"] != plan["source_commit"]
+        or report["source"]["submodules"] != plan["submodules"]
+    ):
+        fail("$.release_profile_report", "does not match the candidate source")
+
+    current_time = now or datetime.now(timezone.utc)
+    qualification = validate_qualification_artifact_index(
+        load_json_strict(qualification_path, require_canonical=True),
+        require_unexpired=True,
+        now=current_time,
+    )
+    qualification_id = (
+        f"qualification-{qualification['workflow']['run_id']}-"
+        f"{qualification['workflow']['run_attempt']}"
+    )
+    _require_reference(
+        plan["qualification_artifact_index"],
+        identifier=qualification_id,
+        path=qualification_path,
+        location="$.qualification_artifact_index",
+    )
+    if (
+        qualification["candidate_version"] != plan["version"]
+        or qualification["source_commit"] != plan["source_commit"]
+        or qualification["submodules"] != plan["submodules"]
+    ):
+        fail("$.qualification_artifact_index", "candidate provenance drifted")
+    expires_at = _require_publication_window(qualification, now=current_time)
+
+    artifact_paths = verify_transported_artifacts(qualification, artifact_root)
+    bind_target_reports(plan, qualification, artifact_paths)
+    bind_aggregate_artifacts(
+        plan,
+        qualification,
+        artifact_paths,
+        source_root=source_root,
+    )
+    marketplace = _validate_supporting_evidence(
+        plan=plan,
+        report=report,
+        claims_path=claims_path,
+        rust_report_path=rust_report_path,
+        documentation_path=documentation_path,
+        release_notes_path=release_notes_path,
+        editor_report_path=artifact_paths["editor-qualification-report"],
+    )
+
+    live_sha256 = sha256_file(live_index_path)
+    live_index = load_json_strict(live_index_path, require_canonical=True)
+    mutation = materialize_stable_mutation(
+        plan_path=plan_path,
+        live_index_path=live_index_path,
+        expected_generation=live_index["generation"],
+        expected_sha256=live_sha256,
+        proposed_generation=proposed_generation,
+    )
+    mutation_evidence = mutation.evidence()
+    validate_stable_mutation_evidence(mutation_evidence)
+    summary = {
+        "schema_version": 2,
+        "operation": operation,
+        "mode": mode,
+        "version": plan["version"],
+        "evidence": {
+            "commit": evidence_commit,
+            "candidate_path": candidate_path,
+            "plan_sha256": expected_plan_sha256,
+        },
+        "source": {
+            "commit": plan["source_commit"],
+            "submodules": plan["submodules"],
+        },
+        "release_report": {
+            "id": report["report_id"],
+            "sha256": sha256_file(report_path),
+        },
+        "qualification": {
+            "id": qualification_id,
+            "sha256": sha256_file(qualification_path),
+            "run_id": qualification["workflow"]["run_id"],
+            "run_attempt": qualification["workflow"]["run_attempt"],
+            "expires_at": expires_at,
+        },
+        "live_index": {
+            "generation": live_index["generation"],
+            "sha256": live_sha256,
+        },
+        "mutation": mutation_evidence,
+        "artifacts": {
+            artifact["id"]: {
+                "name": artifact["name"],
+                "sha256": artifact["sha256"],
+                "size_bytes": artifact["size_bytes"],
+                "workflow_artifact_id": artifact["workflow_artifact_id"],
+                "workflow_artifact_name": artifact["workflow_artifact_name"],
+            }
+            for artifact in qualification["artifacts"]
+        },
+        "marketplace": marketplace,
+        "site": {
+            "repository": plan["site"]["repository"],
+            "base_commit": plan["site"]["base_commit"],
+        },
+    }
+    validate_stable_prepare_summary(summary)
+    return summary
+
+
+def validate_stable_prepare_summary(payload: object) -> dict[str, Any]:
+    """Validate the protected reviewer-visible summary contract."""
+    summary = require_object(payload, "$")
+    require_exact_keys(
+        summary,
+        required={
+            "schema_version",
+            "operation",
+            "mode",
+            "version",
+            "evidence",
+            "source",
+            "release_report",
+            "qualification",
+            "live_index",
+            "mutation",
+            "artifacts",
+            "marketplace",
+            "site",
+        },
+        location="$",
+    )
+    require_schema_v2(summary)
+    operation = require_enum(
+        summary["operation"],
+        {"ga-activation", "normal"},
+        "$.operation",
+    )
+    require_enum(summary["mode"], {"initial", "resume"}, "$.mode")
+    version = summary["version"]
+    if version_channel(version, "$.version") != "stable":
+        fail("$.version", "must be an exact stable version")
+    evidence = require_object(summary["evidence"], "$.evidence")
+    require_exact_keys(
+        evidence,
+        required={"commit", "candidate_path", "plan_sha256"},
+        location="$.evidence",
+    )
+    require_commit(evidence["commit"], "$.evidence.commit")
+    require_sha256(evidence["plan_sha256"], "$.evidence.plan_sha256")
+    match = CANDIDATE_PATH_RE.fullmatch(
+        require_nonempty_string(evidence["candidate_path"], "$.evidence.candidate_path")
+    )
+    if match is None or match.group(1) != version:
+        fail("$.evidence.candidate_path", "does not bind the summary version")
+    source = require_object(summary["source"], "$.source")
+    require_exact_keys(
+        source,
+        required={"commit", "submodules"},
+        location="$.source",
+    )
+    source_commit = require_commit(source["commit"], "$.source.commit")
+    submodules = require_object(source["submodules"], "$.source.submodules")
+    if not submodules:
+        fail("$.source.submodules", "must contain recursive submodule identities")
+    for path, commit in submodules.items():
+        require_nonempty_string(path, "$.source.submodules key")
+        require_commit(commit, f"$.source.submodules.{path}")
+
+    _validate_reference(summary["release_report"], "$.release_report")
+    qualification = require_object(summary["qualification"], "$.qualification")
+    require_exact_keys(
+        qualification,
+        required={"id", "sha256", "run_id", "run_attempt", "expires_at"},
+        location="$.qualification",
+    )
+    qualification_id = require_nonempty_string(
+        qualification["id"],
+        "$.qualification.id",
+    )
+    require_sha256(qualification["sha256"], "$.qualification.sha256")
+    run_id = require_positive_int(
+        qualification["run_id"],
+        "$.qualification.run_id",
+    )
+    run_attempt = require_positive_int(
+        qualification["run_attempt"],
+        "$.qualification.run_attempt",
+    )
+    if qualification_id != f"qualification-{run_id}-{run_attempt}":
+        fail("$.qualification.id", "does not bind the workflow run identity")
+    expires_at = require_nonempty_string(
+        qualification["expires_at"],
+        "$.qualification.expires_at",
+    )
+    try:
+        expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except ValueError:
+        fail("$.qualification.expires_at", "must be an ISO-8601 timestamp")
+    if expiry.tzinfo is None:
+        fail("$.qualification.expires_at", "must include a timezone")
+
+    mutation = validate_stable_mutation_evidence(summary["mutation"])
+    if (
+        mutation["transition"] != operation
+        or mutation["version"] != version
+        or mutation["plan_sha256"] != evidence["plan_sha256"]
+    ):
+        fail("$.mutation", "does not bind the requested operation and plan")
+    release = mutation["proposed_index"]["releases"].get(version)
+    if not isinstance(release, dict) or release.get("source_commit") != source_commit:
+        fail("$.source.commit", "does not equal the proposed release source")
+
+    live = require_object(summary["live_index"], "$.live_index")
+    require_exact_keys(
+        live,
+        required={"generation", "sha256"},
+        location="$.live_index",
+    )
+    require_positive_int(live["generation"], "$.live_index.generation")
+    require_sha256(live["sha256"], "$.live_index.sha256")
+    if (
+        mutation["previous_index"]["generation"] != live["generation"]
+        or mutation["previous_index"]["sha256"] != live["sha256"]
+    ):
+        fail("$.live_index", "does not equal the mutation predecessor")
+
+    artifacts = require_object(summary["artifacts"], "$.artifacts")
+    if set(artifacts) != EXPECTED_ARTIFACT_IDS:
+        fail("$.artifacts", "must contain exact governed artifact identifiers")
+    workflow_id_to_name: dict[int, str] = {}
+    workflow_name_to_id: dict[str, int] = {}
+    for artifact_id, value in artifacts.items():
+        artifact = require_object(value, f"$.artifacts.{artifact_id}")
+        require_exact_keys(
+            artifact,
+            required={
+                "name",
+                "sha256",
+                "size_bytes",
+                "workflow_artifact_id",
+                "workflow_artifact_name",
+            },
+            location=f"$.artifacts.{artifact_id}",
+        )
+        require_nonempty_string(
+            artifact["name"],
+            f"$.artifacts.{artifact_id}.name",
+        )
+        require_sha256(
+            artifact["sha256"],
+            f"$.artifacts.{artifact_id}.sha256",
+        )
+        workflow_artifact_id = require_positive_int(
+            artifact["workflow_artifact_id"],
+            f"$.artifacts.{artifact_id}.workflow_artifact_id",
+        )
+        workflow_name = require_nonempty_string(
+            artifact["workflow_artifact_name"],
+            f"$.artifacts.{artifact_id}.workflow_artifact_name",
+        )
+        require_positive_int(
+            artifact["size_bytes"],
+            f"$.artifacts.{artifact_id}.size_bytes",
+        )
+        if (
+            workflow_id_to_name.setdefault(workflow_artifact_id, workflow_name)
+            != workflow_name
+            or workflow_name_to_id.setdefault(workflow_name, workflow_artifact_id)
+            != workflow_artifact_id
+        ):
+            fail(
+                f"$.artifacts.{artifact_id}",
+                "workflow artifact id/name mapping must be one-to-one",
+            )
+    if len(workflow_id_to_name) != 6:
+        fail("$.artifacts", "must bind the six governed transported uploads")
+
+    marketplace = require_object(summary["marketplace"], "$.marketplace")
+    require_exact_keys(
+        marketplace,
+        required={"publisher", "extension", "version", "vsix_sha256"},
+        location="$.marketplace",
+    )
+    for key in ("publisher", "extension", "version"):
+        require_nonempty_string(marketplace[key], f"$.marketplace.{key}")
+    vsix_sha256 = require_sha256(
+        marketplace["vsix_sha256"],
+        "$.marketplace.vsix_sha256",
+    )
+    if vsix_sha256 != artifacts["vsix"]["sha256"]:
+        fail("$.marketplace.vsix_sha256", "does not match the transported VSIX")
+
+    site = require_object(summary["site"], "$.site")
+    require_exact_keys(
+        site,
+        required={"repository", "base_commit"},
+        location="$.site",
+    )
+    if site["repository"] != "sifr-lang/sifr-website":
+        fail("$.site.repository", "must be sifr-lang/sifr-website")
+    require_commit(site["base_commit"], "$.site.base_commit")
+    return summary
+
+
+def _require_checkout(root: Path, expected_commit: str, label: str) -> None:
+    if _git(root, "rev-parse", "HEAD") != expected_commit:
+        fail(label, "checkout does not equal the expected commit")
+    if _git(root, "status", "--porcelain", "--untracked-files=all"):
+        fail(label, "checkout must be clean")
+    if _git(root, "diff", "--name-only", "--diff-filter=U"):
+        fail(label, "checkout has unresolved files")
+
+
+def _require_candidate_files(candidate_root: Path) -> None:
+    entries = list(candidate_root.iterdir())
+    unsafe = sorted(
+        path.name for path in entries if path.is_symlink() or not path.is_file()
+    )
+    if unsafe:
+        fail(
+            "candidate_path",
+            f"contains unsupported entry/entries: {', '.join(unsafe)}",
+        )
+    files = {path.name for path in entries}
+    missing = sorted(REQUIRED_CANDIDATE_FILES.difference(files))
+    unknown = sorted(
+        files.difference(REQUIRED_CANDIDATE_FILES | OPTIONAL_CANDIDATE_FILES)
+    )
+    if missing:
+        fail("candidate_path", f"missing evidence file(s): {', '.join(missing)}")
+    if unknown:
+        fail(
+            "candidate_path",
+            f"contains unsupported evidence file(s): {', '.join(unknown)}",
+        )
+
+
+def _validate_source_contracts(plan: dict[str, Any], source_root: Path) -> None:
+    if sha256_file(source_root / "Cargo.lock") != plan["cargo_lock_sha256"]:
+        fail("$.cargo_lock_sha256", "does not match the source checkout")
+    profile_sha256 = canonical_profile_digest(
+        source_root / "verification/profiles/release.json"
+    )
+    if profile_sha256 != plan["toolchain"]["profile_manifest_sha256"]:
+        fail("$.toolchain.profile_manifest_sha256", "does not match the source")
+    for key, relative in (
+        (
+            "compatibility_matrix_sha256",
+            "verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json",
+        ),
+        (
+            "facts_schema_sha256",
+            "verification/areas/distribution_release/schemas/stable_site_release_facts.schema.json",
+        ),
+        (
+            "facts_generator_sha256",
+            "verification/areas/distribution_release/governance/release_plan.py",
+        ),
+    ):
+        expected = (
+            plan["rust_interop"][key]
+            if key == "compatibility_matrix_sha256"
+            else plan["site"][key]
+        )
+        if sha256_file(source_root / relative) != expected:
+            fail(f"$.{key}", "does not match the source checkout")
+    for tool in ("rustc", "cargo"):
+        if _command(source_root, tool, "--version") != plan["toolchain"][tool]:
+            fail(f"$.toolchain.{tool}", "does not match the source checkout")
+
+
+def _validate_supporting_evidence(
+    *,
+    plan: dict[str, Any],
+    report: dict[str, Any],
+    claims_path: Path,
+    rust_report_path: Path,
+    documentation_path: Path,
+    release_notes_path: Path,
+    editor_report_path: Path,
+) -> dict[str, str]:
+    if sha256_file(claims_path) != plan["rust_interop"]["stable_support_claims_sha256"]:
+        fail("$.rust_interop.stable_support_claims_sha256", "evidence digest drifted")
+    claims = load_json_strict(claims_path, require_canonical=True)
+    if stable_claim_ids(claims) != plan["rust_interop"]["advertised_claim_ids"]:
+        fail("$.rust_interop.advertised_claim_ids", "does not match candidate evidence")
+    if (
+        sha256_file(rust_report_path)
+        != plan["rust_interop"]["validation_report_sha256"]
+    ):
+        fail("$.rust_interop.validation_report_sha256", "evidence digest drifted")
+    validate_rust_candidate_result(
+        load_json_strict(rust_report_path, require_canonical=True),
+        expected_digest=plan["rust_interop"]["validation_report_sha256"],
+        release_report=report,
+    )
+    if sha256_file(documentation_path) != plan["documentation_report"]["sha256"]:
+        fail("$.documentation_report.sha256", "evidence digest drifted")
+    documentation = validate_documentation_report(
+        load_json_strict(documentation_path, require_canonical=True),
+        source_commit=plan["source_commit"],
+    )
+    if documentation["report_id"] != plan["documentation_report"]["id"]:
+        fail("$.documentation_report.id", "does not match candidate evidence")
+    if sha256_file(release_notes_path) != plan["release_notes_sha256"]:
+        fail("$.release_notes_sha256", "evidence digest drifted")
+    editor = load_json_strict(editor_report_path, require_canonical=True)
+    marketplace = require_object(
+        editor["marketplace_publish_plan"],
+        "$.marketplace_publish_plan",
+    )
+    return {
+        "publisher": marketplace["publisher"],
+        "extension": marketplace["extension"],
+        "version": marketplace["version"],
+        "vsix_sha256": marketplace["vsix_sha256"],
+    }
+
+
+def _require_publication_window(
+    qualification: dict[str, Any],
+    *,
+    now: datetime,
+) -> str:
+    expires_at = qualification["workflow"]["expires_at"]
+    expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    if now.tzinfo is None:
+        fail("now", "must include a timezone")
+    if expiry - now < MINIMUM_PUBLICATION_WINDOW:
+        fail("$.qualification.expires_at", "must leave at least seven full days")
+    return expires_at
+
+
+def _require_reference(
+    payload: object,
+    *,
+    identifier: str,
+    path: Path,
+    location: str,
+) -> None:
+    reference = require_object(payload, location)
+    if reference["id"] != identifier or reference["sha256"] != sha256_file(path):
+        fail(location, "does not match the exact candidate evidence")
+
+
+def _validate_reference(payload: object, location: str) -> dict[str, Any]:
+    reference = require_object(payload, location)
+    require_exact_keys(
+        reference,
+        required={"id", "sha256"},
+        location=location,
+    )
+    require_nonempty_string(reference["id"], f"{location}.id")
+    require_sha256(reference["sha256"], f"{location}.sha256")
+    return reference
+
+
+def _git(root: Path, *args: str) -> str:
+    return _command(root, "git", *args)
+
+
+def _command(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        list(args),
+        cwd=root,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise GovernanceError(
+            f"{' '.join(args)} failed in {root}: {result.stderr.strip()}"
+        )
+    return result.stdout.rstrip("\r\n")

--- a/verification/areas/distribution_release/governance/stable_prepare_selftest.py
+++ b/verification/areas/distribution_release/governance/stable_prepare_selftest.py
@@ -303,6 +303,26 @@ def test_safe_artifact_extractor() -> None:
             if any(destination.iterdir()):
                 raise AssertionError(f"unsafe artifact ZIP wrote bytes: {archive.name}")
 
+        mismatch_destination = root / "rejected-byte-count"
+        mismatch_destination.mkdir()
+        mismatch = subprocess.run(
+            [
+                "python3",
+                str(script),
+                str(safe_archive),
+                str(mismatch_destination),
+                "--expected-uncompressed-bytes",
+                "12",
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if mismatch.returncode == 0:
+            raise AssertionError("artifact ZIP byte-count mismatch passed")
+        if any(mismatch_destination.iterdir()):
+            raise AssertionError("artifact ZIP byte-count mismatch wrote bytes")
+
 
 class StablePrepareFixture:
     """Context manager that creates an exact source/evidence/artifact bundle."""

--- a/verification/areas/distribution_release/governance/stable_prepare_selftest.py
+++ b/verification/areas/distribution_release/governance/stable_prepare_selftest.py
@@ -1,0 +1,390 @@
+"""Mutation tests for credential-free protected stable publication preparation."""
+
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+import stat
+import subprocess
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from .common import (
+    GovernanceError,
+    sha256_file,
+)
+from .qualification_fixture import (
+    build_evidence_bundle,
+    create_fixture_source,
+)
+from .qualification_fixture_support import (
+    configure_git,
+    git,
+    git_output,
+)
+from .stable_prepare import (
+    materialize_stable_prepare,
+    validate_stable_prepare_summary,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+NOW = datetime(2098, 12, 20, tzinfo=timezone.utc)
+CANDIDATE_PATH = "plans/releases/candidates/0.1.0"
+EVIDENCE_FILES = {
+    "plan_spec": "stable-release-plan.json",
+    "release_report": "release-profile-report.json",
+    "qualification_index": "qualification-artifact-index.json",
+    "stable_support_claims": "stable-support-claims.json",
+    "rust_validation_report": "rust-validation-report.json",
+    "documentation_report": "documentation-report.json",
+    "release_notes": "release-notes.md",
+}
+
+
+def run_self_tests() -> int:
+    tests = (
+        test_materialized_prepare,
+        test_materialized_normal_prepare,
+        test_prepare_rejects_input_drift,
+        test_summary_contract,
+        test_cli_producer,
+        test_safe_artifact_extractor,
+    )
+    for test in tests:
+        test()
+        print(f"stable-prepare pass: {test.__name__}")
+    print(f"stable publication prepare self-tests ok: tests={len(tests)}")
+    return 0
+
+
+def test_materialized_prepare() -> None:
+    with StablePrepareFixture() as context:
+        summary = prepare(context)
+        assert summary["operation"] == "ga-activation"
+        assert summary["mode"] == "initial"
+        assert summary["source"]["commit"] == context["source_commit"]
+        assert summary["evidence"]["commit"] == context["evidence_commit"]
+        assert summary["mutation"]["proposed_index"]["generation"] == 8
+        assert len(summary["artifacts"]) == 20
+        assert (
+            summary["marketplace"]["vsix_sha256"]
+            == summary["artifacts"]["vsix"]["sha256"]
+        )
+
+
+def test_materialized_normal_prepare() -> None:
+    with StablePrepareFixture(transition="normal") as context:
+        arguments = prepare_arguments(context)
+        arguments["mode"] = "resume"
+        summary = materialize_stable_prepare(**arguments)
+        assert summary["operation"] == "normal"
+        assert summary["mode"] == "resume"
+        assert summary["mutation"]["previous_index"]["generation"] == 8
+        assert summary["mutation"]["proposed_index"]["generation"] == 9
+        assert summary["mutation"]["proposed_index"]["channels"]["stable"] == "0.1.0"
+
+
+def test_prepare_rejects_input_drift() -> None:
+    with StablePrepareFixture() as context:
+        mutations: tuple[tuple[str, Callable[[dict[str, Any]], None]], ...] = (
+            (
+                "evidence commit",
+                lambda value: value.update({"evidence_commit": "a" * 40}),
+            ),
+            (
+                "candidate path",
+                lambda value: value.update(
+                    {"candidate_path": "plans/releases/candidates/0.1.1"}
+                ),
+            ),
+            (
+                "plan digest",
+                lambda value: value.update({"expected_plan_sha256": "b" * 64}),
+            ),
+            (
+                "operation",
+                lambda value: value.update({"operation": "normal"}),
+            ),
+            (
+                "generation",
+                lambda value: value.update({"proposed_generation": 7}),
+            ),
+            (
+                "publication window",
+                lambda value: value.update(
+                    {"now": datetime(2098, 12, 26, tzinfo=timezone.utc)}
+                ),
+            ),
+        )
+        for label, mutation in mutations:
+            arguments = prepare_arguments(context)
+            mutation(arguments)
+            expect_rejected(
+                lambda value: materialize_stable_prepare(**value),
+                arguments,
+                label=label,
+            )
+
+        source_marker = context["source_root"] / "untracked.txt"
+        source_marker.write_text("dirty\n", encoding="utf-8")
+        expect_rejected(
+            lambda value: materialize_stable_prepare(**value),
+            prepare_arguments(context),
+            label="dirty source",
+        )
+        source_marker.unlink()
+
+        evidence_marker = context["evidence_root"] / "untracked.txt"
+        evidence_marker.write_text("dirty\n", encoding="utf-8")
+        expect_rejected(
+            lambda value: materialize_stable_prepare(**value),
+            prepare_arguments(context),
+            label="dirty evidence",
+        )
+        evidence_marker.unlink()
+
+        qualification = json.loads(
+            (
+                context["evidence_root"]
+                / context["candidate_path"]
+                / "qualification-artifact-index.json"
+            ).read_text(encoding="utf-8")
+        )
+        artifact = qualification["artifacts"][0]
+        artifact_path = (
+            context["artifact_root"]
+            / artifact["workflow_artifact_name"]
+            / artifact["name"]
+        )
+        artifact_path.write_bytes(artifact_path.read_bytes() + b"drift")
+        expect_rejected(
+            lambda value: materialize_stable_prepare(**value),
+            prepare_arguments(context),
+            label="transported artifact drift",
+        )
+
+
+def test_summary_contract() -> None:
+    with StablePrepareFixture() as context:
+        summary = prepare(context)
+        mutations: tuple[Callable[[dict[str, Any]], None], ...] = (
+            lambda value: value["evidence"].update(
+                {"candidate_path": "plans/releases/candidates/0.1.1"}
+            ),
+            lambda value: value["source"].update({"commit": "a" * 40}),
+            lambda value: value["release_report"].update({"sha256": "0" * 64}),
+            lambda value: value["qualification"].update({"run_attempt": 2}),
+            lambda value: value["live_index"].update({"generation": 6}),
+            lambda value: value["artifacts"].pop("installer"),
+            lambda value: value["artifacts"]["vsix"].update(
+                {"workflow_artifact_id": 99}
+            ),
+            lambda value: value["marketplace"].update({"vsix_sha256": "a" * 64}),
+            lambda value: value["site"].update({"repository": "example.invalid/site"}),
+        )
+        for mutation in mutations:
+            changed = copy.deepcopy(summary)
+            mutation(changed)
+            expect_rejected(
+                validate_stable_prepare_summary,
+                changed,
+                label="summary mutation",
+            )
+
+
+def test_cli_producer() -> None:
+    with StablePrepareFixture() as context:
+        output = context["root"] / "stable-prepare.json"
+        arguments = prepare_arguments(context)
+        command = [
+            "python3",
+            str(REPO_ROOT / "scripts/distribution/release_governance.py"),
+            "prepare-stable-publication",
+            "--operation",
+            arguments["operation"],
+            "--mode",
+            arguments["mode"],
+            "--evidence-root",
+            str(arguments["evidence_root"]),
+            "--evidence-commit",
+            arguments["evidence_commit"],
+            "--candidate-path",
+            arguments["candidate_path"],
+            "--expected-plan-sha256",
+            arguments["expected_plan_sha256"],
+            "--source-root",
+            str(arguments["source_root"]),
+            "--live-index",
+            str(arguments["live_index_path"]),
+            "--artifact-root",
+            str(arguments["artifact_root"]),
+            "--proposed-generation",
+            str(arguments["proposed_generation"]),
+            "--out",
+            str(output),
+        ]
+        completed = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if completed.returncode != 0:
+            raise AssertionError(completed.stderr)
+        validate_stable_prepare_summary(json.loads(output.read_text(encoding="utf-8")))
+        second = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if second.returncode == 0:
+            raise AssertionError("CLI overwrote an existing prepare summary")
+
+
+def test_safe_artifact_extractor() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-artifact-extractor-") as directory:
+        root = Path(directory)
+        script = REPO_ROOT / "scripts/distribution/extract_github_artifact.py"
+        safe_archive = root / "safe.zip"
+        with zipfile.ZipFile(safe_archive, "w") as archive:
+            archive.writestr("artifact.bin", b"exact bytes")
+        safe_destination = root / "safe"
+        safe_destination.mkdir()
+        subprocess.run(
+            [
+                "python3",
+                str(script),
+                str(safe_archive),
+                str(safe_destination),
+                "--expected-uncompressed-bytes",
+                "11",
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert (safe_destination / "artifact.bin").read_bytes() == b"exact bytes"
+
+        traversal_archive = root / "traversal.zip"
+        with zipfile.ZipFile(traversal_archive, "w") as archive:
+            archive.writestr("../escaped.bin", b"unsafe")
+        link_archive = root / "link.zip"
+        link = zipfile.ZipInfo("link")
+        link.create_system = 3
+        link.external_attr = (stat.S_IFLNK | 0o777) << 16
+        with zipfile.ZipFile(link_archive, "w") as archive:
+            archive.writestr(link, "target")
+        for index, archive in enumerate((traversal_archive, link_archive)):
+            destination = root / f"rejected-{index}"
+            destination.mkdir()
+            completed = subprocess.run(
+                [
+                    "python3",
+                    str(script),
+                    str(archive),
+                    str(destination),
+                    "--expected-uncompressed-bytes",
+                    "6",
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            if completed.returncode == 0:
+                raise AssertionError(f"unsafe artifact ZIP passed: {archive.name}")
+            if any(destination.iterdir()):
+                raise AssertionError(f"unsafe artifact ZIP wrote bytes: {archive.name}")
+
+
+class StablePrepareFixture:
+    """Context manager that creates an exact source/evidence/artifact bundle."""
+
+    def __init__(self, *, transition: str = "ga-activation") -> None:
+        self.temporary: tempfile.TemporaryDirectory[str] | None = None
+        self.transition = transition
+
+    def __enter__(self) -> dict[str, Any]:
+        self.temporary = tempfile.TemporaryDirectory(
+            prefix="sifr-stable-prepare-self-test-"
+        )
+        root = Path(self.temporary.name)
+        source_root = create_fixture_source(root)
+        bundle = build_evidence_bundle(
+            source_root=source_root,
+            evidence_root=root / "qualification",
+            result_root=source_root / "target/results",
+            transition=self.transition,
+        )
+        evidence_root = root / "evidence"
+        candidate_root = evidence_root / CANDIDATE_PATH
+        candidate_root.mkdir(parents=True)
+        for source_key, destination_name in EVIDENCE_FILES.items():
+            shutil.copyfile(bundle[source_key], candidate_root / destination_name)
+        git(evidence_root, "init")
+        configure_git(evidence_root)
+        git(evidence_root, "add", ".")
+        git(evidence_root, "commit", "-m", "candidate evidence")
+        return {
+            "root": root,
+            "source_root": source_root,
+            "source_commit": git_output(source_root, "rev-parse", "HEAD"),
+            "evidence_root": evidence_root,
+            "evidence_commit": git_output(evidence_root, "rev-parse", "HEAD"),
+            "candidate_path": CANDIDATE_PATH,
+            "expected_plan_sha256": sha256_file(
+                candidate_root / "stable-release-plan.json"
+            ),
+            "live_index_path": bundle["active_index"],
+            "artifact_root": bundle["artifact_root"],
+            "operation": self.transition,
+            "proposed_generation": 8 if self.transition == "ga-activation" else 9,
+        }
+
+    def __exit__(self, *_: object) -> None:
+        if self.temporary is not None:
+            self.temporary.cleanup()
+
+
+def prepare(context: dict[str, Any]) -> dict[str, Any]:
+    return materialize_stable_prepare(**prepare_arguments(context))
+
+
+def prepare_arguments(context: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "operation": context["operation"],
+        "mode": "initial",
+        "evidence_root": context["evidence_root"],
+        "evidence_commit": context["evidence_commit"],
+        "candidate_path": context["candidate_path"],
+        "expected_plan_sha256": context["expected_plan_sha256"],
+        "source_root": context["source_root"],
+        "live_index_path": context["live_index_path"],
+        "artifact_root": context["artifact_root"],
+        "proposed_generation": context["proposed_generation"],
+        "now": NOW,
+    }
+
+
+def expect_rejected(
+    validator: Callable[[Any], Any],
+    payload: Any,
+    *,
+    label: str,
+) -> None:
+    try:
+        validator(payload)
+    except (GovernanceError, ValueError):
+        return
+    raise AssertionError(f"{label} unexpectedly passed")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_self_tests())

--- a/verification/areas/distribution_release/manifest.json
+++ b/verification/areas/distribution_release/manifest.json
@@ -100,6 +100,19 @@
           "diagnostic_formats": []
         }
       ]
+    },
+    {
+      "name": "stable-prepare",
+      "kind": "adapter",
+      "cases": [
+        {
+          "id": "stable-publication-prepare",
+          "entry": "verification/areas/distribution_release/governance/stable_prepare_selftest.py",
+          "command": "distribution-stable-prepare",
+          "expect_exit_code": 0,
+          "diagnostic_formats": []
+        }
+      ]
     }
   ],
   "network_mode": "offline",

--- a/verification/areas/distribution_release/runner.py
+++ b/verification/areas/distribution_release/runner.py
@@ -59,12 +59,16 @@ def main(argv: list[str] | None = None) -> int:
     drill_suite_selected = any(
         str(suite["name"]) == "protected-drill" for suite in selected
     )
+    stable_prepare_selected = any(
+        str(suite["name"]) == "stable-prepare" for suite in selected
+    )
     suite_results = [
         run_suite(
             suite,
             include_incident=not incident_suite_selected,
             include_epoch_bootstrap=not epoch_suite_selected,
             include_protected_drill=not drill_suite_selected,
+            include_stable_prepare=not stable_prepare_selected,
         )
         for suite in selected
     ]
@@ -124,6 +128,7 @@ def run_suite(
     include_incident: bool = True,
     include_epoch_bootstrap: bool = True,
     include_protected_drill: bool = True,
+    include_stable_prepare: bool = True,
 ) -> dict[str, Any]:
     suite_name = str(suite["name"])
     case = validate_suite_case(suite)
@@ -154,6 +159,13 @@ def run_suite(
                 "governance.protected_drill_selftest",
                 "protected-stable-release-drill",
                 scrub_credentials=True,
+            )
+        ]
+    elif suite_name == "stable-prepare":
+        variants = [
+            run_python_module(
+                "governance.stable_prepare_selftest",
+                "stable-publication-prepare",
             )
         ]
     elif suite_name == "qualification":
@@ -190,6 +202,13 @@ def run_suite(
                         scrub_credentials=True,
                     )
                 )
+            if include_stable_prepare:
+                variants.append(
+                    run_python_module(
+                        "governance.stable_prepare_selftest",
+                        "stable-publication-prepare",
+                    )
+                )
     failures = sum(1 for variant in variants if variant["status"] == "fail")
     return {
         "name": suite_name,
@@ -220,6 +239,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
         "incident-governance",
         "epoch-bootstrap",
         "protected-drill",
+        "stable-prepare",
     }:
         raise SystemExit(f"unsupported distribution_release suite: {suite_name}")
     cases = suite.get("cases", [])
@@ -231,6 +251,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
         "incident-governance": "distribution-incident-recovery",
         "epoch-bootstrap": "distribution-schema-bootstrap",
         "protected-drill": "distribution-protected-drill",
+        "stable-prepare": "distribution-stable-prepare",
         "qualification": "distribution-stable-qualification",
     }.get(suite_name, "distribution-case-directory")
     if str(case.get("command")) != expected_command:
@@ -241,6 +262,7 @@ def validate_suite_case(suite: dict[str, Any]) -> dict[str, Any]:
         "incident-governance": AREA_ROOT / "governance" / "incident_recovery_selftest.py",
         "epoch-bootstrap": AREA_ROOT / "governance" / "schema_bootstrap_selftest.py",
         "protected-drill": AREA_ROOT / "governance" / "protected_drill_selftest.py",
+        "stable-prepare": AREA_ROOT / "governance" / "stable_prepare_selftest.py",
         "qualification": AREA_ROOT / "governance" / "qualification_selftest.py",
     }.get(suite_name, CASES_ROOT)
     if entry != expected_entry or not entry.exists():

--- a/verification/areas/distribution_release/schemas/stable_publication_prepare.schema.json
+++ b/verification/areas/distribution_release/schemas/stable_publication_prepare.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Stable publication protected-prepare summary",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "operation",
+    "mode",
+    "version",
+    "evidence",
+    "source",
+    "release_report",
+    "qualification",
+    "live_index",
+    "mutation",
+    "artifacts",
+    "marketplace",
+    "site"
+  ],
+  "properties": {
+    "schema_version": {"const": 2},
+    "operation": {"enum": ["ga-activation", "normal"]},
+    "mode": {"enum": ["initial", "resume"]},
+    "version": {"$ref": "#/$defs/version"},
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commit", "candidate_path", "plan_sha256"],
+      "properties": {
+        "commit": {"$ref": "#/$defs/commit"},
+        "candidate_path": {
+          "type": "string",
+          "pattern": "^plans/releases/candidates/[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "plan_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commit", "submodules"],
+      "properties": {
+        "commit": {"$ref": "#/$defs/commit"},
+        "submodules": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {"$ref": "#/$defs/commit"}
+        }
+      }
+    },
+    "release_report": {"$ref": "#/$defs/reference"},
+    "qualification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sha256", "run_id", "run_attempt", "expires_at"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "run_id": {"type": "integer", "minimum": 1},
+        "run_attempt": {"type": "integer", "minimum": 1},
+        "expires_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "live_index": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generation", "sha256"],
+      "properties": {
+        "generation": {"type": "integer", "minimum": 1},
+        "sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "mutation": {"$ref": "stable_index_mutation_evidence.schema.json"},
+    "artifacts": {
+      "type": "object",
+      "minProperties": 20,
+      "propertyNames": {
+        "enum": [
+          "binary-archive-aarch64-apple-darwin",
+          "binary-archive-aarch64-unknown-linux-gnu",
+          "binary-archive-x86_64-apple-darwin",
+          "binary-archive-x86_64-unknown-linux-gnu",
+          "checksum-aarch64-apple-darwin",
+          "checksum-aarch64-unknown-linux-gnu",
+          "checksum-x86_64-apple-darwin",
+          "checksum-x86_64-unknown-linux-gnu",
+          "checksums",
+          "editor-qualification-report",
+          "installer",
+          "qualification-report-aarch64-apple-darwin",
+          "qualification-report-aarch64-unknown-linux-gnu",
+          "qualification-report-x86_64-apple-darwin",
+          "qualification-report-x86_64-unknown-linux-gnu",
+          "sysroot-aarch64-apple-darwin",
+          "sysroot-aarch64-unknown-linux-gnu",
+          "sysroot-x86_64-apple-darwin",
+          "sysroot-x86_64-unknown-linux-gnu",
+          "vsix"
+        ]
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "sha256",
+          "size_bytes",
+          "workflow_artifact_id",
+          "workflow_artifact_name"
+        ],
+        "properties": {
+          "name": {"type": "string", "minLength": 1},
+          "sha256": {"$ref": "#/$defs/sha256"},
+          "size_bytes": {"type": "integer", "minimum": 1},
+          "workflow_artifact_id": {"type": "integer", "minimum": 1},
+          "workflow_artifact_name": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "marketplace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["publisher", "extension", "version", "vsix_sha256"],
+      "properties": {
+        "publisher": {"type": "string", "minLength": 1},
+        "extension": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "vsix_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "site": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "base_commit"],
+      "properties": {
+        "repository": {"const": "sifr-lang/sifr-website"},
+        "base_commit": {"$ref": "#/$defs/commit"}
+      }
+    }
+  },
+  "$defs": {
+    "commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "not": {
+        "const": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+    },
+    "reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sha256"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "sha256": {"$ref": "#/$defs/sha256"}
+      }
+    }
+  }
+}

--- a/verification/profiles/merge.json
+++ b/verification/profiles/merge.json
@@ -245,7 +245,8 @@
         "qualification",
         "incident-governance",
         "epoch-bootstrap",
-        "protected-drill"
+        "protected-drill",
+        "stable-prepare"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/profiles/nightly.json
+++ b/verification/profiles/nightly.json
@@ -224,7 +224,8 @@
         "qualification",
         "incident-governance",
         "epoch-bootstrap",
-        "protected-drill"
+        "protected-drill",
+        "stable-prepare"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/profiles/release.json
+++ b/verification/profiles/release.json
@@ -223,7 +223,8 @@
         "evidence-custody",
         "incident-governance",
         "epoch-bootstrap",
-        "protected-drill"
+        "protected-drill",
+        "stable-prepare"
       ],
       "resource_classes": [
         "default-local"

--- a/verification/runner/sifr_verify/release_evidence_selftest.py
+++ b/verification/runner/sifr_verify/release_evidence_selftest.py
@@ -1,0 +1,145 @@
+"""Focused self-tests for release-profile evidence production."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from .release_evidence import (
+    CRITICAL_RESULTS,
+    build_release_profile_payload,
+    prepare_release_report_output,
+    validate_release_profile_report,
+)
+
+
+def release_report_precondition_self_test() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="sifr-release-report-self-test-"
+    ) as directory:
+        existing = Path(directory) / "release-profile-report.json"
+        existing.write_text("occupied", encoding="utf-8")
+        cases = [
+            (existing, "release", "already exists"),
+            (
+                Path(directory) / "non-release.json",
+                "merge",
+                "accepted only for the release",
+            ),
+            (
+                Path(__file__).resolve().parents[3]
+                / "target"
+                / "release-profile-report.json",
+                "release",
+                "outside the repository checkout",
+            ),
+        ]
+        for path, profile, expected in cases:
+            try:
+                prepare_release_report_output(str(path), profile_name=profile)
+            except ValueError as exc:
+                if expected not in str(exc):
+                    raise AssertionError(
+                        f"unexpected release report rejection: {exc}"
+                    ) from exc
+            else:
+                raise AssertionError(
+                    f"release report precondition mutation passed: {path}"
+                )
+
+
+def release_report_production_self_test() -> None:
+    selected = {
+        "rust_interop": [
+            "matrix",
+            "tiers",
+            "compatibility-matrix",
+            "stale-drafts",
+            "stable-candidate",
+        ],
+        "developer_tooling": ["full"],
+        "documentation": ["structure", "ga-release"],
+        "distribution_release": [
+            "full",
+            "qualification",
+            "evidence-custody",
+            "incident-governance",
+            "epoch-bootstrap",
+            "protected-drill",
+            "stable-prepare",
+        ],
+    }
+    with tempfile.TemporaryDirectory(
+        prefix="sifr-release-report-production-"
+    ) as directory:
+        root = Path(directory)
+        result_root = root / "target" / "verification" / "areas"
+        result_root.mkdir(parents=True)
+        for area, filename in CRITICAL_RESULTS.items():
+            suites = []
+            for suite_name in selected[area]:
+                labels = [f"{suite_name}:case"]
+                if area == "developer_tooling":
+                    labels.append("editor-release:package")
+                suites.append(
+                    {
+                        "name": suite_name,
+                        "cases": [{"variants": [{"label": label} for label in labels]}],
+                    }
+                )
+            (result_root / filename).write_text(
+                json.dumps({"area": area, "suites": suites}),
+                encoding="utf-8",
+            )
+        log_path = root / "release.log"
+        log_path.write_text(
+            "".join(
+                f"[sifr-lane-step] name={name} elapsed_ms=1 status=pass\n"
+                for name in (
+                    "rust_interop_checks",
+                    "developer_tooling_checks",
+                    "documentation_checks",
+                    "distribution_validation",
+                )
+            ),
+            encoding="utf-8",
+        )
+        output_path = root / "release-profile-report.json"
+        payload = build_release_profile_payload(
+            output_path=output_path,
+            log_path=log_path,
+            profile={
+                "selected_areas": [
+                    {"area": area, "suites": suites}
+                    for area, suites in selected.items()
+                ]
+            },
+            profile_digest="a" * 64,
+            commit="e" * 40,
+            submodules={},
+            toolchain={
+                "rustc": "rustc fixture",
+                "cargo": "cargo fixture",
+                "uv": "uv fixture",
+                "python": "python fixture",
+            },
+            result_root=result_root,
+            artifact_root=root,
+        )
+        canonical = (
+            json.dumps(
+                payload,
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode()
+        output_path.write_bytes(canonical)
+        validate_release_profile_report(
+            json.loads(output_path.read_text(encoding="utf-8")),
+            canonical_bytes=output_path.read_bytes(),
+            expected_profile_sha256="a" * 64,
+        )

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -33,11 +33,9 @@ from .profile_runner import (
 )
 from .profile_area_steps import run_selected_area
 from .profile_results import AreaResultError, validate_area_result
-from .release_evidence import (
-    CRITICAL_RESULTS,
-    build_release_profile_payload,
-    prepare_release_report_output,
-    validate_release_profile_report,
+from .release_evidence_selftest import (
+    release_report_precondition_self_test,
+    release_report_production_self_test,
 )
 from .results import build_result
 from .schemas import load_schema, validate_all_committed_schemas, validate_data, validate_schema_requirement
@@ -51,8 +49,8 @@ def run_all() -> list[str]:
         ("crate membership self-test", _crate_membership_self_test),
         ("Rust interop profile execution self-test", _rust_interop_profile_self_test),
         ("documentation profile execution self-test", _documentation_profile_self_test),
-        ("release report precondition self-test", _release_report_precondition_self_test),
-        ("release report production self-test", _release_report_production_self_test),
+        ("release report precondition self-test", release_report_precondition_self_test),
+        ("release report production self-test", release_report_production_self_test),
         ("e2e profile self-test", _e2e_profile_self_test),
         ("runner discovery self-test", _discovery_self_test),
         ("resource class selection self-test", _resource_class_self_test),
@@ -86,7 +84,7 @@ def _schema_self_test() -> None:
         / "schemas"
     )
     governed = [lint_schema(path) for path in sorted(governance_schemas.glob("*.schema.json"))]
-    if len(governed) != 15:
+    if len(governed) != 16:
         raise AssertionError("release-governance schema lint registration drifted")
     try:
         validate_schema_requirement({"type": "object", "oneOf": []}, Path("bad.schema.json"))
@@ -638,131 +636,6 @@ def _documentation_profile_self_test() -> None:
             pass
         else:
             raise AssertionError("selected-but-unrun documentation suite was accepted")
-
-
-def _release_report_precondition_self_test() -> None:
-    with tempfile.TemporaryDirectory(prefix="sifr-release-report-self-test-") as directory:
-        existing = Path(directory) / "release-profile-report.json"
-        existing.write_text("occupied", encoding="utf-8")
-        cases = [
-            (existing, "release", "already exists"),
-            (Path(directory) / "non-release.json", "merge", "accepted only for the release"),
-            (
-                Path(__file__).resolve().parents[3]
-                / "target"
-                / "release-profile-report.json",
-                "release",
-                "outside the repository checkout",
-            ),
-        ]
-        for path, profile, expected in cases:
-            try:
-                prepare_release_report_output(str(path), profile_name=profile)
-            except ValueError as exc:
-                if expected not in str(exc):
-                    raise AssertionError(f"unexpected release report rejection: {exc}") from exc
-            else:
-                raise AssertionError(f"release report precondition mutation passed: {path}")
-
-
-def _release_report_production_self_test() -> None:
-    selected = {
-        "rust_interop": [
-            "matrix",
-            "tiers",
-            "compatibility-matrix",
-            "stale-drafts",
-            "stable-candidate",
-        ],
-        "developer_tooling": ["full"],
-        "documentation": ["structure", "ga-release"],
-        "distribution_release": [
-            "full",
-            "qualification",
-            "evidence-custody",
-            "incident-governance",
-            "epoch-bootstrap",
-            "protected-drill",
-        ],
-    }
-    with tempfile.TemporaryDirectory(prefix="sifr-release-report-production-") as directory:
-        root = Path(directory)
-        result_root = root / "target" / "verification" / "areas"
-        result_root.mkdir(parents=True)
-        for area, filename in CRITICAL_RESULTS.items():
-            suites = []
-            for suite_name in selected[area]:
-                labels = [f"{suite_name}:case"]
-                if area == "developer_tooling":
-                    labels.append("editor-release:package")
-                suites.append(
-                    {
-                        "name": suite_name,
-                        "cases": [
-                            {
-                                "variants": [
-                                    {"label": label}
-                                    for label in labels
-                                ]
-                            }
-                        ],
-                    }
-                )
-            (result_root / filename).write_text(
-                json.dumps({"area": area, "suites": suites}),
-                encoding="utf-8",
-            )
-        log_path = root / "release.log"
-        log_path.write_text(
-            "".join(
-                f"[sifr-lane-step] name={name} elapsed_ms=1 status=pass\n"
-                for name in (
-                    "rust_interop_checks",
-                    "developer_tooling_checks",
-                    "documentation_checks",
-                    "distribution_validation",
-                )
-            ),
-            encoding="utf-8",
-        )
-        output_path = root / "release-profile-report.json"
-        payload = build_release_profile_payload(
-            output_path=output_path,
-            log_path=log_path,
-            profile={
-                "selected_areas": [
-                    {"area": area, "suites": suites}
-                    for area, suites in selected.items()
-                ]
-            },
-            profile_digest="a" * 64,
-            commit="e" * 40,
-            submodules={},
-            toolchain={
-                "rustc": "rustc fixture",
-                "cargo": "cargo fixture",
-                "uv": "uv fixture",
-                "python": "python fixture",
-            },
-            result_root=result_root,
-            artifact_root=root,
-        )
-        canonical = (
-            json.dumps(
-                payload,
-                ensure_ascii=False,
-                allow_nan=False,
-                sort_keys=True,
-                separators=(",", ":"),
-            )
-            + "\n"
-        ).encode()
-        output_path.write_bytes(canonical)
-        validate_release_profile_report(
-            json.loads(output_path.read_text(encoding="utf-8")),
-            canonical_bytes=output_path.read_bytes(),
-            expected_profile_sha256="a" * 64,
-        )
 
 
 def _e2e_profile_self_test() -> None:


### PR DESCRIPTION
## Summary

- add credential-free protected prepare for GA activation and normal stable publication
- bind exact candidate, qualification artifacts, source, Marketplace, site, and live-index evidence
- add safe exact-ID GitHub artifact extraction and schema-v2 stable prepare evidence
- register the stable-prepare verification suite and release-report requirement

## Validation

- `scripts/run_all_tests.sh --profile create-pr` (pass; 131/131 e2e)
- distribution full + stable-prepare: 60/60
- governance selftest: 14/14
- stable-prepare selftest: 6/6
- runner foundation: 11/11
- coverage readiness: 5/5
- workflow contracts, Ruff, diff/file-size guardrails

## Review

- Claude Opus pass 1: SATISFIED (archived in the repository)
- exact PR-head review rounds will follow before merge