### PR TITLE
Fix Rust interop taxonomy ownership

### DIFF
--- a/docs/rust-interop.mdx
+++ b/docs/rust-interop.mdx
@@ -73,11 +73,11 @@ contract-only, cargo-probed, or runtime-observed. A contract-only row never
 satisfies a runtime claim.
 
 `structural_bridge_calls` is a planned, future-owned runtime deferral. Structural
-calls are not supported until their implementation milestone replaces both
-planned evidence directions with passing construction, projection, callback,
-and rejection evidence. That milestone removes the `bridge-version` manifest
-field and all version-specific paths rather than retaining a compatibility mode
-or fallback. The separate planned `bridge_version_field_removal` diagnostic row
+calls are not supported until both evidence directions pass for construction,
+projection, callbacks, and deliberate rejections. Enabling that support removes
+the `bridge-version` manifest field and all version-specific paths rather than
+retaining a compatibility mode or fallback. The separate planned
+`bridge_version_field_removal` diagnostic row
 tracks acceptance of unversioned manifests and rejection of the removed field.
 
 ### Stable Support Claims

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -350,17 +350,16 @@ Bridge version 1 covers:
 
 ### Structural Rust bridge calls
 
-This section is the accepted contract owned by Native Pydantic-Sifr
-`milestone_ps_2`; it is specified before implementation and is not yet a
-supported compiler surface. The current compiler continues to reject
-`@rust.structural`. The future-owned `structural_bridge_calls` compatibility row
-remains non-passing until the implementation wave flips its positive and
-negative evidence atomically. The companion future-owned
+This section is the accepted structural bridge contract. It is specified before
+implementation and is not yet a supported compiler surface. The current
+compiler continues to reject `@rust.structural`. The future-owned
+`structural_bridge_calls` compatibility row remains non-passing until its
+positive and negative evidence pass atomically. The companion future-owned
 `bridge_version_field_removal` row governs removal of the versioned manifest
-schema in that same wave.
+schema at the same boundary.
 
 Once that row passes, the structural contract replaces the current versioned
