### PR TITLE
test(rust-interop): certify native build scripts

### DIFF
--- a/crates/sifr_driver/src/tests/package_rust_interop_build_tests.rs
+++ b/crates/sifr_driver/src/tests/package_rust_interop_build_tests.rs
@@ -4,6 +4,8 @@ use super::*;
 mod advanced_data_support;
 #[path = "package_rust_interop_callback_subscription_support.rs"]
 mod callback_subscription_support;
+#[path = "package_rust_interop_native_build_support.rs"]
+mod native_build_support;
 #[path = "package_rust_interop_zero_copy_support.rs"]
 mod zero_copy_support;
 

--- a/crates/sifr_driver/src/tests/package_rust_interop_native_build_support.rs
+++ b/crates/sifr_driver/src/tests/package_rust_interop_native_build_support.rs
@@ -1,0 +1,315 @@
+use super::*;
+
+const NATIVE_BUILD_EVIDENCE: &str = include_str!(
+    "../../../../verification/areas/rust_interop/fixtures/native_build_script/positive/trusted_build_script_native_evidence.sifr"
+);
+const NATIVE_BUILD_NEGATIVE: &str = include_str!(
+    "../../../../verification/areas/rust_interop/fixtures/native_build_script/negative/untrusted_native_link_rejected.sifr"
+);
+const EVIDENCE_FILES: [&str; 5] = [
+    "sifr-bindgen-bindings.rs",
+    "sifr-bindgen-evidence.txt",
+    "sifr-cc-evidence.txt",
+    "sifr-cxx-evidence.txt",
+    "sifr-zstd-evidence.txt",
+];
+
+#[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
+#[doc = "sifr-evidence: executes-cargo-probe"]
+fn test_build_native_build_script_trusted_artifacts() {
+    let package_root = copied_scenario(
+        "native_build_script",
+        "native_trust_package",
+        "rust_interop_native_build_trusted",
+    );
+    install_evidence_source(
+        &package_root,
+        &format!(
+            "{NATIVE_BUILD_EVIDENCE}\n\ndef main() -> Result[None, NativeError | RustPanicError]:\n    try:\n        print(verify_trusted_build_script_native_evidence())\n    except NativeError as error:\n        raise error\n    except RustPanicError as error:\n        raise error\n    return None\n"
+        ),
+    );
+    let first_target = mktemp_dir("rust_interop_native_build_artifacts_first");
+    let second_target = mktemp_dir("rust_interop_native_build_artifacts_second");
+    let first_artifacts = cargo_build_artifacts(&package_root, &first_target);
+    let second_artifacts = cargo_build_artifacts(&package_root, &second_target);
+    assert_eq!(
+        first_artifacts, second_artifacts,
+        "fresh locked builds must emit byte-identical evidence"
+    );
+    assert_eq!(
+        first_artifacts
+            .get("sifr-cc-evidence.txt")
+            .map(Vec::as_slice),
+        Some(b"cc=1.2.63;compiled=sifr_cc_probe".as_slice())
+    );
+    assert_eq!(
+        first_artifacts
+            .get("sifr-bindgen-evidence.txt")
+            .map(Vec::as_slice),
+        Some(b"bindgen=0.72.1;function=sifr_bindgen_probe".as_slice())
+    );
+    assert_eq!(
+        first_artifacts
+            .get("sifr-cxx-evidence.txt")
+            .map(Vec::as_slice),
+        Some(b"cxx=1.0.198;bridge=sifr_cxx_probe".as_slice())
+    );
+    assert_eq!(
+        first_artifacts
+            .get("sifr-zstd-evidence.txt")
+            .map(Vec::as_slice),
+        Some(b"zstd=0.13.3;level=3".as_slice())
+    );
+    assert!(
+        first_artifacts["sifr-bindgen-bindings.rs"]
+            .windows(b"sifr_bindgen_probe".len())
+            .any(|window| window == b"sifr_bindgen_probe"),
+        "bindgen must generate the allowlisted function"
+    );
+
+    let entrypoint = package_entrypoint_from_cargo_layout(&package_root, "native-trust-package");
+    let errors = check_package_project(&entrypoint);
+    assert!(
+        errors.is_empty(),
+        "trusted native package must pass compiler checking: {errors:#?}"
+    );
+    let output = built_package_output(&entrypoint);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "Ok(\"cc=1.2.63;compiled=sifr_cc_probe|bindgen=0.72.1;function=sifr_bindgen_probe|cxx=1.0.198;bridge=sifr_cxx_probe;value=1000198|zstd=0.13.3;level=3|compressed=zstd-roundtrip\")"
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "trusted native package must not emit stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let _ = std::fs::remove_dir_all(first_target);
+    let _ = std::fs::remove_dir_all(second_target);
+    let _ = std::fs::remove_dir_all(package_root);
+}
+
+#[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
+#[doc = "sifr-evidence: executes-compiler-diagnostic"]
+fn test_check_native_build_script_untrusted_native_link_rejected_pre_execution() {
+    assert_armed_build_script_writes_sentinel();
+    for (case, manifest_line, untrusted_line, required_trust, required_evidence) in [
+        (
+            "build_script",
+            "rust-build-scripts = [\"cc\", \"bindgen\", \"cxx\", \"zstd\"]",
+            "rust-build-scripts = [\"cc\", \"bindgen\", \"cxx\"]",
+            "zstd",
+            "build script in Cargo dependency `zstd`",
+        ),
+        (
+            "native_link",
+            "native-links = [\"c++\", \"cxxbridge1\", \"link-cplusplus\", \"sifr_cc_probe\", \"sifr_zstd_probe\", \"stdc++\", \"zstd\"]",
+            "native-links = [\"c++\", \"cxxbridge1\", \"link-cplusplus\", \"sifr_cc_probe\", \"stdc++\", \"zstd\"]",
+            "sifr_zstd_probe",
+            "native links `sifr_zstd_probe` declared by Cargo dependency `zstd`",
+        ),
+    ] {
+        assert_untrusted_native_build_rejected(
+            case,
+            manifest_line,
+            untrusted_line,
+            required_trust,
+            required_evidence,
+        );
+    }
+    assert_untrusted_transitive_native_link_rejected();
+}
+
+fn assert_untrusted_native_build_rejected(
+    case: &str,
+    manifest_line: &str,
+    untrusted_line: &str,
+    required_trust: &str,
+    required_evidence: &str,
+) {
+    let package_root = copied_scenario(
+        "native_build_script",
+        "native_trust_package",
+        &format!("rust_interop_native_build_untrusted_{case}"),
+    );
+    install_evidence_source(&package_root, NATIVE_BUILD_NEGATIVE);
+    let manifest_path = package_root.join("sifr.toml");
+    let manifest =
+        std::fs::read_to_string(&manifest_path).expect("scenario manifest should be readable");
+    let untrusted = manifest.replace(manifest_line, untrusted_line);
+    assert_ne!(
+        untrusted, manifest,
+        "negative scenario must remove the {case} trust entry"
+    );
+    std::fs::write(&manifest_path, untrusted).expect("negative trust manifest should be installed");
+
+    let sentinel = arm_zstd_build_script_sentinel(&package_root);
+    assert!(!sentinel.exists(), "sentinel must start absent");
+
+    let entrypoint = package_entrypoint_from_cargo_layout(&package_root, "native-trust-package");
+    let errors = check_package_project(&entrypoint);
+    let rendered = format!("{errors:#?}");
+
+    assert_eq!(
+        errors.len(),
+        1,
+        "missing {case} trust must stop before any Cargo probe: {errors:#?}"
+    );
+    assert_eq!(errors[0].code, DiagnosticCode::RUST_TRUST_MISSING.code());
+    assert!(
+        rendered.contains(required_trust)
+            && rendered.contains(required_evidence)
+            && rendered.contains("before Cargo executes this dependency"),
+        "diagnostic must identify missing {case} trust: {errors:#?}"
+    );
+    assert!(
+        !sentinel.exists(),
+        "untrusted build script must be rejected before sentinel creation"
+    );
+    let _ = std::fs::remove_dir_all(package_root);
+}
+
+fn assert_armed_build_script_writes_sentinel() {
+    let package_root = copied_scenario(
+        "native_build_script",
+        "native_trust_package",
+        "rust_interop_native_build_sentinel_control",
+    );
+    let sentinel = arm_zstd_build_script_sentinel(&package_root);
+    let target_dir = mktemp_dir("rust_interop_native_build_sentinel_control_target");
+    let output = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "--workspace",
+            "--locked",
+            "--offline",
+            "--frozen",
+            "--target-dir",
+        ])
+        .arg(&target_dir)
+        .current_dir(&package_root)
+        .output()
+        .expect("sentinel control build should execute");
+    assert!(
+        output.status.success(),
+        "sentinel control build must pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        sentinel.exists(),
+        "armed build-script control must create its sentinel when Cargo executes it"
+    );
+    let _ = std::fs::remove_dir_all(target_dir);
+    let _ = std::fs::remove_dir_all(package_root);
+}
+
+fn arm_zstd_build_script_sentinel(package_root: &Path) -> PathBuf {
+    let build_script_path = package_root.join("rust/zstd/build.rs");
+    let build_script = std::fs::read_to_string(&build_script_path)
+        .expect("zstd wrapper build script should be readable");
+    let armed_build_script = build_script.replace(
+        "fn main() -> Result<(), Box<dyn Error>> {\n",
+        "fn main() -> Result<(), Box<dyn Error>> {\n    std::fs::write(PathBuf::from(std::env::var(\"CARGO_MANIFEST_DIR\")?).join(\"UNTRUSTED_BUILD_SCRIPT_EXECUTED\"), \"executed\")?;\n",
+    );
+    assert_ne!(
+        armed_build_script, build_script,
+        "negative sentinel mutation must arm the checked-in build script"
+    );
+    std::fs::write(build_script_path, armed_build_script)
+        .expect("armed build script should be installed");
+    package_root.join("rust/zstd/UNTRUSTED_BUILD_SCRIPT_EXECUTED")
+}
+
+fn assert_untrusted_transitive_native_link_rejected() {
+    let package_root = copied_scenario(
+        "native_build_script",
+        "native_trust_package",
+        "rust_interop_native_build_untrusted_transitive_link",
+    );
+    install_evidence_source(&package_root, NATIVE_BUILD_NEGATIVE);
+    let manifest_path = package_root.join("sifr.toml");
+    let manifest =
+        std::fs::read_to_string(&manifest_path).expect("scenario manifest should be readable");
+    let untrusted = manifest.replace(
+        "native-links = [\"c++\", \"cxxbridge1\", \"link-cplusplus\", \"sifr_cc_probe\", \"sifr_zstd_probe\", \"stdc++\", \"zstd\"]",
+        "native-links = [\"c++\", \"cxxbridge1\", \"link-cplusplus\", \"sifr_cc_probe\", \"sifr_zstd_probe\", \"stdc++\"]",
+    );
+    assert_ne!(
+        untrusted, manifest,
+        "negative scenario must remove transitive zstd link trust"
+    );
+    std::fs::write(&manifest_path, untrusted)
+        .expect("negative transitive-link manifest should be installed");
+    let entrypoint = package_entrypoint_from_cargo_layout(&package_root, "native-trust-package");
+    let errors = match build_cached_package_project(&entrypoint) {
+        Ok(_) => panic!("undeclared transitive native link must fail the generated package build"),
+        Err(errors) => errors,
+    };
+    assert!(
+        errors.iter().any(|error| {
+            error.code == DiagnosticCode::RUST_TRUST_MISSING.code()
+                && error.message.contains("untrusted native link evidence")
+                && error.message.contains("zstd")
+        }),
+        "undeclared transitive native link must be rejected after Cargo evidence: {errors:#?}"
+    );
+    let _ = std::fs::remove_dir_all(package_root);
+}
+
+fn cargo_build_artifacts(
+    package_root: &Path,
+    target_dir: &Path,
+) -> std::collections::BTreeMap<String, Vec<u8>> {
+    let output = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "--workspace",
+            "--release",
+            "--locked",
+            "--offline",
+            "--frozen",
+            "--target-dir",
+        ])
+        .arg(target_dir)
+        .current_dir(package_root)
+        .output()
+        .expect("locked native evidence build should execute");
+    assert!(
+        output.status.success(),
+        "locked native evidence build must pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut artifacts = std::collections::BTreeMap::new();
+    collect_evidence_files(target_dir, &mut artifacts);
+    assert_eq!(
+        artifacts.len(),
+        EVIDENCE_FILES.len(),
+        "every build-script evidence file must be present: {artifacts:#?}"
+    );
+    artifacts
+}
+
+fn collect_evidence_files(
+    path: &Path,
+    artifacts: &mut std::collections::BTreeMap<String, Vec<u8>>,
+) {
+    for entry in std::fs::read_dir(path).expect("artifact directory should be readable") {
+        let entry = entry.expect("artifact entry should be readable");
+        let entry_path = entry.path();
+        if entry_path.is_dir() {
+            collect_evidence_files(&entry_path, artifacts);
+            continue;
+        }
+        let file_name = entry.file_name().to_string_lossy().into_owned();
+        if !EVIDENCE_FILES.contains(&file_name.as_str()) {
+            continue;
+        }
+        let contents = std::fs::read(&entry_path).expect("evidence file should be readable");
+        assert!(
+            artifacts.insert(file_name, contents).is_none(),
+            "evidence filename must be unique within a fresh target"
+        );
+    }
+}

