### PR TITLE
Fix dict missing-key augmented assignment semantics

### DIFF
--- a/crates/sifr/tests/e2e/fail/dict_augassign_unhandled_key_error.sifr
+++ b/crates/sifr/tests/e2e/fail/dict_augassign_unhandled_key_error.sifr
@@ -1,0 +1,6 @@
+# expect-error: SIFR-RESULT-0001
+
+
+def main():
+    values: dict[int, int] = {1: 2}
+    values[1] += 3

--- a/crates/sifr/tests/e2e/pass/dict_missing_key_augassign_checked_error.sifr
+++ b/crates/sifr/tests/e2e/pass/dict_missing_key_augassign_checked_error.sifr
@@ -1,0 +1,28 @@
+from sifr.collections import defaultdict
+
+
+def main():
+    present: dict[str, int] = {"ready": 4}
+    try:
+        present["ready"] += 3
+    except KeyError:
+        assert False
+    assert present["ready"] == 7
+
+    missing: dict[str, int] = {}
+    missing_caught = False
+    try:
+        missing["absent"] += 1
+    except KeyError as error:
+        assert error.message == "key not found"
+        missing_caught = True
+    assert missing_caught
+    assert len(missing) == 0
+
+    annotated: dict[str, int] = defaultdict(int)
+    annotated["new"] += 5
+    assert annotated["new"] == 5
+
+    inferred = defaultdict(int)
+    inferred["new"] += 2
+    assert inferred["new"] == 2

--- a/crates/sifr_codegen/src/error_refs.rs
+++ b/crates/sifr_codegen/src/error_refs.rs
@@ -256,10 +256,21 @@ fn collect_stmt_error_refs(
                 collect_stmt_error_refs(finalbody, referenced, builtin_error_classes);
             }
             HirStmt::SubscriptAssign { index, value, .. }
-            | HirStmt::SubscriptAugAssign { index, value, .. }
             | HirStmt::AttributeSubscriptAssign { index, value, .. } => {
                 collect_expr_error_refs(index, referenced, builtin_error_classes);
                 collect_expr_error_refs(value, referenced, builtin_error_classes);
+            }
+            HirStmt::SubscriptAugAssign {
+                index,
+                value,
+                missing_key_error,
+                ..
+            } => {
+                collect_expr_error_refs(index, referenced, builtin_error_classes);
+                collect_expr_error_refs(value, referenced, builtin_error_classes);
+                if let Some(error_ty) = missing_key_error {
+                    collect_type_error_refs(error_ty, referenced, builtin_error_classes);
+                }
             }
             HirStmt::NestedSubscriptAssign {
                 outer_index,

--- a/crates/sifr_codegen/src/lib_codegen_tests/structured_lowering_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structured_lowering_codegen_tests.rs
@@ -774,6 +774,7 @@ fn test_structured_stmt_path_handles_nested_subscript_augassign_inside_loop_if()
                 op: "*=".to_string(),
                 value: HirExpr::IntLiteral(2),
                 object_ty: Type::List(Box::new(Type::Int)),
+                missing_key_error: None,
             }],
             elif_clauses: vec![],
             else_body: None,

