### PR TITLE
Skip structural interop work without demand

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -81,6 +81,8 @@ mod recursive_node_codegen_tests;
 #[cfg(test)]
 mod string_concat_codegen_tests;
 #[cfg(test)]
+mod structural_impl_demand_codegen_tests;
+#[cfg(test)]
 mod structured_condition_codegen_tests;
 #[cfg(test)]
 mod structured_intrinsic_codegen_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/collections_and_stdlib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/collections_and_stdlib_codegen_tests.rs
@@ -628,7 +628,8 @@ fn test_generate_rust_multi_assembles_single_rust_file() {
         .expect("generate_project docs should exist");
     let generate_block = &lib_src[start..end];
 
-    assert!(generate_block.contains("generate_rust_with_stdlib(module, &module_codegen_code)"));
+    assert!(generate_block.contains("generate_rust_with_stdlib_for_module_with_structural_policy("));
+    assert!(generate_block.contains("structural_interop_enabled,"));
     assert!(generate_block.contains("register_imported_generic_classes("));
     assert!(generate_block.contains("render_local_module_imports(module, &project_modules)"));
     assert!(generate_block.contains("publicize_generated_module_source(&rust_source)"));

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -14,6 +14,11 @@ fn ordinary_class_codegen_skips_structural_impls() {
     assert!(!generated.contains("StructuralType"));
     assert!(!generated.contains("StructuralConstruct"));
     assert!(!generated.contains("StructuralProject"));
+
+    let metadata = crate::generate_rust_with_metadata(&module);
+    assert!(!metadata
+        .required_features
+        .contains(&sifr_stdlib_manifest::StdlibFeature::StructuralRuntime));
 }
 
 #[test]
@@ -27,6 +32,14 @@ fn project_structural_demand_enables_implicit_classes_across_modules() {
     assert!(models_rust.contains("StructuralType"));
     assert!(models_rust.contains("StructuralConstruct"));
     assert!(models_rust.contains("StructuralProject"));
+
+    let metadata = crate::generate_rust_multi_with_metadata(
+        &[("models", &models), ("api", &api)],
+        &crate::StdlibCode::default(),
+    );
+    assert!(metadata
+        .required_features
+        .contains(&sifr_stdlib_manifest::StdlibFeature::StructuralRuntime));
 }
 
 fn module(functions: Vec<HirFunction>, classes: Vec<HirClass>) -> HirModule {

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -1,0 +1,88 @@
+use crate::{generate_rust, generate_rust_multi};
+use sifr_ir::{
+    HirClass, HirClassKind, HirFunction, HirModule, MethodKind, RustInteropAbiRequirements,
+    RustInteropDeclaration, RustInteropDecoratorKind, RustInteropEffect,
+};
+use sifr_type_system::Type;
+
+#[test]
+fn ordinary_class_codegen_skips_structural_impls() {
+    let module = module(Vec::new(), vec![payload_class()]);
+
+    let generated = generate_rust(&module);
+
+    assert!(!generated.contains("StructuralType"));
+    assert!(!generated.contains("StructuralConstruct"));
+    assert!(!generated.contains("StructuralProject"));
+}
+
+#[test]
+fn project_structural_demand_enables_implicit_classes_across_modules() {
+    let models = module(Vec::new(), vec![payload_class()]);
+    let api = module(vec![structural_function()], Vec::new());
+
+    let generated = generate_rust_multi(&[("models", &models), ("api", &api)]);
+    let models_rust = generated.get("models").expect("models module is generated");
+
+    assert!(models_rust.contains("StructuralType"));
+    assert!(models_rust.contains("StructuralConstruct"));
+    assert!(models_rust.contains("StructuralProject"));
+}
+
+fn module(functions: Vec<HirFunction>, classes: Vec<HirClass>) -> HirModule {
+    HirModule {
+        functions,
+        classes,
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: std::collections::HashMap::new(),
+        type_param_bounds: std::collections::HashMap::new(),
+    }
+}
+
+fn payload_class() -> HirClass {
+    HirClass {
+        name: "Payload".to_string(),
+        identity: None,
+        fields: vec![("value".to_string(), Type::Int)],
+        field_defaults: Vec::new(),
+        declaration_metadata: Vec::new(),
+        methods: Vec::new(),
+        is_hashable: false,
+        is_error_type: false,
+        kind: HirClassKind::Regular,
+        operator_impls: Vec::new(),
+        newtype_inner: None,
+        implements_protocols: Vec::new(),
+        parent_class: None,
+        parent_type: None,
+        type_params: Vec::new(),
+        enum_variants: Vec::new(),
+        rust_interop: Vec::new(),
+    }
+}
+
+fn structural_function() -> HirFunction {
+    HirFunction {
+        name: "construct".to_string(),
+        params: Vec::new(),
+        return_type: Type::None,
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        receiver: None,
+        decorators: Vec::new(),
+        rust_interop: vec![RustInteropDeclaration {
+            kind: RustInteropDecoratorKind::Structural,
+            target: None,
+            arguments: Vec::new(),
+            span: Default::default(),
+            effect: RustInteropEffect::Sync,
+            abi_requirements: RustInteropAbiRequirements::default(),
+            consumes_receiver: false,
+        }],
+        python_interop: Vec::new(),
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    }
+}

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -41,6 +41,9 @@ pub struct RustEmitter {
     pub(crate) current_class_name: Option<String>,
     /// The source module currently being emitted, when known.
     pub(crate) current_module_name: Option<String>,
+    /// Emit structural bridge implementations only when the project declares
+    /// a structural Rust interop boundary.
+    pub(crate) structural_interop_enabled: bool,
     /// Set of stdlib/intrinsic modules used (for Cargo dependency injection)
     pub used_stdlib_modules: HashSet<String>,
     /// Set of intrinsic function names (for codegen dispatch)
@@ -215,6 +218,7 @@ impl RustEmitter {
             parent_fields: HashMap::new(),
             current_class_name: None,
             current_module_name: None,
+            structural_interop_enabled: false,
             used_stdlib_modules: HashSet::new(),
             intrinsic_functions: HashSet::new(),
             intrinsic_registry_features: HashSet::new(),

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -798,6 +798,9 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_structural_policy(
             if needs_sifr_runtime {
                 features.insert(StdlibFeature::SifrRuntime);
             }
+            if structural_interop_enabled {
+                features.insert(StdlibFeature::StructuralRuntime);
+            }
             if has_async_main_entrypoint
                 || uses_task_sleep
                 || module_uses_task_scope(module)

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -209,7 +209,22 @@ pub fn generate_rust_with_stdlib_for_module(
     stdlib_code: &StdlibCode,
     module_name: Option<&str>,
 ) -> CodegenResult {
+    generate_rust_with_stdlib_for_module_with_structural_policy(
+        module,
+        stdlib_code,
+        module_name,
+        crate::rust_interop_plan::module_uses_structural_interop(module),
+    )
+}
+
+pub(crate) fn generate_rust_with_stdlib_for_module_with_structural_policy(
+    module: &HirModule,
+    stdlib_code: &StdlibCode,
+    module_name: Option<&str>,
+    structural_interop_enabled: bool,
+) -> CodegenResult {
     let mut emitter = RustEmitter::new();
+    emitter.structural_interop_enabled = structural_interop_enabled;
     // Register stdlib generic classes so user code skips explicit type annotations
     emitter
         .generic_classes

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -1,7 +1,7 @@
 use super::{
-    generate_rust, generate_rust_with_stdlib, module_class_fields,
-    publicize_generated_module_source, HashMap, HashSet, HirModule, MultiModuleCodegenResult,
-    Renderer, RustFile, RustItem, StdlibCode,
+    generate_rust, generate_rust_with_stdlib_for_module_with_structural_policy,
+    module_class_fields, publicize_generated_module_source, HashMap, HashSet, HirModule,
+    MultiModuleCodegenResult, Renderer, RustFile, RustItem, StdlibCode,
 };
 use crate::lib_project_signatures::project_func_signatures;
 use sifr_stdlib_manifest::{try_generated_cargo_dependencies, StdlibFeature};
@@ -187,6 +187,9 @@ pub fn generate_rust_multi_with_metadata(
     let mut required_features = HashSet::new();
     let mut project_codegen_code = stdlib_code.clone();
     let project_modules = modules.iter().copied().collect::<HashMap<_, _>>();
+    let structural_interop_enabled = modules
+        .iter()
+        .any(|(_, module)| crate::rust_interop_plan::module_uses_structural_interop(module));
 
     project_codegen_code
         .func_signatures
@@ -201,7 +204,12 @@ pub fn generate_rust_multi_with_metadata(
         let module_public = *module_name != "main";
         let mut module_codegen_code = project_codegen_code.clone();
         register_imported_generic_classes(&mut module_codegen_code, module, &project_modules);
-        let codegen_result = generate_rust_with_stdlib(module, &module_codegen_code);
+        let codegen_result = generate_rust_with_stdlib_for_module_with_structural_policy(
+            module,
+            &module_codegen_code,
+            None,
+            structural_interop_enabled,
+        );
         let local_imports = render_local_module_imports(module, &project_modules);
         let mut rust_source = codegen_result.rust_source;
         if !local_imports.trim().is_empty() {

--- a/crates/sifr_codegen/src/rust_interop_plan.rs
+++ b/crates/sifr_codegen/src/rust_interop_plan.rs
@@ -279,11 +279,32 @@ pub fn interop_build_plan_for_named_modules<'a>(
     let mut rust = RustInteropPlan::default();
     for (module_name, module) in &module_entries {
         collect_module_declarations(*module_name, module, &mut rust.declarations);
-        collect_structural_shape_identities(*module_name, module, &mut rust);
+    }
+    if rust.declarations.iter().any(|declaration| {
+        declaration.declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural
+    }) {
+        for (module_name, module) in &module_entries {
+            collect_structural_shape_identities(*module_name, module, &mut rust);
+        }
     }
     rust.bridge_contracts =
         bridge_contract_plan_for_named_modules(module_entries, &rust.declarations);
     InteropBuildPlan { rust, python }
+}
+
+pub(crate) fn module_uses_structural_interop(module: &HirModule) -> bool {
+    module
+        .functions
+        .iter()
+        .chain(module.classes.iter().flat_map(|class| {
+            class
+                .methods
+                .iter()
+                .chain(class.operator_impls.iter().map(|(_, method)| method))
+        }))
+        .flat_map(|function| &function.rust_interop)
+        .chain(module.classes.iter().flat_map(|class| &class.rust_interop))
+        .any(|declaration| declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural)
 }
 
 fn collect_structural_shape_identities(
@@ -747,6 +768,9 @@ fn push_span(out: &mut String, span: ruff_text_size::TextRange) {
     out.push_str(&span.end().to_u32().to_string());
 }
 
+#[cfg(test)]
+#[path = "rust_interop_plan_demand_tests.rs"]
+mod rust_interop_plan_demand_tests;
 #[cfg(test)]
 #[path = "rust_interop_plan_tests.rs"]
 mod rust_interop_plan_tests;

--- a/crates/sifr_codegen/src/rust_interop_plan_demand_tests.rs
+++ b/crates/sifr_codegen/src/rust_interop_plan_demand_tests.rs
@@ -1,0 +1,27 @@
+use super::{interop_build_plan_for_named_modules, rust_interop_plan_tests::class};
+use sifr_ir::{HirClassKind, HirModule};
+use sifr_type_system::Type;
+
+#[test]
+fn ordinary_modules_skip_structural_identity_collection() {
+    let module = HirModule {
+        functions: Vec::new(),
+        classes: vec![class(
+            "Payload",
+            HirClassKind::Regular,
+            vec![("value".to_string(), Type::Int)],
+        )],
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: std::collections::HashMap::new(),
+        type_param_bounds: std::collections::HashMap::new(),
+    };
+
+    let plan = interop_build_plan_for_named_modules([(Some("main"), &module)]);
+
+    assert_eq!(plan.rust.structural_identity_algorithm_version, None);
+    assert!(plan.rust.structural_shape_identities.is_empty());
+    assert!(plan
+        .cache_key_fragment()
+        .contains("rust.structural_shape_identities=0"));
+}

--- a/crates/sifr_codegen/src/rust_interop_plan_tests.rs
+++ b/crates/sifr_codegen/src/rust_interop_plan_tests.rs
@@ -765,7 +765,7 @@ fn function_with_declaration(
     }
 }
 
-fn class(name: &str, kind: HirClassKind, fields: Vec<(String, Type)>) -> HirClass {
+pub(super) fn class(name: &str, kind: HirClassKind, fields: Vec<(String, Type)>) -> HirClass {
     HirClass {
         name: name.to_string(),
         identity: None,
@@ -790,7 +790,11 @@ fn class(name: &str, kind: HirClassKind, fields: Vec<(String, Type)>) -> HirClas
 #[test]
 fn interop_cache_fragment_includes_structural_algorithm_and_concrete_identity() {
     let module = HirModule {
-        functions: Vec::new(),
+        functions: vec![function_with_declaration(
+            "construct",
+            RustInteropDecoratorKind::Structural,
+            "bridge.payload.construct",
+        )],
         classes: vec![class(
             "Payload",
             HirClassKind::Regular,

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -7,7 +7,7 @@ const STRUCTURAL: &str = "::sifr_runtime::interop::structural";
 
 impl RustEmitter {
     pub(crate) fn emit_structural_record_impls(&mut self, class: &HirClass, module: &HirModule) {
-        if !structural_record_supported(class, module) {
+        if !self.structural_interop_enabled || !structural_record_supported(class, module) {
             return;
         }
         let target = Self::class_impl_target(class);

--- a/crates/sifr_runtime/Cargo.toml
+++ b/crates/sifr_runtime/Cargo.toml
@@ -24,7 +24,7 @@ indexmap = { workspace = true }
 libc = { workspace = true, optional = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
-sifr_structural_identity = { workspace = true }
+sifr_structural_identity = { workspace = true, optional = true }
 pyo3 = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 rustls-pemfile = { workspace = true, optional = true }
@@ -39,6 +39,7 @@ unicode_names2 = { workspace = true, optional = true }
 [dev-dependencies]
 pyo3 = { workspace = true, features = ["macros"] }
 rcgen = { workspace = true }
+sifr_structural_identity = { workspace = true }
 tokio = { workspace = true }
 
 [features]
@@ -52,6 +53,7 @@ i18n = [
 ]
 unicode = ["dep:unicode-normalization", "dep:unicode-segmentation", "dep:unicode_names2"]
 python = ["dep:libc", "dep:pyo3", "dep:tokio"]
+structural = ["dep:sifr_structural_identity"]
 net = ["dep:tokio"]
 tls = [
     "net",

--- a/crates/sifr_runtime/src/interop.rs
+++ b/crates/sifr_runtime/src/interop.rs
@@ -13,6 +13,7 @@ pub use crate::interop_callbacks::{
     ThreadsafeCallbackBridge, ThreadsafeCallbackPolicy,
 };
 
+#[cfg(any(test, feature = "structural"))]
 pub mod structural;
 
 type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync + 'static>;

--- a/crates/sifr_stdlib_manifest/src/features.rs
+++ b/crates/sifr_stdlib_manifest/src/features.rs
@@ -49,6 +49,7 @@ pub enum StdlibFeature {
     Sha1,
     Sha2,
     SifrRuntime,
+    StructuralRuntime,
     Sys,
     Tokio,
     TokioRustls,
@@ -106,6 +107,7 @@ impl StdlibFeature {
             Self::Sha1 => "sha1",
             Self::Sha2 => "sha2",
             Self::SifrRuntime => "sifr_runtime",
+            Self::StructuralRuntime => "sifr_runtime/structural",
             Self::Sys => "sys",
             Self::Tokio => "tokio",
             Self::TokioRustls => "tokio-rustls",
@@ -168,6 +170,9 @@ pub fn feature_for_codegen_requirement(name: &str) -> Option<StdlibFeature> {
         "sha1" => Some(StdlibFeature::Sha1),
         "sha2" => Some(StdlibFeature::Sha2),
         "sifr_runtime" | "sifr-runtime" => Some(StdlibFeature::SifrRuntime),
+        "sifr_runtime/structural" | "sifr-runtime/structural" | "structural-runtime" => {
+            Some(StdlibFeature::StructuralRuntime)
+        }
         "sys" => Some(StdlibFeature::Sys),
         "tokio" => Some(StdlibFeature::Tokio),
         "tokio-rustls" | "tokio_rustls" => Some(StdlibFeature::TokioRustls),

--- a/crates/sifr_stdlib_manifest/src/features/generated_stdlib_features.rs
+++ b/crates/sifr_stdlib_manifest/src/features/generated_stdlib_features.rs
@@ -109,6 +109,7 @@ fn features_for_requirement(feature: StdlibFeature) -> &'static [&'static str] {
         | StdlibFeature::Cookie
         | StdlibFeature::Ipc
         | StdlibFeature::SifrRuntime
+        | StdlibFeature::StructuralRuntime
         | StdlibFeature::Tokio => &[],
     }
 }

--- a/crates/sifr_stdlib_manifest/src/features/runtime_features.rs
+++ b/crates/sifr_stdlib_manifest/src/features/runtime_features.rs
@@ -7,6 +7,7 @@ pub(super) struct RuntimeFeatures {
     pub(super) i18n: bool,
     pub(super) net: bool,
     pub(super) python: bool,
+    pub(super) structural: bool,
     pub(super) tls: bool,
     pub(super) unicode: bool,
 }
@@ -21,13 +22,20 @@ impl RuntimeFeatures {
             i18n: needs_sifr_runtime_i18n(required_features),
             net: needs_sifr_runtime_net(stdlib_modules),
             python: needs_sifr_runtime_python(stdlib_modules, required_features),
+            structural: required_features.contains(&StdlibFeature::StructuralRuntime),
             tls: needs_sifr_runtime_tls(stdlib_modules, required_features),
             unicode: needs_sifr_runtime_unicode(stdlib_modules, required_features),
         }
     }
 
     pub(super) const fn requires_runtime_crate(self) -> bool {
-        self.http || self.i18n || self.net || self.python || self.tls || self.unicode
+        self.http
+            || self.i18n
+            || self.net
+            || self.python
+            || self.structural
+            || self.tls
+            || self.unicode
     }
 
     pub(super) fn feature_names(self) -> std::collections::BTreeSet<String> {
@@ -40,6 +48,9 @@ impl RuntimeFeatures {
         }
         if self.python {
             features.insert("python".to_string());
+        }
+        if self.structural {
+            features.insert("structural".to_string());
         }
         if self.tls || self.http {
             features.insert("tls".to_string());

--- a/crates/sifr_stdlib_manifest/src/features_tests.rs
+++ b/crates/sifr_stdlib_manifest/src/features_tests.rs
@@ -84,6 +84,33 @@ fn runtime_and_tokio_features_render_retained_glue_dependency_specs() {
 }
 
 #[test]
+fn structural_runtime_feature_is_demand_gated_in_generated_dependencies() {
+    let ordinary = generated_cargo_dependencies(
+        &HashSet::new(),
+        &HashSet::from([StdlibFeature::SifrRuntime]),
+    );
+    assert!(ordinary.iter().any(|dependency| {
+        dependency.starts_with("sifr_runtime = ")
+            && dependency.contains("default-features = false")
+            && !dependency.contains("features = [")
+    }));
+
+    let structural = generated_cargo_dependencies(
+        &HashSet::new(),
+        &HashSet::from([StdlibFeature::StructuralRuntime]),
+    );
+    assert!(structural.iter().any(|dependency| {
+        dependency.starts_with("sifr_runtime = ")
+            && dependency.contains("default-features = false")
+            && dependency.contains("features = [\"structural\"]")
+    }));
+    assert_eq!(
+        feature_for_codegen_requirement("structural-runtime"),
+        Some(StdlibFeature::StructuralRuntime)
+    );
+}
+
+#[test]
 fn ipc_feature_renders_sysroot_specs_without_json() {
     let deps = generated_cargo_dependencies(
         &HashSet::from(["sifr.ipc".to_string(), "_sifr.ipc".to_string()]),

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -355,6 +355,13 @@ This section is the supported structural bridge contract.
 callback, and deliberate-rejection evidence. The companion
 `bridge_version_field_removal` row passes at the same boundary.
 
+Generated projects enable the `sifr_runtime/structural` Cargo feature when the
+project declares a structural Rust boundary. Without that demand, the compiler
+does not collect structural identities, emit structural implementations, or
+compile `sifr_structural_identity`. A backend crate that imports structural
+runtime traits must enable the `sifr_runtime` `structural` feature in its own
+Cargo manifest.
+
 The structural contract replaced the versioned bridge schema. That cutover
 atomically removed `[rust]
 bridge-version` from the manifest schema, every in-repository package and

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/Cargo.toml
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sifr_runtime = { path = "../../../../../../../crates/sifr_runtime" }
+sifr_runtime = { path = "../../../../../../../crates/sifr_runtime", features = ["structural"] }
 
 [package.metadata.sifr]
 manifest = "sifr.toml"


### PR DESCRIPTION
## Scope

- skip structural shape identity collection when no `Structural` Rust interop declaration exists
- skip structural record support checks and impl emission in ordinary programs
- preserve project-wide implicit structural eligibility when any module declares a structural bridge
- make `sifr_structural_identity` optional behind `sifr_runtime/structural`
- enable the runtime structural feature only for generated projects and backend crates with actual structural demand
- add plan, emitter, dependency-plan, generated-manifest, and cross-module regression tests

## Performance evidence

Initial demand gating removed the check/diagnostic regression. A controlled integrated run then isolated residual generated-build work from the unconditional runtime dependency.

After runtime feature gating, five warm `/usr/bin/time -l` samples per residual case under qlty=2 and Sifr build jobs=6:

- build project median: 117,828,333,610 retired instructions; threshold 119,984,530,852; CV 0.0241%
- build single median: 111,958,572,272; threshold 113,587,510,625; CV 0.0199%

Both ordinary generated Cargo manifests use `sifr_runtime` with `default-features = false` and no structural feature. The normal Cargo graph excludes `sifr_structural_identity` unless `sifr_runtime/structural` is enabled. Raw time-file digest: `6d36529358b8ea4ab3bc4c6ab9e7d24bd5a1ee4c5a85bf65d259caac4fe164df`.

## Validation

- `sifr_runtime`: 66 passed in default and structural configurations
- `sifr_stdlib_manifest`: 29 passed
- `sifr_codegen`: 975 passed; focused structural 8 passed
- native structural bridge runtime fixture: 1 passed with exact runtime assertion
- Rust interop verification area: 10/10 plus all self-tests
- file-size, HIR, taxonomy, formatting, and diff guards: pass
- affected package Clippy: pass with only unchanged current-main Rust 1.94 baseline lints allowed
- Claude Opus complete exact-SHA review: SATISFIED, no blocking findings
