### PR TITLE
fix: preserve package error types across exports

### DIFF
--- a/crates/sifr_driver/src/stdlib/bootstrap.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap.rs
@@ -132,6 +132,7 @@ fn compile_stdlib_sources_with_sysroot(
         let mut fn_exports = HashMap::new();
         let mut compiler_intrinsic_exports = HashMap::new();
         let mut class_exports = HashMap::new();
+        let mut error_exports = HashSet::new();
         let mut class_instance_method_exports = HashMap::new();
         let mut class_type_param_exports = HashMap::new();
         let mut default_exports = HashMap::new();
@@ -188,6 +189,7 @@ fn compile_stdlib_sources_with_sysroot(
                         functions: &mut fn_exports,
                         compiler_intrinsics: &mut compiler_intrinsic_exports,
                         classes: &mut class_exports,
+                        error_types: &mut error_exports,
                         class_type_params: &mut class_type_param_exports,
                         defaults: &mut default_exports,
                         varargs: &mut vararg_exports,
@@ -208,6 +210,7 @@ fn compile_stdlib_sources_with_sysroot(
                         functions: &mut fn_exports,
                         compiler_intrinsics: &mut compiler_intrinsic_exports,
                         classes: &mut class_exports,
+                        error_types: &mut error_exports,
                         class_type_params: &mut class_type_param_exports,
                         defaults: &mut default_exports,
                         varargs: &mut vararg_exports,
@@ -297,7 +300,7 @@ fn compile_stdlib_sources_with_sysroot(
                     class_type_param_exports.insert(class.name.clone(), class.type_params.clone());
                 }
                 if class.is_error_type {
-                    stdlib_defs.error_types.insert(class.name.clone());
+                    error_exports.insert(class.name.clone());
                 }
             }
         }
@@ -468,6 +471,13 @@ fn compile_stdlib_sources_with_sysroot(
         stdlib_defs
             .classes
             .insert(module_name.to_string(), class_exports);
+        if error_exports.is_empty() {
+            stdlib_defs.error_types.remove(module_name);
+        } else {
+            stdlib_defs
+                .error_types
+                .insert(module_name.to_string(), error_exports);
+        }
         stdlib_defs
             .class_instance_methods
             .insert(module_name.to_string(), class_instance_method_exports);

--- a/crates/sifr_driver/src/stdlib/re_exports.rs
+++ b/crates/sifr_driver/src/stdlib/re_exports.rs
@@ -6,6 +6,7 @@ pub(super) struct ReExportMaps<'a> {
     pub(super) functions: &'a mut HashMap<String, FunctionType>,
     pub(super) compiler_intrinsics: &'a mut HashMap<String, CompilerIntrinsicId>,
     pub(super) classes: &'a mut HashMap<String, Type>,
+    pub(super) error_types: &'a mut HashSet<String>,
     pub(super) class_type_params: &'a mut HashMap<String, Vec<String>>,
     pub(super) defaults: &'a mut HashMap<String, Vec<(usize, HirExpr)>>,
     pub(super) varargs: &'a mut HashMap<String, usize>,
@@ -50,6 +51,9 @@ fn copy_named_exports(
             .get(import_module)
             .and_then(|module_classes| module_classes.get(name))
         {
+            if stdlib_defs.is_error_type(import_module, name) {
+                exports.error_types.insert(name.clone());
+            }
             if !exports.classes.contains_key(name) {
                 exports.classes.insert(name.clone(), class_ty.clone());
                 if let Some(type_params) = stdlib_defs
@@ -163,10 +167,26 @@ mod tests {
                     return_type: Box::new(Type::None),
                 },
             );
+        defs.insert_error_type("sifr.origin", "Failure");
+        defs.classes
+            .entry("sifr.origin".to_string())
+            .or_default()
+            .insert(
+                "Failure".to_string(),
+                Type::Class {
+                    identity: None,
+                    type_args: Vec::new(),
+                    name: "Failure".to_string(),
+                    fields: Vec::new(),
+                    methods: Vec::new(),
+                    parent_class: Some("Error".to_string()),
+                },
+            );
 
         let mut functions = HashMap::new();
         let mut compiler_intrinsics = HashMap::new();
         let mut classes = HashMap::new();
+        let mut error_types = HashSet::new();
         let mut class_type_params = HashMap::new();
         let mut defaults = HashMap::new();
         let mut varargs = HashMap::new();
@@ -177,6 +197,7 @@ mod tests {
                 functions: &mut functions,
                 compiler_intrinsics: &mut compiler_intrinsics,
                 classes: &mut classes,
+                error_types: &mut error_types,
                 class_type_params: &mut class_type_params,
                 defaults: &mut defaults,
                 varargs: &mut varargs,
@@ -185,12 +206,13 @@ mod tests {
             },
             &defs,
             "sifr.origin",
-            &["verify".to_string()],
+            &["verify".to_string(), "Failure".to_string()],
         );
 
         assert_eq!(
             compiler_intrinsics.get("verify"),
             Some(&CompilerIntrinsicId::TestAssertTrue)
         );
+        assert!(error_types.contains("Failure"));
     }
 }

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod discovery_and_workspace;
 mod package_project_build_check;
 mod panic_boundary;
 mod project_build_check;
+mod project_error_exports;
 mod project_generic_identity;
 mod project_graph;
 mod project_python_class_metadata;

--- a/crates/sifr_driver/src/tests/project_error_exports.rs
+++ b/crates/sifr_driver/src/tests/project_error_exports.rs
@@ -1,0 +1,75 @@
+use super::project_build_check::mktemp_dir;
+use crate::{build_project, check_project};
+use sifr_diagnostics::DiagnosticCode;
+
+fn write_aliased_error_project(dir: &std::path::Path) {
+    std::fs::write(
+        dir.join("errors.sifr"),
+        "class PackageError(Error):\n    message: str\n",
+    )
+    .expect("error module should be written");
+    std::fs::write(
+        dir.join("api.sifr"),
+        "from errors import PackageError as ApiError\n",
+    )
+    .expect("facade module should be written");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from api import ApiError as PublicError\n\ndef fail() -> Result[int, PublicError]:\n    raise PublicError(\"failed\")\n\ndef main() -> Result[None, PublicError]:\n    try:\n        value: int = fail()\n        assert value == 1\n    except PublicError as error:\n        assert error.message == \"failed\"\n        return None\n    return None\n",
+    )
+    .expect("main module should be written");
+}
+
+#[test]
+fn test_check_project_preserves_aliased_error_status_through_facade() {
+    let dir = mktemp_dir("aliased_error_facade_check");
+    write_aliased_error_project(&dir);
+
+    let errors = check_project(&dir.join("main.sifr"));
+
+    assert!(errors.is_empty(), "aliased error should check: {errors:?}");
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
+fn test_build_project_preserves_aliased_error_status_through_facade() {
+    let dir = mktemp_dir("aliased_error_facade_native");
+    write_aliased_error_project(&dir);
+
+    let binary = build_project(&dir.join("main.sifr"), &dir.join("build_out"))
+        .expect("aliased error project should build natively");
+    let status = std::process::Command::new(binary)
+        .status()
+        .expect("aliased error binary should run");
+
+    assert!(status.success());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn test_check_project_does_not_leak_error_status_between_modules() {
+    let dir = mktemp_dir("module_scoped_error_status");
+    std::fs::write(
+        dir.join("errors.sifr"),
+        "class Record(Error):\n    message: str\n",
+    )
+    .expect("error module should be written");
+    std::fs::write(dir.join("data.sifr"), "class Record:\n    value: int\n")
+        .expect("data module should be written");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from errors import Record as PackageError\nfrom data import Record\n\ndef invalid() -> Result[int, Record]:\n    return 1\n\ndef main() -> None:\n    error: PackageError = PackageError(\"failed\")\n    assert error.message == \"failed\"\n",
+    )
+    .expect("main module should be written");
+
+    let errors = check_project(&dir.join("main.sifr"));
+
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.code == DiagnosticCode::RESULT_INVALID_ERROR_TYPE.code()),
+        "same-name non-error class must remain invalid: {errors:?}"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -183,6 +183,7 @@ pub fn collect_module_exports(
     let mut vararg_exports = HashMap::new();
     let mut python_shape_exports = HashMap::new();
     let mut workload_exports = HashMap::new();
+    let mut error_exports = std::collections::HashSet::new();
     let mut rust_callback_exports = RustCallbackExports::default();
     let (mut generic_exports, mut type_param_bound_exports, local_classes) =
         declared_generic_metadata(module_name, module);
@@ -222,6 +223,9 @@ pub fn collect_module_exports(
 
     for class in &module.classes {
         if !class.name.starts_with('_') {
+            if class.is_error_type {
+                error_exports.insert(class.name.clone());
+            }
             if class
                 .rust_interop
                 .iter()
@@ -375,6 +379,9 @@ pub fn collect_module_exports(
             }
             if let Some(module_classes) = external_defs.classes.get(&import.module) {
                 if let Some(class_type) = module_classes.get(name) {
+                    if external_defs.is_error_type(&import.module, name) {
+                        error_exports.insert(local_name.clone());
+                    }
                     if external_defs
                         .rust_opaque_classes
                         .get(&import.module)
@@ -433,6 +440,13 @@ pub fn collect_module_exports(
     external_defs
         .classes
         .insert(module_name.to_string(), class_exports);
+    if error_exports.is_empty() {
+        external_defs.error_types.remove(module_name);
+    } else {
+        external_defs
+            .error_types
+            .insert(module_name.to_string(), error_exports);
+    }
     if !rust_opaque_exports.is_empty() {
         external_defs
             .rust_opaque_classes

--- a/crates/sifr_frontend/src/query_diagnostics_behavior_tests.rs
+++ b/crates/sifr_frontend/src/query_diagnostics_behavior_tests.rs
@@ -32,6 +32,34 @@ fn frontend_export_policy_hides_math_bridge_helpers() {
 }
 
 #[test]
+fn project_exports_preserve_imported_error_class_status() {
+    let dir = temp_project_dir("imported_error_class_status");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from api import ApiError\n\ndef fail() -> Result[int, ApiError]:\n    raise ApiError(\"failed\")\n\ndef main() -> Result[None, ApiError]:\n    try:\n        value: int = fail()\n        assert value == 1\n    except ApiError as error:\n        raise error\n    return None\n",
+    )
+    .expect("main should be written");
+    std::fs::write(
+        dir.join("errors.sifr"),
+        "class PackageError(Error):\n    message: str\n",
+    )
+    .expect("error module should be written");
+    std::fs::write(
+        dir.join("api.sifr"),
+        "from errors import PackageError as ApiError\n",
+    )
+    .expect("facade module should be written");
+    let mut context = load_temp_project(&dir);
+
+    let diagnostics = context.diagnostics_for_project().into_value().diagnostics;
+
+    assert!(
+        diagnostics.is_empty(),
+        "unexpected diagnostics: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn public_constant_value_update_invalidates_reverse_dependents() {
     let dir = temp_project_dir("constant_export_signature_invalidation");
     std::fs::write(

--- a/crates/sifr_lowering/src/lower/external_defs.rs
+++ b/crates/sifr_lowering/src/lower/external_defs.rs
@@ -62,8 +62,8 @@ pub struct ExternalDefs {
     /// Map of `module_name` -> (`constant_name` -> compile-time integer value)
     pub constant_integer_values:
         std::collections::HashMap<String, std::collections::HashMap<String, num_bigint::BigInt>>,
-    /// Set of class names that are error types (class Foo(Error)) across all modules
-    pub error_types: std::collections::HashSet<String>,
+    /// Map of `module_name` -> error class names declared or re-exported by that module.
+    pub error_types: std::collections::HashMap<String, std::collections::HashSet<String>>,
     /// Map of `module_name` -> (`owner_name` -> (`type_var_name` -> bounds))
     pub type_param_bounds: std::collections::HashMap<
         String,
@@ -92,6 +92,20 @@ pub struct ExternalDefs {
 }
 
 impl ExternalDefs {
+    pub fn insert_error_type(&mut self, module_name: &str, class_name: &str) {
+        self.error_types
+            .entry(module_name.to_string())
+            .or_default()
+            .insert(class_name.to_string());
+    }
+
+    #[must_use]
+    pub fn is_error_type(&self, module_name: &str, class_name: &str) -> bool {
+        self.error_types
+            .get(module_name)
+            .is_some_and(|names| names.contains(class_name))
+    }
+
     #[must_use]
     pub fn take_module_specialization_metadata(
         &mut self,

--- a/crates/sifr_lowering/src/lower/imports.rs
+++ b/crates/sifr_lowering/src/lower/imports.rs
@@ -290,7 +290,7 @@ pub(in crate::lower) fn resolve_imports_early(
                                 );
                             }
                             // Register as error type if flagged
-                            if externals.error_types.contains(name) {
+                            if externals.is_error_type(&module_key, name) {
                                 ctx.error_types.insert(local.clone());
                             }
                             if let Some(module_workloads) =

--- a/crates/sifr_lowering/src/lower/mod_impl.rs
+++ b/crates/sifr_lowering/src/lower/mod_impl.rs
@@ -520,7 +520,7 @@ pub(in crate::lower) fn lower_module_impl(
                                         );
                                     }
                                     // Register as error type if flagged in external defs
-                                    if externals.error_types.contains(name) {
+                                    if externals.is_error_type(&stdlib_module_key, name) {
                                         ctx.error_types.insert(local.clone());
                                     }
                                     if let Some(ft) = super::imported_class_identity::imported_constructor_function_type(class_ty) {
@@ -689,7 +689,7 @@ pub(in crate::lower) fn lower_module_impl(
                                     &local,
                                 );
                             }
-                            if externals.error_types.contains(name) {
+                            if externals.is_error_type(&module_name, name) {
                                 ctx.error_types.insert(local.clone());
                             }
                             imports::register_imported_class_instance_methods(

--- a/crates/sifr_lowering/src/lower/private_stdlib_imports.rs
+++ b/crates/sifr_lowering/src/lower/private_stdlib_imports.rs
@@ -131,7 +131,7 @@ fn resolve_class(
             local,
         );
     }
-    if externals.error_types.contains(name) {
+    if externals.is_error_type(module_name, name) {
         ctx.error_types.insert(local.to_string());
     }
     register_constructor(ctx, externals, module_name, name, local, class_ty);

--- a/crates/sifr_lowering/src/lower/python_async_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_async_tests.rs
@@ -76,7 +76,7 @@ fn python_externals() -> ExternalDefs {
     externals
         .function_workloads
         .insert("sifr.python".to_string(), workloads);
-    externals.error_types.insert("PythonError".to_string());
+    externals.insert_error_type("sifr.python", "PythonError");
     externals
 }
 

--- a/crates/sifr_lowering/src/lower/python_interop_callback_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_interop_callback_tests.rs
@@ -129,7 +129,7 @@ def compute(
         .entry("sifr.python".to_string())
         .or_default()
         .insert("PythonError".to_string(), canonical);
-    externals.error_types.insert("PythonError".to_string());
+    externals.insert_error_type("sifr.python", "PythonError");
     let parsed = parse_module(source).expect("source should parse");
     let lowered = crate::lower_module_with_externals(parsed.suite(), &externals)
         .expect("nominally distinct payloads should lower");

--- a/crates/sifr_lowering/src/lower/python_trust_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_trust_tests.rs
@@ -38,7 +38,7 @@ fn python_externals() -> ExternalDefs {
         .functions
         .insert("sifr.python".to_string(), functions);
     externals.classes.insert("sifr.python".to_string(), classes);
-    externals.error_types.insert("PythonError".to_string());
+    externals.insert_error_type("sifr.python", "PythonError");
     externals
 }
 


### PR DESCRIPTION
## Summary
- scope imported Error-class metadata by module to prevent same-name collisions
- preserve Error status through aliased and two-hop package re-exports
- preserve the same metadata through stdlib facade re-exports
- add positive check/native coverage and a same-name non-error rejection control

## Review
- exact candidate: \`3d00cb2fd71d4fc5d93b467ef49ef789bf9c3350\`
- Claude Opus exact-SHA review: SATISFIED, no blockers

## Validation
- focused native two-hop alias build/run: PASS
- driver lib: 459 passed, 0 failed, 74 ignored
- frontend: 66 passed
- lowering: 976 passed, 0 failed, 1 ignored
- affected library Clippy with \`-D warnings\`: PASS
- formatter, maintainability, and 900-line guardrails: PASS
- canonical create-PR warm gate: functional PASS; E2E 140/140, Python 19/19, Rust 10/10, generated quality 5/5, hardening 0 failures
- create-PR receipt SHA-256: \`e58f8ef4a129d8b419535a1397a05160b486988c85ea498784c6f81514f6a79a\`

The required cold-cache run also passed every functional case, but the known generated-code cold-artifact issue #3134 made the generated-quality step exceed 120 seconds. Its preserved receipt digest is \`7e3e43028447de5fa4cf4ed842b7530e81a066dbd604da6bcc05bf536e1b497c\`. The unchanged warm governed rerun passed the same step in 8.7 seconds without changing budgets.