--- a/docs/rust-interop.mdx
+++ b/docs/rust-interop.mdx
@@ -192,6 +192,22 @@ package declares the architecture-specific native-link envelope covering the
 locked default-feature graph on arm64 and x86_64. Compiler diagnostics
 reject schema-root, shape/rank, and non-CPU device mismatches before Cargo.
 
+`native_build_script` is a locked `cargo-probe` claim for exact-pinned
+`cc`, `bindgen`, `cxx`, and `zstd`. Four direct wrapper crates expose their
+build-script and native identities through Cargo metadata before execution,
+write versioned artifacts only beneath `OUT_DIR`, and are built twice under
+`--locked --offline --frozen` to prove byte-identical evidence. Generated
+Sifr package glue observes all four artifacts and proves a zstd encode/decode
+roundtrip.
+The manifest declares the portable `cxxbridge1`, `link-cplusplus`,
+`c++`/`stdc++`, wrapper, and zstd native-link envelope; post-build evidence
+outside it is rejected. Removing either the zstd wrapper's build-script
+permission or its native-link permission produces `SIFR-RUST-TRUST-0001`
+before an armed build script can create its sentinel. This claim is certified
+for the checked-in Apple/GNU arm64 and x86_64 host envelope and requires a
+working C/C++ compiler plus a `libclang` installation discoverable by bindgen;
+it does not advertise an MSVC build-script envelope.
+
 <!-- rust-interop-stable-claims:start -->
 | Compatibility row | Category | Execution scope |
 | --- | --- | --- |
@@ -226,6 +242,7 @@ reject schema-root, shape/rank, and non-CPU device mismatches before Cargo.
 | `tensor_dlpack_bridge` | `supported-through-bridge` | `contract-only` |
 | `advanced_data_matrix` | `supported-through-bridge` | `contract-only` |
 | `advanced_data_runtime_matrix` | `supported-through-bridge` | `runtime-observed` |
+| `native_build_script` | `supported` | `cargo-probe` |
 <!-- rust-interop-stable-claims:end -->
 
 ## Direct Bindings

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -954,6 +954,31 @@ arm64/x86_64 native-output envelope declared by this locked graph. The
 `arrow_record_batch`, `tensor_dlpack_bridge`, and `advanced_data_matrix` rows
 remain contract-only and cannot satisfy a crate-backed runtime exchange claim.
 
+## Native Build Scripts and Links
+
+`native_build_script` is the tier-3 `cargo-probe` claim for build-script and
+native-link trust. Its locked scenario uses four direct wrapper crates whose
+Cargo metadata exposes build scripts before execution. Those wrappers compile
+the exact root-lock `cc = 1.2.63`, `bindgen = 0.72.1`, `cxx = 1.0.198`, and
+`zstd = 0.13.3` graph, keep generated evidence under `OUT_DIR`, and expose the
+versioned artifacts through safe Rust functions. Two fresh
+`--locked --offline --frozen` builds must produce byte-identical evidence,
+and generated Sifr package glue must observe every artifact plus a real zstd
+encode/decode roundtrip.
+
+Direct wrapper identities (`sifr_cc_probe` and `sifr_zstd_probe`), the zstd
+link, `cxxbridge1`, `link-cplusplus`, and the platform C++ runtime names form
+an exact portable allowlist. Cargo metadata trust rejects a missing direct
+build-script or native-link entry before direct probing; the negative evidence
+arms the rejected zstd build script with a sentinel and requires the sentinel
+to remain absent. Post-build Cargo messages remain fail-closed for any emitted
+native link outside the declared envelope. This claim covers the checked-in
+hermetic probe package on the certified Apple/GNU arm64 and x86_64 host
+envelope, not arbitrary build scripts, MSVC, or undeclared host libraries.
+Executing the bindgen and native compilation probes requires a working C/C++
+compiler and a `libclang` installation discoverable by bindgen; locked/offline
+Cargo does not package those host-toolchain components.
+
 ## Callbacks
 
 Callbacks are supported only with declared lifetime and threading policy.

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -153,12 +153,12 @@ only. Remaining compiler-native stdlib glue is explicitly allowlisted in
 
 Rust interop ecosystem certification is not fully complete. The active matrix
 `verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json`
-currently has 18 supported rows, 12 bridge-supported rows, 1
-unsupported-by-design row, and 5 rows owned by separate certification work.
+currently has 19 supported rows, 12 bridge-supported rows, 1
+unsupported-by-design row, and 4 rows owned by separate certification work.
 The separately owned rows are `ecosystem_backend_certification`,
-`ecosystem_cli_certification`, `native_build_script`, `proc_macro_trust`, and
-`cargo_locked_offline`. Resource migrations must not claim stable support for
-any row that remains separately owned by certification work.
+`ecosystem_cli_certification`, `proc_macro_trust`, and `cargo_locked_offline`.
+Resource migrations must not claim stable support for any row that remains
+separately owned by certification work.
 
 ## Stdlib Rust Interop Adapter Policy
 

