### PR TITLE
fix: close receiver-place review diagnostics

### DIFF
--- a/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
@@ -110,27 +110,11 @@ impl RustEmitter {
 
         let needs_clone = (is_self_access || is_borrowed_parameter) && needs_clone_for_type(ty);
 
-        let lowered_base = if let Some(ref class_name) = class_name_for_parent {
-            if let Some((parent_name, parent_field_names)) = self.parent_fields.get(class_name) {
-                if parent_field_names.contains(field) {
-                    crate::RustExpr::Field {
-                        expr: Box::new(lowered_object),
-                        field: parent_name.to_lowercase(),
-                    }
-                } else {
-                    lowered_object
-                }
-            } else {
-                lowered_object
-            }
-        } else {
-            lowered_object
-        };
-
-        let lowered_field = crate::RustExpr::Field {
-            expr: Box::new(lowered_base),
-            field: field.to_string(),
-        };
+        let lowered_field = self.lower_field_storage_access_for_class(
+            class_name_for_parent.as_deref(),
+            field,
+            lowered_object,
+        );
 
         if is_recursive_field {
             if crate::helpers::is_option_type(ty) {

--- a/crates/sifr_codegen/src/expr_render_helpers/tests.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/tests.rs
@@ -30,6 +30,41 @@ fn field_read_from_borrowed_parameter_clones_move_value() {
 }
 
 #[test]
+fn inherited_field_value_read_uses_shared_storage_rerooting() {
+    let child = Type::Class {
+        identity: None,
+        type_args: Vec::new(),
+        name: "Child".to_string(),
+        fields: vec![("items".to_string(), Type::List(Box::new(Type::Int)))],
+        methods: Vec::new(),
+        parent_class: Some("Base".to_string()),
+    };
+    let object = HirExpr::Name {
+        name: "self".to_string(),
+        binding_id: None,
+        ty: child,
+    };
+    let mut emitter = RustEmitter::new();
+    emitter.current_class_name = Some("Child".to_string());
+    emitter.parent_fields.insert(
+        "Child".to_string(),
+        (
+            "Base".to_string(),
+            ["items".to_string()].into_iter().collect(),
+        ),
+    );
+
+    let lowered = emitter.lower_field_access_expr_with_lowered_object(
+        &object,
+        "items",
+        &Type::List(Box::new(Type::Int)),
+        RustExpr::Ident("self".to_string()),
+    );
+
+    assert_eq!(crate::render_expr(&lowered), "self.base.items.clone()");
+}
+
+#[test]
 fn checked_mutating_field_receiver_does_not_clone() {
     let class = Type::Class {
         identity: None,

--- a/crates/sifr_codegen/src/place_emitter.rs
+++ b/crates/sifr_codegen/src/place_emitter.rs
@@ -213,14 +213,27 @@ impl RustEmitter {
                 _ => None,
             }
         };
-        let lowered_base = class_name
-            .as_ref()
+        self.lower_field_storage_access_for_class(class_name.as_deref(), field, lowered_object)
+    }
+
+    pub(crate) fn lower_field_storage_access_for_class(
+        &self,
+        class_name: Option<&str>,
+        field: &str,
+        lowered_object: RustExpr,
+    ) -> RustExpr {
+        let parent_name = class_name
             .and_then(|class_name| self.parent_fields.get(class_name))
             .filter(|(_, parent_fields)| parent_fields.contains(field))
-            .map_or(lowered_object.clone(), |(parent_name, _)| RustExpr::Field {
+            .map(|(parent_name, _)| parent_name);
+        let lowered_base = if let Some(parent_name) = parent_name {
+            RustExpr::Field {
                 expr: Box::new(lowered_object),
                 field: parent_name.to_lowercase(),
-            });
+            }
+        } else {
+            lowered_object
+        };
         RustExpr::Field {
             expr: Box::new(lowered_base),
             field: field.to_string(),

--- a/crates/sifr_lowering/src/lower/method_receiver_analysis_tests.rs
+++ b/crates/sifr_lowering/src/lower/method_receiver_analysis_tests.rs
@@ -179,6 +179,38 @@ class Counter:
 }
 
 #[test]
+fn same_call_place_conflict_populates_canonical_binding_argument() {
+    let source = r#"
+class Helper:
+    items: list[int]
+
+    def absorb(self, mut other: Helper) -> None:
+        self.items.append(1)
+        other.items.append(2)
+
+class Owner:
+    helper: Helper
+
+def conflict(mut owner: Owner) -> None:
+    owner.helper.absorb(owner.helper)
+"#;
+    let parsed = parse_module(source).expect("source should parse");
+    let errors = match lower_module(parsed.suite()) {
+        Ok(_) => panic!("overlapping receiver and argument should be rejected"),
+        Err(errors) => errors,
+    };
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::OWN_DOUBLE_MUTABLE_BORROW)
+            && matches!(
+                error.args.get("binding"),
+                Some(sifr_diagnostics::DiagnosticArg::String(binding))
+                    if binding == "owner.helper"
+            )
+    }));
+}
+
+#[test]
 fn receiver_inference_closes_transitive_delegation_and_attaches_call_metadata() {
     let source = r#"
 class Leaf:

--- a/crates/sifr_lowering/src/lower/ownership_diagnostics.rs
+++ b/crates/sifr_lowering/src/lower/ownership_diagnostics.rs
@@ -18,8 +18,9 @@ pub(in crate::lower) fn double_mutable_borrow(
     func_name: &str,
     range: TextRange,
 ) {
-    ctx.error_with_code_at(
-        DiagnosticCode::OWN_DOUBLE_MUTABLE_BORROW,
+    same_call_borrow_conflict(
+        ctx,
+        name,
         format!(
             "cannot borrow '{name}' as mutable more than once in the same call to '{func_name}'"
         ),
@@ -33,8 +34,9 @@ pub(in crate::lower) fn mutable_borrow_after_immutable(
     func_name: &str,
     range: TextRange,
 ) {
-    ctx.error_with_code_at(
-        DiagnosticCode::OWN_DOUBLE_MUTABLE_BORROW,
+    same_call_borrow_conflict(
+        ctx,
+        name,
         format!(
             "cannot borrow '{name}' as mutable because it is already borrowed as immutable in the same call to '{func_name}'"
         ),
@@ -48,8 +50,9 @@ pub(in crate::lower) fn immutable_borrow_after_mutable(
     func_name: &str,
     range: TextRange,
 ) {
-    ctx.error_with_code_at(
-        DiagnosticCode::OWN_DOUBLE_MUTABLE_BORROW,
+    same_call_borrow_conflict(
+        ctx,
+        name,
         format!(
             "cannot borrow '{name}' as immutable because it is already borrowed as mutable in the same call to '{func_name}'"
         ),
@@ -223,9 +226,25 @@ pub(in crate::lower) fn same_call_place_conflict(
     place: &str,
     range: TextRange,
 ) {
-    ctx.error_with_code_at(
-        DiagnosticCode::OWN_DOUBLE_MUTABLE_BORROW,
+    same_call_borrow_conflict(
+        ctx,
+        place,
         format!("borrow conflict for {place} in the same call"),
+        range,
+    );
+}
+
+fn same_call_borrow_conflict(ctx: &mut LowerCtx, binding: &str, message: String, range: TextRange) {
+    let mut args = BTreeMap::new();
+    args.insert(
+        "binding".to_string(),
+        DiagnosticArg::String(binding.to_string()),
+    );
+    ctx.error_with_code_args_help_at(
+        DiagnosticCode::OWN_DOUBLE_MUTABLE_BORROW,
+        message,
+        args,
+        None,
         range,
     );
 }

--- a/verification/areas/diagnostics/fixtures/diagnostics/hir_mixed_semantic_recovery/baselines/check-json.stderr.txt
+++ b/verification/areas/diagnostics/fixtures/diagnostics/hir_mixed_semantic_recovery/baselines/check-json.stderr.txt
@@ -77,6 +77,10 @@
     "message": "[main] cannot borrow 'items' as mutable because it is already borrowed as immutable in the same call to 'read_then_mutate'",
     "message_template": "{message}",
     "args": {
+      "binding": {
+        "kind": "string",
+        "value": "items"
+      },
       "message": {
         "kind": "string",
         "value": "[main] cannot borrow 'items' as mutable because it is already borrowed as immutable in the same call to 'read_then_mutate'"


### PR DESCRIPTION
## Summary
- populate the declared `binding` argument for all SIFR-OWN-0002 same-call borrow conflicts
- centralize inherited-field storage rerooting for value reads and checked places
- add focused lowering/codegen regressions and refresh the intended JSON diagnostic baseline

## Validation
- `scripts/run_all_tests.sh --profile create-pr` (exit 0)
- lowering: 937 passed, 1 ignored
- codegen: 954 passed
- E2E create-PR: 131/131, signature `7c39b8c1dd4fec7c`
- HIR/docs/file-size guardrails pass

## Context
Remediates the two actionable implementation findings from the whole-phase Claude Opus review for class-field mutating receiver place semantics.