### PR TITLE
fix: escape structural keyword fields

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -43,6 +43,24 @@ fn project_structural_demand_enables_implicit_classes_across_modules() {
 }
 
 #[test]
+fn structural_impls_escape_rust_keyword_field_identifiers() {
+    let mut keyword = payload_class();
+    keyword.name = "KeywordPayload".to_string();
+    keyword.fields = vec![("type".to_string(), Type::Int)];
+    let models = module(Vec::new(), vec![keyword]);
+    let api = module(vec![structural_function()], Vec::new());
+
+    let generated = generate_rust_multi(&[("models", &models), ("api", &api)]);
+    let models_rust = generated.get("models").expect("models module is generated");
+
+    assert!(models_rust.contains("let r#type ="));
+    assert!(models_rust.contains("Ok(Self { r#type })"));
+    assert!(models_rust.contains("&self.r#type"));
+    assert!(models_rust.contains("RecordField"));
+    assert!(models_rust.contains("\"type\""));
+}
+
+#[test]
 fn static_program_owners_use_structural_implementation_eligibility() {
     let supported = payload_class();
     let mut unsupported = payload_class();

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -205,15 +205,16 @@ fn structural_construct_impl(
         .iter()
         .enumerate()
         .map(|(index, (name, ty))| {
+            let rust_name = crate::Renderer::render_identifier(name);
             if matches!(ty.resolve_alias(), Type::Bytes) {
                 return format!(
-                    "let {name} = {STRUCTURAL}::construct_bytes_at(source, child_nodes[{index}], token)?;"
+                    "let {rust_name} = {STRUCTURAL}::construct_bytes_at(source, child_nodes[{index}], token)?;"
                 );
             }
             let rust_type = emitter.class_struct_field_rust_type(class, name, ty);
             let rust_type = crate::Renderer::render_type_string(&rust_type);
             format!(
-                "let {name} = <{rust_type} as {STRUCTURAL}::StructuralConstruct>::structural_construct_at(source, child_nodes[{index}], token)?;"
+                "let {rust_name} = <{rust_type} as {STRUCTURAL}::StructuralConstruct>::structural_construct_at(source, child_nodes[{index}], token)?;"
             )
         })
         .collect::<Vec<_>>()
@@ -221,7 +222,7 @@ fn structural_construct_impl(
     let mut initializers = class
         .fields
         .iter()
-        .map(|(name, _)| name.clone())
+        .map(|(name, _)| crate::Renderer::render_identifier(name))
         .collect::<Vec<_>>();
     if RustEmitter::class_needs_phantom_marker(class) {
         initializers.push("__sifr_type_marker: std::marker::PhantomData".to_string());
@@ -279,13 +280,14 @@ fn structural_project_impl(
         .fields
         .iter()
         .map(|(name, ty)| {
+            let rust_name = crate::Renderer::render_identifier(name);
             if matches!(ty.resolve_alias(), Type::Bytes) {
                 return format!(
-                    "visitor.edge({STRUCTURAL}::StructuralEdge::new({STRUCTURAL}::StructuralEdgeKind::RecordField(\"{name}\")))?;\n{STRUCTURAL}::project_bytes(&self.{name}, visitor)?;"
+                    "visitor.edge({STRUCTURAL}::StructuralEdge::new({STRUCTURAL}::StructuralEdgeKind::RecordField(\"{name}\")))?;\n{STRUCTURAL}::project_bytes(&self.{rust_name}, visitor)?;"
                 );
             }
             format!(
-                "visitor.edge({STRUCTURAL}::StructuralEdge::new({STRUCTURAL}::StructuralEdgeKind::RecordField(\"{name}\")))?;\n{STRUCTURAL}::StructuralProject::structural_project(&self.{name}, visitor)?;"
+                "visitor.edge({STRUCTURAL}::StructuralEdge::new({STRUCTURAL}::StructuralEdgeKind::RecordField(\"{name}\")))?;\n{STRUCTURAL}::StructuralProject::structural_project(&self.{rust_name}, visitor)?;"
             )
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
## Summary
- render generated Rust field locals and self access through the canonical identifier renderer
- keep structural wire names unchanged
- cover a structural record field named `type`

## Validation
- Claude Opus exact-SHA review: SATISFIED (`6c7cbdbdeff40dc6a9330f4e13c70e0f36149380`)
- focused structural demand tests: pass
- `cargo test -p sifr_codegen`: 984 passed
- `cargo clippy -p sifr_codegen -- -D warnings`: pass
- `cargo fmt --check`: pass
- warm canonical create-PR gate: exit 0; Python 19/19, Rust 10/10, E2E 140/140

## Follow-up
- reserved roots and synthesized-local collisions are tracked separately in #3151.