### PR TITLE
M2: enforce cache-aware Python interop budgets

### DIFF
--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -6,8 +6,8 @@ Status: in progress.
 
 | Milestone | Scope | Status |
 | --- | --- | --- |
-| M1: controlled measurement and provenance | Host/cache telemetry, controlled admission, stable-sample retries, stale-result producer/checker binding, and governed trend-reference refresh | in progress |
-| M2: Python interop cold-cache budget | Classify cold versus warm aggregate execution and enforce a cache-aware create-PR step budget with deterministic policy tests | pending |
+| M1: controlled measurement and provenance | Host/cache telemetry, controlled admission, stable-sample retries, stale-result producer/checker binding, and governed trend-reference refresh | complete on draft PR #3101 |
+| M2: Python interop cold-cache budget | Classify cold versus warm aggregate execution and enforce a cache-aware create-PR step budget with deterministic policy tests | in progress |
 | M3: qualification and closure | Five consecutive controlled representative verdicts, seeded-regression proof, final merge gate, full-phase review, and closure records | pending |
 
 Each implementation milestone uses one draft PR, exact-SHA validation, and
@@ -24,23 +24,52 @@ evidence. Extending either expiry remains prohibited.
 
 ### Current handoff
 
-- State: the original M1 implementation is externally reviewed and satisfied;
-  the delegated trend-reference owner fix is in implementation.
+- State: M1 is externally reviewed and satisfied on the draft PR; M2 is in
+  implementation as a stacked milestone because the repository's create-PR
+  gate cannot merge M1 until this phase-owned Python-interop blocker closes.
 - Branch: `codex/adhoc-performance-budget-host-variance`.
 - Reviewed M1 implementation candidate:
-  `869c05d3eb7440cbcbaed38099e372768e61ccc7`.
+  `28bca35551321b109e272c61ae52fe6201eb810d`.
 - Draft PR: [#3101](https://github.com/sifr-lang/sifr/pull/3101).
-- Validation on the reviewed candidate: manifest, benchmark-runner self-test, budget-policy self-test,
-  checked-in baseline budget gate, Python compile/lint, stale-producer probe,
-  diff check, and file-size guardrail passed. The broader rules-suite failure
-  was the then-out-of-scope trend deferral now delegated into M1.
+- Validation on the reviewed candidate: all 65 governed benchmarks passed in
+  one approved controlled-host capture; the trend record contains no
+  deferrals and binds raw-evidence digest
+  `878fceea8e1eef6472b74b3e83e43c796d90f5215dba7c4c9bf03ca07b083d4d`.
+  Performance rules 6/6, manifest, runner self-tests, budget/trend policy,
+  Python compile/lint, maintainability, diff, and file-size checks passed.
 - Review: Claude Opus returned `SATISFIED` with no blocking findings for base
-  `1cb731fcb67c520d35fcf2376a88b2d2a4b255b1` against candidate
-  `869c05d3eb7440cbcbaed38099e372768e61ccc7`. External evidence SHA-256:
-  `51d7ab8f176bd1efa8756596f7727534b72ea1c29a2a06664fd593e705ee9baf`.
+  `01c43b9cd67df6174b44fbbf7d2328ac5a831cb7` against candidate
+  `28bca35551321b109e272c61ae52fe6201eb810d`. External evidence SHA-256:
+  `2d23bfbc49ca58cd39aea7945614edfbc9ad8f8bc7ec74ef9e44822b03f7eef1`.
 - Base update: merged current `origin/main` at
   `01c43b9cd67df6174b44fbbf7d2328ac5a831cb7`; the final owner-fix candidate
   requires a fresh exact-SHA review and validation round.
+
+### M2 reproduced evidence
+
+On exact M1 candidate `28bca35551321b109e272c61ae52fe6201eb810d`,
+the canonical create-PR profile passed every preceding lane and 18 of 19
+Python-interop variants, then failed only `readonly-check-doctor` at its fixed
+120-second subprocess timeout. The Python-interop step had run for 1,131.589
+seconds when it failed. An immediate unchanged aggregate replay again passed
+18 of 19, reproduced the same case at 120.479 seconds, and took 821.95 seconds;
+`callback-examples` alone varied to 341.399 seconds.
+
+M2 separates the functional hang guard from the performance budget. The doctor
+subprocess guard is 300 seconds. The create-PR aggregate keeps its 600-second
+warm budget and uses a 1,200-second cold budget only when an atomic receipt
+cannot prove a prior successful run for the exact source commit, tracked-tree
+state, selected suites, Cargo lock, Rust/Python toolchains, Sifr binary, and
+required cache artifacts. Failed, dirty-tree, unavailable-input, changed-input,
+or missing-cache runs cannot establish a warm receipt. The classification and
+selected budget are emitted in the machine lane report.
+
+Targeted validation passed `readonly-check-doctor` at 169.710 seconds. The
+complete unchanged 19-variant selection then passed 19/19 in 522.69 seconds;
+the doctor case took 170.125 seconds and `callback-examples` took 78.678
+seconds. Deterministic self-tests cover missing, exact, changed, invalid, and
+missing-artifact receipts, blocking cold overruns, report parsing, and the
+governed create-PR profile values.
 
 ## Problem
 

--- a/verification/areas/python_interop/runner/readonly_check_doctor.py
+++ b/verification/areas/python_interop/runner/readonly_check_doctor.py
@@ -13,6 +13,8 @@ sys.path.insert(0, str(COMMON_ROOT))
 
 from sifr_binary import resolve_sifr_binary  # noqa: E402
 
+COMMAND_HANG_TIMEOUT_SECONDS = 300
+
 
 def main() -> int:
     binary = resolve_sifr_binary(REPO_ROOT)
@@ -29,10 +31,16 @@ def main() -> int:
     require(check["application"] is False, "library report must be deferred")
     require(check["environment"]["status"] == "deferred", "library environment must defer")
     require(check["trust"] == "deferred-to-final-application", "library trust must defer")
-    require(check["targets"] == [{"target": "math.sqrt", "status": "deferred"}], "library target must defer")
+    require(
+        check["targets"] == [{"target": "math.sqrt", "status": "deferred"}],
+        "library target must defer",
+    )
     first_doctor = run(binary, library, "python", "doctor", "--json")
     second_doctor = run(binary, library, "python", "doctor", "--json")
-    require(first_doctor.stdout == second_doctor.stdout, "doctor output must be deterministic")
+    require(
+        first_doctor.stdout == second_doctor.stdout,
+        "doctor output must be deterministic",
+    )
     doctor = json.loads(first_doctor.stdout)
     require(
         doctor["suggestions"][0]["patch"]
@@ -47,7 +55,10 @@ def main() -> int:
     normal = run(binary, application, "check", "src/main.sifr", "--frozen")
     require(normal.returncode == 0, f"normal check failed: {normal.stderr}")
     require(app_check["application"] is True, "application report must resolve")
-    require(app_check["environment"]["status"] == "resolved", "application environment must resolve")
+    require(
+        app_check["environment"]["status"] == "resolved",
+        "application environment must resolve",
+    )
     require(app_check["trust"] == "verified", "application trust must verify")
     require(
         app_check["targets"]
@@ -57,26 +68,36 @@ def main() -> int:
         ],
         "every application target must verify",
     )
-    require(snapshot(application) == application_before, "application inspection mutated its package")
+    require(
+        snapshot(application) == application_before,
+        "application inspection mutated its package",
+    )
 
     source = application / "src" / "main.sifr"
     source.write_text(source.read_text(encoding="utf-8") + "\n# snapshot change\n", encoding="utf-8")
     changed_before = snapshot(application)
     changed = run_json(binary, application, "python", "check", "--json")
-    require(changed["source_digest"] != app_check["source_digest"], "source digest ignored source bytes")
+    require(
+        changed["source_digest"] != app_check["source_digest"],
+        "source digest ignored source bytes",
+    )
     require(snapshot(application) == changed_before, "snapshot check mutated its package")
 
     source.write_text(application_source("math.not_a_real_target"), encoding="utf-8")
     invalid_before = snapshot(application)
     python_failure = run(binary, application, "python", "check", expected=1)
     normal_failure = run(binary, application, "check", "src/main.sifr", "--frozen", expected=1)
-    require("SIFR-PYIMP-0001" in python_failure.stderr, "python check target diagnostic drifted")
-    require("SIFR-PYIMP-0001" in normal_failure.stderr, "normal check target diagnostic drifted")
+    require(
+        "SIFR-PYIMP-0001" in python_failure.stderr,
+        "python check target diagnostic drifted",
+    )
+    require(
+        "SIFR-PYIMP-0001" in normal_failure.stderr,
+        "normal check target diagnostic drifted",
+    )
     require(snapshot(application) == invalid_before, "failure checks mutated their package")
 
-    selected_library = create_package(
-        root / "selected-library", "readonly-selected-library", application=True
-    )
+    selected_library = create_package(root / "selected-library", "readonly-selected-library", application=True)
     (selected_library / "src" / "main.sifr").unlink()
     shutil.rmtree(selected_library / "src" / "bin")
     selected_source = selected_library / "src" / "__init__.sifr"
@@ -89,8 +110,14 @@ def main() -> int:
         "session-root library selection must resolve",
     )
     require(selected["trust"] == "verified", "selected library trust must verify")
-    require(selected["targets"][0]["status"] == "verified", "selected library target must verify")
-    require(snapshot(selected_library) == selected_before, "selected library check mutated files")
+    require(
+        selected["targets"][0]["status"] == "verified",
+        "selected library target must verify",
+    )
+    require(
+        snapshot(selected_library) == selected_before,
+        "selected library check mutated files",
+    )
 
     selected_source.write_text(application_source("math.not_a_real_target"), encoding="utf-8")
     selected_invalid_before = snapshot(selected_library)
