### PR TITLE
perf: stabilize local performance work budgets

### DIFF
--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -1540,14 +1540,13 @@ The readiness coverage matrix is the executable registry for shipped guarantees,
 
 `profile_runner.py` emits a per-profile runtime report under `target/validation_lane_reports/` (`<profile>.latest.json`, `<profile>.latest.log`, `<profile>.latest.time`). The report summarizes wall/CPU time, e2e compile-build-run timing, cache hits and rebuilt groups, group-skew tail behavior, cache footprints, default worker settings, and advisory resource signals such as swap activity or default-profile RSS regressions.
 
-Blocking representative and full performance measurements additionally use a
-controlled-host admission boundary. The performance producer records load,
-thermal/power state, effective CPU-frequency behavior, competing build
-processes, and cache state; rejects contaminated or statistically unstable
-sample batches; and binds the accepted report to the budget checker with a
-per-invocation identity. Producer failure cannot fall through to stale
-`*.budget.latest.json` evidence. This classifies host instability separately
-from a stable product regression without changing the governed baselines.
+Blocking representative and full performance measurements use a controlled-host
+boundary. Work-controlled measurements use retired instructions from the local
+macOS process tree. Latency-controlled measurements use elapsed time and require
+a quiet host. Both modes reject competing build work, thermal pressure, and
+unstable samples. The accepted report includes an invocation identity. Producer
+failure cannot use stale `*.budget.latest.json` evidence. This design separates
+host delay from additional compiler work without changing elapsed-time budgets.
 
 Approved trend-baseline refreshes use the same controlled producer but are a
 separate governance path from threshold-budget updates. A refresh is accepted

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -1541,9 +1541,10 @@ The readiness coverage matrix is the executable registry for shipped guarantees,
 `profile_runner.py` emits a per-profile runtime report under `target/validation_lane_reports/` (`<profile>.latest.json`, `<profile>.latest.log`, `<profile>.latest.time`). The report summarizes wall/CPU time, e2e compile-build-run timing, cache hits and rebuilt groups, group-skew tail behavior, cache footprints, default worker settings, and advisory resource signals such as swap activity or default-profile RSS regressions.
 
 Blocking representative and full performance measurements use a controlled-host
-boundary. Work-controlled measurements use retired instructions from the local
-macOS process tree. Latency-controlled measurements use elapsed time and require
-a quiet host. Both modes reject competing build work, thermal pressure, and
+boundary. Work-controlled measurements use retired instructions and
+process-tree RSS from the local macOS host. Latency-controlled measurements use
+elapsed time and generic RSS after a quiet-host admission. Both modes reject
+competing build work, thermal pressure, and
 unstable samples. The accepted report includes an invocation identity. Producer
 failure cannot use stale `*.budget.latest.json` evidence. This design separates
 host delay from additional compiler work without changing elapsed-time budgets.

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -1543,7 +1543,8 @@ The readiness coverage matrix is the executable registry for shipped guarantees,
 Blocking representative and full performance measurements use a controlled-host
 boundary. Work-controlled measurements use retired instructions and
 process-tree RSS from the local macOS host. Latency-controlled measurements use
-elapsed time and generic RSS after a quiet-host admission. Both modes reject
+elapsed time and generic RSS after a quiet-host admission. Non-macOS profiles
+retain latency mode because they do not expose the Darwin counter. Both modes reject
 competing build work, thermal pressure, and
 unstable samples. The accepted report includes an invocation identity. Producer
 failure cannot use stale `*.budget.latest.json` evidence. This design separates

--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -59,10 +59,14 @@ them, the unprivileged throughput proxy otherwise, external CPU consumption and
 its top processes, memory-pressure counters, and the compiler/generated-artifact
 cache state. Per-case monitoring applies the same external-CPU limit and records
 pressure that appears after admission. The benchmark runner and its descendants
-are excluded, so measured work cannot reject itself. On hosts without direct
-frequency telemetry, the throughput calibration runs only during admission
-because running it inside a measured case would contaminate the samples; the case
-coefficient of variation rejects frequency-driven in-window instability.
+and ancestors are excluded, so measured work and its command launcher cannot
+reject the run. On macOS, `ps` supplies recent decayed CPU use. On Linux, `ps`
+supplies process-lifetime average CPU use; controlled Linux evidence must record
+that limitation until the runner provides interval sampling there. On hosts
+without direct frequency telemetry, the throughput calibration runs only during
+admission because running it inside a measured case would contaminate the
+samples; the case coefficient of variation rejects frequency-driven in-window
+instability.
 Competing-work classification uses the actual executable or Python module/script
 identity, not arbitrary shell argument text that merely mentions Cargo or a
 benchmark. A top-level `git fetch` is not rejected by itself; its CPU/disk-heavy

--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -50,14 +50,19 @@ Representative and full budget producers require a controlled host window
 before measuring. Admission requires three consecutive quiet snapshots on AC
 power on macOS, no thermal or CPU-power warning, no competing Cargo, rustc,
 benchmark, or Git indexing process, normalized one-minute load at or below
-`0.85`, and a stable fixed-work CPU-throughput calibration. The report records
-load, power, thermal state, direct CPU frequencies when the host exposes them,
-the unprivileged throughput proxy otherwise, memory-pressure counters, and the
-compiler/generated-artifact cache state. Per-case monitoring records pressure
-that appears after admission. On hosts without direct frequency telemetry, the
-throughput calibration runs only during admission because running it inside a
-measured case would contaminate the samples; the case coefficient of variation
-rejects frequency-driven in-window instability.
+`0.85`, no more than `50%` of one logical CPU consumed by unrelated processes,
+and a stable fixed-work CPU-throughput calibration. The unrelated-CPU limit is
+intentionally independent of logical CPU count because the governed command
+benchmarks are sensitive to contention for one performance core. The report
+records load, power, thermal state, direct CPU frequencies when the host exposes
+them, the unprivileged throughput proxy otherwise, external CPU consumption and
+its top processes, memory-pressure counters, and the compiler/generated-artifact
+cache state. Per-case monitoring applies the same external-CPU limit and records
+pressure that appears after admission. The benchmark runner and its descendants
+are excluded, so measured work cannot reject itself. On hosts without direct
+frequency telemetry, the throughput calibration runs only during admission
+because running it inside a measured case would contaminate the samples; the case
+coefficient of variation rejects frequency-driven in-window instability.
 Competing-work classification uses the actual executable or Python module/script
 identity, not arbitrary shell argument text that merely mentions Cargo or a
 benchmark. A top-level `git fetch` is not rejected by itself; its CPU/disk-heavy

--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -101,8 +101,9 @@ python3 verification/areas/performance/run_benchmarks.py --capture-baseline
 python3 verification/areas/performance/check_budgets.py
 ```
 
-The retired-instruction baseline is a separate governed artifact. This command
-does not change the elapsed-time baseline or its thresholds:
+The local work baseline is a separate governed artifact. It records Darwin
+retired instructions and Darwin process-tree RSS. This command does not change
+the generic elapsed-time baseline or its thresholds:
 
 ```bash
 python3 verification/areas/performance/run_benchmarks.py \
@@ -113,8 +114,9 @@ python3 verification/areas/performance/run_benchmarks.py \
 python3 verification/areas/performance/check_budgets.py
 ```
 
-The capture writes `data/work_budgets.json` after all cases pass. Each work
-threshold is `max(baseline * 1.02, baseline + 1,000,000 instructions)`.
+The capture writes `data/work_budgets.json` after all cases pass. The instruction
+threshold is `max(baseline * 1.02, baseline + 1,000,000 instructions)`. The
+local RSS threshold is `max(baseline * 1.10, baseline + 32MiB)`.
 
 Updating `data/trend/current.json` does not change blocking budgets. It requires
 an owner-approved reference run from a clean exact commit, the complete
@@ -149,9 +151,13 @@ Command benchmarks use:
 - p95 latency: `max(baseline_p95 * 1.15, baseline_p95 + 50ms)`
 - peak RSS: `max(baseline_peak_rss * 1.10, baseline_peak_rss + 32MiB)`
 
-Work-controlled results use the retired-instruction threshold as the blocking
-performance metric. Latency-controlled results use the elapsed-time thresholds.
-Timeout, RSS, cache, and correctness requirements block in both modes.
+Work-controlled results use the local instruction and Darwin process-tree RSS
+thresholds. Latency-controlled results use the generic elapsed-time and RSS
+thresholds. Timeout, cache, and correctness requirements block in both modes.
+
+Darwin rusage includes the spawned query server and its descendants. The
+generic baseline can use a different operating-system RSS boundary. The local
+artifact prevents these two RSS meanings from sharing one threshold.
 
 Command benchmark RSS is measured per command invocation with `/usr/bin/time` when available (`-l` on macOS, `-v` on Linux). Python `RUSAGE_CHILDREN` is used only as a fallback because it is process-cumulative on some platforms and can otherwise contaminate later samples with earlier validation work.
 

--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -47,7 +47,8 @@ incremental cache behavior, interactive diagnostics, and diagnostic architecture
 diagnostic/exit-code non-regression.
 
 Representative and full budget producers use work-controlled admission on
-macOS. Admission requires three accepted snapshots, AC power, and nominal
+macOS. They retain latency-controlled admission on other operating systems.
+macOS admission requires three accepted snapshots, AC power, and nominal
 thermal state. The host must provide retired-instruction counters. Competing
 Cargo, rustc, benchmark, or Git indexing processes reject admission.
 

--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -46,27 +46,29 @@ covers single-file check, project check, single-file build, project build,
 incremental cache behavior, interactive diagnostics, and diagnostic architecture
 diagnostic/exit-code non-regression.
 
-Representative and full budget producers require a controlled host window
-before measuring. Admission requires three consecutive quiet snapshots on AC
-power on macOS, no thermal or CPU-power warning, no competing Cargo, rustc,
-benchmark, or Git indexing process, normalized one-minute load at or below
-`0.85`, no more than `50%` of one logical CPU consumed by unrelated processes,
-and a stable fixed-work CPU-throughput calibration. The unrelated-CPU limit is
-intentionally independent of logical CPU count because the governed command
-benchmarks are sensitive to contention for one performance core. The report
-records load, power, thermal state, direct CPU frequencies when the host exposes
-them, the unprivileged throughput proxy otherwise, external CPU consumption and
-its top processes, memory-pressure counters, and the compiler/generated-artifact
-cache state. Per-case monitoring applies the same external-CPU limit and records
-pressure that appears after admission. The benchmark runner and its descendants
-and ancestors are excluded, so measured work and its command launcher cannot
-reject the run. On macOS, `ps` supplies recent decayed CPU use. On Linux, `ps`
-supplies process-lifetime average CPU use; controlled Linux evidence must record
-that limitation until the runner provides interval sampling there. On hosts
-without direct frequency telemetry, the throughput calibration runs only during
-admission because running it inside a measured case would contaminate the
-samples; the case coefficient of variation rejects frequency-driven in-window
-instability.
+Representative and full budget producers use work-controlled admission on
+macOS. Admission requires three accepted snapshots, AC power, and nominal
+thermal state. The host must provide retired-instruction counters. Competing
+Cargo, rustc, benchmark, or Git indexing processes reject admission.
+
+Work-controlled admission records load and unrelated CPU use. It does not
+reject a sample only because unrelated CPU use is high. Retired instructions
+measure work in the benchmark process tree. Unrelated processes do not add to
+that count. Each case rejects an instruction coefficient of variation above
+`0.02`.
+
+Latency-controlled admission remains available for elapsed-time evidence. It
+also requires normalized one-minute load at or below `0.85`. Unrelated
+processes can use no more than `50%` of one logical CPU. A stable CPU-throughput
+calibration is also required. The approved trend capture uses this mode.
+
+Both modes record load, power, thermal state, CPU behavior, external CPU use,
+memory pressure, and cache state. Per-case monitoring rejects new competing
+build work or thermal pressure. The monitor excludes the benchmark runner and
+its process tree.
+
+On macOS, `ps` supplies recent decayed CPU use. On Linux, `ps` supplies the
+process-lifetime average. Linux evidence records this limitation.
 Competing-work classification uses the actual executable or Python module/script
 identity, not arbitrary shell argument text that merely mentions Cargo or a
 benchmark. A top-level `git fetch` is not rejected by itself; its CPU/disk-heavy
@@ -75,14 +77,12 @@ subcommand appears. If all three attempts are rejected, their snapshots and
 reasons are persisted under the run's `control-failures/` directory before the
 producer exits.
 
-Each case must produce samples whose coefficient of variation is within its
-manifest `stability_limit` (default `0.10`). An unstable or host-contaminated
-case is discarded and retried up to two times. Before each retry, the producer
-must reacquire the same complete controlled-host admission window; it does not
-spend another attempt inside known continuing contention. Exhausting the three
-controlled attempts fails the producer as host instability. Stable samples are
-compared to the unchanged governed budgets, so a uniform seeded slowdown still
-fails. The budget checker treats sample instability as non-waiverable.
+Latency-controlled cases use the manifest `stability_limit` (default `0.10`).
+Work-controlled cases use `work_stability_limit` (default `0.02`). An unstable
+or contaminated case is discarded. The producer retries the case two times.
+It obtains a new admission window before each retry. Three rejected attempts
+stop the producer. The budget checker does not permit a waiver for sample
+instability.
 
 The profile adapter invalidates the fixed `*.budget.latest.json` path before
 production and binds producer and checker with a unique invocation id. If the
@@ -101,6 +101,21 @@ python3 verification/areas/performance/run_benchmarks.py --capture-baseline
 python3 verification/areas/performance/check_budgets.py
 ```
 
+The retired-instruction baseline is a separate governed artifact. This command
+does not change the elapsed-time baseline or its thresholds:
+
+```bash
+python3 verification/areas/performance/run_benchmarks.py \
+  --capture-work-baseline \
+  --require-controlled-host \
+  --controlled-host-mode work \
+  --reference-approval compiler/performance
+python3 verification/areas/performance/check_budgets.py
+```
+
+The capture writes `data/work_budgets.json` after all cases pass. Each work
+threshold is `max(baseline * 1.02, baseline + 1,000,000 instructions)`.
+
 Updating `data/trend/current.json` does not change blocking budgets. It requires
 an owner-approved reference run from a clean exact commit, the complete
 manifest with manifest sample counts, and controlled-host admission and
@@ -112,6 +127,7 @@ SIFR_THERMAL_POLICY=controlled-host \
 python3 verification/areas/performance/run_benchmarks.py \
   --capture-trend-baseline \
   --require-controlled-host \
+  --controlled-host-mode latency \
   --reference-approval compiler/performance
 python3 verification/areas/performance/check_trend_policy.py
 ```
@@ -132,6 +148,10 @@ Command benchmarks use:
 - median latency: `max(baseline_median * 1.10, baseline_median + 25ms)`
 - p95 latency: `max(baseline_p95 * 1.15, baseline_p95 + 50ms)`
 - peak RSS: `max(baseline_peak_rss * 1.10, baseline_peak_rss + 32MiB)`
+
+Work-controlled results use the retired-instruction threshold as the blocking
+performance metric. Latency-controlled results use the elapsed-time thresholds.
+Timeout, RSS, cache, and correctness requirements block in both modes.
 
 Command benchmark RSS is measured per command invocation with `/usr/bin/time` when available (`-l` on macOS, `-v` on Linux). Python `RUSAGE_CHILDREN` is used only as a fallback because it is process-cumulative on some platforms and can otherwise contaminate later samples with earlier validation work.
 
@@ -206,6 +226,9 @@ Waivers are allowed only for temporary performance threshold regressions. They m
 - `rationale`
 - `removal_criteria`
 
-Waivers may override `median_ms`, `p95_ms`, `peak_rss_bytes`, or `cache_hits`. They may not suppress timeouts, missing or malformed results, unknown ids, stale-cache/correctness failures, diagnostic drift, split-brain semantics, or panic-safety failures.
+Waivers can override `median_ms`, `p95_ms`, `median_instructions`,
+`peak_rss_bytes`, or `cache_hits`. They cannot suppress timeouts, malformed
+results, cache errors, diagnostic drift, split-brain semantics, or panic-safety
+errors.
 
 Expired waivers, ownerless waivers, issue-less waivers, unknown benchmark/budget references, and non-performance overrides fail `check_budgets.py`.

--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -115,7 +115,7 @@ python3 verification/areas/performance/check_budgets.py
 ```
 
 The capture writes `data/work_budgets.json` after all cases pass. The instruction
-threshold is `max(baseline * 1.02, baseline + 1,000,000 instructions)`. The
+threshold is `max(baseline * 1.02, baseline + 2,000,000 instructions)`. The
 local RSS threshold is `max(baseline * 1.10, baseline + 32MiB)`.
 
 Updating `data/trend/current.json` does not change blocking budgets. It requires

--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -68,13 +68,14 @@ different process boundary. Separate governed thresholds prevent those RSS
 meanings from being compared as if they were equal.
 
 The approved full-manifest work capture passed all 65 cases on implementation
-commit `00ae57a0f569ed578f665e01a017cec0e3c19369`. It produced work-budget
+commit `c5d4c68f317d01f86bb15f45862a52d6f54af86e`. It produced work-budget
 artifact digest
-`40f3cd6df531294fb72c9fe36a327dcbc32f30fc317164405b310dc6340e1d35`
+`d2e48c6f96d7cd160b01b1fa1c2e6641b203d107ec201f91f00fbc927de9c51d`
 and raw-evidence digest
-`99013460c5692fddef52b4ff10bc95a4a82a5bc03ddbc10d7fb092c76dc3b1a5`.
-The largest instruction coefficient of variation was `0.010884`. All cases
-passed on their first controlled attempt.
+`4e7991fe787b2f9db55513acc312fe90cf262b1e4b870bd53e520e3b49dba2b6`.
+The largest accepted instruction coefficient of variation was `0.013556`.
+The formatter corpus rejected an unstable `0.030451` attempt and accepted its
+`0.013556` retry. All other cases passed on their first controlled attempt.
 
 The first representative verdict found that independent query processes had
 reduced aggregate cache counts. The producer now uses one aggregate invocation
@@ -82,6 +83,12 @@ for latency, cache, and diagnostics. It uses independent invocations only for
 process-work samples. A deterministic self-test protects this boundary. The
 two affected cases report 2,300 cache hits and 2,300 misses in the replacement
 capture.
+
+The full evidence comparison also found that generic RSS baselines used a
+different process boundary from Darwin rusage. Work mode now uses the approved
+Darwin process-tree RSS values from the same local artifact. Latency mode keeps
+the existing generic RSS thresholds. Seeded tests reject both instruction and
+local-RSS work regressions without using elapsed-time thresholds.
 
 ### M2 reproduced evidence
 

--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -98,6 +98,12 @@ largest individual sample was 37.298 million. M3 therefore uses a general
 2-million-instruction floor for small processes. Larger workloads keep the 2%
 rule. No case-specific threshold or waiver was added.
 
+The M3 exact-SHA review found two non-Darwin regressions before merge. The
+profile adapter had selected Darwin work mode on Linux. Latency producers also
+emitted an empty instruction array that failed result validation. Profiles now
+select work mode only on Darwin and retain latency mode elsewhere. Producers
+omit instruction evidence when the host does not provide it.
+
 ### M2 reproduced evidence
 
 On exact M1 candidate `28bca35551321b109e272c61ae52fe6201eb810d`,

--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -90,6 +90,13 @@ Darwin process-tree RSS values from the same local artifact. Latency mode keeps
 the existing generic RSS thresholds. Seeded tests reject both instruction and
 local-RSS work regressions without using elapsed-time thresholds.
 
+The first exact-candidate representative verdict rejected the formatter corpus
+at 36.916 million instructions against a 36.759 million threshold. Four runs
+placed its medians between 35.721 million and 36.916 million instructions. The
+largest individual sample was 37.298 million. M3 therefore uses a general
+2-million-instruction floor for small processes. Larger workloads keep the 2%
+rule. No case-specific threshold or waiver was added.
+
 ### M2 reproduced evidence
 
 On exact M1 candidate `28bca35551321b109e272c61ae52fe6201eb810d`,

--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -7,8 +7,8 @@ Status: in progress.
 | Milestone | Scope | Status |
 | --- | --- | --- |
 | M1: controlled measurement and provenance | Host/cache telemetry, controlled admission, stable-sample retries, stale-result producer/checker binding, and governed trend-reference refresh | complete on draft PR #3101 |
-| M2: Python interop cold-cache budget | Classify cold versus warm aggregate execution and enforce a cache-aware create-PR step budget with deterministic policy tests | in progress |
-| M3: qualification and closure | Five consecutive controlled representative verdicts, seeded-regression proof, final merge gate, full-phase review, and closure records | pending |
+| M2: Python interop cold-cache budget | Classify cold versus warm aggregate execution and enforce a cache-aware create-PR step budget with deterministic policy tests | complete on stacked PR #3115 |
+| M3: qualification and closure | Local retired-instruction budgets, five consecutive controlled verdicts, seeded-regression proof, final merge gate, review, and closure records | in progress on draft PR #3116 |
 
 Each implementation milestone uses one draft PR, exact-SHA validation, and
 repeated Claude Opus review under the phase-closure loop. Review and validation
@@ -24,10 +24,11 @@ evidence. Extending either expiry remains prohibited.
 
 ### Current handoff
 
-- State: M1 is externally reviewed and satisfied on the draft PR; M2 is in
-  implementation as a stacked milestone because the repository's create-PR
-  gate cannot merge M1 until this phase-owned Python-interop blocker closes.
-- Branch: `codex/adhoc-performance-budget-host-variance`.
+- State: M1 and M2 are complete on the stacked owner branch. M3 replaces the
+  desktop-idle blocker with local retired-instruction evidence. It preserves
+  the separate elapsed-time policy for quiet-host qualification.
+- Owner branch: `codex/adhoc-performance-budget-host-variance`.
+- M3 branch: `codex/adhoc-performance-budget-host-variance-m3`.
 - Reviewed M1 implementation candidate:
   `28bca35551321b109e272c61ae52fe6201eb810d`.
 - Draft PR: [#3101](https://github.com/sifr-lang/sifr/pull/3101).
@@ -44,6 +45,22 @@ evidence. Extending either expiry remains prohibited.
 - Base update: merged current `origin/main` at
   `01c43b9cd67df6174b44fbbf7d2328ac5a831cb7`; the final owner-fix candidate
   requires a fresh exact-SHA review and validation round.
+
+### M3 local-host decision
+
+The phase uses this Mac as the permanent performance host. macOS does not
+provide a user-space CPU reservation. Its `/usr/bin/time -l` command provides
+retired instructions and cycles for the benchmark process tree.
+
+An exploratory arithmetic control ran while unrelated CPU use reached
+`419.5%`. Its five elapsed samples were `1503.105` to `1527.412` milliseconds.
+The retired-instruction coefficient of variation was `0.000240`. An LSP
+diagnostics control also produced process-tree instruction evidence.
+
+M3 adds two controlled modes. Work mode uses retired instructions as the
+blocking performance metric. Latency mode keeps the existing load and
+unrelated-CPU limits for elapsed-time evidence. No existing elapsed-time
+threshold, waiver, or baseline is increased.
 
 ### M2 reproduced evidence
 

--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -68,14 +68,16 @@ different process boundary. Separate governed thresholds prevent those RSS
 meanings from being compared as if they were equal.
 
 The approved full-manifest work capture passed all 65 cases on implementation
-commit `79186d67a2c0cd4cfae329bcad51d0edff76a5ac`. It produced work-budget
+commit `7e5d6648b6885863e60bab2a55d76cca8b59cdfb`. It produced work-budget
 artifact digest
-`5802f3ce45b8413027604079681ea42885055e63f1593bf6c6f1a7a47ec274e9`
+`aa57ee57b95177832845a4b1a8b2bce603f39fa1da25e9f14c73e28bd26253cc`
 and raw-evidence digest
-`e6f4504ec828a3710893de3bbf7f998bfe8f16d423521d52172163e97c930144`.
+`0b3ca547e4b13afeb2afa909d87927f942f4f4e0ff16bcb184c806db79cabeac`.
 Every case produced at least five retired-instruction samples. The largest
-accepted instruction coefficient of variation was `0.011637`, below the
-`0.02` limit. All cases passed on their first controlled attempt.
+accepted instruction coefficient of variation was `0.012365`, below the
+`0.02` limit. The formatter corpus rejected an unstable `0.031108` first
+attempt and accepted its second attempt at `0.001955`. All other cases passed
+on their first controlled attempt.
 
 The first representative verdict found that independent query processes had
 reduced aggregate cache counts. The producer now uses one aggregate invocation

--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -103,6 +103,11 @@ emitted an empty instruction array that failed result validation. Profiles now
 select work mode only on Darwin and retain latency mode elsewhere. Producers
 omit instruction evidence when the host does not provide it.
 
+The first post-review area-adapter verdict found that the performance runner's
+new sibling import worked only when the runner was executed as a script. The
+runner now adds its area directory before importing host control. Both direct
+and `sifr_verify areas run` rules invocations pass.
+
 ### M2 reproduced evidence
 
 On exact M1 candidate `28bca35551321b109e272c61ae52fe6201eb810d`,

--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -62,6 +62,18 @@ blocking performance metric. Latency mode keeps the existing load and
 unrelated-CPU limits for elapsed-time evidence. No existing elapsed-time
 threshold, waiver, or baseline is increased.
 
+The approved full-manifest work capture passed all 65 cases on implementation
+commit `64881055453937d596bff6d7d569a97beba7bd8a`. It produced work-budget
+artifact digest
+`c536e08e1b982d7a2d14d4961adbbcbbde1e3f114d88082deadee97e527f4ef6`
+and raw-evidence digest
+`c9cea6eef1d925c4436b8cfeebb6b783b5ac9503b04e04f5dabc514e3393840a`.
+The largest accepted instruction coefficient of variation was `0.017947`.
+One case rejected an unstable `0.021404` attempt and accepted its `0.006001`
+retry. The accepted retry observed unrelated CPU use between `193.2%` and
+`399.7%`. This result demonstrates that work mode does not require an idle
+desktop.
+
 ### M2 reproduced evidence
 
 On exact M1 candidate `28bca35551321b109e272c61ae52fe6201eb810d`,

--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -68,15 +68,14 @@ different process boundary. Separate governed thresholds prevent those RSS
 meanings from being compared as if they were equal.
 
 The approved full-manifest work capture passed all 65 cases on implementation
-commit `8899996656ca2258ac84ef30136cc013ea0e3dd8`. It produced work-budget
+commit `79186d67a2c0cd4cfae329bcad51d0edff76a5ac`. It produced work-budget
 artifact digest
-`2586824b46ab5a70f6fd43ecfc55e77d67d84bf7dbd9eece13b02c2000663294`
+`5802f3ce45b8413027604079681ea42885055e63f1593bf6c6f1a7a47ec274e9`
 and raw-evidence digest
-`d512c11c65c0a8bc21f185d496a93774adf85078abb3fe5b654ddc69dcec1e10`.
-The largest accepted instruction coefficient of variation was `0.010295`.
-The formatter corpus rejected unstable `0.031762` and `0.031574` attempts. It
-accepted the third attempt at `0.004752`. All other cases passed on their first
-controlled attempt.
+`e6f4504ec828a3710893de3bbf7f998bfe8f16d423521d52172163e97c930144`.
+Every case produced at least five retired-instruction samples. The largest
+accepted instruction coefficient of variation was `0.011637`, below the
+`0.02` limit. All cases passed on their first controlled attempt.
 
 The first representative verdict found that independent query processes had
 reduced aggregate cache counts. The producer now uses one aggregate invocation

--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -62,17 +62,26 @@ blocking performance metric. Latency mode keeps the existing load and
 unrelated-CPU limits for elapsed-time evidence. No existing elapsed-time
 threshold, waiver, or baseline is increased.
 
+Work mode also uses a fresh Darwin process-tree RSS baseline. Darwin includes
+the spawned LSP server and descendants. The generic baseline can measure a
+different process boundary. Separate governed thresholds prevent those RSS
+meanings from being compared as if they were equal.
+
 The approved full-manifest work capture passed all 65 cases on implementation
-commit `64881055453937d596bff6d7d569a97beba7bd8a`. It produced work-budget
+commit `00ae57a0f569ed578f665e01a017cec0e3c19369`. It produced work-budget
 artifact digest
-`c536e08e1b982d7a2d14d4961adbbcbbde1e3f114d88082deadee97e527f4ef6`
+`40f3cd6df531294fb72c9fe36a327dcbc32f30fc317164405b310dc6340e1d35`
 and raw-evidence digest
-`c9cea6eef1d925c4436b8cfeebb6b783b5ac9503b04e04f5dabc514e3393840a`.
-The largest accepted instruction coefficient of variation was `0.017947`.
-One case rejected an unstable `0.021404` attempt and accepted its `0.006001`
-retry. The accepted retry observed unrelated CPU use between `193.2%` and
-`399.7%`. This result demonstrates that work mode does not require an idle
-desktop.
+`99013460c5692fddef52b4ff10bc95a4a82a5bc03ddbc10d7fb092c76dc3b1a5`.
+The largest instruction coefficient of variation was `0.010884`. All cases
+passed on their first controlled attempt.
+
+The first representative verdict found that independent query processes had
+reduced aggregate cache counts. The producer now uses one aggregate invocation
+for latency, cache, and diagnostics. It uses independent invocations only for
+process-work samples. A deterministic self-test protects this boundary. The
+two affected cases report 2,300 cache hits and 2,300 misses in the replacement
+capture.
 
 ### M2 reproduced evidence
 

--- a/plans/issues/active/adhoc_performance_budget_host_variance.md
+++ b/plans/issues/active/adhoc_performance_budget_host_variance.md
@@ -68,14 +68,15 @@ different process boundary. Separate governed thresholds prevent those RSS
 meanings from being compared as if they were equal.
 
 The approved full-manifest work capture passed all 65 cases on implementation
-commit `c5d4c68f317d01f86bb15f45862a52d6f54af86e`. It produced work-budget
+commit `8899996656ca2258ac84ef30136cc013ea0e3dd8`. It produced work-budget
 artifact digest
-`d2e48c6f96d7cd160b01b1fa1c2e6641b203d107ec201f91f00fbc927de9c51d`
+`2586824b46ab5a70f6fd43ecfc55e77d67d84bf7dbd9eece13b02c2000663294`
 and raw-evidence digest
-`4e7991fe787b2f9db55513acc312fe90cf262b1e4b870bd53e520e3b49dba2b6`.
-The largest accepted instruction coefficient of variation was `0.013556`.
-The formatter corpus rejected an unstable `0.030451` attempt and accepted its
-`0.013556` retry. All other cases passed on their first controlled attempt.
+`d512c11c65c0a8bc21f185d496a93774adf85078abb3fe5b654ddc69dcec1e10`.
+The largest accepted instruction coefficient of variation was `0.010295`.
+The formatter corpus rejected unstable `0.031762` and `0.031574` attempts. It
+accepted the third attempt at `0.004752`. All other cases passed on their first
+controlled attempt.
 
 The first representative verdict found that independent query processes had
 reduced aggregate cache counts. The producer now uses one aggregate invocation

--- a/verification/areas/performance/benchmark_baseline.py
+++ b/verification/areas/performance/benchmark_baseline.py
@@ -10,7 +10,7 @@ from typing import Any
 from benchmark_manifest import RUNNER_VERSION, BenchmarkCase, BenchmarkError
 
 WORK_HEADROOM_RATIO = 1.02
-WORK_HEADROOM_FLOOR = 1_000_000
+WORK_HEADROOM_FLOOR = 2_000_000
 RSS_HEADROOM_RATIO = 1.10
 RSS_HEADROOM_FLOOR = 32 * 1024 * 1024
 
@@ -160,7 +160,7 @@ def work_budgets_from_run(
         },
         "instruction_threshold_rule": (
             "max(baseline_median_instructions * 1.02, "
-            "baseline_median_instructions + 1000000)"
+            "baseline_median_instructions + 2000000)"
         ),
         "rss_threshold_rule": (
             "max(baseline_peak_rss_bytes * 1.10, "
@@ -176,3 +176,38 @@ def sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             hasher.update(chunk)
     return hasher.hexdigest()
+
+
+def run_self_test() -> None:
+    budgets = {
+        "budgets": [
+            {
+                "benchmark_id": "small-work-self-test",
+                "budget_id": "perf.self-test.small-work",
+            }
+        ]
+    }
+    report = {
+        "metadata": {
+            "work_baseline_source_commit": "a" * 40,
+            "host_os": "macOS-self-test",
+            "architecture": "arm64",
+        },
+        "results": [
+            {
+                "id": "small-work-self-test",
+                "metrics": {
+                    "median_instructions": 10_000_000,
+                    "peak_rss_bytes": 64 * 1024 * 1024,
+                },
+            }
+        ],
+    }
+    captured = work_budgets_from_run(budgets, report)
+    entry = captured["budgets"][0]
+    if entry["threshold_median_instructions"] != 12_000_000:
+        raise BenchmarkError(
+            "work baseline self-test did not apply the small-process floor"
+        )
+    if entry["threshold_peak_rss_bytes"] != 96 * 1024 * 1024:
+        raise BenchmarkError("work baseline self-test did not apply the RSS floor")

--- a/verification/areas/performance/benchmark_baseline.py
+++ b/verification/areas/performance/benchmark_baseline.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import hashlib
+import math
 from pathlib import Path
 from typing import Any
 
 from benchmark_manifest import RUNNER_VERSION, BenchmarkCase, BenchmarkError
+
+WORK_HEADROOM_RATIO = 1.02
+WORK_HEADROOM_FLOOR = 1_000_000
 
 
 def validate_baseline_capture(
@@ -51,11 +55,26 @@ def validate_baseline_capture(
                 f"baseline result {case_id} is missing cache hit/miss metrics"
             )
         case = cases_by_id[str(case_id)]
-        cv = float(metrics["coefficient_variation"])
-        if cv > case.stability_limit:
+        control_mode = result.get("control", {}).get("mode", "latency")
+        if control_mode == "work":
+            instruction_samples = result.get("samples_instructions")
+            if (
+                not isinstance(instruction_samples, list)
+                or len(instruction_samples) != len(samples)
+                or metrics.get("median_instructions") is None
+            ):
+                raise BenchmarkError(
+                    f"work-controlled baseline result {case_id} is missing retired-instruction evidence"
+                )
+            cv = float(metrics["instructions_coefficient_variation"])
+            stability_limit = case.work_stability_limit
+        else:
+            cv = float(metrics["coefficient_variation"])
+            stability_limit = case.stability_limit
+        if cv > stability_limit:
             raise BenchmarkError(
                 f"baseline result {case_id} is unstable: coefficient_variation={cv:.6f} "
-                f"limit={case.stability_limit:.6f}"
+                f"limit={stability_limit:.6f}"
             )
 
 
@@ -69,6 +88,68 @@ def baseline_from_run(
         "default_stability_limit": manifest.get("default_stability_limit", 0.10),
         "metadata": run_report["metadata"],
         "results": run_report["results"],
+    }
+
+
+def work_budgets_from_run(
+    budgets: dict[str, Any], run_report: dict[str, Any]
+) -> dict[str, Any]:
+    entries = budgets.get("budgets")
+    if not isinstance(entries, list):
+        raise BenchmarkError("performance budgets are missing the budgets list")
+    results = run_report.get("results")
+    if not isinstance(results, list):
+        raise BenchmarkError("performance baseline is missing results")
+    results_by_id = {
+        result.get("id"): result
+        for result in results
+        if isinstance(result, dict) and isinstance(result.get("id"), str)
+    }
+    work_entries: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise BenchmarkError("performance budget entries must be objects")
+        case_id = entry.get("benchmark_id")
+        result = results_by_id.get(case_id)
+        if not isinstance(result, dict):
+            raise BenchmarkError(
+                f"work baseline is missing benchmark result {case_id!r}"
+            )
+        metrics = result.get("metrics")
+        if not isinstance(metrics, dict) or not isinstance(
+            metrics.get("median_instructions"), int
+        ):
+            raise BenchmarkError(
+                f"work baseline result {case_id!r} is missing median_instructions"
+            )
+        median = int(metrics["median_instructions"])
+        threshold = max(
+            math.ceil(median * WORK_HEADROOM_RATIO), median + WORK_HEADROOM_FLOOR
+        )
+        work_entries.append(
+            {
+                "benchmark_id": case_id,
+                "budget_id": entry.get("budget_id"),
+                "baseline_median_instructions": median,
+                "threshold_median_instructions": threshold,
+            }
+        )
+    return {
+        "version": 1,
+        "runner_version": RUNNER_VERSION,
+        "source_commit": run_report.get("metadata", {}).get(
+            "work_baseline_source_commit"
+        ),
+        "host": {
+            "host_os": run_report.get("metadata", {}).get("host_os"),
+            "architecture": run_report.get("metadata", {}).get("architecture"),
+            "work_counter_source": "darwin-rusage-instructions",
+        },
+        "threshold_rule": (
+            "max(baseline_median_instructions * 1.02, "
+            "baseline_median_instructions + 1000000)"
+        ),
+        "budgets": work_entries,
     }
 
 

--- a/verification/areas/performance/benchmark_baseline.py
+++ b/verification/areas/performance/benchmark_baseline.py
@@ -11,6 +11,8 @@ from benchmark_manifest import RUNNER_VERSION, BenchmarkCase, BenchmarkError
 
 WORK_HEADROOM_RATIO = 1.02
 WORK_HEADROOM_FLOOR = 1_000_000
+RSS_HEADROOM_RATIO = 1.10
+RSS_HEADROOM_FLOOR = 32 * 1024 * 1024
 
 
 def validate_baseline_capture(
@@ -122,16 +124,26 @@ def work_budgets_from_run(
             raise BenchmarkError(
                 f"work baseline result {case_id!r} is missing median_instructions"
             )
+        if not isinstance(metrics.get("peak_rss_bytes"), int):
+            raise BenchmarkError(
+                f"work baseline result {case_id!r} is missing peak_rss_bytes"
+            )
         median = int(metrics["median_instructions"])
-        threshold = max(
+        instruction_threshold = max(
             math.ceil(median * WORK_HEADROOM_RATIO), median + WORK_HEADROOM_FLOOR
+        )
+        peak_rss = int(metrics["peak_rss_bytes"])
+        rss_threshold = max(
+            math.ceil(peak_rss * RSS_HEADROOM_RATIO), peak_rss + RSS_HEADROOM_FLOOR
         )
         work_entries.append(
             {
                 "benchmark_id": case_id,
                 "budget_id": entry.get("budget_id"),
                 "baseline_median_instructions": median,
-                "threshold_median_instructions": threshold,
+                "threshold_median_instructions": instruction_threshold,
+                "baseline_peak_rss_bytes": peak_rss,
+                "threshold_peak_rss_bytes": rss_threshold,
             }
         )
     return {
@@ -144,10 +156,15 @@ def work_budgets_from_run(
             "host_os": run_report.get("metadata", {}).get("host_os"),
             "architecture": run_report.get("metadata", {}).get("architecture"),
             "work_counter_source": "darwin-rusage-instructions",
+            "rss_counter_source": "darwin-rusage-process-tree",
         },
-        "threshold_rule": (
+        "instruction_threshold_rule": (
             "max(baseline_median_instructions * 1.02, "
             "baseline_median_instructions + 1000000)"
+        ),
+        "rss_threshold_rule": (
+            "max(baseline_peak_rss_bytes * 1.10, "
+            "baseline_peak_rss_bytes + 33554432)"
         ),
         "budgets": work_entries,
     }

--- a/verification/areas/performance/benchmark_manifest.py
+++ b/verification/areas/performance/benchmark_manifest.py
@@ -50,6 +50,10 @@ class BenchmarkCase:
     def stability_limit(self) -> float:
         return float(self.raw.get("stability_limit", 0.10))
 
+    @property
+    def work_stability_limit(self) -> float:
+        return float(self.raw.get("work_stability_limit", 0.02))
+
 
 def load_manifest(path: Path) -> dict[str, Any]:
     try:

--- a/verification/areas/performance/check_budgets.py
+++ b/verification/areas/performance/check_budgets.py
@@ -174,6 +174,18 @@ def validate_budgets(
             require_number(
                 thresholds, "median_instructions", f"budget {budget_id} thresholds"
             )
+        work_thresholds = raw.get("work_thresholds")
+        if work_thresholds is not None:
+            if not isinstance(work_thresholds, dict):
+                raise BudgetError(
+                    f"budget {budget_id} work_thresholds must be an object"
+                )
+            for field in ["median_instructions", "peak_rss_bytes"]:
+                require_number(
+                    work_thresholds,
+                    field,
+                    f"budget {budget_id} work_thresholds",
+                )
         cache = raw.get("cache", {})
         if not isinstance(cache, dict):
             raise BudgetError(f"budget {budget_id} cache policy must be an object")
@@ -206,6 +218,8 @@ def apply_work_budgets(
         "darwin-rusage-instructions"
     ):
         raise BudgetError("work budgets must bind the retired-instruction source")
+    if host.get("rss_counter_source") != "darwin-rusage-process-tree":
+        raise BudgetError("work budgets must bind the Darwin process-tree RSS source")
     work_entries = work_budgets.get("budgets")
     if not isinstance(work_entries, list):
         raise BudgetError("work budgets must contain a budgets list")
@@ -244,9 +258,25 @@ def apply_work_budgets(
             raise BudgetError(
                 f"work budget {budget_id} has invalid threshold_median_instructions"
             )
-        entry.setdefault("baseline", {})["median_instructions"] = baseline
-        entry.setdefault("thresholds", {})["median_instructions"] = threshold
-        entry["work_policy"] = "retired-instructions-default"
+        rss_baseline = work_entry.get("baseline_peak_rss_bytes")
+        rss_threshold = work_entry.get("threshold_peak_rss_bytes")
+        if not isinstance(rss_baseline, int) or rss_baseline <= 0:
+            raise BudgetError(
+                f"work budget {budget_id} has invalid baseline_peak_rss_bytes"
+            )
+        if not isinstance(rss_threshold, int) or rss_threshold < rss_baseline:
+            raise BudgetError(
+                f"work budget {budget_id} has invalid threshold_peak_rss_bytes"
+            )
+        entry["work_baseline"] = {
+            "median_instructions": baseline,
+            "peak_rss_bytes": rss_baseline,
+        }
+        entry["work_thresholds"] = {
+            "median_instructions": threshold,
+            "peak_rss_bytes": rss_threshold,
+        }
+        entry["work_policy"] = "darwin-process-tree-default"
     missing = sorted(set(by_case) - seen)
     if missing:
         raise BudgetError(f"work budgets are missing benchmark ids: {missing}")
@@ -456,7 +486,8 @@ def compare_result(
         )
     checks: list[tuple[str, Any, Any]] = []
     if control_mode == "work":
-        if thresholds.get("median_instructions") is None:
+        work_thresholds = budget.get("work_thresholds")
+        if not isinstance(work_thresholds, dict):
             failures.append(
                 format_failure(
                     case_id,
@@ -473,26 +504,32 @@ def compare_result(
                 (
                     "median_instructions",
                     metrics["median_instructions"],
-                    thresholds["median_instructions"],
+                    work_thresholds["median_instructions"],
                 )
             )
+            if metrics.get("peak_rss_bytes") is not None:
+                checks.append(
+                    (
+                        "peak_rss_bytes",
+                        metrics["peak_rss_bytes"],
+                        work_thresholds["peak_rss_bytes"],
+                    )
+                )
     else:
         checks.append(("median_ms", metrics["median_ms"], thresholds["median_ms"]))
         if should_enforce_p95(result):
             checks.append(("p95_ms", metrics["p95_ms"], thresholds["p95_ms"]))
         if (
-            thresholds.get("median_instructions") is not None
-            and metrics.get("median_instructions") is not None
+            thresholds.get("peak_rss_bytes") is not None
+            and metrics.get("peak_rss_bytes") is not None
         ):
             checks.append(
                 (
-                    "median_instructions",
-                    metrics["median_instructions"],
-                    thresholds["median_instructions"],
+                    "peak_rss_bytes",
+                    metrics["peak_rss_bytes"],
+                    thresholds["peak_rss_bytes"],
                 )
             )
-    if thresholds.get("peak_rss_bytes") is not None and metrics.get("peak_rss_bytes") is not None:
-        checks.append(("peak_rss_bytes", metrics["peak_rss_bytes"], thresholds["peak_rss_bytes"]))
     for metric, measured, threshold in checks:
         if float(measured) > float(threshold) and not has_waiver(case_id, budget_id, metric, waivers):
             failures.append(format_failure(case_id, budget_id, metric, measured, threshold, waivers))
@@ -622,6 +659,10 @@ def run_self_test() -> None:
         make_instruction_seed(baselines, budgets, regress=True),
         "median_instructions regression",
     )
+    assert_result_fails(
+        make_work_rss_seed(baselines, budgets),
+        "peak_rss_bytes regression",
+    )
     check_budgets(
         manifest,
         budgets,
@@ -686,8 +727,8 @@ def make_instruction_seed(
     result = copy.deepcopy(baselines)
     budget = budgets["budgets"][0]
     case_id = budget["benchmark_id"]
-    threshold = int(budget["thresholds"]["median_instructions"])
-    baseline = int(budget["baseline"]["median_instructions"])
+    threshold = int(budget["work_thresholds"]["median_instructions"])
+    baseline = int(budget["work_baseline"]["median_instructions"])
     for entry in result["results"]:
         if entry["id"] != case_id:
             continue
@@ -702,6 +743,7 @@ def make_instruction_seed(
                 "instructions_mad": 0,
                 "instructions_coefficient_variation": 0.0,
                 "median_cycles_per_instruction": 0.5,
+                "peak_rss_bytes": budget["work_baseline"]["peak_rss_bytes"],
             }
         )
         if not regress:
@@ -713,6 +755,21 @@ def make_instruction_seed(
             ) + 1.0
         return result
     raise BudgetError(f"instruction self-test could not find benchmark {case_id}")
+
+
+def make_work_rss_seed(
+    baselines: dict[str, Any], budgets: dict[str, Any]
+) -> dict[str, Any]:
+    result = make_instruction_seed(baselines, budgets, regress=False)
+    budget = budgets["budgets"][0]
+    case_id = budget["benchmark_id"]
+    for entry in result["results"]:
+        if entry["id"] == case_id:
+            entry["metrics"]["peak_rss_bytes"] = (
+                int(budget["work_thresholds"]["peak_rss_bytes"]) + 1
+            )
+            return result
+    raise BudgetError(f"work RSS self-test could not find benchmark {case_id}")
 
 
 def load_json(path: Path) -> dict[str, Any]:

--- a/verification/areas/performance/check_budgets.py
+++ b/verification/areas/performance/check_budgets.py
@@ -11,17 +11,23 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PERF_ROOT = REPO_ROOT / "verification" / "areas" / "performance"
 PERF_DATA = PERF_ROOT / "data"
 DEFAULT_MANIFEST = PERF_DATA / "benchmark_manifest.json"
 DEFAULT_BASELINES = PERF_DATA / "baselines.json"
 DEFAULT_BUDGETS = PERF_DATA / "budgets.json"
+DEFAULT_WORK_BUDGETS = PERF_DATA / "work_budgets.json"
 DEFAULT_WAIVERS = PERF_DATA / "waivers.json"
 NEGATIVE_ROOT = PERF_ROOT / "negative_seeds"
 RUNNER_VERSION = 1
-ALLOWED_WAIVER_OVERRIDE_KEYS = {"median_ms", "p95_ms", "peak_rss_bytes", "cache_hits"}
+ALLOWED_WAIVER_OVERRIDE_KEYS = {
+    "median_ms",
+    "p95_ms",
+    "median_instructions",
+    "peak_rss_bytes",
+    "cache_hits",
+}
 # The nearest-rank p95 used by the benchmark runner collapses to the maximum
 # sample below 20 samples, making quick representative runs scheduler-bound.
 MIN_P95_SAMPLE_COUNT = 20
@@ -40,6 +46,7 @@ def main() -> int:
     parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
     parser.add_argument("--results", default=str(DEFAULT_BASELINES))
     parser.add_argument("--budgets", default=str(DEFAULT_BUDGETS))
+    parser.add_argument("--work-budgets", default=str(DEFAULT_WORK_BUDGETS))
     parser.add_argument("--waivers", default=str(DEFAULT_WAIVERS))
     parser.add_argument("--allow-subset", action="store_true")
     parser.add_argument("--expected-invocation-id", default="")
@@ -53,7 +60,9 @@ def main() -> int:
             return 0
 
         manifest = load_json(Path(args.manifest))
-        budgets = load_json(Path(args.budgets))
+        budgets = apply_work_budgets(
+            load_json(Path(args.budgets)), load_json(Path(args.work_budgets))
+        )
         waivers = load_json(Path(args.waivers))
         results = load_json(Path(args.results))
         check_budgets(
@@ -161,6 +170,10 @@ def validate_budgets(
             require_number(thresholds, field, f"budget {budget_id} thresholds")
         if "peak_rss_bytes" in thresholds and thresholds["peak_rss_bytes"] is not None:
             require_number(thresholds, "peak_rss_bytes", f"budget {budget_id} thresholds")
+        if "median_instructions" in thresholds:
+            require_number(
+                thresholds, "median_instructions", f"budget {budget_id} thresholds"
+            )
         cache = raw.get("cache", {})
         if not isinstance(cache, dict):
             raise BudgetError(f"budget {budget_id} cache policy must be an object")
@@ -174,6 +187,70 @@ def validate_budgets(
     if missing:
         raise BudgetError(f"budgets are missing benchmark ids: {missing}")
     return by_case
+
+
+def apply_work_budgets(
+    budgets: dict[str, Any], work_budgets: dict[str, Any]
+) -> dict[str, Any]:
+    if work_budgets.get("version") != 1:
+        raise BudgetError("work budgets version must be 1")
+    if work_budgets.get("runner_version") != RUNNER_VERSION:
+        raise BudgetError(
+            f"work budgets runner_version must be {RUNNER_VERSION}"
+        )
+    source_commit = work_budgets.get("source_commit")
+    if not isinstance(source_commit, str) or len(source_commit) != 40:
+        raise BudgetError("work budgets must bind a full source commit")
+    host = work_budgets.get("host")
+    if not isinstance(host, dict) or host.get("work_counter_source") != (
+        "darwin-rusage-instructions"
+    ):
+        raise BudgetError("work budgets must bind the retired-instruction source")
+    work_entries = work_budgets.get("budgets")
+    if not isinstance(work_entries, list):
+        raise BudgetError("work budgets must contain a budgets list")
+    updated = copy.deepcopy(budgets)
+    entries = updated.get("budgets")
+    if not isinstance(entries, list):
+        raise BudgetError("budgets must contain a budgets list")
+    by_case = {
+        entry.get("benchmark_id"): entry
+        for entry in entries
+        if isinstance(entry, dict)
+    }
+    seen: set[str] = set()
+    for work_entry in work_entries:
+        if not isinstance(work_entry, dict):
+            raise BudgetError("work budget entries must be objects")
+        case_id = require_string(work_entry, "benchmark_id", "work budget entry")
+        budget_id = require_string(
+            work_entry, "budget_id", f"work budget entry {case_id}"
+        )
+        if case_id in seen:
+            raise BudgetError(f"duplicate work budget for benchmark id {case_id}")
+        seen.add(case_id)
+        entry = by_case.get(case_id)
+        if not isinstance(entry, dict) or entry.get("budget_id") != budget_id:
+            raise BudgetError(
+                f"work budget {budget_id} does not match governed benchmark {case_id}"
+            )
+        baseline = work_entry.get("baseline_median_instructions")
+        threshold = work_entry.get("threshold_median_instructions")
+        if not isinstance(baseline, int) or baseline <= 0:
+            raise BudgetError(
+                f"work budget {budget_id} has invalid baseline_median_instructions"
+            )
+        if not isinstance(threshold, int) or threshold < baseline:
+            raise BudgetError(
+                f"work budget {budget_id} has invalid threshold_median_instructions"
+            )
+        entry.setdefault("baseline", {})["median_instructions"] = baseline
+        entry.setdefault("thresholds", {})["median_instructions"] = threshold
+        entry["work_policy"] = "retired-instructions-default"
+    missing = sorted(set(by_case) - seen)
+    if missing:
+        raise BudgetError(f"work budgets are missing benchmark ids: {missing}")
+    return updated
 
 
 def validate_waivers(
@@ -265,6 +342,19 @@ def validate_results_shape(
             raise BudgetError(f"benchmark result {result_id} samples_ms length must match sample_count")
         if not all(isinstance(sample, int | float) and not isinstance(sample, bool) for sample in samples):
             raise BudgetError(f"benchmark result {result_id} samples_ms entries must be numeric")
+        instruction_samples = raw.get("samples_instructions")
+        if instruction_samples is not None:
+            if not isinstance(instruction_samples, list) or len(instruction_samples) != sample_count:
+                raise BudgetError(
+                    f"benchmark result {result_id} samples_instructions length must match sample_count"
+                )
+            if not all(
+                isinstance(sample, int) and not isinstance(sample, bool) and sample > 0
+                for sample in instruction_samples
+            ):
+                raise BudgetError(
+                    f"benchmark result {result_id} samples_instructions entries must be positive integers"
+                )
         metrics = raw.get("metrics")
         if not isinstance(metrics, dict):
             raise BudgetError(f"benchmark result {result_id} is missing metrics")
@@ -283,6 +373,22 @@ def validate_results_shape(
         require_number(metrics, "coefficient_variation", f"benchmark result {result_id} metrics")
         if metrics["peak_rss_bytes"] is not None:
             require_number(metrics, "peak_rss_bytes", f"benchmark result {result_id} metrics")
+        for field in [
+            "median_instructions",
+            "p95_instructions",
+            "instructions_mad",
+            "instructions_coefficient_variation",
+            "median_cycles_per_instruction",
+        ]:
+            if field in metrics and metrics[field] is not None:
+                require_number(metrics, field, f"benchmark result {result_id} metrics")
+        control_mode = raw.get("control", {}).get("mode")
+        if control_mode == "work" and (
+            instruction_samples is None or metrics.get("median_instructions") is None
+        ):
+            raise BudgetError(
+                f"work-controlled benchmark result {result_id} is missing retired-instruction evidence"
+            )
         cache = raw.get("cache")
         if not isinstance(cache, dict) or not isinstance(cache.get("hits"), int) or not isinstance(cache.get("misses"), int):
             raise BudgetError(f"benchmark result {result_id} is missing cache hit/miss metrics")
@@ -316,24 +422,75 @@ def compare_result(
         return failures
     metrics = result["metrics"]
     thresholds = budget["thresholds"]
-    stability_limit = float(case.get("stability_limit", 0.10))
-    if float(metrics["coefficient_variation"]) > stability_limit:
+    control_mode = result.get("control", {}).get("mode", "latency")
+    if control_mode == "work":
+        stability_metric = "instructions_coefficient_variation"
+        stability_limit = float(case.get("work_stability_limit", 0.02))
+    else:
+        stability_metric = "coefficient_variation"
+        stability_limit = float(case.get("stability_limit", 0.10))
+    stability_value = metrics.get(stability_metric)
+    if stability_value is None:
         failures.append(
             format_failure(
                 case_id,
                 budget_id,
-                "coefficient_variation",
-                metrics["coefficient_variation"],
+                stability_metric,
+                "unavailable",
                 stability_limit,
                 waivers,
                 waiverable=False,
             )
         )
-    checks = [
-        ("median_ms", metrics["median_ms"], thresholds["median_ms"]),
-    ]
-    if should_enforce_p95(result):
-        checks.append(("p95_ms", metrics["p95_ms"], thresholds["p95_ms"]))
+    elif float(stability_value) > stability_limit:
+        failures.append(
+            format_failure(
+                case_id,
+                budget_id,
+                stability_metric,
+                stability_value,
+                stability_limit,
+                waivers,
+                waiverable=False,
+            )
+        )
+    checks: list[tuple[str, Any, Any]] = []
+    if control_mode == "work":
+        if thresholds.get("median_instructions") is None:
+            failures.append(
+                format_failure(
+                    case_id,
+                    budget_id,
+                    "median_instructions",
+                    metrics.get("median_instructions", "unavailable"),
+                    "governed threshold",
+                    waivers,
+                    waiverable=False,
+                )
+            )
+        else:
+            checks.append(
+                (
+                    "median_instructions",
+                    metrics["median_instructions"],
+                    thresholds["median_instructions"],
+                )
+            )
+    else:
+        checks.append(("median_ms", metrics["median_ms"], thresholds["median_ms"]))
+        if should_enforce_p95(result):
+            checks.append(("p95_ms", metrics["p95_ms"], thresholds["p95_ms"]))
+        if (
+            thresholds.get("median_instructions") is not None
+            and metrics.get("median_instructions") is not None
+        ):
+            checks.append(
+                (
+                    "median_instructions",
+                    metrics["median_instructions"],
+                    thresholds["median_instructions"],
+                )
+            )
     if thresholds.get("peak_rss_bytes") is not None and metrics.get("peak_rss_bytes") is not None:
         checks.append(("peak_rss_bytes", metrics["peak_rss_bytes"], thresholds["peak_rss_bytes"]))
     for metric, measured, threshold in checks:
@@ -413,7 +570,7 @@ def format_failure(
 
 def run_self_test() -> None:
     manifest = load_json(DEFAULT_MANIFEST)
-    budgets = load_json(DEFAULT_BUDGETS)
+    budgets = governed_budgets()
     waivers = load_json(DEFAULT_WAIVERS)
     baselines = load_json(DEFAULT_BASELINES)
     check_budgets(manifest, budgets, waivers, baselines)
@@ -461,6 +618,16 @@ def run_self_test() -> None:
         "invocation_id does not match",
         expected_invocation_id="current-invocation",
     )
+    assert_result_fails(
+        make_instruction_seed(baselines, budgets, regress=True),
+        "median_instructions regression",
+    )
+    check_budgets(
+        manifest,
+        budgets,
+        EMPTY_WAIVERS,
+        make_instruction_seed(baselines, budgets, regress=False),
+    )
 
 
 def assert_budget_fails(seed: str, expected: str, *, allow_subset: bool = False) -> None:
@@ -479,7 +646,7 @@ def assert_result_fails(
     try:
         check_budgets(
             load_json(DEFAULT_MANIFEST),
-            load_json(DEFAULT_BUDGETS),
+            governed_budgets(),
             EMPTY_WAIVERS,
             result,
             allow_subset=allow_subset,
@@ -496,7 +663,7 @@ def assert_waiver_fails(seed: str, expected: str) -> None:
     try:
         check_budgets(
             load_json(DEFAULT_MANIFEST),
-            load_json(DEFAULT_BUDGETS),
+            governed_budgets(),
             load_json(NEGATIVE_ROOT / seed),
             load_json(DEFAULT_BASELINES),
         )
@@ -505,6 +672,47 @@ def assert_waiver_fails(seed: str, expected: str) -> None:
             raise BudgetError(f"negative waiver seed {seed} failed with wrong diagnostic: {error}") from error
         return
     raise BudgetError(f"negative waiver seed {seed} did not fail")
+
+
+def governed_budgets() -> dict[str, Any]:
+    return apply_work_budgets(
+        load_json(DEFAULT_BUDGETS), load_json(DEFAULT_WORK_BUDGETS)
+    )
+
+
+def make_instruction_seed(
+    baselines: dict[str, Any], budgets: dict[str, Any], *, regress: bool
+) -> dict[str, Any]:
+    result = copy.deepcopy(baselines)
+    budget = budgets["budgets"][0]
+    case_id = budget["benchmark_id"]
+    threshold = int(budget["thresholds"]["median_instructions"])
+    baseline = int(budget["baseline"]["median_instructions"])
+    for entry in result["results"]:
+        if entry["id"] != case_id:
+            continue
+        measured = threshold + 1 if regress else baseline
+        sample_count = int(entry["sample_count"])
+        entry["samples_instructions"] = [measured] * sample_count
+        entry["control"] = {"mode": "work"}
+        entry["metrics"].update(
+            {
+                "median_instructions": measured,
+                "p95_instructions": measured,
+                "instructions_mad": 0,
+                "instructions_coefficient_variation": 0.0,
+                "median_cycles_per_instruction": 0.5,
+            }
+        )
+        if not regress:
+            entry["metrics"]["median_ms"] = float(
+                budget["thresholds"]["median_ms"]
+            ) + 1.0
+            entry["metrics"]["p95_ms"] = float(
+                budget["thresholds"]["p95_ms"]
+            ) + 1.0
+        return result
+    raise BudgetError(f"instruction self-test could not find benchmark {case_id}")
 
 
 def load_json(path: Path) -> dict[str, Any]:

--- a/verification/areas/performance/controlled_sampling.py
+++ b/verification/areas/performance/controlled_sampling.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from benchmark_manifest import RUNNER_VERSION, BenchmarkCase, BenchmarkError
 from host_control import HostActivityMonitor
@@ -17,9 +18,10 @@ def run_controlled_case(
     sample_scale: str,
     *,
     require_controlled_host: bool,
+    control_mode: str = "latency",
     run_case_fn: Callable[[BenchmarkCase, Path, str], dict[str, Any]],
     retry_admission_fn: Callable[[], dict[str, Any]] | None,
-    monitor_factory: Callable[[], Any] = HostActivityMonitor,
+    monitor_factory: Callable[..., Any] = HostActivityMonitor,
     repo_root: Path | None = None,
 ) -> dict[str, Any]:
     attempts: list[dict[str, Any]] = []
@@ -32,19 +34,35 @@ def run_controlled_case(
                 )
             retry_admission = retry_admission_fn()
         attempt_root = run_root / "attempts" / str(attempt_index)
-        with monitor_factory() as monitor:
+        with monitor_factory(control_mode=control_mode) as monitor:
             result = run_case_fn(case, attempt_root, sample_scale)
         rejection_reasons = (
             monitor.rejection_reasons() if require_controlled_host else []
         )
-        coefficient_variation = float(result["metrics"]["coefficient_variation"])
-        if coefficient_variation > case.stability_limit:
+        if control_mode == "work":
+            raw_variation = result["metrics"].get(
+                "instructions_coefficient_variation"
+            )
+            stability_metric = "instructions_coefficient_variation"
+            stability_limit = case.work_stability_limit
+        else:
+            raw_variation = result["metrics"].get("coefficient_variation")
+            stability_metric = "coefficient_variation"
+            stability_limit = case.stability_limit
+        if raw_variation is None:
+            rejection_reasons.append(f"{stability_metric}-unavailable")
+            coefficient_variation = None
+        else:
+            coefficient_variation = float(raw_variation)
+        if coefficient_variation is not None and coefficient_variation > stability_limit:
             rejection_reasons.append("unstable-samples")
         rejection_reasons = sorted(set(rejection_reasons))
         attempt_evidence = {
             "attempt": attempt_index,
+            "control_mode": control_mode,
+            "stability_metric": stability_metric,
             "coefficient_variation": coefficient_variation,
-            "stability_limit": case.stability_limit,
+            "stability_limit": stability_limit,
             "host_snapshots": monitor.snapshots,
             "rejection_reasons": rejection_reasons,
         }
@@ -54,6 +72,7 @@ def run_controlled_case(
         if not rejection_reasons:
             result["control"] = {
                 "status": "controlled" if require_controlled_host else "record-only",
+                "mode": control_mode,
                 "accepted_attempt": attempt_index,
                 "attempts": attempts,
             }
@@ -88,7 +107,8 @@ def run_self_test(output_root: Path) -> None:
         return {"metrics": {"coefficient_variation": next(coefficients)}}
 
     class FakeMonitor:
-        snapshots = [{"self_test": True}]
+        def __init__(self, **_kwargs: object) -> None:
+            self.snapshots = [{"self_test": True}]
 
         def __enter__(self) -> Any:
             return self
@@ -126,6 +146,33 @@ def run_self_test(output_root: Path) -> None:
     if accepted["control"]["attempts"][1].get("retry_admission") != retry_admissions[0]:
         raise BenchmarkError(
             "controlled retry self-test did not record retry admission evidence"
+        )
+
+    def stable_work_run(
+        _case: BenchmarkCase, _root: Path, _scale: str
+    ) -> dict[str, Any]:
+        return {
+            "metrics": {
+                "coefficient_variation": 0.50,
+                "instructions_coefficient_variation": 0.001,
+            }
+        }
+
+    work_accepted = run_controlled_case(
+        case,
+        output_root,
+        "manifest",
+        require_controlled_host=True,
+        control_mode="work",
+        run_case_fn=stable_work_run,
+        retry_admission_fn=fake_retry_admission,
+        monitor_factory=FakeMonitor,
+    )
+    if work_accepted["control"]["attempts"][0]["stability_metric"] != (
+        "instructions_coefficient_variation"
+    ):
+        raise BenchmarkError(
+            "controlled sampling self-test did not select work stability"
         )
 
     def unstable_run(_case: BenchmarkCase, _root: Path, _scale: str) -> dict[str, Any]:

--- a/verification/areas/performance/data/work_budgets.json
+++ b/verification/areas/performance/data/work_budgets.json
@@ -1,524 +1,524 @@
 {
   "budgets": [
     {
-      "baseline_median_instructions": 117229829132,
-      "baseline_peak_rss_bytes": 208404480,
+      "baseline_median_instructions": 117192298028,
+      "baseline_peak_rss_bytes": 209010688,
       "benchmark_id": "build-project-001-additional-modules",
       "budget_id": "perf.build.project.additional_modules",
-      "threshold_median_instructions": 119574425715,
-      "threshold_peak_rss_bytes": 241958912
+      "threshold_median_instructions": 119536143989,
+      "threshold_peak_rss_bytes": 242565120
     },
     {
-      "baseline_median_instructions": 111171964863,
-      "baseline_peak_rss_bytes": 146292736,
+      "baseline_median_instructions": 111170857281,
+      "baseline_peak_rss_bytes": 145948672,
       "benchmark_id": "build-project-002-branch-paths",
       "budget_id": "perf.build.project.branch_paths",
-      "threshold_median_instructions": 113395404161,
-      "threshold_peak_rss_bytes": 179847168
+      "threshold_median_instructions": 113394274427,
+      "threshold_peak_rss_bytes": 179503104
     },
     {
-      "baseline_median_instructions": 111162641563,
-      "baseline_peak_rss_bytes": 146604032,
+      "baseline_median_instructions": 111178621124,
+      "baseline_peak_rss_bytes": 147111936,
       "benchmark_id": "build-project-003-cargo-manifest",
       "budget_id": "perf.build.project.cargo_manifest",
-      "threshold_median_instructions": 113385894395,
-      "threshold_peak_rss_bytes": 180158464
+      "threshold_median_instructions": 113402193547,
+      "threshold_peak_rss_bytes": 180666368
     },
     {
-      "baseline_median_instructions": 115836158169,
-      "baseline_peak_rss_bytes": 156041216,
+      "baseline_median_instructions": 115835001295,
+      "baseline_peak_rss_bytes": 155992064,
       "benchmark_id": "build-project-004-dependency-manifest",
       "budget_id": "perf.build.project.dependency_manifest",
-      "threshold_median_instructions": 118152881333,
-      "threshold_peak_rss_bytes": 189595648
+      "threshold_median_instructions": 118151701321,
+      "threshold_peak_rss_bytes": 189546496
     },
     {
-      "baseline_median_instructions": 111289986816,
-      "baseline_peak_rss_bytes": 146964480,
+      "baseline_median_instructions": 111252837600,
+      "baseline_peak_rss_bytes": 147734528,
       "benchmark_id": "build-project-005-project-graph",
       "budget_id": "perf.build.project.project_graph",
-      "threshold_median_instructions": 113515786553,
-      "threshold_peak_rss_bytes": 180518912
+      "threshold_median_instructions": 113477894352,
+      "threshold_peak_rss_bytes": 181288960
     },
     {
-      "baseline_median_instructions": 111123816056,
-      "baseline_peak_rss_bytes": 147816448,
+      "baseline_median_instructions": 111155378214,
+      "baseline_peak_rss_bytes": 147701760,
       "benchmark_id": "build-single-file-001-break-continue",
       "budget_id": "perf.build.single.break_continue",
-      "threshold_median_instructions": 113346292378,
-      "threshold_peak_rss_bytes": 181370880
+      "threshold_median_instructions": 113378485779,
+      "threshold_peak_rss_bytes": 181256192
     },
     {
-      "baseline_median_instructions": 111101271401,
-      "baseline_peak_rss_bytes": 147013632,
+      "baseline_median_instructions": 111204438638,
+      "baseline_peak_rss_bytes": 147554304,
       "benchmark_id": "build-single-file-002-builtin-any-all",
       "budget_id": "perf.build.single.builtin_any_all",
-      "threshold_median_instructions": 113323296830,
-      "threshold_peak_rss_bytes": 180568064
+      "threshold_median_instructions": 113428527411,
+      "threshold_peak_rss_bytes": 181108736
     },
     {
-      "baseline_median_instructions": 111096951479,
-      "baseline_peak_rss_bytes": 146243584,
+      "baseline_median_instructions": 111083914303,
+      "baseline_peak_rss_bytes": 145293312,
       "benchmark_id": "build-single-file-003-builtin-enumerate-zip",
       "budget_id": "perf.build.single.builtin_enumerate_zip",
-      "threshold_median_instructions": 113318890509,
-      "threshold_peak_rss_bytes": 179798016
+      "threshold_median_instructions": 113305592590,
+      "threshold_peak_rss_bytes": 178847744
     },
     {
-      "baseline_median_instructions": 111136188484,
-      "baseline_peak_rss_bytes": 147636224,
+      "baseline_median_instructions": 111115843116,
+      "baseline_peak_rss_bytes": 146931712,
       "benchmark_id": "build-single-file-004-bytes-constructors",
       "budget_id": "perf.build.single.bytes_constructors",
-      "threshold_median_instructions": 113358912254,
-      "threshold_peak_rss_bytes": 181190656
+      "threshold_median_instructions": 113338159979,
+      "threshold_peak_rss_bytes": 180486144
     },
     {
-      "baseline_median_instructions": 111101446409,
-      "baseline_peak_rss_bytes": 148127744,
+      "baseline_median_instructions": 111086525380,
+      "baseline_peak_rss_bytes": 147374080,
       "benchmark_id": "build-single-file-005-class-methods",
       "budget_id": "perf.build.single.class_methods",
-      "threshold_median_instructions": 113323475338,
-      "threshold_peak_rss_bytes": 181682176
+      "threshold_median_instructions": 113308255888,
+      "threshold_peak_rss_bytes": 180928512
     },
     {
-      "baseline_median_instructions": 111105563929,
-      "baseline_peak_rss_bytes": 146128896,
+      "baseline_median_instructions": 111118409557,
+      "baseline_peak_rss_bytes": 148111360,
       "benchmark_id": "build-single-file-006-collection-len",
       "budget_id": "perf.build.single.collection_len",
-      "threshold_median_instructions": 113327675208,
-      "threshold_peak_rss_bytes": 179683328
+      "threshold_median_instructions": 113340777749,
+      "threshold_peak_rss_bytes": 181665792
     },
     {
-      "baseline_median_instructions": 111083940172,
-      "baseline_peak_rss_bytes": 146866176,
+      "baseline_median_instructions": 111102140232,
+      "baseline_peak_rss_bytes": 147111936,
       "benchmark_id": "build-single-file-007-comp-set",
       "budget_id": "perf.build.single.comp_set",
-      "threshold_median_instructions": 113305618976,
-      "threshold_peak_rss_bytes": 180420608
+      "threshold_median_instructions": 113324183037,
+      "threshold_peak_rss_bytes": 180666368
     },
     {
-      "baseline_median_instructions": 115067842334,
-      "baseline_peak_rss_bytes": 166395904,
+      "baseline_median_instructions": 115067973572,
+      "baseline_peak_rss_bytes": 166232064,
       "benchmark_id": "build-single-file-008-decimal-conversions",
       "budget_id": "perf.build.single.decimal_conversions",
-      "threshold_median_instructions": 117369199181,
-      "threshold_peak_rss_bytes": 199950336
+      "threshold_median_instructions": 117369333044,
+      "threshold_peak_rss_bytes": 199786496
     },
     {
-      "baseline_median_instructions": 111193384994,
-      "baseline_peak_rss_bytes": 148258816,
+      "baseline_median_instructions": 111144271691,
+      "baseline_peak_rss_bytes": 147079168,
       "benchmark_id": "build-single-file-009-dict-get-option",
       "budget_id": "perf.build.single.dict_get_option",
-      "threshold_median_instructions": 113417252694,
-      "threshold_peak_rss_bytes": 181813248
+      "threshold_median_instructions": 113367157125,
+      "threshold_peak_rss_bytes": 180633600
     },
     {
-      "baseline_median_instructions": 111103526898,
-      "baseline_peak_rss_bytes": 146849792,
+      "baseline_median_instructions": 111099064791,
+      "baseline_peak_rss_bytes": 147685376,
       "benchmark_id": "build-single-file-010-generic-identity",
       "budget_id": "perf.build.single.generic_identity",
-      "threshold_median_instructions": 113325597436,
-      "threshold_peak_rss_bytes": 180404224
+      "threshold_median_instructions": 113321046087,
+      "threshold_peak_rss_bytes": 181239808
     },
     {
-      "baseline_median_instructions": 13626633971,
-      "baseline_peak_rss_bytes": 146374656,
+      "baseline_median_instructions": 13633327630,
+      "baseline_peak_rss_bytes": 146898944,
       "benchmark_id": "check-project-001-imports",
       "budget_id": "perf.check.project.imports",
-      "threshold_median_instructions": 13899166651,
-      "threshold_peak_rss_bytes": 179929088
+      "threshold_median_instructions": 13905994183,
+      "threshold_peak_rss_bytes": 180453376
     },
     {
-      "baseline_median_instructions": 13618941815,
-      "baseline_peak_rss_bytes": 147095552,
+      "baseline_median_instructions": 13625838660,
+      "baseline_peak_rss_bytes": 147341312,
       "benchmark_id": "check-project-002-mode-consistency",
       "budget_id": "perf.check.project.mode_consistency",
-      "threshold_median_instructions": 13891320652,
-      "threshold_peak_rss_bytes": 180649984
+      "threshold_median_instructions": 13898355434,
+      "threshold_peak_rss_bytes": 180895744
     },
     {
-      "baseline_median_instructions": 13650698745,
-      "baseline_peak_rss_bytes": 147226624,
+      "baseline_median_instructions": 13659535242,
+      "baseline_peak_rss_bytes": 146391040,
       "benchmark_id": "check-project-003-project-build",
       "budget_id": "perf.check.project.project_build",
-      "threshold_median_instructions": 13923712720,
-      "threshold_peak_rss_bytes": 180781056
-    },
-    {
-      "baseline_median_instructions": 13659934948,
-      "baseline_peak_rss_bytes": 146178048,
-      "benchmark_id": "check-project-004-project-graph",
-      "budget_id": "perf.check.project.project_graph",
-      "threshold_median_instructions": 13933133647,
-      "threshold_peak_rss_bytes": 179732480
-    },
-    {
-      "baseline_median_instructions": 13667001929,
-      "baseline_peak_rss_bytes": 147521536,
-      "benchmark_id": "check-project-005-rooted-entrypoint",
-      "budget_id": "perf.check.project.rooted_entrypoint",
-      "threshold_median_instructions": 13940341968,
-      "threshold_peak_rss_bytes": 181075968
-    },
-    {
-      "baseline_median_instructions": 13587060706,
-      "baseline_peak_rss_bytes": 145850368,
-      "benchmark_id": "check-single-file-001-arithmetic",
-      "budget_id": "perf.check.single.arithmetic",
-      "threshold_median_instructions": 13858801921,
-      "threshold_peak_rss_bytes": 179404800
-    },
-    {
-      "baseline_median_instructions": 13592077276,
-      "baseline_peak_rss_bytes": 148537344,
-      "benchmark_id": "check-single-file-002-break-continue",
-      "budget_id": "perf.check.single.break_continue",
-      "threshold_median_instructions": 13863918822,
-      "threshold_peak_rss_bytes": 182091776
-    },
-    {
-      "baseline_median_instructions": 13588586573,
-      "baseline_peak_rss_bytes": 146243584,
-      "benchmark_id": "check-single-file-003-builtin-any-all",
-      "budget_id": "perf.check.single.builtin_any_all",
-      "threshold_median_instructions": 13860358305,
-      "threshold_peak_rss_bytes": 179798016
-    },
-    {
-      "baseline_median_instructions": 13591562875,
-      "baseline_peak_rss_bytes": 146620416,
-      "benchmark_id": "check-single-file-004-builtin-enumerate-zip",
-      "budget_id": "perf.check.single.builtin_enumerate_zip",
-      "threshold_median_instructions": 13863394133,
-      "threshold_peak_rss_bytes": 180174848
-    },
-    {
-      "baseline_median_instructions": 13601382667,
-      "baseline_peak_rss_bytes": 146440192,
-      "benchmark_id": "check-single-file-005-bytes-constructors",
-      "budget_id": "perf.check.single.bytes_constructors",
-      "threshold_median_instructions": 13873410321,
-      "threshold_peak_rss_bytes": 179994624
-    },
-    {
-      "baseline_median_instructions": 13600588054,
-      "baseline_peak_rss_bytes": 146391040,
-      "benchmark_id": "check-single-file-006-class-methods",
-      "budget_id": "perf.check.single.class_methods",
-      "threshold_median_instructions": 13872599816,
+      "threshold_median_instructions": 13932725947,
       "threshold_peak_rss_bytes": 179945472
     },
     {
-      "baseline_median_instructions": 13594050338,
-      "baseline_peak_rss_bytes": 146112512,
-      "benchmark_id": "check-single-file-007-collection-len",
-      "budget_id": "perf.check.single.collection_len",
-      "threshold_median_instructions": 13865931345,
-      "threshold_peak_rss_bytes": 179666944
+      "baseline_median_instructions": 13661609398,
+      "baseline_peak_rss_bytes": 146161664,
+      "benchmark_id": "check-project-004-project-graph",
+      "budget_id": "perf.check.project.project_graph",
+      "threshold_median_instructions": 13934841586,
+      "threshold_peak_rss_bytes": 179716096
     },
     {
-      "baseline_median_instructions": 13590551054,
-      "baseline_peak_rss_bytes": 145670144,
-      "benchmark_id": "check-single-file-008-comp-set",
-      "budget_id": "perf.check.single.comp_set",
-      "threshold_median_instructions": 13862362076,
-      "threshold_peak_rss_bytes": 179224576
+      "baseline_median_instructions": 13654505916,
+      "baseline_peak_rss_bytes": 146309120,
+      "benchmark_id": "check-project-005-rooted-entrypoint",
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "threshold_median_instructions": 13927596035,
+      "threshold_peak_rss_bytes": 179863552
     },
     {
-      "baseline_median_instructions": 13595202543,
-      "baseline_peak_rss_bytes": 146128896,
-      "benchmark_id": "check-single-file-009-decimal-conversions",
-      "budget_id": "perf.check.single.decimal_conversions",
-      "threshold_median_instructions": 13867106594,
-      "threshold_peak_rss_bytes": 179683328
+      "baseline_median_instructions": 13595792448,
+      "baseline_peak_rss_bytes": 147177472,
+      "benchmark_id": "check-single-file-001-arithmetic",
+      "budget_id": "perf.check.single.arithmetic",
+      "threshold_median_instructions": 13867708297,
+      "threshold_peak_rss_bytes": 180731904
     },
     {
-      "baseline_median_instructions": 13586828891,
-      "baseline_peak_rss_bytes": 146833408,
-      "benchmark_id": "check-single-file-010-dict-get-option",
-      "budget_id": "perf.check.single.dict_get_option",
-      "threshold_median_instructions": 13858565469,
-      "threshold_peak_rss_bytes": 180387840
+      "baseline_median_instructions": 13592552329,
+      "baseline_peak_rss_bytes": 146997248,
+      "benchmark_id": "check-single-file-002-break-continue",
+      "budget_id": "perf.check.single.break_continue",
+      "threshold_median_instructions": 13864403376,
+      "threshold_peak_rss_bytes": 180551680
     },
     {
-      "baseline_median_instructions": 13589840135,
-      "baseline_peak_rss_bytes": 147357696,
-      "benchmark_id": "diagnostic-non-regression-001-human-success-exit",
-      "budget_id": "perf.diagnostic.human_success_exit",
-      "threshold_median_instructions": 13861636938,
-      "threshold_peak_rss_bytes": 180912128
-    },
-    {
-      "baseline_median_instructions": 13590374665,
-      "baseline_peak_rss_bytes": 146472960,
-      "benchmark_id": "diagnostic-non-regression-002-json-diagnostic-schema",
-      "budget_id": "perf.diagnostic.json_diagnostic_schema",
-      "threshold_median_instructions": 13862182159,
-      "threshold_peak_rss_bytes": 180027392
-    },
-    {
-      "baseline_median_instructions": 13599656590,
-      "baseline_peak_rss_bytes": 148029440,
-      "benchmark_id": "diagnostic-non-regression-003-compact-diagnostic-schema",
-      "budget_id": "perf.diagnostic.compact_diagnostic_schema",
-      "threshold_median_instructions": 13871649722,
-      "threshold_peak_rss_bytes": 181583872
-    },
-    {
-      "baseline_median_instructions": 13592424286,
-      "baseline_peak_rss_bytes": 147800064,
-      "benchmark_id": "diagnostic-non-regression-004-recovery-limit",
-      "budget_id": "perf.diagnostic.recovery_limit",
-      "threshold_median_instructions": 13864272772,
-      "threshold_peak_rss_bytes": 181354496
-    },
-    {
-      "baseline_median_instructions": 13518234635,
+      "baseline_median_instructions": 13587114953,
       "baseline_peak_rss_bytes": 146702336,
-      "benchmark_id": "diagnostic-non-regression-005-project-error-exit",
-      "budget_id": "perf.diagnostic.project_error_exit",
-      "threshold_median_instructions": 13788599328,
+      "benchmark_id": "check-single-file-003-builtin-any-all",
+      "budget_id": "perf.check.single.builtin_any_all",
+      "threshold_median_instructions": 13858857253,
       "threshold_peak_rss_bytes": 180256768
     },
     {
-      "baseline_median_instructions": 35759387,
+      "baseline_median_instructions": 13586024384,
+      "baseline_peak_rss_bytes": 147488768,
+      "benchmark_id": "check-single-file-004-builtin-enumerate-zip",
+      "budget_id": "perf.check.single.builtin_enumerate_zip",
+      "threshold_median_instructions": 13857744872,
+      "threshold_peak_rss_bytes": 181043200
+    },
+    {
+      "baseline_median_instructions": 13606615417,
+      "baseline_peak_rss_bytes": 148094976,
+      "benchmark_id": "check-single-file-005-bytes-constructors",
+      "budget_id": "perf.check.single.bytes_constructors",
+      "threshold_median_instructions": 13878747726,
+      "threshold_peak_rss_bytes": 181649408
+    },
+    {
+      "baseline_median_instructions": 13594371075,
+      "baseline_peak_rss_bytes": 146325504,
+      "benchmark_id": "check-single-file-006-class-methods",
+      "budget_id": "perf.check.single.class_methods",
+      "threshold_median_instructions": 13866258497,
+      "threshold_peak_rss_bytes": 179879936
+    },
+    {
+      "baseline_median_instructions": 13600392754,
+      "baseline_peak_rss_bytes": 147062784,
+      "benchmark_id": "check-single-file-007-collection-len",
+      "budget_id": "perf.check.single.collection_len",
+      "threshold_median_instructions": 13872400610,
+      "threshold_peak_rss_bytes": 180617216
+    },
+    {
+      "baseline_median_instructions": 13602013737,
+      "baseline_peak_rss_bytes": 147226624,
+      "benchmark_id": "check-single-file-008-comp-set",
+      "budget_id": "perf.check.single.comp_set",
+      "threshold_median_instructions": 13874054012,
+      "threshold_peak_rss_bytes": 180781056
+    },
+    {
+      "baseline_median_instructions": 13587716796,
+      "baseline_peak_rss_bytes": 146259968,
+      "benchmark_id": "check-single-file-009-decimal-conversions",
+      "budget_id": "perf.check.single.decimal_conversions",
+      "threshold_median_instructions": 13859471132,
+      "threshold_peak_rss_bytes": 179814400
+    },
+    {
+      "baseline_median_instructions": 13587772421,
+      "baseline_peak_rss_bytes": 146505728,
+      "benchmark_id": "check-single-file-010-dict-get-option",
+      "budget_id": "perf.check.single.dict_get_option",
+      "threshold_median_instructions": 13859527870,
+      "threshold_peak_rss_bytes": 180060160
+    },
+    {
+      "baseline_median_instructions": 13601055069,
+      "baseline_peak_rss_bytes": 147177472,
+      "benchmark_id": "diagnostic-non-regression-001-human-success-exit",
+      "budget_id": "perf.diagnostic.human_success_exit",
+      "threshold_median_instructions": 13873076171,
+      "threshold_peak_rss_bytes": 180731904
+    },
+    {
+      "baseline_median_instructions": 13599858453,
+      "baseline_peak_rss_bytes": 147046400,
+      "benchmark_id": "diagnostic-non-regression-002-json-diagnostic-schema",
+      "budget_id": "perf.diagnostic.json_diagnostic_schema",
+      "threshold_median_instructions": 13871855623,
+      "threshold_peak_rss_bytes": 180600832
+    },
+    {
+      "baseline_median_instructions": 13599170110,
+      "baseline_peak_rss_bytes": 146341888,
+      "benchmark_id": "diagnostic-non-regression-003-compact-diagnostic-schema",
+      "budget_id": "perf.diagnostic.compact_diagnostic_schema",
+      "threshold_median_instructions": 13871153513,
+      "threshold_peak_rss_bytes": 179896320
+    },
+    {
+      "baseline_median_instructions": 13593223358,
+      "baseline_peak_rss_bytes": 146898944,
+      "benchmark_id": "diagnostic-non-regression-004-recovery-limit",
+      "budget_id": "perf.diagnostic.recovery_limit",
+      "threshold_median_instructions": 13865087826,
+      "threshold_peak_rss_bytes": 180453376
+    },
+    {
+      "baseline_median_instructions": 13514155876,
+      "baseline_peak_rss_bytes": 146309120,
+      "benchmark_id": "diagnostic-non-regression-005-project-error-exit",
+      "budget_id": "perf.diagnostic.project_error_exit",
+      "threshold_median_instructions": 13784438994,
+      "threshold_peak_rss_bytes": 179863552
+    },
+    {
+      "baseline_median_instructions": 35683120,
       "baseline_peak_rss_bytes": 11239424,
       "benchmark_id": "formatter-corpus-001-project-check",
       "budget_id": "perf.formatter.corpus.project_check",
-      "threshold_median_instructions": 36759387,
+      "threshold_median_instructions": 37683120,
       "threshold_peak_rss_bytes": 44793856
     },
     {
-      "baseline_median_instructions": 57335766,
-      "baseline_peak_rss_bytes": 11468800,
+      "baseline_median_instructions": 56837431,
+      "baseline_peak_rss_bytes": 11517952,
       "benchmark_id": "formatter-large-file-001-check",
       "budget_id": "perf.formatter.large_file.check",
-      "threshold_median_instructions": 58482482,
-      "threshold_peak_rss_bytes": 45023232
+      "threshold_median_instructions": 58837431,
+      "threshold_peak_rss_bytes": 45072384
     },
     {
-      "baseline_median_instructions": 898070648,
-      "baseline_peak_rss_bytes": 5029888,
+      "baseline_median_instructions": 897864330,
+      "baseline_peak_rss_bytes": 5111808,
       "benchmark_id": "incremental-local-loop-001-unchanged-file-update",
       "budget_id": "perf.incremental.unchanged_file_update",
-      "threshold_median_instructions": 916032061,
-      "threshold_peak_rss_bytes": 38584320
+      "threshold_median_instructions": 915821617,
+      "threshold_peak_rss_bytes": 38666240
     },
     {
-      "baseline_median_instructions": 674959890,
-      "baseline_peak_rss_bytes": 5029888,
+      "baseline_median_instructions": 675058002,
+      "baseline_peak_rss_bytes": 5111808,
       "benchmark_id": "incremental-local-loop-002-leaf-module-change",
       "budget_id": "perf.incremental.leaf_module_change",
-      "threshold_median_instructions": 688459088,
-      "threshold_peak_rss_bytes": 38584320
+      "threshold_median_instructions": 688559163,
+      "threshold_peak_rss_bytes": 38666240
     },
     {
-      "baseline_median_instructions": 3811347061,
-      "baseline_peak_rss_bytes": 7995392,
+      "baseline_median_instructions": 3813020387,
+      "baseline_peak_rss_bytes": 8192000,
       "benchmark_id": "incremental-local-loop-003-imported-module-change",
       "budget_id": "perf.incremental.imported_module_change",
-      "threshold_median_instructions": 3887574003,
-      "threshold_peak_rss_bytes": 41549824
+      "threshold_median_instructions": 3889280795,
+      "threshold_peak_rss_bytes": 41746432
     },
     {
-      "baseline_median_instructions": 4454966824,
-      "baseline_peak_rss_bytes": 8159232,
+      "baseline_median_instructions": 4455793542,
+      "baseline_peak_rss_bytes": 8175616,
       "benchmark_id": "incremental-local-loop-004-public-api-change",
       "budget_id": "perf.incremental.public_api_change",
-      "threshold_median_instructions": 4544066161,
-      "threshold_peak_rss_bytes": 41713664
+      "threshold_median_instructions": 4544909413,
+      "threshold_peak_rss_bytes": 41730048
     },
     {
-      "baseline_median_instructions": 4158051331,
-      "baseline_peak_rss_bytes": 8159232,
+      "baseline_median_instructions": 4158417417,
+      "baseline_peak_rss_bytes": 8241152,
       "benchmark_id": "incremental-local-loop-005-failure-recovery",
       "budget_id": "perf.incremental.failure_recovery",
-      "threshold_median_instructions": 4241212358,
-      "threshold_peak_rss_bytes": 41713664
+      "threshold_median_instructions": 4241585766,
+      "threshold_peak_rss_bytes": 41795584
     },
     {
-      "baseline_median_instructions": 373173937,
-      "baseline_peak_rss_bytes": 4751360,
+      "baseline_median_instructions": 373246992,
+      "baseline_peak_rss_bytes": 4767744,
       "benchmark_id": "interactive-tooling-foundation-001-cold-context-load",
       "budget_id": "perf.interactive.cold_context_load",
-      "threshold_median_instructions": 380637416,
-      "threshold_peak_rss_bytes": 38305792
-    },
-    {
-      "baseline_median_instructions": 1446357930,
-      "baseline_peak_rss_bytes": 7946240,
-      "benchmark_id": "interactive-tooling-foundation-002-warm-diagnostics-query",
-      "budget_id": "perf.interactive.warm_diagnostics_query",
-      "threshold_median_instructions": 1475285089,
-      "threshold_peak_rss_bytes": 41500672
-    },
-    {
-      "baseline_median_instructions": 584595066,
-      "baseline_peak_rss_bytes": 4767744,
-      "benchmark_id": "interactive-tooling-foundation-003-unchanged-file-update",
-      "budget_id": "perf.interactive.unchanged_file_update",
-      "threshold_median_instructions": 596286968,
+      "threshold_median_instructions": 380711932,
       "threshold_peak_rss_bytes": 38322176
     },
     {
-      "baseline_median_instructions": 2341062730,
-      "baseline_peak_rss_bytes": 8142848,
+      "baseline_median_instructions": 1446926912,
+      "baseline_peak_rss_bytes": 7798784,
+      "benchmark_id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "threshold_median_instructions": 1475865451,
+      "threshold_peak_rss_bytes": 41353216
+    },
+    {
+      "baseline_median_instructions": 585035132,
+      "baseline_peak_rss_bytes": 4718592,
+      "benchmark_id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "threshold_median_instructions": 596735835,
+      "threshold_peak_rss_bytes": 38273024
+    },
+    {
+      "baseline_median_instructions": 2347333277,
+      "baseline_peak_rss_bytes": 7995392,
       "benchmark_id": "interactive-tooling-foundation-004-changed-file-invalidation",
       "budget_id": "perf.interactive.changed_file_invalidation",
-      "threshold_median_instructions": 2387883985,
-      "threshold_peak_rss_bytes": 41697280
+      "threshold_median_instructions": 2394279943,
+      "threshold_peak_rss_bytes": 41549824
     },
     {
-      "baseline_median_instructions": 216326563,
-      "baseline_peak_rss_bytes": 4653056,
+      "baseline_median_instructions": 216397080,
+      "baseline_peak_rss_bytes": 4685824,
       "benchmark_id": "interactive-tooling-foundation-005-source-map-lookup",
       "budget_id": "perf.interactive.source_map_lookup",
-      "threshold_median_instructions": 220653095,
-      "threshold_peak_rss_bytes": 38207488
+      "threshold_median_instructions": 220725022,
+      "threshold_peak_rss_bytes": 38240256
     },
     {
-      "baseline_median_instructions": 378036689,
-      "baseline_peak_rss_bytes": 117899264,
+      "baseline_median_instructions": 377597441,
+      "baseline_peak_rss_bytes": 116916224,
       "benchmark_id": "lsp-query-001-request-families",
       "budget_id": "perf.lsp.request_families",
-      "threshold_median_instructions": 385597423,
-      "threshold_peak_rss_bytes": 151453696
+      "threshold_median_instructions": 385149390,
+      "threshold_peak_rss_bytes": 150470656
     },
     {
-      "baseline_median_instructions": 322496634,
-      "baseline_peak_rss_bytes": 21495808,
+      "baseline_median_instructions": 323581136,
+      "baseline_peak_rss_bytes": 21561344,
       "benchmark_id": "lsp-query-002-cold-start",
       "budget_id": "perf.lsp.cold_start.workspace",
-      "threshold_median_instructions": 328946567,
-      "threshold_peak_rss_bytes": 55050240
+      "threshold_median_instructions": 330052759,
+      "threshold_peak_rss_bytes": 55115776
     },
     {
-      "baseline_median_instructions": 380033096,
-      "baseline_peak_rss_bytes": 74760192,
+      "baseline_median_instructions": 380966950,
+      "baseline_peak_rss_bytes": 73728000,
       "benchmark_id": "lsp-query-003-diagnostics",
       "budget_id": "perf.lsp.diagnostics.document",
-      "threshold_median_instructions": 387633758,
-      "threshold_peak_rss_bytes": 108314624
+      "threshold_median_instructions": 388586289,
+      "threshold_peak_rss_bytes": 107282432
     },
     {
-      "baseline_median_instructions": 342285214,
-      "baseline_peak_rss_bytes": 159301632,
+      "baseline_median_instructions": 344390874,
+      "baseline_peak_rss_bytes": 157417472,
       "benchmark_id": "lsp-query-004-workspace-diagnostics",
       "budget_id": "perf.lsp.diagnostics.workspace",
-      "threshold_median_instructions": 349130919,
-      "threshold_peak_rss_bytes": 192856064
+      "threshold_median_instructions": 351278692,
+      "threshold_peak_rss_bytes": 190971904
     },
     {
-      "baseline_median_instructions": 1318680329,
-      "baseline_peak_rss_bytes": 76578816,
+      "baseline_median_instructions": 1320896124,
+      "baseline_peak_rss_bytes": 76759040,
       "benchmark_id": "lsp-query-005-completion",
       "budget_id": "perf.lsp.completion.local_scope",
-      "threshold_median_instructions": 1345053936,
-      "threshold_peak_rss_bytes": 110133248
+      "threshold_median_instructions": 1347314047,
+      "threshold_peak_rss_bytes": 110313472
     },
     {
-      "baseline_median_instructions": 359609484,
-      "baseline_peak_rss_bytes": 74022912,
+      "baseline_median_instructions": 359981811,
+      "baseline_peak_rss_bytes": 74186752,
       "benchmark_id": "lsp-query-006-hover",
       "budget_id": "perf.lsp.hover.symbol",
-      "threshold_median_instructions": 366801674,
-      "threshold_peak_rss_bytes": 107577344
+      "threshold_median_instructions": 367181448,
+      "threshold_peak_rss_bytes": 107741184
     },
     {
-      "baseline_median_instructions": 360658640,
-      "baseline_peak_rss_bytes": 75317248,
+      "baseline_median_instructions": 360794288,
+      "baseline_peak_rss_bytes": 73302016,
       "benchmark_id": "lsp-query-007-signature-help",
       "budget_id": "perf.lsp.signature_help.call",
-      "threshold_median_instructions": 367871813,
-      "threshold_peak_rss_bytes": 108871680
+      "threshold_median_instructions": 368010174,
+      "threshold_peak_rss_bytes": 106856448
     },
     {
-      "baseline_median_instructions": 491458380,
-      "baseline_peak_rss_bytes": 75005952,
+      "baseline_median_instructions": 492050837,
+      "baseline_peak_rss_bytes": 73957376,
       "benchmark_id": "lsp-query-008-navigation",
       "budget_id": "perf.lsp.navigation.symbol",
-      "threshold_median_instructions": 501287548,
-      "threshold_peak_rss_bytes": 108560384
+      "threshold_median_instructions": 501891854,
+      "threshold_peak_rss_bytes": 107511808
     },
     {
-      "baseline_median_instructions": 344011946,
+      "baseline_median_instructions": 343856587,
       "baseline_peak_rss_bytes": 158171136,
       "benchmark_id": "lsp-query-009-references",
       "budget_id": "perf.lsp.references.workspace_symbol",
-      "threshold_median_instructions": 350892185,
+      "threshold_median_instructions": 350733719,
       "threshold_peak_rss_bytes": 191725568
     },
     {
-      "baseline_median_instructions": 361840562,
-      "baseline_peak_rss_bytes": 158236672,
+      "baseline_median_instructions": 362987183,
+      "baseline_peak_rss_bytes": 158826496,
       "benchmark_id": "lsp-query-010-rename",
       "budget_id": "perf.lsp.rename.workspace_edit",
-      "threshold_median_instructions": 369077374,
-      "threshold_peak_rss_bytes": 191791104
+      "threshold_median_instructions": 370246927,
+      "threshold_peak_rss_bytes": 192380928
     },
     {
-      "baseline_median_instructions": 394944744,
-      "baseline_peak_rss_bytes": 74563584,
+      "baseline_median_instructions": 395140684,
+      "baseline_peak_rss_bytes": 73482240,
       "benchmark_id": "lsp-query-011-semantic-tokens",
       "budget_id": "perf.lsp.semantic_tokens.full",
-      "threshold_median_instructions": 402843639,
-      "threshold_peak_rss_bytes": 108118016
+      "threshold_median_instructions": 403043498,
+      "threshold_peak_rss_bytes": 107036672
     },
     {
-      "baseline_median_instructions": 361263160,
-      "baseline_peak_rss_bytes": 74563584,
+      "baseline_median_instructions": 361422936,
+      "baseline_peak_rss_bytes": 74711040,
       "benchmark_id": "lsp-query-012-inlay-hints",
       "budget_id": "perf.lsp.inlay_hints.module",
-      "threshold_median_instructions": 368488424,
-      "threshold_peak_rss_bytes": 108118016
+      "threshold_median_instructions": 368651395,
+      "threshold_peak_rss_bytes": 108265472
     },
     {
-      "baseline_median_instructions": 362533008,
-      "baseline_peak_rss_bytes": 74219520,
+      "baseline_median_instructions": 362932719,
+      "baseline_peak_rss_bytes": 73531392,
       "benchmark_id": "lsp-query-013-selection-range",
       "budget_id": "perf.lsp.selection_ranges.nested",
-      "threshold_median_instructions": 369783669,
-      "threshold_peak_rss_bytes": 107773952
+      "threshold_median_instructions": 370191374,
+      "threshold_peak_rss_bytes": 107085824
     },
     {
-      "baseline_median_instructions": 358694618,
-      "baseline_peak_rss_bytes": 74055680,
+      "baseline_median_instructions": 358978778,
+      "baseline_peak_rss_bytes": 73842688,
       "benchmark_id": "lsp-query-014-type-hierarchy",
       "budget_id": "perf.lsp.type_hierarchy.symbol",
-      "threshold_median_instructions": 365868511,
-      "threshold_peak_rss_bytes": 107610112
+      "threshold_median_instructions": 366158354,
+      "threshold_peak_rss_bytes": 107397120
     },
     {
-      "baseline_median_instructions": 359339289,
-      "baseline_peak_rss_bytes": 73580544,
+      "baseline_median_instructions": 360032015,
+      "baseline_peak_rss_bytes": 73416704,
       "benchmark_id": "lsp-query-015-code-actions",
       "budget_id": "perf.lsp.code_action.diagnostic",
-      "threshold_median_instructions": 366526075,
-      "threshold_peak_rss_bytes": 107134976
+      "threshold_median_instructions": 367232656,
+      "threshold_peak_rss_bytes": 106971136
     },
     {
-      "baseline_median_instructions": 382561712,
-      "baseline_peak_rss_bytes": 75841536,
+      "baseline_median_instructions": 382406446,
+      "baseline_peak_rss_bytes": 75366400,
       "benchmark_id": "lsp-query-016-formatting",
       "budget_id": "perf.lsp.formatting.document",
-      "threshold_median_instructions": 390212947,
-      "threshold_peak_rss_bytes": 109395968
+      "threshold_median_instructions": 390054575,
+      "threshold_peak_rss_bytes": 108920832
     },
     {
-      "baseline_median_instructions": 361199696,
-      "baseline_peak_rss_bytes": 114540544,
+      "baseline_median_instructions": 361322228,
+      "baseline_peak_rss_bytes": 112492544,
       "benchmark_id": "lsp-query-017-generated-rust-preview",
       "budget_id": "perf.lsp.generated_rust_preview.document",
-      "threshold_median_instructions": 368423690,
-      "threshold_peak_rss_bytes": 148094976
+      "threshold_median_instructions": 368548673,
+      "threshold_peak_rss_bytes": 146046976
     },
     {
-      "baseline_median_instructions": 409463304,
-      "baseline_peak_rss_bytes": 2538471424,
+      "baseline_median_instructions": 408080212,
+      "baseline_peak_rss_bytes": 2500657152,
       "benchmark_id": "lsp-query-018-did-open-diagnostics",
       "budget_id": "perf.lsp.document_sync.did_open",
-      "threshold_median_instructions": 417652571,
-      "threshold_peak_rss_bytes": 2792318567
+      "threshold_median_instructions": 416241817,
+      "threshold_peak_rss_bytes": 2750722868
     }
   ],
   "host": {
@@ -527,9 +527,9 @@
     "rss_counter_source": "darwin-rusage-process-tree",
     "work_counter_source": "darwin-rusage-instructions"
   },
-  "instruction_threshold_rule": "max(baseline_median_instructions * 1.02, baseline_median_instructions + 1000000)",
+  "instruction_threshold_rule": "max(baseline_median_instructions * 1.02, baseline_median_instructions + 2000000)",
   "rss_threshold_rule": "max(baseline_peak_rss_bytes * 1.10, baseline_peak_rss_bytes + 33554432)",
   "runner_version": 1,
-  "source_commit": "c5d4c68f317d01f86bb15f45862a52d6f54af86e",
+  "source_commit": "8899996656ca2258ac84ef30136cc013ea0e3dd8",
   "version": 1
 }

--- a/verification/areas/performance/data/work_budgets.json
+++ b/verification/areas/performance/data/work_budgets.json
@@ -1,403 +1,535 @@
 {
   "budgets": [
     {
-      "baseline_median_instructions": 117192357214,
+      "baseline_median_instructions": 117229829132,
+      "baseline_peak_rss_bytes": 208404480,
       "benchmark_id": "build-project-001-additional-modules",
       "budget_id": "perf.build.project.additional_modules",
-      "threshold_median_instructions": 119536204359
+      "threshold_median_instructions": 119574425715,
+      "threshold_peak_rss_bytes": 241958912
     },
     {
-      "baseline_median_instructions": 111178721364,
+      "baseline_median_instructions": 111171964863,
+      "baseline_peak_rss_bytes": 146292736,
       "benchmark_id": "build-project-002-branch-paths",
       "budget_id": "perf.build.project.branch_paths",
-      "threshold_median_instructions": 113402295792
+      "threshold_median_instructions": 113395404161,
+      "threshold_peak_rss_bytes": 179847168
     },
     {
-      "baseline_median_instructions": 111187546626,
+      "baseline_median_instructions": 111162641563,
+      "baseline_peak_rss_bytes": 146604032,
       "benchmark_id": "build-project-003-cargo-manifest",
       "budget_id": "perf.build.project.cargo_manifest",
-      "threshold_median_instructions": 113411297559
+      "threshold_median_instructions": 113385894395,
+      "threshold_peak_rss_bytes": 180158464
     },
     {
-      "baseline_median_instructions": 115832468655,
+      "baseline_median_instructions": 115836158169,
+      "baseline_peak_rss_bytes": 156041216,
       "benchmark_id": "build-project-004-dependency-manifest",
       "budget_id": "perf.build.project.dependency_manifest",
-      "threshold_median_instructions": 118149118029
+      "threshold_median_instructions": 118152881333,
+      "threshold_peak_rss_bytes": 189595648
     },
     {
-      "baseline_median_instructions": 111269782458,
+      "baseline_median_instructions": 111289986816,
+      "baseline_peak_rss_bytes": 146964480,
       "benchmark_id": "build-project-005-project-graph",
       "budget_id": "perf.build.project.project_graph",
-      "threshold_median_instructions": 113495178108
+      "threshold_median_instructions": 113515786553,
+      "threshold_peak_rss_bytes": 180518912
     },
     {
-      "baseline_median_instructions": 111102094757,
+      "baseline_median_instructions": 111123816056,
+      "baseline_peak_rss_bytes": 147816448,
       "benchmark_id": "build-single-file-001-break-continue",
       "budget_id": "perf.build.single.break_continue",
-      "threshold_median_instructions": 113324136653
+      "threshold_median_instructions": 113346292378,
+      "threshold_peak_rss_bytes": 181370880
     },
     {
-      "baseline_median_instructions": 111139266143,
+      "baseline_median_instructions": 111101271401,
+      "baseline_peak_rss_bytes": 147013632,
       "benchmark_id": "build-single-file-002-builtin-any-all",
       "budget_id": "perf.build.single.builtin_any_all",
-      "threshold_median_instructions": 113362051466
+      "threshold_median_instructions": 113323296830,
+      "threshold_peak_rss_bytes": 180568064
     },
     {
-      "baseline_median_instructions": 111105474077,
+      "baseline_median_instructions": 111096951479,
+      "baseline_peak_rss_bytes": 146243584,
       "benchmark_id": "build-single-file-003-builtin-enumerate-zip",
       "budget_id": "perf.build.single.builtin_enumerate_zip",
-      "threshold_median_instructions": 113327583559
+      "threshold_median_instructions": 113318890509,
+      "threshold_peak_rss_bytes": 179798016
     },
     {
-      "baseline_median_instructions": 111120164382,
+      "baseline_median_instructions": 111136188484,
+      "baseline_peak_rss_bytes": 147636224,
       "benchmark_id": "build-single-file-004-bytes-constructors",
       "budget_id": "perf.build.single.bytes_constructors",
-      "threshold_median_instructions": 113342567670
+      "threshold_median_instructions": 113358912254,
+      "threshold_peak_rss_bytes": 181190656
     },
     {
-      "baseline_median_instructions": 111118904464,
+      "baseline_median_instructions": 111101446409,
+      "baseline_peak_rss_bytes": 148127744,
       "benchmark_id": "build-single-file-005-class-methods",
       "budget_id": "perf.build.single.class_methods",
-      "threshold_median_instructions": 113341282554
+      "threshold_median_instructions": 113323475338,
+      "threshold_peak_rss_bytes": 181682176
     },
     {
-      "baseline_median_instructions": 111111800423,
+      "baseline_median_instructions": 111105563929,
+      "baseline_peak_rss_bytes": 146128896,
       "benchmark_id": "build-single-file-006-collection-len",
       "budget_id": "perf.build.single.collection_len",
-      "threshold_median_instructions": 113334036432
+      "threshold_median_instructions": 113327675208,
+      "threshold_peak_rss_bytes": 179683328
     },
     {
-      "baseline_median_instructions": 111108018825,
+      "baseline_median_instructions": 111083940172,
+      "baseline_peak_rss_bytes": 146866176,
       "benchmark_id": "build-single-file-007-comp-set",
       "budget_id": "perf.build.single.comp_set",
-      "threshold_median_instructions": 113330179202
+      "threshold_median_instructions": 113305618976,
+      "threshold_peak_rss_bytes": 180420608
     },
     {
-      "baseline_median_instructions": 115073894479,
+      "baseline_median_instructions": 115067842334,
+      "baseline_peak_rss_bytes": 166395904,
       "benchmark_id": "build-single-file-008-decimal-conversions",
       "budget_id": "perf.build.single.decimal_conversions",
-      "threshold_median_instructions": 117375372369
+      "threshold_median_instructions": 117369199181,
+      "threshold_peak_rss_bytes": 199950336
     },
     {
-      "baseline_median_instructions": 111098033311,
+      "baseline_median_instructions": 111193384994,
+      "baseline_peak_rss_bytes": 148258816,
       "benchmark_id": "build-single-file-009-dict-get-option",
       "budget_id": "perf.build.single.dict_get_option",
-      "threshold_median_instructions": 113319993978
+      "threshold_median_instructions": 113417252694,
+      "threshold_peak_rss_bytes": 181813248
     },
     {
-      "baseline_median_instructions": 111093460489,
+      "baseline_median_instructions": 111103526898,
+      "baseline_peak_rss_bytes": 146849792,
       "benchmark_id": "build-single-file-010-generic-identity",
       "budget_id": "perf.build.single.generic_identity",
-      "threshold_median_instructions": 113315329699
+      "threshold_median_instructions": 113325597436,
+      "threshold_peak_rss_bytes": 180404224
     },
     {
-      "baseline_median_instructions": 13632354971,
+      "baseline_median_instructions": 13626633971,
+      "baseline_peak_rss_bytes": 146374656,
       "benchmark_id": "check-project-001-imports",
       "budget_id": "perf.check.project.imports",
-      "threshold_median_instructions": 13905002071
+      "threshold_median_instructions": 13899166651,
+      "threshold_peak_rss_bytes": 179929088
     },
     {
-      "baseline_median_instructions": 13624898891,
+      "baseline_median_instructions": 13618941815,
+      "baseline_peak_rss_bytes": 147095552,
       "benchmark_id": "check-project-002-mode-consistency",
       "budget_id": "perf.check.project.mode_consistency",
-      "threshold_median_instructions": 13897396869
+      "threshold_median_instructions": 13891320652,
+      "threshold_peak_rss_bytes": 180649984
     },
     {
-      "baseline_median_instructions": 13653137179,
+      "baseline_median_instructions": 13650698745,
+      "baseline_peak_rss_bytes": 147226624,
       "benchmark_id": "check-project-003-project-build",
       "budget_id": "perf.check.project.project_build",
-      "threshold_median_instructions": 13926199923
+      "threshold_median_instructions": 13923712720,
+      "threshold_peak_rss_bytes": 180781056
     },
     {
-      "baseline_median_instructions": 13656554038,
+      "baseline_median_instructions": 13659934948,
+      "baseline_peak_rss_bytes": 146178048,
       "benchmark_id": "check-project-004-project-graph",
       "budget_id": "perf.check.project.project_graph",
-      "threshold_median_instructions": 13929685119
+      "threshold_median_instructions": 13933133647,
+      "threshold_peak_rss_bytes": 179732480
     },
     {
-      "baseline_median_instructions": 13660569954,
+      "baseline_median_instructions": 13667001929,
+      "baseline_peak_rss_bytes": 147521536,
       "benchmark_id": "check-project-005-rooted-entrypoint",
       "budget_id": "perf.check.project.rooted_entrypoint",
-      "threshold_median_instructions": 13933781354
+      "threshold_median_instructions": 13940341968,
+      "threshold_peak_rss_bytes": 181075968
     },
     {
-      "baseline_median_instructions": 13597160515,
+      "baseline_median_instructions": 13587060706,
+      "baseline_peak_rss_bytes": 145850368,
       "benchmark_id": "check-single-file-001-arithmetic",
       "budget_id": "perf.check.single.arithmetic",
-      "threshold_median_instructions": 13869103726
+      "threshold_median_instructions": 13858801921,
+      "threshold_peak_rss_bytes": 179404800
     },
     {
-      "baseline_median_instructions": 13597251401,
+      "baseline_median_instructions": 13592077276,
+      "baseline_peak_rss_bytes": 148537344,
       "benchmark_id": "check-single-file-002-break-continue",
       "budget_id": "perf.check.single.break_continue",
-      "threshold_median_instructions": 13869196430
+      "threshold_median_instructions": 13863918822,
+      "threshold_peak_rss_bytes": 182091776
     },
     {
-      "baseline_median_instructions": 13602123402,
+      "baseline_median_instructions": 13588586573,
+      "baseline_peak_rss_bytes": 146243584,
       "benchmark_id": "check-single-file-003-builtin-any-all",
       "budget_id": "perf.check.single.builtin_any_all",
-      "threshold_median_instructions": 13874165871
+      "threshold_median_instructions": 13860358305,
+      "threshold_peak_rss_bytes": 179798016
     },
     {
-      "baseline_median_instructions": 13587041244,
+      "baseline_median_instructions": 13591562875,
+      "baseline_peak_rss_bytes": 146620416,
       "benchmark_id": "check-single-file-004-builtin-enumerate-zip",
       "budget_id": "perf.check.single.builtin_enumerate_zip",
-      "threshold_median_instructions": 13858782069
+      "threshold_median_instructions": 13863394133,
+      "threshold_peak_rss_bytes": 180174848
     },
     {
-      "baseline_median_instructions": 13600527541,
+      "baseline_median_instructions": 13601382667,
+      "baseline_peak_rss_bytes": 146440192,
       "benchmark_id": "check-single-file-005-bytes-constructors",
       "budget_id": "perf.check.single.bytes_constructors",
-      "threshold_median_instructions": 13872538092
+      "threshold_median_instructions": 13873410321,
+      "threshold_peak_rss_bytes": 179994624
     },
     {
-      "baseline_median_instructions": 13597418983,
+      "baseline_median_instructions": 13600588054,
+      "baseline_peak_rss_bytes": 146391040,
       "benchmark_id": "check-single-file-006-class-methods",
       "budget_id": "perf.check.single.class_methods",
-      "threshold_median_instructions": 13869367363
+      "threshold_median_instructions": 13872599816,
+      "threshold_peak_rss_bytes": 179945472
     },
     {
-      "baseline_median_instructions": 13594890943,
+      "baseline_median_instructions": 13594050338,
+      "baseline_peak_rss_bytes": 146112512,
       "benchmark_id": "check-single-file-007-collection-len",
       "budget_id": "perf.check.single.collection_len",
-      "threshold_median_instructions": 13866788762
+      "threshold_median_instructions": 13865931345,
+      "threshold_peak_rss_bytes": 179666944
     },
     {
-      "baseline_median_instructions": 13601114510,
+      "baseline_median_instructions": 13590551054,
+      "baseline_peak_rss_bytes": 145670144,
       "benchmark_id": "check-single-file-008-comp-set",
       "budget_id": "perf.check.single.comp_set",
-      "threshold_median_instructions": 13873136801
+      "threshold_median_instructions": 13862362076,
+      "threshold_peak_rss_bytes": 179224576
     },
     {
-      "baseline_median_instructions": 13602099240,
+      "baseline_median_instructions": 13595202543,
+      "baseline_peak_rss_bytes": 146128896,
       "benchmark_id": "check-single-file-009-decimal-conversions",
       "budget_id": "perf.check.single.decimal_conversions",
-      "threshold_median_instructions": 13874141225
+      "threshold_median_instructions": 13867106594,
+      "threshold_peak_rss_bytes": 179683328
     },
     {
-      "baseline_median_instructions": 13603639445,
+      "baseline_median_instructions": 13586828891,
+      "baseline_peak_rss_bytes": 146833408,
       "benchmark_id": "check-single-file-010-dict-get-option",
       "budget_id": "perf.check.single.dict_get_option",
-      "threshold_median_instructions": 13875712234
+      "threshold_median_instructions": 13858565469,
+      "threshold_peak_rss_bytes": 180387840
     },
     {
-      "baseline_median_instructions": 13596011880,
+      "baseline_median_instructions": 13589840135,
+      "baseline_peak_rss_bytes": 147357696,
       "benchmark_id": "diagnostic-non-regression-001-human-success-exit",
       "budget_id": "perf.diagnostic.human_success_exit",
-      "threshold_median_instructions": 13867932118
+      "threshold_median_instructions": 13861636938,
+      "threshold_peak_rss_bytes": 180912128
     },
     {
-      "baseline_median_instructions": 13599762979,
+      "baseline_median_instructions": 13590374665,
+      "baseline_peak_rss_bytes": 146472960,
       "benchmark_id": "diagnostic-non-regression-002-json-diagnostic-schema",
       "budget_id": "perf.diagnostic.json_diagnostic_schema",
-      "threshold_median_instructions": 13871758239
+      "threshold_median_instructions": 13862182159,
+      "threshold_peak_rss_bytes": 180027392
     },
     {
-      "baseline_median_instructions": 13609997694,
+      "baseline_median_instructions": 13599656590,
+      "baseline_peak_rss_bytes": 148029440,
       "benchmark_id": "diagnostic-non-regression-003-compact-diagnostic-schema",
       "budget_id": "perf.diagnostic.compact_diagnostic_schema",
-      "threshold_median_instructions": 13882197648
+      "threshold_median_instructions": 13871649722,
+      "threshold_peak_rss_bytes": 181583872
     },
     {
-      "baseline_median_instructions": 13588631309,
+      "baseline_median_instructions": 13592424286,
+      "baseline_peak_rss_bytes": 147800064,
       "benchmark_id": "diagnostic-non-regression-004-recovery-limit",
       "budget_id": "perf.diagnostic.recovery_limit",
-      "threshold_median_instructions": 13860403936
+      "threshold_median_instructions": 13864272772,
+      "threshold_peak_rss_bytes": 181354496
     },
     {
-      "baseline_median_instructions": 13518276765,
+      "baseline_median_instructions": 13518234635,
+      "baseline_peak_rss_bytes": 146702336,
       "benchmark_id": "diagnostic-non-regression-005-project-error-exit",
       "budget_id": "perf.diagnostic.project_error_exit",
-      "threshold_median_instructions": 13788642301
+      "threshold_median_instructions": 13788599328,
+      "threshold_peak_rss_bytes": 180256768
     },
     {
-      "baseline_median_instructions": 35720680,
+      "baseline_median_instructions": 35759387,
+      "baseline_peak_rss_bytes": 11239424,
       "benchmark_id": "formatter-corpus-001-project-check",
       "budget_id": "perf.formatter.corpus.project_check",
-      "threshold_median_instructions": 36720680
+      "threshold_median_instructions": 36759387,
+      "threshold_peak_rss_bytes": 44793856
     },
     {
-      "baseline_median_instructions": 56932702,
+      "baseline_median_instructions": 57335766,
+      "baseline_peak_rss_bytes": 11468800,
       "benchmark_id": "formatter-large-file-001-check",
       "budget_id": "perf.formatter.large_file.check",
-      "threshold_median_instructions": 58071357
+      "threshold_median_instructions": 58482482,
+      "threshold_peak_rss_bytes": 45023232
     },
     {
-      "baseline_median_instructions": 898390406,
+      "baseline_median_instructions": 898070648,
+      "baseline_peak_rss_bytes": 5029888,
       "benchmark_id": "incremental-local-loop-001-unchanged-file-update",
       "budget_id": "perf.incremental.unchanged_file_update",
-      "threshold_median_instructions": 916358215
+      "threshold_median_instructions": 916032061,
+      "threshold_peak_rss_bytes": 38584320
     },
     {
-      "baseline_median_instructions": 675527694,
+      "baseline_median_instructions": 674959890,
+      "baseline_peak_rss_bytes": 5029888,
       "benchmark_id": "incremental-local-loop-002-leaf-module-change",
       "budget_id": "perf.incremental.leaf_module_change",
-      "threshold_median_instructions": 689038248
+      "threshold_median_instructions": 688459088,
+      "threshold_peak_rss_bytes": 38584320
     },
     {
-      "baseline_median_instructions": 3813412453,
+      "baseline_median_instructions": 3811347061,
+      "baseline_peak_rss_bytes": 7995392,
       "benchmark_id": "incremental-local-loop-003-imported-module-change",
       "budget_id": "perf.incremental.imported_module_change",
-      "threshold_median_instructions": 3889680703
+      "threshold_median_instructions": 3887574003,
+      "threshold_peak_rss_bytes": 41549824
     },
     {
-      "baseline_median_instructions": 4456618705,
+      "baseline_median_instructions": 4454966824,
+      "baseline_peak_rss_bytes": 8159232,
       "benchmark_id": "incremental-local-loop-004-public-api-change",
       "budget_id": "perf.incremental.public_api_change",
-      "threshold_median_instructions": 4545751080
+      "threshold_median_instructions": 4544066161,
+      "threshold_peak_rss_bytes": 41713664
     },
     {
-      "baseline_median_instructions": 4154665248,
+      "baseline_median_instructions": 4158051331,
+      "baseline_peak_rss_bytes": 8159232,
       "benchmark_id": "incremental-local-loop-005-failure-recovery",
       "budget_id": "perf.incremental.failure_recovery",
-      "threshold_median_instructions": 4237758553
+      "threshold_median_instructions": 4241212358,
+      "threshold_peak_rss_bytes": 41713664
     },
     {
-      "baseline_median_instructions": 373196094,
+      "baseline_median_instructions": 373173937,
+      "baseline_peak_rss_bytes": 4751360,
       "benchmark_id": "interactive-tooling-foundation-001-cold-context-load",
       "budget_id": "perf.interactive.cold_context_load",
-      "threshold_median_instructions": 380660016
+      "threshold_median_instructions": 380637416,
+      "threshold_peak_rss_bytes": 38305792
     },
     {
-      "baseline_median_instructions": 1446757916,
+      "baseline_median_instructions": 1446357930,
+      "baseline_peak_rss_bytes": 7946240,
       "benchmark_id": "interactive-tooling-foundation-002-warm-diagnostics-query",
       "budget_id": "perf.interactive.warm_diagnostics_query",
-      "threshold_median_instructions": 1475693075
+      "threshold_median_instructions": 1475285089,
+      "threshold_peak_rss_bytes": 41500672
     },
     {
-      "baseline_median_instructions": 584290916,
+      "baseline_median_instructions": 584595066,
+      "baseline_peak_rss_bytes": 4767744,
       "benchmark_id": "interactive-tooling-foundation-003-unchanged-file-update",
       "budget_id": "perf.interactive.unchanged_file_update",
-      "threshold_median_instructions": 595976735
+      "threshold_median_instructions": 596286968,
+      "threshold_peak_rss_bytes": 38322176
     },
     {
-      "baseline_median_instructions": 2343099786,
+      "baseline_median_instructions": 2341062730,
+      "baseline_peak_rss_bytes": 8142848,
       "benchmark_id": "interactive-tooling-foundation-004-changed-file-invalidation",
       "budget_id": "perf.interactive.changed_file_invalidation",
-      "threshold_median_instructions": 2389961782
+      "threshold_median_instructions": 2387883985,
+      "threshold_peak_rss_bytes": 41697280
     },
     {
-      "baseline_median_instructions": 216852466,
+      "baseline_median_instructions": 216326563,
+      "baseline_peak_rss_bytes": 4653056,
       "benchmark_id": "interactive-tooling-foundation-005-source-map-lookup",
       "budget_id": "perf.interactive.source_map_lookup",
-      "threshold_median_instructions": 221189516
+      "threshold_median_instructions": 220653095,
+      "threshold_peak_rss_bytes": 38207488
     },
     {
-      "baseline_median_instructions": 380309831,
+      "baseline_median_instructions": 378036689,
+      "baseline_peak_rss_bytes": 117899264,
       "benchmark_id": "lsp-query-001-request-families",
       "budget_id": "perf.lsp.request_families",
-      "threshold_median_instructions": 387916028
+      "threshold_median_instructions": 385597423,
+      "threshold_peak_rss_bytes": 151453696
     },
     {
-      "baseline_median_instructions": 323379510,
+      "baseline_median_instructions": 322496634,
+      "baseline_peak_rss_bytes": 21495808,
       "benchmark_id": "lsp-query-002-cold-start",
       "budget_id": "perf.lsp.cold_start.workspace",
-      "threshold_median_instructions": 329847101
+      "threshold_median_instructions": 328946567,
+      "threshold_peak_rss_bytes": 55050240
     },
     {
-      "baseline_median_instructions": 380518900,
+      "baseline_median_instructions": 380033096,
+      "baseline_peak_rss_bytes": 74760192,
       "benchmark_id": "lsp-query-003-diagnostics",
       "budget_id": "perf.lsp.diagnostics.document",
-      "threshold_median_instructions": 388129278
+      "threshold_median_instructions": 387633758,
+      "threshold_peak_rss_bytes": 108314624
     },
     {
-      "baseline_median_instructions": 342811786,
+      "baseline_median_instructions": 342285214,
+      "baseline_peak_rss_bytes": 159301632,
       "benchmark_id": "lsp-query-004-workspace-diagnostics",
       "budget_id": "perf.lsp.diagnostics.workspace",
-      "threshold_median_instructions": 349668022
+      "threshold_median_instructions": 349130919,
+      "threshold_peak_rss_bytes": 192856064
     },
     {
-      "baseline_median_instructions": 1320788464,
+      "baseline_median_instructions": 1318680329,
+      "baseline_peak_rss_bytes": 76578816,
       "benchmark_id": "lsp-query-005-completion",
       "budget_id": "perf.lsp.completion.local_scope",
-      "threshold_median_instructions": 1347204234
+      "threshold_median_instructions": 1345053936,
+      "threshold_peak_rss_bytes": 110133248
     },
     {
-      "baseline_median_instructions": 360911118,
+      "baseline_median_instructions": 359609484,
+      "baseline_peak_rss_bytes": 74022912,
       "benchmark_id": "lsp-query-006-hover",
       "budget_id": "perf.lsp.hover.symbol",
-      "threshold_median_instructions": 368129341
+      "threshold_median_instructions": 366801674,
+      "threshold_peak_rss_bytes": 107577344
     },
     {
-      "baseline_median_instructions": 360487038,
+      "baseline_median_instructions": 360658640,
+      "baseline_peak_rss_bytes": 75317248,
       "benchmark_id": "lsp-query-007-signature-help",
       "budget_id": "perf.lsp.signature_help.call",
-      "threshold_median_instructions": 367696779
+      "threshold_median_instructions": 367871813,
+      "threshold_peak_rss_bytes": 108871680
     },
     {
-      "baseline_median_instructions": 491463696,
+      "baseline_median_instructions": 491458380,
+      "baseline_peak_rss_bytes": 75005952,
       "benchmark_id": "lsp-query-008-navigation",
       "budget_id": "perf.lsp.navigation.symbol",
-      "threshold_median_instructions": 501292970
+      "threshold_median_instructions": 501287548,
+      "threshold_peak_rss_bytes": 108560384
     },
     {
-      "baseline_median_instructions": 342870666,
+      "baseline_median_instructions": 344011946,
+      "baseline_peak_rss_bytes": 158171136,
       "benchmark_id": "lsp-query-009-references",
       "budget_id": "perf.lsp.references.workspace_symbol",
-      "threshold_median_instructions": 349728080
+      "threshold_median_instructions": 350892185,
+      "threshold_peak_rss_bytes": 191725568
     },
     {
-      "baseline_median_instructions": 362041233,
+      "baseline_median_instructions": 361840562,
+      "baseline_peak_rss_bytes": 158236672,
       "benchmark_id": "lsp-query-010-rename",
       "budget_id": "perf.lsp.rename.workspace_edit",
-      "threshold_median_instructions": 369282058
+      "threshold_median_instructions": 369077374,
+      "threshold_peak_rss_bytes": 191791104
     },
     {
-      "baseline_median_instructions": 395659428,
+      "baseline_median_instructions": 394944744,
+      "baseline_peak_rss_bytes": 74563584,
       "benchmark_id": "lsp-query-011-semantic-tokens",
       "budget_id": "perf.lsp.semantic_tokens.full",
-      "threshold_median_instructions": 403572617
+      "threshold_median_instructions": 402843639,
+      "threshold_peak_rss_bytes": 108118016
     },
     {
-      "baseline_median_instructions": 361340398,
+      "baseline_median_instructions": 361263160,
+      "baseline_peak_rss_bytes": 74563584,
       "benchmark_id": "lsp-query-012-inlay-hints",
       "budget_id": "perf.lsp.inlay_hints.module",
-      "threshold_median_instructions": 368567206
+      "threshold_median_instructions": 368488424,
+      "threshold_peak_rss_bytes": 108118016
     },
     {
-      "baseline_median_instructions": 362778236,
+      "baseline_median_instructions": 362533008,
+      "baseline_peak_rss_bytes": 74219520,
       "benchmark_id": "lsp-query-013-selection-range",
       "budget_id": "perf.lsp.selection_ranges.nested",
-      "threshold_median_instructions": 370033801
+      "threshold_median_instructions": 369783669,
+      "threshold_peak_rss_bytes": 107773952
     },
     {
-      "baseline_median_instructions": 358831784,
+      "baseline_median_instructions": 358694618,
+      "baseline_peak_rss_bytes": 74055680,
       "benchmark_id": "lsp-query-014-type-hierarchy",
       "budget_id": "perf.lsp.type_hierarchy.symbol",
-      "threshold_median_instructions": 366008420
+      "threshold_median_instructions": 365868511,
+      "threshold_peak_rss_bytes": 107610112
     },
     {
-      "baseline_median_instructions": 360126993,
+      "baseline_median_instructions": 359339289,
+      "baseline_peak_rss_bytes": 73580544,
       "benchmark_id": "lsp-query-015-code-actions",
       "budget_id": "perf.lsp.code_action.diagnostic",
-      "threshold_median_instructions": 367329533
+      "threshold_median_instructions": 366526075,
+      "threshold_peak_rss_bytes": 107134976
     },
     {
-      "baseline_median_instructions": 383007442,
+      "baseline_median_instructions": 382561712,
+      "baseline_peak_rss_bytes": 75841536,
       "benchmark_id": "lsp-query-016-formatting",
       "budget_id": "perf.lsp.formatting.document",
-      "threshold_median_instructions": 390667591
+      "threshold_median_instructions": 390212947,
+      "threshold_peak_rss_bytes": 109395968
     },
     {
-      "baseline_median_instructions": 360914375,
+      "baseline_median_instructions": 361199696,
+      "baseline_peak_rss_bytes": 114540544,
       "benchmark_id": "lsp-query-017-generated-rust-preview",
       "budget_id": "perf.lsp.generated_rust_preview.document",
-      "threshold_median_instructions": 368132663
+      "threshold_median_instructions": 368423690,
+      "threshold_peak_rss_bytes": 148094976
     },
     {
-      "baseline_median_instructions": 406391682,
+      "baseline_median_instructions": 409463304,
+      "baseline_peak_rss_bytes": 2538471424,
       "benchmark_id": "lsp-query-018-did-open-diagnostics",
       "budget_id": "perf.lsp.document_sync.did_open",
-      "threshold_median_instructions": 414519516
+      "threshold_median_instructions": 417652571,
+      "threshold_peak_rss_bytes": 2792318567
     }
   ],
   "host": {
     "architecture": "arm64",
     "host_os": "macOS-26.6-arm64-arm-64bit-Mach-O",
+    "rss_counter_source": "darwin-rusage-process-tree",
     "work_counter_source": "darwin-rusage-instructions"
   },
+  "instruction_threshold_rule": "max(baseline_median_instructions * 1.02, baseline_median_instructions + 1000000)",
+  "rss_threshold_rule": "max(baseline_peak_rss_bytes * 1.10, baseline_peak_rss_bytes + 33554432)",
   "runner_version": 1,
-  "source_commit": "00ae57a0f569ed578f665e01a017cec0e3c19369",
-  "threshold_rule": "max(baseline_median_instructions * 1.02, baseline_median_instructions + 1000000)",
+  "source_commit": "c5d4c68f317d01f86bb15f45862a52d6f54af86e",
   "version": 1
 }

--- a/verification/areas/performance/data/work_budgets.json
+++ b/verification/areas/performance/data/work_budgets.json
@@ -1,524 +1,524 @@
 {
   "budgets": [
     {
-      "baseline_median_instructions": 117209565091,
-      "baseline_peak_rss_bytes": 208617472,
+      "baseline_median_instructions": 117366879367,
+      "baseline_peak_rss_bytes": 208338944,
       "benchmark_id": "build-project-001-additional-modules",
       "budget_id": "perf.build.project.additional_modules",
-      "threshold_median_instructions": 119553756393,
-      "threshold_peak_rss_bytes": 242171904
+      "threshold_median_instructions": 119714216955,
+      "threshold_peak_rss_bytes": 241893376
     },
     {
-      "baseline_median_instructions": 111176753544,
-      "baseline_peak_rss_bytes": 146964480,
+      "baseline_median_instructions": 111363544304,
+      "baseline_peak_rss_bytes": 147849216,
       "benchmark_id": "build-project-002-branch-paths",
       "budget_id": "perf.build.project.branch_paths",
-      "threshold_median_instructions": 113400288615,
-      "threshold_peak_rss_bytes": 180518912
+      "threshold_median_instructions": 113590815191,
+      "threshold_peak_rss_bytes": 181403648
     },
     {
-      "baseline_median_instructions": 111177118760,
-      "baseline_peak_rss_bytes": 146718720,
+      "baseline_median_instructions": 111358067829,
+      "baseline_peak_rss_bytes": 147062784,
       "benchmark_id": "build-project-003-cargo-manifest",
       "budget_id": "perf.build.project.cargo_manifest",
-      "threshold_median_instructions": 113400661136,
-      "threshold_peak_rss_bytes": 180273152
+      "threshold_median_instructions": 113585229186,
+      "threshold_peak_rss_bytes": 180617216
     },
     {
-      "baseline_median_instructions": 115837303412,
-      "baseline_peak_rss_bytes": 155828224,
+      "baseline_median_instructions": 116021392507,
+      "baseline_peak_rss_bytes": 155910144,
       "benchmark_id": "build-project-004-dependency-manifest",
       "budget_id": "perf.build.project.dependency_manifest",
-      "threshold_median_instructions": 118154049481,
-      "threshold_peak_rss_bytes": 189382656
+      "threshold_median_instructions": 118341820358,
+      "threshold_peak_rss_bytes": 189464576
     },
     {
-      "baseline_median_instructions": 111266842588,
-      "baseline_peak_rss_bytes": 146358272,
+      "baseline_median_instructions": 111449344172,
+      "baseline_peak_rss_bytes": 146276352,
       "benchmark_id": "build-project-005-project-graph",
       "budget_id": "perf.build.project.project_graph",
-      "threshold_median_instructions": 113492179440,
-      "threshold_peak_rss_bytes": 179912704
+      "threshold_median_instructions": 113678331056,
+      "threshold_peak_rss_bytes": 179830784
     },
     {
-      "baseline_median_instructions": 111113538568,
-      "baseline_peak_rss_bytes": 147456000,
+      "baseline_median_instructions": 111273671600,
+      "baseline_peak_rss_bytes": 148045824,
       "benchmark_id": "build-single-file-001-break-continue",
       "budget_id": "perf.build.single.break_continue",
-      "threshold_median_instructions": 113335809340,
-      "threshold_peak_rss_bytes": 181010432
+      "threshold_median_instructions": 113499145032,
+      "threshold_peak_rss_bytes": 181600256
     },
     {
-      "baseline_median_instructions": 111110114389,
-      "baseline_peak_rss_bytes": 146456576,
+      "baseline_median_instructions": 111263137801,
+      "baseline_peak_rss_bytes": 147947520,
       "benchmark_id": "build-single-file-002-builtin-any-all",
       "budget_id": "perf.build.single.builtin_any_all",
-      "threshold_median_instructions": 113332316677,
-      "threshold_peak_rss_bytes": 180011008
+      "threshold_median_instructions": 113488400558,
+      "threshold_peak_rss_bytes": 181501952
     },
     {
-      "baseline_median_instructions": 111094621330,
-      "baseline_peak_rss_bytes": 146292736,
+      "baseline_median_instructions": 111254004968,
+      "baseline_peak_rss_bytes": 146915328,
       "benchmark_id": "build-single-file-003-builtin-enumerate-zip",
       "budget_id": "perf.build.single.builtin_enumerate_zip",
-      "threshold_median_instructions": 113316513757,
-      "threshold_peak_rss_bytes": 179847168
+      "threshold_median_instructions": 113479085068,
+      "threshold_peak_rss_bytes": 180469760
     },
     {
-      "baseline_median_instructions": 111134363649,
-      "baseline_peak_rss_bytes": 146178048,
+      "baseline_median_instructions": 111295921732,
+      "baseline_peak_rss_bytes": 148013056,
       "benchmark_id": "build-single-file-004-bytes-constructors",
       "budget_id": "perf.build.single.bytes_constructors",
-      "threshold_median_instructions": 113357050922,
-      "threshold_peak_rss_bytes": 179732480
+      "threshold_median_instructions": 113521840167,
+      "threshold_peak_rss_bytes": 181567488
     },
     {
-      "baseline_median_instructions": 111120205202,
-      "baseline_peak_rss_bytes": 147128320,
+      "baseline_median_instructions": 111287235483,
+      "baseline_peak_rss_bytes": 147652608,
       "benchmark_id": "build-single-file-005-class-methods",
       "budget_id": "perf.build.single.class_methods",
-      "threshold_median_instructions": 113342609307,
-      "threshold_peak_rss_bytes": 180682752
+      "threshold_median_instructions": 113512980193,
+      "threshold_peak_rss_bytes": 181207040
     },
     {
-      "baseline_median_instructions": 111106072567,
-      "baseline_peak_rss_bytes": 146571264,
+      "baseline_median_instructions": 111259140667,
+      "baseline_peak_rss_bytes": 146882560,
       "benchmark_id": "build-single-file-006-collection-len",
       "budget_id": "perf.build.single.collection_len",
-      "threshold_median_instructions": 113328194019,
-      "threshold_peak_rss_bytes": 180125696
+      "threshold_median_instructions": 113484323481,
+      "threshold_peak_rss_bytes": 180436992
     },
     {
-      "baseline_median_instructions": 111094715611,
-      "baseline_peak_rss_bytes": 147521536,
+      "baseline_median_instructions": 111263407113,
+      "baseline_peak_rss_bytes": 147898368,
       "benchmark_id": "build-single-file-007-comp-set",
       "budget_id": "perf.build.single.comp_set",
-      "threshold_median_instructions": 113316609924,
-      "threshold_peak_rss_bytes": 181075968
+      "threshold_median_instructions": 113488675256,
+      "threshold_peak_rss_bytes": 181452800
     },
     {
-      "baseline_median_instructions": 115064991613,
-      "baseline_peak_rss_bytes": 166264832,
+      "baseline_median_instructions": 115242632287,
+      "baseline_peak_rss_bytes": 166100992,
       "benchmark_id": "build-single-file-008-decimal-conversions",
       "budget_id": "perf.build.single.decimal_conversions",
-      "threshold_median_instructions": 117366291446,
-      "threshold_peak_rss_bytes": 199819264
+      "threshold_median_instructions": 117547484933,
+      "threshold_peak_rss_bytes": 199655424
     },
     {
-      "baseline_median_instructions": 111105665779,
-      "baseline_peak_rss_bytes": 146145280,
+      "baseline_median_instructions": 111279967570,
+      "baseline_peak_rss_bytes": 146669568,
       "benchmark_id": "build-single-file-009-dict-get-option",
       "budget_id": "perf.build.single.dict_get_option",
-      "threshold_median_instructions": 113327779095,
-      "threshold_peak_rss_bytes": 179699712
+      "threshold_median_instructions": 113505566922,
+      "threshold_peak_rss_bytes": 180224000
     },
     {
-      "baseline_median_instructions": 111108046581,
-      "baseline_peak_rss_bytes": 146784256,
+      "baseline_median_instructions": 111283440813,
+      "baseline_peak_rss_bytes": 148209664,
       "benchmark_id": "build-single-file-010-generic-identity",
       "budget_id": "perf.build.single.generic_identity",
-      "threshold_median_instructions": 113330207513,
-      "threshold_peak_rss_bytes": 180338688
+      "threshold_median_instructions": 113509109630,
+      "threshold_peak_rss_bytes": 181764096
     },
     {
-      "baseline_median_instructions": 13626785484,
-      "baseline_peak_rss_bytes": 145997824,
+      "baseline_median_instructions": 13628063634,
+      "baseline_peak_rss_bytes": 146341888,
       "benchmark_id": "check-project-001-imports",
       "budget_id": "perf.check.project.imports",
-      "threshold_median_instructions": 13899321194,
-      "threshold_peak_rss_bytes": 179552256
+      "threshold_median_instructions": 13900624907,
+      "threshold_peak_rss_bytes": 179896320
     },
     {
-      "baseline_median_instructions": 13623155443,
-      "baseline_peak_rss_bytes": 147324928,
+      "baseline_median_instructions": 13621193633,
+      "baseline_peak_rss_bytes": 147210240,
       "benchmark_id": "check-project-002-mode-consistency",
       "budget_id": "perf.check.project.mode_consistency",
-      "threshold_median_instructions": 13895618552,
-      "threshold_peak_rss_bytes": 180879360
+      "threshold_median_instructions": 13893617506,
+      "threshold_peak_rss_bytes": 180764672
     },
     {
-      "baseline_median_instructions": 13659775453,
-      "baseline_peak_rss_bytes": 146587648,
+      "baseline_median_instructions": 13658729713,
+      "baseline_peak_rss_bytes": 147374080,
       "benchmark_id": "check-project-003-project-build",
       "budget_id": "perf.check.project.project_build",
-      "threshold_median_instructions": 13932970963,
-      "threshold_peak_rss_bytes": 180142080
+      "threshold_median_instructions": 13931904308,
+      "threshold_peak_rss_bytes": 180928512
     },
     {
-      "baseline_median_instructions": 13654644871,
-      "baseline_peak_rss_bytes": 146571264,
+      "baseline_median_instructions": 13654684063,
+      "baseline_peak_rss_bytes": 146669568,
       "benchmark_id": "check-project-004-project-graph",
       "budget_id": "perf.check.project.project_graph",
-      "threshold_median_instructions": 13927737769,
-      "threshold_peak_rss_bytes": 180125696
+      "threshold_median_instructions": 13927777745,
+      "threshold_peak_rss_bytes": 180224000
     },
     {
-      "baseline_median_instructions": 13649941834,
-      "baseline_peak_rss_bytes": 147537920,
+      "baseline_median_instructions": 13653828260,
+      "baseline_peak_rss_bytes": 146325504,
       "benchmark_id": "check-project-005-rooted-entrypoint",
       "budget_id": "perf.check.project.rooted_entrypoint",
-      "threshold_median_instructions": 13922940671,
-      "threshold_peak_rss_bytes": 181092352
+      "threshold_median_instructions": 13926904826,
+      "threshold_peak_rss_bytes": 179879936
     },
     {
-      "baseline_median_instructions": 13584137194,
-      "baseline_peak_rss_bytes": 147111936,
+      "baseline_median_instructions": 13598720598,
+      "baseline_peak_rss_bytes": 146096128,
       "benchmark_id": "check-single-file-001-arithmetic",
       "budget_id": "perf.check.single.arithmetic",
-      "threshold_median_instructions": 13855819938,
-      "threshold_peak_rss_bytes": 180666368
+      "threshold_median_instructions": 13870695010,
+      "threshold_peak_rss_bytes": 179650560
     },
     {
-      "baseline_median_instructions": 13585430760,
-      "baseline_peak_rss_bytes": 147390464,
+      "baseline_median_instructions": 13593945257,
+      "baseline_peak_rss_bytes": 147619840,
       "benchmark_id": "check-single-file-002-break-continue",
       "budget_id": "perf.check.single.break_continue",
-      "threshold_median_instructions": 13857139376,
-      "threshold_peak_rss_bytes": 180944896
+      "threshold_median_instructions": 13865824163,
+      "threshold_peak_rss_bytes": 181174272
     },
     {
-      "baseline_median_instructions": 13591069267,
-      "baseline_peak_rss_bytes": 147193856,
+      "baseline_median_instructions": 13587989293,
+      "baseline_peak_rss_bytes": 146735104,
       "benchmark_id": "check-single-file-003-builtin-any-all",
       "budget_id": "perf.check.single.builtin_any_all",
-      "threshold_median_instructions": 13862890653,
-      "threshold_peak_rss_bytes": 180748288
+      "threshold_median_instructions": 13859749079,
+      "threshold_peak_rss_bytes": 180289536
     },
     {
-      "baseline_median_instructions": 13594599134,
-      "baseline_peak_rss_bytes": 146571264,
+      "baseline_median_instructions": 13592734841,
+      "baseline_peak_rss_bytes": 146489344,
       "benchmark_id": "check-single-file-004-builtin-enumerate-zip",
       "budget_id": "perf.check.single.builtin_enumerate_zip",
-      "threshold_median_instructions": 13866491117,
-      "threshold_peak_rss_bytes": 180125696
-    },
-    {
-      "baseline_median_instructions": 13599607981,
-      "baseline_peak_rss_bytes": 146063360,
-      "benchmark_id": "check-single-file-005-bytes-constructors",
-      "budget_id": "perf.check.single.bytes_constructors",
-      "threshold_median_instructions": 13871600141,
-      "threshold_peak_rss_bytes": 179617792
-    },
-    {
-      "baseline_median_instructions": 13589589616,
-      "baseline_peak_rss_bytes": 146489344,
-      "benchmark_id": "check-single-file-006-class-methods",
-      "budget_id": "perf.check.single.class_methods",
-      "threshold_median_instructions": 13861381409,
+      "threshold_median_instructions": 13864589538,
       "threshold_peak_rss_bytes": 180043776
     },
     {
-      "baseline_median_instructions": 13591810560,
-      "baseline_peak_rss_bytes": 147996672,
+      "baseline_median_instructions": 13602484283,
+      "baseline_peak_rss_bytes": 147243008,
+      "benchmark_id": "check-single-file-005-bytes-constructors",
+      "budget_id": "perf.check.single.bytes_constructors",
+      "threshold_median_instructions": 13874533969,
+      "threshold_peak_rss_bytes": 180797440
+    },
+    {
+      "baseline_median_instructions": 13591422176,
+      "baseline_peak_rss_bytes": 147193856,
+      "benchmark_id": "check-single-file-006-class-methods",
+      "budget_id": "perf.check.single.class_methods",
+      "threshold_median_instructions": 13863250620,
+      "threshold_peak_rss_bytes": 180748288
+    },
+    {
+      "baseline_median_instructions": 13588889227,
+      "baseline_peak_rss_bytes": 145932288,
       "benchmark_id": "check-single-file-007-collection-len",
       "budget_id": "perf.check.single.collection_len",
-      "threshold_median_instructions": 13863646772,
-      "threshold_peak_rss_bytes": 181551104
+      "threshold_median_instructions": 13860667012,
+      "threshold_peak_rss_bytes": 179486720
     },
     {
-      "baseline_median_instructions": 13589509356,
-      "baseline_peak_rss_bytes": 147095552,
+      "baseline_median_instructions": 13594338945,
+      "baseline_peak_rss_bytes": 147292160,
       "benchmark_id": "check-single-file-008-comp-set",
       "budget_id": "perf.check.single.comp_set",
-      "threshold_median_instructions": 13861299544,
-      "threshold_peak_rss_bytes": 180649984
+      "threshold_median_instructions": 13866225724,
+      "threshold_peak_rss_bytes": 180846592
     },
     {
-      "baseline_median_instructions": 13594326804,
-      "baseline_peak_rss_bytes": 146751488,
+      "baseline_median_instructions": 13599886025,
+      "baseline_peak_rss_bytes": 146882560,
       "benchmark_id": "check-single-file-009-decimal-conversions",
       "budget_id": "perf.check.single.decimal_conversions",
-      "threshold_median_instructions": 13866213341,
+      "threshold_median_instructions": 13871883746,
+      "threshold_peak_rss_bytes": 180436992
+    },
+    {
+      "baseline_median_instructions": 13596932317,
+      "baseline_peak_rss_bytes": 146751488,
+      "benchmark_id": "check-single-file-010-dict-get-option",
+      "budget_id": "perf.check.single.dict_get_option",
+      "threshold_median_instructions": 13868870964,
       "threshold_peak_rss_bytes": 180305920
     },
     {
-      "baseline_median_instructions": 13592509384,
-      "baseline_peak_rss_bytes": 146554880,
-      "benchmark_id": "check-single-file-010-dict-get-option",
-      "budget_id": "perf.check.single.dict_get_option",
-      "threshold_median_instructions": 13864359572,
-      "threshold_peak_rss_bytes": 180109312
-    },
-    {
-      "baseline_median_instructions": 13592960600,
-      "baseline_peak_rss_bytes": 146423808,
+      "baseline_median_instructions": 13588915720,
+      "baseline_peak_rss_bytes": 147324928,
       "benchmark_id": "diagnostic-non-regression-001-human-success-exit",
       "budget_id": "perf.diagnostic.human_success_exit",
-      "threshold_median_instructions": 13864819812,
-      "threshold_peak_rss_bytes": 179978240
+      "threshold_median_instructions": 13860694035,
+      "threshold_peak_rss_bytes": 180879360
     },
     {
-      "baseline_median_instructions": 13586178758,
-      "baseline_peak_rss_bytes": 146259968,
+      "baseline_median_instructions": 13593930029,
+      "baseline_peak_rss_bytes": 146374656,
       "benchmark_id": "diagnostic-non-regression-002-json-diagnostic-schema",
       "budget_id": "perf.diagnostic.json_diagnostic_schema",
-      "threshold_median_instructions": 13857902334,
-      "threshold_peak_rss_bytes": 179814400
+      "threshold_median_instructions": 13865808630,
+      "threshold_peak_rss_bytes": 179929088
     },
     {
-      "baseline_median_instructions": 13586469815,
-      "baseline_peak_rss_bytes": 146604032,
+      "baseline_median_instructions": 13590487638,
+      "baseline_peak_rss_bytes": 146194432,
       "benchmark_id": "diagnostic-non-regression-003-compact-diagnostic-schema",
       "budget_id": "perf.diagnostic.compact_diagnostic_schema",
-      "threshold_median_instructions": 13858199212,
-      "threshold_peak_rss_bytes": 180158464
+      "threshold_median_instructions": 13862297391,
+      "threshold_peak_rss_bytes": 179748864
     },
     {
-      "baseline_median_instructions": 13590813905,
-      "baseline_peak_rss_bytes": 146423808,
+      "baseline_median_instructions": 13597589857,
+      "baseline_peak_rss_bytes": 148062208,
       "benchmark_id": "diagnostic-non-regression-004-recovery-limit",
       "budget_id": "perf.diagnostic.recovery_limit",
-      "threshold_median_instructions": 13862630184,
-      "threshold_peak_rss_bytes": 179978240
+      "threshold_median_instructions": 13869541655,
+      "threshold_peak_rss_bytes": 181616640
     },
     {
-      "baseline_median_instructions": 13512216054,
-      "baseline_peak_rss_bytes": 146440192,
+      "baseline_median_instructions": 13512422104,
+      "baseline_peak_rss_bytes": 146096128,
       "benchmark_id": "diagnostic-non-regression-005-project-error-exit",
       "budget_id": "perf.diagnostic.project_error_exit",
-      "threshold_median_instructions": 13782460376,
-      "threshold_peak_rss_bytes": 179994624
+      "threshold_median_instructions": 13782670547,
+      "threshold_peak_rss_bytes": 179650560
     },
     {
-      "baseline_median_instructions": 35832568,
-      "baseline_peak_rss_bytes": 11272192,
+      "baseline_median_instructions": 35740514,
+      "baseline_peak_rss_bytes": 11223040,
       "benchmark_id": "formatter-corpus-001-project-check",
       "budget_id": "perf.formatter.corpus.project_check",
-      "threshold_median_instructions": 37832568,
-      "threshold_peak_rss_bytes": 44826624
+      "threshold_median_instructions": 37740514,
+      "threshold_peak_rss_bytes": 44777472
     },
     {
-      "baseline_median_instructions": 56924882,
+      "baseline_median_instructions": 56993708,
       "baseline_peak_rss_bytes": 11517952,
       "benchmark_id": "formatter-large-file-001-check",
       "budget_id": "perf.formatter.large_file.check",
-      "threshold_median_instructions": 58924882,
+      "threshold_median_instructions": 58993708,
       "threshold_peak_rss_bytes": 45072384
     },
     {
-      "baseline_median_instructions": 897964056,
+      "baseline_median_instructions": 912264683,
       "baseline_peak_rss_bytes": 5128192,
       "benchmark_id": "incremental-local-loop-001-unchanged-file-update",
       "budget_id": "perf.incremental.unchanged_file_update",
-      "threshold_median_instructions": 915923338,
+      "threshold_median_instructions": 930509977,
       "threshold_peak_rss_bytes": 38682624
     },
     {
-      "baseline_median_instructions": 674931340,
-      "baseline_peak_rss_bytes": 5046272,
+      "baseline_median_instructions": 686173679,
+      "baseline_peak_rss_bytes": 5029888,
       "benchmark_id": "incremental-local-loop-002-leaf-module-change",
       "budget_id": "perf.incremental.leaf_module_change",
-      "threshold_median_instructions": 688429967,
-      "threshold_peak_rss_bytes": 38600704
+      "threshold_median_instructions": 699897153,
+      "threshold_peak_rss_bytes": 38584320
     },
     {
-      "baseline_median_instructions": 3813105990,
-      "baseline_peak_rss_bytes": 8224768,
+      "baseline_median_instructions": 3823339120,
+      "baseline_peak_rss_bytes": 8159232,
       "benchmark_id": "incremental-local-loop-003-imported-module-change",
       "budget_id": "perf.incremental.imported_module_change",
-      "threshold_median_instructions": 3889368110,
-      "threshold_peak_rss_bytes": 41779200
+      "threshold_median_instructions": 3899805903,
+      "threshold_peak_rss_bytes": 41713664
     },
     {
-      "baseline_median_instructions": 4455611948,
-      "baseline_peak_rss_bytes": 8175616,
+      "baseline_median_instructions": 4467146083,
+      "baseline_peak_rss_bytes": 7979008,
       "benchmark_id": "incremental-local-loop-004-public-api-change",
       "budget_id": "perf.incremental.public_api_change",
-      "threshold_median_instructions": 4544724187,
+      "threshold_median_instructions": 4556489005,
+      "threshold_peak_rss_bytes": 41533440
+    },
+    {
+      "baseline_median_instructions": 4169104580,
+      "baseline_peak_rss_bytes": 8192000,
+      "benchmark_id": "incremental-local-loop-005-failure-recovery",
+      "budget_id": "perf.incremental.failure_recovery",
+      "threshold_median_instructions": 4252486672,
+      "threshold_peak_rss_bytes": 41746432
+    },
+    {
+      "baseline_median_instructions": 376122368,
+      "baseline_peak_rss_bytes": 4734976,
+      "benchmark_id": "interactive-tooling-foundation-001-cold-context-load",
+      "budget_id": "perf.interactive.cold_context_load",
+      "threshold_median_instructions": 383644816,
+      "threshold_peak_rss_bytes": 38289408
+    },
+    {
+      "baseline_median_instructions": 1450757474,
+      "baseline_peak_rss_bytes": 7798784,
+      "benchmark_id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "threshold_median_instructions": 1479772624,
+      "threshold_peak_rss_bytes": 41353216
+    },
+    {
+      "baseline_median_instructions": 590843118,
+      "baseline_peak_rss_bytes": 4767744,
+      "benchmark_id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "threshold_median_instructions": 602659981,
+      "threshold_peak_rss_bytes": 38322176
+    },
+    {
+      "baseline_median_instructions": 2344895148,
+      "baseline_peak_rss_bytes": 8175616,
+      "benchmark_id": "interactive-tooling-foundation-004-changed-file-invalidation",
+      "budget_id": "perf.interactive.changed_file_invalidation",
+      "threshold_median_instructions": 2391793051,
       "threshold_peak_rss_bytes": 41730048
     },
     {
-      "baseline_median_instructions": 4153795778,
-      "baseline_peak_rss_bytes": 8224768,
-      "benchmark_id": "incremental-local-loop-005-failure-recovery",
-      "budget_id": "perf.incremental.failure_recovery",
-      "threshold_median_instructions": 4236871694,
-      "threshold_peak_rss_bytes": 41779200
-    },
-    {
-      "baseline_median_instructions": 373263308,
-      "baseline_peak_rss_bytes": 4784128,
-      "benchmark_id": "interactive-tooling-foundation-001-cold-context-load",
-      "budget_id": "perf.interactive.cold_context_load",
-      "threshold_median_instructions": 380728575,
-      "threshold_peak_rss_bytes": 38338560
-    },
-    {
-      "baseline_median_instructions": 1447004242,
-      "baseline_peak_rss_bytes": 7831552,
-      "benchmark_id": "interactive-tooling-foundation-002-warm-diagnostics-query",
-      "budget_id": "perf.interactive.warm_diagnostics_query",
-      "threshold_median_instructions": 1475944327,
-      "threshold_peak_rss_bytes": 41385984
-    },
-    {
-      "baseline_median_instructions": 584909349,
-      "baseline_peak_rss_bytes": 4800512,
-      "benchmark_id": "interactive-tooling-foundation-003-unchanged-file-update",
-      "budget_id": "perf.interactive.unchanged_file_update",
-      "threshold_median_instructions": 596607536,
-      "threshold_peak_rss_bytes": 38354944
-    },
-    {
-      "baseline_median_instructions": 2341417888,
-      "baseline_peak_rss_bytes": 8142848,
-      "benchmark_id": "interactive-tooling-foundation-004-changed-file-invalidation",
-      "budget_id": "perf.interactive.changed_file_invalidation",
-      "threshold_median_instructions": 2388246246,
-      "threshold_peak_rss_bytes": 41697280
-    },
-    {
-      "baseline_median_instructions": 216149363,
-      "baseline_peak_rss_bytes": 4653056,
+      "baseline_median_instructions": 219137306,
+      "baseline_peak_rss_bytes": 4685824,
       "benchmark_id": "interactive-tooling-foundation-005-source-map-lookup",
       "budget_id": "perf.interactive.source_map_lookup",
-      "threshold_median_instructions": 220472351,
-      "threshold_peak_rss_bytes": 38207488
+      "threshold_median_instructions": 223520053,
+      "threshold_peak_rss_bytes": 38240256
     },
     {
-      "baseline_median_instructions": 380218082,
-      "baseline_peak_rss_bytes": 115032064,
+      "baseline_median_instructions": 379865318,
+      "baseline_peak_rss_bytes": 117260288,
       "benchmark_id": "lsp-query-001-request-families",
       "budget_id": "perf.lsp.request_families",
-      "threshold_median_instructions": 387822444,
-      "threshold_peak_rss_bytes": 148586496
+      "threshold_median_instructions": 387462625,
+      "threshold_peak_rss_bytes": 150814720
     },
     {
-      "baseline_median_instructions": 323058464,
-      "baseline_peak_rss_bytes": 21544960,
+      "baseline_median_instructions": 324056118,
+      "baseline_peak_rss_bytes": 21528576,
       "benchmark_id": "lsp-query-002-cold-start",
       "budget_id": "perf.lsp.cold_start.workspace",
-      "threshold_median_instructions": 329519634,
-      "threshold_peak_rss_bytes": 55099392
+      "threshold_median_instructions": 330537241,
+      "threshold_peak_rss_bytes": 55083008
     },
     {
-      "baseline_median_instructions": 380083966,
-      "baseline_peak_rss_bytes": 74465280,
+      "baseline_median_instructions": 380808384,
+      "baseline_peak_rss_bytes": 73531392,
       "benchmark_id": "lsp-query-003-diagnostics",
       "budget_id": "perf.lsp.diagnostics.document",
-      "threshold_median_instructions": 387685646,
-      "threshold_peak_rss_bytes": 108019712
+      "threshold_median_instructions": 388424552,
+      "threshold_peak_rss_bytes": 107085824
     },
     {
-      "baseline_median_instructions": 340673100,
-      "baseline_peak_rss_bytes": 158171136,
+      "baseline_median_instructions": 344220086,
+      "baseline_peak_rss_bytes": 157417472,
       "benchmark_id": "lsp-query-004-workspace-diagnostics",
       "budget_id": "perf.lsp.diagnostics.workspace",
-      "threshold_median_instructions": 347486562,
-      "threshold_peak_rss_bytes": 191725568
+      "threshold_median_instructions": 351104488,
+      "threshold_peak_rss_bytes": 190971904
     },
     {
-      "baseline_median_instructions": 1320214578,
-      "baseline_peak_rss_bytes": 76988416,
+      "baseline_median_instructions": 1318881876,
+      "baseline_peak_rss_bytes": 77119488,
       "benchmark_id": "lsp-query-005-completion",
       "budget_id": "perf.lsp.completion.local_scope",
-      "threshold_median_instructions": 1346618870,
-      "threshold_peak_rss_bytes": 110542848
+      "threshold_median_instructions": 1345259514,
+      "threshold_peak_rss_bytes": 110673920
     },
     {
-      "baseline_median_instructions": 359050384,
-      "baseline_peak_rss_bytes": 75431936,
+      "baseline_median_instructions": 359901907,
+      "baseline_peak_rss_bytes": 74891264,
       "benchmark_id": "lsp-query-006-hover",
       "budget_id": "perf.lsp.hover.symbol",
-      "threshold_median_instructions": 366231392,
-      "threshold_peak_rss_bytes": 108986368
+      "threshold_median_instructions": 367099946,
+      "threshold_peak_rss_bytes": 108445696
     },
     {
-      "baseline_median_instructions": 359483846,
-      "baseline_peak_rss_bytes": 74612736,
+      "baseline_median_instructions": 360106184,
+      "baseline_peak_rss_bytes": 74743808,
       "benchmark_id": "lsp-query-007-signature-help",
       "budget_id": "perf.lsp.signature_help.call",
-      "threshold_median_instructions": 366673523,
-      "threshold_peak_rss_bytes": 108167168
+      "threshold_median_instructions": 367308308,
+      "threshold_peak_rss_bytes": 108298240
     },
     {
-      "baseline_median_instructions": 490977524,
-      "baseline_peak_rss_bytes": 74547200,
+      "baseline_median_instructions": 491335950,
+      "baseline_peak_rss_bytes": 74956800,
       "benchmark_id": "lsp-query-008-navigation",
       "budget_id": "perf.lsp.navigation.symbol",
-      "threshold_median_instructions": 500797075,
-      "threshold_peak_rss_bytes": 108101632
+      "threshold_median_instructions": 501162669,
+      "threshold_peak_rss_bytes": 108511232
     },
     {
-      "baseline_median_instructions": 340858978,
-      "baseline_peak_rss_bytes": 157908992,
+      "baseline_median_instructions": 344051513,
+      "baseline_peak_rss_bytes": 158547968,
       "benchmark_id": "lsp-query-009-references",
       "budget_id": "perf.lsp.references.workspace_symbol",
-      "threshold_median_instructions": 347676158,
-      "threshold_peak_rss_bytes": 191463424
+      "threshold_median_instructions": 350932544,
+      "threshold_peak_rss_bytes": 192102400
     },
     {
-      "baseline_median_instructions": 361560252,
-      "baseline_peak_rss_bytes": 157859840,
+      "baseline_median_instructions": 362697306,
+      "baseline_peak_rss_bytes": 159023104,
       "benchmark_id": "lsp-query-010-rename",
       "budget_id": "perf.lsp.rename.workspace_edit",
-      "threshold_median_instructions": 368791458,
-      "threshold_peak_rss_bytes": 191414272
+      "threshold_median_instructions": 369951253,
+      "threshold_peak_rss_bytes": 192577536
     },
     {
-      "baseline_median_instructions": 393444814,
-      "baseline_peak_rss_bytes": 74711040,
+      "baseline_median_instructions": 396257226,
+      "baseline_peak_rss_bytes": 74629120,
       "benchmark_id": "lsp-query-011-semantic-tokens",
       "budget_id": "perf.lsp.semantic_tokens.full",
-      "threshold_median_instructions": 401313711,
-      "threshold_peak_rss_bytes": 108265472
+      "threshold_median_instructions": 404182371,
+      "threshold_peak_rss_bytes": 108183552
     },
     {
-      "baseline_median_instructions": 361092899,
-      "baseline_peak_rss_bytes": 73613312,
+      "baseline_median_instructions": 361564288,
+      "baseline_peak_rss_bytes": 75448320,
       "benchmark_id": "lsp-query-012-inlay-hints",
       "budget_id": "perf.lsp.inlay_hints.module",
-      "threshold_median_instructions": 368314757,
-      "threshold_peak_rss_bytes": 107167744
+      "threshold_median_instructions": 368795574,
+      "threshold_peak_rss_bytes": 109002752
     },
     {
-      "baseline_median_instructions": 361209882,
-      "baseline_peak_rss_bytes": 73285632,
+      "baseline_median_instructions": 364159396,
+      "baseline_peak_rss_bytes": 73498624,
       "benchmark_id": "lsp-query-013-selection-range",
       "budget_id": "perf.lsp.selection_ranges.nested",
-      "threshold_median_instructions": 368434080,
-      "threshold_peak_rss_bytes": 106840064
+      "threshold_median_instructions": 371442584,
+      "threshold_peak_rss_bytes": 107053056
     },
     {
-      "baseline_median_instructions": 357726506,
-      "baseline_peak_rss_bytes": 74203136,
+      "baseline_median_instructions": 359354772,
+      "baseline_peak_rss_bytes": 73465856,
       "benchmark_id": "lsp-query-014-type-hierarchy",
       "budget_id": "perf.lsp.type_hierarchy.symbol",
-      "threshold_median_instructions": 364881037,
-      "threshold_peak_rss_bytes": 107757568
+      "threshold_median_instructions": 366541868,
+      "threshold_peak_rss_bytes": 107020288
     },
     {
-      "baseline_median_instructions": 357473489,
-      "baseline_peak_rss_bytes": 73580544,
+      "baseline_median_instructions": 360830528,
+      "baseline_peak_rss_bytes": 73629696,
       "benchmark_id": "lsp-query-015-code-actions",
       "budget_id": "perf.lsp.code_action.diagnostic",
-      "threshold_median_instructions": 364622959,
-      "threshold_peak_rss_bytes": 107134976
+      "threshold_median_instructions": 368047139,
+      "threshold_peak_rss_bytes": 107184128
     },
     {
-      "baseline_median_instructions": 382003658,
-      "baseline_peak_rss_bytes": 74366976,
+      "baseline_median_instructions": 383946752,
+      "baseline_peak_rss_bytes": 74268672,
       "benchmark_id": "lsp-query-016-formatting",
       "budget_id": "perf.lsp.formatting.document",
-      "threshold_median_instructions": 389643732,
-      "threshold_peak_rss_bytes": 107921408
+      "threshold_median_instructions": 391625688,
+      "threshold_peak_rss_bytes": 107823104
     },
     {
-      "baseline_median_instructions": 361828992,
-      "baseline_peak_rss_bytes": 112623616,
+      "baseline_median_instructions": 362272364,
+      "baseline_peak_rss_bytes": 110313472,
       "benchmark_id": "lsp-query-017-generated-rust-preview",
       "budget_id": "perf.lsp.generated_rust_preview.document",
-      "threshold_median_instructions": 369065572,
-      "threshold_peak_rss_bytes": 146178048
+      "threshold_median_instructions": 369517812,
+      "threshold_peak_rss_bytes": 143867904
     },
     {
-      "baseline_median_instructions": 407490070,
-      "baseline_peak_rss_bytes": 2467971072,
+      "baseline_median_instructions": 409337134,
+      "baseline_peak_rss_bytes": 2455863296,
       "benchmark_id": "lsp-query-018-did-open-diagnostics",
       "budget_id": "perf.lsp.document_sync.did_open",
-      "threshold_median_instructions": 415639872,
-      "threshold_peak_rss_bytes": 2714768180
+      "threshold_median_instructions": 417523877,
+      "threshold_peak_rss_bytes": 2701449626
     }
   ],
   "host": {
@@ -530,6 +530,6 @@
   "instruction_threshold_rule": "max(baseline_median_instructions * 1.02, baseline_median_instructions + 2000000)",
   "rss_threshold_rule": "max(baseline_peak_rss_bytes * 1.10, baseline_peak_rss_bytes + 33554432)",
   "runner_version": 1,
-  "source_commit": "79186d67a2c0cd4cfae329bcad51d0edff76a5ac",
+  "source_commit": "7e5d6648b6885863e60bab2a55d76cca8b59cdfb",
   "version": 1
 }

--- a/verification/areas/performance/data/work_budgets.json
+++ b/verification/areas/performance/data/work_budgets.json
@@ -1,394 +1,394 @@
 {
   "budgets": [
     {
-      "baseline_median_instructions": 117282886569,
+      "baseline_median_instructions": 117192357214,
       "benchmark_id": "build-project-001-additional-modules",
       "budget_id": "perf.build.project.additional_modules",
-      "threshold_median_instructions": 119628544301
+      "threshold_median_instructions": 119536204359
     },
     {
-      "baseline_median_instructions": 111192690906,
+      "baseline_median_instructions": 111178721364,
       "benchmark_id": "build-project-002-branch-paths",
       "budget_id": "perf.build.project.branch_paths",
-      "threshold_median_instructions": 113416544725
+      "threshold_median_instructions": 113402295792
     },
     {
-      "baseline_median_instructions": 111166311188,
+      "baseline_median_instructions": 111187546626,
       "benchmark_id": "build-project-003-cargo-manifest",
       "budget_id": "perf.build.project.cargo_manifest",
-      "threshold_median_instructions": 113389637412
+      "threshold_median_instructions": 113411297559
     },
     {
-      "baseline_median_instructions": 115841429458,
+      "baseline_median_instructions": 115832468655,
       "benchmark_id": "build-project-004-dependency-manifest",
       "budget_id": "perf.build.project.dependency_manifest",
-      "threshold_median_instructions": 118158258048
+      "threshold_median_instructions": 118149118029
     },
     {
-      "baseline_median_instructions": 111322000211,
+      "baseline_median_instructions": 111269782458,
       "benchmark_id": "build-project-005-project-graph",
       "budget_id": "perf.build.project.project_graph",
-      "threshold_median_instructions": 113548440216
+      "threshold_median_instructions": 113495178108
     },
     {
-      "baseline_median_instructions": 111063220954,
+      "baseline_median_instructions": 111102094757,
       "benchmark_id": "build-single-file-001-break-continue",
       "budget_id": "perf.build.single.break_continue",
-      "threshold_median_instructions": 113284485374
+      "threshold_median_instructions": 113324136653
     },
     {
-      "baseline_median_instructions": 111100277976,
+      "baseline_median_instructions": 111139266143,
       "benchmark_id": "build-single-file-002-builtin-any-all",
       "budget_id": "perf.build.single.builtin_any_all",
-      "threshold_median_instructions": 113322283536
+      "threshold_median_instructions": 113362051466
     },
     {
-      "baseline_median_instructions": 111094255490,
+      "baseline_median_instructions": 111105474077,
       "benchmark_id": "build-single-file-003-builtin-enumerate-zip",
       "budget_id": "perf.build.single.builtin_enumerate_zip",
-      "threshold_median_instructions": 113316140600
+      "threshold_median_instructions": 113327583559
     },
     {
-      "baseline_median_instructions": 111133440378,
+      "baseline_median_instructions": 111120164382,
       "benchmark_id": "build-single-file-004-bytes-constructors",
       "budget_id": "perf.build.single.bytes_constructors",
-      "threshold_median_instructions": 113356109186
+      "threshold_median_instructions": 113342567670
     },
     {
-      "baseline_median_instructions": 111095028409,
+      "baseline_median_instructions": 111118904464,
       "benchmark_id": "build-single-file-005-class-methods",
       "budget_id": "perf.build.single.class_methods",
-      "threshold_median_instructions": 113316928978
+      "threshold_median_instructions": 113341282554
     },
     {
-      "baseline_median_instructions": 111103582562,
+      "baseline_median_instructions": 111111800423,
       "benchmark_id": "build-single-file-006-collection-len",
       "budget_id": "perf.build.single.collection_len",
-      "threshold_median_instructions": 113325654214
+      "threshold_median_instructions": 113334036432
     },
     {
-      "baseline_median_instructions": 111138253984,
+      "baseline_median_instructions": 111108018825,
       "benchmark_id": "build-single-file-007-comp-set",
       "budget_id": "perf.build.single.comp_set",
-      "threshold_median_instructions": 113361019064
+      "threshold_median_instructions": 113330179202
     },
     {
-      "baseline_median_instructions": 115140328824,
+      "baseline_median_instructions": 115073894479,
       "benchmark_id": "build-single-file-008-decimal-conversions",
       "budget_id": "perf.build.single.decimal_conversions",
-      "threshold_median_instructions": 117443135401
+      "threshold_median_instructions": 117375372369
     },
     {
-      "baseline_median_instructions": 111100225541,
+      "baseline_median_instructions": 111098033311,
       "benchmark_id": "build-single-file-009-dict-get-option",
       "budget_id": "perf.build.single.dict_get_option",
-      "threshold_median_instructions": 113322230052
+      "threshold_median_instructions": 113319993978
     },
     {
-      "baseline_median_instructions": 111065658403,
+      "baseline_median_instructions": 111093460489,
       "benchmark_id": "build-single-file-010-generic-identity",
       "budget_id": "perf.build.single.generic_identity",
-      "threshold_median_instructions": 113286971572
+      "threshold_median_instructions": 113315329699
     },
     {
-      "baseline_median_instructions": 13631146633,
+      "baseline_median_instructions": 13632354971,
       "benchmark_id": "check-project-001-imports",
       "budget_id": "perf.check.project.imports",
-      "threshold_median_instructions": 13903769566
+      "threshold_median_instructions": 13905002071
     },
     {
-      "baseline_median_instructions": 13630649013,
+      "baseline_median_instructions": 13624898891,
       "benchmark_id": "check-project-002-mode-consistency",
       "budget_id": "perf.check.project.mode_consistency",
-      "threshold_median_instructions": 13903261994
+      "threshold_median_instructions": 13897396869
     },
     {
-      "baseline_median_instructions": 13660151798,
+      "baseline_median_instructions": 13653137179,
       "benchmark_id": "check-project-003-project-build",
       "budget_id": "perf.check.project.project_build",
-      "threshold_median_instructions": 13933354834
+      "threshold_median_instructions": 13926199923
     },
     {
-      "baseline_median_instructions": 13659380853,
+      "baseline_median_instructions": 13656554038,
       "benchmark_id": "check-project-004-project-graph",
       "budget_id": "perf.check.project.project_graph",
-      "threshold_median_instructions": 13932568471
+      "threshold_median_instructions": 13929685119
     },
     {
-      "baseline_median_instructions": 13653454005,
+      "baseline_median_instructions": 13660569954,
       "benchmark_id": "check-project-005-rooted-entrypoint",
       "budget_id": "perf.check.project.rooted_entrypoint",
-      "threshold_median_instructions": 13926523086
+      "threshold_median_instructions": 13933781354
     },
     {
-      "baseline_median_instructions": 13591024854,
+      "baseline_median_instructions": 13597160515,
       "benchmark_id": "check-single-file-001-arithmetic",
       "budget_id": "perf.check.single.arithmetic",
-      "threshold_median_instructions": 13862845352
+      "threshold_median_instructions": 13869103726
     },
     {
-      "baseline_median_instructions": 13587399744,
+      "baseline_median_instructions": 13597251401,
       "benchmark_id": "check-single-file-002-break-continue",
       "budget_id": "perf.check.single.break_continue",
-      "threshold_median_instructions": 13859147739
+      "threshold_median_instructions": 13869196430
     },
     {
-      "baseline_median_instructions": 13589055438,
+      "baseline_median_instructions": 13602123402,
       "benchmark_id": "check-single-file-003-builtin-any-all",
       "budget_id": "perf.check.single.builtin_any_all",
-      "threshold_median_instructions": 13860836547
+      "threshold_median_instructions": 13874165871
     },
     {
-      "baseline_median_instructions": 13589014660,
+      "baseline_median_instructions": 13587041244,
       "benchmark_id": "check-single-file-004-builtin-enumerate-zip",
       "budget_id": "perf.check.single.builtin_enumerate_zip",
-      "threshold_median_instructions": 13860794954
+      "threshold_median_instructions": 13858782069
     },
     {
-      "baseline_median_instructions": 13597957111,
+      "baseline_median_instructions": 13600527541,
       "benchmark_id": "check-single-file-005-bytes-constructors",
       "budget_id": "perf.check.single.bytes_constructors",
-      "threshold_median_instructions": 13869916254
+      "threshold_median_instructions": 13872538092
     },
     {
-      "baseline_median_instructions": 13587308624,
+      "baseline_median_instructions": 13597418983,
       "benchmark_id": "check-single-file-006-class-methods",
       "budget_id": "perf.check.single.class_methods",
-      "threshold_median_instructions": 13859054797
+      "threshold_median_instructions": 13869367363
     },
     {
-      "baseline_median_instructions": 13589092630,
+      "baseline_median_instructions": 13594890943,
       "benchmark_id": "check-single-file-007-collection-len",
       "budget_id": "perf.check.single.collection_len",
-      "threshold_median_instructions": 13860874483
+      "threshold_median_instructions": 13866788762
     },
     {
-      "baseline_median_instructions": 13582277131,
+      "baseline_median_instructions": 13601114510,
       "benchmark_id": "check-single-file-008-comp-set",
       "budget_id": "perf.check.single.comp_set",
-      "threshold_median_instructions": 13853922674
+      "threshold_median_instructions": 13873136801
     },
     {
-      "baseline_median_instructions": 13591206430,
+      "baseline_median_instructions": 13602099240,
       "benchmark_id": "check-single-file-009-decimal-conversions",
       "budget_id": "perf.check.single.decimal_conversions",
-      "threshold_median_instructions": 13863030559
+      "threshold_median_instructions": 13874141225
     },
     {
-      "baseline_median_instructions": 13590141550,
+      "baseline_median_instructions": 13603639445,
       "benchmark_id": "check-single-file-010-dict-get-option",
       "budget_id": "perf.check.single.dict_get_option",
-      "threshold_median_instructions": 13861944381
+      "threshold_median_instructions": 13875712234
     },
     {
-      "baseline_median_instructions": 13586565961,
+      "baseline_median_instructions": 13596011880,
       "benchmark_id": "diagnostic-non-regression-001-human-success-exit",
       "budget_id": "perf.diagnostic.human_success_exit",
-      "threshold_median_instructions": 13858297281
+      "threshold_median_instructions": 13867932118
     },
     {
-      "baseline_median_instructions": 13584237890,
+      "baseline_median_instructions": 13599762979,
       "benchmark_id": "diagnostic-non-regression-002-json-diagnostic-schema",
       "budget_id": "perf.diagnostic.json_diagnostic_schema",
-      "threshold_median_instructions": 13855922648
+      "threshold_median_instructions": 13871758239
     },
     {
-      "baseline_median_instructions": 13602623157,
+      "baseline_median_instructions": 13609997694,
       "benchmark_id": "diagnostic-non-regression-003-compact-diagnostic-schema",
       "budget_id": "perf.diagnostic.compact_diagnostic_schema",
-      "threshold_median_instructions": 13874675621
+      "threshold_median_instructions": 13882197648
     },
     {
-      "baseline_median_instructions": 13604456358,
+      "baseline_median_instructions": 13588631309,
       "benchmark_id": "diagnostic-non-regression-004-recovery-limit",
       "budget_id": "perf.diagnostic.recovery_limit",
-      "threshold_median_instructions": 13876545486
+      "threshold_median_instructions": 13860403936
     },
     {
-      "baseline_median_instructions": 13550299971,
+      "baseline_median_instructions": 13518276765,
       "benchmark_id": "diagnostic-non-regression-005-project-error-exit",
       "budget_id": "perf.diagnostic.project_error_exit",
-      "threshold_median_instructions": 13821305971
+      "threshold_median_instructions": 13788642301
     },
     {
-      "baseline_median_instructions": 36741481,
+      "baseline_median_instructions": 35720680,
       "benchmark_id": "formatter-corpus-001-project-check",
       "budget_id": "perf.formatter.corpus.project_check",
-      "threshold_median_instructions": 37741481
+      "threshold_median_instructions": 36720680
     },
     {
-      "baseline_median_instructions": 57766905,
+      "baseline_median_instructions": 56932702,
       "benchmark_id": "formatter-large-file-001-check",
       "budget_id": "perf.formatter.large_file.check",
-      "threshold_median_instructions": 58922244
+      "threshold_median_instructions": 58071357
     },
     {
-      "baseline_median_instructions": 902600920,
+      "baseline_median_instructions": 898390406,
       "benchmark_id": "incremental-local-loop-001-unchanged-file-update",
       "budget_id": "perf.incremental.unchanged_file_update",
-      "threshold_median_instructions": 920652939
+      "threshold_median_instructions": 916358215
     },
     {
-      "baseline_median_instructions": 677467842,
+      "baseline_median_instructions": 675527694,
       "benchmark_id": "incremental-local-loop-002-leaf-module-change",
       "budget_id": "perf.incremental.leaf_module_change",
-      "threshold_median_instructions": 691017199
+      "threshold_median_instructions": 689038248
     },
     {
-      "baseline_median_instructions": 3817064021,
+      "baseline_median_instructions": 3813412453,
       "benchmark_id": "incremental-local-loop-003-imported-module-change",
       "budget_id": "perf.incremental.imported_module_change",
-      "threshold_median_instructions": 3893405302
+      "threshold_median_instructions": 3889680703
     },
     {
-      "baseline_median_instructions": 4456725544,
+      "baseline_median_instructions": 4456618705,
       "benchmark_id": "incremental-local-loop-004-public-api-change",
       "budget_id": "perf.incremental.public_api_change",
-      "threshold_median_instructions": 4545860055
+      "threshold_median_instructions": 4545751080
     },
     {
-      "baseline_median_instructions": 4156388914,
+      "baseline_median_instructions": 4154665248,
       "benchmark_id": "incremental-local-loop-005-failure-recovery",
       "budget_id": "perf.incremental.failure_recovery",
-      "threshold_median_instructions": 4239516693
+      "threshold_median_instructions": 4237758553
     },
     {
-      "baseline_median_instructions": 373463167,
+      "baseline_median_instructions": 373196094,
       "benchmark_id": "interactive-tooling-foundation-001-cold-context-load",
       "budget_id": "perf.interactive.cold_context_load",
-      "threshold_median_instructions": 380932431
+      "threshold_median_instructions": 380660016
     },
     {
-      "baseline_median_instructions": 1448302744,
+      "baseline_median_instructions": 1446757916,
       "benchmark_id": "interactive-tooling-foundation-002-warm-diagnostics-query",
       "budget_id": "perf.interactive.warm_diagnostics_query",
-      "threshold_median_instructions": 1477268799
+      "threshold_median_instructions": 1475693075
     },
     {
-      "baseline_median_instructions": 584625090,
+      "baseline_median_instructions": 584290916,
       "benchmark_id": "interactive-tooling-foundation-003-unchanged-file-update",
       "budget_id": "perf.interactive.unchanged_file_update",
-      "threshold_median_instructions": 596317592
+      "threshold_median_instructions": 595976735
     },
     {
-      "baseline_median_instructions": 2342114988,
+      "baseline_median_instructions": 2343099786,
       "benchmark_id": "interactive-tooling-foundation-004-changed-file-invalidation",
       "budget_id": "perf.interactive.changed_file_invalidation",
-      "threshold_median_instructions": 2388957288
+      "threshold_median_instructions": 2389961782
     },
     {
-      "baseline_median_instructions": 216307837,
+      "baseline_median_instructions": 216852466,
       "benchmark_id": "interactive-tooling-foundation-005-source-map-lookup",
       "budget_id": "perf.interactive.source_map_lookup",
-      "threshold_median_instructions": 220633994
+      "threshold_median_instructions": 221189516
     },
     {
-      "baseline_median_instructions": 380729297,
+      "baseline_median_instructions": 380309831,
       "benchmark_id": "lsp-query-001-request-families",
       "budget_id": "perf.lsp.request_families",
-      "threshold_median_instructions": 388343883
+      "threshold_median_instructions": 387916028
     },
     {
-      "baseline_median_instructions": 323934418,
+      "baseline_median_instructions": 323379510,
       "benchmark_id": "lsp-query-002-cold-start",
       "budget_id": "perf.lsp.cold_start.workspace",
-      "threshold_median_instructions": 330413107
+      "threshold_median_instructions": 329847101
     },
     {
-      "baseline_median_instructions": 381052486,
+      "baseline_median_instructions": 380518900,
       "benchmark_id": "lsp-query-003-diagnostics",
       "budget_id": "perf.lsp.diagnostics.document",
-      "threshold_median_instructions": 388673536
+      "threshold_median_instructions": 388129278
     },
     {
-      "baseline_median_instructions": 343554524,
+      "baseline_median_instructions": 342811786,
       "benchmark_id": "lsp-query-004-workspace-diagnostics",
       "budget_id": "perf.lsp.diagnostics.workspace",
-      "threshold_median_instructions": 350425615
+      "threshold_median_instructions": 349668022
     },
     {
-      "baseline_median_instructions": 1321566414,
+      "baseline_median_instructions": 1320788464,
       "benchmark_id": "lsp-query-005-completion",
       "budget_id": "perf.lsp.completion.local_scope",
-      "threshold_median_instructions": 1347997743
+      "threshold_median_instructions": 1347204234
     },
     {
-      "baseline_median_instructions": 360158838,
+      "baseline_median_instructions": 360911118,
       "benchmark_id": "lsp-query-006-hover",
       "budget_id": "perf.lsp.hover.symbol",
-      "threshold_median_instructions": 367362015
+      "threshold_median_instructions": 368129341
     },
     {
-      "baseline_median_instructions": 360681364,
+      "baseline_median_instructions": 360487038,
       "benchmark_id": "lsp-query-007-signature-help",
       "budget_id": "perf.lsp.signature_help.call",
-      "threshold_median_instructions": 367894992
+      "threshold_median_instructions": 367696779
     },
     {
-      "baseline_median_instructions": 491682698,
+      "baseline_median_instructions": 491463696,
       "benchmark_id": "lsp-query-008-navigation",
       "budget_id": "perf.lsp.navigation.symbol",
-      "threshold_median_instructions": 501516352
+      "threshold_median_instructions": 501292970
     },
     {
-      "baseline_median_instructions": 344139058,
+      "baseline_median_instructions": 342870666,
       "benchmark_id": "lsp-query-009-references",
       "budget_id": "perf.lsp.references.workspace_symbol",
-      "threshold_median_instructions": 351021840
+      "threshold_median_instructions": 349728080
     },
     {
-      "baseline_median_instructions": 363144018,
+      "baseline_median_instructions": 362041233,
       "benchmark_id": "lsp-query-010-rename",
       "budget_id": "perf.lsp.rename.workspace_edit",
-      "threshold_median_instructions": 370406899
+      "threshold_median_instructions": 369282058
     },
     {
-      "baseline_median_instructions": 395587118,
+      "baseline_median_instructions": 395659428,
       "benchmark_id": "lsp-query-011-semantic-tokens",
       "budget_id": "perf.lsp.semantic_tokens.full",
-      "threshold_median_instructions": 403498861
+      "threshold_median_instructions": 403572617
     },
     {
-      "baseline_median_instructions": 361363905,
+      "baseline_median_instructions": 361340398,
       "benchmark_id": "lsp-query-012-inlay-hints",
       "budget_id": "perf.lsp.inlay_hints.module",
-      "threshold_median_instructions": 368591184
+      "threshold_median_instructions": 368567206
     },
     {
-      "baseline_median_instructions": 363352079,
+      "baseline_median_instructions": 362778236,
       "benchmark_id": "lsp-query-013-selection-range",
       "budget_id": "perf.lsp.selection_ranges.nested",
-      "threshold_median_instructions": 370619121
+      "threshold_median_instructions": 370033801
     },
     {
-      "baseline_median_instructions": 358821461,
+      "baseline_median_instructions": 358831784,
       "benchmark_id": "lsp-query-014-type-hierarchy",
       "budget_id": "perf.lsp.type_hierarchy.symbol",
-      "threshold_median_instructions": 365997891
+      "threshold_median_instructions": 366008420
     },
     {
-      "baseline_median_instructions": 359860734,
+      "baseline_median_instructions": 360126993,
       "benchmark_id": "lsp-query-015-code-actions",
       "budget_id": "perf.lsp.code_action.diagnostic",
-      "threshold_median_instructions": 367057949
+      "threshold_median_instructions": 367329533
     },
     {
-      "baseline_median_instructions": 383279912,
+      "baseline_median_instructions": 383007442,
       "benchmark_id": "lsp-query-016-formatting",
       "budget_id": "perf.lsp.formatting.document",
-      "threshold_median_instructions": 390945511
+      "threshold_median_instructions": 390667591
     },
     {
-      "baseline_median_instructions": 363844482,
+      "baseline_median_instructions": 360914375,
       "benchmark_id": "lsp-query-017-generated-rust-preview",
       "budget_id": "perf.lsp.generated_rust_preview.document",
-      "threshold_median_instructions": 371121372
+      "threshold_median_instructions": 368132663
     },
     {
-      "baseline_median_instructions": 408244055,
+      "baseline_median_instructions": 406391682,
       "benchmark_id": "lsp-query-018-did-open-diagnostics",
       "budget_id": "perf.lsp.document_sync.did_open",
-      "threshold_median_instructions": 416408937
+      "threshold_median_instructions": 414519516
     }
   ],
   "host": {
@@ -397,7 +397,7 @@
     "work_counter_source": "darwin-rusage-instructions"
   },
   "runner_version": 1,
-  "source_commit": "64881055453937d596bff6d7d569a97beba7bd8a",
+  "source_commit": "00ae57a0f569ed578f665e01a017cec0e3c19369",
   "threshold_rule": "max(baseline_median_instructions * 1.02, baseline_median_instructions + 1000000)",
   "version": 1
 }

--- a/verification/areas/performance/data/work_budgets.json
+++ b/verification/areas/performance/data/work_budgets.json
@@ -1,524 +1,524 @@
 {
   "budgets": [
     {
-      "baseline_median_instructions": 117192298028,
-      "baseline_peak_rss_bytes": 209010688,
+      "baseline_median_instructions": 117209565091,
+      "baseline_peak_rss_bytes": 208617472,
       "benchmark_id": "build-project-001-additional-modules",
       "budget_id": "perf.build.project.additional_modules",
-      "threshold_median_instructions": 119536143989,
-      "threshold_peak_rss_bytes": 242565120
+      "threshold_median_instructions": 119553756393,
+      "threshold_peak_rss_bytes": 242171904
     },
     {
-      "baseline_median_instructions": 111170857281,
-      "baseline_peak_rss_bytes": 145948672,
+      "baseline_median_instructions": 111176753544,
+      "baseline_peak_rss_bytes": 146964480,
       "benchmark_id": "build-project-002-branch-paths",
       "budget_id": "perf.build.project.branch_paths",
-      "threshold_median_instructions": 113394274427,
-      "threshold_peak_rss_bytes": 179503104
+      "threshold_median_instructions": 113400288615,
+      "threshold_peak_rss_bytes": 180518912
     },
     {
-      "baseline_median_instructions": 111178621124,
-      "baseline_peak_rss_bytes": 147111936,
+      "baseline_median_instructions": 111177118760,
+      "baseline_peak_rss_bytes": 146718720,
       "benchmark_id": "build-project-003-cargo-manifest",
       "budget_id": "perf.build.project.cargo_manifest",
-      "threshold_median_instructions": 113402193547,
-      "threshold_peak_rss_bytes": 180666368
+      "threshold_median_instructions": 113400661136,
+      "threshold_peak_rss_bytes": 180273152
     },
     {
-      "baseline_median_instructions": 115835001295,
-      "baseline_peak_rss_bytes": 155992064,
+      "baseline_median_instructions": 115837303412,
+      "baseline_peak_rss_bytes": 155828224,
       "benchmark_id": "build-project-004-dependency-manifest",
       "budget_id": "perf.build.project.dependency_manifest",
-      "threshold_median_instructions": 118151701321,
-      "threshold_peak_rss_bytes": 189546496
+      "threshold_median_instructions": 118154049481,
+      "threshold_peak_rss_bytes": 189382656
     },
     {
-      "baseline_median_instructions": 111252837600,
-      "baseline_peak_rss_bytes": 147734528,
+      "baseline_median_instructions": 111266842588,
+      "baseline_peak_rss_bytes": 146358272,
       "benchmark_id": "build-project-005-project-graph",
       "budget_id": "perf.build.project.project_graph",
-      "threshold_median_instructions": 113477894352,
-      "threshold_peak_rss_bytes": 181288960
+      "threshold_median_instructions": 113492179440,
+      "threshold_peak_rss_bytes": 179912704
     },
     {
-      "baseline_median_instructions": 111155378214,
-      "baseline_peak_rss_bytes": 147701760,
+      "baseline_median_instructions": 111113538568,
+      "baseline_peak_rss_bytes": 147456000,
       "benchmark_id": "build-single-file-001-break-continue",
       "budget_id": "perf.build.single.break_continue",
-      "threshold_median_instructions": 113378485779,
-      "threshold_peak_rss_bytes": 181256192
+      "threshold_median_instructions": 113335809340,
+      "threshold_peak_rss_bytes": 181010432
     },
     {
-      "baseline_median_instructions": 111204438638,
-      "baseline_peak_rss_bytes": 147554304,
+      "baseline_median_instructions": 111110114389,
+      "baseline_peak_rss_bytes": 146456576,
       "benchmark_id": "build-single-file-002-builtin-any-all",
       "budget_id": "perf.build.single.builtin_any_all",
-      "threshold_median_instructions": 113428527411,
-      "threshold_peak_rss_bytes": 181108736
+      "threshold_median_instructions": 113332316677,
+      "threshold_peak_rss_bytes": 180011008
     },
     {
-      "baseline_median_instructions": 111083914303,
-      "baseline_peak_rss_bytes": 145293312,
+      "baseline_median_instructions": 111094621330,
+      "baseline_peak_rss_bytes": 146292736,
       "benchmark_id": "build-single-file-003-builtin-enumerate-zip",
       "budget_id": "perf.build.single.builtin_enumerate_zip",
-      "threshold_median_instructions": 113305592590,
-      "threshold_peak_rss_bytes": 178847744
+      "threshold_median_instructions": 113316513757,
+      "threshold_peak_rss_bytes": 179847168
     },
     {
-      "baseline_median_instructions": 111115843116,
-      "baseline_peak_rss_bytes": 146931712,
+      "baseline_median_instructions": 111134363649,
+      "baseline_peak_rss_bytes": 146178048,
       "benchmark_id": "build-single-file-004-bytes-constructors",
       "budget_id": "perf.build.single.bytes_constructors",
-      "threshold_median_instructions": 113338159979,
-      "threshold_peak_rss_bytes": 180486144
+      "threshold_median_instructions": 113357050922,
+      "threshold_peak_rss_bytes": 179732480
     },
     {
-      "baseline_median_instructions": 111086525380,
-      "baseline_peak_rss_bytes": 147374080,
+      "baseline_median_instructions": 111120205202,
+      "baseline_peak_rss_bytes": 147128320,
       "benchmark_id": "build-single-file-005-class-methods",
       "budget_id": "perf.build.single.class_methods",
-      "threshold_median_instructions": 113308255888,
-      "threshold_peak_rss_bytes": 180928512
+      "threshold_median_instructions": 113342609307,
+      "threshold_peak_rss_bytes": 180682752
     },
     {
-      "baseline_median_instructions": 111118409557,
-      "baseline_peak_rss_bytes": 148111360,
+      "baseline_median_instructions": 111106072567,
+      "baseline_peak_rss_bytes": 146571264,
       "benchmark_id": "build-single-file-006-collection-len",
       "budget_id": "perf.build.single.collection_len",
-      "threshold_median_instructions": 113340777749,
-      "threshold_peak_rss_bytes": 181665792
+      "threshold_median_instructions": 113328194019,
+      "threshold_peak_rss_bytes": 180125696
     },
     {
-      "baseline_median_instructions": 111102140232,
-      "baseline_peak_rss_bytes": 147111936,
+      "baseline_median_instructions": 111094715611,
+      "baseline_peak_rss_bytes": 147521536,
       "benchmark_id": "build-single-file-007-comp-set",
       "budget_id": "perf.build.single.comp_set",
-      "threshold_median_instructions": 113324183037,
+      "threshold_median_instructions": 113316609924,
+      "threshold_peak_rss_bytes": 181075968
+    },
+    {
+      "baseline_median_instructions": 115064991613,
+      "baseline_peak_rss_bytes": 166264832,
+      "benchmark_id": "build-single-file-008-decimal-conversions",
+      "budget_id": "perf.build.single.decimal_conversions",
+      "threshold_median_instructions": 117366291446,
+      "threshold_peak_rss_bytes": 199819264
+    },
+    {
+      "baseline_median_instructions": 111105665779,
+      "baseline_peak_rss_bytes": 146145280,
+      "benchmark_id": "build-single-file-009-dict-get-option",
+      "budget_id": "perf.build.single.dict_get_option",
+      "threshold_median_instructions": 113327779095,
+      "threshold_peak_rss_bytes": 179699712
+    },
+    {
+      "baseline_median_instructions": 111108046581,
+      "baseline_peak_rss_bytes": 146784256,
+      "benchmark_id": "build-single-file-010-generic-identity",
+      "budget_id": "perf.build.single.generic_identity",
+      "threshold_median_instructions": 113330207513,
+      "threshold_peak_rss_bytes": 180338688
+    },
+    {
+      "baseline_median_instructions": 13626785484,
+      "baseline_peak_rss_bytes": 145997824,
+      "benchmark_id": "check-project-001-imports",
+      "budget_id": "perf.check.project.imports",
+      "threshold_median_instructions": 13899321194,
+      "threshold_peak_rss_bytes": 179552256
+    },
+    {
+      "baseline_median_instructions": 13623155443,
+      "baseline_peak_rss_bytes": 147324928,
+      "benchmark_id": "check-project-002-mode-consistency",
+      "budget_id": "perf.check.project.mode_consistency",
+      "threshold_median_instructions": 13895618552,
+      "threshold_peak_rss_bytes": 180879360
+    },
+    {
+      "baseline_median_instructions": 13659775453,
+      "baseline_peak_rss_bytes": 146587648,
+      "benchmark_id": "check-project-003-project-build",
+      "budget_id": "perf.check.project.project_build",
+      "threshold_median_instructions": 13932970963,
+      "threshold_peak_rss_bytes": 180142080
+    },
+    {
+      "baseline_median_instructions": 13654644871,
+      "baseline_peak_rss_bytes": 146571264,
+      "benchmark_id": "check-project-004-project-graph",
+      "budget_id": "perf.check.project.project_graph",
+      "threshold_median_instructions": 13927737769,
+      "threshold_peak_rss_bytes": 180125696
+    },
+    {
+      "baseline_median_instructions": 13649941834,
+      "baseline_peak_rss_bytes": 147537920,
+      "benchmark_id": "check-project-005-rooted-entrypoint",
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "threshold_median_instructions": 13922940671,
+      "threshold_peak_rss_bytes": 181092352
+    },
+    {
+      "baseline_median_instructions": 13584137194,
+      "baseline_peak_rss_bytes": 147111936,
+      "benchmark_id": "check-single-file-001-arithmetic",
+      "budget_id": "perf.check.single.arithmetic",
+      "threshold_median_instructions": 13855819938,
       "threshold_peak_rss_bytes": 180666368
     },
     {
-      "baseline_median_instructions": 115067973572,
-      "baseline_peak_rss_bytes": 166232064,
-      "benchmark_id": "build-single-file-008-decimal-conversions",
-      "budget_id": "perf.build.single.decimal_conversions",
-      "threshold_median_instructions": 117369333044,
-      "threshold_peak_rss_bytes": 199786496
-    },
-    {
-      "baseline_median_instructions": 111144271691,
-      "baseline_peak_rss_bytes": 147079168,
-      "benchmark_id": "build-single-file-009-dict-get-option",
-      "budget_id": "perf.build.single.dict_get_option",
-      "threshold_median_instructions": 113367157125,
-      "threshold_peak_rss_bytes": 180633600
-    },
-    {
-      "baseline_median_instructions": 111099064791,
-      "baseline_peak_rss_bytes": 147685376,
-      "benchmark_id": "build-single-file-010-generic-identity",
-      "budget_id": "perf.build.single.generic_identity",
-      "threshold_median_instructions": 113321046087,
-      "threshold_peak_rss_bytes": 181239808
-    },
-    {
-      "baseline_median_instructions": 13633327630,
-      "baseline_peak_rss_bytes": 146898944,
-      "benchmark_id": "check-project-001-imports",
-      "budget_id": "perf.check.project.imports",
-      "threshold_median_instructions": 13905994183,
-      "threshold_peak_rss_bytes": 180453376
-    },
-    {
-      "baseline_median_instructions": 13625838660,
-      "baseline_peak_rss_bytes": 147341312,
-      "benchmark_id": "check-project-002-mode-consistency",
-      "budget_id": "perf.check.project.mode_consistency",
-      "threshold_median_instructions": 13898355434,
-      "threshold_peak_rss_bytes": 180895744
-    },
-    {
-      "baseline_median_instructions": 13659535242,
-      "baseline_peak_rss_bytes": 146391040,
-      "benchmark_id": "check-project-003-project-build",
-      "budget_id": "perf.check.project.project_build",
-      "threshold_median_instructions": 13932725947,
-      "threshold_peak_rss_bytes": 179945472
-    },
-    {
-      "baseline_median_instructions": 13661609398,
-      "baseline_peak_rss_bytes": 146161664,
-      "benchmark_id": "check-project-004-project-graph",
-      "budget_id": "perf.check.project.project_graph",
-      "threshold_median_instructions": 13934841586,
-      "threshold_peak_rss_bytes": 179716096
-    },
-    {
-      "baseline_median_instructions": 13654505916,
-      "baseline_peak_rss_bytes": 146309120,
-      "benchmark_id": "check-project-005-rooted-entrypoint",
-      "budget_id": "perf.check.project.rooted_entrypoint",
-      "threshold_median_instructions": 13927596035,
-      "threshold_peak_rss_bytes": 179863552
-    },
-    {
-      "baseline_median_instructions": 13595792448,
-      "baseline_peak_rss_bytes": 147177472,
-      "benchmark_id": "check-single-file-001-arithmetic",
-      "budget_id": "perf.check.single.arithmetic",
-      "threshold_median_instructions": 13867708297,
-      "threshold_peak_rss_bytes": 180731904
-    },
-    {
-      "baseline_median_instructions": 13592552329,
-      "baseline_peak_rss_bytes": 146997248,
+      "baseline_median_instructions": 13585430760,
+      "baseline_peak_rss_bytes": 147390464,
       "benchmark_id": "check-single-file-002-break-continue",
       "budget_id": "perf.check.single.break_continue",
-      "threshold_median_instructions": 13864403376,
-      "threshold_peak_rss_bytes": 180551680
+      "threshold_median_instructions": 13857139376,
+      "threshold_peak_rss_bytes": 180944896
     },
     {
-      "baseline_median_instructions": 13587114953,
-      "baseline_peak_rss_bytes": 146702336,
+      "baseline_median_instructions": 13591069267,
+      "baseline_peak_rss_bytes": 147193856,
       "benchmark_id": "check-single-file-003-builtin-any-all",
       "budget_id": "perf.check.single.builtin_any_all",
-      "threshold_median_instructions": 13858857253,
-      "threshold_peak_rss_bytes": 180256768
+      "threshold_median_instructions": 13862890653,
+      "threshold_peak_rss_bytes": 180748288
     },
     {
-      "baseline_median_instructions": 13586024384,
-      "baseline_peak_rss_bytes": 147488768,
+      "baseline_median_instructions": 13594599134,
+      "baseline_peak_rss_bytes": 146571264,
       "benchmark_id": "check-single-file-004-builtin-enumerate-zip",
       "budget_id": "perf.check.single.builtin_enumerate_zip",
-      "threshold_median_instructions": 13857744872,
-      "threshold_peak_rss_bytes": 181043200
+      "threshold_median_instructions": 13866491117,
+      "threshold_peak_rss_bytes": 180125696
     },
     {
-      "baseline_median_instructions": 13606615417,
-      "baseline_peak_rss_bytes": 148094976,
+      "baseline_median_instructions": 13599607981,
+      "baseline_peak_rss_bytes": 146063360,
       "benchmark_id": "check-single-file-005-bytes-constructors",
       "budget_id": "perf.check.single.bytes_constructors",
-      "threshold_median_instructions": 13878747726,
-      "threshold_peak_rss_bytes": 181649408
+      "threshold_median_instructions": 13871600141,
+      "threshold_peak_rss_bytes": 179617792
     },
     {
-      "baseline_median_instructions": 13594371075,
-      "baseline_peak_rss_bytes": 146325504,
+      "baseline_median_instructions": 13589589616,
+      "baseline_peak_rss_bytes": 146489344,
       "benchmark_id": "check-single-file-006-class-methods",
       "budget_id": "perf.check.single.class_methods",
-      "threshold_median_instructions": 13866258497,
-      "threshold_peak_rss_bytes": 179879936
+      "threshold_median_instructions": 13861381409,
+      "threshold_peak_rss_bytes": 180043776
     },
     {
-      "baseline_median_instructions": 13600392754,
-      "baseline_peak_rss_bytes": 147062784,
+      "baseline_median_instructions": 13591810560,
+      "baseline_peak_rss_bytes": 147996672,
       "benchmark_id": "check-single-file-007-collection-len",
       "budget_id": "perf.check.single.collection_len",
-      "threshold_median_instructions": 13872400610,
-      "threshold_peak_rss_bytes": 180617216
+      "threshold_median_instructions": 13863646772,
+      "threshold_peak_rss_bytes": 181551104
     },
     {
-      "baseline_median_instructions": 13602013737,
-      "baseline_peak_rss_bytes": 147226624,
+      "baseline_median_instructions": 13589509356,
+      "baseline_peak_rss_bytes": 147095552,
       "benchmark_id": "check-single-file-008-comp-set",
       "budget_id": "perf.check.single.comp_set",
-      "threshold_median_instructions": 13874054012,
-      "threshold_peak_rss_bytes": 180781056
+      "threshold_median_instructions": 13861299544,
+      "threshold_peak_rss_bytes": 180649984
     },
     {
-      "baseline_median_instructions": 13587716796,
-      "baseline_peak_rss_bytes": 146259968,
+      "baseline_median_instructions": 13594326804,
+      "baseline_peak_rss_bytes": 146751488,
       "benchmark_id": "check-single-file-009-decimal-conversions",
       "budget_id": "perf.check.single.decimal_conversions",
-      "threshold_median_instructions": 13859471132,
+      "threshold_median_instructions": 13866213341,
+      "threshold_peak_rss_bytes": 180305920
+    },
+    {
+      "baseline_median_instructions": 13592509384,
+      "baseline_peak_rss_bytes": 146554880,
+      "benchmark_id": "check-single-file-010-dict-get-option",
+      "budget_id": "perf.check.single.dict_get_option",
+      "threshold_median_instructions": 13864359572,
+      "threshold_peak_rss_bytes": 180109312
+    },
+    {
+      "baseline_median_instructions": 13592960600,
+      "baseline_peak_rss_bytes": 146423808,
+      "benchmark_id": "diagnostic-non-regression-001-human-success-exit",
+      "budget_id": "perf.diagnostic.human_success_exit",
+      "threshold_median_instructions": 13864819812,
+      "threshold_peak_rss_bytes": 179978240
+    },
+    {
+      "baseline_median_instructions": 13586178758,
+      "baseline_peak_rss_bytes": 146259968,
+      "benchmark_id": "diagnostic-non-regression-002-json-diagnostic-schema",
+      "budget_id": "perf.diagnostic.json_diagnostic_schema",
+      "threshold_median_instructions": 13857902334,
       "threshold_peak_rss_bytes": 179814400
     },
     {
-      "baseline_median_instructions": 13587772421,
-      "baseline_peak_rss_bytes": 146505728,
-      "benchmark_id": "check-single-file-010-dict-get-option",
-      "budget_id": "perf.check.single.dict_get_option",
-      "threshold_median_instructions": 13859527870,
-      "threshold_peak_rss_bytes": 180060160
-    },
-    {
-      "baseline_median_instructions": 13601055069,
-      "baseline_peak_rss_bytes": 147177472,
-      "benchmark_id": "diagnostic-non-regression-001-human-success-exit",
-      "budget_id": "perf.diagnostic.human_success_exit",
-      "threshold_median_instructions": 13873076171,
-      "threshold_peak_rss_bytes": 180731904
-    },
-    {
-      "baseline_median_instructions": 13599858453,
-      "baseline_peak_rss_bytes": 147046400,
-      "benchmark_id": "diagnostic-non-regression-002-json-diagnostic-schema",
-      "budget_id": "perf.diagnostic.json_diagnostic_schema",
-      "threshold_median_instructions": 13871855623,
-      "threshold_peak_rss_bytes": 180600832
-    },
-    {
-      "baseline_median_instructions": 13599170110,
-      "baseline_peak_rss_bytes": 146341888,
+      "baseline_median_instructions": 13586469815,
+      "baseline_peak_rss_bytes": 146604032,
       "benchmark_id": "diagnostic-non-regression-003-compact-diagnostic-schema",
       "budget_id": "perf.diagnostic.compact_diagnostic_schema",
-      "threshold_median_instructions": 13871153513,
-      "threshold_peak_rss_bytes": 179896320
+      "threshold_median_instructions": 13858199212,
+      "threshold_peak_rss_bytes": 180158464
     },
     {
-      "baseline_median_instructions": 13593223358,
-      "baseline_peak_rss_bytes": 146898944,
+      "baseline_median_instructions": 13590813905,
+      "baseline_peak_rss_bytes": 146423808,
       "benchmark_id": "diagnostic-non-regression-004-recovery-limit",
       "budget_id": "perf.diagnostic.recovery_limit",
-      "threshold_median_instructions": 13865087826,
-      "threshold_peak_rss_bytes": 180453376
+      "threshold_median_instructions": 13862630184,
+      "threshold_peak_rss_bytes": 179978240
     },
     {
-      "baseline_median_instructions": 13514155876,
-      "baseline_peak_rss_bytes": 146309120,
+      "baseline_median_instructions": 13512216054,
+      "baseline_peak_rss_bytes": 146440192,
       "benchmark_id": "diagnostic-non-regression-005-project-error-exit",
       "budget_id": "perf.diagnostic.project_error_exit",
-      "threshold_median_instructions": 13784438994,
-      "threshold_peak_rss_bytes": 179863552
+      "threshold_median_instructions": 13782460376,
+      "threshold_peak_rss_bytes": 179994624
     },
     {
-      "baseline_median_instructions": 35683120,
-      "baseline_peak_rss_bytes": 11239424,
+      "baseline_median_instructions": 35832568,
+      "baseline_peak_rss_bytes": 11272192,
       "benchmark_id": "formatter-corpus-001-project-check",
       "budget_id": "perf.formatter.corpus.project_check",
-      "threshold_median_instructions": 37683120,
-      "threshold_peak_rss_bytes": 44793856
+      "threshold_median_instructions": 37832568,
+      "threshold_peak_rss_bytes": 44826624
     },
     {
-      "baseline_median_instructions": 56837431,
+      "baseline_median_instructions": 56924882,
       "baseline_peak_rss_bytes": 11517952,
       "benchmark_id": "formatter-large-file-001-check",
       "budget_id": "perf.formatter.large_file.check",
-      "threshold_median_instructions": 58837431,
+      "threshold_median_instructions": 58924882,
       "threshold_peak_rss_bytes": 45072384
     },
     {
-      "baseline_median_instructions": 897864330,
-      "baseline_peak_rss_bytes": 5111808,
+      "baseline_median_instructions": 897964056,
+      "baseline_peak_rss_bytes": 5128192,
       "benchmark_id": "incremental-local-loop-001-unchanged-file-update",
       "budget_id": "perf.incremental.unchanged_file_update",
-      "threshold_median_instructions": 915821617,
-      "threshold_peak_rss_bytes": 38666240
+      "threshold_median_instructions": 915923338,
+      "threshold_peak_rss_bytes": 38682624
     },
     {
-      "baseline_median_instructions": 675058002,
-      "baseline_peak_rss_bytes": 5111808,
+      "baseline_median_instructions": 674931340,
+      "baseline_peak_rss_bytes": 5046272,
       "benchmark_id": "incremental-local-loop-002-leaf-module-change",
       "budget_id": "perf.incremental.leaf_module_change",
-      "threshold_median_instructions": 688559163,
-      "threshold_peak_rss_bytes": 38666240
+      "threshold_median_instructions": 688429967,
+      "threshold_peak_rss_bytes": 38600704
     },
     {
-      "baseline_median_instructions": 3813020387,
-      "baseline_peak_rss_bytes": 8192000,
+      "baseline_median_instructions": 3813105990,
+      "baseline_peak_rss_bytes": 8224768,
       "benchmark_id": "incremental-local-loop-003-imported-module-change",
       "budget_id": "perf.incremental.imported_module_change",
-      "threshold_median_instructions": 3889280795,
-      "threshold_peak_rss_bytes": 41746432
+      "threshold_median_instructions": 3889368110,
+      "threshold_peak_rss_bytes": 41779200
     },
     {
-      "baseline_median_instructions": 4455793542,
+      "baseline_median_instructions": 4455611948,
       "baseline_peak_rss_bytes": 8175616,
       "benchmark_id": "incremental-local-loop-004-public-api-change",
       "budget_id": "perf.incremental.public_api_change",
-      "threshold_median_instructions": 4544909413,
+      "threshold_median_instructions": 4544724187,
       "threshold_peak_rss_bytes": 41730048
     },
     {
-      "baseline_median_instructions": 4158417417,
-      "baseline_peak_rss_bytes": 8241152,
+      "baseline_median_instructions": 4153795778,
+      "baseline_peak_rss_bytes": 8224768,
       "benchmark_id": "incremental-local-loop-005-failure-recovery",
       "budget_id": "perf.incremental.failure_recovery",
-      "threshold_median_instructions": 4241585766,
-      "threshold_peak_rss_bytes": 41795584
+      "threshold_median_instructions": 4236871694,
+      "threshold_peak_rss_bytes": 41779200
     },
     {
-      "baseline_median_instructions": 373246992,
-      "baseline_peak_rss_bytes": 4767744,
+      "baseline_median_instructions": 373263308,
+      "baseline_peak_rss_bytes": 4784128,
       "benchmark_id": "interactive-tooling-foundation-001-cold-context-load",
       "budget_id": "perf.interactive.cold_context_load",
-      "threshold_median_instructions": 380711932,
-      "threshold_peak_rss_bytes": 38322176
+      "threshold_median_instructions": 380728575,
+      "threshold_peak_rss_bytes": 38338560
     },
     {
-      "baseline_median_instructions": 1446926912,
-      "baseline_peak_rss_bytes": 7798784,
+      "baseline_median_instructions": 1447004242,
+      "baseline_peak_rss_bytes": 7831552,
       "benchmark_id": "interactive-tooling-foundation-002-warm-diagnostics-query",
       "budget_id": "perf.interactive.warm_diagnostics_query",
-      "threshold_median_instructions": 1475865451,
-      "threshold_peak_rss_bytes": 41353216
+      "threshold_median_instructions": 1475944327,
+      "threshold_peak_rss_bytes": 41385984
     },
     {
-      "baseline_median_instructions": 585035132,
-      "baseline_peak_rss_bytes": 4718592,
+      "baseline_median_instructions": 584909349,
+      "baseline_peak_rss_bytes": 4800512,
       "benchmark_id": "interactive-tooling-foundation-003-unchanged-file-update",
       "budget_id": "perf.interactive.unchanged_file_update",
-      "threshold_median_instructions": 596735835,
-      "threshold_peak_rss_bytes": 38273024
+      "threshold_median_instructions": 596607536,
+      "threshold_peak_rss_bytes": 38354944
     },
     {
-      "baseline_median_instructions": 2347333277,
-      "baseline_peak_rss_bytes": 7995392,
+      "baseline_median_instructions": 2341417888,
+      "baseline_peak_rss_bytes": 8142848,
       "benchmark_id": "interactive-tooling-foundation-004-changed-file-invalidation",
       "budget_id": "perf.interactive.changed_file_invalidation",
-      "threshold_median_instructions": 2394279943,
-      "threshold_peak_rss_bytes": 41549824
+      "threshold_median_instructions": 2388246246,
+      "threshold_peak_rss_bytes": 41697280
     },
     {
-      "baseline_median_instructions": 216397080,
-      "baseline_peak_rss_bytes": 4685824,
+      "baseline_median_instructions": 216149363,
+      "baseline_peak_rss_bytes": 4653056,
       "benchmark_id": "interactive-tooling-foundation-005-source-map-lookup",
       "budget_id": "perf.interactive.source_map_lookup",
-      "threshold_median_instructions": 220725022,
-      "threshold_peak_rss_bytes": 38240256
+      "threshold_median_instructions": 220472351,
+      "threshold_peak_rss_bytes": 38207488
     },
     {
-      "baseline_median_instructions": 377597441,
-      "baseline_peak_rss_bytes": 116916224,
+      "baseline_median_instructions": 380218082,
+      "baseline_peak_rss_bytes": 115032064,
       "benchmark_id": "lsp-query-001-request-families",
       "budget_id": "perf.lsp.request_families",
-      "threshold_median_instructions": 385149390,
-      "threshold_peak_rss_bytes": 150470656
+      "threshold_median_instructions": 387822444,
+      "threshold_peak_rss_bytes": 148586496
     },
     {
-      "baseline_median_instructions": 323581136,
-      "baseline_peak_rss_bytes": 21561344,
+      "baseline_median_instructions": 323058464,
+      "baseline_peak_rss_bytes": 21544960,
       "benchmark_id": "lsp-query-002-cold-start",
       "budget_id": "perf.lsp.cold_start.workspace",
-      "threshold_median_instructions": 330052759,
-      "threshold_peak_rss_bytes": 55115776
+      "threshold_median_instructions": 329519634,
+      "threshold_peak_rss_bytes": 55099392
     },
     {
-      "baseline_median_instructions": 380966950,
-      "baseline_peak_rss_bytes": 73728000,
+      "baseline_median_instructions": 380083966,
+      "baseline_peak_rss_bytes": 74465280,
       "benchmark_id": "lsp-query-003-diagnostics",
       "budget_id": "perf.lsp.diagnostics.document",
-      "threshold_median_instructions": 388586289,
-      "threshold_peak_rss_bytes": 107282432
+      "threshold_median_instructions": 387685646,
+      "threshold_peak_rss_bytes": 108019712
     },
     {
-      "baseline_median_instructions": 344390874,
-      "baseline_peak_rss_bytes": 157417472,
+      "baseline_median_instructions": 340673100,
+      "baseline_peak_rss_bytes": 158171136,
       "benchmark_id": "lsp-query-004-workspace-diagnostics",
       "budget_id": "perf.lsp.diagnostics.workspace",
-      "threshold_median_instructions": 351278692,
-      "threshold_peak_rss_bytes": 190971904
-    },
-    {
-      "baseline_median_instructions": 1320896124,
-      "baseline_peak_rss_bytes": 76759040,
-      "benchmark_id": "lsp-query-005-completion",
-      "budget_id": "perf.lsp.completion.local_scope",
-      "threshold_median_instructions": 1347314047,
-      "threshold_peak_rss_bytes": 110313472
-    },
-    {
-      "baseline_median_instructions": 359981811,
-      "baseline_peak_rss_bytes": 74186752,
-      "benchmark_id": "lsp-query-006-hover",
-      "budget_id": "perf.lsp.hover.symbol",
-      "threshold_median_instructions": 367181448,
-      "threshold_peak_rss_bytes": 107741184
-    },
-    {
-      "baseline_median_instructions": 360794288,
-      "baseline_peak_rss_bytes": 73302016,
-      "benchmark_id": "lsp-query-007-signature-help",
-      "budget_id": "perf.lsp.signature_help.call",
-      "threshold_median_instructions": 368010174,
-      "threshold_peak_rss_bytes": 106856448
-    },
-    {
-      "baseline_median_instructions": 492050837,
-      "baseline_peak_rss_bytes": 73957376,
-      "benchmark_id": "lsp-query-008-navigation",
-      "budget_id": "perf.lsp.navigation.symbol",
-      "threshold_median_instructions": 501891854,
-      "threshold_peak_rss_bytes": 107511808
-    },
-    {
-      "baseline_median_instructions": 343856587,
-      "baseline_peak_rss_bytes": 158171136,
-      "benchmark_id": "lsp-query-009-references",
-      "budget_id": "perf.lsp.references.workspace_symbol",
-      "threshold_median_instructions": 350733719,
+      "threshold_median_instructions": 347486562,
       "threshold_peak_rss_bytes": 191725568
     },
     {
-      "baseline_median_instructions": 362987183,
-      "baseline_peak_rss_bytes": 158826496,
+      "baseline_median_instructions": 1320214578,
+      "baseline_peak_rss_bytes": 76988416,
+      "benchmark_id": "lsp-query-005-completion",
+      "budget_id": "perf.lsp.completion.local_scope",
+      "threshold_median_instructions": 1346618870,
+      "threshold_peak_rss_bytes": 110542848
+    },
+    {
+      "baseline_median_instructions": 359050384,
+      "baseline_peak_rss_bytes": 75431936,
+      "benchmark_id": "lsp-query-006-hover",
+      "budget_id": "perf.lsp.hover.symbol",
+      "threshold_median_instructions": 366231392,
+      "threshold_peak_rss_bytes": 108986368
+    },
+    {
+      "baseline_median_instructions": 359483846,
+      "baseline_peak_rss_bytes": 74612736,
+      "benchmark_id": "lsp-query-007-signature-help",
+      "budget_id": "perf.lsp.signature_help.call",
+      "threshold_median_instructions": 366673523,
+      "threshold_peak_rss_bytes": 108167168
+    },
+    {
+      "baseline_median_instructions": 490977524,
+      "baseline_peak_rss_bytes": 74547200,
+      "benchmark_id": "lsp-query-008-navigation",
+      "budget_id": "perf.lsp.navigation.symbol",
+      "threshold_median_instructions": 500797075,
+      "threshold_peak_rss_bytes": 108101632
+    },
+    {
+      "baseline_median_instructions": 340858978,
+      "baseline_peak_rss_bytes": 157908992,
+      "benchmark_id": "lsp-query-009-references",
+      "budget_id": "perf.lsp.references.workspace_symbol",
+      "threshold_median_instructions": 347676158,
+      "threshold_peak_rss_bytes": 191463424
+    },
+    {
+      "baseline_median_instructions": 361560252,
+      "baseline_peak_rss_bytes": 157859840,
       "benchmark_id": "lsp-query-010-rename",
       "budget_id": "perf.lsp.rename.workspace_edit",
-      "threshold_median_instructions": 370246927,
-      "threshold_peak_rss_bytes": 192380928
+      "threshold_median_instructions": 368791458,
+      "threshold_peak_rss_bytes": 191414272
     },
     {
-      "baseline_median_instructions": 395140684,
-      "baseline_peak_rss_bytes": 73482240,
+      "baseline_median_instructions": 393444814,
+      "baseline_peak_rss_bytes": 74711040,
       "benchmark_id": "lsp-query-011-semantic-tokens",
       "budget_id": "perf.lsp.semantic_tokens.full",
-      "threshold_median_instructions": 403043498,
-      "threshold_peak_rss_bytes": 107036672
-    },
-    {
-      "baseline_median_instructions": 361422936,
-      "baseline_peak_rss_bytes": 74711040,
-      "benchmark_id": "lsp-query-012-inlay-hints",
-      "budget_id": "perf.lsp.inlay_hints.module",
-      "threshold_median_instructions": 368651395,
+      "threshold_median_instructions": 401313711,
       "threshold_peak_rss_bytes": 108265472
     },
     {
-      "baseline_median_instructions": 362932719,
-      "baseline_peak_rss_bytes": 73531392,
+      "baseline_median_instructions": 361092899,
+      "baseline_peak_rss_bytes": 73613312,
+      "benchmark_id": "lsp-query-012-inlay-hints",
+      "budget_id": "perf.lsp.inlay_hints.module",
+      "threshold_median_instructions": 368314757,
+      "threshold_peak_rss_bytes": 107167744
+    },
+    {
+      "baseline_median_instructions": 361209882,
+      "baseline_peak_rss_bytes": 73285632,
       "benchmark_id": "lsp-query-013-selection-range",
       "budget_id": "perf.lsp.selection_ranges.nested",
-      "threshold_median_instructions": 370191374,
-      "threshold_peak_rss_bytes": 107085824
+      "threshold_median_instructions": 368434080,
+      "threshold_peak_rss_bytes": 106840064
     },
     {
-      "baseline_median_instructions": 358978778,
-      "baseline_peak_rss_bytes": 73842688,
+      "baseline_median_instructions": 357726506,
+      "baseline_peak_rss_bytes": 74203136,
       "benchmark_id": "lsp-query-014-type-hierarchy",
       "budget_id": "perf.lsp.type_hierarchy.symbol",
-      "threshold_median_instructions": 366158354,
-      "threshold_peak_rss_bytes": 107397120
+      "threshold_median_instructions": 364881037,
+      "threshold_peak_rss_bytes": 107757568
     },
     {
-      "baseline_median_instructions": 360032015,
-      "baseline_peak_rss_bytes": 73416704,
+      "baseline_median_instructions": 357473489,
+      "baseline_peak_rss_bytes": 73580544,
       "benchmark_id": "lsp-query-015-code-actions",
       "budget_id": "perf.lsp.code_action.diagnostic",
-      "threshold_median_instructions": 367232656,
-      "threshold_peak_rss_bytes": 106971136
+      "threshold_median_instructions": 364622959,
+      "threshold_peak_rss_bytes": 107134976
     },
     {
-      "baseline_median_instructions": 382406446,
-      "baseline_peak_rss_bytes": 75366400,
+      "baseline_median_instructions": 382003658,
+      "baseline_peak_rss_bytes": 74366976,
       "benchmark_id": "lsp-query-016-formatting",
       "budget_id": "perf.lsp.formatting.document",
-      "threshold_median_instructions": 390054575,
-      "threshold_peak_rss_bytes": 108920832
+      "threshold_median_instructions": 389643732,
+      "threshold_peak_rss_bytes": 107921408
     },
     {
-      "baseline_median_instructions": 361322228,
-      "baseline_peak_rss_bytes": 112492544,
+      "baseline_median_instructions": 361828992,
+      "baseline_peak_rss_bytes": 112623616,
       "benchmark_id": "lsp-query-017-generated-rust-preview",
       "budget_id": "perf.lsp.generated_rust_preview.document",
-      "threshold_median_instructions": 368548673,
-      "threshold_peak_rss_bytes": 146046976
+      "threshold_median_instructions": 369065572,
+      "threshold_peak_rss_bytes": 146178048
     },
     {
-      "baseline_median_instructions": 408080212,
-      "baseline_peak_rss_bytes": 2500657152,
+      "baseline_median_instructions": 407490070,
+      "baseline_peak_rss_bytes": 2467971072,
       "benchmark_id": "lsp-query-018-did-open-diagnostics",
       "budget_id": "perf.lsp.document_sync.did_open",
-      "threshold_median_instructions": 416241817,
-      "threshold_peak_rss_bytes": 2750722868
+      "threshold_median_instructions": 415639872,
+      "threshold_peak_rss_bytes": 2714768180
     }
   ],
   "host": {
@@ -530,6 +530,6 @@
   "instruction_threshold_rule": "max(baseline_median_instructions * 1.02, baseline_median_instructions + 2000000)",
   "rss_threshold_rule": "max(baseline_peak_rss_bytes * 1.10, baseline_peak_rss_bytes + 33554432)",
   "runner_version": 1,
-  "source_commit": "8899996656ca2258ac84ef30136cc013ea0e3dd8",
+  "source_commit": "79186d67a2c0cd4cfae329bcad51d0edff76a5ac",
   "version": 1
 }

--- a/verification/areas/performance/data/work_budgets.json
+++ b/verification/areas/performance/data/work_budgets.json
@@ -1,0 +1,403 @@
+{
+  "budgets": [
+    {
+      "baseline_median_instructions": 117282886569,
+      "benchmark_id": "build-project-001-additional-modules",
+      "budget_id": "perf.build.project.additional_modules",
+      "threshold_median_instructions": 119628544301
+    },
+    {
+      "baseline_median_instructions": 111192690906,
+      "benchmark_id": "build-project-002-branch-paths",
+      "budget_id": "perf.build.project.branch_paths",
+      "threshold_median_instructions": 113416544725
+    },
+    {
+      "baseline_median_instructions": 111166311188,
+      "benchmark_id": "build-project-003-cargo-manifest",
+      "budget_id": "perf.build.project.cargo_manifest",
+      "threshold_median_instructions": 113389637412
+    },
+    {
+      "baseline_median_instructions": 115841429458,
+      "benchmark_id": "build-project-004-dependency-manifest",
+      "budget_id": "perf.build.project.dependency_manifest",
+      "threshold_median_instructions": 118158258048
+    },
+    {
+      "baseline_median_instructions": 111322000211,
+      "benchmark_id": "build-project-005-project-graph",
+      "budget_id": "perf.build.project.project_graph",
+      "threshold_median_instructions": 113548440216
+    },
+    {
+      "baseline_median_instructions": 111063220954,
+      "benchmark_id": "build-single-file-001-break-continue",
+      "budget_id": "perf.build.single.break_continue",
+      "threshold_median_instructions": 113284485374
+    },
+    {
+      "baseline_median_instructions": 111100277976,
+      "benchmark_id": "build-single-file-002-builtin-any-all",
+      "budget_id": "perf.build.single.builtin_any_all",
+      "threshold_median_instructions": 113322283536
+    },
+    {
+      "baseline_median_instructions": 111094255490,
+      "benchmark_id": "build-single-file-003-builtin-enumerate-zip",
+      "budget_id": "perf.build.single.builtin_enumerate_zip",
+      "threshold_median_instructions": 113316140600
+    },
+    {
+      "baseline_median_instructions": 111133440378,
+      "benchmark_id": "build-single-file-004-bytes-constructors",
+      "budget_id": "perf.build.single.bytes_constructors",
+      "threshold_median_instructions": 113356109186
+    },
+    {
+      "baseline_median_instructions": 111095028409,
+      "benchmark_id": "build-single-file-005-class-methods",
+      "budget_id": "perf.build.single.class_methods",
+      "threshold_median_instructions": 113316928978
+    },
+    {
+      "baseline_median_instructions": 111103582562,
+      "benchmark_id": "build-single-file-006-collection-len",
+      "budget_id": "perf.build.single.collection_len",
+      "threshold_median_instructions": 113325654214
+    },
+    {
+      "baseline_median_instructions": 111138253984,
+      "benchmark_id": "build-single-file-007-comp-set",
+      "budget_id": "perf.build.single.comp_set",
+      "threshold_median_instructions": 113361019064
+    },
+    {
+      "baseline_median_instructions": 115140328824,
+      "benchmark_id": "build-single-file-008-decimal-conversions",
+      "budget_id": "perf.build.single.decimal_conversions",
+      "threshold_median_instructions": 117443135401
+    },
+    {
+      "baseline_median_instructions": 111100225541,
+      "benchmark_id": "build-single-file-009-dict-get-option",
+      "budget_id": "perf.build.single.dict_get_option",
+      "threshold_median_instructions": 113322230052
+    },
+    {
+      "baseline_median_instructions": 111065658403,
+      "benchmark_id": "build-single-file-010-generic-identity",
+      "budget_id": "perf.build.single.generic_identity",
+      "threshold_median_instructions": 113286971572
+    },
+    {
+      "baseline_median_instructions": 13631146633,
+      "benchmark_id": "check-project-001-imports",
+      "budget_id": "perf.check.project.imports",
+      "threshold_median_instructions": 13903769566
+    },
+    {
+      "baseline_median_instructions": 13630649013,
+      "benchmark_id": "check-project-002-mode-consistency",
+      "budget_id": "perf.check.project.mode_consistency",
+      "threshold_median_instructions": 13903261994
+    },
+    {
+      "baseline_median_instructions": 13660151798,
+      "benchmark_id": "check-project-003-project-build",
+      "budget_id": "perf.check.project.project_build",
+      "threshold_median_instructions": 13933354834
+    },
+    {
+      "baseline_median_instructions": 13659380853,
+      "benchmark_id": "check-project-004-project-graph",
+      "budget_id": "perf.check.project.project_graph",
+      "threshold_median_instructions": 13932568471
+    },
+    {
+      "baseline_median_instructions": 13653454005,
+      "benchmark_id": "check-project-005-rooted-entrypoint",
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "threshold_median_instructions": 13926523086
+    },
+    {
+      "baseline_median_instructions": 13591024854,
+      "benchmark_id": "check-single-file-001-arithmetic",
+      "budget_id": "perf.check.single.arithmetic",
+      "threshold_median_instructions": 13862845352
+    },
+    {
+      "baseline_median_instructions": 13587399744,
+      "benchmark_id": "check-single-file-002-break-continue",
+      "budget_id": "perf.check.single.break_continue",
+      "threshold_median_instructions": 13859147739
+    },
+    {
+      "baseline_median_instructions": 13589055438,
+      "benchmark_id": "check-single-file-003-builtin-any-all",
+      "budget_id": "perf.check.single.builtin_any_all",
+      "threshold_median_instructions": 13860836547
+    },
+    {
+      "baseline_median_instructions": 13589014660,
+      "benchmark_id": "check-single-file-004-builtin-enumerate-zip",
+      "budget_id": "perf.check.single.builtin_enumerate_zip",
+      "threshold_median_instructions": 13860794954
+    },
+    {
+      "baseline_median_instructions": 13597957111,
+      "benchmark_id": "check-single-file-005-bytes-constructors",
+      "budget_id": "perf.check.single.bytes_constructors",
+      "threshold_median_instructions": 13869916254
+    },
+    {
+      "baseline_median_instructions": 13587308624,
+      "benchmark_id": "check-single-file-006-class-methods",
+      "budget_id": "perf.check.single.class_methods",
+      "threshold_median_instructions": 13859054797
+    },
+    {
+      "baseline_median_instructions": 13589092630,
+      "benchmark_id": "check-single-file-007-collection-len",
+      "budget_id": "perf.check.single.collection_len",
+      "threshold_median_instructions": 13860874483
+    },
+    {
+      "baseline_median_instructions": 13582277131,
+      "benchmark_id": "check-single-file-008-comp-set",
+      "budget_id": "perf.check.single.comp_set",
+      "threshold_median_instructions": 13853922674
+    },
+    {
+      "baseline_median_instructions": 13591206430,
+      "benchmark_id": "check-single-file-009-decimal-conversions",
+      "budget_id": "perf.check.single.decimal_conversions",
+      "threshold_median_instructions": 13863030559
+    },
+    {
+      "baseline_median_instructions": 13590141550,
+      "benchmark_id": "check-single-file-010-dict-get-option",
+      "budget_id": "perf.check.single.dict_get_option",
+      "threshold_median_instructions": 13861944381
+    },
+    {
+      "baseline_median_instructions": 13586565961,
+      "benchmark_id": "diagnostic-non-regression-001-human-success-exit",
+      "budget_id": "perf.diagnostic.human_success_exit",
+      "threshold_median_instructions": 13858297281
+    },
+    {
+      "baseline_median_instructions": 13584237890,
+      "benchmark_id": "diagnostic-non-regression-002-json-diagnostic-schema",
+      "budget_id": "perf.diagnostic.json_diagnostic_schema",
+      "threshold_median_instructions": 13855922648
+    },
+    {
+      "baseline_median_instructions": 13602623157,
+      "benchmark_id": "diagnostic-non-regression-003-compact-diagnostic-schema",
+      "budget_id": "perf.diagnostic.compact_diagnostic_schema",
+      "threshold_median_instructions": 13874675621
+    },
+    {
+      "baseline_median_instructions": 13604456358,
+      "benchmark_id": "diagnostic-non-regression-004-recovery-limit",
+      "budget_id": "perf.diagnostic.recovery_limit",
+      "threshold_median_instructions": 13876545486
+    },
+    {
+      "baseline_median_instructions": 13550299971,
+      "benchmark_id": "diagnostic-non-regression-005-project-error-exit",
+      "budget_id": "perf.diagnostic.project_error_exit",
+      "threshold_median_instructions": 13821305971
+    },
+    {
+      "baseline_median_instructions": 36741481,
+      "benchmark_id": "formatter-corpus-001-project-check",
+      "budget_id": "perf.formatter.corpus.project_check",
+      "threshold_median_instructions": 37741481
+    },
+    {
+      "baseline_median_instructions": 57766905,
+      "benchmark_id": "formatter-large-file-001-check",
+      "budget_id": "perf.formatter.large_file.check",
+      "threshold_median_instructions": 58922244
+    },
+    {
+      "baseline_median_instructions": 902600920,
+      "benchmark_id": "incremental-local-loop-001-unchanged-file-update",
+      "budget_id": "perf.incremental.unchanged_file_update",
+      "threshold_median_instructions": 920652939
+    },
+    {
+      "baseline_median_instructions": 677467842,
+      "benchmark_id": "incremental-local-loop-002-leaf-module-change",
+      "budget_id": "perf.incremental.leaf_module_change",
+      "threshold_median_instructions": 691017199
+    },
+    {
+      "baseline_median_instructions": 3817064021,
+      "benchmark_id": "incremental-local-loop-003-imported-module-change",
+      "budget_id": "perf.incremental.imported_module_change",
+      "threshold_median_instructions": 3893405302
+    },
+    {
+      "baseline_median_instructions": 4456725544,
+      "benchmark_id": "incremental-local-loop-004-public-api-change",
+      "budget_id": "perf.incremental.public_api_change",
+      "threshold_median_instructions": 4545860055
+    },
+    {
+      "baseline_median_instructions": 4156388914,
+      "benchmark_id": "incremental-local-loop-005-failure-recovery",
+      "budget_id": "perf.incremental.failure_recovery",
+      "threshold_median_instructions": 4239516693
+    },
+    {
+      "baseline_median_instructions": 373463167,
+      "benchmark_id": "interactive-tooling-foundation-001-cold-context-load",
+      "budget_id": "perf.interactive.cold_context_load",
+      "threshold_median_instructions": 380932431
+    },
+    {
+      "baseline_median_instructions": 1448302744,
+      "benchmark_id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "threshold_median_instructions": 1477268799
+    },
+    {
+      "baseline_median_instructions": 584625090,
+      "benchmark_id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "threshold_median_instructions": 596317592
+    },
+    {
+      "baseline_median_instructions": 2342114988,
+      "benchmark_id": "interactive-tooling-foundation-004-changed-file-invalidation",
+      "budget_id": "perf.interactive.changed_file_invalidation",
+      "threshold_median_instructions": 2388957288
+    },
+    {
+      "baseline_median_instructions": 216307837,
+      "benchmark_id": "interactive-tooling-foundation-005-source-map-lookup",
+      "budget_id": "perf.interactive.source_map_lookup",
+      "threshold_median_instructions": 220633994
+    },
+    {
+      "baseline_median_instructions": 380729297,
+      "benchmark_id": "lsp-query-001-request-families",
+      "budget_id": "perf.lsp.request_families",
+      "threshold_median_instructions": 388343883
+    },
+    {
+      "baseline_median_instructions": 323934418,
+      "benchmark_id": "lsp-query-002-cold-start",
+      "budget_id": "perf.lsp.cold_start.workspace",
+      "threshold_median_instructions": 330413107
+    },
+    {
+      "baseline_median_instructions": 381052486,
+      "benchmark_id": "lsp-query-003-diagnostics",
+      "budget_id": "perf.lsp.diagnostics.document",
+      "threshold_median_instructions": 388673536
+    },
+    {
+      "baseline_median_instructions": 343554524,
+      "benchmark_id": "lsp-query-004-workspace-diagnostics",
+      "budget_id": "perf.lsp.diagnostics.workspace",
+      "threshold_median_instructions": 350425615
+    },
+    {
+      "baseline_median_instructions": 1321566414,
+      "benchmark_id": "lsp-query-005-completion",
+      "budget_id": "perf.lsp.completion.local_scope",
+      "threshold_median_instructions": 1347997743
+    },
+    {
+      "baseline_median_instructions": 360158838,
+      "benchmark_id": "lsp-query-006-hover",
+      "budget_id": "perf.lsp.hover.symbol",
+      "threshold_median_instructions": 367362015
+    },
+    {
+      "baseline_median_instructions": 360681364,
+      "benchmark_id": "lsp-query-007-signature-help",
+      "budget_id": "perf.lsp.signature_help.call",
+      "threshold_median_instructions": 367894992
+    },
+    {
+      "baseline_median_instructions": 491682698,
+      "benchmark_id": "lsp-query-008-navigation",
+      "budget_id": "perf.lsp.navigation.symbol",
+      "threshold_median_instructions": 501516352
+    },
+    {
+      "baseline_median_instructions": 344139058,
+      "benchmark_id": "lsp-query-009-references",
+      "budget_id": "perf.lsp.references.workspace_symbol",
+      "threshold_median_instructions": 351021840
+    },
+    {
+      "baseline_median_instructions": 363144018,
+      "benchmark_id": "lsp-query-010-rename",
+      "budget_id": "perf.lsp.rename.workspace_edit",
+      "threshold_median_instructions": 370406899
+    },
+    {
+      "baseline_median_instructions": 395587118,
+      "benchmark_id": "lsp-query-011-semantic-tokens",
+      "budget_id": "perf.lsp.semantic_tokens.full",
+      "threshold_median_instructions": 403498861
+    },
+    {
+      "baseline_median_instructions": 361363905,
+      "benchmark_id": "lsp-query-012-inlay-hints",
+      "budget_id": "perf.lsp.inlay_hints.module",
+      "threshold_median_instructions": 368591184
+    },
+    {
+      "baseline_median_instructions": 363352079,
+      "benchmark_id": "lsp-query-013-selection-range",
+      "budget_id": "perf.lsp.selection_ranges.nested",
+      "threshold_median_instructions": 370619121
+    },
+    {
+      "baseline_median_instructions": 358821461,
+      "benchmark_id": "lsp-query-014-type-hierarchy",
+      "budget_id": "perf.lsp.type_hierarchy.symbol",
+      "threshold_median_instructions": 365997891
+    },
+    {
+      "baseline_median_instructions": 359860734,
+      "benchmark_id": "lsp-query-015-code-actions",
+      "budget_id": "perf.lsp.code_action.diagnostic",
+      "threshold_median_instructions": 367057949
+    },
+    {
+      "baseline_median_instructions": 383279912,
+      "benchmark_id": "lsp-query-016-formatting",
+      "budget_id": "perf.lsp.formatting.document",
+      "threshold_median_instructions": 390945511
+    },
+    {
+      "baseline_median_instructions": 363844482,
+      "benchmark_id": "lsp-query-017-generated-rust-preview",
+      "budget_id": "perf.lsp.generated_rust_preview.document",
+      "threshold_median_instructions": 371121372
+    },
+    {
+      "baseline_median_instructions": 408244055,
+      "benchmark_id": "lsp-query-018-did-open-diagnostics",
+      "budget_id": "perf.lsp.document_sync.did_open",
+      "threshold_median_instructions": 416408937
+    }
+  ],
+  "host": {
+    "architecture": "arm64",
+    "host_os": "macOS-26.6-arm64-arm-64bit-Mach-O",
+    "work_counter_source": "darwin-rusage-instructions"
+  },
+  "runner_version": 1,
+  "source_commit": "64881055453937d596bff6d7d569a97beba7bd8a",
+  "threshold_rule": "max(baseline_median_instructions * 1.02, baseline_median_instructions + 1000000)",
+  "version": 1
+}

--- a/verification/areas/performance/host_control.py
+++ b/verification/areas/performance/host_control.py
@@ -9,9 +9,11 @@ import subprocess
 import tempfile
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
+from process_metrics import parse_process_metrics
 
 MAX_NORMALIZED_LOAD = 0.85
 MAX_CALIBRATION_CV = 0.12
@@ -19,6 +21,7 @@ MAX_EXTERNAL_CPU_PERCENT = 50.0
 DEFAULT_QUIET_SNAPSHOTS = 3
 DEFAULT_QUIET_INTERVAL_SECONDS = 1.0
 MONITOR_INTERVAL_SECONDS = 5.0
+CONTROL_MODES = {"latency", "work"}
 
 
 class HostControlError(Exception):
@@ -47,13 +50,25 @@ def capture_host_snapshot(*, include_calibration: bool = True) -> dict[str, Any]
         "thermal": thermal,
         "power": power,
         "cpu_frequency_behavior": frequency,
+        "work_counter": (
+            work_counter_state()
+            if include_calibration
+            else {"source": "not-sampled"}
+        ),
         "competing_processes": competitors,
         "external_cpu_pressure": cpu_pressure,
         "memory_pressure": memory_pressure_state(),
     }
 
 
-def evaluate_snapshot(snapshot: dict[str, Any], *, enforce_load: bool) -> list[str]:
+def evaluate_snapshot(
+    snapshot: dict[str, Any],
+    *,
+    enforce_load: bool,
+    control_mode: str = "latency",
+    require_work_counter: bool = False,
+) -> list[str]:
+    validate_control_mode(control_mode)
     reasons: list[str] = []
     competitors = snapshot.get("competing_processes", [])
     if competitors:
@@ -66,18 +81,26 @@ def evaluate_snapshot(snapshot: dict[str, Any], *, enforce_load: bool) -> list[s
         reasons.append("not-on-ac-power")
     frequency = snapshot.get("cpu_frequency_behavior", {})
     calibration_cv = frequency.get("calibration_cv")
-    if isinstance(calibration_cv, int | float) and calibration_cv > MAX_CALIBRATION_CV:
+    if (
+        control_mode == "latency"
+        and isinstance(calibration_cv, int | float)
+        and calibration_cv > MAX_CALIBRATION_CV
+    ):
         reasons.append("unstable-frequency-proxy")
+    if require_work_counter and snapshot.get("work_counter", {}).get("source") != (
+        "darwin-rusage-instructions"
+    ):
+        reasons.append("retired-instructions-unavailable")
     cpu_pressure = snapshot.get("external_cpu_pressure", {})
     external_cpu_percent = cpu_pressure.get("external_cpu_percent")
     if cpu_pressure.get("source") != "ps":
         reasons.append("external-cpu-pressure-unavailable")
-    elif (
+    elif control_mode == "latency" and (
         isinstance(external_cpu_percent, int | float)
         and external_cpu_percent > MAX_EXTERNAL_CPU_PERCENT
     ):
         reasons.append("external-cpu-pressure")
-    if enforce_load:
+    if enforce_load and control_mode == "latency":
         normalized_load = snapshot.get("load_average", {}).get(
             "one_minute_per_logical_cpu"
         )
@@ -92,17 +115,24 @@ def evaluate_snapshot(snapshot: dict[str, Any], *, enforce_load: bool) -> list[s
 def wait_for_controlled_host(
     timeout_seconds: float,
     *,
+    control_mode: str = "latency",
     snapshot_fn: Callable[..., dict[str, Any]] = capture_host_snapshot,
     sleep_fn: Callable[[float], None] = time.sleep,
     quiet_snapshots: int = DEFAULT_QUIET_SNAPSHOTS,
     interval_seconds: float = DEFAULT_QUIET_INTERVAL_SECONDS,
 ) -> dict[str, Any]:
+    validate_control_mode(control_mode)
     deadline = time.monotonic() + timeout_seconds
     consecutive: list[dict[str, Any]] = []
     observations: list[dict[str, Any]] = []
     while True:
         snapshot = snapshot_fn(include_calibration=True)
-        reasons = evaluate_snapshot(snapshot, enforce_load=True)
+        reasons = evaluate_snapshot(
+            snapshot,
+            enforce_load=True,
+            control_mode=control_mode,
+            require_work_counter=control_mode == "work",
+        )
         observation = {"snapshot": snapshot, "rejection_reasons": reasons}
         observations.append(observation)
         if reasons:
@@ -112,7 +142,8 @@ def wait_for_controlled_host(
             if len(consecutive) >= quiet_snapshots:
                 return {
                     "status": "controlled",
-                    "policy": controlled_policy(),
+                    "mode": control_mode,
+                    "policy": controlled_policy(control_mode),
                     "accepted_snapshots": consecutive,
                     "observation_count": len(observations),
                     "rejected_observation_count": sum(
@@ -131,24 +162,36 @@ def wait_for_controlled_host(
         sleep_fn(interval_seconds)
 
 
-def controlled_policy() -> dict[str, Any]:
+def controlled_policy(control_mode: str = "latency") -> dict[str, Any]:
+    validate_control_mode(control_mode)
     return {
+        "mode": control_mode,
         "quiet_snapshots": DEFAULT_QUIET_SNAPSHOTS,
         "quiet_interval_seconds": DEFAULT_QUIET_INTERVAL_SECONDS,
         "max_one_minute_load_per_logical_cpu": MAX_NORMALIZED_LOAD,
         "max_frequency_proxy_cv": MAX_CALIBRATION_CV,
         "max_external_cpu_percent": MAX_EXTERNAL_CPU_PERCENT,
+        "external_cpu_limit_applied": control_mode == "latency",
+        "load_limit_applied": control_mode == "latency",
         "requires_ac_power_on_macos": True,
         "rejects_competing_build_processes": True,
         "rejects_thermal_pressure": True,
+        "wall_latency_qualified": control_mode == "latency",
+        "requires_retired_instructions": control_mode == "work",
     }
 
 
 class HostActivityMonitor:
     """Record host pressure that appears while one benchmark case is running."""
 
-    def __init__(self, interval_seconds: float = MONITOR_INTERVAL_SECONDS) -> None:
+    def __init__(
+        self,
+        interval_seconds: float = MONITOR_INTERVAL_SECONDS,
+        control_mode: str = "latency",
+    ) -> None:
+        validate_control_mode(control_mode)
         self._interval_seconds = interval_seconds
+        self._control_mode = control_mode
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self.snapshots: list[dict[str, Any]] = []
@@ -174,7 +217,13 @@ class HostActivityMonitor:
     def rejection_reasons(self) -> list[str]:
         reasons: set[str] = set()
         for snapshot in self.snapshots:
-            reasons.update(evaluate_snapshot(snapshot, enforce_load=False))
+            reasons.update(
+                evaluate_snapshot(
+                    snapshot,
+                    enforce_load=False,
+                    control_mode=self._control_mode,
+                )
+            )
         return sorted(reasons)
 
 
@@ -201,6 +250,23 @@ def cache_state(
         "generated_artifact_entries": artifact_entries,
         "cargo_lock_present": repo_root.joinpath("Cargo.lock").is_file(),
     }
+
+
+def work_counter_state() -> dict[str, Any]:
+    if platform.system() != "Darwin" or not Path("/usr/bin/time").is_file():
+        return {"source": "unavailable", "retired_instructions": None}
+    parsed = parse_process_metrics(
+        command_output(["/usr/bin/time", "-l", "/usr/bin/true"])
+    )
+    return {
+        "source": parsed["work_counter_source"],
+        "retired_instructions": parsed["retired_instructions"],
+    }
+
+
+def validate_control_mode(control_mode: str) -> None:
+    if control_mode not in CONTROL_MODES:
+        raise HostControlError(f"unsupported host control mode {control_mode!r}")
 
 
 def cpu_frequency_state(*, include_calibration: bool) -> dict[str, Any]:
@@ -454,6 +520,10 @@ def run_self_test() -> None:
         "thermal": {"status": "nominal"},
         "power": {"source": "ac", "required": True},
         "cpu_frequency_behavior": {"calibration_cv": 0.01},
+        "work_counter": {
+            "source": "darwin-rusage-instructions",
+            "retired_instructions": 100,
+        },
         "competing_processes": [],
         "external_cpu_pressure": {
             "source": "ps",
@@ -476,6 +546,26 @@ def run_self_test() -> None:
     ]:
         raise HostControlError(
             "host control self-test did not reject external CPU pressure"
+        )
+    if evaluate_snapshot(
+        cpu_pressured,
+        enforce_load=True,
+        control_mode="work",
+        require_work_counter=True,
+    ):
+        raise HostControlError(
+            "work control self-test rejected measurable external CPU pressure"
+        )
+    missing_counter = dict(nominal)
+    missing_counter["work_counter"] = {"source": "unavailable"}
+    if evaluate_snapshot(
+        missing_counter,
+        enforce_load=True,
+        control_mode="work",
+        require_work_counter=True,
+    ) != ["retired-instructions-unavailable"]:
+        raise HostControlError(
+            "work control self-test did not require retired instructions"
         )
     cpu_unavailable = dict(nominal)
     cpu_unavailable["external_cpu_pressure"] = {"source": "unavailable"}

--- a/verification/areas/performance/host_control.py
+++ b/verification/areas/performance/host_control.py
@@ -15,6 +15,7 @@ from typing import Any, Callable
 
 MAX_NORMALIZED_LOAD = 0.85
 MAX_CALIBRATION_CV = 0.12
+MAX_EXTERNAL_CPU_PERCENT = 50.0
 DEFAULT_QUIET_SNAPSHOTS = 3
 DEFAULT_QUIET_INTERVAL_SECONDS = 1.0
 MONITOR_INTERVAL_SECONDS = 5.0
@@ -33,6 +34,7 @@ def capture_host_snapshot(*, include_calibration: bool = True) -> dict[str, Any]
     thermal = thermal_state()
     power = power_state()
     frequency = cpu_frequency_state(include_calibration=include_calibration)
+    competitors, cpu_pressure = process_activity()
     return {
         "captured_at_unix": round(time.time(), 3),
         "logical_cpus": logical_cpus,
@@ -45,7 +47,8 @@ def capture_host_snapshot(*, include_calibration: bool = True) -> dict[str, Any]
         "thermal": thermal,
         "power": power,
         "cpu_frequency_behavior": frequency,
-        "competing_processes": competing_processes(),
+        "competing_processes": competitors,
+        "external_cpu_pressure": cpu_pressure,
         "memory_pressure": memory_pressure_state(),
     }
 
@@ -65,6 +68,15 @@ def evaluate_snapshot(snapshot: dict[str, Any], *, enforce_load: bool) -> list[s
     calibration_cv = frequency.get("calibration_cv")
     if isinstance(calibration_cv, int | float) and calibration_cv > MAX_CALIBRATION_CV:
         reasons.append("unstable-frequency-proxy")
+    cpu_pressure = snapshot.get("external_cpu_pressure", {})
+    external_cpu_percent = cpu_pressure.get("external_cpu_percent")
+    if cpu_pressure.get("source") != "ps":
+        reasons.append("external-cpu-pressure-unavailable")
+    elif (
+        isinstance(external_cpu_percent, int | float)
+        and external_cpu_percent > MAX_EXTERNAL_CPU_PERCENT
+    ):
+        reasons.append("external-cpu-pressure")
     if enforce_load:
         normalized_load = snapshot.get("load_average", {}).get(
             "one_minute_per_logical_cpu"
@@ -125,6 +137,7 @@ def controlled_policy() -> dict[str, Any]:
         "quiet_interval_seconds": DEFAULT_QUIET_INTERVAL_SECONDS,
         "max_one_minute_load_per_logical_cpu": MAX_NORMALIZED_LOAD,
         "max_frequency_proxy_cv": MAX_CALIBRATION_CV,
+        "max_external_cpu_percent": MAX_EXTERNAL_CPU_PERCENT,
         "requires_ac_power_on_macos": True,
         "rejects_competing_build_processes": True,
         "rejects_thermal_pressure": True,
@@ -300,23 +313,67 @@ def memory_pressure_state() -> dict[str, Any]:
     return {"source": "unavailable"}
 
 
-def competing_processes() -> list[dict[str, Any]]:
-    output = command_output(["ps", "-axo", "pid=,ppid=,comm=,args="])
-    rows: list[tuple[int, int, str, str]] = []
+def process_activity() -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    output = command_output(["ps", "-axo", "pid=,ppid=,pcpu=,comm=,args="])
+    rows: list[tuple[int, int, float, str, str]] = []
     for line in output.splitlines():
-        parts = line.strip().split(maxsplit=3)
-        if len(parts) < 4 or not parts[0].isdigit() or not parts[1].isdigit():
+        parts = line.strip().split(maxsplit=4)
+        if len(parts) < 5 or not parts[0].isdigit() or not parts[1].isdigit():
             continue
-        rows.append((int(parts[0]), int(parts[1]), parts[2], parts[3]))
-    excluded = related_process_ids(rows, os.getpid())
-    competitors = []
-    for pid, _parent, command, args in rows:
+        try:
+            cpu_percent = float(parts[2])
+        except ValueError:
+            continue
+        rows.append((int(parts[0]), int(parts[1]), cpu_percent, parts[3], parts[4]))
+    if not rows:
+        return [], {
+            "source": "unavailable",
+            "external_cpu_percent": None,
+            "max_external_cpu_percent": MAX_EXTERNAL_CPU_PERCENT,
+            "top_processes": [],
+        }
+    return summarize_process_activity(rows, os.getpid())
+
+
+def summarize_process_activity(
+    rows: list[tuple[int, int, float, str, str]], current_pid: int
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    excluded = related_process_ids(rows, current_pid)
+    competitors: list[dict[str, Any]] = []
+    external_rows: list[tuple[int, float, str]] = []
+    for pid, _parent, cpu_percent, command, args in rows:
         if pid in excluded:
             continue
+        executable = executable_from_process(command, args)
+        external_rows.append((pid, cpu_percent, executable))
         category = process_category(command, args)
         if category is not None:
             competitors.append({"pid": pid, "category": category})
-    return competitors
+    external_cpu_percent = sum(cpu_percent for _pid, cpu_percent, _name in external_rows)
+    top_processes = [
+        {
+            "pid": pid,
+            "cpu_percent": round(cpu_percent, 1),
+            "executable": executable,
+        }
+        for pid, cpu_percent, executable in sorted(
+            external_rows, key=lambda row: row[1], reverse=True
+        )[:5]
+        if cpu_percent > 0.0
+    ]
+    return competitors, {
+        "source": "ps",
+        "external_cpu_percent": round(external_cpu_percent, 1),
+        "max_external_cpu_percent": MAX_EXTERNAL_CPU_PERCENT,
+        "top_processes": top_processes,
+    }
+
+
+def executable_from_process(command: str, args: str) -> str:
+    argument_tokens = args.split()
+    if argument_tokens:
+        return Path(argument_tokens[0]).name
+    return Path(command).name
 
 
 def process_category(command: str, args: str) -> str | None:
@@ -348,11 +405,11 @@ def process_category(command: str, args: str) -> str | None:
 
 
 def related_process_ids(
-    rows: list[tuple[int, int, str, str]], current_pid: int
+    rows: list[tuple[int, int, float, str, str]], current_pid: int
 ) -> set[int]:
-    parents = {pid: parent for pid, parent, _command, _args in rows}
+    parents = {pid: parent for pid, parent, _cpu, _command, _args in rows}
     children: dict[int, list[int]] = {}
-    for pid, parent, _command, _args in rows:
+    for pid, parent, _cpu, _command, _args in rows:
         children.setdefault(parent, []).append(pid)
     related = {current_pid}
     cursor = current_pid
@@ -390,6 +447,10 @@ def run_self_test() -> None:
         "power": {"source": "ac", "required": True},
         "cpu_frequency_behavior": {"calibration_cv": 0.01},
         "competing_processes": [],
+        "external_cpu_pressure": {
+            "source": "ps",
+            "external_cpu_percent": 1.0,
+        },
     }
     if evaluate_snapshot(nominal, enforce_load=True):
         raise HostControlError("host control self-test rejected a nominal snapshot")
@@ -397,6 +458,25 @@ def run_self_test() -> None:
     pressured["competing_processes"] = [{"pid": 42}]
     if evaluate_snapshot(pressured, enforce_load=True) != ["competing-build-process"]:
         raise HostControlError("host control self-test did not reject competing work")
+    cpu_pressured = dict(nominal)
+    cpu_pressured["external_cpu_pressure"] = {
+        "source": "ps",
+        "external_cpu_percent": MAX_EXTERNAL_CPU_PERCENT + 0.1,
+    }
+    if evaluate_snapshot(cpu_pressured, enforce_load=True) != [
+        "external-cpu-pressure"
+    ]:
+        raise HostControlError(
+            "host control self-test did not reject external CPU pressure"
+        )
+    cpu_unavailable = dict(nominal)
+    cpu_unavailable["external_cpu_pressure"] = {"source": "unavailable"}
+    if evaluate_snapshot(cpu_unavailable, enforce_load=True) != [
+        "external-cpu-pressure-unavailable"
+    ]:
+        raise HostControlError(
+            "host control self-test did not fail closed without external CPU telemetry"
+        )
     sequence = iter([pressured, nominal, nominal, nominal])
     admission = wait_for_controlled_host(
         1.0,
@@ -424,6 +504,24 @@ def run_self_test() -> None:
         )
     if process_category("/usr/bin/git", "git index-pack --stdin") != "git":
         raise HostControlError("host control self-test missed Git indexing work")
+    competitors, cpu_pressure = summarize_process_activity(
+        [
+            (1, 0, 0.1, "/sbin/launchd", "/sbin/launchd"),
+            (10, 1, 10.0, "/usr/bin/python3", "python3 run_benchmarks.py"),
+            (11, 10, 90.0, "/usr/bin/rustc", "rustc --crate-name measured"),
+            (20, 1, 30.0, "/usr/bin/cargo", "cargo build"),
+            (21, 1, 25.1, "/opt/agent", "/opt/agent --scan"),
+        ],
+        10,
+    )
+    if competitors != [{"pid": 20, "category": "cargo"}]:
+        raise HostControlError(
+            "host control self-test did not isolate external build work"
+        )
+    if cpu_pressure["external_cpu_percent"] != 55.1:
+        raise HostControlError(
+            "host control self-test included related benchmark CPU activity"
+        )
     if (
         process_category(
             "/Users/example",

--- a/verification/areas/performance/host_control.py
+++ b/verification/areas/performance/host_control.py
@@ -28,6 +28,11 @@ class HostControlError(Exception):
     """Raised when the host cannot provide a controlled measurement window."""
 
 
+def profile_control_mode(host_system: str | None = None) -> str:
+    system = platform.system() if host_system is None else host_system
+    return "work" if system == "Darwin" else "latency"
+
+
 def capture_host_snapshot(*, include_calibration: bool = True) -> dict[str, Any]:
     logical_cpus = os.cpu_count() or 1
     try:
@@ -515,6 +520,10 @@ def executable_name(name: str) -> str:
 
 
 def run_self_test() -> None:
+    if profile_control_mode("Darwin") != "work":
+        raise HostControlError("Darwin profile mode self-test did not select work")
+    if profile_control_mode("Linux") != "latency":
+        raise HostControlError("Linux profile mode self-test did not select latency")
     nominal = {
         "load_average": {"one_minute_per_logical_cpu": 0.1},
         "thermal": {"status": "nominal"},

--- a/verification/areas/performance/host_control.py
+++ b/verification/areas/performance/host_control.py
@@ -313,8 +313,23 @@ def memory_pressure_state() -> dict[str, Any]:
     return {"source": "unavailable"}
 
 
-def process_activity() -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    output = command_output(["ps", "-axo", "pid=,ppid=,pcpu=,comm=,args="])
+def process_activity(
+    output: str | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if output is None:
+        output = command_output(["ps", "-axo", "pid=,ppid=,pcpu=,comm=,args="])
+    rows = parse_process_rows(output)
+    if not rows:
+        return [], {
+            "source": "unavailable",
+            "external_cpu_percent": None,
+            "max_external_cpu_percent": MAX_EXTERNAL_CPU_PERCENT,
+            "top_processes": [],
+        }
+    return summarize_process_activity(rows, os.getpid())
+
+
+def parse_process_rows(output: str) -> list[tuple[int, int, float, str, str]]:
     rows: list[tuple[int, int, float, str, str]] = []
     for line in output.splitlines():
         parts = line.strip().split(maxsplit=4)
@@ -325,14 +340,7 @@ def process_activity() -> tuple[list[dict[str, Any]], dict[str, Any]]:
         except ValueError:
             continue
         rows.append((int(parts[0]), int(parts[1]), cpu_percent, parts[3], parts[4]))
-    if not rows:
-        return [], {
-            "source": "unavailable",
-            "external_cpu_percent": None,
-            "max_external_cpu_percent": MAX_EXTERNAL_CPU_PERCENT,
-            "top_processes": [],
-        }
-    return summarize_process_activity(rows, os.getpid())
+    return rows
 
 
 def summarize_process_activity(
@@ -521,6 +529,24 @@ def run_self_test() -> None:
     if cpu_pressure["external_cpu_percent"] != 55.1:
         raise HostControlError(
             "host control self-test included related benchmark CPU activity"
+        )
+    parsed_rows = parse_process_rows(
+        "bad row\n"
+        "42 1 not-a-number /usr/bin/noop noop\n"
+        "43 1 12.5 /usr/bin/tool /usr/bin/tool --work\n"
+    )
+    if parsed_rows != [
+        (43, 1, 12.5, "/usr/bin/tool", "/usr/bin/tool --work")
+    ]:
+        raise HostControlError("host control self-test did not parse ps rows safely")
+    unavailable_competitors, unavailable_cpu = process_activity("")
+    if unavailable_competitors or unavailable_cpu["source"] != "unavailable":
+        raise HostControlError(
+            "host control self-test did not fail closed on empty ps output"
+        )
+    if executable_from_process("/truncated", "/usr/bin/tool --work") != "tool":
+        raise HostControlError(
+            "host control self-test did not prefer the argv executable"
         )
     if (
         process_category(

--- a/verification/areas/performance/process_metrics.py
+++ b/verification/areas/performance/process_metrics.py
@@ -126,6 +126,12 @@ def work_metrics(
     }
 
 
+def work_sample_evidence(instruction_samples: list[int]) -> dict[str, list[int]]:
+    if not instruction_samples:
+        return {}
+    return {"samples_instructions": instruction_samples}
+
+
 def run_self_test() -> None:
     darwin = parse_process_metrics(
         "        1.25 real         0.80 user         0.20 sys\n"
@@ -152,6 +158,10 @@ def run_self_test() -> None:
     metrics = work_metrics([100, 101, 99], [50, 51, 49])
     if metrics["median_instructions"] != 100:
         raise ValueError(f"work metric median mismatch: {metrics!r}")
+    if work_sample_evidence([]) != {}:
+        raise ValueError("empty work samples must not emit evidence")
+    if work_sample_evidence([100]) != {"samples_instructions": [100]}:
+        raise ValueError("available work samples must emit evidence")
 
 
 def leading_integer(value: str) -> int | None:

--- a/verification/areas/performance/process_metrics.py
+++ b/verification/areas/performance/process_metrics.py
@@ -1,0 +1,172 @@
+"""Portable subprocess timing and low-variance work-counter parsing."""
+
+from __future__ import annotations
+
+import math
+import platform
+import re
+import statistics
+from pathlib import Path
+from typing import Any
+
+DARWIN_TIME_RE = re.compile(
+    r"^\s*(?P<real>[0-9.]+) real\s+(?P<user>[0-9.]+) user\s+(?P<sys>[0-9.]+) sys\s*$"
+)
+
+
+def timed_command(command: list[str]) -> list[str]:
+    if platform.system() == "Darwin" and Path("/usr/bin/time").exists():
+        return ["/usr/bin/time", "-l", *command]
+    if platform.system() == "Linux" and Path("/usr/bin/time").exists():
+        return ["/usr/bin/time", "-v", *command]
+    return command
+
+
+def parse_process_metrics(stderr: str) -> dict[str, int | float | str | None]:
+    peak_rss_bytes: int | None = None
+    retired_instructions: int | None = None
+    cycles_elapsed: int | None = None
+    cpu_time_ms: float | None = None
+    for line in stderr.splitlines():
+        stripped = line.strip()
+        match = DARWIN_TIME_RE.match(line)
+        if match is not None:
+            cpu_time_ms = (
+                float(match.group("user")) + float(match.group("sys"))
+            ) * 1000.0
+        if stripped.endswith("maximum resident set size"):
+            peak_rss_bytes = leading_integer(stripped)
+        elif "Maximum resident set size (kbytes):" in stripped:
+            value = trailing_integer(stripped)
+            peak_rss_bytes = value * 1024 if value is not None else None
+        elif stripped.endswith("instructions retired"):
+            retired_instructions = leading_integer(stripped)
+        elif stripped.endswith("cycles elapsed"):
+            cycles_elapsed = leading_integer(stripped)
+        elif stripped.startswith("User time (seconds):"):
+            user_seconds = trailing_float(stripped)
+            if user_seconds is not None:
+                cpu_time_ms = user_seconds * 1000.0
+        elif stripped.startswith("System time (seconds):"):
+            system_seconds = trailing_float(stripped)
+            if system_seconds is not None:
+                cpu_time_ms = (cpu_time_ms or 0.0) + system_seconds * 1000.0
+    source = (
+        "darwin-rusage-instructions"
+        if retired_instructions is not None
+        else "unavailable"
+    )
+    return {
+        "peak_rss_bytes": peak_rss_bytes,
+        "retired_instructions": retired_instructions,
+        "cycles_elapsed": cycles_elapsed,
+        "cpu_time_ms": round(cpu_time_ms, 3) if cpu_time_ms is not None else None,
+        "work_counter_source": source,
+    }
+
+
+def sample_stats(samples: list[float]) -> dict[str, float]:
+    if not samples:
+        raise ValueError("cannot compute metrics for an empty sample list")
+    median = statistics.median(samples)
+    p95 = percentile(samples, 95)
+    mad = statistics.median([abs(sample - median) for sample in samples])
+    mean = statistics.mean(samples)
+    stdev = statistics.pstdev(samples) if len(samples) > 1 else 0.0
+    cv = 0.0 if mean == 0 else stdev / mean
+    return {
+        "median": round(median, 3),
+        "p95": round(p95, 3),
+        "mad": round(mad, 3),
+        "coefficient_variation": round(cv, 6),
+    }
+
+
+def latency_metrics(samples: list[float]) -> dict[str, float]:
+    stats = sample_stats(samples)
+    return {
+        "median_ms": stats["median"],
+        "p95_ms": stats["p95"],
+        "mad_ms": stats["mad"],
+        "coefficient_variation": stats["coefficient_variation"],
+    }
+
+
+def percentile(samples: list[float], percentile_value: int) -> float:
+    ordered = sorted(samples)
+    rank = math.ceil((percentile_value / 100.0) * len(ordered))
+    return ordered[max(0, rank - 1)]
+
+
+def work_metrics(
+    instruction_samples: list[int], cycle_samples: list[int]
+) -> dict[str, Any]:
+    if not instruction_samples:
+        return {
+            "median_instructions": None,
+            "p95_instructions": None,
+            "instructions_mad": None,
+            "instructions_coefficient_variation": None,
+            "median_cycles_per_instruction": None,
+        }
+    stats = sample_stats([float(value) for value in instruction_samples])
+    ratios = [
+        cycles / instructions
+        for cycles, instructions in zip(cycle_samples, instruction_samples, strict=False)
+        if instructions > 0
+    ]
+    return {
+        "median_instructions": round(stats["median"]),
+        "p95_instructions": round(stats["p95"]),
+        "instructions_mad": round(stats["mad"]),
+        "instructions_coefficient_variation": stats["coefficient_variation"],
+        "median_cycles_per_instruction": (
+            round(statistics.median(ratios), 6) if ratios else None
+        ),
+    }
+
+
+def run_self_test() -> None:
+    darwin = parse_process_metrics(
+        "        1.25 real         0.80 user         0.20 sys\n"
+        "            123456  maximum resident set size\n"
+        "          98765432  instructions retired\n"
+        "          45678901  cycles elapsed\n"
+    )
+    expected = {
+        "peak_rss_bytes": 123456,
+        "retired_instructions": 98765432,
+        "cycles_elapsed": 45678901,
+        "cpu_time_ms": 1000.0,
+        "work_counter_source": "darwin-rusage-instructions",
+    }
+    if darwin != expected:
+        raise ValueError(f"Darwin process metric parsing mismatch: {darwin!r}")
+    linux = parse_process_metrics(
+        "User time (seconds): 1.50\n"
+        "System time (seconds): 0.25\n"
+        "Maximum resident set size (kbytes): 1024\n"
+    )
+    if linux["peak_rss_bytes"] != 1024 * 1024 or linux["cpu_time_ms"] != 1750.0:
+        raise ValueError(f"Linux process metric parsing mismatch: {linux!r}")
+    metrics = work_metrics([100, 101, 99], [50, 51, 49])
+    if metrics["median_instructions"] != 100:
+        raise ValueError(f"work metric median mismatch: {metrics!r}")
+
+
+def leading_integer(value: str) -> int | None:
+    token = value.split(maxsplit=1)[0]
+    return int(token) if token.isdigit() else None
+
+
+def trailing_integer(value: str) -> int | None:
+    token = value.rsplit(":", maxsplit=1)[-1].strip()
+    return int(token) if token.isdigit() else None
+
+
+def trailing_float(value: str) -> float | None:
+    token = value.rsplit(":", maxsplit=1)[-1].strip()
+    try:
+        return float(token)
+    except ValueError:
+        return None

--- a/verification/areas/performance/query_processes.py
+++ b/verification/areas/performance/query_processes.py
@@ -34,9 +34,6 @@ def run_query_processes(
     samples = aggregate_samples[warmups:]
     instruction_samples: list[int] = []
     cycle_samples: list[int] = []
-    peak_rss_values: list[int] = []
-    if aggregate_result["peak_rss_bytes"] is not None:
-        peak_rss_values.append(aggregate_result["peak_rss_bytes"])
     for _ in range(measured):
         result, _payload, _process_samples = run_query_invocation(
             case,
@@ -49,8 +46,6 @@ def run_query_processes(
             instruction_samples.append(result["retired_instructions"])
         if result["cycles_elapsed"] is not None:
             cycle_samples.append(result["cycles_elapsed"])
-        if result["peak_rss_bytes"] is not None:
-            peak_rss_values.append(result["peak_rss_bytes"])
     return {
         "id": case.id,
         "group": case.group,
@@ -62,7 +57,7 @@ def run_query_processes(
         "samples_instructions": instruction_samples,
         "metrics": latency_metrics(samples)
         | work_metrics(instruction_samples, cycle_samples)
-        | {"peak_rss_bytes": max(peak_rss_values) if peak_rss_values else None}
+        | {"peak_rss_bytes": aggregate_result["peak_rss_bytes"]}
         | SIZE_METRIC_DEFAULTS,
         "cache": {
             "hits": int(aggregate_payload.get("cache_hits", 0)),
@@ -173,4 +168,8 @@ def run_self_test() -> None:
     if result["diagnostics_count"] != 7:
         raise BenchmarkError(
             "query process self-test did not preserve aggregate diagnostics"
+        )
+    if result["metrics"]["peak_rss_bytes"] != 1001:
+        raise BenchmarkError(
+            "query process self-test did not preserve aggregate peak RSS"
         )

--- a/verification/areas/performance/query_processes.py
+++ b/verification/areas/performance/query_processes.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from typing import Any
 
 from benchmark_manifest import BenchmarkCase, BenchmarkError
-from process_metrics import latency_metrics, work_metrics
+from process_metrics import latency_metrics, work_metrics, work_sample_evidence
 
 SIZE_METRIC_DEFAULTS = {
     "generated_binary_bytes": None,
@@ -54,7 +54,7 @@ def run_query_processes(
         "evidence_category": case.raw["evidence_category"],
         "sample_count": len(samples),
         "samples_ms": samples,
-        "samples_instructions": instruction_samples,
+        **work_sample_evidence(instruction_samples),
         "metrics": latency_metrics(samples)
         | work_metrics(instruction_samples, cycle_samples)
         | {"peak_rss_bytes": aggregate_result["peak_rss_bytes"]}

--- a/verification/areas/performance/query_processes.py
+++ b/verification/areas/performance/query_processes.py
@@ -1,0 +1,176 @@
+"""Latency, cache, and process-work measurement for query benchmarks."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from benchmark_manifest import BenchmarkCase, BenchmarkError
+from process_metrics import latency_metrics, work_metrics
+
+SIZE_METRIC_DEFAULTS = {
+    "generated_binary_bytes": None,
+    "emitted_rust_lines": None,
+    "emitted_rust_bytes": None,
+}
+
+
+def run_query_processes(
+    case: BenchmarkCase,
+    measured: int,
+    label: str,
+    command_for_iterations: Callable[[int], list[str]],
+    process_runner: Callable[[list[str], int], dict[str, Any]],
+) -> dict[str, Any]:
+    warmups = case.warmups if measured == case.measured else 1
+    aggregate_result, aggregate_payload, aggregate_samples = run_query_invocation(
+        case,
+        label,
+        command_for_iterations(warmups + measured),
+        warmups + measured,
+        process_runner,
+    )
+    samples = aggregate_samples[warmups:]
+    instruction_samples: list[int] = []
+    cycle_samples: list[int] = []
+    peak_rss_values: list[int] = []
+    if aggregate_result["peak_rss_bytes"] is not None:
+        peak_rss_values.append(aggregate_result["peak_rss_bytes"])
+    for _ in range(measured):
+        result, _payload, _process_samples = run_query_invocation(
+            case,
+            label,
+            command_for_iterations(warmups + 1),
+            warmups + 1,
+            process_runner,
+        )
+        if result["retired_instructions"] is not None:
+            instruction_samples.append(result["retired_instructions"])
+        if result["cycles_elapsed"] is not None:
+            cycle_samples.append(result["cycles_elapsed"])
+        if result["peak_rss_bytes"] is not None:
+            peak_rss_values.append(result["peak_rss_bytes"])
+    return {
+        "id": case.id,
+        "group": case.group,
+        "kind": case.kind,
+        "budget_id": case.raw["budget_id"],
+        "evidence_category": case.raw["evidence_category"],
+        "sample_count": len(samples),
+        "samples_ms": samples,
+        "samples_instructions": instruction_samples,
+        "metrics": latency_metrics(samples)
+        | work_metrics(instruction_samples, cycle_samples)
+        | {"peak_rss_bytes": max(peak_rss_values) if peak_rss_values else None}
+        | SIZE_METRIC_DEFAULTS,
+        "cache": {
+            "hits": int(aggregate_payload.get("cache_hits", 0)),
+            "misses": int(aggregate_payload.get("cache_misses", 0)),
+        },
+        "diagnostics_count": int(aggregate_payload.get("diagnostics_count", 0)),
+        "timed_out": False,
+    }
+
+
+def run_query_invocation(
+    case: BenchmarkCase,
+    label: str,
+    command: list[str],
+    expected_samples: int,
+    process_runner: Callable[[list[str], int], dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any], list[float]]:
+    result = process_runner(command, case.timeout_ms)
+    if result["timed_out"]:
+        raise BenchmarkError(
+            f"{label} benchmark {case.id} timed out after {case.timeout_ms}ms"
+        )
+    if result["exit_code"] != 0:
+        raise BenchmarkError(
+            f"{label} benchmark {case.id} failed: {result['stderr_tail']}"
+        )
+    try:
+        payload = json.loads(result["stdout"])
+    except json.JSONDecodeError as error:
+        raise BenchmarkError(
+            f"{label} benchmark {case.id} emitted invalid JSON: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise BenchmarkError(f"{label} benchmark {case.id} emitted non-object JSON")
+    raw_samples = payload.get("samples_ms")
+    if (
+        not isinstance(raw_samples, list)
+        or len(raw_samples) != expected_samples
+        or not all(isinstance(sample, int | float) for sample in raw_samples)
+    ):
+        raise BenchmarkError(
+            f"{label} benchmark {case.id} did not emit all requested numeric samples_ms"
+        )
+    if payload.get("timed_out"):
+        raise BenchmarkError(f"{label} benchmark {case.id} reported a timeout")
+    return result, payload, [float(sample) for sample in raw_samples]
+
+
+def run_self_test() -> None:
+    case = BenchmarkCase(
+        {
+            "id": "query-process-self-test",
+            "group": "self-test",
+            "kind": "frontend-query",
+            "warmups": 1,
+            "measured": 2,
+            "timeout_ms": 1000,
+            "budget_id": "perf.self-test.query-process",
+            "evidence_category": "self-test",
+        }
+    )
+    calls: list[int] = []
+
+    def fake_process(command: list[str], _timeout_ms: int) -> dict[str, Any]:
+        iterations = int(command[-1])
+        calls.append(iterations)
+        is_aggregate = len(calls) == 1
+        payload = {
+            "samples_ms": list(range(1, iterations + 1)),
+            "cache_hits": 2300 if is_aggregate else 400,
+            "cache_misses": 100 if is_aggregate else 400,
+            "diagnostics_count": 7 if is_aggregate else 1,
+            "timed_out": False,
+        }
+        return {
+            "peak_rss_bytes": 1000 + len(calls),
+            "retired_instructions": 10_000 + len(calls),
+            "cycles_elapsed": 5_000 + len(calls),
+            "exit_code": 0,
+            "timed_out": False,
+            "stdout": json.dumps(payload),
+            "stderr_tail": "",
+        }
+
+    result = run_query_processes(
+        case,
+        2,
+        "self-test query",
+        lambda iterations: ["fake-query", str(iterations)],
+        fake_process,
+    )
+    if calls != [3, 2, 2]:
+        raise BenchmarkError(
+            f"query process self-test used wrong iteration counts: {calls!r}"
+        )
+    if result["samples_ms"] != [2.0, 3.0]:
+        raise BenchmarkError(
+            "query process self-test did not preserve aggregate latency samples"
+        )
+    if result["samples_instructions"] != [10_002, 10_003]:
+        raise BenchmarkError(
+            "query process self-test did not collect independent work samples"
+        )
+    if result["cache"] != {"hits": 2300, "misses": 100}:
+        raise BenchmarkError(
+            "query process self-test did not preserve aggregate cache evidence"
+        )
+    if result["diagnostics_count"] != 7:
+        raise BenchmarkError(
+            "query process self-test did not preserve aggregate diagnostics"
+        )

--- a/verification/areas/performance/run_benchmarks.py
+++ b/verification/areas/performance/run_benchmarks.py
@@ -52,6 +52,7 @@ from process_metrics import (
     parse_process_metrics,
     timed_command,
     work_metrics,
+    work_sample_evidence,
 )
 from process_metrics import (
     run_self_test as run_process_metrics_self_test,
@@ -456,7 +457,7 @@ def run_case(case: BenchmarkCase, run_root: Path, sample_scale: str) -> dict[str
         "evidence_category": case.raw["evidence_category"],
         "sample_count": len(samples),
         "samples_ms": samples,
-        "samples_instructions": instruction_samples,
+        **work_sample_evidence(instruction_samples),
         "metrics": stats
         | work_metrics(instruction_samples, cycle_samples)
         | {"peak_rss_bytes": max(peak_rss_values) if peak_rss_values else None}

--- a/verification/areas/performance/run_benchmarks.py
+++ b/verification/areas/performance/run_benchmarks.py
@@ -21,6 +21,7 @@ from benchmark_baseline import (
     validate_baseline_capture,
     work_budgets_from_run,
 )
+from benchmark_baseline import run_self_test as run_benchmark_baseline_self_test
 from benchmark_manifest import (
     RUNNER_VERSION,
     BenchmarkCase,
@@ -698,6 +699,7 @@ def invalidate_output(path: Path) -> None:
 
 
 def run_self_test() -> None:
+    run_benchmark_baseline_self_test()
     run_process_metrics_self_test()
     run_query_processes_self_test()
     run_work_baseline_self_test()

--- a/verification/areas/performance/run_benchmarks.py
+++ b/verification/areas/performance/run_benchmarks.py
@@ -12,7 +12,6 @@ import resource
 import subprocess
 import sys
 import time
-from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -56,6 +55,8 @@ from process_metrics import (
 from process_metrics import (
     run_self_test as run_process_metrics_self_test,
 )
+from query_processes import run_query_processes
+from query_processes import run_self_test as run_query_processes_self_test
 from trend_baseline import (
     TrendBaselineError,
     baseline_from_reference_run,
@@ -477,6 +478,7 @@ def run_frontend_query_case(case: BenchmarkCase, measured: int) -> dict[str, Any
             str(iterations),
             str(case.raw.get("inner_repetitions", 100)),
         ],
+        run_subprocess,
     )
 
 
@@ -494,83 +496,8 @@ def run_lsp_query_case(case: BenchmarkCase, measured: int) -> dict[str, Any]:
             str(case.raw.get("inner_repetitions", 1)),
             str(case.raw["workspace_mode"]),
         ],
+        run_subprocess,
     )
-
-
-def run_query_processes(
-    case: BenchmarkCase,
-    measured: int,
-    label: str,
-    command_for_iterations: Callable[[int], list[str]],
-) -> dict[str, Any]:
-    warmups = case.warmups if measured == case.measured else 1
-    samples: list[float] = []
-    instruction_samples: list[int] = []
-    cycle_samples: list[int] = []
-    peak_rss_values: list[int] = []
-    hits: list[int] = []
-    misses: list[int] = []
-    diagnostics_counts: list[int] = []
-    for _ in range(measured):
-        result = run_subprocess(
-            command_for_iterations(warmups + 1), case.timeout_ms
-        )
-        if result["timed_out"]:
-            raise BenchmarkError(
-                f"{label} benchmark {case.id} timed out after {case.timeout_ms}ms"
-            )
-        if result["exit_code"] != 0:
-            raise BenchmarkError(
-                f"{label} benchmark {case.id} failed: {result['stderr_tail']}"
-            )
-        try:
-            payload = json.loads(result["stdout"])
-        except json.JSONDecodeError as error:
-            raise BenchmarkError(
-                f"{label} benchmark {case.id} emitted invalid JSON: {error}"
-            ) from error
-        process_samples = payload.get("samples_ms")
-        if not isinstance(process_samples, list) or len(process_samples) < warmups + 1:
-            raise BenchmarkError(
-                f"{label} benchmark {case.id} did not emit all requested samples_ms"
-            )
-        measured_sample = process_samples[-1]
-        if not isinstance(measured_sample, int | float):
-            raise BenchmarkError(
-                f"{label} benchmark {case.id} emitted a non-numeric measured sample"
-            )
-        samples.append(float(measured_sample))
-        if result["retired_instructions"] is not None:
-            instruction_samples.append(result["retired_instructions"])
-        if result["cycles_elapsed"] is not None:
-            cycle_samples.append(result["cycles_elapsed"])
-        if result["peak_rss_bytes"] is not None:
-            peak_rss_values.append(result["peak_rss_bytes"])
-        hits.append(int(payload.get("cache_hits", 0)))
-        misses.append(int(payload.get("cache_misses", 0)))
-        diagnostics_counts.append(int(payload.get("diagnostics_count", 0)))
-        if payload.get("timed_out"):
-            raise BenchmarkError(f"{label} benchmark {case.id} reported a timeout")
-    return {
-        "id": case.id,
-        "group": case.group,
-        "kind": case.kind,
-        "budget_id": case.raw["budget_id"],
-        "evidence_category": case.raw["evidence_category"],
-        "sample_count": len(samples),
-        "samples_ms": samples,
-        "samples_instructions": instruction_samples,
-        "metrics": latency_metrics(samples)
-        | work_metrics(instruction_samples, cycle_samples)
-        | {"peak_rss_bytes": max(peak_rss_values) if peak_rss_values else None}
-        | SIZE_METRIC_DEFAULTS,
-        "cache": {
-            "hits": min(hits, default=0),
-            "misses": max(misses, default=0),
-        },
-        "diagnostics_count": max(diagnostics_counts, default=0),
-        "timed_out": False,
-    }
 
 
 def ensure_frontend_query_bench() -> None:
@@ -772,6 +699,7 @@ def invalidate_output(path: Path) -> None:
 
 def run_self_test() -> None:
     run_process_metrics_self_test()
+    run_query_processes_self_test()
     run_work_baseline_self_test()
     run_trend_report_self_test()
     run_host_control_self_test()

--- a/verification/areas/performance/run_benchmarks.py
+++ b/verification/areas/performance/run_benchmarks.py
@@ -6,18 +6,22 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import math
 import os
 import platform
 import resource
-import statistics
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
+from benchmark_baseline import (
+    baseline_from_run,
+    validate_baseline_capture,
+    work_budgets_from_run,
+)
 from benchmark_manifest import (
     RUNNER_VERSION,
     BenchmarkCase,
@@ -26,9 +30,10 @@ from benchmark_manifest import (
     select_cases,
     validate_manifest,
 )
-from benchmark_baseline import baseline_from_run, validate_baseline_capture
 from controlled_sampling import (
     run_controlled_case,
+)
+from controlled_sampling import (
     run_self_test as run_controlled_sampling_self_test,
 )
 from host_control import (
@@ -37,27 +42,54 @@ from host_control import (
     capture_host_snapshot,
     controlled_policy,
     evaluate_snapshot,
-    run_self_test as run_host_control_self_test,
     wait_for_controlled_host,
 )
-from trend_reports import (
-    TrendReportError,
-    build_trend_report,
-    run_self_test as run_trend_report_self_test,
+from host_control import (
+    run_self_test as run_host_control_self_test,
+)
+from process_metrics import (
+    latency_metrics,
+    parse_process_metrics,
+    timed_command,
+    work_metrics,
+)
+from process_metrics import (
+    run_self_test as run_process_metrics_self_test,
 )
 from trend_baseline import (
     TrendBaselineError,
     baseline_from_reference_run,
-    run_self_test as run_trend_baseline_self_test,
     validate_capture_request,
 )
-
+from trend_baseline import (
+    run_self_test as run_trend_baseline_self_test,
+)
+from trend_reports import (
+    TrendReportError,
+    build_trend_report,
+)
+from trend_reports import (
+    run_self_test as run_trend_report_self_test,
+)
+from work_baseline import (
+    WorkBaselineError,
+)
+from work_baseline import (
+    run_self_test as run_work_baseline_self_test,
+)
+from work_baseline import (
+    validate_capture_request as validate_work_capture_request,
+)
+from work_baseline import (
+    validate_source_unchanged as validate_work_source_unchanged,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PERF_ROOT = REPO_ROOT / "verification" / "areas" / "performance"
 PERF_DATA = PERF_ROOT / "data"
 DEFAULT_MANIFEST = PERF_DATA / "benchmark_manifest.json"
 DEFAULT_TREND_BASELINES = PERF_DATA / "trend" / "current.json"
+DEFAULT_BUDGETS = PERF_DATA / "budgets.json"
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "target" / "performance"
 NEGATIVE_ROOT = PERF_ROOT / "negative_seeds"
 SIZE_METRIC_DEFAULTS = {
@@ -104,7 +136,9 @@ def main() -> int:
     )
     parser.add_argument("--validate-only", action="store_true")
     parser.add_argument("--capture-baseline", action="store_true")
+    parser.add_argument("--capture-work-baseline", action="store_true")
     parser.add_argument("--baseline-output", default="")
+    parser.add_argument("--work-budget-output", default="")
     parser.add_argument("--capture-trend-baseline", action="store_true")
     parser.add_argument("--trend-baseline-output", default="")
     parser.add_argument("--reference-approval", default="")
@@ -113,6 +147,11 @@ def main() -> int:
     parser.add_argument("--json-out", default="")
     parser.add_argument("--invocation-id", default="")
     parser.add_argument("--require-controlled-host", action="store_true")
+    parser.add_argument(
+        "--controlled-host-mode",
+        choices=["latency", "work"],
+        default="latency",
+    )
     parser.add_argument("--controlled-host-timeout-seconds", type=float, default=180.0)
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
@@ -154,6 +193,21 @@ def main() -> int:
             approval_owner=args.reference_approval,
             profile=os.environ.get("SIFR_VALIDATION_PROFILE", "standalone"),
             thermal_policy=os.environ.get("SIFR_THERMAL_POLICY", "unspecified"),
+            control_mode=args.controlled_host_mode,
+            repo_root=REPO_ROOT,
+        )
+        work_source_commit = validate_work_capture_request(
+            capture_requested=args.capture_work_baseline,
+            capture_budget_baseline=args.capture_baseline,
+            require_controlled_host=args.require_controlled_host,
+            control_mode=args.controlled_host_mode,
+            sample_scale=args.sample_scale,
+            selected_count=len(selected),
+            manifest_count=len(cases),
+            groups=parse_csv(args.groups),
+            case_ids=set(args.case),
+            case_limit=args.case_limit,
+            approval_owner=args.reference_approval,
             repo_root=REPO_ROOT,
         )
 
@@ -166,8 +220,14 @@ def main() -> int:
             args.sample_scale,
             invocation_id=invocation_id,
             require_controlled_host=args.require_controlled_host,
+            control_mode=args.controlled_host_mode,
             controlled_host_timeout_seconds=args.controlled_host_timeout_seconds,
         )
+        if work_source_commit is not None:
+            validate_work_source_unchanged(work_source_commit, REPO_ROOT)
+            run_report["metadata"]["work_baseline_source_commit"] = (
+                work_source_commit
+            )
         evidence_path = write_run_report(run_report, Path(args.output_root))
         trend_report = build_trend_report(
             run_report, load_json(Path(args.trend_baselines)), RUNNER_VERSION
@@ -179,6 +239,21 @@ def main() -> int:
             trend_path = write_trend_report(trend_report, Path(args.output_root))
         if json_out is not None:
             write_json(json_out, run_report)
+        if args.capture_work_baseline:
+            validate_baseline_capture(run_report, {case.id: case for case in cases})
+            work_budgets = work_budgets_from_run(
+                load_json(DEFAULT_BUDGETS), run_report
+            )
+            work_budget_output = (
+                (REPO_ROOT / args.work_budget_output).resolve()
+                if args.work_budget_output
+                else PERF_DATA / "work_budgets.json"
+            )
+            write_json(work_budget_output, work_budgets)
+            print(
+                "performance work budgets captured: "
+                f"{work_budget_output.relative_to(REPO_ROOT)}"
+            )
         if args.capture_baseline:
             validate_baseline_capture(run_report, {case.id: case for case in cases})
             baseline = baseline_from_run(run_report, manifest, Path(args.manifest))
@@ -222,6 +297,7 @@ def main() -> int:
         HostControlError,
         TrendBaselineError,
         TrendReportError,
+        WorkBaselineError,
     ) as error:
         print(f"performance benchmark error: {error}", file=sys.stderr)
         return 1
@@ -246,6 +322,7 @@ def run_cases(
     *,
     invocation_id: str,
     require_controlled_host: bool,
+    control_mode: str,
     controlled_host_timeout_seconds: float,
 ) -> dict[str, Any]:
     run_id = f"bench-{int(time.time())}-{os.getpid()}"
@@ -253,17 +330,25 @@ def run_cases(
     run_root.mkdir(parents=True, exist_ok=True)
     cache_before = current_cache_state()
     if require_controlled_host:
-        admission = wait_for_controlled_host(controlled_host_timeout_seconds)
+        admission = wait_for_controlled_host(
+            controlled_host_timeout_seconds, control_mode=control_mode
+        )
     else:
         snapshot = capture_host_snapshot(include_calibration=True)
         admission = {
             "status": "record-only",
-            "policy": controlled_policy(),
+            "mode": control_mode,
+            "policy": controlled_policy(control_mode),
             "accepted_snapshots": [snapshot],
             "observation_count": 1,
             "rejected_observation_count": 0,
             "recent_rejected_observations": [],
-            "advisory_reasons": evaluate_snapshot(snapshot, enforce_load=True),
+            "advisory_reasons": evaluate_snapshot(
+                snapshot,
+                enforce_load=True,
+                control_mode=control_mode,
+                require_work_counter=control_mode == "work",
+            ),
         }
     results = []
     for case in cases:
@@ -275,9 +360,15 @@ def run_cases(
                 run_root,
                 sample_scale,
                 require_controlled_host=require_controlled_host,
+                control_mode=control_mode,
                 run_case_fn=run_case,
                 retry_admission_fn=(
-                    (lambda: wait_for_controlled_host(controlled_host_timeout_seconds))
+                    (
+                        lambda: wait_for_controlled_host(
+                            controlled_host_timeout_seconds,
+                            control_mode=control_mode,
+                        )
+                    )
                     if require_controlled_host
                     else None
                 ),
@@ -317,8 +408,10 @@ def run_case(case: BenchmarkCase, run_root: Path, sample_scale: str) -> dict[str
         return run_lsp_query_case(case, measured)
 
     ensure_sifr_binary()
-    samples = []
-    peak_rss_values = []
+    samples: list[float] = []
+    peak_rss_values: list[int] = []
+    instruction_samples: list[int] = []
+    cycle_samples: list[int] = []
     shared_build_dir = run_root / "artifacts" / case.id / "shared-build"
     for sample_index in range(warmups + measured):
         output_dir = (
@@ -333,6 +426,10 @@ def run_case(case: BenchmarkCase, run_root: Path, sample_scale: str) -> dict[str
         samples.append(result["duration_ms"])
         if result["peak_rss_bytes"] is not None:
             peak_rss_values.append(result["peak_rss_bytes"])
+        if result["retired_instructions"] is not None:
+            instruction_samples.append(result["retired_instructions"])
+        if result["cycles_elapsed"] is not None:
+            cycle_samples.append(result["cycles_elapsed"])
         if result["timed_out"]:
             raise BenchmarkError(
                 f"benchmark {case.id} timed out after {case.timeout_ms}ms"
@@ -343,7 +440,7 @@ def run_case(case: BenchmarkCase, run_root: Path, sample_scale: str) -> dict[str
                 f"benchmark {case.id} exited {result['exit_code']}, expected {sorted(expected_exit_codes)}"
             )
 
-    stats = sample_stats(samples)
+    stats = latency_metrics(samples)
     size_metrics = (
         collect_build_size_metrics(shared_build_dir)
         if case.raw.get("mode") == "build"
@@ -357,7 +454,9 @@ def run_case(case: BenchmarkCase, run_root: Path, sample_scale: str) -> dict[str
         "evidence_category": case.raw["evidence_category"],
         "sample_count": len(samples),
         "samples_ms": samples,
+        "samples_instructions": instruction_samples,
         "metrics": stats
+        | work_metrics(instruction_samples, cycle_samples)
         | {"peak_rss_bytes": max(peak_rss_values) if peak_rss_values else None}
         | size_metrics,
         "cache": {"hits": 0, "misses": 0},
@@ -367,94 +466,91 @@ def run_case(case: BenchmarkCase, run_root: Path, sample_scale: str) -> dict[str
 
 def run_frontend_query_case(case: BenchmarkCase, measured: int) -> dict[str, Any]:
     ensure_frontend_query_bench()
-    warmups = case.warmups if measured == case.measured else 1
-    iterations = warmups + measured
-    command = [
-        str(frontend_bench_binary()),
-        str(case.raw["scenario"]),
-        str(REPO_ROOT / case.raw["source_path"]),
-        str(iterations),
-        str(case.raw.get("inner_repetitions", 100)),
-    ]
-    result = run_subprocess(command, case.timeout_ms)
-    if result["timed_out"]:
-        raise BenchmarkError(
-            f"frontend query benchmark {case.id} timed out after {case.timeout_ms}ms"
-        )
-    if result["exit_code"] != 0:
-        raise BenchmarkError(
-            f"frontend query benchmark {case.id} failed: {result['stderr_tail']}"
-        )
-    try:
-        payload = json.loads(result["stdout"])
-    except json.JSONDecodeError as error:
-        raise BenchmarkError(
-            f"frontend query benchmark {case.id} emitted invalid JSON: {error}"
-        ) from error
-    samples = payload.get("samples_ms")
-    if not isinstance(samples, list) or not all(
-        isinstance(sample, int | float) for sample in samples
-    ):
-        raise BenchmarkError(
-            f"frontend query benchmark {case.id} did not emit numeric samples_ms"
-        )
-    samples = samples[warmups:]
-    stats = sample_stats([float(sample) for sample in samples])
-    return {
-        "id": case.id,
-        "group": case.group,
-        "kind": case.kind,
-        "budget_id": case.raw["budget_id"],
-        "evidence_category": case.raw["evidence_category"],
-        "sample_count": len(samples),
-        "samples_ms": [float(sample) for sample in samples],
-        "metrics": stats
-        | {"peak_rss_bytes": result["peak_rss_bytes"]}
-        | SIZE_METRIC_DEFAULTS,
-        "cache": {
-            "hits": int(payload.get("cache_hits", 0)),
-            "misses": int(payload.get("cache_misses", 0)),
-        },
-        "diagnostics_count": int(payload.get("diagnostics_count", 0)),
-        "timed_out": bool(payload.get("timed_out", False)),
-    }
+    return run_query_processes(
+        case,
+        measured,
+        "frontend query",
+        lambda iterations: [
+            str(frontend_bench_binary()),
+            str(case.raw["scenario"]),
+            str(REPO_ROOT / case.raw["source_path"]),
+            str(iterations),
+            str(case.raw.get("inner_repetitions", 100)),
+        ],
+    )
 
 
 def run_lsp_query_case(case: BenchmarkCase, measured: int) -> dict[str, Any]:
+    return run_query_processes(
+        case,
+        measured,
+        "LSP query",
+        lambda iterations: [
+            "python3",
+            str(PERF_ROOT / "lsp_query_bench.py"),
+            str(case.raw["scenario"]),
+            str(REPO_ROOT / case.raw["source_path"]),
+            str(iterations),
+            str(case.raw.get("inner_repetitions", 1)),
+            str(case.raw["workspace_mode"]),
+        ],
+    )
+
+
+def run_query_processes(
+    case: BenchmarkCase,
+    measured: int,
+    label: str,
+    command_for_iterations: Callable[[int], list[str]],
+) -> dict[str, Any]:
     warmups = case.warmups if measured == case.measured else 1
-    command = [
-        "python3",
-        str(PERF_ROOT / "lsp_query_bench.py"),
-        str(case.raw["scenario"]),
-        str(REPO_ROOT / case.raw["source_path"]),
-        str(warmups + measured),
-        str(case.raw.get("inner_repetitions", 1)),
-        str(case.raw["workspace_mode"]),
-    ]
-    result = run_subprocess(command, case.timeout_ms)
-    if result["timed_out"]:
-        raise BenchmarkError(
-            f"LSP query benchmark {case.id} timed out after {case.timeout_ms}ms"
+    samples: list[float] = []
+    instruction_samples: list[int] = []
+    cycle_samples: list[int] = []
+    peak_rss_values: list[int] = []
+    hits: list[int] = []
+    misses: list[int] = []
+    diagnostics_counts: list[int] = []
+    for _ in range(measured):
+        result = run_subprocess(
+            command_for_iterations(warmups + 1), case.timeout_ms
         )
-    if result["exit_code"] != 0:
-        raise BenchmarkError(
-            f"LSP query benchmark {case.id} failed: {result['stderr_tail']}"
-        )
-    try:
-        payload = json.loads(result["stdout"])
-    except json.JSONDecodeError as error:
-        raise BenchmarkError(
-            f"LSP query benchmark {case.id} emitted invalid JSON: {error}"
-        ) from error
-    samples = payload.get("samples_ms")
-    if not isinstance(samples, list) or not all(
-        isinstance(sample, int | float) for sample in samples
-    ):
-        raise BenchmarkError(
-            f"LSP query benchmark {case.id} did not emit numeric samples_ms"
-        )
-    samples = [float(sample) for sample in samples[warmups:]]
-    stats = sample_stats(samples)
+        if result["timed_out"]:
+            raise BenchmarkError(
+                f"{label} benchmark {case.id} timed out after {case.timeout_ms}ms"
+            )
+        if result["exit_code"] != 0:
+            raise BenchmarkError(
+                f"{label} benchmark {case.id} failed: {result['stderr_tail']}"
+            )
+        try:
+            payload = json.loads(result["stdout"])
+        except json.JSONDecodeError as error:
+            raise BenchmarkError(
+                f"{label} benchmark {case.id} emitted invalid JSON: {error}"
+            ) from error
+        process_samples = payload.get("samples_ms")
+        if not isinstance(process_samples, list) or len(process_samples) < warmups + 1:
+            raise BenchmarkError(
+                f"{label} benchmark {case.id} did not emit all requested samples_ms"
+            )
+        measured_sample = process_samples[-1]
+        if not isinstance(measured_sample, int | float):
+            raise BenchmarkError(
+                f"{label} benchmark {case.id} emitted a non-numeric measured sample"
+            )
+        samples.append(float(measured_sample))
+        if result["retired_instructions"] is not None:
+            instruction_samples.append(result["retired_instructions"])
+        if result["cycles_elapsed"] is not None:
+            cycle_samples.append(result["cycles_elapsed"])
+        if result["peak_rss_bytes"] is not None:
+            peak_rss_values.append(result["peak_rss_bytes"])
+        hits.append(int(payload.get("cache_hits", 0)))
+        misses.append(int(payload.get("cache_misses", 0)))
+        diagnostics_counts.append(int(payload.get("diagnostics_count", 0)))
+        if payload.get("timed_out"):
+            raise BenchmarkError(f"{label} benchmark {case.id} reported a timeout")
     return {
         "id": case.id,
         "group": case.group,
@@ -463,15 +559,17 @@ def run_lsp_query_case(case: BenchmarkCase, measured: int) -> dict[str, Any]:
         "evidence_category": case.raw["evidence_category"],
         "sample_count": len(samples),
         "samples_ms": samples,
-        "metrics": stats
-        | {"peak_rss_bytes": result["peak_rss_bytes"]}
+        "samples_instructions": instruction_samples,
+        "metrics": latency_metrics(samples)
+        | work_metrics(instruction_samples, cycle_samples)
+        | {"peak_rss_bytes": max(peak_rss_values) if peak_rss_values else None}
         | SIZE_METRIC_DEFAULTS,
         "cache": {
-            "hits": int(payload.get("cache_hits", 0)),
-            "misses": int(payload.get("cache_misses", 0)),
+            "hits": min(hits, default=0),
+            "misses": max(misses, default=0),
         },
-        "diagnostics_count": int(payload.get("diagnostics_count", 0)),
-        "timed_out": bool(payload.get("timed_out", False)),
+        "diagnostics_count": max(diagnostics_counts, default=0),
+        "timed_out": False,
     }
 
 
@@ -567,29 +665,6 @@ def collect_build_size_metrics(output_dir: Path) -> dict[str, int | None]:
     return metrics
 
 
-def timed_command(command: list[str]) -> list[str]:
-    if platform.system() == "Darwin" and Path("/usr/bin/time").exists():
-        return ["/usr/bin/time", "-l", *command]
-    if platform.system() == "Linux" and Path("/usr/bin/time").exists():
-        return ["/usr/bin/time", "-v", *command]
-    return command
-
-
-def parse_peak_rss(stderr: str) -> int | None:
-    for line in stderr.splitlines():
-        stripped = line.strip()
-        if stripped.endswith("maximum resident set size"):
-            value = stripped.split(maxsplit=1)[0]
-            if value.isdigit():
-                return int(value)
-        if "Maximum resident set size (kbytes):" in stripped:
-            _, value = stripped.rsplit(":", maxsplit=1)
-            value = value.strip()
-            if value.isdigit():
-                return int(value) * 1024
-    return None
-
-
 def run_subprocess(command: list[str], timeout_ms: int) -> dict[str, Any]:
     started = time.perf_counter()
     rss_before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
@@ -606,50 +681,32 @@ def run_subprocess(command: list[str], timeout_ms: int) -> dict[str, Any]:
         return {
             "duration_ms": (time.perf_counter() - started) * 1000.0,
             "peak_rss_bytes": None,
+            "retired_instructions": None,
+            "cycles_elapsed": None,
+            "cpu_time_ms": None,
+            "work_counter_source": "unavailable",
             "exit_code": None,
             "timed_out": True,
             "stdout": error.stdout or "",
             "stderr_tail": tail(error.stderr or ""),
         }
     rss_after = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
-    peak_rss_bytes = parse_peak_rss(completed.stderr)
+    process_data = parse_process_metrics(completed.stderr)
+    peak_rss_bytes = process_data["peak_rss_bytes"]
     if peak_rss_bytes is None:
-        peak_rss_bytes = normalize_rss(
-            rss_after if rss_after >= rss_before else rss_before
-        )
+        peak_rss_bytes = normalize_rss(max(rss_after, rss_before))
     return {
         "duration_ms": (time.perf_counter() - started) * 1000.0,
         "peak_rss_bytes": peak_rss_bytes,
+        "retired_instructions": process_data["retired_instructions"],
+        "cycles_elapsed": process_data["cycles_elapsed"],
+        "cpu_time_ms": process_data["cpu_time_ms"],
+        "work_counter_source": process_data["work_counter_source"],
         "exit_code": completed.returncode,
         "timed_out": False,
         "stdout": completed.stdout,
         "stderr_tail": tail(completed.stderr),
     }
-
-
-def sample_stats(samples: list[float]) -> dict[str, float]:
-    if not samples:
-        raise BenchmarkError("cannot compute metrics for an empty sample list")
-    median = statistics.median(samples)
-    p95 = percentile(samples, 95)
-    mad = statistics.median([abs(sample - median) for sample in samples])
-    mean = statistics.mean(samples)
-    stdev = statistics.pstdev(samples) if len(samples) > 1 else 0.0
-    cv = 0.0 if mean == 0 else stdev / mean
-    return {
-        "median_ms": round(median, 3),
-        "p95_ms": round(p95, 3),
-        "mad_ms": round(mad, 3),
-        "coefficient_variation": round(cv, 6),
-    }
-
-
-def percentile(samples: list[float], percentile_value: int) -> float:
-    ordered = sorted(samples)
-    if len(ordered) == 1:
-        return ordered[0]
-    rank = math.ceil((percentile_value / 100.0) * len(ordered)) - 1
-    return ordered[max(0, min(rank, len(ordered) - 1))]
 
 
 def host_metadata() -> dict[str, Any]:
@@ -714,6 +771,8 @@ def invalidate_output(path: Path) -> None:
 
 
 def run_self_test() -> None:
+    run_process_metrics_self_test()
+    run_work_baseline_self_test()
     run_trend_report_self_test()
     run_host_control_self_test()
     run_trend_baseline_self_test()

--- a/verification/areas/performance/runner.py
+++ b/verification/areas/performance/runner.py
@@ -10,10 +10,13 @@ import time
 from pathlib import Path
 from typing import Any
 
-from host_control import profile_control_mode
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 AREA_ROOT = Path(__file__).resolve().parent
+if str(AREA_ROOT) not in sys.path:
+    sys.path.insert(0, str(AREA_ROOT))
+
+from host_control import profile_control_mode  # noqa: E402
+
 DATA_ROOT = AREA_ROOT / "data"
 MANIFEST_PATH = AREA_ROOT / "manifest.json"
 BENCHMARK_MANIFEST = DATA_ROOT / "benchmark_manifest.json"

--- a/verification/areas/performance/runner.py
+++ b/verification/areas/performance/runner.py
@@ -10,6 +10,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from host_control import profile_control_mode
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 AREA_ROOT = Path(__file__).resolve().parent
 DATA_ROOT = AREA_ROOT / "data"
@@ -207,7 +209,7 @@ def run_profile_variants(suite_name: str) -> list[dict[str, Any]]:
         invocation_id,
         "--require-controlled-host",
         "--controlled-host-mode",
-        "work",
+        profile_control_mode(),
     ]
     for case_id in REPRESENTATIVE_CASES:
         run_argv.extend(["--case", case_id])

--- a/verification/areas/performance/runner.py
+++ b/verification/areas/performance/runner.py
@@ -206,6 +206,8 @@ def run_profile_variants(suite_name: str) -> list[dict[str, Any]]:
         "--invocation-id",
         invocation_id,
         "--require-controlled-host",
+        "--controlled-host-mode",
+        "work",
     ]
     for case_id in REPRESENTATIVE_CASES:
         run_argv.extend(["--case", case_id])

--- a/verification/areas/performance/trend_baseline.py
+++ b/verification/areas/performance/trend_baseline.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Callable
-
+from typing import Any
 
 APPROVED_PROFILE = "approved-reference"
 APPROVED_THERMAL_POLICY = "controlled-host"
@@ -32,6 +32,7 @@ def validate_capture_request(
     approval_owner: str,
     profile: str,
     thermal_policy: str,
+    control_mode: str,
     repo_root: Path,
     git_output: Callable[[list[str], Path], str] | None = None,
 ) -> str | None:
@@ -65,6 +66,10 @@ def validate_capture_request(
     if thermal_policy != APPROVED_THERMAL_POLICY:
         raise TrendBaselineError(
             f"approved trend baseline capture requires SIFR_THERMAL_POLICY={APPROVED_THERMAL_POLICY}"
+        )
+    if control_mode != "latency":
+        raise TrendBaselineError(
+            "approved trend baseline capture requires --controlled-host-mode latency"
         )
     status = git_output(["git", "status", "--porcelain"], repo_root)
     if status != "":
@@ -173,6 +178,7 @@ def run_self_test() -> None:
         "approval_owner": APPROVAL_OWNER,
         "profile": APPROVED_PROFILE,
         "thermal_policy": APPROVED_THERMAL_POLICY,
+        "control_mode": "latency",
     }
 
     def clean_git(command: list[str], _cwd: Path) -> str:

--- a/verification/areas/performance/work_baseline.py
+++ b/verification/areas/performance/work_baseline.py
@@ -1,0 +1,157 @@
+"""Governed local retired-instruction baseline capture."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+APPROVAL_OWNER = "compiler/performance"
+
+
+class WorkBaselineError(Exception):
+    pass
+
+
+def validate_capture_request(
+    *,
+    capture_requested: bool,
+    capture_budget_baseline: bool,
+    require_controlled_host: bool,
+    control_mode: str,
+    sample_scale: str,
+    selected_count: int,
+    manifest_count: int,
+    groups: set[str],
+    case_ids: set[str],
+    case_limit: int,
+    approval_owner: str,
+    repo_root: Path,
+    git_output: Callable[[list[str], Path], str] | None = None,
+) -> str | None:
+    if not capture_requested:
+        return None
+    if capture_budget_baseline:
+        raise WorkBaselineError(
+            "work and wall-latency baselines must be captured separately"
+        )
+    if not require_controlled_host or control_mode != "work":
+        raise WorkBaselineError(
+            "work baseline capture requires controlled work-mode admission"
+        )
+    if sample_scale != "manifest":
+        raise WorkBaselineError(
+            "work baseline capture requires manifest sample counts"
+        )
+    if groups or case_ids or case_limit or selected_count != manifest_count:
+        raise WorkBaselineError(
+            "work baseline capture requires the complete benchmark manifest"
+        )
+    if approval_owner != APPROVAL_OWNER:
+        raise WorkBaselineError(
+            f"work baseline capture requires --reference-approval {APPROVAL_OWNER}"
+        )
+    git_output = git_output or command_output
+    if git_output(["git", "status", "--porcelain"], repo_root) != "":
+        raise WorkBaselineError("work baseline capture requires a clean worktree")
+    source_commit = git_output(["git", "rev-parse", "HEAD"], repo_root)
+    validate_source_commit(source_commit)
+    return source_commit
+
+
+def validate_source_unchanged(
+    expected_source_commit: str,
+    repo_root: Path,
+    git_output: Callable[[list[str], Path], str] | None = None,
+) -> None:
+    git_output = git_output or command_output
+    if git_output(["git", "status", "--porcelain"], repo_root) != "":
+        raise WorkBaselineError(
+            "work baseline capture worktree changed during measurement"
+        )
+    source_commit = git_output(["git", "rev-parse", "HEAD"], repo_root)
+    validate_source_commit(source_commit)
+    if source_commit != expected_source_commit:
+        raise WorkBaselineError(
+            "work baseline capture source commit changed during measurement"
+        )
+
+
+def validate_source_commit(source_commit: str) -> None:
+    if len(source_commit) != 40 or any(
+        char not in "0123456789abcdef" for char in source_commit
+    ):
+        raise WorkBaselineError(
+            "work baseline capture could not resolve a full source commit"
+        )
+
+
+def command_output(command: list[str], cwd: Path) -> str:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise WorkBaselineError(
+            f"work baseline git command failed: {' '.join(command)}"
+        )
+    return completed.stdout.strip()
+
+
+def run_self_test() -> None:
+    common = {
+        "capture_requested": True,
+        "capture_budget_baseline": False,
+        "require_controlled_host": True,
+        "control_mode": "work",
+        "sample_scale": "manifest",
+        "selected_count": 2,
+        "manifest_count": 2,
+        "groups": set(),
+        "case_ids": set(),
+        "case_limit": 0,
+        "approval_owner": APPROVAL_OWNER,
+    }
+
+    def clean_git(command: list[str], _cwd: Path) -> str:
+        return "a" * 40 if command[1:3] == ["rev-parse", "HEAD"] else ""
+
+    source = validate_capture_request(
+        **common, repo_root=Path("/self-test"), git_output=clean_git
+    )
+    if source != "a" * 40:
+        raise WorkBaselineError("work baseline self-test lost source binding")
+    bad_mode = dict(common)
+    bad_mode["control_mode"] = "latency"
+    assert_fails(
+        lambda: validate_capture_request(
+            **bad_mode, repo_root=Path("/self-test"), git_output=clean_git
+        ),
+        "work-mode",
+    )
+    assert_fails(
+        lambda: validate_capture_request(
+            **(common | {"case_limit": 1}),
+            repo_root=Path("/self-test"),
+            git_output=clean_git,
+        ),
+        "complete benchmark manifest",
+    )
+
+
+def assert_fails(action: Callable[[], object], expected: str) -> None:
+    try:
+        action()
+    except WorkBaselineError as error:
+        if expected not in str(error):
+            raise WorkBaselineError(
+                f"work baseline self-test failed with wrong diagnostic: {error}"
+            ) from error
+        return
+    raise WorkBaselineError(
+        f"work baseline self-test did not fail; expected {expected!r}"
+    )


### PR DESCRIPTION
## Scope

M3 root-cause hardening for #3100 and phase PR #3101.

- enforce retired-instruction budgets on this supported macOS arm64 host
- enforce Darwin process-tree RSS with a separate approved local baseline
- keep elapsed-time and generic RSS evidence behind the quiet-host latency policy
- select work mode only on Darwin and preserve latency mode on non-Darwin hosts
- preserve aggregate query latency, cache, diagnostics, and RSS semantics while independent processes provide work samples
- use a 2% instruction rule with a general 2,000,000-instruction floor and a 10%/32MiB local-RSS rule
- reject unstable instruction samples and retry under controlled admission
- load the performance runner correctly through both direct and sifr_verify area-adapter paths
- keep all existing elapsed thresholds, generic RSS thresholds, and waivers unchanged

The governed artifact binds clean producer `7e5d6648b6885863e60bab2a55d76cca8b59cdfb`. The exact reviewed PR candidate is `2d64321038f7f6e150c40e4fa2c5ccb63480bcc5`.

## Governed capture

- approved full-manifest work capture: 65/65
- artifact digest: `aa57ee57b95177832845a4b1a8b2bce603f39fa1da25e9f14c73e28bd26253cc`
- raw evidence digest: `0b3ca547e4b13afeb2afa909d87927f942f4f4e0ff16bcb184c806db79cabeac`
- at least five retired-instruction samples per case
- maximum accepted instruction CV: 1.2365% against 2%
- formatter capture rejected 3.1108% and accepted 0.1955%
- seeded instruction and local-RSS regressions rejected
- performance rules: 6/6; raw checker, Python compile/Ruff F, file-size, maintainability, and diff checks pass

## Five consecutive exact-candidate verdicts

All passed 8/8 without edits:

1. `bench-1786245199-40092.json` — `c6b4d13158a61446d51fb3d95a022cfc3fb35e80e5b0105c7cd11ff951b3166a`
2. `bench-1786245416-49560.json` — `705283cf5d7816010e831834a50e87f7527f822e63bdbca9a18149d88f578382`
3. `bench-1786245634-59408.json` — `bd5fa82da0148a35ee7abb2b951dc2cc3d896a1f4f4e8535379b48dd4984691b`
4. `bench-1786245853-69350.json` — `6ebaa4638bc7b14b182144175d1dad804e049fb9809800370eae1be35f05eb00`
5. `bench-1786246071-78899.json` — `7cbd2c331ff7c241f61832b5fcebd3f2ecfd26d80a3dc69d400bb6d39022d427`

The fifth run rejected formatter CVs 2.5238% and 2.6748%, then accepted 0.0762%.

## Review and gate

- Claude Opus exact-base review: `SATISFIED`, no blocking findings; response digest `476cac763f05905eb84ced8f85a33124fc75ee386d66f7e8e7d808937407a9cf`
- canonical create-PR gate passed on the exact candidate
- Python interop 19/19 at 522.086s/600s warm; Rust interop 10/10 at 6.180s/10s
- developer tooling 18/18; performance smoke 7/7; E2E 140/140
- one prior cold gate saw an out-of-scope transient LSP executeCommand stall; immediate isolated replay passed 6/6 and the unchanged full retry passed. Tracked in #3117; no timeout or LSP code was changed.