--- a/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
+++ b/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
@@ -287,7 +287,15 @@ pub(super) fn try_lower_simple_stmt_with_ctx_and_bindings(
             op,
             value,
             object_ty,
-        } => try_lower_simple_subscript_augassign_stmt(object, index, op, value, object_ty),
+            missing_key_error,
+        } => try_lower_simple_subscript_augassign_stmt(
+            object,
+            index,
+            op,
+            value,
+            object_ty,
+            missing_key_error.as_ref(),
+        ),
         HirStmt::Delete { object, index } => try_lower_simple_delete_stmt(object, index),
         HirStmt::Yield { value } => try_lower_simple_yield_stmt(value, ctx),
         HirStmt::With { items, body } => {

--- a/crates/sifr_codegen/src/lower_stmt/subscript_assignment.rs
+++ b/crates/sifr_codegen/src/lower_stmt/subscript_assignment.rs
@@ -561,7 +561,11 @@ pub(super) fn try_lower_simple_subscript_augassign_stmt(
     op: &str,
     value: &HirExpr,
     object_ty: &Type,
+    missing_key_error: Option<&Type>,
 ) -> Option<Vec<RustStmt>> {
+    if missing_key_error.is_some() {
+        return None;
+    }
     if !is_supported_subscript_augassign_op(op) {
         return None;
     }
@@ -648,13 +652,9 @@ pub(super) fn try_lower_simple_subscript_augassign_stmt(
 }
 
 pub(super) fn build_dict_get_mut_key_arg(lowered_index: RustExpr) -> RustExpr {
-    if matches!(&lowered_index, RustExpr::Literal(RustLiteral::Str(_))) {
-        lowered_index
-    } else {
-        RustExpr::Ref {
-            mutable: false,
-            expr: Box::new(lowered_index),
-        }
+    RustExpr::Ref {
+        mutable: false,
+        expr: Box::new(lowered_index),
     }
 }
 

--- a/crates/sifr_codegen/src/lower_stmt/subscript_augassign_assignment_tests.rs
+++ b/crates/sifr_codegen/src/lower_stmt/subscript_augassign_assignment_tests.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+fn key_error_type() -> Type {
+    Type::Class {
+        identity: None,
+        type_args: Vec::new(),
+        name: "KeyError".to_string(),
+        fields: vec![("message".to_string(), Type::Str)],
+        methods: Vec::new(),
+        parent_class: Some("Error".to_string()),
+    }
+}
+
 #[test]
 fn lowers_simple_list_subscript_augassign_plus_equal_stmt() {
     let stmt = HirStmt::SubscriptAugAssign {
@@ -16,6 +27,7 @@ fn lowers_simple_list_subscript_augassign_plus_equal_stmt() {
             ty: Type::Int,
         },
         object_ty: Type::List(Box::new(Type::Int)),
+        missing_key_error: None,
     };
     let lowered = try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new())
         .expect("list subscript augassign lowered");
@@ -56,6 +68,7 @@ fn lowers_simple_string_list_subscript_augassign_plus_equal_stmt() {
             ty: Type::Str,
         },
         object_ty: Type::List(Box::new(Type::Str)),
+        missing_key_error: None,
     };
     let lowered = try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new())
         .expect("string list subscript augassign lowered");
@@ -110,6 +123,7 @@ fn lowers_simple_list_subscript_augassign_bitwise_and_shift_ops() {
                 ty: Type::Int,
             },
             object_ty: Type::List(Box::new(Type::Int)),
+            missing_key_error: None,
         };
         let lowered = try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new())
             .expect("list subscript bitwise/shift augassign lowered");
@@ -154,6 +168,7 @@ fn lowers_simple_dict_subscript_augassign_with_name_key() {
             ty: Type::Int,
         },
         object_ty: Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+        missing_key_error: None,
     };
     let lowered = try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new())
         .expect("dict subscript augassign lowered");
@@ -199,6 +214,7 @@ fn lowers_simple_dict_subscript_augassign_with_string_literal_key() {
         op: "-=".to_string(),
         value: HirExpr::IntLiteral(1),
         object_ty: Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+        missing_key_error: None,
     };
     let lowered = try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new())
         .expect("dict subscript augassign lowered");
@@ -209,7 +225,8 @@ fn lowers_simple_dict_subscript_augassign_with_string_literal_key() {
             ..
         } if matches!(
             args.first(),
-            Some(RustExpr::Literal(RustLiteral::Str(key))) if key == "k"
+            Some(RustExpr::Ref { mutable: false, expr })
+                if matches!(expr.as_ref(), RustExpr::Literal(RustLiteral::Str(key)) if key == "k")
         )
     ));
 }
@@ -229,8 +246,92 @@ fn lowers_simple_alias_dict_subscript_augassign_stmt() {
             "IntMap",
             Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
         ),
+        missing_key_error: None,
     };
     let lowered = try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new())
         .expect("alias-dict subscript augassign lowered");
     assert!(matches!(lowered[0], RustStmt::IfLet { .. }));