-bridge schema. The implementation wave atomically removes `[rust]
+bridge schema. That change atomically removes `[rust]
 bridge-version` from the manifest schema, every in-repository package and
 fixture, managed projections, archive expectations, cache records, diagnostics,
 and generated-build assertions. That inventory explicitly includes the
@@ -371,14 +370,14 @@ assertion, `_scenario_registry.py`'s literal token, `_matrix_inventory.py`'s
 required-fixture entry, and `runner/bridge_check.py`'s version
 parameter/default. Compiler-side removal explicitly includes the
 `rust_interop_plan.rs` module/cache fields, the package-graph digest field, and
-the sysroot's synthesized `Some(1)`. The wave deletes the entire
+the sysroot's synthesized `Some(1)`. It deletes the entire
 `bridge_version_mismatch` fixture/scenario and its matrix, tier, and
 stable-claim entries rather than preserving legacy acceptance evidence.
 
 The same cutover deletes this document's `bridge-version = 1` subsection above
 and rewrites every remaining version-keyed statement throughout
-`internal_docs/**`, `docs/**`, active issues, `plans/phases/**`, and the
-roadmap. Named public surfaces include `docs/packages/manifest.mdx`,
+`internal_docs/**`, `docs/**`, and active planning records. Named public
+surfaces include `docs/packages/manifest.mdx`,
 `docs/rust-interop.mdx`, and the Blake3 and Reqwest interop guides; the other
 architecture surface includes
 `internal_docs/sifr_sysroot_and_stdlib_architecture.md`. Dated review records,
@@ -1860,7 +1859,7 @@ Compatibility categories are:
 - `unsupported-by-design`: passing diagnostics for a rejected surface with no
   fallback path.
 - `future-owned-by-separate-phase`: documented separately because at least one
-  evidence direction is not passing. Future-owned rows must reference a concrete
-  active issue or phase for that row. The current future-owned rows
-  `structural_bridge_calls` and `bridge_version_field_removal` are owned by
-  [`plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md`](../plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md).
+  evidence direction is not passing. Future-owned rows must reference their
+  durable technical owner. The current future-owned rows
+  `structural_bridge_calls` and `bridge_version_field_removal` are owned by the
+  structural Rust bridge section above.

--- a/internal_docs/sifr_sysroot_and_stdlib_architecture.md
+++ b/internal_docs/sifr_sysroot_and_stdlib_architecture.md
@@ -154,9 +154,9 @@ only. Remaining compiler-native stdlib glue is explicitly allowlisted in
 Rust interop Track A certification is complete. The active matrix
 `verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json`
 currently has 21 supported rows, 14 bridge-supported rows, 1
-unsupported-by-design row, and 2 future-owned Native Pydantic-Sifr rows. Those
-future rows are `structural_bridge_calls` and `bridge_version_field_removal`,
-owned by `plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md`.
+unsupported-by-design row, and 2 future-owned rows. Those future rows are
+`structural_bridge_calls` and `bridge_version_field_removal`, owned by the
+structural Rust bridge contract in `rust_interop_architecture.md`.
 Resource migrations must not claim stable support for a future-owned row until
 its positive and negative evidence pass and its stable-claim gate accepts it.
 

--- a/verification/areas/rust_interop/checks/check_compatibility_matrix.py
+++ b/verification/areas/rust_interop/checks/check_compatibility_matrix.py
@@ -27,6 +27,7 @@ VALID_CATEGORIES = {
 CLAIMED_SUPPORT_CATEGORIES = {"supported", "supported-through-bridge", "unsupported-by-design"}
 OPTIONAL_EMPTY_CATEGORIES = {"future-owned-by-separate-phase"}
 FUTURE_OWNER_PREFIXES = ("plans/issues/active/", "plans/phases/")
+FUTURE_OWNER_PATHS = {"internal_docs/rust_interop_architecture.md"}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -174,11 +175,15 @@ def _validate_row(
         future_owner = row.get("future_owner")
         if not isinstance(future_owner, str) or not future_owner:
             failures.append(f"{row_id}: future-owned row must name future_owner")
-        elif not future_owner.startswith(FUTURE_OWNER_PREFIXES):
+        elif (
+            not future_owner.startswith(FUTURE_OWNER_PREFIXES)
+            and future_owner not in FUTURE_OWNER_PATHS
+        ):
             failures.append(
-                f"{row_id}: future_owner must reference plans/issues/active/ or plans/phases/"
+                f"{row_id}: future_owner must reference an active plan or "
+                "the durable Rust interop architecture"
             )
-        elif not (REPO_ROOT / future_owner).is_file():
+        elif not (repo_root / future_owner).is_file():
             failures.append(f"{row_id}: future_owner does not exist: {future_owner}")
     notes = row.get("notes")
     if not isinstance(notes, str) or not notes.strip():
@@ -418,7 +423,54 @@ def _run_self_test() -> int:
                 file=sys.stderr,
             )
             return 1
-    print(f"rust interop compatibility matrix self-test ok: cases={len(cases) + 4}")
+
+        future_fixture = {
+            **fixture,
+            "positive_evidence": {"id": "positive", "status": "planned"},
+            "negative_evidence": {"id": "negative", "status": "planned"},
+        }
+        future_row = {
+            **future_fixture,
+            "fixture": "diagnostic_fixture",
+            "category": "future-owned-by-separate-phase",
+            "notes": "future-owned diagnostic behavior",
+        }
+        future_owner_cases = (
+            (
+                "off-allowlist future owner",
+                "internal_docs/not-a-rust-interop-owner.md",
+                "future_owner must reference an active plan or the durable Rust interop architecture",
+            ),
+            (
+                "missing allowlisted future owner",
+                "internal_docs/rust_interop_architecture.md",
+                "future_owner does not exist: internal_docs/rust_interop_architecture.md",
+            ),
+        )
+        for name, future_owner, expected in future_owner_cases:
+            failures = []
+            _validate_row(
+                failures,
+                {**future_row, "future_owner": future_owner},
+                {"diagnostic_fixture": future_fixture},
+                {},
+                profiles,
+                repo_root,
+                {},
+                set(),
+                set(),
+                set(),
+            )
+            if not any(expected in failure for failure in failures):
+                print(
+                    f"rust interop compatibility matrix self-test error: {name} passed",
+                    file=sys.stderr,
+                )
+                return 1
+    print(
+        "rust interop compatibility matrix self-test ok: "
+        f"cases={len(cases) + len(future_owner_cases) + 4}"
+    )
     return 0
 
 

--- a/verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json
+++ b/verification/areas/rust_interop/data/rust_interop_compatibility_matrix.json
@@ -180,8 +180,8 @@
       "required_crates": [],
       "positive_evidence": {"id": "unversioned_bridge_manifest_accepted", "status": "planned"},
       "negative_evidence": {"id": "bridge_version_field_rejected", "status": "planned"},
-      "future_owner": "plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md",
-      "notes": "Future-owned by Native Pydantic-Sifr milestone_ps_2; the implementation removes the bridge-version manifest field and version-specific tooling, accepts only unversioned bridge manifests, and rejects the removed field without rewrite, compatibility mode, or fallback."
+      "future_owner": "internal_docs/rust_interop_architecture.md",
+      "notes": "Reserved by the structural Rust bridge contract; support requires removing the bridge-version manifest field and version-specific tooling, accepting only unversioned bridge manifests, and rejecting the removed field without rewrite, compatibility mode, or fallback."
     },
     {
       "id": "structural_bridge_calls",
@@ -193,8 +193,8 @@
       "required_crates": [],
       "positive_evidence": {"id": "nested_recursive_structural_roundtrip", "status": "planned"},
       "negative_evidence": {"id": "shape_callback_and_lifetime_mismatches_rejected", "status": "planned"},
-      "future_owner": "plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md",
-      "notes": "Future-owned by Native Pydantic-Sifr milestone_ps_2; structural calls remain unavailable until nested recursive construction/projection/callback runtime evidence and deliberate shape, callback, and lifetime rejection evidence pass together."
+      "future_owner": "internal_docs/rust_interop_architecture.md",
+      "notes": "Reserved by the structural Rust bridge contract; structural calls remain unavailable until nested recursive construction, projection, callback runtime evidence, and deliberate shape, callback, and lifetime rejection evidence pass together."
     },
     {
       "id": "panic_boundary",

--- a/verification/areas/rust_interop/fixtures/bridge_version_field_removal/README.md
+++ b/verification/areas/rust_interop/fixtures/bridge_version_field_removal/README.md
@@ -1,9 +1,8 @@
 # bridge_version_field_removal
 
-Future-owned Native Pydantic-Sifr `milestone_ps_2` evidence for removing the
-versioned Rust bridge manifest schema.
+Reserved evidence for removing the versioned Rust bridge manifest schema.
 
-The implementation wave replaces the current `bridge_version_mismatch` row:
+The completed evidence must establish that:
 
 - an unversioned `[rust]` manifest is accepted by the normal compiler manifest
   diagnostic path; and

--- a/verification/areas/rust_interop/fixtures/bridge_version_field_removal/negative/bridge_version_field_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_version_field_removal/negative/bridge_version_field_rejected.sifr
@@ -4,7 +4,6 @@
 # execution-kind: compiler-diagnostic
 # expected-result: future-owned-diagnostic
 # expected-diagnostic: SIFR-RUST-CARGO-0001
-# future-owner: plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md
 # fixture-cargo: rust.bridge-version = 1
 
 @rust(bridge.version.removed, panic=trusted_no_panic)

--- a/verification/areas/rust_interop/fixtures/bridge_version_field_removal/positive/unversioned_bridge_manifest_accepted.sifr
+++ b/verification/areas/rust_interop/fixtures/bridge_version_field_removal/positive/unversioned_bridge_manifest_accepted.sifr
@@ -3,7 +3,6 @@
 # evidence-status: planned
 # execution-kind: compiler-diagnostic
 # expected-result: future-owned
-# future-owner: plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md
 # fixture-cargo: rust.bridge-version = absent
 
 @rust(bridge.version.unversioned, panic=trusted_no_panic)

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/README.md
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/README.md
@@ -1,11 +1,9 @@
 # structural_bridge_calls
 
-Future-owned Native Pydantic-Sifr `milestone_ps_2` evidence for monomorphized
-structural Rust bridge calls.
+Reserved evidence for monomorphized structural Rust bridge calls.
 
 The row is intentionally planned while the structural contract is not yet
-implemented. The implementation wave must replace these planned evidence files
-with passing generated-package evidence that:
+implemented. The generated-package evidence must establish that the bridge:
 
 - round-trips nested generic and recursive values through a native opaque
   source with node-scoped construction and allocation-free projection; and

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/negative/shape_callback_and_lifetime_mismatches_rejected.sifr
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/negative/shape_callback_and_lifetime_mismatches_rejected.sifr
@@ -4,10 +4,8 @@
 # execution-kind: runtime-observed
 # expected-result: future-owned-diagnostic
 # expected-diagnostic: SIFR-RUST-TYPE-0001
-# future-owner: plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md
-
-# milestone_ps_2 replaces this planned marker with deliberate compiler and
-# Cargo-probe rejection evidence after the structural bridge is implemented.
+# Deliberate compiler and Cargo-probe rejection evidence remains reserved until
+# the structural bridge is implemented.
 
 from sifr.meta import Structural
 

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/positive/nested_recursive_structural_roundtrip.sifr
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/positive/nested_recursive_structural_roundtrip.sifr
@@ -3,10 +3,8 @@
 # evidence-status: planned
 # execution-kind: runtime-observed
 # expected-result: future-owned
-# future-owner: plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md
-
-# milestone_ps_2 replaces this planned marker with an executable generated
-# package round-trip only after the structural bridge contract is implemented.
+# The executable generated-package round-trip remains reserved until the
+# structural bridge contract is implemented.
 
 from sifr.meta import Structural
 


### PR DESCRIPTION
## Summary

- remove delivery-plan taxonomy from active Rust-interop fixtures and architecture surfaces
- rekey the two future-owned rows to the durable Rust-interop architecture contract
- preserve exact owner and existence validation, with negative self-tests for unapproved and missing owners

## Validation

- verification taxonomy check and self-test: pass
- Rust-interop verification area: 10/10 variants pass
- compatibility matrix check and self-test: pass (9 self-test cases)
- stable claims, stale drafts, tier checks, file-size guardrail, HIR guardrail, and git diff check: pass
- Opus review round 3: SATISFIED, no actionable findings
- create-PR profile: reaches and passes this repair's taxonomy and guardrail scope; blocked later by the known externally owned #3110 Python readonly/doctor timeout on current main. #3110 is itself blocked on this taxonomy repair, so this PR intentionally closes that dependency cycle without absorbing #3110 code.
