### PR TITLE
fix(perf): make work-mode CPU admission robust

### DIFF
--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -1545,10 +1545,12 @@ boundary. Work-controlled measurements use retired instructions and
 process-tree RSS from the local macOS host. Latency-controlled measurements use
 elapsed time and generic RSS after a quiet-host admission. Non-macOS profiles
 retain latency mode because they do not expose the Darwin counter. Both modes reject
-competing build work, thermal pressure, external CPU use that violates the
-selected capacity policy, and unstable samples. Darwin work mode reserves 60%
-of logical CPU capacity for the measured process tree without requiring an idle
-desktop. The accepted report includes an invocation identity. Producer
+competing build work, thermal pressure, and unstable samples. Darwin work mode
+reserves 60% of logical CPU capacity at admission. During the attempt, external
+CPU pressure is blocking when retired-instruction samples are unstable and is
+advisory when those work samples remain stable. This avoids requiring an idle
+desktop without weakening the work budget. The accepted report includes an
+invocation identity. Producer
 failure cannot use stale `*.budget.latest.json` evidence. This design separates
 host delay from additional compiler work without changing elapsed-time budgets.
 

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -1545,8 +1545,10 @@ boundary. Work-controlled measurements use retired instructions and
 process-tree RSS from the local macOS host. Latency-controlled measurements use
 elapsed time and generic RSS after a quiet-host admission. Non-macOS profiles
 retain latency mode because they do not expose the Darwin counter. Both modes reject
-competing build work, thermal pressure, and
-unstable samples. The accepted report includes an invocation identity. Producer
+competing build work, thermal pressure, external CPU use that violates the
+selected capacity policy, and unstable samples. Darwin work mode reserves 60%
+of logical CPU capacity for the measured process tree without requiring an idle
+desktop. The accepted report includes an invocation identity. Producer
 failure cannot use stale `*.budget.latest.json` evidence. This design separates
 host delay from additional compiler work without changing elapsed-time budgets.
 

--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -56,15 +56,17 @@ Work-controlled admission records load and unrelated CPU use. It reserves 60%
 of the host's logical CPU capacity for the measured process tree. External
 activity can use at most the remaining 40%; on a 10-thread host, the limit is
 `400%` as reported by `ps`. This permits ordinary bounded desktop and container
-activity without waiting for an idle machine, but rejects attempts that cannot
-retain the measured CPU share. Retired instructions measure work in the
-benchmark process tree. Unrelated processes do not add to that count. Each
-case rejects an instruction coefficient of variation above `0.02`.
+activity without waiting for an idle machine. Retired instructions measure work
+in the benchmark process tree. Unrelated processes do not add to that count.
+Each case rejects an instruction coefficient of variation above `0.02`.
 
 Work mode does not apply the normalized one-minute load limit. That metric
 includes the measured process and lags a rejected attempt, so it cannot prove
-current external capacity. The external-process CPU limit is sampled directly
-during admission and throughout each attempt.
+current external capacity. The external-process CPU limit is enforced during
+admission and sampled throughout each attempt. A transient in-attempt CPU spike
+is advisory when the retired-instruction samples remain within their stability
+limit. The spike remains blocking when the work samples are unstable, so the
+failure evidence distinguishes host contamination from additional compiler work.
 
 Latency-controlled admission remains available for elapsed-time evidence. It
 also requires normalized one-minute load at or below `0.85`. Unrelated
@@ -73,8 +75,10 @@ calibration is also required. The approved trend capture uses this mode.
 
 Both modes record load, power, thermal state, CPU behavior, external CPU use,
 memory pressure, and cache state. Per-case monitoring rejects new competing
-build work, thermal pressure, or external CPU use above the selected mode's
-limit. The monitor excludes the benchmark runner and its process tree.
+build work and thermal pressure. Latency mode also rejects external CPU use
+above its limit. Work mode applies that in-attempt limit when retired-instruction
+samples are unstable and records transient pressure as advisory when they are
+stable. The monitor excludes the benchmark runner and its process tree.
 
 On macOS, `ps` supplies recent decayed CPU use. On Linux, `ps` supplies the
 process-lifetime average. Linux evidence records this limitation.

--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -52,11 +52,19 @@ macOS admission requires three accepted snapshots, AC power, and nominal
 thermal state. The host must provide retired-instruction counters. Competing
 Cargo, rustc, benchmark, or Git indexing processes reject admission.
 