+}
+
+#[test]
+fn checked_dict_subscript_augassign_returns_key_error_when_missing() {
+    let error_ty = key_error_type();
+    let stmt = HirStmt::SubscriptAugAssign {
+        object: "mapping".to_string(),
+        index: HirExpr::StringLiteral("missing".to_string()),
+        op: "+=".to_string(),
+        value: HirExpr::IntLiteral(1),
+        object_ty: Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+        missing_key_error: Some(error_ty.clone()),
+    };
+    assert!(try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new()).is_none());
+
+    let mut emitter = crate::RustEmitter::new();
+    let HirStmt::SubscriptAugAssign {
+        object,
+        index,
+        op,
+        value,
+        object_ty,
+        ..
+    } = &stmt
+    else {
+        panic!("expected subscript augassign");
+    };
+    let lowered = emitter
+        .lower_subscript_augassign_stmt_for_ir(object, index, op, value, object_ty, Some(&error_ty))
+        .expect("checked dict augassign lowering should succeed")
+        .expect("checked dict augassign should lower");
+    assert!(matches!(
+        lowered,
+        RustStmt::IfLet {
+            expr: RustExpr::MethodCall { args: key_args, .. },
+            then_body,
+            else_body: Some(else_body),
+            ..
+        } if matches!(key_args.as_slice(), [RustExpr::Ref { mutable: false, .. }])
+            && !then_body.is_empty()
+            && matches!(
+                else_body.as_slice(),
+                [RustStmt::Return(Some(RustExpr::FnCall { func, args }))]
+                    if matches!(func.as_ref(), RustExpr::Path(path) if path == &vec!["Err".to_string()])
+                        && matches!(
+                            args.as_slice(),
+                            [RustExpr::FnCall { func, .. }]
+                                if matches!(func.as_ref(), RustExpr::Path(path) if path == &vec!["KeyError".to_string(), "new".to_string()])
+                        )
+            )
+    ));
+}
+
+#[test]
+fn annotated_defaultdict_alias_keeps_entry_insertion_codegen() {
+    let stmt = HirStmt::SubscriptAugAssign {
+        object: "mapping".to_string(),
+        index: HirExpr::StringLiteral("missing".to_string()),
+        op: "+=".to_string(),
+        value: HirExpr::IntLiteral(3),
+        object_ty: Type::alias(
+            "__sifr_defaultdict_int",
+            Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+        ),
+        missing_key_error: None,
+    };
+    let lowered = try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new())
+        .expect("defaultdict augassign should lower");
+    assert!(matches!(
+        &lowered[0],
+        RustStmt::Block(stmts)
+            if matches!(
+                stmts.first(),
+                Some(RustStmt::Let {
+                    value: RustExpr::MethodCall { receiver, method, .. },
+                    ..
+                }) if method == "or_insert"
+                    && matches!(
+                        receiver.as_ref(),
+                        RustExpr::MethodCall { method, .. } if method == "entry"
+                    )
+            )
+    ));
 }

--- a/crates/sifr_codegen/src/lower_stmt/subscript_augassign_tests.rs
+++ b/crates/sifr_codegen/src/lower_stmt/subscript_augassign_tests.rs
@@ -11,6 +11,7 @@ fn lowers_simple_list_subscript_augassign_floor_div_equal_stmt() {
             ty: Type::Int,
         },
         object_ty: Type::List(Box::new(Type::Int)),
+        missing_key_error: None,
     };
     let lowered = try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new())
         .expect("list subscript floor-div augassign lowered");
@@ -50,6 +51,7 @@ fn lowers_simple_list_subscript_augassign_power_equal_stmt() {
             ty: Type::Int,
         },
         object_ty: Type::List(Box::new(Type::Int)),
+        missing_key_error: None,
     };
     let lowered = try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new())
         .expect("list subscript power augassign lowered");
@@ -91,6 +93,7 @@ fn lowers_simple_alias_list_subscript_augassign_stmt() {
         op: "+=".to_string(),
         value: HirExpr::IntLiteral(1),
         object_ty: Type::alias("IntList", Type::List(Box::new(Type::Int))),
+        missing_key_error: None,
     };
     let lowered = try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new())
         .expect("alias-list subscript augassign lowered");
@@ -110,6 +113,7 @@ fn does_not_lower_subscript_augassign_with_non_leaf_value() {
             ty: Type::Int,
         },
         object_ty: Type::List(Box::new(Type::Int)),
+        missing_key_error: None,
     };
 
     assert!(try_lower_simple_stmt(&stmt, false, &HashSet::new(), &HashSet::new()).is_none());

