### PR TITLE
docs: track generated NaN Clippy follow-up

### DIFF
--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -283,6 +283,18 @@ Review and upstream coordination ledger:
   variant passed on the same run. Milestone 40.5 also owns the missing
   test-only endpoint override so installed-sysroot qualification uses an
   isolated schema-v2 fixture instead of mutable public network state.
+- On exact source `8a23f90869a68438a7b4ae3b8f9623531d1ce68f`, a
+  low-noise canonical release-profile run passed all eight performance
+  variants, all 69 distribution-release variants, all 25 Python-interop
+  variants, all 10 consumed Rust-interop variants, all 48 developer-tooling
+  variants, and both GA documentation variants. The blocking release profile
+  later reached its first generated-code Clippy failure at
+  `e2e-018-cpython-math-semantic-corrections`, whose emitted
+  `const NAN: f64 = (0.0_f64) / (0.0_f64);` is rejected by Rust 1.94
+  `clippy::zero_divided_by_zero`; later ordered corpus entries were not
+  Clippy-checked by that run. This generated stdlib constant defect is recorded
+  in indexed, non-prerequisite follow-up `GENC-NAN`; no Clippy allow,
+  release-profile selection, threshold, or stable-governance contract changed.
 - Milestone evidence-closure Claude Opus review passes 1 through 4 are archived
   at
   `plans/reviews/archive/phase-40-milestone-40-4-evidence-closure-review-pass-{1,2,3,4}.md`.

--- a/plans/phases/adhoc_generated_nan_constant_clippy_quality.md
+++ b/plans/phases/adhoc_generated_nan_constant_clippy_quality.md
@@ -1,0 +1,89 @@
+# Ad Hoc Phase: Generated NaN Constant Clippy Quality
+
+Status: deferred follow-up; not a prerequisite for Phase 40.
+
+## Problem
+
+The generated-code quality release gate rejects the emitted Rust representation
+of the Sifr `math.nan` constant in the CPython math semantic-corrections
+fixture. The generated constant is:
+
+```rust
+const NAN: f64 = (0.0_f64) / (0.0_f64);
+```
+
+Rust 1.94 Clippy reports `clippy::zero_divided_by_zero` under the governed
+generated-code `-D warnings` policy and recommends the canonical `f64::NAN`
+constant.
+
+The fixture compiles, formats, and emits deterministically. This is a generated
+stdlib constant quality failure, not a Phase 40 stable-channel governance or
+release-artifact failure.
+
+## Evidence
+
+On exact Phase 40 source commit
+`8a23f90869a68438a7b4ae3b8f9623531d1ce68f`, the unchanged canonical release
+profile:
+
+- passed the full performance area (8 variants);
+- passed the complete distribution-release area (69 variants);
+- passed all 25 selected Python-interop variants;
+- consumed and passed all 10 selected Rust-interop variants;
+- passed all 48 developer-tooling variants;
+- passed both GA documentation variants;
+- passed generated-code corpus, panic scan, intrinsic panic lint, rustfmt,
+  determinism, and demos;
+- reached its first generated-code Clippy failure at
+  `e2e-018-cpython-math-semantic-corrections`, where the Clippy variant stopped.
+  Entries later in the ordered corpus were not Clippy-checked by this run and
+  must be exercised after the first failure is fixed.
+
+The release profile therefore exited with the blocking
+`generated_code_quality_checks` step failed (`blocking_failures=1`) and no
+release-profile report was emitted. It also reported the separate advisory
+that the warm wall-time target was exceeded. Deferring this generated-constant
+defect is an explicit scope decision; it does not reclassify the canonical
+release profile as passing.
+
+The generated crate containing the offending code is:
+
+`/private/tmp/sifr-phase40-release-source-8a23f908-20260728T165853Z/target/sifr_generated_code_quality/release.shared/entries/e2e-018-cpython-math-semantic-corrections-0108e9606ab793b2/sifr_output`
+
+The authoritative run log is:
+
+`/tmp/sifr-phase40-ga-release-profile-retry-7.log`
+
+No Clippy allow, performance waiver, release-profile selection, source
+baseline, or stable-governance contract was changed.
+
+## Scope
+
+- Identify the canonical Sifr-to-Rust representation for non-finite float
+  constants, including the `stdlib/_sifr/math.sifr` definitions that currently
+  express NaN and infinity through division.
+- Emit `f64::NAN` for the Sifr `math.nan` constant without changing its Sifr
+  runtime semantics.
+- Audit positive and negative infinity constants for the same canonical
+  representation boundary.
+- Add focused codegen coverage for NaN and infinity constant emission.
+- Run the focused generated-code Clippy group and the complete generated-code
+  quality area.
+- Confirm the governed generated-code Clippy allowlist does not gain
+  `clippy::zero_divided_by_zero`.
+
+## Out of Scope
+
+- Renaming the CPython math semantic-corrections fixture or any demo.
+- Removing the fixture from generated-code quality coverage.
+- Adding a broad Clippy allow for constant division by zero.
+- Changing Phase 40 release-governance schemas, workflows, artifacts, or
+  publication policy.
+
+## Definition of Done
+
+- Non-finite Sifr float constants emit canonical Rust constants.
+- The focused math semantic-corrections fixture passes generated-code Clippy
+  with `-D warnings`.
+- The complete generated-code quality area passes without a new allow.
+- Codegen tests cover NaN and both infinity signs.

