### PR TITLE
fix(release): canonicalize candidate custody evidence

### DIFF
--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -229,7 +229,15 @@ python3 scripts/distribution/release_governance.py \
 The release-profile evidence writer similarly canonicalizes the exact
 Rust-interop result emitted by that release run before hashing it into
 `release-profile-report.json`. Candidate custody copies that same result file;
-a standalone Rust-suite rerun is not interchangeable evidence.
+a standalone Rust-suite rerun is not interchangeable evidence:
+
+```bash
+cp \
+  <clean-source-checkout>/target/verification/areas/rust-interop-release-results.json \
+  <release-work-dir>/rust-validation-report.json
+```
+
+Pass that copied result to the planner's `--rust-validation-report` argument.
 
 The final collector reads the current workflow run's artifact API, verifies
 source/run attribution, and writes canonical

--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -213,6 +213,24 @@ python3 scripts/distribution/qualify_stable_documentation.py \
 
 Pass that exact report to the planner's `--documentation-report` argument.
 
+Stage the source commit's certified Rust support claims into canonical candidate
+custody bytes from the clean source checkout used for the release. The command
+validates the claims contract, refuses an in-checkout or existing output, and
+the planner later verifies source cleanliness and requires the staged bytes to
+equal the canonical representation of the exact source file:
+
+```bash
+python3 scripts/distribution/release_governance.py \
+  stage-stable-support-claims \
+  --source-root <clean-source-checkout> \
+  --out <release-work-dir>/stable-support-claims.json
+```
+
+The release-profile evidence writer similarly canonicalizes the exact
+Rust-interop result emitted by that release run before hashing it into
+`release-profile-report.json`. Candidate custody copies that same result file;
+a standalone Rust-suite rerun is not interchangeable evidence.
+
 The final collector reads the current workflow run's artifact API, verifies
 source/run attribution, and writes canonical
 `qualification-artifact-index.json`. The index binds recursive submodules,

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -332,6 +332,55 @@ Review and upstream coordination ledger:
   and returned `VERDICT: SATISFIED`. The release-divergence slice merged
   through [PR #3049](https://github.com/sifr-lang/sifr/pull/3049) as
   `bae42ba47d4c1324b2d34dc654effaef2d39576e`.
+- Fresh exact-source qualification run
+  [#30406842210](https://github.com/sifr-lang/sifr/actions/runs/30406842210)
+  passed at source `53cc9c4bf36762d39a0b372402d202589f920c2e`: all four
+  targets, aggregate installer/checksums, editor/VSIX qualification, and the
+  collector succeeded. Independent custody replay verified the canonical index,
+  all six unexpired uploads, and all 20 transported payloads by exact size and
+  SHA-256.
+- Final qualification-evidence review pass 1 is archived at
+  `plans/reviews/archive/phase-40-final-qualification-evidence-review-pass-1-not-satisfied.md`.
+  It returned `VERDICT: NOT SATISFIED` after proving a real supporting-evidence
+  incompatibility: the release report hashed the Rust runner's pretty-printed
+  result while candidate custody required canonical JSON, the certified stable
+  claims source also needed deterministic canonical staging, and the staged
+  Rust report had come from a standalone rerun instead of the release-profile
+  invocation. The qualification transport itself passed the full independent
+  audit.
+- The remediation stays within Phase 40 release custody: the passing release
+  evidence writer canonicalizes the exact consumed Rust result before binding
+  its digest; a governed staging command derives canonical stable-claims bytes
+  from the exact source file; and the planner requires those staged bytes to
+  match that source-derived representation. No Rust-interop capability,
+  compatibility claim, suite selection, or implementation changes.
+- Canonical candidate-evidence review pass 2 is archived at
+  `plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-2-satisfied.md`.
+  It independently reproduced all three blocker closures, ran the complete
+  distribution area at 125/125, and returned `VERDICT: SATISFIED` with no
+  blocking finding. Its recommended hardening is included before the next
+  review: Rust-claim digest sensitivity now asserts both changed claim digest
+  and ids despite the necessarily changed source commit; mutation tests cover
+  noncanonical, drifted, in-checkout, missing, duplicate-key, wrong-area, and
+  symlink evidence; the real CLI wiring is exercised; and the planner requires
+  canonical Rust report bytes at its earliest load.
+- Hardened-tree review pass 3 is archived at
+  `plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-3-satisfied.md`.
+  It mutation-tested every new guard, independently reran the complete
+  distribution area at 125/125 plus runner, qualification, custody, formatting,
+  diff, and file-size gates, found no blocking issue, and returned
+  `VERDICT: SATISFIED`. The reviewed diff touches no Rust-interop implementation
+  or demo.
+- The first authoritative create-PR attempt passed every case around the
+  pre-existing `readonly-check-doctor` command, which hit its fixed 120-second
+  subprocess limit under host contention. Its exact isolated suite immediately
+  passed with one variant and zero failures. The warmed authoritative rerun then
+  passed every blocking lane: Python interop 19/19, consumed Rust interop 10/10,
+  generated-code and performance gates, all selected crates and runtime checks,
+  and E2E 131/131 with `report_signature=7c39b8c1dd4fec7c`. Every enforced
+  per-step budget passed; only the indexed nonblocking warm wall-time advisory
+  remained. No timeout, threshold, baseline, waiver, or profile selection
+  changed.
 - Milestone evidence-closure Claude Opus review passes 1 through 4 are archived
   at
   `plans/reviews/archive/phase-40-milestone-40-4-evidence-closure-review-pass-{1,2,3,4}.md`.

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -1326,3 +1326,32 @@ updating or deleting that exact tag with no bypass actors.
   `e42bb9a3d4fb48ae3ba50fc9209aa2e8cd5c10d7`.
 - Main-repository [PR #3032](https://github.com/sifr-lang/sifr/pull/3032)
   merged as `97df4acb4656ee55754ec87d4c2d982b13df740e`.
+
+### canonical_candidate_evidence_remediation
+
+- Final qualification-evidence review pass 1 is archived at
+  `plans/reviews/archive/phase-40-final-qualification-evidence-review-pass-1-not-satisfied.md`.
+  The reviewer confirmed the transport and retention evidence, then found that
+  pretty-printed Rust results and stable-support claims could not satisfy the
+  candidate custody contract's canonical-JSON requirement. It also found that
+  the staged Rust report had to be the exact release-profile result rather than
+  a standalone rerun.
+- Release-report generation now canonicalizes that exact release-run Rust
+  result before hashing it. Stable-support claims are staged deterministically
+  from the exact source checkout into custody, and both the source and staged
+  bytes are validated as canonical JSON. The planner rejects noncanonical,
+  drifted, symlinked, duplicate-key, and wrong-area inputs.
+- Reviewer passes 2 and 3 are archived at
+  `plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-2-satisfied.md`
+  and
+  `plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-3-satisfied.md`.
+  Both returned `SATISFIED`; pass 3 independently reran the complete
+  distribution area (125/125) and found no blocking issue.
+- The authoritative create-PR profile passed at implementation commit
+  `8048de4343`, including Python interop 19/19, consumed Rust interop 10/10,
+  and E2E 131/131 (`report_signature=7c39b8c1dd4fec7c`). A preceding cold
+  attempt hit only the already indexed `PERF-HOST` timeout in
+  `readonly-check-doctor`; an isolated replay passed 1/1 in 160.114 seconds.
+- Main-repository [PR #3051](https://github.com/sifr-lang/sifr/pull/3051)
+  carries the focused Phase 40 remediation from implementation commit
+  `8048de4343`. Its exact pushed-head review follows after this tracking update.

--- a/plans/issues/active/phase-40-stable-channel-ga-execution.md
+++ b/plans/issues/active/phase-40-stable-channel-ga-execution.md
@@ -1338,9 +1338,11 @@ updating or deleting that exact tag with no bypass actors.
   a standalone rerun.
 - Release-report generation now canonicalizes that exact release-run Rust
   result before hashing it. Stable-support claims are staged deterministically
-  from the exact source checkout into custody, and both the source and staged
-  bytes are validated as canonical JSON. The planner rejects noncanonical,
-  drifted, symlinked, duplicate-key, and wrong-area inputs.
+  from the exact source checkout into custody; the staged bytes must be
+  canonical JSON and exactly equal the source claims' canonical
+  representation. The release evidence writer rejects a wrong-area Rust
+  result, while the writer and planner reject applicable noncanonical,
+  drifted, symlinked, and duplicate-key inputs.
 - Reviewer passes 2 and 3 are archived at
   `plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-2-satisfied.md`
   and
@@ -1355,3 +1357,13 @@ updating or deleting that exact tag with no bypass actors.
 - Main-repository [PR #3051](https://github.com/sifr-lang/sifr/pull/3051)
   carries the focused Phase 40 remediation from implementation commit
   `8048de4343`. Its exact pushed-head review follows after this tracking update.
+- Exact PR-head reviewer pass 4 is archived at
+  `plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-4-pr-head.md`.
+  It independently verified remote head `1841576ce`, reran the complete
+  distribution area 125/125 and the isolated `readonly-check-doctor` case 1/1,
+  closed blockers A-C, and returned `SATISFIED`. Its four low-severity
+  observations are also resolved: release-result and source-claims symlinks
+  now fail closed, operator documentation names the exact Rust result copy,
+  and this ledger precisely distinguishes source JSON from canonical staged
+  bytes. The focused qualification/custody selection, runner self-tests, both
+  guardrails, and diff checks pass after that hardening.

--- a/plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-2-satisfied.md
+++ b/plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-2-satisfied.md
@@ -1,0 +1,42 @@
+# VERDICT: SATISFIED
+
+All three pass‑1 blockers are closed, and I reproduced each closure independently against real code paths. No blocking findings. Nine non‑blocking items follow, the first two of which I'd fix before merge.
+
+## Blocker closure — independently verified
+
+**Finding A (release‑report digest vs. canonical custody) — CLOSED.** `release_evidence.py:130-140` canonicalizes the exact release‑run Rust result in place, and `write_release_profile_report:91-112` calls it *before* `build_release_profile_payload` (which hashes via `sha256_file` at `:249`) and before both `validate_release_profile_report` passes. Ordering is correct. Driving the real `rust_candidate_result()` fixture through it:
+
+```
+pretty digest      : 18c3bfae2c78fdc9...      (pre-normalization)
+post-write digest  : 7dcf81696f2030a4...
+canonical digest   : 7dcf81696f2030a4...      tie holds: True
+custody require_canonical on post-write bytes: ACCEPT
+```
+
+The formerly impossible state is now the only satisfiable one. Fail‑closed branches all fire: missing result → `REJECT`, wrong `area` identity → `REJECT`, duplicate keys → `REJECT`.
+
+**Finding B (noncanonical source claims) — CLOSED.** The real `verification/areas/rust_interop/data/stable_support_claims.json` is confirmed noncanonical; `stage_stable_support_claims` (`planner.py:195-207`) emits `canonical_json_bytes(source)` (29 claims, 4517 B), and `validate_staged_support_claims:210-223` requires exactly those bytes. Verified rejections: noncanonical staged bytes, canonical‑but‑drifted staged bytes, staged bytes after the source drifts underneath, missing source, overwrite, out‑path inside the source root, and out‑path reaching the source root through a symlinked parent. The digest is safe to move off the source file's raw bytes — I confirmed no validator compares `stable_support_claims_sha256` to the in‑repo file (`stable_prepare.py:753-784` binds only the compatibility matrix, facts schema, and facts generator to source).
+
+**Finding C (standalone rerun) — CLOSED.** Candidate custody's rust report must equal the release report's `result_artifacts` digest (`planner.py:728-746`, `evidence_custody.py:252-260`, `stable_prepare.py:801-810`), and the planner additionally re‑verifies that artifact on disk under `source_root` (`verify_artifacts=True` → `release_report.py:347-352`). Since that digest is now the canonicalized release‑run bytes, a standalone rerun (which differs in `duration_ms`) cannot satisfy it. The doc's "a standalone Rust‑suite rerun is not interchangeable evidence" is enforced, not aspirational.
+
+**Post‑run ordering / interactions.** `write_release_profile_report` runs at `profile_runner.py:885-894`, after the full run and after `reports.summarize`, so no consumer sees rewritten bytes; `prepare_release_report_output` deletes the critical results up front, so no stale double‑normalization. Dirty‑source staging fails closed downstream via `validate_source_identity`. Re‑ran locally: `distribution_release` area 125/125 variants, 0 failures; `sifr_verify --self-test` all pass including release report production; file‑size guardrails PASS (2952 files); `git diff --check` clean. Zero files under `crates/`, `demos/`, or `rust_interop/` touched — no Rust‑interop implementation and no demo‑naming violation.
+
+## Findings
+
+**1 · MEDIUM — the `rust-claims` digest‑sensitivity assertion is now degenerate.** `qualification_plan_digest_selftest.py:65,83` moves `rust-claims` from the same‑source input group into the new‑source group. That variant now rewrites the fixture source's claims file, which changes the fixture commit — verified: baseline `4efeff2cfa67…`, rust‑claims `0d31dbd046ac…`. The plan digest therefore changes via `$.source_commit` alone, so the assertion passes even if claim content were ignored entirely. Phase DoD line 563‑564 ("changing any … Rust-claim input … changes the fixture plan digest") and the ledger's "Rust‑claim … digest sensitivity" evidence line are now trivially satisfied. The move itself is *necessary* — a same‑source claims variant would now be rejected by the source binding — but the isolation was lost with it. Fix: inside the `rust-claims` branch, also assert the produced plan's `rust_interop.stable_support_claims_sha256` and `advertised_claim_ids` differ from baseline's.
+
+**2 · MEDIUM — the branches that actually close A and B have no regression test.** Untested: `validate_staged_support_claims`'s source‑mismatch branch and its `require_canonical` gate; `stage_stable_support_claims`'s in‑source‑output refusal; `canonicalize_custodied_results`'s missing‑file and area‑identity branches. `_test_stable_support_claim_staging` covers only canonical output and overwrite refusal. Nothing exercises the two layers end‑to‑end — pretty runner bytes → canonicalized digest → custody `require_canonical` + digest tie — which is precisely Finding A's defect class; each side asserts its half with the same helper. I verified all of it by hand, so this is coverage, not correctness. Recommend one `qualification_selftest` drift case (noncanonical / source‑drifted staged claims) and one custody case seeded from pretty‑printed rust bytes passed through `canonicalize_custodied_results`.
+
+**3 · LOW — new CLI subcommand untested.** `stage-stable-support-claims` is exercised only at function level; an argparse wiring error would be invisible. Verified manually: it stages canonically and refuses overwrite with a governed message.
+
+**4 · LOW — symlinked source claims accepted.** `stage_stable_support_claims` does not reject a symlinked `stable_support_claims.json` (verified `ACCEPT`), unlike the sibling convention at `planner.py:425` (`validate_installer_bytes` refuses a symlinked generator). Low risk — the planner requires a clean checkout, so the link would have to be committed — but a `source_path.is_symlink()` refusal would match the surrounding code. Same for the staged path in `validate_staged_support_claims` (candidate custody catches it later, at `evidence_custody.py:175-181`).
+
+**5 · LOW — planner still loads the rust report without `require_canonical`.** `planner.py:153` is now the only planner evidence load that omits the flag. It's enforced transitively by the digest tie, but a report from a pre‑remediation writer would pass the planner and fail only later in custody. Adding the flag moves the failure to the earliest point.
+
+**6 · INFO — two housekeeping items before commit.** `plans/reviews/active/phase-40-canonical-candidate-evidence-review-pass-2.md` is a 0‑byte placeholder, and the pass‑1 archive the ledger cites is still untracked. Both must land in the commit for the ledger reference at `phase-40-stable-channel-ga-execution.md:344-345` to be truthful.
+
+**7 · INFO — doc vs. flag default.** `internal_docs/distribution_pipeline.md:223` shows `--source-root <clean-source-checkout>`, but the flag defaults to the invoking repo root and staging performs no cleanliness check. It fails closed downstream, so this is documentation nuance only. Every other claim in the new doc block and the new ledger entries checks out against the code.
+
+**8 · INFO — NaN handling.** A NaN in a runner result surfaces as a plain `ValueError` from `canonical_json_bytes` rather than `GovernanceError` (verified). `profile_runner.py:894` catches `ValueError`, so it fails closed with status 2 and no traceback leak. This is strictly stronger than the pre‑diff behavior, which would have hashed the bytes and moved on.
+
+**9 · INFO — headroom.** `planner.py` 816/900, `qualification_fixture.py` 853/900. The next change to either should split rather than append.

--- a/plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-3-satisfied.md
+++ b/plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-3-satisfied.md
@@ -1,0 +1,41 @@
+## VERDICT: SATISFIED
+
+All six hardening requirements are implemented and independently reproduced. No blocking findings.
+
+### Independent verification
+
+**1 · Rust-claims sensitivity is no longer degenerate — CLOSED.** `qualification_plan_digest_selftest.py:101-113` now asserts, inside the `rust-claims` branch, that both `rust_interop.stable_support_claims_sha256` **and** `advertised_claim_ids` differ from baseline (`or`-joined equality → fails if either matches). The assertion is substantive, not tautological: `stable_claims(variant="rust-claims")` (`qualification_fixture.py:820-828`) appends `diagnostic_fixture`, so ids and digest genuinely diverge, and `write_source_contracts(..., variant=variant)` keeps source and staged claims consistent so the planner still binds them. `test_plan_digest_sensitivity` passes in-suite; the `nochange`/fresh-control commit-stability invariants (lines 38-62, 79-80) still hold with the new source file present.
+
+**2 · Canonicalized release-run bytes + digest binding — CLOSED, and format-faithful.** `release_evidence_selftest.py:99-121` writes results with `indent=2, sort_keys=True` — byte-for-byte the real producer's format (`verification/areas/rust_interop/runner/report.py:13`), so the fixture is not a straw man — then asserts `before != after`, `after == canonical`, and `load_json_strict(..., require_canonical=True)`; `:155-162` asserts the payload's `result_artifacts` digest equals `sha256_file` of the canonicalized file. `_assert_canonicalization_rejections` covers missing, wrong-area, and duplicate-key with message matching (`fail()` → `GovernanceError` carrying "duplicate object key", confirmed at `common.py:201`). Ordering re-verified: `write_release_profile_report:91-92` canonicalizes before payload build and both validation passes; nothing else in `reports.py`/`profile_results.py`/`results.py` records a pre-canonical digest.
+
+**3 · Staging/validation mutations + real CLI — CLOSED.** `_test_stable_support_claim_staging` covers canonical staging, real `subprocess` CLI wiring, overwrite refusal, noncanonical staged bytes, source drift, in-checkout output, and symlinked source. I ran the CLI myself: `rc=0`, 56 ms, output canonical. I also confirmed the untested-but-present branches fail closed against the **real** repo claims file (29 claims, 4517 B canonical): symlinked staged path → reject, top-level array → reject, missing source → reject.
+
+**Mutation efficacy (each guard individually neutralized in-memory, no repo files touched):**
+
+| weakening | test result |
+|---|---|
+| drop source-byte binding (keep `require_canonical`) | caught → "source-drifted … passed" |
+| drop `require_canonical` + binding | caught → "noncanonical … passed" |
+| drop in-checkout `--out` check | caught → "in-source … passed" |
+| drop symlink-source check | caught → "symlinked source … passed" |
+| no-op `canonicalize_custodied_results` | caught → "did not canonicalize the exact Rust result bytes" |
+| drop area-identity check | caught → "mutation passed: identity mismatch" |
+
+**4 · Planner earliest-load canonical gate — CLOSED.** `planner.py:153` now loads the rust validation report with `require_canonical=True`; it is the only planner load of that path (earlier lines 148-151 are digest-only, no load). No new breakage: custody already required canonical bytes at `evidence_custody.py:261`.
+
+**5 · Blockers A–C intact, scope clean.** Ordering, source-derived staging (`validate_staged_support_claims` returning the ids the plan must match), and the digest tie to the release-run result all hold. Zero files under `crates/`, `demos/`, or `verification/areas/rust_interop/` — only `rust_interop` in custody is the rust *result*, and canonicalizing only that key is correct: it is the sole `CRITICAL_RESULTS` entry that enters candidate custody (`evidence_custody.py:190-207, 247-263`).
+
+**6 · Docs/ledger/guardrails truthful.** The new doc block's claims all check out, including "the planner later verifies source cleanliness" (`planner.py:270`) and the `stable-support-claims.json` name matching custody's required filename — this also resolves pass-2 finding 7. Ledger entries match the archives on disk. File-size guardrails PASS (2952 files); `git diff --check` clean; import ordering alphabetical.
+
+**Gates re-run independently:** `sifr_verify --self-test` all pass (incl. release report production); `distribution_release` full area **125/125, 0 failures**; qualification suite 9/9; evidence-custody pass; `--suite full` 67/67 with `test_evidence_custody_mutations` passing in `governance-contracts`.
+
+### Non-blocking findings
+
+1. **LOW — `canonicalize_custodied_results` accepts a symlinked critical result and writes through it.** Verified: a `rust-interop-release-results.json` symlink is followed and the target is rewritten. The dir is runner-owned (`target/`), so risk is nil, but sibling code (`validate_staged_support_claims`, `validate_installer_bytes`) refuses symlinks; `path.is_symlink()` would match convention.
+2. **LOW — `stage_stable_support_claims` writes through a dangling `--out` symlink.** `output_path.resolve()` means the in-checkout and refuse-existing checks apply to the *resolved* target, so it stays fail-closed — but the bytes land somewhere other than the literal `--out`. Cosmetic.
+3. **LOW — the planner's new `require_canonical` on the rust report has no negative test.** Only the happy path is exercised; a noncanonical case in the existing `test_planner_rejects_drift_cases` framework would be a few lines.
+4. **INFO — `plans/reviews/active/phase-40-canonical-candidate-evidence-review-pass-3.md` is a 0-byte placeholder** (same shape as pass-2 finding 6). It must carry a real verdict or not be committed, since the ledger pattern cites these files.
+5. **INFO — pass-2 finding 8 is moot.** `GovernanceError` subclasses `ValueError`, so the NaN path (plain `ValueError` from `canonical_json_bytes`) is indistinguishable to `profile_runner.py:894`, which fails closed with status 2.
+6. **INFO — headroom shrank.** `planner.py` 826/900, `qualification_fixture.py` 853/900. The next addition to either should split by responsibility rather than append.
+
+No files were modified.

--- a/plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-4-pr-head.md
+++ b/plans/reviews/archive/phase-40-canonical-candidate-evidence-review-pass-4-pr-head.md
@@ -1,0 +1,54 @@
+## Reviewed head
+
+- **PR #3051** — `codex/phase40-canonical-rust-evidence` → `main`, state OPEN, `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`
+- **Exact reviewed remote head: `1841576ce667a23b680b2c248f178025e49d0930`** (`gh pr view` `headRefOid` == `git rev-parse origin/codex/phase40-canonical-rust-evidence` == local `HEAD`)
+- Base `origin/main` = `53cc9c4bf36762d39a0b372402d202589f920c2e`; diff = 12 files, +558/−14
+- Two commits: `8048de4343` (entire implementation + tests + docs + 3 review archives, 529 lines) and `1841576ce` (ledger-only, 29 lines)
+- Working tree carries one untracked file (`plans/reviews/active/…pass-4-pr-head.md`), not part of the PR. I modified nothing.
+
+## Commands run
+
+| Check | Result |
+|---|---|
+| `sifr_verify --self-test` | 11/11 pass, incl. `release report production self-test` |
+| `areas run --area distribution_release` | **125/125**, 0 failures (independently reproduces the claimed count) |
+| `areas run --area distribution_release --suite qualification --suite evidence-custody` | 2/2; `qualification self-tests ok: tests=9` incl. `test_plan_digest_sensitivity` |
+| `areas run --area python_interop --suite readonly-check-doctor` (isolated) | **1/1 pass, elapsed_ms=131984** (2:12 wall) |
+| `check_file_size_guardrails.py` | PASS (2952 files, limit 900); largest touched file `planner.py` 826 |
+| `check_hir_maintainability_guardrails.py` | PASS |
+| `git diff --check origin/main..HEAD` | clean |
+| Custom adversarial probe of every new branch (14 cases) | see below |
+
+Probe results (real repo + temp fixtures): real `stable_support_claims.json` is **non-canonical** (5776 B; raw digest `4913b281…` vs canonical `b62f5b93…`), staging produces canonical bytes and 29 ids; `canonicalize_custodied_results` REJECTS non-dict, wrong-area, missing, directory, duplicate-key, and is idempotent; `validate_staged_support_claims` REJECTS missing source, noncanonical staged, source-drift, symlinked staged; `stage_stable_support_claims` REJECTS symlinked source, contract-violating source (and writes nothing), `--out` inside source, `--out` == source root, `--out` reaching source through a symlinked parent, duplicate source keys.
+
+## Disposition of previous blockers A–C
+
+**A (release report hashed pretty bytes, custody demanded canonical) — CLOSED.** `release_evidence.py:91-92` canonicalizes the rust result *before* `build_release_profile_payload`, so `collect_critical_results`' `sha256_file` (`release_evidence.py:249`) binds canonical bytes and custody's `require_canonical=True` (`evidence_custody.py:262`) and the digest tie now agree. Confirmed the runner emits `json.dumps(payload, indent=2, sort_keys=True)` with no trailing newline (`area_adapter.py:94`) — never canonical, so the step always applies. Ordering is safe: `write_release_profile_report` runs after `reports.summarize` (`profile_runner.py:872-889`), so no in-run consumer sees pre-canonical bytes, and the operation is idempotent.
+
+**B (staged claims non-canonical) — CLOSED, and the digest move is safe.** `planner.py:195-212` emits `canonical_json_bytes(source)`; `planner.py:215-233` requires the staged file to equal exactly that. I re-verified pass-2's key premise at this head: nothing compares `stable_support_claims_sha256` to the raw source file — `stable_prepare.py:757-781` binds only the compatibility matrix, facts schema, and facts generator to the checkout. The claims digest is still auditable after the fact, since canonicalization of the source file at `plan.source_commit` is deterministic.
+
+**C (staged rust report came from a standalone rerun) — CLOSED.** `validate_rust_candidate_result` (`planner.py:738-756`) requires the candidate report's digest to be the single `result_artifacts` entry named `rust-interop-release-results.json` *and* the single `stable-candidate` `suite_results` digest; `validate_release_profile_report(..., verify_artifacts=True)` re-hashes that path on disk in the release checkout (`release_report.py:347-352`). A rerun differs in `duration_ms`, so it cannot satisfy the tie.
+
+**Plan-digest sensitivity** is no longer degenerate: `qualification_plan_digest_selftest.py:98-113` asserts inside the `rust-claims` branch that both `stable_support_claims_sha256` and `advertised_claim_ids` differ from baseline, and `stable_claims(variant="rust-claims")` (`qualification_fixture.py:820-828`) genuinely appends `diagnostic_fixture`, so the assertion is substantive rather than riding on the changed fixture commit.
+
+## Findings (all non-blocking)
+
+1. **LOW — `canonicalize_custodied_results` accepts a symlinked result path and writes through it.** `release_evidence.py:133-140` uses `path.is_file()` (follows links) and `path.write_bytes`. Probe: symlink to a file outside `target/` → ACCEPT, symlink preserved, outside file rewritten. Inconsistent with the sibling convention in this same PR (`planner.py:204`, `planner.py:220`) and with `planner.py:435`. Integrity is preserved (the digest is taken on the resolved file) and `clear_critical_result_files` (`release_evidence.py:77-80`) unlinks the path at prepare time, so only the write location can escape. Fix: add `path.is_symlink()` to the guard.
+
+2. **LOW — asymmetric symlink policy on the *source* claims file.** `stage_stable_support_claims` refuses a symlinked source (`planner.py:204-208`) but the enforcing gate `validate_staged_support_claims` does not (`planner.py:226` loads `source_root / STABLE_SUPPORT_CLAIMS` unchecked). Probe: stage REJECT, validate ACCEPT. Requires a committed symlink at that path, so low risk — but the check belongs on the side that gates the plan.
+
+3. **LOW (docs) — the block never names the file to pass as `--rust-validation-report`.** `internal_docs/distribution_pipeline.md:229-232` states the principle ("Candidate custody copies that same result file; a standalone Rust-suite rerun is not interchangeable evidence") but, unlike the documentation-report block directly above it which gives a command plus "Pass that exact report to the planner's `--documentation-report` argument", never names `target/verification/areas/rust-interop-release-results.json` → `<work-dir>/rust-validation-report.json`. That is exactly the step the operator got wrong in pass 1. Fail-closed at the planner now, so this is completeness, not correctness.
+
+4. **LOW (tracking accuracy — introduced by the post-implementation commit `1841576ce`).** The new ledger bullet at `plans/issues/active/phase-40-stable-channel-ga-execution.md:1339-1341` says "both the source and staged bytes are validated as canonical JSON." The source bytes are explicitly *not* canonical — that is Finding B's premise, and `stage_stable_support_claims` loads the source with `load_json_strict(source_path)` with no `require_canonical`. The same bullet attributes "wrong-area" rejection to the planner; it lives in the evidence writer (`release_evidence.py:138`). The corresponding bullets in `8048de4343` are accurate; only this restatement is loose. **Otherwise the tracking-only commit introduces nothing** — it touches one markdown file, no code, no test, no schema.
+
+5. **INFO — coverage residuals, none of them a real hole.** (a) No planner-level negative case for a non-canonical `--rust-validation-report`; the digest chain already forecloses it, so the new `require_canonical=True` at `planner.py:153` is belt-and-braces. (b) The planner fixture writes canonical source claims (`qualification_fixture.py:143`) and a directly-written staged copy (`:366-368`) rather than calling the governed staging function, so the pretty→canonical transformation in the planner path is covered only by `_test_stable_support_claim_staging` (`evidence_custody_selftest.py:121-205`) — which does write a pretty source, so the class is covered. (c) `collect_critical_results` still uses plain `json.loads` (`release_evidence.py:246`) for all four areas, so duplicate keys in the three non-rust results would be tolerated when deriving `suite_results` case ids; those are not candidate-planner entrances and their JSON semantics never reach custody, and the one that does is now strict. Pass-3's carried cosmetic (dangling `--out` symlink writes to the resolved target) reproduces and remains fail-closed.
+
+**PERF-HOST:** reasonably nonblocking. `python_interop` is untouched by this diff (its last commits predate the branch), the diff changes no timeout, threshold, baseline, or profile selection, and PERF-HOST is a pre-existing indexed deferred follow-up (`plans/phases/index.md:54`). My isolated replay passed 1/1 at 131.98 s, consistent with the reported 160.114 s under different host load.
+
+No regression, no unsafe fallback, and no incomplete Phase 40 contract found. The diff touches no Rust-interop implementation, capability claim, suite selection, or demo — Rust suites are consumed as evidence only.
+
+## Verdict
+
+**SATISFIED**
+
+**PR #3051 is ready to merge.** All three prior blockers are closed and independently reproduced at the exact pushed head; the five findings are LOW/INFO and none gate the release-governance contract. Items 1–2 (symlink guards) and 3–4 (docs/ledger wording) are worth a follow-up, and item 4 in particular is a one-sentence ledger correction that would be cheap to fold in before merge if you want the record exact.

--- a/plans/reviews/archive/phase-40-final-qualification-evidence-review-pass-1-not-satisfied.md
+++ b/plans/reviews/archive/phase-40-final-qualification-evidence-review-pass-1-not-satisfied.md
@@ -1,0 +1,94 @@
+## VERDICT: NOT SATISFIED
+
+Three actionable defects, all in the supporting-evidence layer. The qualification transport itself (run, index, 20 payloads, archives, installer, checksums, targets, editor/VSIX) is fully clean and independently reproduced.
+
+---
+
+## 1. Workflow / source / submodule identity — SATISFIED
+
+`gh api repos/sifr-lang/sifr/actions/runs/30406842210`:
+- `conclusion: success`, `status: completed`, `run_attempt: 1`, `path: .github/workflows/release-qualification.yml`, `repository: sifr-lang/sifr`, `head_sha: 53cc9c4bf36762d39a0b372402d202589f920c2e`.
+- All 8 jobs `success`: validate, 4 target jobs, assemble, editor, collect.
+- `gh run list --workflow=release-qualification.yml` — this is the **only** run at `53cc9c4`.
+- Workflow permissions are `contents: read` / `actions: read` only; all four `upload-artifact` sites declare `retention-days: 30`, `overwrite: false`.
+- All 10 index submodule pins match `git submodule status` in the clean checkout, including nested `editor_integrations/vscode = 273fd5d3eb…`.
+
+## 2. Canonical index, 6 uploads, expiry, 20 payloads, structure — SATISFIED
+
+- `validate_qualification_artifact_index(…, require_unexpired=True)` → OK; JSON Schema validation → OK; bytes are exactly `canonical_json_bytes` (9543 B, sha256 `864b4070868a1998ec3ce87dc85ffd5514361969adaaef1a0c1023d6257a6a45`).
+- All 6 governed `workflow_artifact_id`s resolve live and `expired: false`; each upload's API `expires_at` matches the index **exactly**, and every transported entry shares its upload's single expiry (aarch64-darwin `23:12:52`, aarch64-linux `23:09:34`, x86_64-darwin `23:23:00`, x86_64-linux `23:11:27`, assemble `23:24:07`, editor `23:24:06`). `workflow.expires_at` = the minimum, `23:09:34Z` — ~29.9 days of lifetime, far above the 7-day floor.
+- **20/20 payloads verified by exact size and SHA-256, 534,002,666 bytes total, 0 mismatches.**
+- `verify_release_archive.py` at the source commit passes for all four archives; `validate_target_report` passes for all four (canonical bytes, `smoke_status: pass`, exact builder matrix `macos-15` / `macos-15-intel` / `ubuntu-24.04` / `ubuntu-24.04-arm`).
+- **Installer regenerated from the source commit is byte-identical** to the transported `sifr-installer-0.1.0` (`7a658f2e09d9…`); `checksums.txt` replayed byte-identical, and `validate_aggregate_checksums` binds exactly the 12 target-kind artifacts.
+- `validate_editor_report` passes (canonical); VSIX is `sifr-vscode` 0.2.0, publisher `sifr`, `sifrCompilerCompatibility: ">=0.1.0,<0.2.0"`, `rollback_version: none`, `target_report_sha256` = the x86_64-linux report digest, thin-client contents only, `dist/` has 0 committed files.
+
+## 3. Supporting evidence — TWO BLOCKERS
+
+**Finding A (blocking, unsatisfiable as designed): `rust-validation-report.json` cannot pass custody.**
+
+`evidence_custody.py:255-263` and `stable_prepare.py:799-813` both load the candidate `rust-validation-report.json` with `require_canonical=True`, while `planner.py:688-700` requires its digest to equal the release report's `result_artifacts` entry named `rust-interop-release-results.json`. That digest is computed by `release_evidence.py:232` as `sha256_file(path)` over the runner's **pretty-printed 2-space** output. Proven against the real artifact in the checkout:
+
+```
+release-report-bound digest (runner bytes):  621e3e7157f89b2bbbc1482a96a07fee706ad0bbec2896976f9981cdad0898d1
+digest of canonicalized same content:        eb5d458ad3a0cd08753a115b6e12043cc5e8c25947685c2e29a26dcaf620275d
+```
+
+Verbatim bytes satisfy the digest tie but fail the canonical gate; canonicalized bytes pass the gate but break the digest tie. `evidence_custody_selftest.py:35-36,59` masks this by building `rust_bytes = canonical_json_bytes(...)` and then *setting* the release report's `result_artifacts` digest to that canonical digest — a fixture that cannot occur in a real release run.
+
+**Finding B (blocking): staged `stable-support-claims.json` is non-canonical.** It is a byte-verbatim copy of `verification/areas/rust_interop/data/stable_support_claims.json` (good provenance), but that source file is pretty-printed, so the same `require_canonical=True` gate rejects it. Canonicalizing the copy would sever the plan digest from the in-repo artifact the `stable-candidate` validator actually checked, so this needs an explicit decision, not a silent reserialization.
+
+Direct reproduction:
+```
+rust-validation-report.json:  custody canonical gate REJECTS -> must use canonical JSON bytes
+stable-support-claims.json:   custody canonical gate REJECTS -> must use canonical JSON bytes
+documentation-report.json:    custody canonical gate PASSES
+```
+
+**Finding C (blocking provenance): the staged `rust-validation-report.json` is not the release-profile run's artifact.** `argv[0]` shows it came from a standalone `areas run` in the clean checkout at 02:40 (`be1f537f…`, 9703 B), whereas the release-profile run's `target/verification/areas/rust-interop-release-results.json` is `621e3e71…` (9701 B, 03:01). The two are structurally identical (same 5 suites, `summary.total_failures: 0`, 10 variants, exact `stable-candidate` case ids) and differ only in non-deterministic `duration_ms` fields — so this file can never be reproduced or bound. Candidate evidence must carry the release run's own artifact bytes; this violates the exact-byte/no-rebuild requirement.
+
+**Clean parts of item 3:**
+- `documentation-report.json` — canonical, `validate_documentation_report` OK, `source_commit = 53cc9c4…`, `status: pass`, suites `structure` then `ga-release`, and `result_sha256 = 88e3bd72f52d…` matches `target/verification/areas/documentation-stable-qualification-results.json` exactly, produced by the governed `scripts/distribution/qualify_stable_documentation.py`. `report_id = docs-53cc9c4bf367-88e3bd72f52d` is consistent.
+- `stable-support-claims.json` content — byte-identical to the source-commit artifact; 29 claims, 2 declared runtime deferrals; all intrinsic Rust checks pass. Its `schema_version: 1` is upstream Rust-interop-owned state, not one of the Phase 40 schema-v2 contracts (phase lines 183-189), so not a defect.
+- `rust-validation-report.json` content — all 5 required suites blocking with `failed_cases: 0` / `total_failures: 0`, `validate_passing_cases` OK for every suite, exact `stable-candidate` case ids `{rust-interop-stable-candidate, rust-interop-stable-candidate-self-test}`, `bless: false`.
+- `release-notes.md` — consistent with the phase: four exact targets, extension range `>=0.1.0,<0.2.0`, roll-forward-only first-GA recovery, no rollback predecessor, no signing/notarization claim, Windows/package-manager exclusion, packaged generated-Rust limitation disclosed. Non-actionable note: it does not restate the macOS 15.0 / glibc 2.39 floors, but no contract requires that of the release asset and `check_ga_release_docs.py` enforces them in `docs/` (verified present in `installation.mdx`, `releases/0.1.0.mdx`, `releases/compatibility.mdx`, `troubleshooting.mdx`).
+
+## 4. Staleness / cross-source / exact-byte
+
+Findings A–C above. Everything else is fit: the index, all 20 payloads, and all four target reports plus the editor report bind `53cc9c4…` and the correct submodule set; the installer and checksums are byte-reproducible from the source commit; nothing was rebuilt.
+
+## 5. Rust-interop implementation — respected
+
+No Rust-interop implementation was reviewed or modified. Its suites were treated purely as consumed evidence (structure, verdicts, digests).
+
+## 6. Demo naming — SATISFIED
+
+Recursive scan of 1,473 paths under `demos/` for `phase`, `milestone`, or a standalone `40`/`m40` token: **0 violations**. Release demos are capability-named (`stable_candidate_qualification_demo.sh`, `stable_release_governance_demo.sh`, `stable_incident_recovery_demo.sh`, `stable_self_update_demo.sh`).
+
+## 7. Commands and checks I ran
+
+```bash
+git -C /private/tmp/sifr-phase40-release-source-53cc9c4bf367 rev-parse HEAD; git status --short; git submodule status
+git -C .../editor_integrations submodule status
+gh api repos/sifr-lang/sifr/actions/runs/30406842210
+gh api repos/sifr-lang/sifr/actions/runs/30406842210/jobs --paginate
+gh api repos/sifr-lang/sifr/actions/runs/30406842210/artifacts --paginate
+gh run list --workflow=release-qualification.yml --limit 20 --json databaseId,headSha,status,conclusion,createdAt
+# canonical index: semantic validator + JSON Schema + canonical bytes + all 20 payload size/SHA-256
+uv run --project verification --locked --with jsonschema python /tmp/pass1_full.py
+# archive structure, all four targets
+scripts/distribution/verify_release_archive.py <archive> --version 0.1.0 --target <target>
+# installer + checksums byte replay from the source commit
+scripts/distribution/generate_version_installer.sh --version 0.1.0 --artifact-dir <replay> --out <replay>/sifr-installer-0.1.0
+cmp <regenerated installer> <transported installer>; cmp <replayed checksums.txt> <transported checksums.txt>
+# governed validators against real evidence
+uv run … python /tmp/pass1_final.py     # validate_aggregate_checksums + validate_target_report x4
+uv run … python /tmp/pass1_editor.py    # validate_editor_report
+uv run … python /tmp/pass1_evidence.py  # validate_documentation_report, validate_passing_cases x5
+uv run … python /tmp/pass1_proof.py     # custody require_canonical gate + digest unsatisfiability proof
+cmp <evidence>/stable-support-claims.json verification/areas/rust_interop/data/stable_support_claims.json
+unzip -l / unzip -p sifr-vscode-0.2.0.vsix   # VSIX structure, package.json, compiler range
+git -C editor_integrations/vscode ls-files dist
+python3 -c "<recursive demos/ phase-milestone-40 name scan>"
+```
+
+No repository file was modified. All scratch scripts and the replay directory live under `/tmp`. The absent canonical `release-profile-report.json` was excluded from scope as instructed — note that Finding A is nevertheless a property of that report's digest contract and must be resolved before candidate evidence can be materialized.

--- a/scripts/distribution/release_governance.py
+++ b/scripts/distribution/release_governance.py
@@ -23,10 +23,10 @@ from governance import (  # noqa: E402
     materialize_stable_prepare,
     validate_bootstrap_evidence,
     validate_drill_evidence,
-    validate_incident_request,
-    validate_incident_signoff,
     validate_incident_mutation_evidence,
     validate_incident_prepare_summary,
+    validate_incident_request,
+    validate_incident_signoff,
     validate_install_receipt,
     validate_qualification_artifact_index,
     validate_release_index,
@@ -50,8 +50,14 @@ from governance.common import (  # noqa: E402
 )
 from governance.incident_evidence import validate_incident_evidence_commit  # noqa: E402
 from governance.incident_planner import materialize_incident_mutation  # noqa: E402
-from governance.planner import materialize_stable_plan  # noqa: E402
-from governance.release_index import propose_preview_release, validate_release_record  # noqa: E402
+from governance.planner import (  # noqa: E402
+    materialize_stable_plan,
+    stage_stable_support_claims,
+)
+from governance.release_index import (  # noqa: E402
+    propose_preview_release,
+    validate_release_record,
+)
 from governance.schema_bootstrap import (  # noqa: E402
     build_preview_epoch,
     resolve_distinct_approvers,
@@ -141,6 +147,10 @@ def parse_args() -> argparse.Namespace:
     stable_plan.add_argument("--documentation-report", required=True)
     stable_plan.add_argument("--release-notes", required=True)
     stable_plan.add_argument("--out", required=True)
+
+    stage_claims = commands.add_parser("stage-stable-support-claims")
+    stage_claims.add_argument("--source-root", default=str(REPO_ROOT))
+    stage_claims.add_argument("--out", required=True)
 
     record = commands.add_parser("build-release-record")
     record.add_argument("--version", required=True)
@@ -256,6 +266,8 @@ def main() -> int:
             generate_release_plan(args)
         elif args.command == "plan-stable-release":
             plan_stable_release(args)
+        elif args.command == "stage-stable-support-claims":
+            stage_support_claims(args)
         elif args.command == "generate-site-facts":
             generate_site_facts(args)
         elif args.command == "generate-incident-request":
@@ -406,6 +418,14 @@ def plan_stable_release(args: argparse.Namespace) -> None:
         release_notes_path=Path(args.release_notes),
     )
     write_canonical_json(output, payload, refuse_existing=True)
+
+
+def stage_support_claims(args: argparse.Namespace) -> None:
+    stage_stable_support_claims(
+        source_root=Path(args.source_root),
+        output_path=Path(args.out),
+    )
+    print(f"stable support claims evidence staged: {Path(args.out)}")
 
 
 def build_release_record(args: argparse.Namespace) -> None:

--- a/verification/areas/distribution_release/governance/evidence_custody_selftest.py
+++ b/verification/areas/distribution_release/governance/evidence_custody_selftest.py
@@ -202,6 +202,13 @@ def _test_stable_support_claim_staging() -> None:
             ),
             "symlinked source stable support claims passed",
         )
+        _require_governance_rejection(
+            lambda: validate_staged_support_claims(
+                output,
+                source_root=source_root,
+            ),
+            "validator accepted symlinked source stable support claims",
+        )
 
 
 def _test_changed_paths() -> None:

--- a/verification/areas/distribution_release/governance/evidence_custody_selftest.py
+++ b/verification/areas/distribution_release/governance/evidence_custody_selftest.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
@@ -13,9 +16,12 @@ from .evidence_custody import (
     validate_candidate_directory,
     validate_changed_path_set,
 )
+from .planner import stage_stable_support_claims, validate_staged_support_claims
 from .qualification_fixture import stable_claims
 from .qualification_rust_fixture import rust_candidate_result
 from .schema_contracts import qualification_index
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 def run_evidence_custody_mutations(
@@ -26,6 +32,7 @@ def run_evidence_custody_mutations(
     retained_digest: str,
 ) -> None:
     _test_changed_paths()
+    _test_stable_support_claim_staging()
     with tempfile.TemporaryDirectory() as directory:
         candidate_dir = Path(directory) / "0.1.0"
         candidate_dir.mkdir()
@@ -111,6 +118,92 @@ def run_evidence_custody_mutations(
             raise AssertionError("candidate report digest mismatch passed custody")
 
 
+def _test_stable_support_claim_staging() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        source_root = root / "source"
+        source_path = (
+            source_root
+            / "verification/areas/rust_interop/data/stable_support_claims.json"
+        )
+        source_path.parent.mkdir(parents=True)
+        payload = stable_claims(variant="baseline")
+        source_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        output = root / "evidence/stable-support-claims.json"
+        stage_stable_support_claims(
+            source_root=source_root,
+            output_path=output,
+        )
+        if output.read_bytes() != canonical_json_bytes(payload):
+            raise AssertionError("stable support claims staging was not canonical")
+        cli_output = root / "evidence/cli-stable-support-claims.json"
+        cli = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts/distribution/release_governance.py"),
+                "stage-stable-support-claims",
+                "--source-root",
+                str(source_root),
+                "--out",
+                str(cli_output),
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        if cli.returncode != 0 or cli_output.read_bytes() != canonical_json_bytes(
+            payload
+        ):
+            raise AssertionError(
+                f"stable support claims CLI staging failed: {cli.stderr}"
+            )
+        try:
+            stage_stable_support_claims(
+                source_root=source_root,
+                output_path=output,
+            )
+        except GovernanceError:
+            pass
+        else:
+            raise AssertionError("stable support claims staging overwrote evidence")
+        output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        _require_governance_rejection(
+            lambda: validate_staged_support_claims(output, source_root=source_root),
+            "noncanonical staged stable support claims passed",
+        )
+        output.write_bytes(canonical_json_bytes(payload))
+        source_path.write_bytes(
+            canonical_json_bytes(stable_claims(variant="rust-claims"))
+        )
+        _require_governance_rejection(
+            lambda: validate_staged_support_claims(output, source_root=source_root),
+            "source-drifted stable support claims passed",
+        )
+        in_source = source_root / "candidate-claims.json"
+        _require_governance_rejection(
+            lambda: stage_stable_support_claims(
+                source_root=source_root,
+                output_path=in_source,
+            ),
+            "in-source stable support claims output passed",
+        )
+        source_path.unlink()
+        linked_source = root / "linked-source-claims.json"
+        linked_source.write_bytes(canonical_json_bytes(payload))
+        source_path.symlink_to(linked_source)
+        _require_governance_rejection(
+            lambda: stage_stable_support_claims(
+                source_root=source_root,
+                output_path=root / "evidence/symlink-source-claims.json",
+            ),
+            "symlinked source stable support claims passed",
+        )
+
+
 def _test_changed_paths() -> None:
     try:
         require_comparison_base("", base_ref="missing")
@@ -131,3 +224,11 @@ def _test_changed_paths() -> None:
         except GovernanceError:
             continue
         raise AssertionError(f"invalid evidence custody paths passed: {paths}")
+
+
+def _require_governance_rejection(action: Callable[[], Any], message: str) -> None:
+    try:
+        action()
+    except GovernanceError:
+        return
+    raise AssertionError(message)

--- a/verification/areas/distribution_release/governance/planner.py
+++ b/verification/areas/distribution_release/governance/planner.py
@@ -10,8 +10,9 @@ from typing import Any
 
 from .artifact_index import validate_qualification_artifact_index
 from .common import (
-    GovernanceError,
     TARGETS,
+    GovernanceError,
+    canonical_json_bytes,
     fail,
     load_json_strict,
     require_array,
@@ -33,6 +34,9 @@ from .release_report import (
 RELEASE_PROFILE = Path("verification/profiles/release.json")
 COMPATIBILITY_MATRIX = Path(
     "verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json"
+)
+STABLE_SUPPORT_CLAIMS = Path(
+    "verification/areas/rust_interop/data/stable_support_claims.json"
 )
 SITE_FACTS_SCHEMA = Path(
     "verification/areas/distribution_release/schemas/stable_site_release_facts.schema.json"
@@ -146,11 +150,14 @@ def materialize_stable_plan(
         "$.rust_interop.validation_report_sha256",
     )
     validate_rust_candidate_result(
-        load_json_strict(rust_validation_report_path),
+        load_json_strict(rust_validation_report_path, require_canonical=True),
         expected_digest=plan["rust_interop"]["validation_report_sha256"],
         release_report=report,
     )
-    claim_ids = stable_claim_ids(load_json_strict(stable_support_claims_path))
+    claim_ids = validate_staged_support_claims(
+        stable_support_claims_path,
+        source_root=source_root,
+    )
     if plan["rust_interop"]["advertised_claim_ids"] != claim_ids:
         fail(
             "$.rust_interop.advertised_claim_ids",
@@ -183,6 +190,47 @@ def materialize_stable_plan(
         "$.site.facts_generator_sha256",
     )
     return plan
+
+
+def stage_stable_support_claims(*, source_root: Path, output_path: Path) -> None:
+    """Stage the exact source claims in canonical candidate-custody form."""
+    source_root = source_root.resolve()
+    output_path = output_path.resolve()
+    if output_path == source_root or output_path.is_relative_to(source_root):
+        fail("--out", "stable support claims evidence must be outside the source checkout")
+    if output_path.exists():
+        fail("--out", "refusing to overwrite stable support claims evidence")
+    source_path = source_root / STABLE_SUPPORT_CLAIMS
+    if not source_path.is_file() or source_path.is_symlink():
+        fail(
+            "stable_support_claims.json",
+            "exact source claims must be a regular non-symlink file",
+        )
+    claims = load_json_strict(source_path)
+    stable_claim_ids(claims)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(canonical_json_bytes(claims))
+
+
+def validate_staged_support_claims(
+    path: Path,
+    *,
+    source_root: Path,
+) -> list[str]:
+    if not path.is_file() or path.is_symlink():
+        fail(
+            "stable_support_claims.json",
+            "staged claims must be a regular non-symlink file",
+        )
+    claims = load_json_strict(path, require_canonical=True)
+    source_claims = load_json_strict(source_root / STABLE_SUPPORT_CLAIMS)
+    expected = canonical_json_bytes(source_claims)
+    if path.read_bytes() != expected:
+        fail(
+            "stable_support_claims.json",
+            "does not match the canonical bytes of the exact source claims",
+        )
+    return stable_claim_ids(claims)
 
 
 def resolve_source_once(source_root: Path, source_ref: str) -> str:

--- a/verification/areas/distribution_release/governance/planner.py
+++ b/verification/areas/distribution_release/governance/planner.py
@@ -223,7 +223,13 @@ def validate_staged_support_claims(
             "staged claims must be a regular non-symlink file",
         )
     claims = load_json_strict(path, require_canonical=True)
-    source_claims = load_json_strict(source_root / STABLE_SUPPORT_CLAIMS)
+    source_path = source_root / STABLE_SUPPORT_CLAIMS
+    if not source_path.is_file() or source_path.is_symlink():
+        fail(
+            "stable_support_claims.json",
+            "exact source claims must be a regular non-symlink file",
+        )
+    source_claims = load_json_strict(source_path)
     expected = canonical_json_bytes(source_claims)
     if path.read_bytes() != expected:
         fail(

--- a/verification/areas/distribution_release/governance/qualification_fixture.py
+++ b/verification/areas/distribution_release/governance/qualification_fixture.py
@@ -22,7 +22,6 @@ from .common import (
     write_canonical_json,
 )
 from .planner import RUST_CLAIMS_SCHEMA_VERSION, stable_claim_ids
-from .qualification_rust_fixture import rust_candidate_result
 from .qualification_fixture_support import (
     command_output,
     configure_git,
@@ -30,6 +29,7 @@ from .qualification_fixture_support import (
     git,
     git_output,
 )
+from .qualification_rust_fixture import rust_candidate_result
 from .release_report import canonical_profile_digest, collect_submodules
 from .schema_contracts import preview_index, release_plan, release_report
 
@@ -69,7 +69,7 @@ def create_fixture_source(root: Path, *, variant: str = "baseline") -> Path:
         f"# fixture lock {variant if variant == 'lock' else 'baseline'}\n",
         encoding="utf-8",
     )
-    write_source_contracts(source_root)
+    write_source_contracts(source_root, variant=variant)
     git(
         source_root,
         "-c",
@@ -94,7 +94,7 @@ def create_fixture_source(root: Path, *, variant: str = "baseline") -> Path:
     return source_root
 
 
-def write_source_contracts(source_root: Path) -> None:
+def write_source_contracts(source_root: Path, *, variant: str) -> None:
     profile = {
         "schema_version": PROFILE_SCHEMA_VERSION,
         "name": "release",
@@ -138,6 +138,9 @@ def write_source_contracts(source_root: Path) -> None:
         ): canonical_json_bytes(
             {"schema_version": RUST_CLAIMS_SCHEMA_VERSION, "rows": []}
         ),
+        (
+            "verification/areas/rust_interop/data/stable_support_claims.json"
+        ): canonical_json_bytes(stable_claims(variant=variant)),
         (
             "verification/areas/distribution_release/schemas/"
             "stable_site_release_facts.schema.json"

--- a/verification/areas/distribution_release/governance/qualification_plan_digest_selftest.py
+++ b/verification/areas/distribution_release/governance/qualification_plan_digest_selftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import shutil
 import subprocess
 import tempfile
@@ -27,6 +28,7 @@ def run_plan_digest_sensitivity_test(
             result_root=result_root,
         )
         baseline = run_planner(bundle, baseline_root / "plan.json")
+        baseline_plan = json.loads(baseline)
         baseline_digest = hashlib.sha256(baseline).hexdigest()
         fresh_control_root = root / "fresh-control"
         fresh_control_source = create_fixture_source(
@@ -62,7 +64,6 @@ def run_plan_digest_sensitivity_test(
             "nochange",
             "target-artifact",
             "sysroot",
-            "rust-claims",
             "vsix",
         ):
             variant_root = root / variant
@@ -81,7 +82,7 @@ def run_plan_digest_sensitivity_test(
                 raise AssertionError(
                     f"planner input variant {variant} did not change the plan digest"
                 )
-        for variant in ("source", "submodule", "lock"):
+        for variant in ("source", "submodule", "lock", "rust-claims"):
             variant_root = root / variant
             variant_source = create_fixture_source(variant_root, variant=variant)
             variant_bundle = build_evidence_bundle(
@@ -97,3 +98,16 @@ def run_plan_digest_sensitivity_test(
                 raise AssertionError(
                     f"planner input variant {variant} did not change the plan digest"
                 )
+            if variant == "rust-claims":
+                changed_plan = json.loads(changed)
+                baseline_rust = baseline_plan["rust_interop"]
+                changed_rust = changed_plan["rust_interop"]
+                if (
+                    changed_rust["stable_support_claims_sha256"]
+                    == baseline_rust["stable_support_claims_sha256"]
+                    or changed_rust["advertised_claim_ids"]
+                    == baseline_rust["advertised_claim_ids"]
+                ):
+                    raise AssertionError(
+                        "Rust-claim source change did not alter its plan bindings"
+                    )

--- a/verification/runner/sifr_verify/release_evidence.py
+++ b/verification/runner/sifr_verify/release_evidence.py
@@ -17,6 +17,8 @@ sys.path.insert(0, str(GOVERNANCE_ROOT))
 
 from governance.common import (  # noqa: E402
     GovernanceError,
+    canonical_json_bytes,
+    load_json_strict,
     sha256_file,
     write_canonical_json,
 )
@@ -86,6 +88,8 @@ def write_release_profile_report(
 ) -> None:
     if status != 0:
         raise GovernanceError("cannot write release evidence for a failing profile")
+    result_root = REPO_ROOT / "target" / "verification" / "areas"
+    canonicalize_custodied_results(result_root)
     profile = load_profile("release")
     profile_path = REPO_ROOT / "verification" / "profiles" / "release.json"
     profile_digest = canonical_profile_digest(profile_path)
@@ -103,7 +107,7 @@ def write_release_profile_report(
             "uv": command_version("uv", "--version"),
             "python": command_version(sys.executable, "--version"),
         },
-        result_root=REPO_ROOT / "target" / "verification" / "areas",
+        result_root=result_root,
         artifact_root=REPO_ROOT,
     )
     validate_release_profile_report(
@@ -121,6 +125,19 @@ def write_release_profile_report(
         verify_artifacts=True,
     )
     print(f"release_profile_report={output_path}")
+
+
+def canonicalize_custodied_results(result_root: Path) -> None:
+    """Canonicalize exact result bytes that enter candidate evidence custody."""
+    path = result_root / CRITICAL_RESULTS["rust_interop"]
+    if not path.is_file():
+        raise GovernanceError(
+            "release profile emitted no critical area result: rust_interop"
+        )
+    payload = load_json_strict(path)
+    if not isinstance(payload, dict) or payload.get("area") != "rust_interop":
+        raise GovernanceError(f"critical area result identity mismatch: {path}")
+    path.write_bytes(canonical_json_bytes(payload))
 
 
 def build_release_profile_payload(

--- a/verification/runner/sifr_verify/release_evidence.py
+++ b/verification/runner/sifr_verify/release_evidence.py
@@ -130,7 +130,7 @@ def write_release_profile_report(
 def canonicalize_custodied_results(result_root: Path) -> None:
     """Canonicalize exact result bytes that enter candidate evidence custody."""
     path = result_root / CRITICAL_RESULTS["rust_interop"]
-    if not path.is_file():
+    if not path.is_file() or path.is_symlink():
         raise GovernanceError(
             "release profile emitted no critical area result: rust_interop"
         )

--- a/verification/runner/sifr_verify/release_evidence_selftest.py
+++ b/verification/runner/sifr_verify/release_evidence_selftest.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import json
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 
 from .release_evidence import (
     CRITICAL_RESULTS,
+    GovernanceError,
     build_release_profile_payload,
+    canonicalize_custodied_results,
+    load_json_strict,
     prepare_release_report_output,
+    sha256_file,
     validate_release_profile_report,
 )
 
@@ -91,9 +96,27 @@ def release_report_production_self_test() -> None:
                     }
                 )
             (result_root / filename).write_text(
-                json.dumps({"area": area, "suites": suites}),
+                json.dumps({"area": area, "suites": suites}, indent=2, sort_keys=True),
                 encoding="utf-8",
             )
+        rust_result = result_root / CRITICAL_RESULTS["rust_interop"]
+        before = rust_result.read_bytes()
+        canonicalize_custodied_results(result_root)
+        after = rust_result.read_bytes()
+        if before == after or after != (
+            json.dumps(
+                json.loads(before),
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode():
+            raise AssertionError(
+                "release custody did not canonicalize the exact Rust result bytes"
+            )
+        load_json_strict(rust_result, require_canonical=True)
         log_path = root / "release.log"
         log_path.write_text(
             "".join(
@@ -129,6 +152,15 @@ def release_report_production_self_test() -> None:
             result_root=result_root,
             artifact_root=root,
         )
+        rust_artifact = next(
+            artifact
+            for artifact in payload["result_artifacts"]
+            if Path(artifact["path"]).name == CRITICAL_RESULTS["rust_interop"]
+        )
+        if rust_artifact["sha256"] != sha256_file(rust_result):
+            raise AssertionError(
+                "release report did not bind canonicalized Rust result bytes"
+            )
         canonical = (
             json.dumps(
                 payload,
@@ -145,3 +177,39 @@ def release_report_production_self_test() -> None:
             canonical_bytes=output_path.read_bytes(),
             expected_profile_sha256="a" * 64,
         )
+        _assert_canonicalization_rejections(root)
+
+
+def _assert_canonicalization_rejections(root: Path) -> None:
+    for name, raw, expected in (
+        ("missing", None, "no critical area result"),
+        ("wrong-area", b'{"area":"documentation"}\n', "identity mismatch"),
+        (
+            "duplicate-key",
+            b'{"area":"rust_interop","area":"rust_interop"}\n',
+            "duplicate object key",
+        ),
+    ):
+        result_root = root / name
+        result_root.mkdir()
+        if raw is not None:
+            (result_root / CRITICAL_RESULTS["rust_interop"]).write_bytes(raw)
+        _require_governance_rejection(
+            lambda result_root=result_root: canonicalize_custodied_results(
+                result_root
+            ),
+            expected,
+        )
+
+
+def _require_governance_rejection(
+    action: Callable[[], None],
+    expected: str,
+) -> None:
+    try:
+        action()
+    except GovernanceError as exc:
+        if expected not in str(exc):
+            raise AssertionError(f"unexpected governance rejection: {exc}") from exc
+        return
+    raise AssertionError(f"release custody mutation passed: {expected}")

--- a/verification/runner/sifr_verify/release_evidence_selftest.py
+++ b/verification/runner/sifr_verify/release_evidence_selftest.py
@@ -200,6 +200,18 @@ def _assert_canonicalization_rejections(root: Path) -> None:
             ),
             expected,
         )
+    symlink_root = root / "symlink"
+    symlink_root.mkdir()
+    symlink_target = root / "outside-rust-result.json"
+    symlink_bytes = b'{"area":"rust_interop"}\n'
+    symlink_target.write_bytes(symlink_bytes)
+    (symlink_root / CRITICAL_RESULTS["rust_interop"]).symlink_to(symlink_target)
+    _require_governance_rejection(
+        lambda: canonicalize_custodied_results(symlink_root),
+        "no critical area result",
+    )
+    if symlink_target.read_bytes() != symlink_bytes:
+        raise AssertionError("release custody rewrote a symlink target")
 
 
 def _require_governance_rejection(


### PR DESCRIPTION
## Summary
- canonicalize the exact release-run Rust result before hashing it into the release profile report
- stage and validate source-derived stable-support claims as canonical custody evidence
- strengthen qualification digest and custody self-tests, operator docs, and Phase 40 review records

## Validation
- `scripts/run_all_tests.sh --profile create-pr` — passed (Python 19/19, consumed Rust 10/10, E2E 131/131)
- complete `distribution_release` area — passed 125/125 in independent reviewer run
- Phase 40 distribution qualification/custody selection — passed 69/69
- `python3 scripts/check_hir_maintainability_guardrails.py` — passed
- file-size guardrail — passed
- `cargo fmt --check` and `git diff --check` — passed

## Review
- Claude Opus pass 1 found the canonical-custody incompatibilities
- Claude Opus passes 2 and 3 independently verified the fixes and returned SATISFIED

This PR is scoped only to Phase 40 release governance. It does not implement Rust interop.