--- a/crates/sifr_codegen/src/stmt_support_emitter/nested_subscript_assignment_helpers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/nested_subscript_assignment_helpers.rs
@@ -33,16 +33,9 @@ impl RustEmitter {
     pub(crate) fn build_dict_lookup_key_arg_for_ir(
         lowered_index: crate::RustExpr,
     ) -> crate::RustExpr {
-        if matches!(
-            lowered_index,
-            crate::RustExpr::Literal(crate::RustLiteral::Str(_))
-        ) {
-            lowered_index
-        } else {
-            crate::RustExpr::Ref {
-                mutable: false,
-                expr: Box::new(lowered_index),
-            }
+        crate::RustExpr::Ref {
+            mutable: false,
+            expr: Box::new(lowered_index),
         }
     }
 

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
@@ -369,10 +369,17 @@ impl RustEmitter {
                 op,
                 value,
                 object_ty,
+                missing_key_error,
             } = stmt
             {
-                let Some(lowered_stmt) = self
-                    .lower_subscript_augassign_stmt_for_ir(object, index, op, value, object_ty)?
+                let Some(lowered_stmt) = self.lower_subscript_augassign_stmt_for_ir(
+                    object,
+                    index,
+                    op,
+                    value,
+                    object_ty,
+                    missing_key_error.as_ref(),
+                )?
                 else {
                     return Ok(None);
                 };

--- a/crates/sifr_codegen/src/stmt_support_emitter/structured_return_if_while.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/structured_return_if_while.rs
@@ -159,6 +159,14 @@ impl RustEmitter {
         value: &HirExpr,
         lowered: RustExpr,
     ) -> RustExpr {
+        self.coerce_error_type_for_ir(value.ty(), lowered)
+    }
+
+    pub(crate) fn coerce_error_type_for_ir(
+        &self,
+        source_type: &Type,
+        lowered: RustExpr,
+    ) -> RustExpr {
         let target = self
             .try_closure_error_type_info
             .last()
@@ -173,11 +181,11 @@ impl RustEmitter {
         let Some(target) = target else {
             return lowered;
         };
-        let converted = self.consuming_value_upcast_for_ir(target, value.ty(), lowered.clone());
+        let converted = self.consuming_value_upcast_for_ir(target, source_type, lowered.clone());
         if converted != lowered {
             return converted;
         }
-        let source_name = crate::render_type(&crate::sifr_type_to_rust_type(value.ty()));
+        let source_name = crate::render_type(&crate::sifr_type_to_rust_type(source_type));
         let target_name = crate::render_type(&crate::sifr_type_to_rust_type(target));
         if source_name == target_name {
             lowered

--- a/crates/sifr_codegen/src/stmt_support_emitter/subscript_augassign_delete.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/subscript_augassign_delete.rs
@@ -7,6 +7,7 @@ impl RustEmitter {
         op: &str,
         value: &HirExpr,
         object_ty: &Type,
+        missing_key_error: Option<&Type>,
     ) -> Result<Option<RustStmt>, crate::CodegenError> {
         if !matches!(
             op,
@@ -156,7 +157,26 @@ impl RustEmitter {
                         args: vec![key_arg],
                     },
                     then_body: vec![lowered_body_stmt],
-                    else_body: None,
+                    else_body: missing_key_error.map(|error_ty| {
+                        let error = crate::RustExpr::FnCall {
+                            func: Box::new(crate::RustExpr::Path(vec![
+                                "KeyError".to_string(),
+                                "new".to_string(),
+                            ])),
+                            args: vec![crate::RustExpr::MethodCall {
+                                receiver: Box::new(crate::RustExpr::Literal(
+                                    crate::RustLiteral::Str("key not found".to_string()),
+                                )),
+                                method: "to_string".to_string(),
+                                args: Vec::new(),
+                            }],
+                        };
+                        let error = self.coerce_error_type_for_ir(error_ty, error);
+                        vec![RustStmt::Return(Some(crate::RustExpr::FnCall {
+                            func: Box::new(crate::RustExpr::Path(vec!["Err".to_string()])),
+                            args: vec![error],
+                        }))]
+                    }),
                 }))
             }
             _ => Ok(None),
@@ -340,12 +360,19 @@ impl RustEmitter {
             op,
             value,
             object_ty,
+            missing_key_error,
         } = stmt
         else {
             return Ok(false);
         };
-        let Some(lowered) =
-            self.lower_subscript_augassign_stmt_for_ir(object, index, op, value, object_ty)?
+        let Some(lowered) = self.lower_subscript_augassign_stmt_for_ir(
+            object,
+            index,
+            op,
+            value,
+            object_ty,
+            missing_key_error.as_ref(),
+        )?
         else {
             return Ok(false);
         };

--- a/crates/sifr_ir/src/hir_nodes.rs
+++ b/crates/sifr_ir/src/hir_nodes.rs
@@ -480,6 +480,7 @@ pub enum HirStmt {
         op: String,
         value: HirExpr,
         object_ty: Type,
+        missing_key_error: Option<Type>,
     },
     /// Augmented assignment on attribute: self.field += val
     AttributeAugAssign {

--- a/crates/sifr_ir/src/type_visit.rs
+++ b/crates/sifr_ir/src/type_visit.rs
@@ -563,14 +563,22 @@ where
             value,
             object_ty,
             ..
+        } => {
+            transform_type(object_ty, transform);
+            transform_expr(index, transform, visit);
+            transform_expr(value, transform, visit);
         }
-        | HirStmt::SubscriptAugAssign {
+        HirStmt::SubscriptAugAssign {
             index,
             value,
             object_ty,
+            missing_key_error,
             ..
         } => {
             transform_type(object_ty, transform);
+            if let Some(error_ty) = missing_key_error {
+                transform_type(error_ty, transform);
+            }
             transform_expr(index, transform, visit);
             transform_expr(value, transform, visit);
         }

--- a/crates/sifr_lowering/src/hir_snapshot_tests.rs
+++ b/crates/sifr_lowering/src/hir_snapshot_tests.rs
@@ -320,6 +320,7 @@ fn project_stmt(stmt: &HirStmt) -> Value {
             op,
             value,
             object_ty,
+            missing_key_error,
         } => json!({
             "kind": "SubscriptAugAssign",
             "object": object,
@@ -327,6 +328,7 @@ fn project_stmt(stmt: &HirStmt) -> Value {
             "op": op,
             "value": project_expr(value),
             "object_ty": type_name(object_ty),
+            "missing_key_error": missing_key_error.as_ref().map(type_name),
         }),
         HirStmt::AttributeAugAssign {
             object,

--- a/crates/sifr_lowering/src/lower/aug_assign_lowering.rs
+++ b/crates/sifr_lowering/src/lower/aug_assign_lowering.rs
@@ -29,6 +29,23 @@ fn invalid_subscript_target_shape(ctx: &mut LowerCtx, range: TextRange) {
     invalid_target_shape(ctx, AUGMENTED_SUBSCRIPT_TARGET_SIMPLE_NAME, range);
 }
 
+fn plain_dict_missing_key_error(object_ty: &Type, ctx: &mut LowerCtx) -> Option<Type> {
+    if !matches!(object_ty.resolve_alias(), Type::Dict(_, _))
+        || matches!(
+            object_ty,
+            Type::Alias { name, .. } if name.starts_with("__sifr_defaultdict_")
+        )
+    {
+        return None;
+    }
+    Some(
+        ctx.class_types
+            .get("KeyError")
+            .cloned()
+            .unwrap_or_else(|| super::fallback_error_type("KeyError")),
+    )
+}
+
 fn op_to_augassign_string(
     op: Operator,
     ctx: &mut LowerCtx,
@@ -293,12 +310,24 @@ pub(in crate::lower) fn lower_aug_assign(
                 rhs_range: aug.value.range(),
             },
         );
+        let missing_key_error = plain_dict_missing_key_error(&object_ty, ctx);
+        if let Some(error_ty) = &missing_key_error {
+            if ctx.in_try_block {
+                super::statements::record_try_error_types(ctx, error_ty);
+            } else {
+                super::result_diagnostics::unhandled_dict_augassign_key_error(
+                    ctx,
+                    aug.target.range(),
+                );
+            }
+        }
         return Some(HirStmt::SubscriptAugAssign {
             object: obj_name,
             index,
             op: op_str.to_string(),
             value,
             object_ty,
+            missing_key_error,
         });
     }
     let (name, name_range): (String, TextRange) = if let Expr::Name(n) = aug.target.as_ref() {

--- a/crates/sifr_lowering/src/lower/aug_assign_lowering.rs
+++ b/crates/sifr_lowering/src/lower/aug_assign_lowering.rs
@@ -29,8 +29,13 @@ fn invalid_subscript_target_shape(ctx: &mut LowerCtx, range: TextRange) {
     invalid_target_shape(ctx, AUGMENTED_SUBSCRIPT_TARGET_SIMPLE_NAME, range);
 }
 
-fn plain_dict_missing_key_error(object_ty: &Type, ctx: &mut LowerCtx) -> Option<Type> {
-    if !matches!(object_ty.resolve_alias(), Type::Dict(_, _))
+fn plain_dict_missing_key_error(
+    object_ty: &Type,
+    key_is_proven_present: bool,
+    ctx: &mut LowerCtx,
+) -> Option<Type> {
+    if key_is_proven_present
+        || !matches!(object_ty.resolve_alias(), Type::Dict(_, _))
         || matches!(
             object_ty,
             Type::Alias { name, .. } if name.starts_with("__sifr_defaultdict_")
@@ -294,6 +299,8 @@ pub(in crate::lower) fn lower_aug_assign(
             );
             return None;
         }
+        let key_is_proven_present = ctx.has_dict_key_guard(&obj_name, sub.slice.as_ref())
+            || ctx.has_subscript_guard(&obj_name, sub.slice.as_ref());
         let index = lower_expr(&sub.slice, ctx)?;
         let value = lower_python_context_owned_expr(&aug.value, ctx)?;
         let op_str = op_to_augassign_string(aug.op, ctx, aug.target.range())?;
@@ -310,7 +317,8 @@ pub(in crate::lower) fn lower_aug_assign(
                 rhs_range: aug.value.range(),
             },
         );
-        let missing_key_error = plain_dict_missing_key_error(&object_ty, ctx);
+        let missing_key_error =
+            plain_dict_missing_key_error(&object_ty, key_is_proven_present, ctx);
         if let Some(error_ty) = &missing_key_error {
             if ctx.in_try_block {
                 super::statements::record_try_error_types(ctx, error_ty);

--- a/crates/sifr_lowering/src/lower/expressions_tests.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests.rs
@@ -18,6 +18,7 @@ mod contextual_empty_list_equality;
 mod control_flow_and_strings;
 mod defaultdict_augassign_refinement;
 mod defaultdict_order_independent_inference;
+mod dict_augassign_checked_error;
 mod empty_plain_dict_inference;
 mod exact_int_and_fixed_width;
 mod iteration_and_protocols;

--- a/crates/sifr_lowering/src/lower/expressions_tests/dict_augassign_checked_error.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/dict_augassign_checked_error.rs
@@ -1,0 +1,70 @@
+use super::{lower_source, lower_source_with_stdlib_collections, DiagnosticCode, HirStmt, Type};
+
+#[test]
+fn plain_dict_augassign_requires_checked_error_handling() {
+    let source = "def solve():\n    values: dict[int, int] = {1: 2}\n    values[1] += 3\n";
+    let errors = lower_source(source).expect_err("fallible dict augassign should require try");
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::RESULT_UNUSED_VALUE)
+            && error.message
+                == "plain dict augmented subscript assignment may fail with 'KeyError'; handle it inside try/except"
+    }));
+}
+
+#[test]
+fn handled_plain_dict_augassign_carries_key_error_in_hir() {
+    let source = "def solve():\n    values: dict[int, int] = {1: 2}\n    try:\n        values[1] += 3\n    except KeyError:\n        pass\n";
+    let module = lower_source(source).expect("handled dict augassign should lower");
+    let function = module
+        .functions
+        .iter()
+        .find(|function| function.name == "solve")
+        .expect("solve should lower");
+    let HirStmt::TryExcept {
+        body,
+        body_error_types,
+        ..
+    } = &function.body[1]
+    else {
+        panic!("expected try/except");
+    };
+    assert!(matches!(
+        body_error_types.as_slice(),
+        [Type::Class { name, .. }] if name == "KeyError"
+    ));
+    assert!(matches!(
+        &body[0],
+        HirStmt::SubscriptAugAssign {
+            missing_key_error: Some(Type::Class { name, .. }),
+            ..
+        } if name == "KeyError"
+    ));
+}
+
+#[test]
+fn annotated_defaultdict_keeps_factory_semantics_and_declared_shape() {
+    let source = "from sifr.collections import defaultdict\n\ndef solve():\n    values: dict[str, int] = defaultdict(int)\n    values[\"missing\"] += 3\n";
+    let module = lower_source_with_stdlib_collections(source)
+        .expect("annotated defaultdict augassign should lower without try");
+    let function = module
+        .functions
+        .iter()
+        .find(|function| function.name == "solve")
+        .expect("solve should lower");
+    assert!(matches!(
+        &function.body[0],
+        HirStmt::Let {
+            ty: Type::Alias { name, body, .. },
+            ..
+        } if name == "__sifr_defaultdict_int"
+            && matches!(body.as_ref(), Type::Dict(key, value) if key.as_ref() == &Type::Str && value.as_ref() == &Type::Int)
+    ));
+    assert!(matches!(
+        &function.body[1],
+        HirStmt::SubscriptAugAssign {
+            object_ty: Type::Alias { name, .. },
+            missing_key_error: None,
+            ..
+        } if name == "__sifr_defaultdict_int"
+    ));
+}

--- a/crates/sifr_lowering/src/lower/expressions_tests/dict_augassign_checked_error.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/dict_augassign_checked_error.rs
@@ -42,6 +42,46 @@ fn handled_plain_dict_augassign_carries_key_error_in_hir() {
 }
 
 #[test]
+fn proven_present_plain_dict_key_does_not_require_checked_error_handling() {
+    let source = "def solve(mut values: dict[str, int], key: str):\n    if key in values:\n        values[key] += 1\n";
+    let module = lower_source(source).expect("guarded dict augassign should lower without try");
+    let function = module
+        .functions
+        .iter()
+        .find(|function| function.name == "solve")
+        .expect("solve should lower");
+    let HirStmt::If { then_body, .. } = &function.body[0] else {
+        panic!("expected membership guard");
+    };
+    assert!(matches!(
+        &then_body[0],
+        HirStmt::SubscriptAugAssign {
+            missing_key_error: None,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn preceding_subscript_assignment_proves_plain_dict_key_present() {
+    let source =
+        "def solve(mut values: dict[str, int], key: str):\n    values[key] = 0\n    values[key] += 1\n";
+    let module = lower_source(source).expect("assigned dict key should be proven present");
+    let function = module
+        .functions
+        .iter()
+        .find(|function| function.name == "solve")
+        .expect("solve should lower");
+    assert!(matches!(
+        &function.body[1],
+        HirStmt::SubscriptAugAssign {
+            missing_key_error: None,
+            ..
+        }
+    ));
+}
+
+#[test]
 fn annotated_defaultdict_keeps_factory_semantics_and_declared_shape() {
     let source = "from sifr.collections import defaultdict\n\ndef solve():\n    values: dict[str, int] = defaultdict(int)\n    values[\"missing\"] += 3\n";
     let module = lower_source_with_stdlib_collections(source)

--- a/crates/sifr_lowering/src/lower/result_diagnostics.rs
+++ b/crates/sifr_lowering/src/lower/result_diagnostics.rs
@@ -65,3 +65,12 @@ pub(in crate::lower) fn invalid_except_type(ctx: &mut LowerCtx, reason: &str, ra
         range,
     );
 }
+
+pub(in crate::lower) fn unhandled_dict_augassign_key_error(ctx: &mut LowerCtx, range: TextRange) {
+    ctx.error_with_code_at(
+        DiagnosticCode::RESULT_UNUSED_VALUE,
+        "plain dict augmented subscript assignment may fail with 'KeyError'; handle it inside try/except"
+            .to_string(),
+        range,
+    );
+}

--- a/crates/sifr_lowering/src/lower/statements.rs
+++ b/crates/sifr_lowering/src/lower/statements.rs
@@ -72,7 +72,7 @@ pub(in crate::lower) use control_flow::*;
 mod while_loop;
 pub(in crate::lower) use while_loop::lower_while;
 
-fn record_try_error_types(ctx: &mut LowerCtx, error_type: &Type) {
+pub(in crate::lower) fn record_try_error_types(ctx: &mut LowerCtx, error_type: &Type) {
     match error_type.resolve_alias() {
         Type::Class { .. } => {
             ctx.try_block_error_types

--- a/crates/sifr_lowering/src/lower/statements/patterns_and_assignments.rs
+++ b/crates/sifr_lowering/src/lower/statements/patterns_and_assignments.rs
@@ -316,6 +316,25 @@ pub(super) fn invalidate_rebound_binding_facts(ctx: &mut LowerCtx, name: &str) {
     ctx.clear_proven_nonzero_integer_binding(name);
 }
 
+fn explicit_binding_type(declared_type: &Type, value_type: &Type) -> Type {
+    let Type::Alias {
+        name,
+        type_args,
+        body: _,
+    } = value_type
+    else {
+        return declared_type.clone();
+    };
+    if !name.starts_with("__sifr_defaultdict_") || !matches!(declared_type, Type::Dict(_, _)) {
+        return declared_type.clone();
+    }
+    Type::Alias {
+        name: name.clone(),
+        type_args: type_args.clone(),
+        body: Box::new(declared_type.clone()),
+    }
+}
+
 pub(in crate::lower) fn lower_ann_assign(
     ann: &StmtAnnAssign,
     ctx: &mut LowerCtx,
@@ -427,6 +446,8 @@ pub(in crate::lower) fn lower_ann_assign(
         return None;
     };
 
+    let binding_type = explicit_binding_type(&declared_type, value.ty());
+
     if let Some(borrowed) =
         super::super::python_interop::python_context_borrow_in_owned_expr(&value, ctx)
     {
@@ -468,12 +489,12 @@ pub(in crate::lower) fn lower_ann_assign(
     ctx.pending_container_specialization_patches.remove(&name);
     if let Some(error_taint) = annotation_error_taint {
         ctx.scope
-            .define_poisoned_local(name.clone(), declared_type.clone(), true, error_taint);
+            .define_poisoned_local(name.clone(), binding_type.clone(), true, error_taint);
     } else {
         ctx.scope
-            .define_explicit_local(name.clone(), declared_type.clone());
+            .define_explicit_local(name.clone(), binding_type.clone());
     }
-    ctx.record_must_use_binding(&name, &declared_type);
+    ctx.record_must_use_binding(&name, &binding_type);
     if matches!(value.ty(), Type::Int | Type::LiteralInt(_))
         && value.ty().is_assignable_to(&declared_type)
     {
@@ -506,7 +527,7 @@ pub(in crate::lower) fn lower_ann_assign(
     record_async_generator_advance_binding(ctx, &name, &value);
     Some(HirStmt::Let {
         name,
-        ty: declared_type,
+        ty: binding_type,
         value,
         is_mutable: true,
     })


### PR DESCRIPTION
## Summary

- model missing-key plain-dict augmented subscript assignment as a checked KeyError instead of a silent no-op
- preserve annotated defaultdict semantic aliases and factory insertion behavior
- honor existing exact-key presence flow facts so guarded augmented assignment remains accepted
- borrow dictionary lookup keys consistently in generated Rust

## Validation

- focused lowering: 5 passed
- full sifr_lowering: 962 passed, 1 ignored
- focused codegen augmented subscript assignment: 13 passed
- full sifr_codegen: 969 passed
- focused subscript assignment: 19 passed
- native pass fixture and exact fail diagnostic fixture passed
- pinned LeetCode 0438 regression fixture checks successfully
- workspace Clippy, rustfmt, file-size, HIR maintainability, and diff hygiene passed
- create-pr profile: all selected functional areas passed, including Python interop 19/19; aggregate Python step exceeded its host-sensitive 600s budget (latest 639.010s) while other worktrees contended for global Cargo locks. This exact variance is owned by plans/issues/active/adhoc_performance_budget_host_variance.md and is not a product failure or Phase 40 prerequisite.

## Review

- Opus round 1 found the guarded-key regression in LeetCode 0438.
- Remediation commit b341b47f9 integrates exact-key flow proofs and adds focused regressions.
- Opus round 2 verdict: SATISFIED, no blocking findings.

Phase: plans/issues/active/ad-hoc-dict-missing-key-augassign-semantics.md
