### PR TITLE
feat: expose typed static program payloads

### DIFF
--- a/crates/sifr_codegen/src/static_program_codegen.rs
+++ b/crates/sifr_codegen/src/static_program_codegen.rs
@@ -1,4 +1,4 @@
-use sifr_ir::StaticSpecializationOutput;
+use sifr_ir::{StaticProgramValue, StaticSpecializationOutput};
 use sifr_type_system::source_class_rust_name;
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
@@ -30,6 +30,11 @@ pub fn emit_static_specialization_programs(
             "#[doc(hidden)]\npub(crate) const __SIFR_STATIC_PROGRAM_IDENTITY_{suffix}: [u8; 32] = {:?};",
             output.program_identity
         );
+        let value = static_value_expression(&output.value);
+        let _ = writeln!(
+            out,
+            "#[doc(hidden)]\npub(crate) static __SIFR_STATIC_PROGRAM_VALUE_{suffix}: ::sifr_runtime::interop::structural::StaticProgramValue = {value};"
+        );
         if structural_owners.contains(&output.owner) {
             let owner = source_class_rust_name(&output.owner);
             let identity = output
@@ -40,7 +45,7 @@ pub fn emit_static_specialization_programs(
                 .join(", ");
             let _ = writeln!(
                 out,
-                "#[doc(hidden)]\npub(crate) static __SIFR_STATIC_PROGRAM_{suffix}: ::std::sync::LazyLock<::sifr_runtime::interop::structural::StaticProgram<{owner}>> = ::std::sync::LazyLock::new(|| {{\n    let identity = ::sifr_runtime::interop::structural::StaticProgramIdentity::from_bytes([{identity}]);\n    let shape = <{owner} as ::sifr_runtime::interop::structural::StructuralType>::shape_identity();\n    let header = ::sifr_runtime::interop::structural::StaticProgramHeader::__from_compiler(::sifr_runtime::interop::structural::STATIC_PROGRAM_FORMAT_VERSION, {}, ::sifr_runtime::interop::structural::STRUCTURAL_BRIDGE_CONTRACT_VERSION, identity, shape, ::sifr_runtime::interop::__generated_glue::token());\n    ::sifr_runtime::interop::structural::StaticProgram::__from_compiler(header, __SIFR_STATIC_PROGRAM_BYTES_{suffix}, ::sifr_runtime::interop::__generated_glue::token())\n}});",
+                "#[doc(hidden)]\npub(crate) static __SIFR_STATIC_PROGRAM_{suffix}: ::std::sync::LazyLock<::sifr_runtime::interop::structural::StaticProgram<{owner}>> = ::std::sync::LazyLock::new(|| {{\n    let identity = ::sifr_runtime::interop::structural::StaticProgramIdentity::from_bytes([{identity}]);\n    let shape = <{owner} as ::sifr_runtime::interop::structural::StructuralType>::shape_identity();\n    let header = ::sifr_runtime::interop::structural::StaticProgramHeader::__from_compiler(::sifr_runtime::interop::structural::STATIC_PROGRAM_FORMAT_VERSION, {}, ::sifr_runtime::interop::structural::STRUCTURAL_BRIDGE_CONTRACT_VERSION, identity, shape, ::sifr_runtime::interop::__generated_glue::token());\n    ::sifr_runtime::interop::structural::StaticProgram::__from_compiler(header, __SIFR_STATIC_PROGRAM_BYTES_{suffix}, __SIFR_STATIC_PROGRAM_VALUE_{suffix}, ::sifr_runtime::interop::__generated_glue::token())\n}});",
                 output.structural_contract_version
             );
             let _ = writeln!(
@@ -50,6 +55,40 @@ pub fn emit_static_specialization_programs(
         }
     }
     out
+}
+
+fn static_value_expression(value: &StaticProgramValue) -> String {
+    let path = "::sifr_runtime::interop::structural::StaticProgramValue";
+    match value {
+        StaticProgramValue::None => format!("{path}::None"),
+        StaticProgramValue::Bool(value) => format!("{path}::Bool({value})"),
+        StaticProgramValue::Integer(value) => format!("{path}::Integer({value:?})"),
+        StaticProgramValue::FloatBits(value) => format!("{path}::FloatBits({value})"),
+        StaticProgramValue::String(value) => format!("{path}::String({value:?})"),
+        StaticProgramValue::Bytes(value) => format!("{path}::Bytes(&{value:?})"),
+        StaticProgramValue::Tuple(values) => {
+            format!("{path}::Tuple(&[{}])", static_values_expression(values))
+        }
+        StaticProgramValue::List(values) => {
+            format!("{path}::List(&[{}])", static_values_expression(values))
+        }
+        StaticProgramValue::Record(fields) => format!(
+            "{path}::Record(&[{}])",
+            fields
+                .iter()
+                .map(|(name, value)| format!("({name:?}, {})", static_value_expression(value)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+fn static_values_expression(values: &[StaticProgramValue]) -> String {
+    values
+        .iter()
+        .map(static_value_expression)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Returns only specialization owners that can receive all structural bridge implementations.
@@ -132,6 +171,10 @@ mod tests {
             package_module: "schema.package".to_string(),
             function: "derive".to_string(),
             canonical_value: "record:1:value=int:7".to_string(),
+            value: StaticProgramValue::Record(vec![(
+                "value".to_string(),
+                StaticProgramValue::Integer("7".to_string()),
+            )]),
             program_identity: [identity; 32],
             structural_contract_version: 1,
         }
@@ -146,6 +189,8 @@ mod tests {
         assert!(emitted.contains("static __SIFR_STATIC_PROGRAM_BYTES_RECORD_SCHEMA_PACKAGE_DERIVE"));
         assert!(emitted.contains("StaticProgram<Record>"));
         assert!(emitted.contains("StaticProgramIdentity::from_bytes([7, 7"));
+        assert!(emitted.contains("StaticProgramValue::Record"));
+        assert!(emitted.contains("StaticProgramValue::Integer(\"7\")"));
     }
 
     #[test]

--- a/crates/sifr_codegen/src/static_program_codegen.rs
+++ b/crates/sifr_codegen/src/static_program_codegen.rs
@@ -30,13 +30,13 @@ pub fn emit_static_specialization_programs(
             "#[doc(hidden)]\npub(crate) const __SIFR_STATIC_PROGRAM_IDENTITY_{suffix}: [u8; 32] = {:?};",
             output.program_identity
         );
-        let value = static_value_expression(&output.value);
-        let _ = writeln!(
-            out,
-            "#[doc(hidden)]\npub(crate) static __SIFR_STATIC_PROGRAM_VALUE_{suffix}: ::sifr_runtime::interop::structural::StaticProgramValue = {value};"
-        );
         if structural_owners.contains(&output.owner) {
             let owner = source_class_rust_name(&output.owner);
+            let value = static_value_expression(&output.value);
+            let _ = writeln!(
+                out,
+                "#[doc(hidden)]\npub(crate) static __SIFR_STATIC_PROGRAM_VALUE_{suffix}: ::sifr_runtime::interop::structural::StaticProgramValue = {value};"
+            );
             let identity = output
                 .program_identity
                 .iter()
@@ -198,6 +198,8 @@ mod tests {
         let emitted = emit_static_specialization_programs(&[output(7)], &BTreeSet::new());
         assert!(emitted.contains("__SIFR_STATIC_PROGRAM_BYTES_"));
         assert!(!emitted.contains("impl ::sifr_runtime::interop::structural::StaticProgramType"));
+        assert!(!emitted.contains("sifr_runtime::"));
+        assert!(!emitted.contains("__SIFR_STATIC_PROGRAM_VALUE_"));
     }
 
     #[test]

--- a/crates/sifr_driver/src/tests/package_project_build_check.rs
+++ b/crates/sifr_driver/src/tests/package_project_build_check.rs
@@ -499,6 +499,42 @@ fn generated_project_root(binary_path: &Path) -> PathBuf {
 
 #[test]
 #[ignore = "generated build integration coverage runs in full validation profiles"]
+fn test_build_const_specialization_without_structural_runtime() {
+    let dir = mktemp_dir("package_const_specialization_without_structural_runtime");
+    let app = production_package(&dir, "app", "sifr-const-app", "const_app");
+    let meta = production_package(&dir, "meta", "sifr-const-meta", "const_meta");
+    write_package_source(
+        &meta,
+        "__init__.sifr",
+        "class IssueArgs:\n    problem: str\n\nclass Issue:\n    package: str\n    reason_code: str\n    severity: str\n    arguments: IssueArgs\n    notes: list[str]\n\nclass Outcome:\n    status: str\n    value: str | None\n    issues: list[Issue]\n\n@const_eval\ndef describe(shape: dict[str, str]) -> Outcome:\n    return Outcome(\"produced\", shape[\"canonical_identity\"], [])\n",
+    );
+    write_package_source(
+        &app,
+        "main.sifr",
+        "from const_meta import describe\n\n@const_specialize(\"const_meta\", \"describe\")\nclass Counter:\n    count: int\n\ndef main() -> None:\n    value: Counter = Counter(7)\n    assert value.count == 7\n",
+    );
+    let graph = package_graph(
+        &dir,
+        &[&app, &meta],
+        &[package_edge(&app, "const_meta", &meta)],
+    );
+    let source_map = sifr_package::PackageSourceMap::build(&graph).expect("source map builds");
+    let entrypoint = package_entrypoint(&graph, &source_map, &app, app.root.join("src/main.sifr"));
+    let artifact = build_cached_package_project(&entrypoint)
+        .expect("non-structural const specialization should build");
+    let generated =
+        std::fs::read_to_string(generated_project_root(artifact.binary_path()).join("src/main.rs"))
+            .expect("generated source should be retained");
+    assert!(!generated.contains("sifr_runtime::interop::structural"));
+    let output = std::process::Command::new(artifact.binary_path())
+        .output()
+        .expect("non-structural specialization binary should run");
+    assert!(output.status.success());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_cached_package_project_links_direct_rust_interop_dependency() {
     let dir = mktemp_dir("package_direct_rust_interop");
     let app = production_package(&dir, "app", "sifr-demo-app", "demo_app");

--- a/crates/sifr_frontend/src/const_evaluator.rs
+++ b/crates/sifr_frontend/src/const_evaluator.rs
@@ -358,6 +358,20 @@ impl<'a> DeterministicConstEvaluator<'a> {
                     self.eval_expr(else_expr, environment, depth)
                 }
             }
+            HirExpr::ListLiteral { elements, ty } if matches!(ty.resolve_alias(), Type::Bytes) => {
+                let values = self.eval_elements(elements, environment, depth)?;
+                values
+                    .into_iter()
+                    .map(|value| match value {
+                        ConstValue::Integer(value) => value
+                            .to_string()
+                            .parse::<u8>()
+                            .map_err(|_| type_mismatch("byte literal element is out of range")),
+                        _ => Err(type_mismatch("byte literal element is not an integer")),
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(ConstValue::Bytes)
+            }
             HirExpr::ListLiteral { elements, .. } => self
                 .eval_elements(elements, environment, depth)
                 .map(ConstValue::List),
@@ -760,6 +774,15 @@ mod tests {
                 ConstValue::Integer(BigInt::from(2)),
             ])
         );
+    }
+
+    #[test]
+    fn preserves_bytes_as_the_closed_bytes_const_variant() {
+        let lowered = lower("@const_eval\ndef payload() -> bytes:\n    return b\"typed\"\n");
+        let value = DeterministicConstEvaluator::new(&lowered.module)
+            .evaluate_function("payload", Vec::new())
+            .expect("byte const evaluation succeeds");
+        assert_eq!(value, ConstValue::Bytes(b"typed".to_vec()));
     }
 
     #[test]

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -7,7 +7,7 @@ use ruff_text_size::TextRange;
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode};
 use sifr_lowering::{
     ExternalDefs, HirDiagnostic, HirModule, LoweringResult, LoweringWarningDiagnostic,
-    StaticSpecializationOutput,
+    StaticProgramValue, StaticSpecializationOutput,
 };
 use sifr_type_system::Type;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -117,6 +117,7 @@ pub(crate) fn run_specializations(
             Ok(validated) => {
                 if let Some(value) = &validated.value {
                     let canonical_value = crate::structural_shape::canonical_value(value);
+                    let static_value = static_program_value(value);
                     let structural_contract_version = sifr_structural_identity::ALGORITHM_VERSION;
                     let program_identity = sifr_structural_identity::static_program_identity(
                         structural_contract_version,
@@ -136,6 +137,7 @@ pub(crate) fn run_specializations(
                             package_module: request.package_module.clone(),
                             function: request.function.clone(),
                             canonical_value,
+                            value: static_value,
                             program_identity: *program_identity.as_bytes(),
                             structural_contract_version,
                         });
@@ -168,6 +170,29 @@ pub(crate) fn run_specializations(
         Ok(())
     } else {
         Err(errors)
+    }
+}
+
+fn static_program_value(value: &crate::ConstValue) -> StaticProgramValue {
+    match value {
+        crate::ConstValue::None => StaticProgramValue::None,
+        crate::ConstValue::Bool(value) => StaticProgramValue::Bool(*value),
+        crate::ConstValue::Integer(value) => StaticProgramValue::Integer(value.to_string()),
+        crate::ConstValue::FloatBits(value) => StaticProgramValue::FloatBits(*value),
+        crate::ConstValue::String(value) => StaticProgramValue::String(value.clone()),
+        crate::ConstValue::Bytes(value) => StaticProgramValue::Bytes(value.clone()),
+        crate::ConstValue::Tuple(values) => {
+            StaticProgramValue::Tuple(values.iter().map(static_program_value).collect())
+        }
+        crate::ConstValue::List(values) => {
+            StaticProgramValue::List(values.iter().map(static_program_value).collect())
+        }
+        crate::ConstValue::Record(values) => StaticProgramValue::Record(
+            values
+                .iter()
+                .map(|(name, value)| (name.clone(), static_program_value(value)))
+                .collect(),
+        ),
     }
 }
 

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -639,14 +639,14 @@ pub(crate) fn canonical_value(value: &ConstValue) -> String {
         ConstValue::Integer(value) => format!("int:{value}"),
         ConstValue::FloatBits(value) => format!("float:{value:016x}"),
         ConstValue::String(value) => format!("str:{}:{value}", value.len()),
-        ConstValue::Bytes(value) => canonical_bytes(value),
+        ConstValue::Bytes(value) => format!("bytes:{}:{}", value.len(), canonical_bytes(value)),
         ConstValue::Tuple(values) => canonical_values("tuple", values),
         ConstValue::List(values) => canonical_values("list", values),
         ConstValue::Record(values) => format!(
             "record[{}]",
             values
                 .iter()
-                .map(|(key, value)| format!("{key}={}", canonical_value(value)))
+                .map(|(key, value)| { format!("{}:{key}={}", key.len(), canonical_value(value)) })
                 .collect::<Vec<_>>()
                 .join(",")
         ),
@@ -788,5 +788,29 @@ class Port(int):
             .canonical_identity
             .contains("newtype:fixture.nominal.Port"));
         assert!(port_shape.canonical_identity.contains("fixture.kind"));
+    }
+
+    #[test]
+    fn canonical_values_bind_record_keys_and_bytes_without_collisions() {
+        let ambiguous_key = ConstValue::Record(BTreeMap::from([(
+            "a=str:1:x,b".to_string(),
+            ConstValue::None,
+        )]));
+        let two_fields = ConstValue::Record(BTreeMap::from([
+            ("a".to_string(), ConstValue::String("x".to_string())),
+            ("b".to_string(), ConstValue::None),
+        ]));
+        assert_ne!(
+            canonical_value(&ambiguous_key),
+            canonical_value(&two_fields)
+        );
+        assert_eq!(
+            canonical_value(&ConstValue::Bytes(vec![0, 255])),
+            "bytes:2:00ff"
+        );
+        assert_ne!(
+            canonical_value(&ConstValue::Bytes(Vec::new())),
+            canonical_value(&ConstValue::String(String::new()))
+        );
     }
 }

--- a/crates/sifr_ir/src/specialization_metadata.rs
+++ b/crates/sifr_ir/src/specialization_metadata.rs
@@ -37,6 +37,23 @@ pub struct ConstSpecializationRequest {
     pub range: TextRange,
 }
 
+/// Closed package-neutral value retained from successful const specialization.
+///
+/// Integers use canonical decimal text so later compilation stages do not need
+/// an arbitrary-precision integer representation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StaticProgramValue {
+    None,
+    Bool(bool),
+    Integer(String),
+    FloatBits(u64),
+    String(String),
+    Bytes(Vec<u8>),
+    Tuple(Vec<Self>),
+    List(Vec<Self>),
+    Record(Vec<(String, Self)>),
+}
+
 /// A package-owned, compile-time specialization result retained by the frontend.
 ///
 /// The value uses the compiler's deterministic closed-value encoding so later
@@ -47,6 +64,7 @@ pub struct StaticSpecializationOutput {
     pub package_module: String,
     pub function: String,
     pub canonical_value: String,
+    pub value: StaticProgramValue,
     /// Complete deterministic identity for cache keys and emitted envelopes.
     pub program_identity: [u8; 32],
     pub structural_contract_version: u32,

--- a/crates/sifr_lowering/src/lib.rs
+++ b/crates/sifr_lowering/src/lib.rs
@@ -33,5 +33,5 @@ pub use scope::{NarrowingSnapshot, Scope};
 pub use sifr_ir::{
     rust_opaque_close_method, DeclarationMetadataTargetKind, HirDiagnostic, LoweringOutcome,
     LoweringResult, LoweringWarningDiagnostic, RevealTypeDiagnostic, RustInteropDecoratorKind,
-    StaticSpecializationOutput, TypedDeclarationMetadata,
+    StaticProgramValue, StaticSpecializationOutput, TypedDeclarationMetadata,
 };

--- a/crates/sifr_runtime/src/interop/structural.rs
+++ b/crates/sifr_runtime/src/interop/structural.rs
@@ -16,7 +16,7 @@ pub use sifr_structural_identity::{
 };
 pub use static_program::{
     StaticProgram, StaticProgramEnvelopeError, StaticProgramHeader, StaticProgramType,
-    STATIC_PROGRAM_ENVELOPE_VERSION, STATIC_PROGRAM_FORMAT_VERSION,
+    StaticProgramValue, STATIC_PROGRAM_ENVELOPE_VERSION, STATIC_PROGRAM_FORMAT_VERSION,
     STRUCTURAL_BRIDGE_CONTRACT_VERSION,
 };
 

--- a/crates/sifr_runtime/src/interop/structural/static_program.rs
+++ b/crates/sifr_runtime/src/interop/structural/static_program.rs
@@ -8,6 +8,24 @@ pub const STATIC_PROGRAM_ENVELOPE_VERSION: u32 = 1;
 pub const STATIC_PROGRAM_FORMAT_VERSION: u32 = 1;
 pub const STRUCTURAL_BRIDGE_CONTRACT_VERSION: u32 = 1;
 
+/// Borrowed compiler-emitted value produced by package const specialization.
+///
+/// This closed view is allocation-free. Consumers can traverse the verified
+/// result without parsing its canonical byte representation.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StaticProgramValue {
+    None,
+    Bool(bool),
+    Integer(&'static str),
+    FloatBits(u64),
+    String(&'static str),
+    Bytes(&'static [u8]),
+    Tuple(&'static [Self]),
+    List(&'static [Self]),
+    Record(&'static [(&'static str, Self)]),
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct StaticProgramHeader {
     envelope_version: u32,
@@ -70,6 +88,7 @@ impl StaticProgramHeader {
 pub struct StaticProgram<T> {
     header: StaticProgramHeader,
     bytes: &'static [u8],
+    value: StaticProgramValue,
     _type: PhantomData<fn() -> T>,
 }
 
@@ -84,11 +103,13 @@ impl<T> StaticProgram<T> {
     pub const fn __from_compiler(
         header: StaticProgramHeader,
         bytes: &'static [u8],
+        value: StaticProgramValue,
         _token: GeneratedGlueToken,
     ) -> Self {
         Self {
             header,
             bytes,
+            value,
             _type: PhantomData,
         }
     }
@@ -101,6 +122,11 @@ impl<T> StaticProgram<T> {
     #[must_use]
     pub const fn bytes(&self) -> &'static [u8] {
         self.bytes
+    }
+
+    #[must_use]
+    pub const fn value(&self) -> &StaticProgramValue {
+        &self.value
     }
 
     pub fn verify_envelope(
@@ -176,9 +202,23 @@ mod tests {
             shape,
             __generated_glue::token(),
         );
-        let program =
-            StaticProgram::<String>::__from_compiler(header, b"program", __generated_glue::token());
+        let program = StaticProgram::<String>::__from_compiler(
+            header,
+            b"program",
+            StaticProgramValue::Record(&[(
+                "nodes",
+                StaticProgramValue::List(&[StaticProgramValue::Integer("7")]),
+            )]),
+            __generated_glue::token(),
+        );
         assert_eq!(program.verify_envelope(3, 1, 1, identity, shape), Ok(()));
+        assert_eq!(
+            program.value(),
+            &StaticProgramValue::Record(&[(
+                "nodes",
+                StaticProgramValue::List(&[StaticProgramValue::Integer("7")]),
+            )])
+        );
         assert_eq!(
             program.verify_envelope(4, 1, 1, identity, shape),
             Err(StaticProgramEnvelopeError::FormatVersion)

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -64,12 +64,15 @@ produce retained static data.
 Each retained result also has one static-program identity. The hash includes the declaring module,
 concrete owner, package module, specializer function, canonical structural shape, canonical result,
 and structural-contract identity. Check and editor analysis retain this identity. Build and run emit
-the canonical bytes. The generated-project cache key includes the same identity.
+the canonical bytes. For a structural static program, they also emit an allocation-free borrowed
+view of the same closed value. The generated-project cache key includes the same identity.
 
 For a structural Rust call with the compiler-owned `sifr.meta.StaticProgram` bound, the compiler
 also emits a sealed typed `StaticProgram[T]` envelope and implements `StaticProgramType` for the
 concrete specialized type. This bound requires a produced specialization result. It has no empty
 program, runtime compiler, compatibility path, or fallback to the ordinary `Structural` bound.
+`StaticProgramValue` is non-exhaustive for Rust consumers. Its current compiler-owned variant set
+is closed for this contract. A new variant requires a contract and cache-identity review.
 
 ## Integer boundary verification
 

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -572,6 +572,7 @@ pub trait StaticProgramType: StructuralType + Sized + 'static {
     fn static_program() -> &'static StaticProgram<Self>;
 }
 
+#[non_exhaustive]
 pub enum StaticProgramValue {
     None,
     Bool(bool),
@@ -584,6 +585,10 @@ pub enum StaticProgramValue {
     Record(&'static [(&'static str, StaticProgramValue)]),
 }
 ```
+
+`StaticProgramValue` is non-exhaustive for downstream Rust consumers. Its
+compiler-owned variant set is closed for this contract revision. A new variant
+requires a structural contract and cache-identity review.
 
 `structural_construct` is the sole public construction entry. It compares
 `source.shape_identity()` with `<T as StructuralType>::shape_identity()` before

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -452,8 +452,11 @@ empty program, runtime compilation path, or fallback to `Structural`.
 The frontend hashes the declaring module, concrete owner, package module,
 specializer function, canonical structural shape, canonical program value, and
 structural-contract identity. Check and editor analysis retain this identity.
-Build and run also emit the canonical bytes and a sealed typed `StaticProgram<T>`
-envelope. The identity is part of the generated-project cache key. An unrelated
+Build and run also emit the canonical bytes, the closed const result as immutable
+typed Rust literals, and a sealed `StaticProgram<T>` envelope. The program exposes
+the result as a borrowed `StaticProgramValue`. A consumer does not parse the
+canonical bytes or allocate a second value tree. The identity is part of the
+generated-project cache key. An unrelated
 declaration does not change it, but a relevant shape, metadata, callback, package,
 function, or program change does.
 
@@ -567,6 +570,18 @@ pub trait StructuralProject: StructuralType {
 
 pub trait StaticProgramType: StructuralType + Sized + 'static {
     fn static_program() -> &'static StaticProgram<Self>;
+}
+
+pub enum StaticProgramValue {
+    None,
+    Bool(bool),
+    Integer(&'static str),
+    FloatBits(u64),
+    String(&'static str),
+    Bytes(&'static [u8]),
+    Tuple(&'static [StaticProgramValue]),
+    List(&'static [StaticProgramValue]),
+    Record(&'static [(&'static str, StaticProgramValue)]),
 }
 ```
 

--- a/verification/areas/core_language/fixtures/const_specialization_general/sifr.toml
+++ b/verification/areas/core_language/fixtures/const_specialization_general/sifr.toml
@@ -2,6 +2,7 @@
 name = "const-specialization-general"
 version = "0.0.0"
 edition = "2026"
+sifr-version = ">=0.3,<0.4"
 
 [source]
 roots = ["."]

--- a/verification/areas/rust_interop/fixtures/static_program_arena_bridge/README.md
+++ b/verification/areas/rust_interop/fixtures/static_program_arena_bridge/README.md
@@ -2,8 +2,9 @@
 
 This fixture proves compiler-emitted static program data and a checked structural arena.
 
-The positive case uses one generic, monomorphized Rust call. The call reads the sealed program,
-consumes a validated document, constructs a typed Sifr record, and projects the output.
+The positive case uses one generic, monomorphized Rust call. The call reads the sealed program
+bytes and the compiler-emitted typed value. It consumes a validated document, constructs a typed
+Sifr record, and projects the output.
 The arena runtime test separately proves that a 30-digit exact integer moves into `SifrInt`
 without narrowing.
 

--- a/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/README.md
+++ b/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/README.md
@@ -1,5 +1,6 @@
 # Static program runtime example
 
 This package uses the unversioned Rust manifest contract. The Sifr compiler runs the package
-specializer and emits immutable static bytes for `StaticRecord`. The Rust executor can access the
-program only through the compiler-generated `StaticProgramType` implementation.
+specializer and emits immutable static bytes and a typed value for `StaticRecord`. The Rust
+executor can access the program only through the compiler-generated `StaticProgramType`
+implementation.

--- a/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/bridges/executor.rs
+++ b/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/bridges/executor.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use sifr_runtime::interop::structural::{
     structural_construct, ArenaNode, NodeId, StaticProgramType, StructuralConstruct,
     StructuralContractError, StructuralEdge, StructuralEdgeKind, StructuralEnter, StructuralKind,
-    StructuralNodeEdge, StructuralProject, StructuralScalar, StructuralScalarRef,
+    StructuralNodeEdge, StructuralProject, StructuralScalar, StructuralScalarRef, StaticProgramValue,
     StructuralVisitor, VisitControl, STATIC_PROGRAM_FORMAT_VERSION,
     STRUCTURAL_BRIDGE_CONTRACT_VERSION,
 };
@@ -162,6 +162,7 @@ where
         header.identity(),
         T::shape_identity(),
     )?;
+    verify_typed_program_value(program.value())?;
     let _input = project(input)?;
     if program.bytes().is_empty() {
         return Err(StaticProgramError::new("static program payload is empty"));
@@ -176,6 +177,44 @@ where
     let observed = project(&output)?;
     LAST_OBSERVATION.with_borrow_mut(|slot| *slot = Some(observed.summary()));
     Ok(output)
+}
+
+fn verify_typed_program_value(value: &StaticProgramValue) -> Result<(), StaticProgramError> {
+    let StaticProgramValue::Record(fields) = value else {
+        return Err(StaticProgramError::new("static program value is not a record"));
+    };
+    let valid = matches!(program_field(fields, "absent"), Some(StaticProgramValue::None))
+        && matches!(program_field(fields, "active"), Some(StaticProgramValue::Bool(true)))
+        && matches!(program_field(fields, "count"), Some(StaticProgramValue::Integer("7")))
+        && matches!(
+            program_field(fields, "ratio"),
+            Some(StaticProgramValue::FloatBits(bits)) if *bits == 1.5_f64.to_bits()
+        )
+        && matches!(
+            program_field(fields, "name"),
+            Some(StaticProgramValue::String(name)) if name.contains("StaticRecord")
+        )
+        && matches!(program_field(fields, "raw"), Some(StaticProgramValue::Bytes(b"typed")))
+        && matches!(program_field(fields, "pair"), Some(StaticProgramValue::Tuple(values)) if matches!(values, [StaticProgramValue::String("node"), StaticProgramValue::Integer("2")]))
+        && matches!(program_field(fields, "labels"), Some(StaticProgramValue::List(values)) if matches!(values, [StaticProgramValue::String("model"), StaticProgramValue::String("fields")]))
+        && matches!(program_field(fields, "settings"), Some(StaticProgramValue::Record(values)) if matches!(values, [("mode", StaticProgramValue::String("checked"))]));
+    if valid {
+        Ok(())
+    } else {
+        Err(StaticProgramError::new(
+            "static program typed value does not preserve every const variant",
+        ))
+    }
+}
+
+fn program_field<'value>(
+    fields: &'value [(&'static str, StaticProgramValue)],
+    name: &str,
+) -> Option<&'value StaticProgramValue> {
+    fields
+        .iter()
+        .find(|(field, _)| *field == name)
+        .map(|(_, value)| value)
 }
 
 pub fn execute_corrupt<T>(

--- a/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/schema_program.sifr
+++ b/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/schema_program.sifr
@@ -10,9 +10,21 @@ class ProgramIssue:
     notes: list[str]
 
 
+class ProgramPayload:
+    absent: str | None
+    active: bool
+    count: int
+    ratio: float
+    name: str
+    raw: bytes
+    pair: tuple[str, int]
+    labels: list[str]
+    settings: dict[str, str]
+
+
 class ProgramOutcome:
     status: str
-    value: str | None
+    value: ProgramPayload | None
     issues: list[ProgramIssue]
 
 
@@ -28,4 +40,15 @@ def derive(shape: dict[str, str]) -> ProgramOutcome:
             [],
         )
         return ProgramOutcome("failed", None, [issue])
-    return ProgramOutcome("produced", identity, [])
+    value: ProgramPayload = ProgramPayload(
+        None,
+        True,
+        7,
+        1.5,
+        identity,
+        b"typed",
+        ("node", 2),
+        ["model", "fields"],
+        {"mode": "checked"},
+    )
+    return ProgramOutcome("produced", value, [])


### PR DESCRIPTION
## Outcome

Expose the compiler-verified const-specialization result as an allocation-free borrowed `StaticProgramValue` beside the existing sealed bytes and header.

This is general Sifr substrate for package-owned static executors. It adds no package-specific compiler logic, runtime parser, cache, fallback, compatibility path, or legacy mode.

## Implementation

- retain every closed const value variant in compiler IR
- emit deterministic immutable Rust literals only for structural static-program owners
- add the sealed borrowed `StaticProgram::value()` view
- preserve exact integer text and byte identity
- make canonical record keys and bytes unambiguous for program identity
- repair const byte-literal preservation
- prove structural and non-structural specialization builds

## Review

Claude Opus exact-SHA review round 1 found the non-structural feature-demand blocker. Exact remediation SHA `160e6b789349b20ae02df59ede2b4eb78929e561` received `SATISFIED` in round 2 with no blocking findings.

## Validation before canonical gates

- generated structural positive and corrupt-envelope cases pass
- generated non-structural `@const_specialize` package builds and runs without structural runtime references
- frontend const evaluator, structural shape, and specialization tests pass
- codegen and runtime static-program tests pass
- file-size, HIR, taxonomy, Rust-interop fixture/compatibility/stable-claim/stale-draft/tier checks pass
- formatting passes