--- a/plans/phases/index.md
+++ b/plans/phases/index.md
@@ -49,6 +49,7 @@ successor and is summarized here.
 | 39 | Phase 39: Rust Interop | completed, audited (2026-06-22, PRs #2702-#2729) | [39_rust_interop.md](./39_rust_interop.md) |
 | 40 | Phase 40: Stable Channel GA Promotion and Release Governance | in progress | [40_stable_channel_ga_promotion_and_release_governance.md](./40_stable_channel_ga_promotion_and_release_governance.md) |
 | ALG-CORPUS | Ad Hoc Algorithmic Full-Corpus Pre-Existing Failures | active non-blocking follow-up | [../issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md](../issues/active/ad-hoc-algorithmic-full-corpus-preexisting-failures.md) |
+| GENC-NAN | Ad Hoc Generated NaN Constant Clippy Quality | deferred follow-up | [adhoc_generated_nan_constant_clippy_quality.md](./adhoc_generated_nan_constant_clippy_quality.md) |
 | PKG-RUST | Ad Hoc Packaged Candidate Generated Rust | deferred follow-up | [adhoc_packaged_candidate_generated_rust.md](./adhoc_packaged_candidate_generated_rust.md) |
 | PERF-HOST | Ad Hoc Performance Budget Host Variance | deferred follow-up | [adhoc_performance_budget_host_variance.md](./adhoc_performance_budget_host_variance.md) |
 | 41 | Phase 41: Native Pydantic-Sifr | superseded by canonical ad hoc design | [41_typed_data_model_and_validation.md](./41_typed_data_model_and_validation.md) |

--- a/plans/reviews/archive/generated-nan-constant-clippy-quality-review-pass-1.md
+++ b/plans/reviews/archive/generated-nan-constant-clippy-quality-review-pass-1.md
@@ -1,0 +1,36 @@
+I inspected the plan, the full 1944-line release log, the corpus manifest, the runner, the preserved workspace, and the generated `main.rs`. No files modified.
+
+## What checks out
+
+Every quantitative evidence claim in the plan matches the log exactly:
+
+| Plan claim | Log |
+|---|---|
+| performance 8 variants | `:557` `variants=8, failures=0` |
+| distribution-release 69 | `:839` `variants=69, failures=0` |
+| Python interop 25 | `:331` `variants=25, failures=0` |
+| Rust interop 10 (consumed) | `:363` `variants=10, failures=0` |
+| developer tooling 48 | `:507` `variants=48, failures=0` |
+| GA documentation 2 | `:519` `variants=2, failures=0` |
+| corpus/panic-scan/rustfmt/determinism/demos pass | `:1348,1533,1721,1906,1928` |
+| only failure = clippy on e2e-018 | `:1811` sole `status=fail` case; `:1930` `failures=1` |
+| Rust 1.94 `zero_divided_by_zero`, `f64::NAN` help | `:1731-1737` |
+| source commit `8a23f9086…` | run dir `…-8a23f908-…`; repo HEAD matches |
+
+The diagnosed construct is real and root-level: the generated preamble emits `const INF: f64 = (1.0_f64) / (0.0_f64);` and `const NAN: f64 = (0.0_f64) / (0.0_f64);`, originating from `stdlib/_sifr/math.sifr:4-5`. Scope and Definition of Done correctly target that representation; Out of Scope correctly forbids a Clippy allow, fixture renaming, coverage removal, and any governance/Rust-interop change. The infinity audit item is well-founded (`INF` has the same non-canonical shape).
+
+## Actionable findings
+
+**1 — MEDIUM · Follow-up is not registered in the phase index (`plans/phases/index.md:52-53`).** Both sibling deferrals carry index IDs (`PKG-RUST`, `PERF-HOST`) and are cross-referenced from `plans/issues/active/phase-40-stable-channel-ga-execution.md`. Phase 40's acceptance language throughout the ledger and archived reviews is specifically "the *indexed* … follow-up" (e.g. `phase-40-stable-channel-ga-execution.md:1113,1131`). An unindexed, unreferenced plan cannot be cited by that mechanism, so the deferral it asserts is not yet established anywhere. This is documentation-only and does not touch Phase 40 implementation.
+
+**2 — MEDIUM · Evidence omits the overall lane outcome (`adhoc_generated_nan_constant_clippy_quality.md:30-37`).** The list enumerates passes and the single Clippy failure but never states that the release profile itself exited red: `generated_code_quality_checks … status=fail` (`:1931`), `blocking_failures=1` (`:1930`), plus the advisory `warm wall-time budget exceeded` (`:1943`). Read against line 3's "not a prerequisite for Phase 40", the omission lets the record be read as "the canonical release profile is green apart from a cosmetic nit". The runner classifies this as blocking, and the plan itself confirms no waiver exists (`:47-48`). State the blocking classification explicitly so the deferral is a recorded judgement rather than an implied green gate.
+
+**3 — LOW · "executes" is not supported by the cited evidence (`:19`).** `e2e-018` has `expected_command: "build"` (`corpus_manifest.json:244-249`), and the corpus mode only runs `sifr build … -o` (`generated_code_quality.py:501-509`) — no execution. The log's e2e-018 cases are corpus/panic-scan/rustfmt/clippy/determinism only. "compiles, formats, and emits deterministically" is exactly supported; drop "executes" or cite the e2e pass suite instead.
+
+**4 — LOW · The cited preserved workspace does not contain the offending code (`:39-41`).** `clippy-1785266349-32724/` holds only `negative-clippy/` (the negative-seed scratch crate). The crate that failed is `…/release.shared/entries/e2e-018-cpython-math-semantic-corrections-0108e9606ab793b2/sifr_output` (`:1723`, `:1727`), where `src/main.rs:7` is the flagged line. The plan faithfully copies the log's `preserved=` value, but an implementer following the pointer will find no NaN there — cite the entry path as the artifact.
+
+**5 — LOW · Variant enumeration is incomplete (`:35`).** The generated-code-quality area ran 7 variants; the list names five and silently drops `intrinsic-panic-lint` (`:1536`, passed). Add it so passes + the one failure reconcile to `variants=7`.
+
+Non-blocking note: codegen already renders canonical `f64::NAN` / `f64::INFINITY` for non-finite float literals (`crates/sifr_codegen/src/render/render_expr_and_blocks.rs:384-389`), so the gap is that the `0.0 / 0.0` division in `stdlib/_sifr/math.sifr:4-5` never reaches a float-literal form. Naming that source location in Scope would sharpen the root-cause target without widening it.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/generated-nan-constant-clippy-quality-review-pass-2.md
+++ b/plans/reviews/archive/generated-nan-constant-clippy-quality-review-pass-2.md
@@ -1,0 +1,27 @@
+## Pass-1 closure
+
+All five pass-1 findings are closed:
+
+| Pass 1 | Status |
+|---|---|
+| 1 — not indexed | Closed. `plans/phases/index.md:52` adds `GENC-NAN` beside `PKG-RUST`/`PERF-HOST`, and the ledger cites it at `phase-40-stable-channel-ga-execution.md:295` |
+| 2 — lane outcome omitted | Closed. Plan `:41-45` states `generated_code_quality_checks` blocking failure, `blocking_failures=1`, no report emitted, warm wall-time advisory, and "does not reclassify the canonical release profile as passing" (log `:1930-1931,:1943`) |
+| 3 — "executes" unsupported | Closed. Plan `:19` now reads "compiles, formats, and emits deterministically" |
+| 4 — wrong preserved path | Closed in substance. Plan `:49` cites the failing entry crate instead of the negative-seed scratch dir (see finding 3 for a residual issue) |
+| 5 — incomplete enumeration | Closed. `intrinsic panic lint` added at `:35`; five passing variants + one failure now reconcile to `variants=7` |
+
+Independent re-verification of every quantitative claim against `/tmp/sifr-phase40-ga-release-profile-retry-7.log` matched (8/69/25/10/48/2 variants at `:557,:839,:331,:363,:507,:519`; Rust 1.94 `zero_divided_by_zero` + `f64::NAN` help at `:1731-1737`; quoted constant is byte-exact with `src/main.rs:7`). The diff is documentation-only (`index.md` +1, ledger +11); no allow, profile, demo, or governance change.
+
+## Actionable findings
+
+**1 — MEDIUM · "failed only … entry `e2e-018`" omits that Clippy coverage aborted mid-corpus** (`plans/phases/adhoc_generated_nan_constant_clippy_quality.md:37-38`; `plans/issues/active/phase-40-stable-channel-ga-execution.md:290-292`). `gate_clippy` re-raises on the first failing entry (`verification/areas/generated_code_quality/generated_code_quality.py:763-785`), so the variant terminated at that entry rather than completing. The log shows 34 positive Clippy passes vs 91 positive rustfmt passes; `e2e-018` is index 34 of the 96-entry manifest (`data/corpus_manifest.json`), leaving ~56 entries never Clippy-checked on this run — including `stdlib-007-math`, which has corpus/panic-scan/rustfmt/determinism cases (`:1339-1901`) but no `clippy/` case. As written, the record supports "the rest of the generated-code corpus is Clippy-clean," which the run does not establish; fixing the NaN constant will advance the gate to previously unreached entries. State that Clippy coverage stopped at the first failure.
+
+**2 — LOW · "fixture-quality defect" scopes the root cause too narrowly** (`plans/issues/active/phase-40-stable-channel-ga-execution.md:293-294`; plan `:20-21`). The construct originates in `stdlib/_sifr/math.sifr:4-5` (`inf: float = 1.0 / 0.0`, `nan: float = 0.0 / 0.0`) and is emitted into every crate importing `math` — `stdlib-007-math`'s generated `src/main.rs:6-7` is byte-identical to the flagged lines. The plan's own Scope correctly targets the stdlib definitions, so the ledger label contradicts it; "generated stdlib constant defect" is accurate and equally non-prerequisite.
+
+**3 — LOW · The cited crate path is not resolvable** (plan `:47-49`). The path is given repo-relative (`target/sifr_generated_code_quality/release.shared/entries/e2e-018-…/sifr_output`), but the artifact exists only under the isolated run root `/private/tmp/sifr-phase40-release-source-8a23f908-20260728T165853Z/target/…` (log `:1723`); no such directory exists in the worktree. Cite the absolute run-root path as the log does.
+
+**4 — LOW · Ledger paraphrases the emitted constant** (`plans/issues/active/phase-40-stable-channel-ga-execution.md:292-294`). It quotes `const NAN: f64 = 0.0 / 0.0`; the emitted text is `const NAN: f64 = (0.0_f64) / (0.0_f64);` (log `:1731`). In an exact-source evidence paragraph the quote should be verbatim, as the plan's `:12` already is.
+
+Non-blocking: `plans/reviews/active/generated-nan-constant-clippy-quality-review-pass-2.md` is currently a zero-byte placeholder; I did not modify it.
+
+VERDICT: NOT SATISFIED

--- a/plans/reviews/archive/generated-nan-constant-clippy-quality-review-pass-3.md
+++ b/plans/reviews/archive/generated-nan-constant-clippy-quality-review-pass-3.md
@@ -1,0 +1,31 @@
+I inspected the working tree (tracked diff + all untracked artifacts), archived passes 1–2, the full 1944-line log, the corpus manifest, the runner, and the preserved generated crate. No files modified.
+
+## Independent verification against `/tmp/sifr-phase40-ga-release-profile-retry-7.log` and source
+
+| Claim | Evidence |
+|---|---|
+| source `8a23f9086…` | `git rev-parse HEAD` matches exactly; run root `…-8a23f908-20260728T165853Z` |
+| 8 / 69 / 25 / 10 / 48 / 2 variants | log `:557`, `:839`, `:331`, `:363`, `:507`, `:519` — all `failures=0` |
+| corpus, panic-scan, intrinsic-panic-lint, rustfmt, determinism, demos pass | `:1348`, `:1533`, `:1536`, `:1721`, `:1906`, `:1928` — 6 passes + 1 clippy fail reconcile to `variants=7` (`:1930`) |
+| blocking red + warm advisory | `:1930` `blocking_failures=1`; `:1931` `generated_code_quality_checks status=fail`; `:1943` `advisories=warm wall-time budget exceeded`. "No release-profile report was emitted" is accurate under the repo's own meaning of that term (the canonical governance artifact, written only when `status == 0` — `profile_runner.py:885-896`; `internal_docs/distribution_pipeline.md:234`), distinct from the lane report `release.latest.json` |
+| byte-exact constant | plan `:12` and ledger `:293` both quote `const NAN: f64 = (0.0_f64) / (0.0_f64);` — byte-identical to log `:1731` and to the preserved crate's `src/main.rs:7` |
+| Rust 1.94 / `zero_divided_by_zero` / `f64::NAN` help | `:1734-1737` |
+| absolute isolated artifact path | plan `:51` matches log `:1723`/`:1727` character-for-character; directory exists and contains the offending `src/main.rs` |
+| compiles / formats / emits deterministically (no "executes") | e2e-018 has `corpus` `:1234`, `panic-scan` `:1419`, `rustfmt` `:1607`, `determinism` `:1848` — all pass; no execution case, and no execution is claimed |
+| Clippy aborted at first failure; later entries unchecked | 36 `clippy/` cases vs 92 `rustfmt/` cases; e2e-018 is index 34 of 96 manifest entries; `gate_clippy` re-raises on first failure. Plan `:37-40` and ledger `:292-294` both state the abort and that later ordered entries were not Clippy-checked |
+| root cause scoped to generated stdlib constant | plan `:19-21` "generated stdlib constant quality failure"; ledger `:294` "generated stdlib constant defect"; Scope `:63-64` names `stdlib/_sifr/math.sifr`, whose `:4-5` are `inf: float = 1.0 / 0.0` / `nan: float = 0.0 / 0.0`; the generated `INF` at `src/main.rs:6` shows the same shape, justifying the infinity audit item |
+| indexed + ledger registration | `plans/phases/index.md:52` registers `GENC-NAN` beside `PKG-RUST`/`PERF-HOST`; ledger `:296` cites it as "indexed, non-prerequisite follow-up" |
+
+## Prohibited-change checks
+
+- **No false green**: plan `:42-47` states the blocking failure, `blocking_failures=1`, the warm advisory, and "does not reclassify the canonical release profile as passing".
+- **No Clippy allow**: `zero_divided_by_zero` appears nowhere in `verification/`, `crates/`, or `Cargo.toml`; the allowlist in log `:1723` does not contain it, and Out of Scope `:79` plus DoD `:88` forbid adding it.
+- **No profile weakening, demo rename, Phase 40 implementation, or Rust-interop work**: `git diff HEAD -- crates/ verification/ scripts/ demos/ stdlib/` is empty. The whole change is documentation: `index.md` +1, ledger +12, one new ad-hoc phase plan, plus review artifacts.
+
+## Actionable findings
+
+None.
+
+Two non-blocking observations, neither a defect in the change under review: `plans/reviews/active/generated-nan-constant-clippy-quality-review-pass-3.md` is a zero-byte placeholder (I did not modify it, per instruction), and `plans/releases/candidates/0.1.0/release-notes.md` is unrelated pre-existing untracked Phase 40 work containing no claim about this run.
+
+VERDICT: SATISFIED


### PR DESCRIPTION
## Summary
- register the capability-named GENC-NAN deferred follow-up
- record the exact Phase 40 release-gate evidence and blocking Clippy first failure
- preserve three Claude Opus review rounds, ending SATISFIED

## Validation
- python3 scripts/check_file_size_guardrails.py
- git diff --check
- Claude Opus review pass 3: SATISFIED

This PR is documentation-only. It does not change Phase 40 implementation, release profiles, Clippy policy, demos, or Rust interop.