@@ -116,9 +143,7 @@ def main() -> int:
         "selected-library failure checks mutated files",
     )
 
-    discovered_library = create_package(
-        root / "discovered-library", "readonly-discovered-library", application=True
-    )
+    discovered_library = create_package(root / "discovered-library", "readonly-discovered-library", application=True)
     (discovered_library / "src" / "main.sifr").unlink()
     shutil.rmtree(discovered_library / "src" / "bin")
     discovered_source = discovered_library / "src" / "__init__.sifr"
@@ -140,16 +165,17 @@ def main() -> int:
         "discovered library environment must resolve",
     )
     require(discovered["trust"] == "verified", "discovered library trust must verify")
-    require(discovered["targets"][0]["status"] == "verified", "discovered target must verify")
+    require(
+        discovered["targets"][0]["status"] == "verified",
+        "discovered target must verify",
+    )
     require(
         snapshot(discovered_library) == discovered_before,
         "discovered-library checks mutated files",
     )
     discovered_source.write_text(application_source("math.not_a_real_target"), encoding="utf-8")
     discovered_invalid_before = snapshot(discovered_library)
-    discovered_python_failure = run(
-        binary, discovered_library, "python", "check", expected=1
-    )
+    discovered_python_failure = run(binary, discovered_library, "python", "check", expected=1)
     discovered_normal_failure = run(
         binary,
         discovered_library,
@@ -171,10 +197,7 @@ def main() -> int:
         "discovered-library failure checks mutated files",
     )
 
-    print(
-        "python interop read-only check/doctor ok: "
-        "deferred=1 resolved=3 parity=5 mutations=0"
-    )
+    print("python interop read-only check/doctor ok: deferred=1 resolved=3 parity=5 mutations=0")
     return 0
 
 
@@ -219,9 +242,7 @@ def write_manifest(root: Path, name: str, *, python: bool) -> None:
         'sifr-version = ">=0.3,<0.4"\n\n[source]\nroot = "src"\n'
     )
     if python:
-        manifest += (
-            '\n[python]\nvenv = ".venv"\npyproject = "pyproject.toml"\nlock = "uv.lock"\n'
-        )
+        manifest += '\n[python]\nvenv = ".venv"\npyproject = "pyproject.toml"\nlock = "uv.lock"\n'
     if python or (root / "pyproject.toml").exists():
         manifest += '\n[trust]\npython = ["math"]\n'
     (root / "sifr.toml").write_text(manifest, encoding="utf-8")