-Work-controlled admission records load and unrelated CPU use. It does not
-reject a sample only because unrelated CPU use is high. Retired instructions
-measure work in the benchmark process tree. Unrelated processes do not add to
-that count. Each case rejects an instruction coefficient of variation above
-`0.02`.
+Work-controlled admission records load and unrelated CPU use. It reserves 60%
+of the host's logical CPU capacity for the measured process tree. External
+activity can use at most the remaining 40%; on a 10-thread host, the limit is
+`400%` as reported by `ps`. This permits ordinary bounded desktop and container
+activity without waiting for an idle machine, but rejects attempts that cannot
+retain the measured CPU share. Retired instructions measure work in the
+benchmark process tree. Unrelated processes do not add to that count. Each
+case rejects an instruction coefficient of variation above `0.02`.
+
+Work mode does not apply the normalized one-minute load limit. That metric
+includes the measured process and lags a rejected attempt, so it cannot prove
+current external capacity. The external-process CPU limit is sampled directly
+during admission and throughout each attempt.
 
 Latency-controlled admission remains available for elapsed-time evidence. It
 also requires normalized one-minute load at or below `0.85`. Unrelated
@@ -65,8 +73,8 @@ calibration is also required. The approved trend capture uses this mode.
 
 Both modes record load, power, thermal state, CPU behavior, external CPU use,
 memory pressure, and cache state. Per-case monitoring rejects new competing
-build work or thermal pressure. The monitor excludes the benchmark runner and
-its process tree.
+build work, thermal pressure, or external CPU use above the selected mode's
+limit. The monitor excludes the benchmark runner and its process tree.
 
 On macOS, `ps` supplies recent decayed CPU use. On Linux, `ps` supplies the
 process-lifetime average. Linux evidence records this limitation.