--- a/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
+++ b/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
@@ -152,7 +152,7 @@ normative and must not be broadened.
 | `certification_6` | merged | [PR #3046](https://github.com/sifr-lang/sifr/pull/3046); retained callback subscription lifecycle and capture contract |
 | `certification_7` | merged; retrospective performance rerun pending | [PR #3053](https://github.com/sifr-lang/sifr/pull/3053); crate-backed zero-copy lifecycle and compiler rejection contract |
 | `certification_8` | merged | [PR #3067](https://github.com/sifr-lang/sifr/pull/3067); crate-backed Arrow/tensor generated package and compiler mismatch rejection |
-| `certification_9` | in progress | exact-pinned native build-script package, deterministic artifacts, and pre-execution trust rejection |
+| `certification_9` | in review | [PR #3069](https://github.com/sifr-lang/sifr/pull/3069); exact-pinned native build-script package, deterministic artifacts, and fail-closed direct/transitive trust rejection |
 | `certification_10` | blocked | starts after `certification_9` merges |
 | `certification_11` | blocked | starts after `certification_10` merges |
 | `certification_12` | blocked | starts after `certification_11` merges |
@@ -1091,6 +1091,11 @@ Review and validation notes:
   failure: a parallel `ecosystem_backend_certification` category edit promotes
   that row while its evidence remains planned. Certification 9 does not stage
   or claim that hunk.
+- The authoritative create-PR profile passed every step before Rust interop,
+  including all 19 Python-interop variants. Rust interop passed 9 of 10
+  variants and stopped only on that same unstaged backend category/evidence
+  mismatch; all certification-9 matrix, mutation, tier, stale-draft, and
+  stable-candidate variants passed.
 
 ### certification_14: Track A Closeout and Stable Gate
 

--- a/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
+++ b/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
@@ -1083,6 +1083,11 @@ Review and validation notes:
   validated the committed matrix blob independently, confirmed the unrelated
   backend hunk is absent, re-derived every inventory, and reported
   `SATISFIED` with no actionable findings.
+- [Merge-readiness round 4](../../reviews/active/rust-interop-certification-9-review-round-4.md)
+  verified the doc-only round-3 recording commit at PR head
+  `1d66d90b0014c7218ebe1eac9b46f5a6dd37a772`, reconfirmed the backend hunk
+  remains excluded and the PR is mergeable/clean, and reported `SATISFIED`
+  with no actionable findings.
 - Focused revalidation passes both mandatory generated-package tests: the
   positive proof executes two fresh byte-identical locked/offline/frozen
   builds plus generated Sifr check/build/run in 63.74 seconds, while the

--- a/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
+++ b/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
@@ -1078,6 +1078,11 @@ Review and validation notes:
   agreement, suite binding, lint, formatting, and guardrails; re-inspected all
   eleven round-1 findings; and reported `SATISFIED` with no actionable
   findings.
+- [Exact-head round 3](../../reviews/active/rust-interop-certification-9-review-round-3.md)
+  audited PR #3069 head `b5497901d4d7c7d90a65d03402708f6642e913ea`,
+  validated the committed matrix blob independently, confirmed the unrelated
+  backend hunk is absent, re-derived every inventory, and reported
+  `SATISFIED` with no actionable findings.
 - Focused revalidation passes both mandatory generated-package tests: the
   positive proof executes two fresh byte-identical locked/offline/frozen
   builds plus generated Sifr check/build/run in 63.74 seconds, while the

--- a/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
+++ b/plans/issues/active/rust-interop-runtime-ecosystem-certification.md
@@ -151,8 +151,8 @@ normative and must not be broadened.
 | `certification_5` | merged | [PR #3042](https://github.com/sifr-lang/sifr/pull/3042); opaque resource lifecycle matrix with HTTP/Redis/PostgreSQL loopbacks and a temporary SQLite database |
 | `certification_6` | merged | [PR #3046](https://github.com/sifr-lang/sifr/pull/3046); retained callback subscription lifecycle and capture contract |
 | `certification_7` | merged; retrospective performance rerun pending | [PR #3053](https://github.com/sifr-lang/sifr/pull/3053); crate-backed zero-copy lifecycle and compiler rejection contract |
-| `certification_8` | in review | [PR #3067](https://github.com/sifr-lang/sifr/pull/3067); crate-backed Arrow/tensor generated package and compiler mismatch rejection |
-| `certification_9` | blocked | starts after `certification_8` merges |
+| `certification_8` | merged | [PR #3067](https://github.com/sifr-lang/sifr/pull/3067); crate-backed Arrow/tensor generated package and compiler mismatch rejection |
+| `certification_9` | in progress | exact-pinned native build-script package, deterministic artifacts, and pre-execution trust rejection |
 | `certification_10` | blocked | starts after `certification_9` merges |
 | `certification_11` | blocked | starts after `certification_10` merges |
 | `certification_12` | blocked | starts after `certification_11` merges |
@@ -928,7 +928,7 @@ Implementation checklist:
   tests, promote only `advanced_data_runtime_matrix`, retain all three
   narrower contract-only rows, and update structured claims, public/internal
   docs, provenance, counts, and mutation-tested scenario policy.
-- [ ] Run focused and authoritative local gates, Opus review rounds to
+- [x] Run focused and authoritative local gates, Opus review rounds to
   satisfaction, merge the PR, and unblock only `certification_9`.
 
 Review and validation notes:
@@ -1016,6 +1016,81 @@ Native/proc-macro trust tests must prove rejection happens before the
 untrusted script or macro can create a sentinel file. Ecosystem tests must use
 checked-in lockfile resolution and temp packages; fetching during a validation
 lane is a failure.
+
+#### certification_9: Native Build-Script Trust
+
+Implementation checklist:
+
+- [x] Replace the planning scaffold's local `0.1.0` stand-ins with a
+  locked/offline generated package whose direct wrapper crates compile exact
+  root-lock `cc = 1.2.63`, `bindgen = 0.72.1`, `cxx = 1.0.198`, and
+  `zstd = 0.13.3` dependencies.
+- [x] Make each direct wrapper carry an actual build script so Cargo metadata
+  exposes the pre-execution trust requirement; exercise cc compilation,
+  bindgen generation, cxx bridge expansion, and zstd compression through safe
+  generated-package calls.
+- [x] Emit and runtime-observe deterministic versioned artifacts from every
+  build script, compare fresh-build evidence, and bind the complete package to
+  the checked-in lockfile with exact feature/default-feature policy.
+- [x] Declare the exact direct and transitive native-link envelope, prove the
+  post-build allowlist accepts only that envelope, and keep all build-script,
+  native-link, and artifact paths hermetic to temporary package/target
+  directories.
+- [x] Turn the checked-in negative evidence into a pre-Cargo trust rejection:
+  remove a required declared native link/build-script permission, arm an
+  untrusted build script with a sentinel write, and prove
+  `SIFR-RUST-TRUST-0001` is emitted while the sentinel remains absent.
+- [x] Bind positive and negative evidence to distinct mandatory generated
+  package tests, promote only `native_build_script`, and update structured
+  claims, public/internal docs, provenance, counts, and mutation-tested
+  scenario policy.
+- [ ] Run focused and authoritative local gates, Opus review rounds to
+  satisfaction, merge the PR, and unblock only `certification_10`.
+
+Expected post-item inventory:
+
+- 36 fixture-matrix rows, 36 compatibility rows, and 36 schema-v2 fixture
+  manifests;
+- 64 passing and 8 planned evidence directions;
+- categories: 19 `supported`, 12 `supported-through-bridge`, 1
+  `unsupported-by-design`, and 4 `future-owned-by-separate-phase`;
+- execution kinds remain 13 `cargo-probe`, 4 `compiler-diagnostic`, 10
+  `contract-only`, and 9 `runtime-observed`;
+- 44 required exact-pinned crate aliases in the checked-in root lock graph;
+- 60 package examples and 18 scenario examples; and
+- 32 structured stable claims.
+
+Review and validation notes:
+
+- [Opus round 1](../../reviews/active/rust-interop-certification-9-review-round-1.md)
+  independently reproduced the locked graph, deterministic artifacts,
+  sentinel effectiveness, native-link envelope, area inventory, and safety
+  constraints. It reported two medium and nine low findings before returning
+  `NOT SATISFIED`.
+- The round-1 fixes add a post-build rejection for undeclared transitive
+  `zstd` evidence, an armed-script positive control, kind-specific
+  pre-execution diagnostics, a real zstd encode/decode roundtrip, version
+  literal mutation coverage, and checked `probe.c` identity. Documentation
+  now scopes the claim to the Apple/GNU arm64/x86_64 host envelope and records
+  the C/C++ compiler plus libclang prerequisites.
+- [Opus round 2](../../reviews/active/rust-interop-certification-9-review-round-2.md)
+  independently reran both mandatory tests, all area inventories, pin
+  agreement, suite binding, lint, formatting, and guardrails; re-inspected all
+  eleven round-1 findings; and reported `SATISFIED` with no actionable
+  findings.
+- Focused revalidation passes both mandatory generated-package tests: the
+  positive proof executes two fresh byte-identical locked/offline/frozen
+  builds plus generated Sifr check/build/run in 63.74 seconds, while the
+  negative proof executes the sentinel control, both pre-execution trust
+  removals, and the transitive post-build rejection in 27.66 seconds.
+- Fixture-matrix self-tests pass all 166 mutation cases. Workspace Clippy,
+  scenario Clippy, rustfmt, 429 non-generated driver tests, HIR
+  maintainability, file-size, and diff-hygiene gates passed before the
+  round-1 fixes and are rerun as part of the final authoritative gate.
+- The shared worktree's full Rust-interop area currently has one unrelated
+  failure: a parallel `ecosystem_backend_certification` category edit promotes
+  that row while its evidence remains planned. Certification 9 does not stage
+  or claim that hunk.
 
 ### certification_14: Track A Closeout and Stable Gate
 

--- a/plans/reviews/active/rust-interop-certification-9-review-round-1.md
+++ b/plans/reviews/active/rust-interop-certification-9-review-round-1.md
@@ -1,0 +1,77 @@
+# Rust-Interop `certification_9` (`native_build_script`) — Review
+
+Scope: current worktree (uncommitted branch `agent/rust-interop-certification-9`). Out-of-scope parallel-agent changes (`editor_integrations`, leetcode corpus, `.cert5probe/`, `.claude/`, stray webp files, `plans/phases/43_interoperability.md`, and the `ecosystem_backend_certification` hunk in the compatibility matrix) were excluded from judgement.
+
+## Independent verification performed
+
+- **Lockfile binding**: all 68 packages in `examples/native_trust_package/Cargo.lock` resolve to versions present in the root `Cargo.lock`; `cc 1.2.63`, `bindgen 0.72.1`, `cxx 1.0.198`, `zstd 0.13.3` are exact-pinned and unique in the root graph.
+- **Determinism claim reproduced**: two fresh `cargo build --workspace --release --locked --offline --frozen` runs into separate target dirs produced byte-identical copies of all five evidence artifacts, exactly one copy each, with contents matching the literals asserted in `package_rust_interop_native_build_support.rs:40-63`. Wall time 9s and 14s — no budget risk.
+- **Sentinel arming is effective**: applying the test's exact mutation and building with trust present created `rust/zstd/UNTRUSTED_BUILD_SCRIPT_EXECUTED`. The negative test's premise is factually sound.
+- **Pre-Cargo ordering confirmed in code**: trust is recorded in `resolve_declaration` → `validate_backend_trust` (`crates/sifr_driver/src/build/rust_interop.rs:482-532`) and diagnostics abort before `execute_pending_direct_probes()` (`rust_interop.rs:176-186`), so `SIFR-RUST-TRUST-0001` genuinely precedes any Cargo dependency execution.
+- **Observed native-link envelope on this host** (macOS, `--message-format=json`): `['c++', 'cxxbridge1', 'link-cplusplus', 'sifr_cc_probe', 'zstd']`. `sifr_zstd_probe` and `stdc++` are metadata/portability entries never emitted here — the scenario README and internal docs describe this correctly.
+- **Area run reproduced**: `variants=10, blocking_failures=1`; the sole failure is `ecosystem_backend_certification: supported rows require passing positive and negative fixture evidence`, i.e. the explicitly out-of-scope hunk. `fixtures=36 diagnostics=10 crates=44 package_examples=60 scenario_examples=18`, matrix self-test `cases=165`, claims `32`, all other suites pass.
+- **Safety**: no `unsafe` (now enforced for this fixture via `_scenario_checks.py:452-457`), no `unwrap`/`expect`/panic path in build scripts or bridge code, all build-script output confined to `OUT_DIR` and enforced by `_scenario_native_build.py:370-375`.
+
+## Findings
+
+### MEDIUM — 1. The post-build native-link allowlist has no fixture-bound rejection evidence, but the promoted row claims it
+
+`rust_interop_compatibility_matrix.json:431` asserts the row "validates the exact portable native-link envelope after Cargo"; `docs/rust-interop.mdx:202-203` says "post-build evidence outside it is rejected"; `internal_docs/rust_interop_architecture.md:974-976` says "Post-build Cargo messages remain fail-closed". The plan bullet is explicit: "prove the post-build allowlist **accepts only that envelope**".
+
+Nothing in this row's evidence proves the "only" half, or even that link evidence is observed at all:
+
+- `cargo_build_artifacts` (`package_rust_interop_native_build_support.rs:175-206`) discards `output.stdout` and never runs with `--message-format=json`, so no `build-script-executed`/`linked_libs` data is ever inspected.
+- The positive test (`:71-86`) asserts only that the generated package checks, builds, and prints — acceptance is implicit. If `should_validate_native_link_evidence` regressed to `false`, or `trusted_native_links` returned everything, or Cargo stopped emitting link evidence, this test stays green.
+- The negative test (`:96-113`) covers only the **pre-Cargo direct** path (`backend.links` / `has_build_script`). Transitive names (`zstd` from `zstd-sys`, `cxxbridge1`, `link-cplusplus`, `c++`) are *only* reachable through the post-build check and are untested here.
+
+The repository already has the exact pattern to copy: `crates/sifr_driver/src/tests/package_rust_interop_build_tests.rs:692-737` removes a transitive link from `sifr.toml` and asserts `build_cached_package_project` fails with `RUST_TRUST_MISSING` + `"untrusted native link evidence"`. Add an analogous sub-case here dropping a transitive-only name (e.g. `"zstd"` or `"cxxbridge1"` — verified above to be emitted, and verified not to trip the direct-`links` pre-Cargo check). That single case converts the row's headline claim from prose to evidence and simultaneously proves the emitted envelope is non-empty and actually inspected.
+
+### MEDIUM — 2. The zstd runtime observation is invariant to the encoder
+
+`positive/trusted_build_script_native_evidence.sifr:29` and `examples/.../src/main.sifr:27` observe compression as `assert len(compressed) > 0`, surfaced as the literal `compressed=nonempty` in the asserted stdout (`package_rust_interop_native_build_support.rs:80`). The pre-change stub (`input.iter().copied().rev()`) satisfies this identically, as would any non-empty transform. The only thing pinning real zstd is the source-token check `zstd_upstream::stream::encode_all` (`_scenario_native_build.py:354`) — a source-shape assertion, which the plan's promotion rules treat as insufficient on its own.
+
+Fix cheaply: assert the zstd frame magic (`0x28 0xB5 0x2F 0xFD`) and/or a decode round-trip back to `b"sifr-rust-interop"`, or an exact compressed length, and surface that in the observed stdout string.
+
+### LOW — 3. Version provenance in artifacts is self-asserted, with no single source of truth
+
+`cc=1.2.63`, `bindgen=0.72.1`, `cxx=1.0.198`, `zstd=0.13.3` are hand-written string literals in the four `build.rs` files, and the expectations in `package_rust_interop_native_build_support.rs:40-63` are equally hand-written. The pins live independently in `Cargo.toml` and `_scenario_native_build.py:93-110`. I confirmed all four currently agree, so this is a drift-hardening gap rather than a present inaccuracy: a future pin bump that updates the manifest and the validator but not the literals would keep every gate green while the artifacts report the old versions. Have `_scenario_native_build.py` assert the evidence literals carry the same pinned versions it already enforces.
+
+### LOW — 4. The build-script negative case does not pin the trust *kind*
+
+`package_rust_interop_native_build_support.rs:163-167` asserts `rendered.contains(required_trust)`, with `required_trust = "zstd"` for the `build_script` case. Both possible diagnostics contain `zstd` (`"build script in Cargo dependency \`zstd\`"` and `"native links \`sifr_zstd_probe\` declared by Cargo dependency \`zstd\`"`), so the assertion cannot distinguish which permission was reported. `errors.len() == 1` limits the blast radius, but for evidence-grade coverage assert the kind-specific evidence text per case.
+
+### LOW — 5. `rust/cc/native/probe.c` is required by the build but unvalidated (and currently untracked)
+
+`_validate_build_sources` (`_scenario_native_build.py:333-375`) pins `.compile("sifr_cc_probe")` but never checks that `rust/cc/native/probe.c` exists or defines `sifr_cc_probe`. The file is still `??` in `git status`. If it is omitted from the commit, every blocking fast gate (area check, self-tests, Clippy, guardrails) stays green and only the `#[ignore]`d merge-profile test fails. Add an existence + symbol token check, and confirm the file is staged.
+
+### LOW — 6. New undeclared host-toolchain requirement
+
+`bindgen 0.72.1` with default features loads `libclang` dynamically at build-script execution time; `cc`, `cxx`, and `zstd-sys` need a working C/C++ toolchain. This is the first place in the repo where bindgen actually *executes* (`sifr_rust_interop_catalog` only compiles it). Nothing in the fixture README, `docs/rust-interop.mdx:195-205`, or `.github/workflows/local-first-validation.yml` (bare `ubuntu-24.04`, no toolchain install step) documents the prerequisite, and the failure mode is an opaque build-script error inside an ignored test. Document the prerequisite alongside the scenario.
+
+### LOW — 7. The public claim is not platform-scoped
+
+`docs/rust-interop.mdx:241` promotes `native_build_script` as `supported` with no target scoping, while the envelope is Apple/GNU-specific (`c++`/`stdc++`; `link-cplusplus` emits nothing on MSVC). The adjacent `advanced_data_runtime_matrix` prose sets the precedent by scoping to "arm64 and x86_64". Scope this claim the same way.
+
+### LOW — 8. Plan bookkeeping is incomplete for the work that is actually done
+
+`plans/issues/active/rust-interop-runtime-ecosystem-certification.md:1022-1049` leaves all six `certification_9` checklist items unchecked while line 155 reports "in progress" and the implementation is complete. There is also no `certification_9` "Review and validation notes" section and no "Expected post-item inventory" block (the `certification_8` block at :996 is the established convention; post-`certification_9` values are 36/36/36 rows, 64 passing / 8 planned directions, 19 `supported`, 4 `future-owned-by-separate-phase`, 32 structured claims — the latter two match the sysroot doc update and the observed `claims=32`). `plans/reviews/active/rust-interop-certification-9-review-round-1.md` exists as a 0-byte file and must not be committed empty.
+
+### LOW — 9. `# fixture-trust:` header mirrors only two of three trust lists
+
+`positive/trusted_build_script_native_evidence.sifr:6-7` mirrors `rust-build-scripts` and `native-links` but omits the newly required `rust-no-panic` list from `sifr.toml`. No checker validates these headers against the scenario manifest (`grep fixture-trust` over `verification/**/*.py` returns nothing), so they are unenforced prose in three fixtures.
+
+### LOW — 10. `_scenario_checks.py` is at 891/900 lines
+
+Extracting the native-build validator into `_scenario_native_build.py` was the right decomposition, but the dispatcher still grew from 864 to 891 lines, leaving 9 lines of headroom on a file that every subsequent certification row touches (`certification_10`–`13` remain). The next row should extract the `REQUIRED_SCENARIO_EXAMPLES` / per-fixture dispatch table rather than add to it.
+
+### LOW — 11. No in-test control for the sentinel arming
+
+The negative test proves the mutation was applied (`assert_ne!` at `:144-147`) but never proves the armed script would write the sentinel if Cargo ran — the armed `build.rs` is never compiled. I verified externally that it does write, so the evidence is sound today; the assertion is nevertheless one refactor of `zstd/build.rs` away from becoming vacuous. A one-off control (build once with trust present, observe the sentinel, then rerun untrusted) would close it.
+
+## Non-findings checked and cleared
+
+Hermeticity (explicit `--target-dir`, `--locked --offline --frozen`, `OUT_DIR`-only artifacts enforced by validator + mutation case, in-memory bindgen header, vendored zstd C sources, no network); trust identity correctness (renaming wrapper `links` to `sifr_cc_probe`/`sifr_zstd_probe` is what makes the direct pre-Cargo check meaningful, and the mutation suite pins it); `unsafe-rust-bridges` removal is correct now that the bridge contains no `unsafe`; `rust-no-panic` declarations are honest for all five targets; `assert` in fixture Sifr sources is the repository's sanctioned assertion-first e2e style; `errors.len() == 1` in both negative cases is achievable and correct; provenance records validate against the weakest blocking profile and both `#[ignore]`d tests exist with matching names; mutation coverage (12 cases) hits pins, package identity, `build.rs` declaration, `links` identity, all three trust lists, each crate's execution token, and OUT_DIR containment; `target/` exclusion in `_scenario_files` and `copy_fixture_tree` prevents the stale in-fixture build dir from contaminating checks or copies; the sysroot-doc count update (19 supported / 4 future-owned) is correct for `certification_9` alone.
+
+## Verdict
+
+NOT SATISFIED

--- a/plans/reviews/active/rust-interop-certification-9-review-round-2.md
+++ b/plans/reviews/active/rust-interop-certification-9-review-round-2.md
@@ -1,0 +1,56 @@
+All independent verification is complete. Both mandatory tests pass on this host, the area run reproduces exactly one out-of-scope failure, and every round-1 finding has been re-inspected against the current worktree.
+
+# Rust-Interop `certification_9` (`native_build_script`) — Review Round 2
+
+Scope: current worktree on `agent/rust-interop-certification-9`. Excluded from judgement exactly as specified: `editor_integrations`, the leetcode corpus submodule, `.cert5probe/`, `.claude/`, the two stray `*.webp` files, `plans/phases/43_interoperability.md`, `*.claude.log`, and the `ecosystem_backend_certification` `category`/`future_owner` hunk in `rust_interop_compatibility_matrix.json:396-400`. No files were modified by this review.
+
+## Independent verification performed
+
+- **Both mandatory tests executed green here**: `cargo test -p sifr_driver --lib -- --ignored --test-threads=1 native_build` → `2 passed; 0 failed` in 75.56s (warm caches; consistent with the reported 63.74s + 27.66s cold splits). These are the exact test names bound in `fixtures/native_build_script/fixture.json`.
+- **Suite binding is real, not nominal**: `verification/profiles/merge.json:73` runs `sifr_driver_generated_builds` as `cargo test -p sifr_driver --lib -- --ignored --test-threads=1`, `modes: ["full"]`, `status: blocking`, `executed_in_merge: true`. Both `#[ignore]`d tests are therefore executed by the merge gate, and `crates/sifr_driver/src/tests/package_rust_interop_build_tests.rs:7-8` wires the new module in.
+- **Area run reproduced**: `variants=10, blocking_failures=1`; the sole failure is `ecosystem_backend_certification: supported rows require passing positive and negative fixture evidence` — the explicitly out-of-scope hunk. All other suites green: `fixtures=36 diagnostics=10 crates=44 package_examples=60 scenario_examples=18`, matrix self-test `cases=166`, tiers `tiers=5 fixtures=36`, stale-draft self-test `cases=20`, `claims=32` + self-test `cases=33`.
+- **Inventory recomputed from data, discounting the excluded hunk**: 36 compatibility rows, 36 fixture rows; categories 19 `supported` / 12 `supported-through-bridge` / 1 `unsupported-by-design` / 4 `future-owned-by-separate-phase`; execution kinds 13 `cargo-probe` / 4 `compiler-diagnostic` / 10 `contract-only` / 9 `runtime-observed`; evidence 64 `passing` / 8 `planned`; 32 structured claims. Every figure matches the plan's new "Expected post-item inventory" block (`plans/issues/active/rust-interop-runtime-ecosystem-certification.md:1055-1066`) and the sysroot-doc counts (`internal_docs/sifr_sysroot_and_stdlib_architecture.md:155-161`) exactly.
+- **Pin agreement re-checked end to end**: root `Cargo.lock` resolves exactly one each of `cc 1.2.63`, `bindgen 0.72.1`, `cxx 1.0.198`, `zstd 0.13.3`; identical in the scenario `Cargo.toml:6-9`, in `_scenario_native_build.py:14-17,94-111`, in the four `build.rs` artifact literals, and in the test's asserted evidence strings.
+- **Gates rerun locally**: `cargo fmt --check` clean; `cargo clippy --workspace -- -D warnings` clean; scenario `cargo clippy --workspace --locked --offline -- -D warnings` clean; `scripts/check_file_size_guardrails.py` → `PASS (2978 files, limit 900 lines)`; `git diff --check` clean. (`cargo clippy --workspace --all-targets` fails in `sifr_ipc` on pre-existing `expect_used` lints unrelated to this branch and outside the project's documented clippy command.)
+- **New/untracked files are not gitignored**: `git check-ignore` returns non-zero for `rust/cc/native/probe.c`, `package_rust_interop_native_build_support.rs`, and `_scenario_native_build.py`, so all three will be picked up by `git add`. Only the fixture-local `target/` dir is ignored (`.gitignore:26`).
+
+## Round-1 findings — disposition
+
+**MEDIUM 1 (post-build allowlist had no rejection evidence) — RESOLVED.** `package_rust_interop_native_build_support.rs:225-259` adds `assert_untrusted_transitive_native_link_rejected`, which drops `"zstd"` from `native-links` and requires `build_cached_package_project` to fail with `RUST_TRUST_MISSING` + `"untrusted native link evidence"` + `"zstd"`. I confirmed that message string exists only in the post-build path (`crates/sifr_driver/src/build/materialize.rs:355`, inside `validate_native_link_evidence`, which parses `build-script-executed`/`linked_libs` JSON), and that `"zstd"` is unreachable from the pre-Cargo direct check because the wrapper declares `links = "sifr_zstd_probe"` (`_scenario_native_build.py:66-70`; wrapper `Cargo.toml`). The case therefore proves the emitted envelope is non-empty, actually inspected, and fail-closed — and it makes a regression of `should_validate_native_link_evidence` to `false` test-visible, which was the specific hole called out. The accept-half is exercised by the positive test, which builds and runs through the same `materialize.rs` path with the full seven-name envelope.
+
+**MEDIUM 2 (zstd observation invariant to the encoder) — RESOLVED.** `positive/trusted_build_script_native_evidence.sifr:31-33` and `examples/.../src/main.sifr:29-31` now do `compress` → `decompress` → `assert decoded == b"sifr-rust-interop"`, surfaced as `compressed=zstd-roundtrip` in the asserted stdout (`package_rust_interop_native_build_support.rs:80`). This is no longer encoder-invariant: `decompress` is real `zstd_upstream::stream::decode_all` (`rust/zstd/src/lib.rs:9-11` via `src/bridges/native.rs:21-23`), which errors on non-zstd input, so a stubbed or `rev()`-style encoder now surfaces as `NativeError` and a stdout mismatch. Replacing both sides is separately blocked by the token requirements on `encode_all`/`decode_all` (`_scenario_native_build.py:370-373`) plus the `zstd execution drift` mutation case (`:258-264`).
+
+**LOW 3 (version provenance self-asserted) — RESOLVED with a residual, non-blocking.** `_validate_build_sources` now pins each artifact literal against its build script (`_scenario_native_build.py:352,359,363,368`) and the `artifact version drift` mutation case (`:265-271`) proves the check fires. The literals are still independent constants from the pin dict rather than derived from it, so a hypothetical future bump that edits `Cargo.toml:6-9`, `NATIVE_BUILD_SCENARIO_TOKENS`, `expected_workspace_dependencies`, and the mutation token but misses lines 352/359/363/368 would still leave stale artifact versions green. I judge this non-blocking: all four pins currently agree across five locations, the drift surface shrank from zero enforced sites to four, the failure mode is a cosmetically wrong evidence string rather than a false support claim, and round-1 itself classified this as drift-hardening with no present inaccuracy. Carried forward below.
+
+**LOW 4 (build-script negative case did not pin the trust kind) — RESOLVED.** Each case now carries a kind-specific `required_evidence` string — `"build script in Cargo dependency \`zstd\`"` and `"native links \`sifr_zstd_probe\` declared by Cargo dependency \`zstd\`"` (`:104,:111`) — asserted alongside `"before Cargo executes this dependency"` at `:161-166`, on top of `errors.len() == 1` and the `RUST_TRUST_MISSING` code check. The two diagnostics are now distinguishable.
+
+**LOW 5 (`probe.c` unvalidated and untracked) — RESOLVED.** `_scenario_native_build.py:374-377` requires `rust/cc/native/probe.c` to contain `unsigned int sifr_cc_probe(void)` and `return 1263U;`; the file exists with exactly that content and is not gitignored. The `rust/cc/native/` directory is untracked only because nothing on this branch is committed yet.
+
+**LOW 6 (undeclared host-toolchain requirement) — RESOLVED.** The C/C++-compiler and discoverable-`libclang` prerequisite is now documented in all three places a reader would look: `docs/rust-interop.mdx:206-208`, `internal_docs/rust_interop_architecture.md:974-978`, and `fixtures/native_build_script/examples/native_trust_package/README.md:17-20`. Informational: `.github/workflows/local-first-validation.yml` still has no explicit toolchain install step and relies on the GitHub `ubuntu-24.04` image's preinstalled clang/llvm and gcc; that is a CI-image assumption shared with the existing `cc`-dependent `cargo-probe` rows, not a certification_9 regression.
+
+**LOW 7 (claim not platform-scoped) — RESOLVED.** `docs/rust-interop.mdx:204-208` scopes the claim to "the checked-in Apple/GNU arm64 and x86_64 host envelope" and states it "does not advertise an MSVC build-script envelope", matching the `advanced_data_runtime_matrix` precedent. The scoping is echoed in the matrix note (`rust_interop_compatibility_matrix.json:431`), `internal_docs/rust_interop_architecture.md:970-973`, and both READMEs.
+
+**LOW 8 (plan bookkeeping) — RESOLVED.** `plans/issues/.../rust-interop-runtime-ecosystem-certification.md:1020-1053` now checks the six implementation items and correctly leaves only the merge/gates item open; `:1055-1066` adds the "Expected post-item inventory" block (verified numerically above); `:1068-1090` adds "Review and validation notes" with the round-1 link; `:154-155` updates `certification_8` to `merged` and `certification_9` to `in progress`. The round-1 review file is no longer empty (12,059 bytes).
+
+**LOW 9 (`# fixture-trust:` header parity) — RESOLVED.** `positive/trusted_build_script_native_evidence.sifr:6-8` now mirrors all three lists, byte-identical to `sifr.toml:22-24` including `rust-no-panic`. The headers remain unenforced prose, which round-1 noted but did not make the ask.
+
+**LOW 10 (`_scenario_checks.py` headroom) — ACKNOWLEDGED, correctly deferred.** Still 891/900; guardrail passes. The plan records the extraction as certification_10 work. Round-1 scoped this to "the next row", so it is not actionable here.
+
+**LOW 11 (no in-test control for sentinel arming) — RESOLVED.** `assert_armed_build_script_writes_sentinel` (`:174-206`) is invoked first (`:97`), compiles and runs the armed workspace under `--locked --offline --frozen`, and asserts the sentinel exists; the two rejection cases then assert it stays absent (`:149`, `:167-170`). The mutation is shared through `arm_zstd_build_script_sentinel` (`:208-223`), so the control cannot drift from the cases it validates.
+
+## Findings
+
+None. No actionable findings remain.
+
+## Merge preconditions (mechanical, outside the code under review)
+
+- Write this round-2 review into `plans/reviews/active/rust-interop-certification-9-review-round-2.md`, which is currently a 0-byte placeholder, and link it from the plan's "Review and validation notes"; per round-1 finding 8 it must not be committed empty.
+- Check the final `certification_9` checklist item and flip the status-table row at merge time.
+- Stage only certification_9 files: the six shared-worktree exclusions and the `ecosystem_backend_certification` category/`future_owner` hunk must stay out of the commit. That hunk remains the sole, unrelated reason the full area checker is not all-green.
+
+## Carry-forward for certification_10 (non-blocking)
+
+- Extract the `REQUIRED_SCENARIO_EXAMPLES` / per-fixture dispatch table out of `_scenario_checks.py` before adding to it (9 lines of headroom).
+- Derive the artifact evidence literals in `_scenario_native_build.py` from the pin constants instead of restating them, closing the residual under finding 3.
+
+SATISFIED

--- a/plans/reviews/active/rust-interop-certification-9-review-round-3.md
+++ b/plans/reviews/active/rust-interop-certification-9-review-round-3.md
@@ -1,0 +1,48 @@
+# Rust-Interop `certification_9` (`native_build_script`) — Exact-Head Review
+
+**Head:** `b5497901d4d7c7d90a65d03402708f6642e913ea` · **Base:** `origin/main` = `f188986482e` (the `certification_8` merge, PR #3067) · **PR:** #3069 (`DRAFT`) · 2 commits, 36 files, +1865/−98.
+
+Scope note: the local `main` ref was stale by one merge commit; `git diff main...HEAD` therefore misleadingly shows 65 files including all of `certification_8`. All judgements below use the true merge base `f18898648` / `gh pr diff 3069`. Shared-worktree changes outside the commits (`editor_integrations`, leetcode corpus, `.cert5probe/`, `.claude/`, stray `*.webp`, `plans/phases/43_interoperability.md`, the untracked round-3 placeholder) are excluded as specified.
+
+## Independent verification performed
+
+**Out-of-scope backend hunk is excluded — confirmed two ways.**
+- The PR's only hunk in `rust_interop_compatibility_matrix.json` is the `native_build_script` row (`:422-432`): `category` `future-owned-by-separate-phase` → `supported`, `future_owner` dropped, both evidence directions `planned` → `passing`, note rewritten. The worktree's unstaged promotion of `ecosystem_backend_certification` (`:396-400`) is absent from the diff; `grep ecosystem_backend` over `gh pr diff` hits only prose, review-file text, and unchanged checker context — no data-row change.
+- Behavioural proof, not just textual: running `check_compatibility_matrix.main()` with `COMPATIBILITY_MATRIX_PATH` monkeypatched to the committed HEAD blob (no repo file touched) → `rust interop compatibility matrix ok: rows=36 fixture_rows=36 categories=4`, exit `0`. The same checker against the worktree fails with `ecosystem_backend_certification: supported rows require passing positive and negative fixture evidence`. The full area run reproduces `variants=10, failures=1, blocking_failures=1` with that single failure and every other case green (`fixtures=36 diagnostics=10 crates=44 package_examples=60 scenario_examples=18`, matrix self-test `cases=166`, `tiers=5 fixtures=36`, stale-draft `cases=20`, `claims=32` + `cases=33`). The PR itself is all-green for that variant; the failure is entirely attributable to the excluded hunk.
+
+**Inventory recomputed from committed data** (not from the plan's prose): 36 compatibility rows, 36 fixture rows, 32 structured claims; categories 19 `supported` / 12 `supported-through-bridge` / 4 `future-owned-by-separate-phase` / 1 `unsupported-by-design`; execution kinds 13 `cargo-probe` / 10 `contract-only` / 9 `runtime-observed` / 4 `compiler-diagnostic`; evidence 64 `passing` / 8 `planned`. Exactly matches the plan's "Expected post-item inventory" (`plans/issues/active/rust-interop-runtime-ecosystem-certification.md:1053-1064`) and the sysroot-doc counts (`internal_docs/sifr_sysroot_and_stdlib_architecture.md:155-158`, `18→19` supported / `5→4` future-owned, with `native_build_script` correctly removed from the separately-owned list). `stable_support_claims.json` and the generated `docs/rust-interop.mdx:245` table row agree (`supported` / `cargo-probe`).
+
+**Post-round-2 commit `b5497901d` is accurate.** Its two hunks are: the status row → `in review` with the PR #3069 link, and one new validation paragraph. Each claim checked:
+- "all 19 Python-interop variants" — `verification/profiles/create-pr.json` `selected_areas` lists exactly 19 `python_interop` suites (counted programmatically).
+- "passed every step before Rust interop … stopped only on that same mismatch" — ordering verified in `verification/runner/sifr_verify/profile_runner.py:74-91`: `python_interop` is step 5, `rust_interop_checks` step 6, and `run()` (`:235-242`) returns on the first non-zero step. The sequencing and the "stopped only on" phrasing are literally correct, and the paragraph makes no claim about later steps.
+- "9 of 10 variants" — matches the reproduced `variants=10, blocking_failures=1`.
+- "in review" is honest for a draft PR under review; the plan correctly leaves the final checklist item (`gates, review, merge, unblock certification_10`) unchecked while items 1–6 are `[x]`.
+- Minor: the commit subject says "link certification 9 review" though the round-1/round-2 review links landed in `661498bfa`; this commit adds the *PR* link. Cosmetic only.
+
+**Round-2 merge preconditions met.** Both review files are committed non-empty (`round-1` 12,059 B, `round-2` 11,284 B — round-1 finding 8 explicitly forbade committing empty placeholders) and both are linked from the plan's "Review and validation notes" (`:1066-1088`). Worktree and committed copies of `plans/reviews/active/` are identical (`git diff` empty).
+
+**Test binding is real.** `fixtures/native_build_script/fixture.json` binds both directions to `crates/sifr_driver/src/tests/package_rust_interop_native_build_support.rs` with `profile: merge`, `step: crate_tests`, `suite_id: sifr_driver_generated_builds`. Both functions exist and are `#[ignore]`d (`:18-20`, `:94-96`), the module is wired at `package_rust_interop_build_tests.rs:7-8`, and `create-pr.json:90` runs `sifr_driver_generated_builds` as `cargo test -p sifr_driver --lib -- --ignored --test-threads=1`, `status: blocking`, `executed_in_merge: true`.
+
+**Change is scoped, no regression surface.** The `_scenario_checks.py` diff is confined to the `native_build_script` dispatch (inline checks → `validate_native_build_scenario`), the shared token constant, adding `native_build_script` to `reject_unsafe_rust`, and the new `_scenario_files` helper. `_scenario_files` is the only cross-fixture behaviour change: it excludes any path component named `target` from `rglob`, for all fixtures. That is a strict narrowing of build outputs only, and every fixture's scenario check still passes in the reproduced area run — cleared, not a finding. No compiler-crate files are in the PR (`build/rust_interop.rs`, `trust_validation.rs`, and `rust_interop_contract_tests.rs` belong to `certification_8` and appear only against the stale local `main`). `scripts/check_file_size_guardrails.py` → `PASS (2978 files, limit 900 lines)`; `git show b5497901d --check` clean.
+
+**Docs and matrix prose match observed behaviour.** The Apple/GNU arm64/x86_64 host scoping, the explicit non-advertisement of an MSVC envelope, and the C/C++-compiler + discoverable-`libclang` prerequisite appear consistently in `docs/rust-interop.mdx:195-207`, `internal_docs/rust_interop_architecture.md:957-980`, and both fixture READMEs — matching round-1's observed envelope (`stdc++` and the wrapper metadata names are described as portability entries, not as emitted on macOS).
+
+**Not re-executed here:** the two `#[ignore]`d generated-build tests. Round 2 independently ran them green (`2 passed; 0 failed`, 75.56 s) and the validation context confirms it; the only change since round 2 is `b5497901d`, a documentation-only commit that touches no test, fixture, checker, or data input, so it cannot alter those outcomes.
+
+## Findings
+
+None. No actionable findings remain. All eleven round-1 findings were resolved or correctly deferred per round 2, and no new issue is introduced by the post-round-2 commit.
+
+## Mechanical merge preconditions (outside the code under review)
+
+- `plans/reviews/active/rust-interop-certification-9-review-round-3.md` is a 0-byte untracked placeholder. Per round-1 finding 8 it must be written with this review's content and linked from the plan, or left out of the commit entirely — not committed empty.
+- Check the final `certification_9` checklist item, flip the status row to `merged`, and unblock only `certification_10`.
+- Keep the shared-worktree exclusions and the `ecosystem_backend_certification` `category`/`future_owner` hunk out of any further commit; that hunk remains the sole unrelated reason the full area checker is not all-green.
+- PR #3069 is still `DRAFT`; mark ready before merge.
+
+## Carry-forward for `certification_10` (non-blocking, unchanged from round 2)
+
+- Extract the `REQUIRED_SCENARIO_EXAMPLES` / per-fixture dispatch table out of `_scenario_checks.py` before adding to it (891/900 lines).
+- Derive the artifact evidence literals in `_scenario_native_build.py` from the pin constants rather than restating them.
+
+SATISFIED

--- a/plans/reviews/active/rust-interop-certification-9-review-round-4.md
+++ b/plans/reviews/active/rust-interop-certification-9-review-round-4.md
@@ -1,0 +1,37 @@
+# Rust-Interop `certification_9` — Round 4 Exact-Head Merge-Readiness Review
+
+**Head:** `1d66d90b0014c7218ebe1eac9b46f5a6dd37a772` (matches `gh pr view` `headRefOid`) · **Base:** `main` · **PR #3069**, 3 commits (`661498bfa`, `b5497901d`, `1d66d90b0`), 38 files. Shared-worktree dirt excluded as specified. No files modified by this review.
+
+## Delta since round 3 (`b5497901d`) is exactly the two expected doc changes
+
+`git show 1d66d90b0 --stat` → 2 files, +53/−0, documentation only:
+- `plans/reviews/active/rust-interop-certification-9-review-round-3.md` (new, 8,225 B — non-empty, satisfying round-1 finding 8's ban on empty placeholders).
+- `plans/issues/active/rust-interop-runtime-ecosystem-certification.md:1081-1085` — one 5-line link/summary bullet.
+
+No code, fixture, checker, data, or test input touched, so round 3's execution-based conclusions carry forward unchanged.
+
+## Round-3 verdict is accurately preserved
+
+- Committed round-3 file ends in `SATISFIED` with an explicit "None. No actionable findings remain." findings section — verdict intact.
+- The plan bullet's claims each check out against the file: head `b5497901d4d7c7d90a65d03402708f6642e913ea` (confirmed the full SHA of `b5497901d`), independent validation of the committed matrix blob, absence of the backend hunk, inventory re-derivation, and `SATISFIED` with no actionable findings. No overstatement — the bullet omits nothing material and adds nothing the review didn't establish.
+- Link path `../../reviews/active/rust-interop-certification-9-review-round-3.md` resolves from `plans/issues/active/`; rounds 1–3 are all committed and linked (`:1066-1085`).
+- Worktree and committed copies of `plans/reviews/active/` and the plan file are identical (`git diff HEAD` empty for both).
+
+## Unrelated matrix hunk still excluded
+
+The PR's only hunk in `rust_interop_compatibility_matrix.json` is `@@ -422,15 +422,14 @@` — the `native_build_script` row alone: `future-owned-by-separate-phase` → `supported`, `future_owner` dropped, both evidence directions `planned` → `passing`, notes rewritten. The uncommitted `ecosystem_backend_certification` promotion at `:396-400` remains worktree-only and absent from the diff; every `ecosystem_backend` hit in `gh pr diff` is prose, review-file text, or unchanged checker/fixture context — no second data-row change.
+
+Guardrail re-run at this head: `file-size guardrails: PASS (2978 files, limit 900 lines)`. PR is `MERGEABLE` / `CLEAN`.
+
+## Findings
+
+None actionable. Two non-blocking mechanical notes, both already itemized inside the round-3 file's own "Mechanical merge preconditions" section and unchanged by this commit:
+
+- PR #3069 is still `isDraft: true` — mark ready before merge.
+- Post-merge bookkeeping remains: check the final `certification_9` checklist item, flip the status row (`:155`, currently `in review`) to `merged`, and unblock only `certification_10` (`:156`).
+
+Also cosmetic: the round-3 file's precondition bullet describing itself as "a 0-byte untracked placeholder" is now self-stale, since `1d66d90b0` is precisely the commit that resolved it. Historical review artifacts are records of their moment; no change warranted.
+
+No actionable findings remain.
+
+SATISFIED

--- a/verification/areas/rust_interop/checks/_scenario_checks.py
+++ b/verification/areas/rust_interop/checks/_scenario_checks.py
@@ -23,6 +23,11 @@ from _scenario_callback_subscriptions import (
     validate_callback_subscription_scenario,
 )
 from _scenario_lock_checks import read_root_lock, require_root_lock_subset
+from _scenario_native_build import (
+    NATIVE_BUILD_SCENARIO_TOKENS,
+    run_native_build_self_test,
+    validate_native_build_scenario,
+)
 from _scenario_opaque_resources import (
     OPAQUE_RESOURCE_SCENARIO_TOKENS,
     run_opaque_resource_self_test,
@@ -143,7 +148,7 @@ REQUIRED_SCENARIO_EXAMPLES = {
     },
     "native_build_script": {
         "native_trust_package": {
-            "tokens": ("rust-build-scripts", "native-links", "zstd", "bindgen", "cxx"),
+            "tokens": NATIVE_BUILD_SCENARIO_TOKENS,
         },
     },
     "ecosystem_backend_certification": {
@@ -398,6 +403,13 @@ def run_self_test() -> tuple[int, str | None]:
     if advanced_data_error is not None:
         return cases, advanced_data_error
 
+    native_build_cases, native_build_error = run_native_build_self_test(
+        AREA_ROOT, validate_scenario_examples
+    )
+    cases += native_build_cases
+    if native_build_error is not None:
+        return cases, native_build_error
+
     return cases, None
 
 
@@ -419,9 +431,9 @@ def _validate_scenario_example_dir(
     if not cargo_manifest_path.is_file():
         failures.append(f"{fixture_id}: {raw_path}/Cargo.toml is required")
 
-    sifr_sources = sorted(example_dir.rglob("*.sifr"))
-    cargo_manifests = sorted(example_dir.rglob("Cargo.toml"))
-    rust_sources = sorted(example_dir.rglob("*.rs"))
+    sifr_sources = _scenario_files(example_dir, "*.sifr")
+    cargo_manifests = _scenario_files(example_dir, "Cargo.toml")
+    rust_sources = _scenario_files(example_dir, "*.rs")
     if not sifr_sources:
         failures.append(f"{fixture_id}: {raw_path} must include a Sifr source file")
     if not cargo_manifests:
@@ -439,12 +451,24 @@ def _validate_scenario_example_dir(
             failures.append(f"{fixture_id}: {raw_path} missing scenario token {token!r}")
     if fixture_id == "shared_bridge_crate":
         _reject_generated_bridge_imports(failures, fixture_id, raw_path, rust_sources)
-    if fixture_id in {"advanced_data_runtime_matrix", "zero_copy_runtime_matrix"}:
+    if fixture_id in {
+        "advanced_data_runtime_matrix",
+        "native_build_script",
+        "zero_copy_runtime_matrix",
+    }:
         reject_unsafe_rust(failures, fixture_id, rust_sources, example_dir)
     for source in sifr_sources:
         text = source.read_text(encoding="utf-8")
         raw_source_path = source.relative_to(example_dir).as_posix()
         _validate_scenario_sifr_source(failures, fixture_id, example, f"{raw_path}/{raw_source_path}", text)
+
+
+def _scenario_files(example_dir: Path, pattern: str) -> list[Path]:
+    return sorted(
+        path
+        for path in example_dir.rglob(pattern)
+        if "target" not in path.relative_to(example_dir).parts
+    )
 
 
 def _validate_scenario_manifests(
@@ -612,12 +636,15 @@ def _validate_scenario_manifests(
         _require_trust_targets(failures, fixture_id, raw_path, trust, "rust-proc-macros", ["serde_derive"])
         _require_trust_targets(failures, fixture_id, raw_path, trust, "rust-build-scripts", ["prost-build"])
     elif fixture_id == "native_build_script":
-        for dependency in ("cc", "bindgen", "cxx", "zstd"):
-            _require_path_dependency(failures, fixture_id, raw_path, dependencies, dependency, f"rust/{dependency}")
-            _require_build_script(failures, fixture_id, raw_path, example_dir, f"rust/{dependency}")
-        _require_native_links(failures, fixture_id, raw_path, example_dir, "rust/zstd", "zstd")
-        _require_trust_targets(failures, fixture_id, raw_path, trust, "rust-build-scripts", ["cc", "bindgen", "cxx", "zstd"])
-        _require_trust_targets(failures, fixture_id, raw_path, trust, "native-links", ["zstd"])
+        validate_native_build_scenario(
+            failures,
+            fixture_id,
+            raw_path,
+            cargo,
+            dependencies,
+            trust,
+            example_dir,
+        )
     elif fixture_id == "ecosystem_backend_certification":
         _require_path_dependency(failures, fixture_id, raw_path, dependencies, "axum", "rust/axum")
         _require_path_dependency(failures, fixture_id, raw_path, dependencies, "tower-http", "rust/tower_http")

--- a/verification/areas/rust_interop/checks/_scenario_native_build.py
+++ b/verification/areas/rust_interop/checks/_scenario_native_build.py
@@ -1,0 +1,414 @@
+"""Exact native build-script scenario policy and mutation coverage."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import tomllib
+from pathlib import Path
+from typing import Any, Callable
+
+ScenarioValidator = Callable[[list[str], str, Path, dict[str, Any]], int]
+
+NATIVE_BUILD_SCENARIO_TOKENS = (
+    'bindgen_upstream = { package = "bindgen", version = "=0.72.1"',
+    'cc_upstream = { package = "cc", version = "=1.2.63"',
+    'cxx = { version = "=1.0.198"',
+    'zstd_upstream = { package = "zstd", version = "=0.13.3"',
+    "cc_upstream::Build::new()",
+    '.compile("sifr_cc_probe")',
+    "bindgen_upstream::Builder::default()",
+    '.allowlist_function("sifr_bindgen_probe")',
+    "#[cxx::bridge]",
+    "zstd_upstream::stream::encode_all",
+    "sifr-bindgen-bindings.rs",
+    "sifr-cc-evidence.txt",
+    "sifr-cxx-evidence.txt",
+    "sifr-zstd-evidence.txt",
+    '"c++", "cxxbridge1", "link-cplusplus", "sifr_cc_probe", "sifr_zstd_probe", "stdc++", "zstd"',
+)
+
+EXPECTED_BUILD_SCRIPTS = ["cc", "bindgen", "cxx", "zstd"]
+EXPECTED_NATIVE_LINKS = [
+    "c++",
+    "cxxbridge1",
+    "link-cplusplus",
+    "sifr_cc_probe",
+    "sifr_zstd_probe",
+    "stdc++",
+    "zstd",
+]
+EXPECTED_NO_PANIC = [
+    "bindgen.artifact",
+    "bridge.native.compress",
+    "bridge.native.decompress",
+    "cc.artifact",
+    "cxx.artifact",
+    "zstd.artifact",
+]
+
+WRAPPERS = {
+    "bindgen": {
+        "package": "sifr-bindgen-probe",
+        "build_dependencies": {"bindgen_upstream": {"workspace": True}},
+        "links": None,
+    },
+    "cc": {
+        "package": "sifr-cc-probe",
+        "build_dependencies": {"cc_upstream": {"workspace": True}},
+        "links": "sifr_cc_probe",
+    },
+    "cxx": {
+        "package": "sifr-cxx-probe",
+        "dependencies": {"cxx": {"workspace": True}},
+        "links": None,
+    },
+    "zstd": {
+        "package": "sifr-zstd-probe",
+        "dependencies": {"zstd_upstream": {"workspace": True}},
+        "links": "sifr_zstd_probe",
+    },
+}
+
+
+def validate_native_build_scenario(
+    failures: list[str],
+    fixture_id: str,
+    raw_path: str,
+    cargo: dict[str, Any],
+    dependencies: dict[str, Any],
+    trust: dict[str, Any],
+    example_dir: Path,
+) -> None:
+    workspace = cargo.get("workspace", {})
+    if workspace.get("members") != [
+        "rust/cc",
+        "rust/bindgen",
+        "rust/cxx",
+        "rust/zstd",
+    ]:
+        failures.append(
+            f"{fixture_id}: {raw_path}/Cargo.toml workspace members must equal "
+            "the four native wrapper crates"
+        )
+    expected_workspace_dependencies = {
+        "bindgen_upstream": {
+            "package": "bindgen",
+            "version": "=0.72.1",
+            "default-features": True,
+        },
+        "cc_upstream": {
+            "package": "cc",
+            "version": "=1.2.63",
+            "default-features": True,
+        },
+        "cxx": {"version": "=1.0.198", "default-features": True},
+        "zstd_upstream": {
+            "package": "zstd",
+            "version": "=0.13.3",
+            "default-features": True,
+        },
+    }
+    if workspace.get("dependencies") != expected_workspace_dependencies:
+        failures.append(
+            f"{fixture_id}: {raw_path}/Cargo.toml workspace dependencies must "
+            "exact-pin cc, bindgen, cxx, and zstd"
+        )
+
+    for name, policy in WRAPPERS.items():
+        expected_root = {
+            "package": policy["package"],
+            "path": f"rust/{name}",
+        }
+        if dependencies.get(name) != expected_root:
+            failures.append(
+                f"{fixture_id}: {raw_path}/Cargo.toml dependency {name} "
+                f"must equal {expected_root!r}"
+            )
+        _validate_wrapper_manifest(
+            failures,
+            fixture_id,
+            raw_path,
+            example_dir / f"rust/{name}/Cargo.toml",
+            name,
+            policy,
+        )
+
+    _require_exact_trust(
+        failures,
+        fixture_id,
+        raw_path,
+        trust,
+        "rust-build-scripts",
+        EXPECTED_BUILD_SCRIPTS,
+    )
+    _require_exact_trust(
+        failures,
+        fixture_id,
+        raw_path,
+        trust,
+        "native-links",
+        EXPECTED_NATIVE_LINKS,
+    )
+    _require_exact_trust(
+        failures,
+        fixture_id,
+        raw_path,
+        trust,
+        "rust-no-panic",
+        EXPECTED_NO_PANIC,
+    )
+    _validate_build_sources(failures, fixture_id, raw_path, example_dir)
+
+
+def run_native_build_self_test(
+    area_root: Path,
+    validate_scenarios: ScenarioValidator,
+) -> tuple[int, str | None]:
+    source = area_root / "fixtures/native_build_script"
+    raw_examples = {"native_trust_package": "examples/native_trust_package"}
+    cases = 0
+    with tempfile.TemporaryDirectory(
+        prefix="sifr-rust-native-build-scenario-self-test-"
+    ) as raw_temp:
+        fixture_dir = Path(raw_temp) / "native_build_script"
+        shutil.copytree(source, fixture_dir, ignore=shutil.ignore_patterns("target"))
+        baseline_failures: list[str] = []
+        validate_scenarios(
+            baseline_failures,
+            "native_build_script",
+            fixture_dir,
+            raw_examples,
+        )
+        if baseline_failures:
+            return cases, f"native-build baseline failed: {baseline_failures}"
+        cases += 1
+
+        mutation_cases = (
+            (
+                "cc pin drift",
+                "examples/native_trust_package/Cargo.toml",
+                'version = "=1.2.63"',
+                'version = "1.2.63"',
+                "workspace dependencies must exact-pin",
+            ),
+            (
+                "wrapper package identity drift",
+                "examples/native_trust_package/rust/cc/Cargo.toml",
+                'name = "sifr-cc-probe"',
+                'name = "cc"',
+                "wrapper cc package must be sifr-cc-probe",
+            ),
+            (
+                "wrapper build-script declaration drift",
+                "examples/native_trust_package/rust/zstd/Cargo.toml",
+                'build = "build.rs"',
+                'build = "other.rs"',
+                "wrapper zstd must declare build.rs",
+            ),
+            (
+                "direct native identity drift",
+                "examples/native_trust_package/rust/zstd/Cargo.toml",
+                'links = "sifr_zstd_probe"',
+                'links = "zstd"',
+                "wrapper zstd links must be sifr_zstd_probe",
+            ),
+            (
+                "build-script trust drift",
+                "examples/native_trust_package/sifr.toml",
+                '"bindgen", ',
+                "",
+                "trust.rust-build-scripts",
+            ),
+            (
+                "native-link envelope drift",
+                "examples/native_trust_package/sifr.toml",
+                '"stdc++", ',
+                "",
+                "trust.native-links",
+            ),
+            (
+                "no-panic trust drift",
+                "examples/native_trust_package/sifr.toml",
+                '"cxx.artifact", ',
+                "",
+                "trust.rust-no-panic",
+            ),
+            (
+                "cc compile drift",
+                "examples/native_trust_package/rust/cc/build.rs",
+                '.compile("sifr_cc_probe")',
+                '.compile("other")',
+                'must contain .compile("sifr_cc_probe")',
+            ),
+            (
+                "bindgen generation drift",
+                "examples/native_trust_package/rust/bindgen/build.rs",
+                '.allowlist_function("sifr_bindgen_probe")',
+                '.allowlist_function("other")',
+                'must contain .allowlist_function("sifr_bindgen_probe")',
+            ),
+            (
+                "cxx bridge drift",
+                "examples/native_trust_package/rust/cxx/src/lib.rs",
+                "#[cxx::bridge]",
+                "#[cxx::other]",
+                "must contain #[cxx::bridge]",
+            ),
+            (
+                "zstd execution drift",
+                "examples/native_trust_package/rust/zstd/src/lib.rs",
+                "zstd_upstream::stream::encode_all",
+                "zstd_upstream::stream::decode_all",
+                "must contain zstd_upstream::stream::encode_all",
+            ),
+            (
+                "artifact version drift",
+                "examples/native_trust_package/rust/cc/build.rs",
+                "cc=1.2.63;compiled=sifr_cc_probe",
+                "cc=0.0.0;compiled=sifr_cc_probe",
+                "must contain cc=1.2.63;compiled=sifr_cc_probe",
+            ),
+            (
+                "source-tree artifact drift",
+                "examples/native_trust_package/rust/zstd/build.rs",
+                'std::env::var("OUT_DIR")',
+                'std::env::var("CARGO_MANIFEST_DIR")',
+                "must keep build artifacts under OUT_DIR",
+            ),
+        )
+        for name, relative_path, before, after, expected in mutation_cases:
+            path = fixture_dir / relative_path
+            original = path.read_text(encoding="utf-8")
+            if before not in original:
+                return cases, f"{name} self-test setup token is missing"
+            path.write_text(original.replace(before, after, 1), encoding="utf-8")
+            failures: list[str] = []
+            validate_scenarios(
+                failures,
+                "native_build_script",
+                fixture_dir,
+                raw_examples,
+            )
+            path.write_text(original, encoding="utf-8")
+            if not any(expected in failure for failure in failures):
+                return cases, f"{name} did not report {expected!r}: {failures}"
+            cases += 1
+    return cases, None
+
+
+def _validate_wrapper_manifest(
+    failures: list[str],
+    fixture_id: str,
+    raw_path: str,
+    path: Path,
+    name: str,
+    policy: dict[str, Any],
+) -> None:
+    try:
+        cargo = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        failures.append(f"{fixture_id}: {raw_path}/{name}/Cargo.toml is invalid: {error}")
+        return
+    package = cargo.get("package", {})
+    if package.get("name") != policy["package"]:
+        failures.append(
+            f"{fixture_id}: {raw_path} wrapper {name} package must be "
+            f"{policy['package']}"
+        )
+    if package.get("build") != "build.rs":
+        failures.append(
+            f"{fixture_id}: {raw_path} wrapper {name} must declare build.rs"
+        )
+    if package.get("links") != policy["links"]:
+        failures.append(
+            f"{fixture_id}: {raw_path} wrapper {name} links must be "
+            f"{policy['links']}"
+        )
+    for section in ("dependencies", "build_dependencies"):
+        expected = policy.get(section)
+        if expected is not None and cargo.get(section.replace("_", "-")) != expected:
+            failures.append(
+                f"{fixture_id}: {raw_path} wrapper {name} {section} must equal "
+                f"{expected!r}"
+            )
+    if not path.with_name("build.rs").is_file():
+        failures.append(
+            f"{fixture_id}: {raw_path} wrapper {name} build.rs is required"
+        )
+
+
+def _validate_build_sources(
+    failures: list[str],
+    fixture_id: str,
+    raw_path: str,
+    example_dir: Path,
+) -> None:
+    requirements = {
+        "rust/cc/build.rs": (
+            "cc_upstream::Build::new()",
+            '.compile("sifr_cc_probe")',
+            "sifr-cc-evidence.txt",
+            "cc=1.2.63;compiled=sifr_cc_probe",
+        ),
+        "rust/bindgen/build.rs": (
+            "bindgen_upstream::Builder::default()",
+            '.allowlist_function("sifr_bindgen_probe")',
+            "sifr-bindgen-bindings.rs",
+            "sifr-bindgen-evidence.txt",
+            "bindgen=0.72.1;function=sifr_bindgen_probe",
+        ),
+        "rust/cxx/build.rs": (
+            "sifr-cxx-evidence.txt",
+            "cxx=1.0.198;bridge=sifr_cxx_probe",
+        ),
+        "rust/cxx/src/lib.rs": ("#[cxx::bridge]", "sifr_cxx_probe_value"),
+        "rust/zstd/build.rs": (
+            "sifr-zstd-evidence.txt",
+            "zstd=0.13.3;level=3",
+        ),
+        "rust/zstd/src/lib.rs": (
+            "zstd_upstream::stream::encode_all",
+            "zstd_upstream::stream::decode_all",
+        ),
+        "rust/cc/native/probe.c": (
+            "unsigned int sifr_cc_probe(void)",
+            "return 1263U;",
+        ),
+    }
+    for relative_path, tokens in requirements.items():
+        path = example_dir / relative_path
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError as error:
+            failures.append(
+                f"{fixture_id}: {raw_path}/{relative_path} is unreadable: {error}"
+            )
+            continue
+        for token in tokens:
+            if token not in source:
+                failures.append(
+                    f"{fixture_id}: {raw_path} {relative_path} must contain {token}"
+                )
+        if relative_path.endswith("build.rs"):
+            if "OUT_DIR" not in source or "CARGO_MANIFEST_DIR" in source:
+                failures.append(
+                    f"{fixture_id}: {raw_path} {relative_path} must keep build "
+                    "artifacts under OUT_DIR"
+                )
+
+
+def _require_exact_trust(
+    failures: list[str],
+    fixture_id: str,
+    raw_path: str,
+    trust: Any,
+    key: str,
+    expected: list[str],
+) -> None:
+    actual = trust.get(key) if isinstance(trust, dict) else None
+    if actual != expected:
+        failures.append(
+            f"{fixture_id}: {raw_path}/sifr.toml trust.{key} must equal "
+            f"{expected!r}"
+        )

--- a/verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json
+++ b/verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json
@@ -422,15 +422,14 @@
     {
       "id": "native_build_script",
       "fixture": "native_build_script",
-      "category": "future-owned-by-separate-phase",
-      "future_owner": "plans/issues/active/rust-interop-runtime-ecosystem-certification.md",
+      "category": "supported",
       "tier": 3,
       "capability": "build-script and native-link trust",
       "execution_kind": "cargo-probe",
       "required_crates": ["cc", "bindgen", "cxx", "zstd"],
-      "positive_evidence": {"id": "trusted_build_script_native_evidence", "status": "planned"},
-      "negative_evidence": {"id": "untrusted_native_link_rejected", "status": "planned"},
-      "notes": "Native-link evidence for representative crates is pending until build-script output fixtures pass."
+      "positive_evidence": {"id": "trusted_build_script_native_evidence", "status": "passing"},
+      "negative_evidence": {"id": "untrusted_native_link_rejected", "status": "passing"},
+      "notes": "Generated package evidence compiles exact-pinned cc, bindgen, cxx, and zstd wrappers with locked/offline/frozen Cargo; compares byte-identical fresh-build artifacts; executes the artifacts and a zstd encode/decode roundtrip through generated Sifr package glue; validates the exact Apple/GNU arm64/x86_64 native-link envelope after Cargo; and rejects missing direct native-link trust before an armed build script can create its sentinel."
     },
     {
       "id": "proc_macro_trust",

--- a/verification/areas/rust_interop/data/rust_interop_fixture_matrix.json
+++ b/verification/areas/rust_interop/data/rust_interop_fixture_matrix.json
@@ -344,8 +344,8 @@
       "capability": "build-script and native-link trust",
       "required_crates": ["cc", "bindgen", "cxx", "zstd"],
       "execution_kind": "cargo-probe",
-      "positive_evidence": {"id": "trusted_build_script_native_evidence", "status": "planned"},
-      "negative_evidence": {"id": "untrusted_native_link_rejected", "status": "planned"}
+      "positive_evidence": {"id": "trusted_build_script_native_evidence", "status": "passing"},
+      "negative_evidence": {"id": "untrusted_native_link_rejected", "status": "passing"}
     },
     {
       "id": "proc_macro_trust",

--- a/verification/areas/rust_interop/data/stable_support_claims.json
+++ b/verification/areas/rust_interop/data/stable_support_claims.json
@@ -190,6 +190,12 @@
       "category": "supported-through-bridge",
       "execution_kind": "runtime-observed",
       "capability": "crate-backed Arrow and tensor runtime exchange"
+    },
+    {
+      "id": "native_build_script",
+      "category": "supported",
+      "execution_kind": "cargo-probe",
+      "capability": "build-script and native-link trust"
     }
   ]
 }

--- a/verification/areas/rust_interop/fixtures/native_build_script/README.md
+++ b/verification/areas/rust_interop/fixtures/native_build_script/README.md
@@ -3,11 +3,13 @@
 This fixture family tracks build-script and native-link trust evidence for
 `cc`, `bindgen`, `cxx`, and `zstd`.
 
-- Positive evidence: `trusted_build_script_native_evidence` remains planned for
-  a fixture proving trusted build-script output and native links are recorded
-  before final artifact acceptance.
-- Negative evidence: `untrusted_native_link_rejected` remains planned for a
-  fixture proving untrusted native links fail with `SIFR-RUST-TRUST-*`.
-- Compatibility category: `future-owned-by-separate-phase`. Trust policy
-  plumbing is implemented, but representative native-link ecosystem
-  certification is not listed as verified support.
+- Positive evidence: `trusted_build_script_native_evidence` builds exact-pinned
+  wrapper dependencies twice with locked/offline/frozen Cargo, compares their
+  deterministic artifacts, and observes those artifacts plus a zstd
+  encode/decode roundtrip through generated Sifr package glue.
+- Negative evidence: `untrusted_native_link_rejected` independently removes
+  the zstd wrapper's build-script and native-link permissions and requires
+  `SIFR-RUST-TRUST-0001` before an armed build script can write its sentinel.
+- Compatibility category: `supported` for this exact `cargo-probe` package and
+  portable native-link envelope. Undeclared build scripts and links remain
+  rejected; no general host-library fallback is implied.

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/Cargo.lock
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/Cargo.lock
@@ -3,27 +3,586 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "bindgen"
-version = "0.1.0"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cc"
-version = "0.1.0"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "cxx"
-version = "0.1.0"
+version = "1.0.198"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe442a792c7c736eea18b32a7f8a3b63cf8aafabda6760042dc2fdeda456291"
+dependencies = [
+ "cc",
+ "cxx-build",
+ "cxxbridge-cmd",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "foldhash",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.198"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3184a94384c663718698311a78a51ac00c484c10b4eeac06fb0a068c5f64fa2"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.198"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0148d8fd1199329ddf1d157a5e134e51ceff37c6a7ddd38615c399d81cb05d8d"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.198"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52850339faed2eaadd24e286dc1d8268cc6f8a7bd9524d713adc9099566b4c89"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.198"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c77c856545d886c9bd5215409ebb63b925e262135248b50c79e5a5f194ee47c"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "native-trust-package"
 version = "0.1.0"
 dependencies = [
+ "sifr-bindgen-probe",
+ "sifr-cc-probe",
+ "sifr-cxx-probe",
+ "sifr-zstd-probe",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "sifr-bindgen-probe"
+version = "0.1.0"
+dependencies = [
  "bindgen",
+]
+
+[[package]]
+name = "sifr-cc-probe"
+version = "0.1.0"
+dependencies = [
  "cc",
+]
+
+[[package]]
+name = "sifr-cxx-probe"
+version = "0.1.0"
+dependencies = [
  "cxx",
+]
+
+[[package]]
+name = "sifr-zstd-probe"
+version = "0.1.0"
+dependencies = [
  "zstd",
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "zstd"
-version = "0.1.0"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/Cargo.toml
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/Cargo.toml
@@ -2,16 +2,22 @@
 members = ["rust/cc", "rust/bindgen", "rust/cxx", "rust/zstd"]
 resolver = "2"
 
+[workspace.dependencies]
+bindgen_upstream = { package = "bindgen", version = "=0.72.1", default-features = true }
+cc_upstream = { package = "cc", version = "=1.2.63", default-features = true }
+cxx = { version = "=1.0.198", default-features = true }
+zstd_upstream = { package = "zstd", version = "=0.13.3", default-features = true }
+
 [package]
 name = "native-trust-package"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cc = { path = "rust/cc" }
-bindgen = { path = "rust/bindgen" }
-cxx = { path = "rust/cxx" }
-zstd = { path = "rust/zstd" }
+bindgen = { package = "sifr-bindgen-probe", path = "rust/bindgen" }
+cc = { package = "sifr-cc-probe", path = "rust/cc" }
+cxx = { package = "sifr-cxx-probe", path = "rust/cxx" }
+zstd = { package = "sifr-zstd-probe", path = "rust/zstd" }
 
 [package.metadata.sifr]
 manifest = "sifr.toml"

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/README.md
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/README.md
@@ -1,6 +1,20 @@
 # fixture: native_build_script
 # scenario-example: native_trust_package
 
-This scenario models package-level trust for Rust build scripts and native-link
-metadata. `zstd` exposes native `links` metadata, and every backend crate with a
-build script is listed in `[trust].rust-build-scripts`.
+This locked/offline scenario certifies package-level trust for four direct
+wrapper crates. Their build scripts compile exact root-lock `cc`, `bindgen`,
+`cxx`, and `zstd` dependencies and emit versioned evidence files into
+`OUT_DIR`. The generated Sifr package observes those artifacts and proves a
+zstd encode/decode roundtrip.
+
+The `cc` and zstd wrappers declare `sifr_cc_probe` and
+`sifr_zstd_probe` native identities before Cargo executes. The actual zstd
+dependency emits `zstd`, while the cxx graph emits `cxxbridge1` and
+`link-cplusplus` and selects `c++` on Apple targets or `stdc++` on GNU targets.
+All seven portable-envelope names are exact manifest allowlist entries. Any
+other build-script native link remains a post-build hard error.
+
+The certified host envelope is Apple/GNU arm64 and x86_64. Running this
+scenario requires a working C/C++ compiler and a `libclang` installation
+discoverable by bindgen; these host tools are prerequisites rather than Cargo
+dependencies. MSVC is not covered by this scenario.

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/bindgen/Cargo.toml
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/bindgen/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
-name = "bindgen"
+name = "sifr-bindgen-probe"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"
 
 [lib]
 path = "src/lib.rs"
+
+[build-dependencies]
+bindgen_upstream = { workspace = true }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/bindgen/build.rs
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/bindgen/build.rs
@@ -1,3 +1,29 @@
-fn main() {
+use std::error::Error;
+use std::io;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=build.rs");
+    let bindings = bindgen_upstream::Builder::default()
+        .header_contents(
+            "sifr_bindgen_probe.h",
+            "unsigned int sifr_bindgen_probe(void);",
+        )
+        .allowlist_function("sifr_bindgen_probe")
+        .generate_comments(false)
+        .layout_tests(false)
+        .generate()
+        .map_err(|error| io::Error::other(format!("bindgen probe failed: {error}")))?;
+    let generated = bindings.to_string();
+    if !generated.contains("sifr_bindgen_probe") {
+        return Err(io::Error::other("bindgen output omitted the probe function").into());
+    }
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
+    std::fs::write(out_dir.join("sifr-bindgen-bindings.rs"), generated)?;
+    std::fs::write(
+        out_dir.join("sifr-bindgen-evidence.txt"),
+        "bindgen=0.72.1;function=sifr_bindgen_probe",
+    )?;
+    Ok(())
 }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/bindgen/src/lib.rs
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/bindgen/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn probe() -> Vec<u8> {
-    b"bindgen".to_vec()
+pub fn artifact() -> String {
+    include_str!(concat!(env!("OUT_DIR"), "/sifr-bindgen-evidence.txt")).to_owned()
 }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cc/Cargo.toml
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cc/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
-name = "cc"
+name = "sifr-cc-probe"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"
+links = "sifr_cc_probe"
 
 [lib]
 path = "src/lib.rs"
+
+[build-dependencies]
+cc_upstream = { workspace = true }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cc/build.rs
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cc/build.rs
@@ -1,3 +1,17 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
+use std::error::Error;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=native/probe.c");
+    cc_upstream::Build::new()
+        .file("native/probe.c")
+        .warnings(false)
+        .compile("sifr_cc_probe");
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
+    std::fs::write(
+        out_dir.join("sifr-cc-evidence.txt"),
+        "cc=1.2.63;compiled=sifr_cc_probe",
+    )?;
+    Ok(())
 }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cc/native/probe.c
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cc/native/probe.c
@@ -1,0 +1,3 @@
+unsigned int sifr_cc_probe(void) {
+    return 1263U;
+}

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cc/src/lib.rs
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cc/src/lib.rs
@@ -1,3 +1,3 @@
-pub fn probe() -> Vec<u8> {
-    b"cc".to_vec()
+pub fn artifact() -> String {
+    include_str!(concat!(env!("OUT_DIR"), "/sifr-cc-evidence.txt")).to_owned()
 }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cxx/Cargo.toml
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cxx/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
-name = "cxx"
+name = "sifr-cxx-probe"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"
 
 [lib]
 path = "src/lib.rs"
+
+[dependencies]
+cxx = { workspace = true }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cxx/build.rs
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cxx/build.rs
@@ -1,3 +1,12 @@
-fn main() {
+use std::error::Error;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=build.rs");
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
+    std::fs::write(
+        out_dir.join("sifr-cxx-evidence.txt"),
+        "cxx=1.0.198;bridge=sifr_cxx_probe",
+    )?;
+    Ok(())
 }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cxx/src/lib.rs
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/cxx/src/lib.rs
@@ -1,3 +1,18 @@
-pub fn probe() -> Vec<u8> {
-    b"cxx".to_vec()
+#[cxx::bridge]
+mod ffi {
+    extern "Rust" {
+        fn sifr_cxx_probe_value() -> u32;
+    }
+}
+
+fn sifr_cxx_probe_value() -> u32 {
+    1_000_198
+}
+
+pub fn artifact() -> String {
+    format!(
+        "{};value={}",
+        include_str!(concat!(env!("OUT_DIR"), "/sifr-cxx-evidence.txt")),
+        sifr_cxx_probe_value()
+    )
 }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/zstd/Cargo.toml
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/zstd/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
-name = "zstd"
+name = "sifr-zstd-probe"
 version = "0.1.0"
 edition = "2021"
-links = "zstd"
 build = "build.rs"
+links = "sifr_zstd_probe"
 
 [lib]
 path = "src/lib.rs"
+
+[dependencies]
+zstd_upstream = { workspace = true }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/zstd/build.rs
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/zstd/build.rs
@@ -1,4 +1,12 @@
-fn main() {
-    println!("cargo:rustc-link-lib=zstd");
+use std::error::Error;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=build.rs");
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
+    std::fs::write(
+        out_dir.join("sifr-zstd-evidence.txt"),
+        "zstd=0.13.3;level=3",
+    )?;
+    Ok(())
 }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/zstd/src/lib.rs
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/rust/zstd/src/lib.rs
@@ -1,3 +1,11 @@
-pub fn encode(input: &[u8]) -> Vec<u8> {
-    input.iter().copied().rev().collect()
+pub fn artifact() -> String {
+    include_str!(concat!(env!("OUT_DIR"), "/sifr-zstd-evidence.txt")).to_owned()
+}
+
+pub fn encode(input: &[u8]) -> Result<Vec<u8>, String> {
+    zstd_upstream::stream::encode_all(input, 3).map_err(|error| error.to_string())
+}
+
+pub fn decode(input: &[u8]) -> Result<Vec<u8>, String> {
+    zstd_upstream::stream::decode_all(input).map_err(|error| error.to_string())
 }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/sifr.toml
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/sifr.toml
@@ -16,5 +16,5 @@ direct-crate-bindings = true
 
 [trust]
 rust-build-scripts = ["cc", "bindgen", "cxx", "zstd"]
-native-links = ["zstd"]
-unsafe-rust-bridges = ["src/bridges/native.rs"]
+native-links = ["c++", "cxxbridge1", "link-cplusplus", "sifr_cc_probe", "sifr_zstd_probe", "stdc++", "zstd"]
+rust-no-panic = ["bindgen.artifact", "bridge.native.compress", "bridge.native.decompress", "cc.artifact", "cxx.artifact", "zstd.artifact"]

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/src/bridges/native.rs
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/src/bridges/native.rs
@@ -1,17 +1,22 @@
+use std::fmt;
+
+#[derive(Debug)]
 pub struct NativeErrorBridge {
     pub message: String,
 }
 
-pub fn compress(input: &[u8]) -> Result<Vec<u8>, NativeErrorBridge> {
-    let mut output = zstd::encode(input);
-    output.extend_from_slice(&cc::probe());
-    output.extend_from_slice(&bindgen::probe());
-    output.extend_from_slice(&cxx::probe());
-    Ok(output)
+impl fmt::Display for NativeErrorBridge {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
 }
 
-pub fn map_panic(message: &str) -> NativeErrorBridge {
-    NativeErrorBridge {
-        message: message.to_owned(),
-    }
+impl std::error::Error for NativeErrorBridge {}
+
+pub fn compress(input: &[u8]) -> Result<Vec<u8>, NativeErrorBridge> {
+    zstd::encode(input).map_err(|message| NativeErrorBridge { message })
+}
+
+pub fn decompress(input: &[u8]) -> Result<Vec<u8>, NativeErrorBridge> {
+    zstd::decode(input).map_err(|message| NativeErrorBridge { message })
 }

--- a/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/src/main.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/examples/native_trust_package/src/main.sifr
@@ -6,9 +6,35 @@
 class NativeError(Error):
     message: str
 
-@rust(bridge.native.compress, panic=map_error(bridge.native.map_panic))
+@rust(bindgen.artifact, panic=trusted_no_panic)
+def bindgen_artifact() -> str: ...
+
+@rust(cc.artifact, panic=trusted_no_panic)
+def cc_artifact() -> str: ...
+
+@rust(cxx.artifact, panic=trusted_no_panic)
+def cxx_artifact() -> str: ...
+
+@rust(zstd.artifact, panic=trusted_no_panic)
+def zstd_artifact() -> str: ...
+
+@rust(bridge.native.compress, panic=trusted_no_panic)
 def compress(input: bytes) -> Result[bytes, NativeError | RustPanicError]: ...
 
-def verify_native_trust_package() -> Result[bytes, NativeError | RustPanicError]:
-    compressed_result: Result[bytes, NativeError | RustPanicError] = compress(b"sifr-rust-interop")
-    return compressed_result
+@rust(bridge.native.decompress, panic=trusted_no_panic)
+def decompress(input: bytes) -> Result[bytes, NativeError | RustPanicError]: ...
+
+def verify_native_trust_package() -> Result[str, NativeError | RustPanicError]:
+    try:
+        compressed: bytes = compress(b"sifr-rust-interop")
+        decoded: bytes = decompress(compressed)
+        assert decoded == b"sifr-rust-interop"
+        cc_evidence: str = cc_artifact()
+        bindgen_evidence: str = bindgen_artifact()
+        cxx_evidence: str = cxx_artifact()
+        zstd_evidence: str = zstd_artifact()
+        return cc_evidence + "|" + bindgen_evidence + "|" + cxx_evidence + "|" + zstd_evidence + "|compressed=zstd-roundtrip"
+    except NativeError as error:
+        raise error
+    except RustPanicError as error:
+        raise error

--- a/verification/areas/rust_interop/fixtures/native_build_script/fixture.json
+++ b/verification/areas/rust_interop/fixtures/native_build_script/fixture.json
@@ -4,16 +4,30 @@
   "evidence": {
     "negative": {
       "expected_diagnostic": "SIFR-RUST-TRUST-0001",
-      "expected_result": "future-owned-diagnostic",
+      "expected_result": "diagnostic",
       "id": "untrusted_native_link_rejected",
       "path": "negative/untrusted_native_link_rejected.sifr",
-      "status": "planned"
+      "status": "passing",
+      "validation": {
+        "profile": "merge",
+        "step": "crate_tests",
+        "suite_id": "sifr_driver_generated_builds",
+        "test_file": "crates/sifr_driver/src/tests/package_rust_interop_native_build_support.rs",
+        "test_name": "test_check_native_build_script_untrusted_native_link_rejected_pre_execution"
+      }
     },
     "positive": {
-      "expected_result": "future-owned",
+      "expected_result": "pass",
       "id": "trusted_build_script_native_evidence",
       "path": "positive/trusted_build_script_native_evidence.sifr",
-      "status": "planned"
+      "status": "passing",
+      "validation": {
+        "profile": "merge",
+        "step": "crate_tests",
+        "suite_id": "sifr_driver_generated_builds",
+        "test_file": "crates/sifr_driver/src/tests/package_rust_interop_native_build_support.rs",
+        "test_name": "test_build_native_build_script_trusted_artifacts"
+      }
     }
   },
   "execution_kind": "cargo-probe",

--- a/verification/areas/rust_interop/fixtures/native_build_script/negative/untrusted_native_link_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/negative/untrusted_native_link_rejected.sifr
@@ -1,12 +1,12 @@
 # fixture: native_build_script
 # evidence: negative/untrusted_native_link_rejected
-# evidence-status: planned
+# evidence-status: passing
 # execution-kind: cargo-probe
-# expected-result: future-owned-diagnostic
+# expected-result: diagnostic
 # expected-diagnostic: SIFR-RUST-TRUST-0001
-@rust(bridge.native.compress, panic=trusted_no_panic)
-def compress_without_native_trust(input: bytes) -> bytes: ...
+@rust(zstd.artifact, panic=trusted_no_panic)
+def zstd_artifact_without_native_trust() -> str: ...
 
-def verify_untrusted_native_link_rejected() -> bytes:
-    compress_without_native_trust_result: bytes = compress_without_native_trust(b"sifr-rust-interop")
-    return compress_without_native_trust_result
+def verify_untrusted_native_link_rejected() -> str:
+    result: str = zstd_artifact_without_native_trust()
+    return result

--- a/verification/areas/rust_interop/fixtures/native_build_script/positive/trusted_build_script_native_evidence.sifr
+++ b/verification/areas/rust_interop/fixtures/native_build_script/positive/trusted_build_script_native_evidence.sifr
@@ -1,16 +1,43 @@
 # fixture: native_build_script
 # evidence: positive/trusted_build_script_native_evidence
-# evidence-status: planned
+# evidence-status: passing
 # execution-kind: cargo-probe
-# expected-result: future-owned
-# fixture-trust: rust-build-scripts = ["zstd", "cc", "bindgen", "cxx"]
-# fixture-trust: native-links = ["zstd"]
+# expected-result: pass
+# fixture-trust: rust-build-scripts = ["cc", "bindgen", "cxx", "zstd"]
+# fixture-trust: native-links = ["c++", "cxxbridge1", "link-cplusplus", "sifr_cc_probe", "sifr_zstd_probe", "stdc++", "zstd"]
+# fixture-trust: rust-no-panic = ["bindgen.artifact", "bridge.native.compress", "bridge.native.decompress", "cc.artifact", "cxx.artifact", "zstd.artifact"]
 class NativeError(Error):
     message: str
 
-@rust(bridge.native.compress, panic=map_error(bridge.native.map_panic))
+@rust(bindgen.artifact, panic=trusted_no_panic)
+def bindgen_artifact() -> str: ...
+
+@rust(cc.artifact, panic=trusted_no_panic)
+def cc_artifact() -> str: ...
+
+@rust(cxx.artifact, panic=trusted_no_panic)
+def cxx_artifact() -> str: ...
+
+@rust(zstd.artifact, panic=trusted_no_panic)
+def zstd_artifact() -> str: ...
+
+@rust(bridge.native.compress, panic=trusted_no_panic)
 def compress(input: bytes) -> Result[bytes, NativeError | RustPanicError]: ...
 
-def verify_trusted_build_script_native_evidence() -> Result[bytes, NativeError | RustPanicError]:
-    compress_result: Result[bytes, NativeError | RustPanicError] = compress(b"sifr-rust-interop")
-    return compress_result
+@rust(bridge.native.decompress, panic=trusted_no_panic)
+def decompress(input: bytes) -> Result[bytes, NativeError | RustPanicError]: ...
+
+def verify_trusted_build_script_native_evidence() -> Result[str, NativeError | RustPanicError]:
+    try:
+        compressed: bytes = compress(b"sifr-rust-interop")
+        decoded: bytes = decompress(compressed)
+        assert decoded == b"sifr-rust-interop"
+        cc_evidence: str = cc_artifact()
+        bindgen_evidence: str = bindgen_artifact()
+        cxx_evidence: str = cxx_artifact()
+        zstd_evidence: str = zstd_artifact()
+        return cc_evidence + "|" + bindgen_evidence + "|" + cxx_evidence + "|" + zstd_evidence + "|compressed=zstd-roundtrip"
+    except NativeError as error:
+        raise error
+    except RustPanicError as error:
+        raise error


### PR DESCRIPTION
## Summary

- replace the native-build planning scaffold with an exact-pinned, locked/offline/frozen `cc`/`bindgen`/`cxx`/`zstd` generated package
- prove deterministic `OUT_DIR` artifacts, real zstd roundtrip execution, exact Apple/GNU native-link evidence, and fail-closed direct/transitive trust rejection
- promote only `native_build_script`, update structured stable claims/docs/inventory, and add mutation-tested scenario policy

## Validation

- `cargo test -p sifr_driver test_build_native_build_script_trusted_artifacts -- --ignored --nocapture`
- `cargo test -p sifr_driver test_check_native_build_script_untrusted_native_link_rejected_pre_execution -- --ignored --nocapture`
- native scenario `cargo clippy --workspace --all-targets --locked --offline --frozen -- -D warnings`
- `cargo test -p sifr_driver -- --skip test_e2e_pass` (429 passed)
- fixture/compatibility/tier self-tests (fixture mutations: 166)
- workspace `cargo clippy --workspace -- -D warnings`
- `cargo fmt --check`
- HIR maintainability and file-size guardrails
- `git diff --check`
- `scripts/run_all_tests.sh --profile create-pr`: every completed step passed; Rust interop was 9/10 with the sole failure caused by a deliberately unstaged parallel-worktree edit promoting `ecosystem_backend_certification` while its evidence remains planned. Certification 9's staged matrix state is valid and was independently reproduced by review.

## Review

- Opus round 1: `NOT SATISFIED`; addressed all two medium and nine low findings
- Opus round 2: independently reran both mandatory tests and inventories; `SATISFIED`, no actionable findings

Tracking: `plans/issues/active/rust-interop-runtime-ecosystem-certification.md`