@@ -252,7 +273,7 @@ def run(
         text=True,
         capture_output=True,
         check=False,
-        timeout=120,
+        timeout=COMMAND_HANG_TIMEOUT_SECONDS,
     )
     require(
         result.returncode == expected,

--- a/verification/profiles/create-pr.json
+++ b/verification/profiles/create-pr.json
@@ -12,7 +12,7 @@
     "core_guardrails": {"budget_ms": 360000, "enforcement": "blocking"},
     "diagnostic_rules": {"budget_ms": 90000, "enforcement": "blocking"},
     "cpython_differential": {"budget_ms": 30000, "enforcement": "blocking"},
-    "python_interop": {"budget_ms": 600000, "enforcement": "blocking"},
+    "python_interop": {"warm_budget_ms": 600000, "cold_budget_ms": 1200000, "cache_classifier": "successful-input-receipt", "enforcement": "blocking"},
     "rust_interop_checks": {"budget_ms": 10000, "enforcement": "blocking"},
     "frontend_syntax_guardrails": {"budget_ms": 60000, "enforcement": "blocking"},
     "developer_tooling_checks": {"budget_ms": 180000, "enforcement": "blocking"},

--- a/verification/runner/sifr_verify/profile_commands.py
+++ b/verification/runner/sifr_verify/profile_commands.py
@@ -1,0 +1,62 @@
+"""Subprocess command primitives for validation profile execution."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from .paths import REPO_ROOT
+
+
+class CommandFailed(Exception):
+    """A subprocess returned a non-zero exit code."""
+
+    def __init__(self, returncode: int) -> None:
+        super().__init__(f"command failed with exit code {returncode}")
+        self.returncode = returncode
+
+
+def run_command(command: list[str], *, env: dict[str, str] | None = None) -> None:
+    proc = subprocess.Popen(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        sys.stdout.write(line)
+    returncode = proc.wait()
+    if returncode != 0:
+        raise CommandFailed(returncode)
+
+
+def uv_area_command(*args: str) -> list[str]:
+    return [
+        "uv",
+        "run",
+        "--project",
+        "verification",
+        "--locked",
+        "python",
+        "-m",
+        "sifr_verify",
+        "areas",
+        "run",
+        *args,
+    ]
+
+
+def cargo_command(*args: str) -> list[str]:
+    command = ["cargo", *args]
+    if "--" in command:
+        separator = command.index("--")
+        return [*command[:separator], "--locked", *command[separator:]]
+    return [*command, "--locked"]
+
+
+def run_python(script: str, *args: str) -> None:
+    run_command(["python3", script, *args])

--- a/verification/runner/sifr_verify/profile_reporting.py
+++ b/verification/runner/sifr_verify/profile_reporting.py
@@ -1,0 +1,125 @@
+"""Atomic log, timing, and machine-report publication for profile runs."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import resource
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Callable, TextIO
+
+from . import reports
+from .paths import REPO_ROOT
+
+
+class Tee:
+    """Write text to more than one stream."""
+
+    def __init__(self, *streams: TextIO) -> None:
+        self._streams = streams
+
+    def write(self, data: str) -> int:
+        for stream in self._streams:
+            stream.write(data)
+            stream.flush()
+        return len(data)
+
+    def flush(self) -> None:
+        for stream in self._streams:
+            stream.flush()
+
+
+def write_time_file(path: Path, *, start: float, usage_start: resource.struct_rusage) -> None:
+    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    real_seconds = time.monotonic() - start
+    user_seconds = max(0.0, usage.ru_utime - usage_start.ru_utime)
+    sys_seconds = max(0.0, usage.ru_stime - usage_start.ru_stime)
+    max_rss = int(usage.ru_maxrss)
+    swaps = max(0, int(usage.ru_nswap - usage_start.ru_nswap))
+    path.write_text(
+        f"{real_seconds:.2f} real\n"
+        f"{user_seconds:.2f} user\n"
+        f"{sys_seconds:.2f} sys\n"
+        f"{max_rss} maximum resident set size\n"
+        f"{swaps} swaps\n",
+        encoding="utf-8",
+    )
+
+
+def temporary_report_path(report_dir: Path, prefix: str) -> Path:
+    with tempfile.NamedTemporaryFile(prefix=prefix, dir=report_dir, delete=False) as temp_file:
+        return Path(temp_file.name)
+
+
+def run_profile_with_report(
+    profile_name: str,
+    run_lane: Callable[[], int],
+    *,
+    handled_error: type[Exception],
+    release_report_out: str | None,
+) -> int:
+    release_output = None
+    if release_report_out is not None:
+        from .release_evidence import prepare_release_report_output
+
+        try:
+            release_output = prepare_release_report_output(
+                release_report_out,
+                profile_name=profile_name,
+            )
+        except ValueError as exc:
+            print(f"sifr_verify: {exc}", file=sys.stderr)
+            return 2
+    report_dir = REPO_ROOT / "target" / "validation_lane_reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    temp_log = temporary_report_path(report_dir, f"lane.{profile_name}.log.")
+    temp_time = temporary_report_path(report_dir, f"lane.{profile_name}.time.")
+    latest_log = report_dir / f"{profile_name}.latest.log"
+    latest_time = report_dir / f"{profile_name}.latest.time"
+    json_file = report_dir / f"{profile_name}.latest.json"
+    start = time.monotonic()
+    usage_start = resource.getrusage(resource.RUSAGE_CHILDREN)
+    status = 0
+
+    with temp_log.open("w", encoding="utf-8") as log_file:
+        tee = Tee(sys.stdout, log_file)
+        with contextlib.redirect_stdout(tee), contextlib.redirect_stderr(tee):
+            try:
+                status = run_lane()
+            except handled_error as exc:
+                print(f"sifr_verify: {exc}", file=sys.stderr)
+                status = 2
+
+    write_time_file(temp_time, start=start, usage_start=usage_start)
+    shutil.copyfile(temp_log, latest_log)
+    shutil.copyfile(temp_time, latest_time)
+    try:
+        reports.summarize(
+            argparse.Namespace(
+                profile=profile_name,
+                log=str(latest_log),
+                time_file=str(latest_time),
+                json_out=str(json_file),
+            )
+        )
+    except Exception as exc:  # Preserve validation status while surfacing report regressions.
+        print(f"warning: lane report summarization failed: {exc}", file=sys.stderr)
+    if release_output is not None and status == 0:
+        from .release_evidence import write_release_profile_report
+
+        try:
+            write_release_profile_report(
+                release_output,
+                log_path=latest_log,
+                status=status,
+            )
+        except ValueError as exc:
+            print(f"sifr_verify: {exc}", file=sys.stderr)
+            status = 2
+    temp_log.unlink(missing_ok=True)
+    temp_time.unlink(missing_ok=True)
+    return status

--- a/verification/runner/sifr_verify/profile_runner.py
+++ b/verification/runner/sifr_verify/profile_runner.py
@@ -2,33 +2,40 @@
 
 from __future__ import annotations
 
-import argparse
-import contextlib
 import os
-import resource
-import shutil
-import subprocess
 import sys
-import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, TextIO
+from typing import Any, Callable
 
-from . import reports
 from .cargo_setup import (
     enable_offline_cargo as enable_profile_offline_cargo,
     prepare_cargo_cache as prepare_profile_cargo_cache,
 )
 from .errors import VerificationError
 from .paths import REPO_ROOT
+from .profile_commands import (
+    CommandFailed,
+    cargo_command,
+    run_command,
+    run_python,
+    uv_area_command,
+)
 from .profile_area_steps import AreaResultError, run_selected_area, validate_area_result
+from .profile_reporting import run_profile_with_report
 from .profiles import (
     crate_test_suites_for_mode,
     legacy_facade,
     load_profile,
     resolve_fixture_manifest,
     selected_suites_for_area,
+)
+from .step_budgets import (
+    StepBudgetContext,
+    enforce_step_budget as enforce_prepared_step_budget,
+    prepare_step_budget,
+    record_step_success,
 )
 
 sys.path.insert(0, str(REPO_ROOT / "verification" / "areas" / "common"))
@@ -40,35 +47,10 @@ class ProfileRunnerError(VerificationError):
     """Profile execution failed before a validation command could run."""
 
 
-class CommandFailed(Exception):
-    """A subprocess returned a non-zero exit code."""
-
-    def __init__(self, returncode: int) -> None:
-        super().__init__(f"command failed with exit code {returncode}")
-        self.returncode = returncode
-
-
 @dataclass(frozen=True)
 class StepResult:
     status: int
     elapsed_ms: int
-
-
-class Tee:
-    """Write text to more than one stream."""
-
-    def __init__(self, *streams: TextIO) -> None:
-        self._streams = streams
-
-    def write(self, data: str) -> int:
-        for stream in self._streams:
-            stream.write(data)
-            stream.flush()
-        return len(data)
-
-    def flush(self) -> None:
-        for stream in self._streams:
-            stream.flush()
 
 
 LEGACY_FACADE_STEPS_BEFORE_GENERATED = (
@@ -126,52 +108,6 @@ def validate_rust_interop_result(result_path: Path, expected_suites: list[str]) 
         raise ProfileRunnerError(str(exc)) from exc
 
 
-def run_command(command: list[str], *, env: dict[str, str] | None = None) -> None:
-    proc = subprocess.Popen(
-        command,
-        cwd=REPO_ROOT,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-    )
-    assert proc.stdout is not None
-    for line in proc.stdout:
-        sys.stdout.write(line)
-    returncode = proc.wait()
-    if returncode != 0:
-        raise CommandFailed(returncode)
-
-
-def uv_area_command(*args: str) -> list[str]:
-    return [
-        "uv",
-        "run",
-        "--project",
-        "verification",
-        "--locked",
-        "python",
-        "-m",
-        "sifr_verify",
-        "areas",
-        "run",
-        *args,
-    ]
-
-
-def cargo_command(*args: str) -> list[str]:
-    command = ["cargo", *args]
-    if "--" in command:
-        separator = command.index("--")
-        return [*command[:separator], "--locked", *command[separator:]]
-    return [*command, "--locked"]
-
-
-def run_python(script: str, *args: str) -> None:
-    run_command(["python3", script, *args])
-
-
 def now_ms() -> int:
     return time.monotonic_ns() // 1_000_000
 
@@ -203,9 +139,13 @@ class ProfileRunner:
         self.forward_args = forward_args
         self.env = os.environ.copy()
         configured_sifr_binary = self.env.get("SIFR_GCQ_BIN") or self.env.get("SIFR_RUNTIME_PLATFORM_BIN")
-        sifr_binary = Path(configured_sifr_binary) if configured_sifr_binary else resolve_sifr_binary(
-            REPO_ROOT,
-            default_binary=REPO_ROOT / "target" / "debug" / "sifr",
+        sifr_binary = (
+            Path(configured_sifr_binary)
+            if configured_sifr_binary
+            else resolve_sifr_binary(
+                REPO_ROOT,
+                default_binary=REPO_ROOT / "target" / "debug" / "sifr",
+            )
         )
         self.env.setdefault("SIFR_GCQ_BIN", str(sifr_binary))
         self.env.setdefault("SIFR_RUNTIME_PLATFORM_BIN", str(sifr_binary))
@@ -217,15 +157,18 @@ class ProfileRunner:
 
     def run(self) -> int:
         self.print_header()
+        setup_budget = self.prepare_step_budget("cargo_cache_setup")
         setup_result = self.run_timed_step("cargo_cache_setup", self.prepare_cargo_cache)
         if setup_result.status != 0:
             return setup_result.status
         setup_budget_status = self.enforce_step_budget(
             "cargo_cache_setup",
             setup_result.elapsed_ms,
+            setup_budget,
         )
         if setup_budget_status != 0:
             return setup_budget_status
+        record_step_success(setup_budget)
         if self.profile.get("cargo_policy", {}).get("offline") is True:
             self.enable_offline_cargo()
         if self.execution_mode == "selected-areas-only":
@@ -234,12 +177,14 @@ class ProfileRunner:
         steps = self.legacy_facade_steps()
 
         for name, callback in steps:
+            budget = self.prepare_step_budget(name)
             result = self.run_timed_step(name, callback)
             if result.status != 0:
                 return result.status
-            budget_status = self.enforce_step_budget(name, result.elapsed_ms)
+            budget_status = self.enforce_step_budget(name, result.elapsed_ms, budget)
             if budget_status != 0:
                 return budget_status
+            record_step_success(budget)
         return 0
 
     def prepare_cargo_cache(self) -> None:
@@ -256,10 +201,7 @@ class ProfileRunner:
         enable_profile_offline_cargo(self.env)
 
     def legacy_facade_steps(self) -> list[tuple[str, Callable[[], None]]]:
-        return [
-            (name, getattr(self, method_name))
-            for name, method_name in legacy_facade_step_methods(self.profile)
-        ]
+        return [(name, getattr(self, method_name)) for name, method_name in legacy_facade_step_methods(self.profile)]
 
     @property
     def execution_mode(self) -> str:
@@ -268,11 +210,6 @@ class ProfileRunner:
     @property
     def budgets(self) -> dict[str, Any]:
         return self.profile["budgets"]
-
-    @property
-    def step_budgets(self) -> dict[str, Any]:
-        budgets = self.profile.get("step_budgets", {})
-        return budgets if isinstance(budgets, dict) else {}
 
     @property
     def matrix_suites(self) -> list[str]:
@@ -319,15 +256,9 @@ class ProfileRunner:
         print(f"  profile={self.profile_name}")
         print(f"  lane={self.profile_name}")
         print(
-            "  budget="
-            f"warm<={self.budgets['warm_wall_time_minutes']}m "
-            f"cold<={self.budgets['cold_wall_time_minutes']}m"
+            f"  budget=warm<={self.budgets['warm_wall_time_minutes']}m cold<={self.budgets['cold_wall_time_minutes']}m"
         )
-        print(
-            "  policy="
-            f"thermal:{self.legacy['thermal_policy']} "
-            f"memory:{self.legacy['memory_policy']}"
-        )
+        print(f"  policy=thermal:{self.legacy['thermal_policy']} memory:{self.legacy['memory_policy']}")
 
     def selected_suites_for_area(self, area_name: str) -> list[str]:
         suites: list[str] = []
@@ -339,47 +270,39 @@ class ProfileRunner:
                 suites.extend(str(suite) for suite in raw_suites)
         return suites
 
-    def enforce_step_budget(self, name: str, elapsed_ms: int) -> int:
-        raw_budget = self.step_budgets.get(name)
-        if not isinstance(raw_budget, dict):
-            return 0
-        budget_ms = int(raw_budget.get("budget_ms", 0) or 0)
-        enforcement = str(raw_budget.get("enforcement", "advisory"))
-        exceeded = budget_ms > 0 and elapsed_ms > budget_ms
-        budget_status = "fail" if exceeded else "pass"
-        print(
-            "[sifr-lane-step-budget] "
-            f"name={name} elapsed_ms={elapsed_ms} budget_ms={budget_ms} "
-            f"enforcement={enforcement} status={budget_status}"
+    def prepare_step_budget(self, name: str) -> StepBudgetContext | None:
+        return prepare_step_budget(
+            repo_root=REPO_ROOT,
+            profile=self.profile,
+            profile_name=str(self.profile.get("name", "unknown")),
+            name=name,
+            env=getattr(self, "env", os.environ),
         )
-        disabled = os.environ.get("SIFR_VERIFY_DISABLE_STEP_BUDGETS", "").lower() in {
-            "1",
-            "true",
-            "yes",
-        }
-        if exceeded and enforcement == "blocking" and not disabled:
-            print(
-                f"sifr_verify: step budget exceeded for {name}: "
-                f"{elapsed_ms}ms > {budget_ms}ms",
-                file=sys.stderr,
-            )
-            return 124
-        return 0
+
+    def enforce_step_budget(
+        self,
+        _name: str,
+        elapsed_ms: int,
+        context: StepBudgetContext | None = None,
+    ) -> int:
+        return enforce_prepared_step_budget(context, elapsed_ms)
 
     def run_selected_areas_only(self) -> int:
-        selections = [
-            selection
-            for selection in self.profile.get("selected_areas", [])
-            if isinstance(selection, dict)
-        ]
+        selections = [selection for selection in self.profile.get("selected_areas", []) if isinstance(selection, dict)]
         if not selections:
-            print(f"sifr_verify: profile {self.profile_name} selects no areas", file=sys.stderr)
+            print(
+                f"sifr_verify: profile {self.profile_name} selects no areas",
+                file=sys.stderr,
+            )
             return 2
         for selection in selections:
             area = str(selection["area"])
             suites = [str(suite) for suite in selection.get("suites", [])]
             step_name = f"{area}_selected_suites"
-            result = timed_step(step_name, lambda area=area, suites=suites: self.run_area_suites(area, suites))
+            result = timed_step(
+                step_name,
+                lambda area=area, suites=suites: self.run_area_suites(area, suites),
+            )
             if result.status != 0:
                 return result.status
         return 0
@@ -388,7 +311,7 @@ class ProfileRunner:
         args = ["--area", area]
         for suite in suites:
             args.extend(["--suite", suite])
-        run_command(uv_area_command(*args))
+        run_command(uv_area_command(*args), env=self.env)
 
     def run_coverage_matrix_checks(self) -> None:
         suites = self.selected_suites_for_area("coverage_matrix")
@@ -499,14 +422,12 @@ class ProfileRunner:
         args = ["--area", "python_interop"]
         for suite in suites:
             args.extend(["--suite", suite])
-        run_command(uv_area_command(*args))
+        run_command(uv_area_command(*args), env=self.env)
 
     def run_rust_interop_checks(self) -> None:
         suites = self.selected_suites_for_area("rust_interop")
         if not suites:
-            raise ProfileRunnerError(
-                f"profile {self.profile_name} has no Rust interop suites to execute"
-            )
+            raise ProfileRunnerError(f"profile {self.profile_name} has no Rust interop suites to execute")
         print("Running Rust interop checks")
         try:
             run_selected_area(
@@ -573,17 +494,23 @@ class ProfileRunner:
     def run_verification_runner_foundation_checks(self) -> None:
         print("Running verification runner foundation checks")
         run_command(["uv", "lock", "--project", "verification", "--check"])
-        run_command(["uv", "run", "--project", "verification", "--locked", "python", "-m", "sifr_verify", "--self-test"])
+        run_command(
+            [
+                "uv",
+                "run",
+                "--project",
+                "verification",
+                "--locked",
+                "python",
+                "-m",
+                "sifr_verify",
+                "--self-test",
+            ]
+        )
 
     def run_fuzz_property_suites(self) -> None:
-        legacy_fuzz_suites = {
-            suite for suite in self.hardening_suites if suite in {"property", "fuzz-smoke"}
-        }
-        suites = [
-            suite
-            for suite in self.selected_suites_for_area("fuzz_property")
-            if suite not in legacy_fuzz_suites
-        ]
+        legacy_fuzz_suites = {suite for suite in self.hardening_suites if suite in {"property", "fuzz-smoke"}}
+        suites = [suite for suite in self.selected_suites_for_area("fuzz_property") if suite not in legacy_fuzz_suites]
         if not suites:
             print(f"Skipping fuzz/property checks for lane {self.profile_name}")
             return
@@ -615,8 +542,7 @@ class ProfileRunner:
         suites = self.selected_suites_for_area("distribution_release")
         if self.distribution_mode not in suites:
             raise ProfileRunnerError(
-                f"profile {self.profile_name} does not select distribution mode "
-                f"{self.distribution_mode}"
+                f"profile {self.profile_name} does not select distribution mode {self.distribution_mode}"
             )
         try:
             run_selected_area(
@@ -644,10 +570,13 @@ class ProfileRunner:
     def run_generated_code_quality_checks(self) -> None:
         print("Running Generated Code Quality Checks")
         print(f"  mode={self.generated_code_quality_mode}")
-        if self.generated_code_quality_mode not in {"smoke", "representative", "full", "release-full"}:
-            raise ProfileRunnerError(
-                f"unsupported generated-code quality mode: {self.generated_code_quality_mode}"
-            )
+        if self.generated_code_quality_mode not in {
+            "smoke",
+            "representative",
+            "full",
+            "release-full",
+        }:
+            raise ProfileRunnerError(f"unsupported generated-code quality mode: {self.generated_code_quality_mode}")
         shared_root = REPO_ROOT / "target" / "sifr_generated_code_quality" / f"{self.profile_name}.shared"
         env = self.env | {"SIFR_GCQ_SHARED_ROOT": str(shared_root.relative_to(REPO_ROOT))}
         run_command(
@@ -687,11 +616,7 @@ class ProfileRunner:
                 status = exc.returncode
             elapsed_ms = now_ms() - start_ms
             case_status = "pass" if status == 0 else "fail"
-            print(
-                "[sifr-case-timing] "
-                f"bucket=crate_tests case={suite_id} "
-                f"elapsed_ms={elapsed_ms} status={case_status}"
-            )
+            print(f"[sifr-case-timing] bucket=crate_tests case={suite_id} elapsed_ms={elapsed_ms} status={case_status}")
             if status != 0:
                 raise CommandFailed(status)
 
@@ -753,7 +678,14 @@ class ProfileRunner:
             e2e_args.extend(["--fixture-manifest", str(fixture_manifest)])
         if bool(self.e2e["disable_cache"]):
             e2e_args.append("--no-cache")
-        run_command(["bash", "verification/runner/e2e/run_e2e_pass.sh", *e2e_args, *self.forward_args])
+        run_command(
+            [
+                "bash",
+                "verification/runner/e2e/run_e2e_pass.sh",
+                *e2e_args,
+                *self.forward_args,
+            ]
+        )
 
     def run_hardening_suites(self) -> None:
         if not self.hardening_suites:
@@ -779,22 +711,59 @@ class ProfileRunner:
             else:
                 legacy_args.extend(["--suite", suite])
         if diagnostics:
-            run_command(uv_area_command("--area", "diagnostics", "--suite", "baselines", "--hardening-summary"))
+            run_command(
+                uv_area_command(
+                    "--area",
+                    "diagnostics",
+                    "--suite",
+                    "baselines",
+                    "--hardening-summary",
+                )
+            )
         if project_workspace:
-            run_command(uv_area_command("--area", "project_workspace", "--suite", "baselines", "--hardening-summary"))
+            run_command(
+                uv_area_command(
+                    "--area",
+                    "project_workspace",
+                    "--suite",
+                    "baselines",
+                    "--hardening-summary",
+                )
+            )
         if regression_args:
             run_command(uv_area_command("--area", "regression", *regression_args, "--hardening-summary"))
         if fuzz_property_args:
-            run_command(uv_area_command("--area", "fuzz_property", *fuzz_property_args, "--hardening-summary"))
+            run_command(
+                uv_area_command(
+                    "--area",
+                    "fuzz_property",
+                    *fuzz_property_args,
+                    "--hardening-summary",
+                )
+            )
         if ecosystem_args:
-            run_command(uv_area_command("--area", "ecosystem_compatibility", *ecosystem_args, "--hardening-summary"))
+            run_command(
+                uv_area_command(
+                    "--area",
+                    "ecosystem_compatibility",
+                    *ecosystem_args,
+                    "--hardening-summary",
+                )
+            )
         if len(legacy_args) > 2:
             run_command([sys.executable, "-m", "sifr_verify.hardening", *legacy_args])
 
     def run_extra_e2e_checks(self) -> None:
         if "e2e_report_determinism" in self.extra_checks:
             print("Running e2e report determinism check")
-            run_command(["bash", "verification/runner/e2e/check_report_determinism.sh", "--profile", self.profile_name])
+            run_command(
+                [
+                    "bash",
+                    "verification/runner/e2e/check_report_determinism.sh",
+                    "--profile",
+                    self.profile_name,
+                ]
+            )
         if "e2e_sequential_parallel_equivalence" in self.extra_checks:
             print("Running e2e sequential-vs-parallel equivalence check")
             run_command(
@@ -807,92 +776,15 @@ class ProfileRunner:
             )
 
 
-def write_time_file(path: Path, *, start: float, usage_start: resource.struct_rusage) -> None:
-    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
-    real_seconds = time.monotonic() - start
-    user_seconds = max(0.0, usage.ru_utime - usage_start.ru_utime)
-    sys_seconds = max(0.0, usage.ru_stime - usage_start.ru_stime)
-    max_rss = int(usage.ru_maxrss)
-    swaps = max(0, int(usage.ru_nswap - usage_start.ru_nswap))
-    path.write_text(
-        f"{real_seconds:.2f} real\n"
-        f"{user_seconds:.2f} user\n"
-        f"{sys_seconds:.2f} sys\n"
-        f"{max_rss} maximum resident set size\n"
-        f"{swaps} swaps\n",
-        encoding="utf-8",
-    )
-
-
-def temporary_report_path(report_dir: Path, prefix: str) -> Path:
-    with tempfile.NamedTemporaryFile(prefix=prefix, dir=report_dir, delete=False) as temp_file:
-        return Path(temp_file.name)
-
-
 def run_profile(
     profile_name: str,
     forward_args: list[str],
     *,
     release_report_out: str | None = None,
 ) -> int:
-    release_output = None
-    if release_report_out is not None:
-        from .release_evidence import prepare_release_report_output
-
-        try:
-            release_output = prepare_release_report_output(
-                release_report_out,
-                profile_name=profile_name,
-            )
-        except ValueError as exc:
-            print(f"sifr_verify: {exc}", file=sys.stderr)
-            return 2
-    report_dir = REPO_ROOT / "target" / "validation_lane_reports"
-    report_dir.mkdir(parents=True, exist_ok=True)
-    temp_log = temporary_report_path(report_dir, f"lane.{profile_name}.log.")
-    temp_time = temporary_report_path(report_dir, f"lane.{profile_name}.time.")
-    latest_log = report_dir / f"{profile_name}.latest.log"
-    latest_time = report_dir / f"{profile_name}.latest.time"
-    json_file = report_dir / f"{profile_name}.latest.json"
-    start = time.monotonic()
-    usage_start = resource.getrusage(resource.RUSAGE_CHILDREN)
-    status = 0
-
-    with temp_log.open("w", encoding="utf-8") as log_file:
-        tee = Tee(sys.stdout, log_file)
-        with contextlib.redirect_stdout(tee), contextlib.redirect_stderr(tee):
-            try:
-                status = ProfileRunner(profile_name, forward_args).run()
-            except ProfileRunnerError as exc:
-                print(f"sifr_verify: {exc}", file=sys.stderr)
-                status = 2
-
-    write_time_file(temp_time, start=start, usage_start=usage_start)
-    shutil.copyfile(temp_log, latest_log)
-    shutil.copyfile(temp_time, latest_time)
-    try:
-        reports.summarize(
-            argparse.Namespace(
-                profile=profile_name,
-                log=str(latest_log),
-                time_file=str(latest_time),
-                json_out=str(json_file),
-            )
-        )
-    except Exception as exc:  # Preserve validation status while surfacing report regressions.
-        print(f"warning: lane report summarization failed: {exc}", file=sys.stderr)
-    if release_output is not None and status == 0:
-        from .release_evidence import write_release_profile_report
-
-        try:
-            write_release_profile_report(
-                release_output,
-                log_path=latest_log,
-                status=status,
-            )
-        except ValueError as exc:
-            print(f"sifr_verify: {exc}", file=sys.stderr)
-            status = 2
-    temp_log.unlink(missing_ok=True)
-    temp_time.unlink(missing_ok=True)
-    return status
+    return run_profile_with_report(
+        profile_name,
+        lambda: ProfileRunner(profile_name, forward_args).run(),
+        handled_error=ProfileRunnerError,
+        release_report_out=release_report_out,
+    )

--- a/verification/runner/sifr_verify/profiles.py
+++ b/verification/runner/sifr_verify/profiles.py
@@ -49,9 +49,7 @@ PROFILE_STEP_NAMES = {
 PYTHON_INTEROP_CAPABILITY_MATRIX = (
     REPO_ROOT / "verification" / "areas" / "python_interop" / "declaration_capabilities.json"
 )
-RUST_INTEROP_MANIFEST = (
-    REPO_ROOT / "verification" / "areas" / "rust_interop" / "manifest.json"
-)
+RUST_INTEROP_MANIFEST = REPO_ROOT / "verification" / "areas" / "rust_interop" / "manifest.json"
 
 
 def profile_path(profile: str, profiles_dir: Path = PROFILES_DIR) -> Path:
@@ -70,7 +68,11 @@ def load_profile(profile: str, profiles_dir: Path = PROFILES_DIR) -> dict[str, A
     payload = load_json(path)
     if not isinstance(payload, dict):
         raise ProfileError(f"profile must be a JSON object: {path}")
-    validate_data(payload, load_schema("profile.schema.json"), source=str(path.relative_to(REPO_ROOT)))
+    validate_data(
+        payload,
+        load_schema("profile.schema.json"),
+        source=str(path.relative_to(REPO_ROOT)),
+    )
     if payload.get("name") != profile:
         raise ProfileError(f"profile name '{payload.get('name')}' must match file stem '{profile}'")
     validate_selected_area_suites(payload)
@@ -170,9 +172,7 @@ def validate_selected_area_suites(profile: dict[str, Any]) -> None:
         selected_suites = selection.get("suites", [])
         for suite in selected_suites:
             if suite not in area_suites[area]:
-                raise ProfileError(
-                    f"profile {profile.get('name')} selects unknown suite {area}:{suite}"
-                )
+                raise ProfileError(f"profile {profile.get('name')} selects unknown suite {area}:{suite}")
         if area == "python_interop" and profile.get("execution_mode") != "selected-areas-only":
             required_suites = _compiled_evidence_suites()
             missing = sorted(required_suites.difference(selected_suites))
@@ -191,14 +191,10 @@ def validate_selected_area_suites(profile: dict[str, Any]) -> None:
                 )
     if profile.get("execution_mode") != "selected-areas-only":
         selected_area_names = {
-            selection.get("area")
-            for selection in profile.get("selected_areas", [])
-            if isinstance(selection, dict)
+            selection.get("area") for selection in profile.get("selected_areas", []) if isinstance(selection, dict)
         }
         if "rust_interop" not in selected_area_names:
-            raise ProfileError(
-                f"profile {profile.get('name')} omits the required Rust interop area"
-            )
+            raise ProfileError(f"profile {profile.get('name')} omits the required Rust interop area")
 
 
 def required_rust_interop_suites() -> set[str]:
@@ -206,11 +202,7 @@ def required_rust_interop_suites() -> set[str]:
     suites = manifest.get("suites") if isinstance(manifest, dict) else None
     if not isinstance(suites, list) or not suites:
         raise ProfileError("Rust interop area manifest has no suites")
-    names = {
-        str(suite["name"])
-        for suite in suites
-        if isinstance(suite, dict) and isinstance(suite.get("name"), str)
-    }
+    names = {str(suite["name"]) for suite in suites if isinstance(suite, dict) and isinstance(suite.get("name"), str)}
     if len(names) != len(suites):
         raise ProfileError("Rust interop area manifest has invalid or duplicate suites")
     return names
@@ -300,14 +292,40 @@ def validate_step_budgets(profile: dict[str, Any]) -> None:
             raise ProfileError(f"profile {profile.get('name')} step_budgets has unknown step {step_name}")
         if not isinstance(budget, dict):
             raise ProfileError(f"profile {profile.get('name')} step budget {step_name} must be an object")
-        if set(budget) != {"budget_ms", "enforcement"}:
+        fixed_keys = {"budget_ms", "enforcement"}
+        cache_keys = {
+            "warm_budget_ms",
+            "cold_budget_ms",
+            "cache_classifier",
+            "enforcement",
+        }
+        if set(budget) not in {frozenset(fixed_keys), frozenset(cache_keys)}:
             raise ProfileError(
                 f"profile {profile.get('name')} step budget {step_name} "
-                "must contain only budget_ms and enforcement"
+                "must define either a fixed budget or warm/cold cache budgets"
             )
-        budget_ms = budget.get("budget_ms")
-        if isinstance(budget_ms, bool) or not isinstance(budget_ms, int) or budget_ms <= 0:
-            raise ProfileError(f"profile {profile.get('name')} step budget {step_name} has invalid budget_ms")
+        budget_keys = (
+            ["budget_ms"]
+            if "budget_ms" in budget
+            else [
+                "warm_budget_ms",
+                "cold_budget_ms",
+            ]
+        )
+        for budget_key in budget_keys:
+            budget_ms = budget.get(budget_key)
+            if isinstance(budget_ms, bool) or not isinstance(budget_ms, int) or budget_ms <= 0:
+                raise ProfileError(f"profile {profile.get('name')} step budget {step_name} has invalid {budget_key}")
+        if "cache_classifier" in budget:
+            if budget.get("cache_classifier") != "successful-input-receipt":
+                raise ProfileError(
+                    f"profile {profile.get('name')} step budget {step_name} has invalid cache_classifier"
+                )
+            if int(budget["cold_budget_ms"]) < int(budget["warm_budget_ms"]):
+                raise ProfileError(
+                    f"profile {profile.get('name')} step budget {step_name} "
+                    "cold budget must not be lower than warm budget"
+                )
         enforcement = budget.get("enforcement")
         if enforcement not in {"advisory", "blocking"}:
             raise ProfileError(f"profile {profile.get('name')} step budget {step_name} has invalid enforcement")
@@ -334,9 +352,7 @@ def workspace_package_names() -> set[str]:
     if not isinstance(packages, list):
         raise ProfileError("cargo metadata returned no packages while validating crate membership")
     _WORKSPACE_PACKAGE_NAMES = {
-        package["name"]
-        for package in packages
-        if isinstance(package, dict) and isinstance(package.get("name"), str)
+        package["name"] for package in packages if isinstance(package, dict) and isinstance(package.get("name"), str)
     }
     return _WORKSPACE_PACKAGE_NAMES
 
@@ -357,11 +373,7 @@ def crate_test_suites_for_mode(profile: dict[str, Any], mode: str) -> list[dict[
     suites = membership.get("suites") if isinstance(membership, dict) else None
     if not isinstance(suites, list) or not suites:
         raise ProfileError(f"profile {profile.get('name')} has no crate_test_membership suites")
-    return [
-        suite
-        for suite in suites
-        if isinstance(suite, dict) and mode in suite.get("modes", [])
-    ]
+    return [suite for suite in suites if isinstance(suite, dict) and mode in suite.get("modes", [])]
 
 
 def shell_exports(profile: dict[str, Any]) -> dict[str, Any]:
@@ -393,9 +405,9 @@ def shell_exports(profile: dict[str, Any]) -> dict[str, Any]:
         "RUN_HARDENING": "1" if hardening_suites else "0",
         "HARDENING_SUITES": ",".join(hardening_suites),
         "RUN_E2E_REPORT_DETERMINISM": "1" if "e2e_report_determinism" in extra_checks else "0",
-        "RUN_E2E_SEQUENTIAL_PARALLEL_EQUIVALENCE": "1"
-        if "e2e_sequential_parallel_equivalence" in extra_checks
-        else "0",
+        "RUN_E2E_SEQUENTIAL_PARALLEL_EQUIVALENCE": (
+            "1" if "e2e_sequential_parallel_equivalence" in extra_checks else "0"
+        ),
         "E2E_PROFILE": name,
         "E2E_FIXTURE_MANIFEST": "" if fixture_manifest is None else str(fixture_manifest),
         "E2E_SIFR_JOBS": e2e["sifr_jobs"],
@@ -436,10 +448,7 @@ def print_summary(requested_profile: str) -> None:
     print("  resource_classes=" + ", ".join(profile["resource_policy"]["classes"]))
     print("  matrix_suites=" + (", ".join(legacy["matrix_suites"]) if legacy["matrix_suites"] else "none"))
     print(f"  e2e={fixture_count_display} fixtures (manifest={fixture_manifest_display})")
-    print(
-        "  hardening_suites="
-        + (", ".join(legacy["hardening_suites"]) if legacy["hardening_suites"] else "none")
-    )
+    print("  hardening_suites=" + (", ".join(legacy["hardening_suites"]) if legacy["hardening_suites"] else "none"))
     print("  tooling_suites=" + (", ".join(legacy["tooling_suites"]) if legacy["tooling_suites"] else "none"))
     print(
         "  documentation_suites="
@@ -471,9 +480,7 @@ def build_profile_plan(profile_name: str) -> dict[str, Any]:
     e2e = legacy["e2e"]
     fixture_manifest = resolve_fixture_manifest(str(e2e.get("fixture_manifest", "")))
     fixture_selection = "full-corpus" if fixture_manifest is None else "manifest"
-    selected_fixture_count = (
-        full_pass_fixture_count() if fixture_manifest is None else fixture_count(fixture_manifest)
-    )
+    selected_fixture_count = full_pass_fixture_count() if fixture_manifest is None else fixture_count(fixture_manifest)
     return {
         "schema_version": 1,
         "profile": profile["name"],
@@ -542,7 +549,10 @@ def compare_plans(local_path: str, ci_path: str) -> int:
 
 def run_command(argv: list[str]) -> int:
     if not argv:
-        print("profiles command requires one of: profile, shell, summary, check, plan, compare-plans, run", file=sys.stderr)
+        print(
+            "profiles command requires one of: profile, shell, summary, check, plan, compare-plans, run",
+            file=sys.stderr,
+        )
         return 2
     command = argv[0]
     profile_name = _profile_arg(argv[1:]) if command in {"profile", "shell", "summary", "plan", "run"} else ""
@@ -599,11 +609,7 @@ def _path_arg(argv: list[str], flag: str) -> str:
 
 
 def _optional_arg(argv: list[str], flag: str) -> str | None:
-    values = [
-        argv[index + 1]
-        for index, value in enumerate(argv)
-        if value == flag and index + 1 < len(argv)
-    ]
+    values = [argv[index + 1] for index, value in enumerate(argv) if value == flag and index + 1 < len(argv)]
     if len(values) > 1:
         raise ProfileError(f"{flag} may be provided only once")
     return values[0] if values else None

--- a/verification/runner/sifr_verify/reports.py
+++ b/verification/runner/sifr_verify/reports.py
@@ -35,12 +35,14 @@ HARDENING_OK_RE = re.compile(
     r"\s+non_blocking_failures=(\d+)(?:,\s+skipped=(\d+))?$"
 )
 CACHE_DIR_RE = re.compile(r"^\s*cache_dir=(.+)$")
-LANE_STEP_RE = re.compile(
-    r"^\[sifr-lane-step\]\s+name=([A-Za-z0-9_.-]+)\s+elapsed_ms=(\d+)\s+status=(pass|fail)$"
-)
+LANE_STEP_RE = re.compile(r"^\[sifr-lane-step\]\s+name=([A-Za-z0-9_.-]+)\s+elapsed_ms=(\d+)\s+status=(pass|fail)$")
 LANE_STEP_BUDGET_RE = re.compile(
     r"^\[sifr-lane-step-budget\]\s+name=([A-Za-z0-9_.-]+)\s+elapsed_ms=(\d+)\s+"
     r"budget_ms=(\d+)\s+enforcement=(advisory|blocking)\s+status=(pass|fail)$"
+)
+LANE_STEP_CACHE_RE = re.compile(
+    r"^\[sifr-lane-step-cache\]\s+name=([A-Za-z0-9_.-]+)\s+state=(warm|cold)\s+"
+    r"reason=([a-z0-9-]+)\s+fingerprint=([0-9a-f]+)$"
 )
 CASE_TIMING_RE = re.compile(
     r"^\[sifr-case-timing\]\s+bucket=([A-Za-z0-9_-]+)\s+case=([A-Za-z0-9_.:/+-]+)"
@@ -189,6 +191,7 @@ def parse_log(path: Path) -> dict[str, Any]:
     suite_filters: list[dict[str, int | str]] = []
     lane_steps: list[dict[str, int | str]] = []
     lane_step_budgets: dict[str, dict[str, int | str]] = {}
+    lane_step_cache: dict[str, dict[str, str]] = {}
     case_timings: list[dict[str, int | str]] = []
     artifact_cache: dict[str, dict[str, Any]] = {}
     hardening_summary: dict[str, int] | None = None
@@ -214,6 +217,13 @@ def parse_log(path: Path) -> dict[str, Any]:
                 "budget_ms": int(match.group(3)),
                 "enforcement": match.group(4),
                 "status": match.group(5),
+            }
+            continue
+        if match := LANE_STEP_CACHE_RE.match(line):
+            lane_step_cache[match.group(1)] = {
+                "state": match.group(2),
+                "reason": match.group(3),
+                "fingerprint": match.group(4),
             }
             continue
         if match := CASE_TIMING_RE.match(line):
@@ -298,6 +308,7 @@ def parse_log(path: Path) -> dict[str, Any]:
     return {
         "lane_steps": lane_steps,
         "lane_step_budgets": lane_step_budgets,
+        "lane_step_cache": lane_step_cache,
         "case_timings": case_timings,
         "suite_filters": suite_filters,
         "artifact_cache": artifact_cache,
@@ -349,6 +360,7 @@ def summarize(args: argparse.Namespace) -> int:
     advisories = build_advisories(profile, warm_target_minutes, real_seconds, time_metrics, e2e_metrics)
     lane_steps = list(parsed_log["lane_steps"])
     lane_step_budgets = parsed_log["lane_step_budgets"]
+    lane_step_cache = parsed_log["lane_step_cache"]
     if isinstance(lane_step_budgets, dict):
         for step in lane_steps:
             budget = lane_step_budgets.get(str(step["name"]))
@@ -356,6 +368,11 @@ def summarize(args: argparse.Namespace) -> int:
                 step["budget_ms"] = int(budget["budget_ms"])
                 step["budget_enforcement"] = str(budget["enforcement"])
                 step["budget_status"] = str(budget["status"])
+            cache = lane_step_cache.get(str(step["name"]))
+            if isinstance(cache, dict):
+                step["cache_state"] = str(cache["state"])
+                step["cache_reason"] = str(cache["reason"])
+                step["cache_fingerprint"] = str(cache["fingerprint"])
     case_timings = list(parsed_log["case_timings"])
     slowest_cases = sorted(
         case_timings,
@@ -390,6 +407,7 @@ def summarize(args: argparse.Namespace) -> int:
         "advisories": advisories,
         "lane_steps": lane_steps,
         "lane_step_budgets": lane_step_budgets,
+        "lane_step_cache": lane_step_cache,
         "case_timings": case_timings,
         "suite_filters": parsed_log["suite_filters"],
         "artifact_cache": parsed_log["artifact_cache"],
@@ -453,9 +471,7 @@ def summarize(args: argparse.Namespace) -> int:
     if lane_steps:
         slowest_step = max(lane_steps, key=lambda step: int(step["elapsed_ms"]))
         print(
-            "  slowest_step="
-            f"{slowest_step['name']} {int(slowest_step['elapsed_ms'])}ms "
-            f"status={slowest_step['status']}"
+            f"  slowest_step={slowest_step['name']} {int(slowest_step['elapsed_ms'])}ms status={slowest_step['status']}"
         )
         slowest_steps = sorted(
             lane_steps,
@@ -464,11 +480,7 @@ def summarize(args: argparse.Namespace) -> int:
         )[:5]
         step_summaries = [
             f"{step['name']}={int(step['elapsed_ms'])}ms"
-            + (
-                f"/budget={int(step['budget_ms'])}ms/{step['budget_status']}"
-                if "budget_ms" in step
-                else ""
-            )
+            + (f"/budget={int(step['budget_ms'])}ms/{step['budget_status']}" if "budget_ms" in step else "")
             for step in slowest_steps
         ]
         print("  slowest_steps=" + " ".join(step_summaries))
@@ -480,8 +492,7 @@ def summarize(args: argparse.Namespace) -> int:
             if current is None or int(timing["elapsed_ms"]) > int(current["elapsed_ms"]):
                 by_bucket[bucket] = timing
         slowest_cases = [
-            f"{bucket}:{timing['case']}={int(timing['elapsed_ms'])}ms"
-            for bucket, timing in sorted(by_bucket.items())
+            f"{bucket}:{timing['case']}={int(timing['elapsed_ms'])}ms" for bucket, timing in sorted(by_bucket.items())
         ]
         print("  slowest_cases=" + " ".join(slowest_cases))
         top_cases = [
@@ -499,14 +510,9 @@ def summarize(args: argparse.Namespace) -> int:
             reason_suffix = ""
             miss_reasons = stats.get("miss_reasons")
             if isinstance(miss_reasons, dict) and miss_reasons:
-                reasons = ",".join(
-                    f"{reason}={count}"
-                    for reason, count in sorted(miss_reasons.items())
-                )
+                reasons = ",".join(f"{reason}={count}" for reason, count in sorted(miss_reasons.items()))
                 reason_suffix = f",miss_reasons={reasons}"
-            summaries.append(
-                f"{namespace}:hits={stats['hits']},misses={stats['misses']}{reason_suffix}"
-            )
+            summaries.append(f"{namespace}:hits={stats['hits']},misses={stats['misses']}{reason_suffix}")
         print("  generated_artifact_cache=" + " ".join(summaries))
     if e2e_cache_stats is not None:
         print(

--- a/verification/runner/sifr_verify/selftest.py
+++ b/verification/runner/sifr_verify/selftest.py
@@ -38,7 +38,13 @@ from .release_evidence_selftest import (
     release_report_production_self_test,
 )
 from .results import build_result
-from .schemas import load_schema, validate_all_committed_schemas, validate_data, validate_schema_requirement
+from .schemas import (
+    load_schema,
+    validate_all_committed_schemas,
+    validate_data,
+    validate_schema_requirement,
+)
+from .step_budgets import run_self_test as step_budget_self_test
 from verification.json_schema_202012 import lint_schema
 
 
@@ -46,10 +52,14 @@ def run_all() -> list[str]:
     checks = [
         ("schema self-tests", _schema_self_test),
         ("profile schema self-test", _profile_schema_self_test),
+        ("cache-aware step budget self-test", step_budget_self_test),
         ("crate membership self-test", _crate_membership_self_test),
         ("Rust interop profile execution self-test", _rust_interop_profile_self_test),
         ("documentation profile execution self-test", _documentation_profile_self_test),
-        ("release report precondition self-test", release_report_precondition_self_test),
+        (
+            "release report precondition self-test",
+            release_report_precondition_self_test,
+        ),
         ("release report production self-test", release_report_production_self_test),
         ("e2e profile self-test", _e2e_profile_self_test),
         ("runner discovery self-test", _discovery_self_test),
@@ -77,11 +87,7 @@ def _schema_self_test() -> None:
     if missing:
         raise AssertionError(f"missing schema self-test coverage: {sorted(missing)}")
     governance_schemas = (
-        Path(__file__).resolve().parents[3]
-        / "verification"
-        / "areas"
-        / "distribution_release"
-        / "schemas"
+        Path(__file__).resolve().parents[3] / "verification" / "areas" / "distribution_release" / "schemas"
     )
     governed = [lint_schema(path) for path in sorted(governance_schemas.glob("*.schema.json"))]
     if len(governed) != 19:
@@ -127,18 +133,21 @@ def _profile_schema_self_test() -> None:
     ]:
         raise AssertionError("python-interop-live has a noncanonical Cargo setup command")
     for profile_name in sorted(expected):
-        setup_budget = profiles[profile_name].get("step_budgets", {}).get(
-            "cargo_cache_setup"
-        )
+        setup_budget = profiles[profile_name].get("step_budgets", {}).get("cargo_cache_setup")
         if setup_budget != {
             "budget_ms": 300_000,
             "enforcement": "advisory",
         }:
-            raise AssertionError(
-                f"{profile_name} has a noncanonical Cargo setup budget: "
-                f"{setup_budget}"
-            )
+            raise AssertionError(f"{profile_name} has a noncanonical Cargo setup budget: {setup_budget}")
     create_pr_step_budgets = profiles["create-pr"].get("step_budgets", {})
+    python_interop_budget = create_pr_step_budgets.get("python_interop")
+    if python_interop_budget != {
+        "warm_budget_ms": 600_000,
+        "cold_budget_ms": 1_200_000,
+        "cache_classifier": "successful-input-receipt",
+        "enforcement": "blocking",
+    }:
+        raise AssertionError(f"create-pr Python interop cache budget drifted: {python_interop_budget}")
     required_blocking_steps = {
         "generated_code_quality_checks",
         "rust_interop_checks",
@@ -202,15 +211,13 @@ def _crate_membership_self_test() -> None:
             suite = profile_by_id[suite_id]
             if suite.get("status") != "blocking" or suite.get("executed_in_merge") is not True:
                 raise AssertionError(
-                    f"generated-build crate suite is not blocking/executed in {profile_name}: "
-                    f"{suite}",
+                    f"generated-build crate suite is not blocking/executed in {profile_name}: {suite}",
                 )
         smoke_ids = {str(suite.get("id")) for suite in profile_smoke_suites}
         misplaced_generated = sorted(generated_build_suites.intersection(smoke_ids))
         if misplaced_generated:
             raise AssertionError(
-                f"generated-build crate suites must not run in smoke for {profile_name}: "
-                f"{misplaced_generated}",
+                f"generated-build crate suites must not run in smoke for {profile_name}: {misplaced_generated}",
             )
 
     duplicate_profile = {
@@ -383,19 +390,13 @@ def _rust_interop_profile_self_test() -> None:
     ]
     if recording_runner.events != expected_events:
         raise AssertionError(
-            "profile runner did not execute cache setup before offline steps: "
-            f"{recording_runner.events}"
+            f"profile runner did not execute cache setup before offline steps: {recording_runner.events}"
         )
     timing_output = io.StringIO()
     with redirect_stdout(timing_output):
         timing_result = timed_step("cargo_cache_setup", lambda: None)
-    if timing_result.status != 0 or (
-        "[sifr-lane-step] name=cargo_cache_setup" not in timing_output.getvalue()
-    ):
-        raise AssertionError(
-            "cache setup timing seam did not emit its lane-step report: "
-            f"{timing_output.getvalue()!r}"
-        )
+    if timing_result.status != 0 or ("[sifr-lane-step] name=cargo_cache_setup" not in timing_output.getvalue()):
+        raise AssertionError(f"cache setup timing seam did not emit its lane-step report: {timing_output.getvalue()!r}")
 
     invalid_setup_profile = {
         "cargo_policy": {
@@ -426,10 +427,7 @@ def _rust_interop_profile_self_test() -> None:
     except ProfileError as exc:
         selected = {"matrix", "tiers", "compatibility-matrix"}
         expected_missing = ", ".join(sorted(required_suites - selected))
-        expected_message = (
-            "omits required Rust interop verification suites: "
-            f"{expected_missing}"
-        )
+        expected_message = f"omits required Rust interop verification suites: {expected_missing}"
         if expected_message not in str(exc):
             raise
     else:
@@ -486,7 +484,10 @@ def _rust_interop_profile_self_test() -> None:
             {**valid_payload, "suites": "not-a-list"},
             {
                 **valid_payload,
-                "summary": {"blocking_failures": 1, "total_variants": len(required_suites)},
+                "summary": {
+                    "blocking_failures": 1,
+                    "total_variants": len(required_suites),
+                },
             },
             {
                 **valid_payload,
@@ -532,9 +533,7 @@ def _rust_interop_profile_self_test() -> None:
             except ProfileRunnerError:
                 pass
             else:
-                raise AssertionError(
-                    f"invalid Rust interop result JSON mutation {index} was accepted"
-                )
+                raise AssertionError(f"invalid Rust interop result JSON mutation {index} was accepted")
         result_path.write_text("{not-json", encoding="utf-8")
         try:
             validate_rust_interop_result(result_path, sorted(required_suites))
@@ -547,16 +546,10 @@ def _rust_interop_profile_self_test() -> None:
 def _documentation_profile_self_test() -> None:
     profiles = load_all_profiles()
     release = profiles["release"]
-    selected = [
-        selection
-        for selection in release["selected_areas"]
-        if selection.get("area") == "documentation"
-    ]
+    selected = [selection for selection in release["selected_areas"] if selection.get("area") == "documentation"]
     expected_suites = ["structure", "ga-release"]
     if len(selected) != 1 or selected[0].get("suites") != expected_suites:
-        raise AssertionError(
-            "release profile must select documentation:structure and ga-release exactly once"
-        )
+        raise AssertionError("release profile must select documentation:structure and ga-release exactly once")
     if "documentation_suites" in legacy_facade(release):
         raise AssertionError("documentation suites must have selected_areas as their sole authority")
     if "documentation_checks" not in legacy_facade_step_names(release):
@@ -648,8 +641,7 @@ def _e2e_profile_self_test() -> None:
         fixture_manifest = legacy_facade(profiles[profile_name])["e2e"].get("fixture_manifest")
         if fixture_manifest:
             raise AssertionError(
-                f"{profile_name} e2e must use the full pass corpus, got fixture manifest: "
-                f"{fixture_manifest}",
+                f"{profile_name} e2e must use the full pass corpus, got fixture manifest: {fixture_manifest}",
             )
 
     merge_full_suites = crate_test_suites_for_mode(profiles["merge"], "full")
@@ -694,8 +686,7 @@ def _discovery_self_test() -> None:
   "timeout_seconds": 60,
   "suites": []
 }
-""".strip()
-            + "\n",
+""".strip() + "\n",
             encoding="utf-8",
         )
         areas = discover_areas(areas_dir)
@@ -708,7 +699,10 @@ def _resource_class_self_test() -> None:
         "resource_policy": {"classes": ["default-local", "network", "container-runtime"]},
         "selected_areas": [
             {"area": "core_language", "resource_classes": ["default-local"]},
-            {"area": "ecosystem_compatibility", "resource_classes": ["external-corpus"]},
+            {
+                "area": "ecosystem_compatibility",
+                "resource_classes": ["external-corpus"],
+            },
         ],
     }
     expected = {"default-local", "network", "external-corpus", "container-runtime"}

--- a/verification/runner/sifr_verify/step_budgets.py
+++ b/verification/runner/sifr_verify/step_budgets.py
@@ -1,0 +1,316 @@
+"""Cache-aware profile step-budget policy and deterministic receipts."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CACHE_CLASSIFIER = "successful-input-receipt"
+RECEIPT_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class StepBudgetContext:
+    name: str
+    budget_ms: int
+    enforcement: str
+    cache_state: str | None = None
+    cache_reason: str | None = None
+    cache_fingerprint: str | None = None
+    receipt_path: Path | None = None
+    receipt_eligible: bool = False
+    required_cache_paths: tuple[Path, ...] = ()
+
+
+def prepare_step_budget(
+    *,
+    repo_root: Path,
+    profile: dict[str, Any],
+    profile_name: str,
+    name: str,
+    env: dict[str, str],
+) -> StepBudgetContext | None:
+    budgets = profile.get("step_budgets", {})
+    raw_budget = budgets.get(name) if isinstance(budgets, dict) else None
+    if not isinstance(raw_budget, dict):
+        return None
+    enforcement = str(raw_budget.get("enforcement", "advisory"))
+    if "budget_ms" in raw_budget:
+        return StepBudgetContext(
+            name=name,
+            budget_ms=int(raw_budget.get("budget_ms", 0) or 0),
+            enforcement=enforcement,
+        )
+
+    suites = selected_suites(profile, name)
+    binary = Path(env.get("SIFR_GCQ_BIN", repo_root / "target" / "debug" / "sifr"))
+    fingerprint, eligible, ineligible_reason = input_fingerprint(
+        repo_root=repo_root,
+        profile_name=profile_name,
+        step_name=name,
+        suites=suites,
+        sifr_binary=binary,
+    )
+    receipt_path = repo_root / "target" / "verification" / "cache-receipts" / profile_name / f"{name}.json"
+    required_paths = required_cache_paths(repo_root, name, binary)
+    if not eligible:
+        state, reason = "cold", ineligible_reason
+    else:
+        state, reason = classify_receipt(
+            receipt_path=receipt_path,
+            fingerprint=fingerprint,
+            required_paths=required_paths,
+        )
+    budget_key = "warm_budget_ms" if state == "warm" else "cold_budget_ms"
+    context = StepBudgetContext(
+        name=name,
+        budget_ms=int(raw_budget.get(budget_key, 0) or 0),
+        enforcement=enforcement,
+        cache_state=state,
+        cache_reason=reason,
+        cache_fingerprint=fingerprint,
+        receipt_path=receipt_path,
+        receipt_eligible=eligible,
+        required_cache_paths=required_paths,
+    )
+    env["SIFR_VERIFY_STEP_CACHE_STATE"] = state
+    if name == "python_interop":
+        env["SIFR_PYTHON_INTEROP_CACHE_STATE"] = state
+    print(f"[sifr-lane-step-cache] name={name} state={state} reason={reason} fingerprint={fingerprint[:16]}")
+    return context
+
+
+def enforce_step_budget(context: StepBudgetContext | None, elapsed_ms: int) -> int:
+    if context is None:
+        return 0
+    exceeded = context.budget_ms > 0 and elapsed_ms > context.budget_ms
+    budget_status = "fail" if exceeded else "pass"
+    print(
+        "[sifr-lane-step-budget] "
+        f"name={context.name} elapsed_ms={elapsed_ms} budget_ms={context.budget_ms} "
+        f"enforcement={context.enforcement} status={budget_status}"
+    )
+    disabled = os.environ.get("SIFR_VERIFY_DISABLE_STEP_BUDGETS", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if exceeded and context.enforcement == "blocking" and not disabled:
+        print(
+            f"sifr_verify: step budget exceeded for {context.name}: {elapsed_ms}ms > {context.budget_ms}ms",
+            file=sys.stderr,
+        )
+        return 124
+    return 0
+
+
+def record_step_success(context: StepBudgetContext | None) -> None:
+    if (
+        context is None
+        or context.receipt_path is None
+        or context.cache_fingerprint is None
+        or not context.receipt_eligible
+        or any(not cache_path_available(path) for path in context.required_cache_paths)
+    ):
+        return
+    payload = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "classifier": CACHE_CLASSIFIER,
+        "step": context.name,
+        "input_fingerprint": context.cache_fingerprint,
+    }
+    atomic_write_json(context.receipt_path, payload)
+
+
+def classify_receipt(*, receipt_path: Path, fingerprint: str, required_paths: tuple[Path, ...]) -> tuple[str, str]:
+    missing_cache = [path for path in required_paths if not cache_path_available(path)]
+    if missing_cache:
+        return "cold", "required-cache-missing"
+    try:
+        payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return "cold", "receipt-missing"
+    except (OSError, json.JSONDecodeError):
+        return "cold", "receipt-invalid"
+    if not isinstance(payload, dict):
+        return "cold", "receipt-invalid"
+    if payload.get("schema_version") != RECEIPT_SCHEMA_VERSION or payload.get("classifier") != CACHE_CLASSIFIER:
+        return "cold", "receipt-invalid"
+    if payload.get("input_fingerprint") != fingerprint:
+        return "cold", "input-changed"
+    return "warm", "successful-input-receipt"
+
+
+def input_fingerprint(
+    *,
+    repo_root: Path,
+    profile_name: str,
+    step_name: str,
+    suites: list[str],
+    sifr_binary: Path,
+) -> tuple[str, bool, str]:
+    tracked_state = command_output(["git", "status", "--porcelain", "--untracked-files=no"], repo_root)
+    source_commit = command_output(["git", "rev-parse", "HEAD"], repo_root)
+    cargo_lock_digest = file_digest(repo_root / "Cargo.lock")
+    rustc_version = command_output(["rustc", "-vV"], repo_root)
+    binary_digest = file_digest(sifr_binary)
+    unavailable_inputs = "unavailable" in {source_commit, rustc_version} or "missing" in {
+        cargo_lock_digest,
+        binary_digest,
+    }
+    eligible = tracked_state == "" and not unavailable_inputs
+    payload = {
+        "profile": profile_name,
+        "step": step_name,
+        "source_commit": source_commit,
+        "tracked_state": tracked_state,
+        "suites": suites,
+        "cargo_lock_sha256": cargo_lock_digest,
+        "rustc": rustc_version,
+        "python": sys.version,
+        "sifr_binary_sha256": binary_digest,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return (
+        hashlib.sha256(encoded).hexdigest(),
+        eligible,
+        "eligible" if eligible else "input-unavailable" if unavailable_inputs else "tracked-worktree-dirty",
+    )
+
+
+def selected_suites(profile: dict[str, Any], step_name: str) -> list[str]:
+    area = "python_interop" if step_name == "python_interop" else step_name
+    return [
+        str(suite)
+        for selection in profile.get("selected_areas", [])
+        if isinstance(selection, dict) and selection.get("area") == area
+        for suite in selection.get("suites", [])
+    ]
+
+
+def required_cache_paths(repo_root: Path, step_name: str, binary: Path) -> tuple[Path, ...]:
+    if step_name == "python_interop":
+        return (binary, repo_root / "target" / "cpython311" / "debug")
+    return (binary,)
+
+
+def cache_path_available(path: Path) -> bool:
+    if path.is_file():
+        return True
+    if not path.is_dir():
+        return False
+    try:
+        return next(path.iterdir(), None) is not None
+    except OSError:
+        return False
+
+
+def file_digest(path: Path) -> str:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return "missing"
+
+
+def command_output(command: list[str], cwd: Path) -> str:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "unavailable"
+    return result.stdout.strip() if result.returncode == 0 else "unavailable"
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+        handle.write(encoded)
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def run_self_test() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-step-budget-self-test-") as directory:
+        root = Path(directory)
+        receipt = root / "receipt.json"
+        required = root / "cache"
+        required.mkdir()
+        (required / "artifact").write_text("cached\n", encoding="utf-8")
+        state, reason = classify_receipt(receipt_path=receipt, fingerprint="a" * 64, required_paths=(required,))
+        if (state, reason) != ("cold", "receipt-missing"):
+            raise AssertionError("missing cache receipt was not classified cold")
+        context = StepBudgetContext(
+            name="python_interop",
+            budget_ms=1_200_000,
+            enforcement="blocking",
+            cache_state="cold",
+            cache_reason=reason,
+            cache_fingerprint="a" * 64,
+            receipt_path=receipt,
+            receipt_eligible=True,
+            required_cache_paths=(required,),
+        )
+        record_step_success(context)
+        if classify_receipt(receipt_path=receipt, fingerprint="a" * 64, required_paths=(required,)) != (
+            "warm",
+            "successful-input-receipt",
+        ):
+            raise AssertionError("successful exact-input receipt was not classified warm")
+        if classify_receipt(receipt_path=receipt, fingerprint="b" * 64, required_paths=(required,)) != (
+            "cold",
+            "input-changed",
+        ):
+            raise AssertionError("changed input did not invalidate the cache receipt")
+        receipt.write_text("{\n", encoding="utf-8")
+        if classify_receipt(receipt_path=receipt, fingerprint="a" * 64, required_paths=(required,)) != (
+            "cold",
+            "receipt-invalid",
+        ):
+            raise AssertionError("invalid cache receipt was not classified cold")
+        record_step_success(context)
+        (required / "artifact").unlink()
+        if classify_receipt(receipt_path=receipt, fingerprint="a" * 64, required_paths=(required,)) != (
+            "cold",
+            "required-cache-missing",
+        ):
+            raise AssertionError("missing cache artifacts did not invalidate the receipt")
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+            overrun_status = enforce_step_budget(context, 1_200_001)
+        if overrun_status != 124:
+            raise AssertionError("cold blocking budget did not reject an overrun")
+        from .reports import parse_log
+
+        log = root / "lane.log"
+        log.write_text(
+            "[sifr-lane-step-cache] name=python_interop state=cold "
+            "reason=receipt-missing fingerprint=aaaaaaaaaaaaaaaa\n"
+            "[sifr-lane-step] name=python_interop elapsed_ms=900000 status=pass\n"
+            "[sifr-lane-step-budget] name=python_interop elapsed_ms=900000 "
+            "budget_ms=1200000 enforcement=blocking status=pass\n",
+            encoding="utf-8",
+        )
+        parsed = parse_log(log)
+        expected_cache = {
+            "state": "cold",
+            "reason": "receipt-missing",
+            "fingerprint": "aaaaaaaaaaaaaaaa",
+        }
+        if parsed["lane_step_cache"].get("python_interop") != expected_cache:
+            raise AssertionError("lane report lost the cache classification")


### PR DESCRIPTION
## Scope

- classify create-PR Python interop execution as cold or warm using an exact-input successful-run receipt
- retain the 600s warm aggregate budget and enforce a 1200s cold aggregate budget
- separate the read-only doctor hang guard (300s) from aggregate performance enforcement
- publish cache classification in lane reports and add deterministic policy tests

## Evidence

- runner foundation self-tests: pass
- Ruff and Python compile checks: pass
- file-size guardrail: pass
- targeted `readonly-check-doctor`: pass at 169.710s
- full create-PR Python interop selection: 19/19 pass in 522.69s; doctor 170.125s

Stacked on draft PR #3101 / exact M1 head `28bca35551321b109e272c61ae52fe6201eb810d`.