--- a/verification/areas/performance/controlled_sampling.py
+++ b/verification/areas/performance/controlled_sampling.py
@@ -39,6 +39,7 @@ def run_controlled_case(
         rejection_reasons = (
             monitor.rejection_reasons() if require_controlled_host else []
         )
+        advisory_reasons: list[str] = []
         if control_mode == "work":
             raw_variation = result["metrics"].get(
                 "instructions_coefficient_variation"
@@ -56,6 +57,18 @@ def run_controlled_case(
             coefficient_variation = float(raw_variation)
         if coefficient_variation is not None and coefficient_variation > stability_limit:
             rejection_reasons.append("unstable-samples")
+        if (
+            control_mode == "work"
+            and coefficient_variation is not None
+            and coefficient_variation <= stability_limit
+            and "external-cpu-pressure" in rejection_reasons
+        ):
+            # Retired instructions measure completed work rather than elapsed time.
+            # Admission reserves capacity before the attempt; transient pressure
+            # during a demonstrably stable work sample is useful telemetry, but it
+            # must not make a local desktop require perfect idleness.
+            rejection_reasons.remove("external-cpu-pressure")
+            advisory_reasons.append("external-cpu-pressure")
         rejection_reasons = sorted(set(rejection_reasons))
         attempt_evidence = {
             "attempt": attempt_index,
@@ -66,6 +79,8 @@ def run_controlled_case(
             "host_snapshots": monitor.snapshots,
             "rejection_reasons": rejection_reasons,
         }
+        if advisory_reasons:
+            attempt_evidence["advisory_reasons"] = sorted(set(advisory_reasons))
         if retry_admission is not None:
             attempt_evidence["retry_admission"] = retry_admission
         attempts.append(attempt_evidence)
@@ -173,6 +188,30 @@ def run_self_test(output_root: Path) -> None:
     ):
         raise BenchmarkError(
             "controlled sampling self-test did not select work stability"
+        )
+
+    class PressuredMonitor(FakeMonitor):
+        def rejection_reasons(self) -> list[str]:
+            return ["external-cpu-pressure"]
+
+    pressured_work_accepted = run_controlled_case(
+        case,
+        output_root,
+        "manifest",
+        require_controlled_host=True,
+        control_mode="work",
+        run_case_fn=stable_work_run,
+        retry_admission_fn=fake_retry_admission,
+        monitor_factory=PressuredMonitor,
+    )
+    pressured_attempt = pressured_work_accepted["control"]["attempts"][0]
+    if pressured_attempt["rejection_reasons"]:
+        raise BenchmarkError(
+            "stable work sampling self-test rejected transient CPU pressure"
+        )
+    if pressured_attempt.get("advisory_reasons") != ["external-cpu-pressure"]:
+        raise BenchmarkError(
+            "stable work sampling self-test did not preserve pressure telemetry"
         )
 
     def unstable_run(_case: BenchmarkCase, _root: Path, _scale: str) -> dict[str, Any]:

--- a/verification/areas/performance/host_control.py
+++ b/verification/areas/performance/host_control.py
@@ -34,7 +34,12 @@ def profile_control_mode(host_system: str | None = None) -> str:
     return "work" if system == "Darwin" else "latency"
 
 
-def capture_host_snapshot(*, include_calibration: bool = True) -> dict[str, Any]:
+def capture_host_snapshot(
+    *,
+    include_calibration: bool = True,
+    control_mode: str = "latency",
+) -> dict[str, Any]:
+    validate_control_mode(control_mode)
     logical_cpus = os.cpu_count() or 1
     try:
         load_1m, load_5m, load_15m = os.getloadavg()
@@ -43,7 +48,10 @@ def capture_host_snapshot(*, include_calibration: bool = True) -> dict[str, Any]
     thermal = thermal_state()
     power = power_state()
     frequency = cpu_frequency_state(include_calibration=include_calibration)
-    competitors, cpu_pressure = process_activity()
+    competitors, cpu_pressure = process_activity(
+        control_mode=control_mode,
+        logical_cpus=logical_cpus,
+    )
     return {
         "captured_at_unix": round(time.time(), 3),
         "logical_cpus": logical_cpus,
@@ -102,7 +110,7 @@ def evaluate_snapshot(
     if cpu_pressure.get("source") != "ps":
         reasons.append("external-cpu-pressure-unavailable")
     else:
-        external_cpu_limit = max_external_cpu_percent(snapshot, control_mode)
+        external_cpu_limit = external_cpu_limit_for_mode(snapshot, control_mode)
         if external_cpu_limit is None:
             reasons.append("logical-cpu-count-unavailable")
         elif (
@@ -136,7 +144,10 @@ def wait_for_controlled_host(
     consecutive: list[dict[str, Any]] = []
     observations: list[dict[str, Any]] = []
     while True:
-        snapshot = snapshot_fn(include_calibration=True)
+        snapshot = snapshot_fn(
+            include_calibration=True,
+            control_mode=control_mode,
+        )
         reasons = evaluate_snapshot(
             snapshot,
             enforce_load=True,
@@ -179,7 +190,7 @@ def controlled_policy(
 ) -> dict[str, Any]:
     validate_control_mode(control_mode)
     cpu_count = logical_cpus if logical_cpus is not None else os.cpu_count() or 1
-    external_cpu_limit = max_external_cpu_percent(
+    external_cpu_limit = external_cpu_limit_for_mode(
         {"logical_cpus": cpu_count}, control_mode
     )
     return {
@@ -190,6 +201,11 @@ def controlled_policy(
         "max_frequency_proxy_cv": MAX_CALIBRATION_CV,
         "max_external_cpu_percent": external_cpu_limit,
         "external_cpu_limit_applied": True,
+        "in_attempt_external_cpu_policy": (
+            "advisory-when-work-stable"
+            if control_mode == "work"
+            else "blocking"
+        ),
         "load_limit_applied": control_mode == "latency",
         "work_reserved_logical_cpu_fraction": (
             WORK_RESERVED_LOGICAL_CPU_FRACTION
@@ -204,7 +220,7 @@ def controlled_policy(
     }
 
 
-def max_external_cpu_percent(
+def external_cpu_limit_for_mode(
     snapshot: dict[str, Any], control_mode: str
 ) -> float | None:
     validate_control_mode(control_mode)
@@ -237,7 +253,12 @@ class HostActivityMonitor:
         self.snapshots: list[dict[str, Any]] = []
 
     def __enter__(self) -> HostActivityMonitor:
-        self.snapshots.append(capture_host_snapshot(include_calibration=False))
+        self.snapshots.append(
+            capture_host_snapshot(
+                include_calibration=False,
+                control_mode=self._control_mode,
+            )
+        )
         self._thread = threading.Thread(
             target=self._run, name="sifr-performance-host-monitor", daemon=True
         )
@@ -248,11 +269,21 @@ class HostActivityMonitor:
         self._stop.set()
         if self._thread is not None:
             self._thread.join(timeout=max(1.0, self._interval_seconds * 2.0))
-        self.snapshots.append(capture_host_snapshot(include_calibration=False))
+        self.snapshots.append(
+            capture_host_snapshot(
+                include_calibration=False,
+                control_mode=self._control_mode,
+            )
+        )
 
     def _run(self) -> None:
         while not self._stop.wait(self._interval_seconds):
-            self.snapshots.append(capture_host_snapshot(include_calibration=False))
+            self.snapshots.append(
+                capture_host_snapshot(
+                    include_calibration=False,
+                    control_mode=self._control_mode,
+                )
+            )
 
     def rejection_reasons(self) -> list[str]:
         reasons: set[str] = set()
@@ -421,7 +452,15 @@ def memory_pressure_state() -> dict[str, Any]:
 
 def process_activity(
     output: str | None = None,
+    *,
+    control_mode: str = "latency",
+    logical_cpus: int | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    validate_control_mode(control_mode)
+    cpu_count = logical_cpus if logical_cpus is not None else os.cpu_count() or 1
+    external_cpu_limit = external_cpu_limit_for_mode(
+        {"logical_cpus": cpu_count}, control_mode
+    )
     if output is None:
         output = command_output(["ps", "-axo", "pid=,ppid=,pcpu=,comm=,args="])
     rows = parse_process_rows(output)
@@ -429,10 +468,15 @@ def process_activity(
         return [], {
             "source": "unavailable",
             "external_cpu_percent": None,
-            "max_external_cpu_percent": MAX_EXTERNAL_CPU_PERCENT,
+            "max_external_cpu_percent": external_cpu_limit,
             "top_processes": [],
         }
-    return summarize_process_activity(rows, os.getpid())
+    return summarize_process_activity(
+        rows,
+        os.getpid(),
+        control_mode=control_mode,
+        logical_cpus=cpu_count,
+    )
 
 
 def parse_process_rows(output: str) -> list[tuple[int, int, float, str, str]]:
@@ -450,8 +494,17 @@ def parse_process_rows(output: str) -> list[tuple[int, int, float, str, str]]:
 
 
 def summarize_process_activity(
-    rows: list[tuple[int, int, float, str, str]], current_pid: int
+    rows: list[tuple[int, int, float, str, str]],
+    current_pid: int,
+    *,
+    control_mode: str = "latency",
+    logical_cpus: int | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    validate_control_mode(control_mode)
+    cpu_count = logical_cpus if logical_cpus is not None else os.cpu_count() or 1
+    external_cpu_limit = external_cpu_limit_for_mode(
+        {"logical_cpus": cpu_count}, control_mode
+    )
     excluded = related_process_ids(rows, current_pid)
     competitors: list[dict[str, Any]] = []
     external_rows: list[tuple[int, float, str]] = []
@@ -478,7 +531,7 @@ def summarize_process_activity(
     return competitors, {
         "source": "ps",
         "external_cpu_percent": round(external_cpu_percent, 1),
-        "max_external_cpu_percent": MAX_EXTERNAL_CPU_PERCENT,
+        "max_external_cpu_percent": external_cpu_limit,
         "top_processes": top_processes,
     }
 
@@ -619,6 +672,8 @@ def run_self_test() -> None:
     if (
         work_policy["max_external_cpu_percent"] != 400.0
         or work_policy["external_cpu_limit_applied"] is not True
+        or work_policy["in_attempt_external_cpu_policy"]
+        != "advisory-when-work-stable"
         or work_policy["load_limit_applied"] is not False
         or work_policy["work_reserved_logical_cpu_fraction"] != 0.60
     ):
@@ -695,6 +750,26 @@ def run_self_test() -> None:
         raise HostControlError(
             "host control self-test included related benchmark CPU activity"
         )
+    if cpu_pressure["max_external_cpu_percent"] != 50.0:
+        raise HostControlError(
+            "latency process telemetry recorded the wrong external CPU limit"
+        )
+    _work_competitors, work_cpu_pressure = summarize_process_activity(
+        [
+            (1, 0, 0.1, "/sbin/launchd", "/sbin/launchd"),
+            (10, 1, 10.0, "/usr/bin/python3", "python3 run_benchmarks.py"),
+            (11, 10, 90.0, "/usr/bin/rustc", "rustc --crate-name measured"),
+            (20, 1, 30.0, "/usr/bin/cargo", "cargo build"),
+            (21, 1, 25.1, "/opt/agent", "/opt/agent --scan"),
+        ],
+        10,
+        control_mode="work",
+        logical_cpus=10,
+    )
+    if work_cpu_pressure["max_external_cpu_percent"] != 400.0:
+        raise HostControlError(
+            "work process telemetry recorded the wrong external CPU limit"
+        )
     parsed_rows = parse_process_rows(
         "bad row\n"
         "42 1 not-a-number /usr/bin/noop noop\n"
@@ -708,6 +783,15 @@ def run_self_test() -> None:
     if unavailable_competitors or unavailable_cpu["source"] != "unavailable":
         raise HostControlError(
             "host control self-test did not fail closed on empty ps output"
+        )
+    _work_unavailable_competitors, work_unavailable_cpu = process_activity(
+        "",
+        control_mode="work",
+        logical_cpus=10,
+    )
+    if work_unavailable_cpu["max_external_cpu_percent"] != 400.0:
+        raise HostControlError(
+            "unavailable work telemetry recorded the wrong external CPU limit"
         )
     if executable_from_process("/truncated", "/usr/bin/tool --work") != "tool":
         raise HostControlError(

--- a/verification/areas/performance/host_control.py
+++ b/verification/areas/performance/host_control.py
@@ -18,6 +18,7 @@ from process_metrics import parse_process_metrics
 MAX_NORMALIZED_LOAD = 0.85
 MAX_CALIBRATION_CV = 0.12
 MAX_EXTERNAL_CPU_PERCENT = 50.0
+WORK_RESERVED_LOGICAL_CPU_FRACTION = 0.60
 DEFAULT_QUIET_SNAPSHOTS = 3
 DEFAULT_QUIET_INTERVAL_SECONDS = 1.0
 MONITOR_INTERVAL_SECONDS = 5.0
@@ -100,11 +101,15 @@ def evaluate_snapshot(
     external_cpu_percent = cpu_pressure.get("external_cpu_percent")
     if cpu_pressure.get("source") != "ps":
         reasons.append("external-cpu-pressure-unavailable")
-    elif control_mode == "latency" and (
-        isinstance(external_cpu_percent, int | float)
-        and external_cpu_percent > MAX_EXTERNAL_CPU_PERCENT
-    ):
-        reasons.append("external-cpu-pressure")
+    else:
+        external_cpu_limit = max_external_cpu_percent(snapshot, control_mode)
+        if external_cpu_limit is None:
+            reasons.append("logical-cpu-count-unavailable")
+        elif (
+            isinstance(external_cpu_percent, int | float)
+            and external_cpu_percent > external_cpu_limit
+        ):
+            reasons.append("external-cpu-pressure")
     if enforce_load and control_mode == "latency":
         normalized_load = snapshot.get("load_average", {}).get(
             "one_minute_per_logical_cpu"
@@ -167,23 +172,53 @@ def wait_for_controlled_host(
         sleep_fn(interval_seconds)
 
 
-def controlled_policy(control_mode: str = "latency") -> dict[str, Any]:
+def controlled_policy(
+    control_mode: str = "latency",
+    *,
+    logical_cpus: int | None = None,
+) -> dict[str, Any]:
     validate_control_mode(control_mode)
+    cpu_count = logical_cpus if logical_cpus is not None else os.cpu_count() or 1
+    external_cpu_limit = max_external_cpu_percent(
+        {"logical_cpus": cpu_count}, control_mode
+    )
     return {
         "mode": control_mode,
         "quiet_snapshots": DEFAULT_QUIET_SNAPSHOTS,
         "quiet_interval_seconds": DEFAULT_QUIET_INTERVAL_SECONDS,
         "max_one_minute_load_per_logical_cpu": MAX_NORMALIZED_LOAD,
         "max_frequency_proxy_cv": MAX_CALIBRATION_CV,
-        "max_external_cpu_percent": MAX_EXTERNAL_CPU_PERCENT,
-        "external_cpu_limit_applied": control_mode == "latency",
+        "max_external_cpu_percent": external_cpu_limit,
+        "external_cpu_limit_applied": True,
         "load_limit_applied": control_mode == "latency",
+        "work_reserved_logical_cpu_fraction": (
+            WORK_RESERVED_LOGICAL_CPU_FRACTION
+            if control_mode == "work"
+            else None
+        ),
         "requires_ac_power_on_macos": True,
         "rejects_competing_build_processes": True,
         "rejects_thermal_pressure": True,
         "wall_latency_qualified": control_mode == "latency",
         "requires_retired_instructions": control_mode == "work",
     }
+
+
+def max_external_cpu_percent(
+    snapshot: dict[str, Any], control_mode: str
+) -> float | None:
+    validate_control_mode(control_mode)
+    if control_mode == "latency":
+        return MAX_EXTERNAL_CPU_PERCENT
+    logical_cpus = snapshot.get("logical_cpus")
+    if (
+        not isinstance(logical_cpus, int)
+        or isinstance(logical_cpus, bool)
+        or logical_cpus <= 0
+    ):
+        return None
+    external_fraction = 1.0 - WORK_RESERVED_LOGICAL_CPU_FRACTION
+    return round(logical_cpus * 100.0 * external_fraction, 1)
 
 
 class HostActivityMonitor:
@@ -525,6 +560,7 @@ def run_self_test() -> None:
     if profile_control_mode("Linux") != "latency":
         raise HostControlError("Linux profile mode self-test did not select latency")
     nominal = {
+        "logical_cpus": 10,
         "load_average": {"one_minute_per_logical_cpu": 0.1},
         "thermal": {"status": "nominal"},
         "power": {"source": "ac", "required": True},
@@ -564,6 +600,36 @@ def run_self_test() -> None:
     ):
         raise HostControlError(
             "work control self-test rejected measurable external CPU pressure"
+        )
+    work_cpu_pressured = dict(nominal)
+    work_cpu_pressured["external_cpu_pressure"] = {
+        "source": "ps",
+        "external_cpu_percent": 400.1,
+    }
+    if evaluate_snapshot(
+        work_cpu_pressured,
+        enforce_load=True,
+        control_mode="work",
+        require_work_counter=True,
+    ) != ["external-cpu-pressure"]:
+        raise HostControlError(
+            "work control self-test did not preserve measured CPU capacity"
+        )
+    work_policy = controlled_policy("work", logical_cpus=10)
+    if (
+        work_policy["max_external_cpu_percent"] != 400.0
+        or work_policy["external_cpu_limit_applied"] is not True
+        or work_policy["load_limit_applied"] is not False
+        or work_policy["work_reserved_logical_cpu_fraction"] != 0.60
+    ):
+        raise HostControlError(
+            "work control policy self-test did not expose its capacity reservation"
+        )
+    monitor = HostActivityMonitor(control_mode="work")
+    monitor.snapshots = [work_cpu_pressured]
+    if monitor.rejection_reasons() != ["external-cpu-pressure"]:
+        raise HostControlError(
+            "work activity monitor did not reject external CPU pressure"
         )
     missing_counter = dict(nominal)
     missing_counter["work_counter"] = {"source": "unavailable"}

--- a/verification/areas/performance/run_benchmarks.py
+++ b/verification/areas/performance/run_benchmarks.py
@@ -337,7 +337,10 @@ def run_cases(
             controlled_host_timeout_seconds, control_mode=control_mode
         )
     else:
-        snapshot = capture_host_snapshot(include_calibration=True)
+        snapshot = capture_host_snapshot(
+            include_calibration=True,
+            control_mode=control_mode,
+        )
         admission = {
             "status": "record-only",
             "mode": control_mode,


### PR DESCRIPTION
## What changed

- reserve 60% of logical CPU capacity for the measured work-mode process tree
- enforce the remaining 40% external-CPU limit during controlled admission
- record the same mode-specific limit in every host snapshot
- keep transient in-attempt CPU pressure advisory when retired-instruction samples are stable
- keep competing builds, thermal pressure, unavailable work counters, and unstable samples blocking

## Root cause

Work-mode admission previously disabled both load and external-CPU limits. A dependent merge gate therefore admitted 380% to 734% external CPU and produced three unstable formatter samples. The first repair rejected every transient CPU spike, but local qualification proved that this was too strict: two retries had instruction CVs of 0.000433 and 0.000389 and still failed only because background CPU briefly crossed 400%.

The corrected policy reserves capacity before sampling. During a work sample, the retired-instruction CV is the authority for stability. External pressure remains evidence and remains blocking when the work sample is unstable.

## Validation

- performance benchmark runner self-test: pass
- performance rules: 6/6 pass
- representative performance: 8/8 pass, ten benchmarks, 200.599s
- representative evidence SHA-256: `93ce3f332e6926e24857eef1f1284f1f03b4f41d58924c8dac9c8f76bf8fdb56`
- file-size guard: 3,118 files pass
- HIR maintainability guard: pass
- Python compile and focused Ruff: pass

The representative run used qlty=2 CPUs and Sifr=6 workers on the supported 10-thread Mac. It accepted stable work under ordinary desktop pressure without changing any performance budget or baseline.

## Dependency order

This narrow policy PR must merge first. The dependent LSP candidate can then rerun its merge gate and merge. The interop budget phase will rebase onto the combined main and run its final create-PR and merge qualification.
