### PR TITLE
fix: preserve composite union identity across projects

### DIFF
--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -1,4 +1,6 @@
-use super::{CodegenResult, HirModule, Renderer, RustEmitter, RustFile, RustItem, StdlibCode};
+use super::{
+    CodegenResult, HashSet, HirModule, Renderer, RustEmitter, RustFile, RustItem, StdlibCode,
+};
 use crate::ir_imports::collect_import_needs_from_items;
 use crate::ir_optimize::{remove_trivial_clones_in_items, remove_unneeded_mutability_in_items};
 use crate::ir_validate::validate_items;
@@ -10,10 +12,47 @@ pub fn generate_rust(module: &HirModule) -> String {
 
 /// Generate Rust source code for a test module (with #[test] attributes).
 pub fn generate_rust_test(module: &HirModule, module_name: &str) -> CodegenResult {
+    generate_rust_test_with_project_policy(
+        module,
+        module_name,
+        &StdlibCode::default(),
+        None,
+        None,
+        None,
+    )
+}
+
+pub(crate) fn generate_rust_test_with_project_policy(
+    module: &HirModule,
+    module_name: &str,
+    project_code: &StdlibCode,
+    project_union_enums: Option<&HashSet<String>>,
+    project_ordinary_union_enums: Option<&HashSet<String>>,
+    project_try_error_carrier_enums: Option<&HashSet<String>>,
+) -> CodegenResult {
     let mut emitter = RustEmitter::new();
 
     // First pass: collect all union types used in the module
     emitter.collect_union_types(module);
+    crate::lib_project_codegen::register_imported_union_types(&mut emitter, module, project_code);
+    if let Some(project_ordinary_union_enums) = project_ordinary_union_enums {
+        emitter
+            .ordinary_union_enums
+            .extend(project_ordinary_union_enums.iter().cloned());
+    }
+    if let Some(project_try_error_carrier_enums) = project_try_error_carrier_enums {
+        emitter
+            .try_error_carrier_enums
+            .extend(project_try_error_carrier_enums.iter().cloned());
+    }
+    if let Some(project_union_enums) = project_union_enums {
+        emitter.suppressed_union_enum_definitions = emitter
+            .union_enums
+            .keys()
+            .filter(|name| project_union_enums.contains(*name))
+            .cloned()
+            .collect();
+    }
 
     // Detect recursive (self-referential) class fields that need Box<T>
     emitter.detect_recursive_fields(module);

--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -9,7 +9,7 @@ pub fn generate_rust(module: &HirModule) -> String {
 }
 
 /// Generate Rust source code for a test module (with #[test] attributes).
-pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
+pub fn generate_rust_test(module: &HirModule, module_name: &str) -> CodegenResult {
     let mut emitter = RustEmitter::new();
 
     // First pass: collect all union types used in the module
@@ -22,7 +22,7 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
     emitter.generate_enum_definitions();
 
     // Second pass: emit the actual code
-    emitter.emit_module(module, false, true);
+    emitter.emit_named_module(module, false, true, Some(module_name));
 
     let mut module_import_items: Vec<RustItem> = Vec::new();
     for import in &module.imports {

--- a/crates/sifr_codegen/src/ir_imports.rs
+++ b/crates/sifr_codegen/src/ir_imports.rs
@@ -62,6 +62,9 @@ fn collect_item(item: &RustItem, needs: &mut IrImportNeeds) {
         RustItem::TupleStruct { inner, .. } => collect_type(inner, needs),
         RustItem::Enum { variants, .. } => {
             for variant in variants {
+                for ty in &variant.tuple_fields {
+                    collect_type(ty, needs);
+                }
                 for (_, ty) in &variant.fields {
                     collect_type(ty, needs);
                 }
@@ -353,13 +356,21 @@ fn collect_expr(expr: &RustExpr, needs: &mut IrImportNeeds) {
 fn collect_type(ty: &RustType, needs: &mut IrImportNeeds) {
     match ty {
         RustType::I64 | RustType::F64 | RustType::Bool | RustType::String_ | RustType::Unit => {}
-        RustType::Vec(inner)
-        | RustType::HashSet(inner)
-        | RustType::VecDeque(inner)
-        | RustType::Option(inner) => {
+        RustType::Vec(inner) | RustType::Option(inner) => collect_type(inner, needs),
+        RustType::HashSet(inner) => {
+            needs.collections.needs_hashset = true;
             collect_type(inner, needs);
         }
-        RustType::HashMap(k, v) | RustType::Result(k, v) => {
+        RustType::VecDeque(inner) => {
+            needs.collections.needs_vecdeque = true;
+            collect_type(inner, needs);
+        }
+        RustType::HashMap(k, v) => {
+            needs.collections.needs_hashmap = true;
+            collect_type(k, needs);
+            collect_type(v, needs);
+        }
+        RustType::Result(k, v) => {
             collect_type(k, needs);
             collect_type(v, needs);
         }
@@ -469,7 +480,7 @@ fn mark_symbol(symbol: &str, needs: &mut IrImportNeeds) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{RustLiteral, Visibility};
+    use crate::{RustEnumVariant, RustLiteral, Visibility};
 
     #[test]
     fn collects_unqualified_import_symbols() {
@@ -517,6 +528,29 @@ mod tests {
         assert!(needs.runtime.numeric.needs_bigint);
         assert!(!needs.runtime.numeric.needs_decimal);
         assert!(!needs.runtime.numeric.needs_bigdecimal);
+    }
+
+    #[test]
+    fn collects_imports_from_enum_tuple_payloads() {
+        let items = vec![RustItem::Enum {
+            name: "Payload".to_string(),
+            visibility: Visibility::Private,
+            derives: Vec::new(),
+            repr: None,
+            variants: vec![RustEnumVariant {
+                name: "Mapping".to_string(),
+                tuple_fields: vec![RustType::HashMap(
+                    Box::new(RustType::String_),
+                    Box::new(RustType::I64),
+                )],
+                fields: Vec::new(),
+                value: None,
+            }],
+        }];
+
+        let needs = collect_import_needs_from_items(&items);
+
+        assert!(needs.collections.needs_hashmap);
     }
 
     #[test]

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -25,8 +25,10 @@ pub(crate) use lib_task_scope_offload_needs::{
 };
 mod lib_project_codegen;
 mod lib_project_signatures;
+mod lib_test_project_codegen;
 mod rust_interop_error_mapping;
 pub use lib_project_codegen::*;
+pub use lib_test_project_codegen::*;
 mod lib_emitter_state;
 pub use lib_emitter_state::*;
 mod class_emitter;

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -92,6 +92,7 @@ mod option_binding_mutability;
 mod output_helpers;
 mod place_emitter;
 mod preamble;
+mod project_stdlib_nominals;
 mod protocol_bridge_emitter;
 pub use preamble::*;
 mod python_arrow_codegen;

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -93,6 +93,7 @@ mod output_helpers;
 mod place_emitter;
 mod preamble;
 mod project_stdlib_nominals;
+mod project_union_prelude;
 mod protocol_bridge_emitter;
 pub use preamble::*;
 mod python_arrow_codegen;

--- a/crates/sifr_codegen/src/lib_codegen_tests/classes_and_basics_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/classes_and_basics_codegen_tests.rs
@@ -36,6 +36,22 @@ def main():
 }
 
 #[test]
+fn class_field_union_emits_its_enum_definition() {
+    let union = Type::Union(vec![Type::Int, Type::Str, Type::Bool]);
+    let rust_code = generate_rust_from_source(
+        r#"class Payload:
+    value: int | str | bool
+
+def main():
+    payload = Payload(1)
+"#,
+    );
+
+    assert!(rust_code.contains(&format!("enum {}", union.union_enum_name())));
+    assert!(rust_code.contains(&format!("value: {}", union.union_enum_name())));
+}
+
+#[test]
 fn process_child_resource_derives_are_module_scoped() {
     let module = HirModule {
         functions: vec![],

--- a/crates/sifr_codegen/src/lib_codegen_tests/collections_and_stdlib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/collections_and_stdlib_codegen_tests.rs
@@ -628,7 +628,7 @@ fn test_generate_rust_multi_assembles_single_rust_file() {
         .expect("generate_project docs should exist");
     let generate_block = &lib_src[start..end];
 
-    assert!(generate_block.contains("generate_rust_with_stdlib_for_module_with_structural_policy("));
+    assert!(generate_block.contains("generate_rust_with_stdlib_for_module_with_project_policy("));
     assert!(generate_block.contains("structural_interop_enabled,"));
     assert!(generate_block.contains("register_imported_generic_classes("));
     assert!(generate_block.contains("render_local_module_imports(module, &project_modules)"));

--- a/crates/sifr_codegen/src/lib_codegen_tests/iterators_and_generators_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/iterators_and_generators_codegen_tests.rs
@@ -439,7 +439,7 @@ fn test_generate_rust_test_uses_explicit_test_mode_context() {
         type_param_bounds: std::collections::HashMap::new(),
     };
 
-    let rust_code = generate_rust_test(&module).rust_source;
+    let rust_code = generate_rust_test(&module, "main").rust_source;
     assert!(!rust_code.contains("fn main("));
     assert!(rust_code.contains("#[test]\nfn test_sample()"));
     assert!(rust_code.contains("fn helper()"));
@@ -512,7 +512,7 @@ fn test_generate_rust_test_collects_imports_from_emitted_code() {
         type_param_bounds: std::collections::HashMap::new(),
     };
 
-    let result = generate_rust_test(&module);
+    let result = generate_rust_test(&module, "main");
     assert!(result
         .rust_source
         .contains("use ::std::collections::HashMap;"));
@@ -563,7 +563,7 @@ fn test_generate_rust_test_emits_local_module_import_uses() {
         type_param_bounds: std::collections::HashMap::new(),
     };
 
-    let generated = generate_rust_test(&module);
+    let generated = generate_rust_test(&module, "main");
     assert!(
         generated
             .rust_source

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -33,7 +33,7 @@ fn project_structural_demand_enables_implicit_classes_across_modules() {
     assert!(models_rust.contains("StructuralConstruct"));
     assert!(models_rust.contains("StructuralProject"));
     assert!(models_rust.contains("fn nominal_identity() -> Option<&'static str>"));
-    assert!(models_rust.contains("Some(\"Payload\")"));
+    assert!(models_rust.contains("Some(\"models.Payload\")"));
 
     let metadata = crate::generate_rust_multi_with_metadata(
         &[("models", &models), ("api", &api)],

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -16,9 +16,12 @@ pub struct RustEmitter {
     pub(crate) try_error_carrier_enums: HashSet<String>,
     /// Union enums also used as ordinary source-level values.
     pub(crate) ordinary_union_enums: HashSet<String>,
-    /// Project-owned union enums whose definition is emitted by another module.
+    /// Project-owned union enums whose definition is emitted by the crate-root prelude.
     /// The complete union map remains available to lowering and exhaustiveness checks.
     pub(crate) suppressed_union_enum_definitions: HashSet<String>,
+    /// Canonical nominal identities mapped to their crate-rooted Rust paths.
+    /// Project union definitions use these paths because they live outside source modules.
+    pub(crate) project_nominal_type_paths: HashMap<String, String>,
     /// Accumulated union enum items to prepend
     pub(crate) enum_items: Vec<RustItem>,
     /// Accumulated non-enum body items to assemble before raw output rendering.
@@ -212,6 +215,7 @@ impl RustEmitter {
             try_error_carrier_enums: HashSet::new(),
             ordinary_union_enums: HashSet::new(),
             suppressed_union_enum_definitions: HashSet::new(),
+            project_nominal_type_paths: HashMap::new(),
             enum_items: Vec::new(),
             body_items: Vec::new(),
             current_return_type: None,

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -16,6 +16,9 @@ pub struct RustEmitter {
     pub(crate) try_error_carrier_enums: HashSet<String>,
     /// Union enums also used as ordinary source-level values.
     pub(crate) ordinary_union_enums: HashSet<String>,
+    /// Project-owned union enums whose definition is emitted by another module.
+    /// The complete union map remains available to lowering and exhaustiveness checks.
+    pub(crate) suppressed_union_enum_definitions: HashSet<String>,
     /// Accumulated union enum items to prepend
     pub(crate) enum_items: Vec<RustItem>,
     /// Accumulated non-enum body items to assemble before raw output rendering.
@@ -208,6 +211,7 @@ impl RustEmitter {
             union_enums: HashMap::new(),
             try_error_carrier_enums: HashSet::new(),
             ordinary_union_enums: HashSet::new(),
+            suppressed_union_enum_definitions: HashSet::new(),
             enum_items: Vec::new(),
             body_items: Vec::new(),
             current_return_type: None,

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -227,6 +227,26 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_structural_policy(
     module_name: Option<&str>,
     structural_interop_enabled: bool,
 ) -> CodegenResult {
+    generate_rust_with_stdlib_for_module_with_project_policy(
+        module,
+        stdlib_code,
+        module_name,
+        structural_interop_enabled,
+        None,
+        None,
+        None,
+    )
+}
+
+pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
+    module: &HirModule,
+    stdlib_code: &StdlibCode,
+    module_name: Option<&str>,
+    structural_interop_enabled: bool,
+    owned_union_enums: Option<&HashSet<String>>,
+    project_ordinary_union_enums: Option<&HashSet<String>>,
+    project_try_error_carrier_enums: Option<&HashSet<String>>,
+) -> CodegenResult {
     let mut emitter = RustEmitter::new();
     emitter.structural_interop_enabled = structural_interop_enabled;
     // Register stdlib generic classes so user code skips explicit type annotations
@@ -307,6 +327,25 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_structural_policy(
 
     // First pass: collect all union types used in the module
     emitter.collect_union_types(module);
+    crate::lib_project_codegen::register_imported_union_types(&mut emitter, module, stdlib_code);
+    if let Some(project_ordinary_union_enums) = project_ordinary_union_enums {
+        emitter
+            .ordinary_union_enums
+            .extend(project_ordinary_union_enums.iter().cloned());
+    }
+    if let Some(project_try_error_carrier_enums) = project_try_error_carrier_enums {
+        emitter
+            .try_error_carrier_enums
+            .extend(project_try_error_carrier_enums.iter().cloned());
+    }
+    if let Some(owned_union_enums) = owned_union_enums {
+        emitter.suppressed_union_enum_definitions = emitter
+            .union_enums
+            .keys()
+            .filter(|name| !owned_union_enums.contains(*name))
+            .cloned()
+            .collect();
+    }
 
     // Detect recursive (self-referential) class fields that need Box<T>
     emitter.detect_recursive_fields(module);

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -80,6 +80,8 @@ pub struct CodegenResult {
 /// Result of multi-module code generation, including aggregate dependency metadata.
 pub struct MultiModuleCodegenResult {
     pub rust_files: HashMap<String, String>,
+    /// The single crate-root prelude that owns all non-optional project union enums.
+    pub project_union_prelude: String,
     pub used_stdlib_modules: HashSet<String>,
     pub required_features: HashSet<StdlibFeature>,
     /// Structured interop metadata required before generated project materialization.

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -3,11 +3,11 @@ use super::{
     publicize_generated_module_source, HashMap, HashSet, HirModule, MultiModuleCodegenResult,
     Renderer, RustFile, RustItem, StdlibCode,
 };
-use crate::ir_imports::collect_import_needs_from_items;
 use crate::lib_project_signatures::{project_class_fields, project_func_signatures};
 use crate::project_stdlib_nominals::{
     project_stdlib_nominal_plan, relocate_project_stdlib_nominals,
 };
+use crate::project_union_prelude::render_project_union_prelude;
 use sifr_stdlib_manifest::{try_generated_cargo_dependencies, StdlibFeature};
 use sifr_type_system::source_class_rust_name;
 
@@ -126,64 +126,6 @@ pub(crate) fn project_nominal_type_paths(
         }
     }
     paths
-}
-
-pub(crate) fn render_project_union_prelude(
-    usage: &ProjectUnionUsage,
-    nominal_type_paths: &HashMap<String, String>,
-) -> String {
-    if usage.unions.is_empty() {
-        return String::new();
-    }
-    let mut emitter = super::RustEmitter::new();
-    emitter.union_enums.clone_from(&usage.unions);
-    emitter
-        .ordinary_union_enums
-        .clone_from(&usage.ordinary_unions);
-    emitter
-        .try_error_carrier_enums
-        .clone_from(&usage.try_error_unions);
-    emitter
-        .project_nominal_type_paths
-        .clone_from(nominal_type_paths);
-    emitter.generate_enum_definitions();
-
-    let import_needs = collect_import_needs_from_items(&emitter.enum_items);
-    let mut items = Vec::new();
-    if import_needs.collections.needs_hashmap {
-        items.push(RustItem::Use(vec![
-            "std".to_string(),
-            "collections".to_string(),
-            "HashMap".to_string(),
-        ]));
-    }
-    if import_needs.collections.needs_hashset {
-        items.push(RustItem::Use(vec![
-            "std".to_string(),
-            "collections".to_string(),
-            "HashSet".to_string(),
-        ]));
-    }
-    if import_needs.runtime.numeric.needs_bigint {
-        items.push(RustItem::Use(vec![
-            "num_bigint".to_string(),
-            "BigInt".to_string(),
-        ]));
-    }
-    if import_needs.runtime.numeric.needs_decimal {
-        items.push(RustItem::Use(vec![
-            "rust_decimal".to_string(),
-            "Decimal".to_string(),
-        ]));
-    }
-    if import_needs.runtime.numeric.needs_bigdecimal {
-        items.push(RustItem::Use(vec![
-            "bigdecimal".to_string(),
-            "BigDecimal".to_string(),
-        ]));
-    }
-    items.extend(emitter.enum_items);
-    publicize_generated_module_source(&Renderer::new().render_file(&RustFile { items }))
 }
 
 fn resolve_exported_rust_opaque_class<'a>(

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -1,11 +1,126 @@
 use super::{
-    generate_rust, generate_rust_with_stdlib_for_module_with_structural_policy,
-    module_class_fields, publicize_generated_module_source, HashMap, HashSet, HirModule,
-    MultiModuleCodegenResult, Renderer, RustFile, RustItem, StdlibCode,
+    generate_rust, generate_rust_with_stdlib_for_module_with_project_policy,
+    publicize_generated_module_source, HashMap, HashSet, HirModule, MultiModuleCodegenResult,
+    Renderer, RustFile, RustItem, StdlibCode,
 };
-use crate::lib_project_signatures::project_func_signatures;
+use crate::lib_project_signatures::{project_class_fields, project_func_signatures};
 use sifr_stdlib_manifest::{try_generated_cargo_dependencies, StdlibFeature};
 use sifr_type_system::source_class_rust_name;
+
+pub(crate) fn register_imported_union_types(
+    emitter: &mut super::RustEmitter,
+    module: &HirModule,
+    project_code: &StdlibCode,
+) {
+    for import in &module.imports {
+        if import.module.starts_with("sifr.") || import.module.starts_with("_sifr.") {
+            continue;
+        }
+        if let Some(signatures) = project_code.func_signatures.get(&import.module) {
+            for name in &import.names {
+                if let Some((params, return_type)) = signatures.get(name) {
+                    for (param_type, _) in params {
+                        emitter.register_union_type(param_type);
+                    }
+                    emitter.register_union_type(return_type);
+                }
+            }
+        }
+        if let Some(classes) = project_code.module_class_fields.get(&import.module) {
+            for name in &import.names {
+                if let Some(fields) = classes.get(name) {
+                    for (_, field_type) in fields {
+                        emitter.register_union_type(field_type);
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ProjectUnionUsage {
+    owners: HashMap<String, String>,
+    module_unions: HashMap<String, HashSet<String>>,
+    ordinary_unions: HashSet<String>,
+    try_error_unions: HashSet<String>,
+}
+
+fn project_union_usage(
+    modules: &[(&str, &HirModule)],
+    project_code: &StdlibCode,
+) -> ProjectUnionUsage {
+    let mut owners = HashMap::new();
+    let mut module_unions = HashMap::new();
+    let mut ordinary_unions = HashSet::new();
+    let mut try_error_unions = HashSet::new();
+    for (module_name, module) in modules {
+        let mut emitter = super::RustEmitter::new();
+        emitter.collect_union_types(module);
+        let local_unions = emitter.union_enums.keys().cloned().collect::<HashSet<_>>();
+        register_imported_union_types(&mut emitter, module, project_code);
+        ordinary_unions.extend(emitter.ordinary_union_enums.iter().cloned());
+        try_error_unions.extend(emitter.try_error_carrier_enums.iter().cloned());
+        let names = emitter.union_enums.into_keys().collect::<HashSet<_>>();
+        for name in local_unions {
+            owners
+                .entry(name)
+                .and_modify(|owner: &mut String| {
+                    if *module_name < owner.as_str() {
+                        *owner = (*module_name).to_string();
+                    }
+                })
+                .or_insert_with(|| (*module_name).to_string());
+        }
+        module_unions.insert((*module_name).to_string(), names);
+    }
+    let mut external_owners = HashMap::new();
+    for (module_name, names) in &module_unions {
+        for name in names {
+            external_owners
+                .entry(name.clone())
+                .and_modify(|owner: &mut String| {
+                    if module_name < owner {
+                        owner.clone_from(module_name);
+                    }
+                })
+                .or_insert_with(|| module_name.clone());
+        }
+    }
+    for (name, owner) in external_owners {
+        owners.entry(name).or_insert(owner);
+    }
+    ProjectUnionUsage {
+        owners,
+        module_unions,
+        ordinary_unions,
+        try_error_unions,
+    }
+}
+
+fn render_project_union_imports(
+    module_name: &str,
+    module_unions: &HashSet<String>,
+    owners: &HashMap<String, String>,
+) -> String {
+    let mut names = module_unions.iter().collect::<Vec<_>>();
+    names.sort();
+    let items = names
+        .into_iter()
+        .filter_map(|name| {
+            let owner = owners.get(name)?;
+            if owner == module_name {
+                return None;
+            }
+            let mut path = vec!["crate".to_string()];
+            if owner != "main" {
+                path.extend(owner.split('.').map(str::to_string));
+            }
+            path.push(name.clone());
+            Some(RustItem::Use(path))
+        })
+        .collect::<Vec<_>>();
+    Renderer::new().render_file(&RustFile { items })
+}
 
 fn resolve_exported_rust_opaque_class<'a>(
     module_name: &str,
@@ -190,30 +305,54 @@ pub fn generate_rust_multi_with_metadata(
     let structural_interop_enabled = modules
         .iter()
         .any(|(_, module)| crate::rust_interop_plan::module_uses_structural_interop(module));
-
     project_codegen_code
         .func_signatures
         .extend(project_func_signatures(modules));
-    for (module_name, module) in modules {
-        project_codegen_code
-            .module_class_fields
-            .insert((*module_name).to_string(), module_class_fields(module));
-    }
+    project_codegen_code
+        .module_class_fields
+        .extend(project_class_fields(modules));
+    let union_usage = project_union_usage(modules, &project_codegen_code);
 
     for (module_name, module) in modules {
         let module_public = *module_name != "main";
         let mut module_codegen_code = project_codegen_code.clone();
         register_imported_generic_classes(&mut module_codegen_code, module, &project_modules);
-        let codegen_result = generate_rust_with_stdlib_for_module_with_structural_policy(
+        let used_unions = union_usage
+            .module_unions
+            .get(*module_name)
+            .cloned()
+            .unwrap_or_default();
+        let owned_unions = used_unions
+            .iter()
+            .filter(|name| {
+                union_usage
+                    .owners
+                    .get(*name)
+                    .is_some_and(|owner| owner == module_name)
+            })
+            .cloned()
+            .collect::<HashSet<_>>();
+        let codegen_result = generate_rust_with_stdlib_for_module_with_project_policy(
             module,
             &module_codegen_code,
-            None,
+            Some(module_name),
             structural_interop_enabled,
+            Some(&owned_unions),
+            Some(&union_usage.ordinary_unions),
+            Some(&union_usage.try_error_unions),
         );
         let local_imports = render_local_module_imports(module, &project_modules);
+        let union_imports =
+            render_project_union_imports(module_name, &used_unions, &union_usage.owners);
         let mut rust_source = codegen_result.rust_source;
-        if !local_imports.trim().is_empty() {
-            rust_source = format!("{}\n\n{}", local_imports.trim_end(), rust_source);
+        let imports = [local_imports, union_imports]
+            .into_iter()
+            .filter(|source| !source.trim().is_empty())
+            .map(|source| source.trim_end().to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        if !imports.is_empty() {
+            rust_source = format!("{imports}\n\n{rust_source}");
         }
         if module_public {
             rust_source = publicize_generated_module_source(&rust_source);
@@ -301,9 +440,252 @@ mod tests {
     use super::*;
     use ruff_text_size::TextRange;
     use sifr_ir::{
-        HirClass, HirClassKind, HirFunction, HirImport, MethodKind, RustInteropAbiRequirements,
-        RustInteropDeclaration, RustInteropDecoratorKind, RustInteropEffect,
+        HirClass, HirClassKind, HirExceptHandler, HirFunction, HirImport, MethodKind,
+        RustInteropAbiRequirements, RustInteropDeclaration, RustInteropDecoratorKind,
+        RustInteropEffect,
     };
+
+    fn empty_function(name: &str, return_type: sifr_type_system::Type) -> HirFunction {
+        HirFunction {
+            name: name.to_string(),
+            params: Vec::new(),
+            return_type,
+            body: vec![sifr_ir::HirStmt::Return {
+                value: Some(sifr_ir::HirExpr::IntLiteral(1)),
+            }],
+            is_async: false,
+            method_kind: MethodKind::Regular,
+            receiver: None,
+            decorators: Vec::new(),
+            rust_interop: Vec::new(),
+            python_interop: Vec::new(),
+            compiler_intrinsic: None,
+            type_params: Vec::new(),
+        }
+    }
+
+    fn module_with(functions: Vec<HirFunction>, imports: Vec<HirImport>) -> HirModule {
+        HirModule {
+            functions,
+            classes: Vec::new(),
+            imports,
+            constants: Vec::new(),
+            generic_functions: HashMap::new(),
+            type_param_bounds: HashMap::new(),
+        }
+    }
+
+    fn error_type(name: &str) -> sifr_type_system::Type {
+        sifr_type_system::Type::Class {
+            identity: Some(format!("errors.{name}")),
+            type_args: Vec::new(),
+            name: name.to_string(),
+            fields: vec![("message".to_string(), sifr_type_system::Type::Str)],
+            methods: Vec::new(),
+            parent_class: Some("Error".to_string()),
+        }
+    }
+
+    #[test]
+    fn project_unions_have_one_owner_and_are_imported_by_other_modules() {
+        let union = sifr_type_system::Type::Union(vec![
+            sifr_type_system::Type::Int,
+            sifr_type_system::Type::Str,
+        ]);
+        let enum_name = union.union_enum_name();
+        let provider = module_with(vec![empty_function("produce", union.clone())], Vec::new());
+        let consumer = module_with(
+            vec![empty_function("marker", sifr_type_system::Type::Int)],
+            vec![HirImport {
+                module: "provider".to_string(),
+                names: vec!["produce".to_string()],
+                aliases: Vec::new(),
+            }],
+        );
+
+        let generated = generate_rust_multi_with_metadata(
+            &[("main", &consumer), ("provider", &provider)],
+            &StdlibCode::default(),
+        );
+        let provider_source = &generated.rust_files["provider"];
+        let consumer_source = &generated.rust_files["main"];
+
+        assert!(
+            provider_source.contains(&format!("pub enum {enum_name}")),
+            "{provider_source}"
+        );
+        assert_eq!(
+            provider_source
+                .matches(&format!("enum {enum_name}"))
+                .count(),
+            1
+        );
+        assert!(
+            consumer_source.contains(&format!("use crate::provider::{enum_name};")),
+            "{consumer_source}"
+        );
+        assert!(!consumer_source.contains(&format!("enum {enum_name}")));
+    }
+
+    #[test]
+    fn main_owned_union_is_imported_from_the_crate_root() {
+        let union = sifr_type_system::Type::Union(vec![
+            sifr_type_system::Type::Int,
+            sifr_type_system::Type::Str,
+        ]);
+        let enum_name = union.union_enum_name();
+        let owner = module_with(vec![empty_function("produce", union.clone())], Vec::new());
+        let consumer = module_with(vec![empty_function("relay", union.clone())], Vec::new());
+
+        let generated = generate_rust_multi_with_metadata(
+            &[("main", &owner), ("support", &consumer)],
+            &StdlibCode::default(),
+        );
+
+        assert!(generated.rust_files["main"].contains(&format!("enum {enum_name}")));
+        assert!(
+            generated.rust_files["support"].contains(&format!("use crate::{enum_name};")),
+            "{}",
+            generated.rust_files["support"]
+        );
+    }
+
+    #[test]
+    fn dotted_union_owner_is_imported_through_its_module_path() {
+        let union = sifr_type_system::Type::Union(vec![
+            sifr_type_system::Type::Int,
+            sifr_type_system::Type::Str,
+        ]);
+        let enum_name = union.union_enum_name();
+        let owner = module_with(vec![empty_function("produce", union.clone())], Vec::new());
+        let consumer = module_with(
+            vec![empty_function("marker", sifr_type_system::Type::Int)],
+            vec![HirImport {
+                module: "pkg.errors".to_string(),
+                names: vec!["produce".to_string()],
+                aliases: Vec::new(),
+            }],
+        );
+
+        let generated = generate_rust_multi_with_metadata(
+            &[("pkg.errors", &owner), ("main", &consumer)],
+            &StdlibCode::default(),
+        );
+
+        assert!(
+            generated.rust_files["main"].contains(&format!("use crate::pkg::errors::{enum_name};")),
+            "{}",
+            generated.rust_files["main"]
+        );
+    }
+
+    #[test]
+    fn owner_combines_try_carrier_conversions_with_ordinary_union_traits() {
+        let first = error_type("FirstError");
+        let second = error_type("SecondError");
+        let union = sifr_type_system::Type::Union(vec![first.clone(), second.clone()]);
+        let enum_name = union.union_enum_name();
+        let mut try_function = empty_function("guarded", sifr_type_system::Type::None);
+        try_function.body = vec![sifr_ir::HirStmt::TryExcept {
+            body: vec![sifr_ir::HirStmt::Pass],
+            handlers: vec![HirExceptHandler {
+                error_type: Some("FirstError".to_string()),
+                error_resolved_type: Some(first.clone()),
+                name: None,
+                body: vec![sifr_ir::HirStmt::Pass],
+            }],
+            body_error_types: vec![first, second],
+        }];
+        let owner = module_with(vec![try_function], Vec::new());
+        let consumer = module_with(vec![empty_function("ordinary", union)], Vec::new());
+
+        let generated = generate_rust_multi_with_metadata(
+            &[("errors", &owner), ("main", &consumer)],
+            &StdlibCode::default(),
+        );
+        let owner_source = &generated.rust_files["errors"];
+
+        assert!(
+            owner_source.contains("#[derive(Debug, Clone, PartialEq, Eq, Hash)]"),
+            "{owner_source}"
+        );
+        assert!(
+            owner_source.contains("impl From<FirstError>")
+                && owner_source.contains(&format!("for {enum_name}")),
+            "{owner_source}"
+        );
+        assert!(
+            owner_source.contains("impl From<SecondError>"),
+            "{owner_source}"
+        );
+    }
+
+    #[test]
+    fn owner_election_distinguishes_non_class_nominal_identities() {
+        let nominal_pairs = [
+            (
+                sifr_type_system::Type::Newtype {
+                    identity: Some("left.Token".to_string()),
+                    name: "Token".to_string(),
+                    inner: Box::new(sifr_type_system::Type::Int),
+                },
+                sifr_type_system::Type::Newtype {
+                    identity: Some("right.Token".to_string()),
+                    name: "Token".to_string(),
+                    inner: Box::new(sifr_type_system::Type::Int),
+                },
+            ),
+            (
+                sifr_type_system::Type::Enum {
+                    identity: Some("left.Status".to_string()),
+                    name: "Status".to_string(),
+                    variants: vec![("READY".to_string(), Some(1))],
+                },
+                sifr_type_system::Type::Enum {
+                    identity: Some("right.Status".to_string()),
+                    name: "Status".to_string(),
+                    variants: vec![("READY".to_string(), Some(1))],
+                },
+            ),
+            (
+                sifr_type_system::Type::Protocol {
+                    identity: Some("left.Readable".to_string()),
+                    name: "Readable".to_string(),
+                    methods: Vec::new(),
+                },
+                sifr_type_system::Type::Protocol {
+                    identity: Some("right.Readable".to_string()),
+                    name: "Readable".to_string(),
+                    methods: Vec::new(),
+                },
+            ),
+        ];
+
+        for (left, right) in nominal_pairs {
+            let left = module_with(
+                vec![empty_function(
+                    "left",
+                    sifr_type_system::Type::Union(vec![sifr_type_system::Type::Int, left]),
+                )],
+                Vec::new(),
+            );
+            let right = module_with(
+                vec![empty_function(
+                    "right",
+                    sifr_type_system::Type::Union(vec![sifr_type_system::Type::Int, right]),
+                )],
+                Vec::new(),
+            );
+            let usage = project_union_usage(
+                &[("left", &left), ("right", &right)],
+                &StdlibCode::default(),
+            );
+
+            assert_eq!(usage.owners.len(), 2, "{:?}", usage.owners);
+            assert!(usage.owners.values().any(|owner| owner == "left"));
+            assert!(usage.owners.values().any(|owner| owner == "right"));
+        }
+    }
 
     #[test]
     fn local_imports_bring_opaque_extension_traits_into_scope() {

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -318,7 +318,8 @@ pub fn generate_rust_multi_with_metadata(
         .module_class_fields
         .extend(project_class_fields(modules));
     let union_usage = project_union_usage(modules, &project_codegen_code);
-    let stdlib_nominal_plan = project_stdlib_nominal_plan(&union_usage.unions, stdlib_code);
+    let stdlib_nominal_plan =
+        project_stdlib_nominal_plan(&union_usage.unions, stdlib_code, modules);
     let crate_root_modules = HashSet::from(["main"]);
     let mut nominal_type_paths = project_nominal_type_paths(modules, &crate_root_modules);
     nominal_type_paths.extend(stdlib_nominal_plan.nominal_paths.clone());

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -5,6 +5,9 @@ use super::{
 };
 use crate::ir_imports::collect_import_needs_from_items;
 use crate::lib_project_signatures::{project_class_fields, project_func_signatures};
+use crate::project_stdlib_nominals::{
+    project_stdlib_nominal_plan, relocate_project_stdlib_nominals,
+};
 use sifr_stdlib_manifest::{try_generated_cargo_dependencies, StdlibFeature};
 use sifr_type_system::source_class_rust_name;
 
@@ -373,9 +376,19 @@ pub fn generate_rust_multi_with_metadata(
         .module_class_fields
         .extend(project_class_fields(modules));
     let union_usage = project_union_usage(modules, &project_codegen_code);
+    let stdlib_nominal_plan = project_stdlib_nominal_plan(&union_usage.unions, stdlib_code);
     let crate_root_modules = HashSet::from(["main"]);
-    let nominal_type_paths = project_nominal_type_paths(modules, &crate_root_modules);
-    let project_union_prelude = render_project_union_prelude(&union_usage, &nominal_type_paths);
+    let mut nominal_type_paths = project_nominal_type_paths(modules, &crate_root_modules);
+    nominal_type_paths.extend(stdlib_nominal_plan.nominal_paths.clone());
+    let union_prelude = render_project_union_prelude(&union_usage, &nominal_type_paths);
+    let project_union_prelude = [stdlib_nominal_plan.prelude.as_str(), union_prelude.as_str()]
+        .into_iter()
+        .filter(|source| !source.trim().is_empty())
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    used_stdlib_modules.extend(stdlib_nominal_plan.used_stdlib_modules.iter().cloned());
+    required_features.extend(stdlib_nominal_plan.required_features.iter().copied());
 
     for (module_name, module) in modules {
         let module_public = *module_name != "main";
@@ -398,7 +411,11 @@ pub fn generate_rust_multi_with_metadata(
         );
         let local_imports = render_local_module_imports(module, &project_modules);
         let union_imports = render_project_union_imports(module_name, &used_unions);
-        let mut rust_source = codegen_result.rust_source;
+        let mut rust_source = relocate_project_stdlib_nominals(
+            &codegen_result.rust_source,
+            module_name,
+            &stdlib_nominal_plan,
+        );
         let imports = [local_imports, union_imports]
             .into_iter()
             .filter(|source| !source.trim().is_empty())
@@ -677,7 +694,8 @@ mod tests {
             }],
             body_error_types: vec![first, second],
         }];
-        let owner = module_with(vec![try_function], Vec::new());
+        let mut owner = module_with(vec![try_function], Vec::new());
+        owner.classes = vec![error_class("FirstError"), error_class("SecondError")];
         let consumer = module_with(vec![empty_function("ordinary", union)], Vec::new());
 
         let generated = generate_rust_multi_with_metadata(
@@ -691,11 +709,14 @@ mod tests {
             "{prelude}"
         );
         assert!(
-            prelude.contains("impl From<FirstError>")
+            prelude.contains("impl From<crate::errors::FirstError>")
                 && prelude.contains(&format!("for {enum_name}")),
             "{prelude}"
         );
-        assert!(prelude.contains("impl From<SecondError>"), "{prelude}");
+        assert!(
+            prelude.contains("impl From<crate::errors::SecondError>"),
+            "{prelude}"
+        );
     }
 
     #[test]

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -80,8 +80,9 @@ pub(crate) fn project_union_usage(
 pub(crate) fn render_project_union_imports(
     module_name: &str,
     module_unions: &HashSet<String>,
+    crate_root_modules: &HashSet<&str>,
 ) -> String {
-    if module_name == "main" {
+    if crate_root_modules.contains(module_name) {
         return String::new();
     }
     let mut names = module_unions.iter().collect::<Vec<_>>();
@@ -353,11 +354,13 @@ pub fn generate_rust_multi_with_metadata(
             Some(&union_usage.try_error_unions),
         );
         let local_imports = render_local_module_imports(module, &project_modules);
-        let union_imports = render_project_union_imports(module_name, &used_unions);
+        let union_imports =
+            render_project_union_imports(module_name, &used_unions, &crate_root_modules);
         let mut rust_source = relocate_project_stdlib_nominals(
             &codegen_result.rust_source,
             module_name,
             &stdlib_nominal_plan,
+            &crate_root_modules,
         );
         let imports = [local_imports, union_imports]
             .into_iter()

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -3,6 +3,7 @@ use super::{
     publicize_generated_module_source, HashMap, HashSet, HirModule, MultiModuleCodegenResult,
     Renderer, RustFile, RustItem, StdlibCode,
 };
+use crate::ir_imports::collect_import_needs_from_items;
 use crate::lib_project_signatures::{project_class_fields, project_func_signatures};
 use sifr_stdlib_manifest::{try_generated_cargo_dependencies, StdlibFeature};
 use sifr_type_system::source_class_rust_name;
@@ -38,88 +39,148 @@ pub(crate) fn register_imported_union_types(
     }
 }
 
-struct ProjectUnionUsage {
-    owners: HashMap<String, String>,
-    module_unions: HashMap<String, HashSet<String>>,
-    ordinary_unions: HashSet<String>,
-    try_error_unions: HashSet<String>,
+pub(crate) struct ProjectUnionUsage {
+    pub(crate) unions: HashMap<String, Vec<sifr_type_system::Type>>,
+    pub(crate) module_unions: HashMap<String, HashSet<String>>,
+    pub(crate) ordinary_unions: HashSet<String>,
+    pub(crate) try_error_unions: HashSet<String>,
 }
 
-fn project_union_usage(
+pub(crate) fn project_union_usage(
     modules: &[(&str, &HirModule)],
     project_code: &StdlibCode,
 ) -> ProjectUnionUsage {
-    let mut owners = HashMap::new();
+    let mut unions = HashMap::new();
     let mut module_unions = HashMap::new();
     let mut ordinary_unions = HashSet::new();
     let mut try_error_unions = HashSet::new();
     for (module_name, module) in modules {
         let mut emitter = super::RustEmitter::new();
         emitter.collect_union_types(module);
-        let local_unions = emitter.union_enums.keys().cloned().collect::<HashSet<_>>();
         register_imported_union_types(&mut emitter, module, project_code);
         ordinary_unions.extend(emitter.ordinary_union_enums.iter().cloned());
         try_error_unions.extend(emitter.try_error_carrier_enums.iter().cloned());
-        let names = emitter.union_enums.into_keys().collect::<HashSet<_>>();
-        for name in local_unions {
-            owners
-                .entry(name)
-                .and_modify(|owner: &mut String| {
-                    if *module_name < owner.as_str() {
-                        *owner = (*module_name).to_string();
-                    }
-                })
-                .or_insert_with(|| (*module_name).to_string());
+        let names = emitter.union_enums.keys().cloned().collect::<HashSet<_>>();
+        for (name, members) in emitter.union_enums {
+            unions.entry(name).or_insert(members);
         }
         module_unions.insert((*module_name).to_string(), names);
     }
-    let mut external_owners = HashMap::new();
-    for (module_name, names) in &module_unions {
-        for name in names {
-            external_owners
-                .entry(name.clone())
-                .and_modify(|owner: &mut String| {
-                    if module_name < owner {
-                        owner.clone_from(module_name);
-                    }
-                })
-                .or_insert_with(|| module_name.clone());
-        }
-    }
-    for (name, owner) in external_owners {
-        owners.entry(name).or_insert(owner);
-    }
     ProjectUnionUsage {
-        owners,
+        unions,
         module_unions,
         ordinary_unions,
         try_error_unions,
     }
 }
 
-fn render_project_union_imports(
+pub(crate) fn render_project_union_imports(
     module_name: &str,
     module_unions: &HashSet<String>,
-    owners: &HashMap<String, String>,
 ) -> String {
+    if module_name == "main" {
+        return String::new();
+    }
     let mut names = module_unions.iter().collect::<Vec<_>>();
     names.sort();
     let items = names
         .into_iter()
-        .filter_map(|name| {
-            let owner = owners.get(name)?;
-            if owner == module_name {
-                return None;
-            }
-            let mut path = vec!["crate".to_string()];
-            if owner != "main" {
-                path.extend(owner.split('.').map(str::to_string));
-            }
-            path.push(name.clone());
-            Some(RustItem::Use(path))
-        })
+        .map(|name| RustItem::Use(vec!["crate".to_string(), name.clone()]))
         .collect::<Vec<_>>();
     Renderer::new().render_file(&RustFile { items })
+}
+
+pub(crate) fn project_nominal_type_paths(
+    modules: &[(&str, &HirModule)],
+    crate_root_modules: &HashSet<&str>,
+) -> HashMap<String, String> {
+    let mut paths = HashMap::new();
+    let mut basename_counts = HashMap::new();
+    for (_, module) in modules {
+        for class in &module.classes {
+            *basename_counts
+                .entry(class.name.as_str())
+                .or_insert(0_usize) += 1;
+        }
+    }
+    for (module_name, module) in modules {
+        for class in &module.classes {
+            let rust_name = source_class_rust_name(&class.name);
+            let path = if crate_root_modules.contains(module_name) {
+                format!("crate::{rust_name}")
+            } else {
+                format!("crate::{}::{rust_name}", module_name.replace('.', "::"))
+            };
+            let canonical = class
+                .identity
+                .clone()
+                .unwrap_or_else(|| format!("{module_name}.{}", class.name));
+            paths.insert(canonical, path.clone());
+            paths.insert(format!("{module_name}.{}", class.name), path.clone());
+            if basename_counts.get(class.name.as_str()) == Some(&1) {
+                paths.insert(class.name.clone(), path);
+            }
+        }
+    }
+    paths
+}
+
+pub(crate) fn render_project_union_prelude(
+    usage: &ProjectUnionUsage,
+    nominal_type_paths: &HashMap<String, String>,
+) -> String {
+    if usage.unions.is_empty() {
+        return String::new();
+    }
+    let mut emitter = super::RustEmitter::new();
+    emitter.union_enums.clone_from(&usage.unions);
+    emitter
+        .ordinary_union_enums
+        .clone_from(&usage.ordinary_unions);
+    emitter
+        .try_error_carrier_enums
+        .clone_from(&usage.try_error_unions);
+    emitter
+        .project_nominal_type_paths
+        .clone_from(nominal_type_paths);
+    emitter.generate_enum_definitions();
+
+    let import_needs = collect_import_needs_from_items(&emitter.enum_items);
+    let mut items = Vec::new();
+    if import_needs.collections.needs_hashmap {
+        items.push(RustItem::Use(vec![
+            "std".to_string(),
+            "collections".to_string(),
+            "HashMap".to_string(),
+        ]));
+    }
+    if import_needs.collections.needs_hashset {
+        items.push(RustItem::Use(vec![
+            "std".to_string(),
+            "collections".to_string(),
+            "HashSet".to_string(),
+        ]));
+    }
+    if import_needs.runtime.numeric.needs_bigint {
+        items.push(RustItem::Use(vec![
+            "num_bigint".to_string(),
+            "BigInt".to_string(),
+        ]));
+    }
+    if import_needs.runtime.numeric.needs_decimal {
+        items.push(RustItem::Use(vec![
+            "rust_decimal".to_string(),
+            "Decimal".to_string(),
+        ]));
+    }
+    if import_needs.runtime.numeric.needs_bigdecimal {
+        items.push(RustItem::Use(vec![
+            "bigdecimal".to_string(),
+            "BigDecimal".to_string(),
+        ]));
+    }
+    items.extend(emitter.enum_items);
+    publicize_generated_module_source(&Renderer::new().render_file(&RustFile { items }))
 }
 
 fn resolve_exported_rust_opaque_class<'a>(
@@ -261,7 +322,7 @@ fn resolve_exported_generic_class<'a>(
     None
 }
 
-fn register_imported_generic_classes(
+pub(crate) fn register_imported_generic_classes(
     code: &mut StdlibCode,
     module: &HirModule,
     project_modules: &HashMap<&str, &HirModule>,
@@ -312,6 +373,9 @@ pub fn generate_rust_multi_with_metadata(
         .module_class_fields
         .extend(project_class_fields(modules));
     let union_usage = project_union_usage(modules, &project_codegen_code);
+    let crate_root_modules = HashSet::from(["main"]);
+    let nominal_type_paths = project_nominal_type_paths(modules, &crate_root_modules);
+    let project_union_prelude = render_project_union_prelude(&union_usage, &nominal_type_paths);
 
     for (module_name, module) in modules {
         let module_public = *module_name != "main";
@@ -322,16 +386,7 @@ pub fn generate_rust_multi_with_metadata(
             .get(*module_name)
             .cloned()
             .unwrap_or_default();
-        let owned_unions = used_unions
-            .iter()
-            .filter(|name| {
-                union_usage
-                    .owners
-                    .get(*name)
-                    .is_some_and(|owner| owner == module_name)
-            })
-            .cloned()
-            .collect::<HashSet<_>>();
+        let owned_unions = HashSet::new();
         let codegen_result = generate_rust_with_stdlib_for_module_with_project_policy(
             module,
             &module_codegen_code,
@@ -342,8 +397,7 @@ pub fn generate_rust_multi_with_metadata(
             Some(&union_usage.try_error_unions),
         );
         let local_imports = render_local_module_imports(module, &project_modules);
-        let union_imports =
-            render_project_union_imports(module_name, &used_unions, &union_usage.owners);
+        let union_imports = render_project_union_imports(module_name, &used_unions);
         let mut rust_source = codegen_result.rust_source;
         let imports = [local_imports, union_imports]
             .into_iter()
@@ -368,6 +422,7 @@ pub fn generate_rust_multi_with_metadata(
 
     MultiModuleCodegenResult {
         rust_files: files,
+        project_union_prelude,
         used_stdlib_modules,
         required_features,
         interop: crate::rust_interop_plan::interop_build_plan_for_named_modules(
@@ -486,8 +541,30 @@ mod tests {
         }
     }
 
+    fn error_class(name: &str) -> HirClass {
+        HirClass {
+            name: name.to_string(),
+            identity: Some(format!("errors.{name}")),
+            fields: vec![("message".to_string(), sifr_type_system::Type::Str)],
+            field_defaults: Vec::new(),
+            declaration_metadata: Vec::new(),
+            methods: Vec::new(),
+            is_hashable: true,
+            is_error_type: true,
+            kind: HirClassKind::Regular,
+            operator_impls: Vec::new(),
+            newtype_inner: None,
+            implements_protocols: Vec::new(),
+            parent_class: Some("Error".to_string()),
+            parent_type: None,
+            type_params: Vec::new(),
+            enum_variants: Vec::new(),
+            rust_interop: Vec::new(),
+        }
+    }
+
     #[test]
-    fn project_unions_have_one_owner_and_are_imported_by_other_modules() {
+    fn project_unions_have_one_crate_root_definition() {
         let union = sifr_type_system::Type::Union(vec![
             sifr_type_system::Type::Int,
             sifr_type_system::Type::Str,
@@ -508,23 +585,25 @@ mod tests {
             &StdlibCode::default(),
         );
         let provider_source = &generated.rust_files["provider"];
-        let consumer_source = &generated.rust_files["main"];
-
         assert!(
-            provider_source.contains(&format!("pub enum {enum_name}")),
-            "{provider_source}"
+            generated
+                .project_union_prelude
+                .contains(&format!("pub enum {enum_name}")),
+            "{}",
+            generated.project_union_prelude
         );
         assert_eq!(
-            provider_source
+            generated
+                .project_union_prelude
                 .matches(&format!("enum {enum_name}"))
                 .count(),
             1
         );
         assert!(
-            consumer_source.contains(&format!("use crate::provider::{enum_name};")),
-            "{consumer_source}"
+            provider_source.contains(&format!("use crate::{enum_name};")),
+            "{provider_source}"
         );
-        assert!(!consumer_source.contains(&format!("enum {enum_name}")));
+        assert!(!generated.rust_files["main"].contains(&format!("enum {enum_name}")));
     }
 
     #[test]
@@ -542,7 +621,9 @@ mod tests {
             &StdlibCode::default(),
         );
 
-        assert!(generated.rust_files["main"].contains(&format!("enum {enum_name}")));
+        assert!(generated
+            .project_union_prelude
+            .contains(&format!("enum {enum_name}")));
         assert!(
             generated.rust_files["support"].contains(&format!("use crate::{enum_name};")),
             "{}",
@@ -551,7 +632,7 @@ mod tests {
     }
 
     #[test]
-    fn dotted_union_owner_is_imported_through_its_module_path() {
+    fn dotted_union_user_imports_the_crate_root_definition() {
         let union = sifr_type_system::Type::Union(vec![
             sifr_type_system::Type::Int,
             sifr_type_system::Type::Str,
@@ -573,14 +654,14 @@ mod tests {
         );
 
         assert!(
-            generated.rust_files["main"].contains(&format!("use crate::pkg::errors::{enum_name};")),
+            generated.rust_files["pkg.errors"].contains(&format!("use crate::{enum_name};")),
             "{}",
-            generated.rust_files["main"]
+            generated.rust_files["pkg.errors"]
         );
     }
 
     #[test]
-    fn owner_combines_try_carrier_conversions_with_ordinary_union_traits() {
+    fn root_prelude_combines_try_conversions_with_ordinary_union_traits() {
         let first = error_type("FirstError");
         let second = error_type("SecondError");
         let union = sifr_type_system::Type::Union(vec![first.clone(), second.clone()]);
@@ -603,25 +684,52 @@ mod tests {
             &[("errors", &owner), ("main", &consumer)],
             &StdlibCode::default(),
         );
-        let owner_source = &generated.rust_files["errors"];
+        let prelude = &generated.project_union_prelude;
 
         assert!(
-            owner_source.contains("#[derive(Debug, Clone, PartialEq, Eq, Hash)]"),
-            "{owner_source}"
+            prelude.contains("#[derive(Debug, Clone, PartialEq, Eq, Hash)]"),
+            "{prelude}"
         );
         assert!(
-            owner_source.contains("impl From<FirstError>")
-                && owner_source.contains(&format!("for {enum_name}")),
-            "{owner_source}"
+            prelude.contains("impl From<FirstError>")
+                && prelude.contains(&format!("for {enum_name}")),
+            "{prelude}"
+        );
+        assert!(prelude.contains("impl From<SecondError>"), "{prelude}");
+    }
+
+    #[test]
+    fn root_prelude_uses_crate_rooted_nominal_payload_paths() {
+        let first = error_type("FirstError");
+        let second = error_type("SecondError");
+        let union = sifr_type_system::Type::Union(vec![first, second]);
+        let mut errors = module_with(vec![empty_function("produce", union.clone())], Vec::new());
+        errors.classes = vec![error_class("FirstError"), error_class("SecondError")];
+        let unrelated = module_with(vec![empty_function("consume", union)], Vec::new());
+
+        let generated = generate_rust_multi_with_metadata(
+            &[("app", &unrelated), ("errors", &errors)],
+            &StdlibCode::default(),
+        );
+
+        assert!(
+            generated
+                .project_union_prelude
+                .contains("crate::errors::FirstError"),
+            "{}",
+            generated.project_union_prelude
         );
         assert!(
-            owner_source.contains("impl From<SecondError>"),
-            "{owner_source}"
+            generated
+                .project_union_prelude
+                .contains("crate::errors::SecondError"),
+            "{}",
+            generated.project_union_prelude
         );
     }
 
     #[test]
-    fn owner_election_distinguishes_non_class_nominal_identities() {
+    fn root_union_plan_distinguishes_non_class_nominal_identities() {
         let nominal_pairs = [
             (
                 sifr_type_system::Type::Newtype {
@@ -681,9 +789,7 @@ mod tests {
                 &StdlibCode::default(),
             );
 
-            assert_eq!(usage.owners.len(), 2, "{:?}", usage.owners);
-            assert!(usage.owners.values().any(|owner| owner == "left"));
-            assert!(usage.owners.values().any(|owner| owner == "right"));
+            assert_eq!(usage.unions.len(), 2, "{:?}", usage.unions);
         }
     }
 

--- a/crates/sifr_codegen/src/lib_project_signatures.rs
+++ b/crates/sifr_codegen/src/lib_project_signatures.rs
@@ -1,5 +1,8 @@
-use crate::{module_func_signatures, HirModule, ModuleFuncSignatures};
+use crate::{module_class_fields, module_func_signatures, HirModule, ModuleFuncSignatures};
+use sifr_type_system::Type;
 use std::collections::HashMap;
+
+pub(crate) type ProjectClassFields = HashMap<String, HashMap<String, Vec<(String, Type)>>>;
 
 pub(crate) fn project_func_signatures(
     modules: &[(&str, &HirModule)],
@@ -44,4 +47,40 @@ pub(crate) fn project_func_signatures(
         }
     }
     signatures
+}
+
+pub(crate) fn project_class_fields(modules: &[(&str, &HirModule)]) -> ProjectClassFields {
+    let mut fields = modules
+        .iter()
+        .map(|(name, module)| ((*name).to_string(), module_class_fields(module)))
+        .collect::<ProjectClassFields>();
+    for _ in 0..modules.len() {
+        let previous = fields.clone();
+        let mut changed = false;
+        for (module_name, module) in modules {
+            let target = fields.entry((*module_name).to_string()).or_default();
+            for import in &module.imports {
+                let Some(source) = previous.get(&import.module) else {
+                    continue;
+                };
+                for name in &import.names {
+                    let local = import
+                        .aliases
+                        .iter()
+                        .find(|(original, _)| original == name)
+                        .map_or(name.as_str(), |(_, alias)| alias.as_str());
+                    if let Some(class_fields) = source.get(name) {
+                        changed |= target
+                            .insert(local.to_string(), class_fields.clone())
+                            .as_ref()
+                            != Some(class_fields);
+                    }
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    fields
 }

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -5,12 +5,13 @@ use super::{
 use crate::entrypoints::generate_rust_test_with_project_policy;
 use crate::lib_project_codegen::{
     project_nominal_type_paths, project_union_usage, register_imported_generic_classes,
-    render_local_module_imports, render_project_union_imports, render_project_union_prelude,
+    render_local_module_imports, render_project_union_imports,
 };
 use crate::lib_project_signatures::{project_class_fields, project_func_signatures};
 use crate::project_stdlib_nominals::{
     project_stdlib_nominal_plan, relocate_project_stdlib_nominals,
 };
+use crate::project_union_prelude::render_project_union_prelude;
 use sifr_stdlib_manifest::StdlibFeature;
 
 /// Generated Rust sources and aggregate dependency metadata for one test crate.

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -41,7 +41,8 @@ pub fn generate_rust_test_project_with_metadata(
         .module_class_fields
         .extend(project_class_fields(&all_modules));
     let union_usage = project_union_usage(&all_modules, &project_code);
-    let stdlib_nominal_plan = project_stdlib_nominal_plan(&union_usage.unions, stdlib_code);
+    let stdlib_nominal_plan =
+        project_stdlib_nominal_plan(&union_usage.unions, stdlib_code, &all_modules);
     let crate_root_modules = test_modules
         .iter()
         .map(|(module_name, _)| *module_name)

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -1,0 +1,117 @@
+use super::{
+    generate_rust_with_stdlib_for_module_with_project_policy, publicize_generated_module_source,
+    HashMap, HashSet, HirModule, StdlibCode,
+};
+use crate::entrypoints::generate_rust_test_with_project_policy;
+use crate::lib_project_codegen::{
+    project_nominal_type_paths, project_union_usage, register_imported_generic_classes,
+    render_local_module_imports, render_project_union_imports, render_project_union_prelude,
+};
+use crate::lib_project_signatures::{project_class_fields, project_func_signatures};
+use sifr_stdlib_manifest::StdlibFeature;
+
+/// Generated Rust sources and aggregate dependency metadata for one test crate.
+pub struct TestProjectCodegenResult {
+    pub support_rust_files: HashMap<String, String>,
+    pub test_rust_files: HashMap<String, String>,
+    pub project_union_prelude: String,
+    pub used_stdlib_modules: HashSet<String>,
+    pub required_features: HashSet<StdlibFeature>,
+}
+
+/// Generate support modules and root-level test bodies under one project union policy.
+pub fn generate_rust_test_project_with_metadata(
+    support_modules: &[(&str, &HirModule)],
+    test_modules: &[(&str, &HirModule)],
+    stdlib_code: &StdlibCode,
+) -> TestProjectCodegenResult {
+    let mut all_modules = Vec::with_capacity(support_modules.len() + test_modules.len());
+    all_modules.extend_from_slice(support_modules);
+    all_modules.extend_from_slice(test_modules);
+
+    let mut project_code = stdlib_code.clone();
+    project_code
+        .func_signatures
+        .extend(project_func_signatures(&all_modules));
+    project_code
+        .module_class_fields
+        .extend(project_class_fields(&all_modules));
+    let union_usage = project_union_usage(&all_modules, &project_code);
+    let crate_root_modules = test_modules
+        .iter()
+        .map(|(module_name, _)| *module_name)
+        .collect::<HashSet<_>>();
+    let nominal_type_paths = project_nominal_type_paths(&all_modules, &crate_root_modules);
+    let project_union_prelude = render_project_union_prelude(&union_usage, &nominal_type_paths);
+    let project_modules = all_modules.iter().copied().collect::<HashMap<_, _>>();
+    let structural_interop_enabled = all_modules
+        .iter()
+        .any(|(_, module)| crate::rust_interop_plan::module_uses_structural_interop(module));
+    let all_union_names = union_usage.unions.keys().cloned().collect::<HashSet<_>>();
+
+    let mut support_rust_files = HashMap::new();
+    let mut test_rust_files = HashMap::new();
+    let mut used_stdlib_modules = HashSet::new();
+    let mut required_features = HashSet::new();
+
+    for (module_name, module) in support_modules {
+        let mut module_code = project_code.clone();
+        register_imported_generic_classes(&mut module_code, module, &project_modules);
+        let used_unions = union_usage
+            .module_unions
+            .get(*module_name)
+            .cloned()
+            .unwrap_or_default();
+        let generated = generate_rust_with_stdlib_for_module_with_project_policy(
+            module,
+            &module_code,
+            Some(module_name),
+            structural_interop_enabled,
+            Some(&HashSet::new()),
+            Some(&union_usage.ordinary_unions),
+            Some(&union_usage.try_error_unions),
+        );
+        let imports = [
+            render_local_module_imports(module, &project_modules),
+            render_project_union_imports(module_name, &used_unions),
+        ]
+        .into_iter()
+        .filter(|source| !source.trim().is_empty())
+        .map(|source| source.trim_end().to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+        let source = if imports.is_empty() {
+            generated.rust_source
+        } else {
+            format!("{imports}\n\n{}", generated.rust_source)
+        };
+        support_rust_files.insert(
+            (*module_name).to_string(),
+            publicize_generated_module_source(&source),
+        );
+        used_stdlib_modules.extend(generated.used_stdlib_modules);
+        required_features.extend(generated.required_features);
+    }
+
+    for (module_name, module) in test_modules {
+        let generated = generate_rust_test_with_project_policy(
+            module,
+            module_name,
+            &project_code,
+            Some(&all_union_names),
+            Some(&union_usage.ordinary_unions),
+            Some(&union_usage.try_error_unions),
+        );
+        test_rust_files.insert((*module_name).to_string(), generated.rust_source);
+        used_stdlib_modules.extend(generated.used_stdlib_modules);
+        required_features.extend(generated.required_features);
+    }
+
+    TestProjectCodegenResult {
+        support_rust_files,
+        test_rust_files,
+        project_union_prelude,
+        used_stdlib_modules,
+        required_features,
+    }
+}

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -8,6 +8,9 @@ use crate::lib_project_codegen::{
     render_local_module_imports, render_project_union_imports, render_project_union_prelude,
 };
 use crate::lib_project_signatures::{project_class_fields, project_func_signatures};
+use crate::project_stdlib_nominals::{
+    project_stdlib_nominal_plan, relocate_project_stdlib_nominals,
+};
 use sifr_stdlib_manifest::StdlibFeature;
 
 /// Generated Rust sources and aggregate dependency metadata for one test crate.
@@ -37,12 +40,20 @@ pub fn generate_rust_test_project_with_metadata(
         .module_class_fields
         .extend(project_class_fields(&all_modules));
     let union_usage = project_union_usage(&all_modules, &project_code);
+    let stdlib_nominal_plan = project_stdlib_nominal_plan(&union_usage.unions, stdlib_code);
     let crate_root_modules = test_modules
         .iter()
         .map(|(module_name, _)| *module_name)
         .collect::<HashSet<_>>();
-    let nominal_type_paths = project_nominal_type_paths(&all_modules, &crate_root_modules);
-    let project_union_prelude = render_project_union_prelude(&union_usage, &nominal_type_paths);
+    let mut nominal_type_paths = project_nominal_type_paths(&all_modules, &crate_root_modules);
+    nominal_type_paths.extend(stdlib_nominal_plan.nominal_paths.clone());
+    let union_prelude = render_project_union_prelude(&union_usage, &nominal_type_paths);
+    let project_union_prelude = [stdlib_nominal_plan.prelude.as_str(), union_prelude.as_str()]
+        .into_iter()
+        .filter(|source| !source.trim().is_empty())
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n\n");
     let project_modules = all_modules.iter().copied().collect::<HashMap<_, _>>();
     let structural_interop_enabled = all_modules
         .iter()
@@ -51,8 +62,8 @@ pub fn generate_rust_test_project_with_metadata(
 
     let mut support_rust_files = HashMap::new();
     let mut test_rust_files = HashMap::new();
-    let mut used_stdlib_modules = HashSet::new();
-    let mut required_features = HashSet::new();
+    let mut used_stdlib_modules = stdlib_nominal_plan.used_stdlib_modules.clone();
+    let mut required_features = stdlib_nominal_plan.required_features.clone();
 
     for (module_name, module) in support_modules {
         let mut module_code = project_code.clone();
@@ -85,6 +96,7 @@ pub fn generate_rust_test_project_with_metadata(
         } else {
             format!("{imports}\n\n{}", generated.rust_source)
         };
+        let source = relocate_project_stdlib_nominals(&source, module_name, &stdlib_nominal_plan);
         support_rust_files.insert(
             (*module_name).to_string(),
             publicize_generated_module_source(&source),

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -86,7 +86,7 @@ pub fn generate_rust_test_project_with_metadata(
         );
         let imports = [
             render_local_module_imports(module, &project_modules),
-            render_project_union_imports(module_name, &used_unions),
+            render_project_union_imports(module_name, &used_unions, &crate_root_modules),
         ]
         .into_iter()
         .filter(|source| !source.trim().is_empty())
@@ -98,7 +98,12 @@ pub fn generate_rust_test_project_with_metadata(
         } else {
             format!("{imports}\n\n{}", generated.rust_source)
         };
-        let source = relocate_project_stdlib_nominals(&source, module_name, &stdlib_nominal_plan);
+        let source = relocate_project_stdlib_nominals(
+            &source,
+            module_name,
+            &stdlib_nominal_plan,
+            &crate_root_modules,
+        );
         support_rust_files.insert(
             (*module_name).to_string(),
             publicize_generated_module_source(&source),

--- a/crates/sifr_codegen/src/lower_expr/leaves_and_compound_tests.rs
+++ b/crates/sifr_codegen/src/lower_expr/leaves_and_compound_tests.rs
@@ -17,6 +17,7 @@ pub(super) fn lowers_leaf_expr_variants() {
         enum_name: "Color".to_string(),
         variant: "RED".to_string(),
         ty: sifr_type_system::Type::Enum {
+            identity: None,
             name: "Color".to_string(),
             variants: vec![("RED".to_string(), Some(1))],
         },
@@ -155,6 +156,7 @@ pub(super) fn lowers_bool_and_enum_name_leaf_expr_variants() {
     })
     .expect("alias-bool name lowered");
     let enum_ty = Type::Enum {
+        identity: None,
         name: "Mode".to_string(),
         variants: vec![("A".to_string(), Some(1)), ("B".to_string(), Some(2))],
     };

--- a/crates/sifr_codegen/src/lower_expr/option_compare_tests.rs
+++ b/crates/sifr_codegen/src/lower_expr/option_compare_tests.rs
@@ -232,6 +232,7 @@ pub(super) fn does_not_lower_mismatched_string_int_compare() {
 #[test]
 pub(super) fn lowers_enum_variant_equality_compare() {
     let enum_ty = Type::Enum {
+        identity: None,
         name: "Color".to_string(),
         variants: vec![("RED".to_string(), Some(1)), ("BLUE".to_string(), Some(2))],
     };
@@ -260,6 +261,7 @@ pub(super) fn lowers_enum_variant_equality_compare() {
 #[test]
 pub(super) fn does_not_lower_enum_variant_ordering_compare() {
     let enum_ty = Type::Enum {
+        identity: None,
         name: "Color".to_string(),
         variants: vec![("RED".to_string(), Some(1)), ("BLUE".to_string(), Some(2))],
     };
@@ -286,6 +288,7 @@ pub(super) fn lowers_alias_wrapped_enum_variant_equality_compare() {
     let alias_enum_ty = Type::alias(
         "ColorAlias",
         Type::Enum {
+            identity: None,
             name: "Color".to_string(),
             variants: vec![("RED".to_string(), Some(1)), ("BLUE".to_string(), Some(2))],
         },
@@ -317,6 +320,7 @@ pub(super) fn does_not_lower_alias_wrapped_enum_variant_ordering_compare() {
     let alias_enum_ty = Type::alias(
         "ColorAlias",
         Type::Enum {
+            identity: None,
             name: "Color".to_string(),
             variants: vec![("RED".to_string(), Some(1)), ("BLUE".to_string(), Some(2))],
         },

--- a/crates/sifr_codegen/src/lower_stmt/binding_tests.rs
+++ b/crates/sifr_codegen/src/lower_stmt/binding_tests.rs
@@ -191,6 +191,7 @@ fn lowers_simple_let_alias_enum_name_rhs() {
     let alias_enum = Type::alias(
         "ColorAlias",
         Type::Enum {
+            identity: None,
             name: "Color".to_string(),
             variants: vec![("RED".to_string(), Some(1)), ("BLUE".to_string(), Some(2))],
         },

--- a/crates/sifr_codegen/src/project_stdlib_nominals.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals.rs
@@ -1,7 +1,7 @@
 use crate::stdlib_filter::strip_rust_items_by_name;
 use crate::{
-    generate_rust_with_stdlib_for_module_with_structural_policy, publicize_generated_module_source,
-    HirModule, StdlibCode,
+    build_error_into_error_impl, generate_rust_with_stdlib_for_module_with_structural_policy,
+    publicize_generated_module_source, HirModule, Renderer, RustFile, StdlibCode,
 };
 use sifr_ir::{HirExpr, HirFunction, HirImport, HirStmt, MethodKind};
 use sifr_stdlib_manifest::StdlibFeature;
@@ -60,12 +60,26 @@ pub(crate) fn relocate_project_stdlib_nominals(
 pub(crate) fn project_stdlib_nominal_plan(
     unions: &HashMap<String, Vec<Type>>,
     stdlib_code: &StdlibCode,
+    modules: &[(&str, &HirModule)],
 ) -> ProjectStdlibNominalPlan {
     let mut declarations = BTreeMap::<String, HashSet<String>>::new();
     let mut builtin_types = BTreeMap::<String, Type>::new();
     for members in unions.values() {
         for member in members {
             collect_shared_nominals(member, &mut declarations, &mut builtin_types);
+        }
+    }
+    let mut python_error_rust_names = HashSet::new();
+    if builtin_types.contains_key("Error") {
+        for (_, module) in modules {
+            if !crate::python_interop_common::module_uses_async_python_declaration(module) {
+                continue;
+            }
+            for (rust_name, ty) in crate::python_interop_common::python_error_contract_types(module)
+            {
+                collect_shared_nominals(&ty, &mut declarations, &mut builtin_types);
+                python_error_rust_names.insert(rust_name);
+            }
         }
     }
     if declarations.is_empty() && builtin_types.is_empty() {
@@ -143,7 +157,16 @@ pub(crate) fn project_stdlib_nominal_plan(
     );
     let probe_name_refs = probe_names.iter().map(String::as_str).collect();
     let shared_source = strip_rust_items_by_name(&generated.rust_source, &probe_name_refs);
-    let shared_source = publicize_generated_module_source(&shared_source);
+    let mut shared_source = publicize_generated_module_source(&shared_source);
+    if !python_error_rust_names.is_empty() {
+        let mut names = python_error_rust_names.into_iter().collect::<Vec<_>>();
+        names.sort();
+        let items = names
+            .iter()
+            .map(|name| build_error_into_error_impl(name))
+            .collect();
+        shared_source.push_str(&Renderer::new().render_file(&RustFile { items }));
+    }
     let mut prelude = format!("mod {SHARED_STDLIB_NOMINAL_MODULE} {{\n");
     for line in shared_source.lines() {
         prelude.push_str("    ");

--- a/crates/sifr_codegen/src/project_stdlib_nominals.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals.rs
@@ -1,0 +1,287 @@
+use crate::stdlib_filter::strip_rust_items_by_name;
+use crate::{
+    generate_rust_with_stdlib_for_module_with_structural_policy, publicize_generated_module_source,
+    HirModule, StdlibCode,
+};
+use sifr_ir::{HirExpr, HirFunction, HirImport, HirStmt, MethodKind};
+use sifr_stdlib_manifest::StdlibFeature;
+use sifr_type_system::{class_rust_name, is_global_rust_nominal_identity, FunctionType, Type};
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+const SHARED_STDLIB_NOMINAL_MODULE: &str = "__sifr_project_nominals";
+
+pub(crate) struct ProjectStdlibNominalPlan {
+    pub(crate) prelude: String,
+    pub(crate) rust_names: HashSet<String>,
+    pub(crate) nominal_paths: HashMap<String, String>,
+    pub(crate) used_stdlib_modules: HashSet<String>,
+    pub(crate) required_features: HashSet<StdlibFeature>,
+}
+
+impl ProjectStdlibNominalPlan {
+    pub(crate) fn empty() -> Self {
+        Self {
+            prelude: String::new(),
+            rust_names: HashSet::new(),
+            nominal_paths: HashMap::new(),
+            used_stdlib_modules: HashSet::new(),
+            required_features: HashSet::new(),
+        }
+    }
+}
+
+pub(crate) fn relocate_project_stdlib_nominals(
+    source: &str,
+    module_name: &str,
+    plan: &ProjectStdlibNominalPlan,
+) -> String {
+    if plan.rust_names.is_empty() {
+        return source.to_string();
+    }
+    let names = plan.rust_names.iter().map(String::as_str).collect();
+    let stripped = strip_rust_items_by_name(source, &names);
+    if module_name == "main" {
+        return stripped;
+    }
+    let mut ordered_names = plan.rust_names.iter().collect::<Vec<_>>();
+    ordered_names.sort();
+    let mut imports = String::new();
+    for name in ordered_names {
+        if !stripped.contains(name) {
+            continue;
+        }
+        imports.push_str("use crate::");
+        imports.push_str(name);
+        imports.push_str(";\n");
+    }
+    format!("{imports}\n{stripped}")
+}
+
+pub(crate) fn project_stdlib_nominal_plan(
+    unions: &HashMap<String, Vec<Type>>,
+    stdlib_code: &StdlibCode,
+) -> ProjectStdlibNominalPlan {
+    let mut declarations = BTreeMap::<String, HashSet<String>>::new();
+    let mut builtin_types = BTreeMap::<String, Type>::new();
+    for members in unions.values() {
+        for member in members {
+            collect_shared_nominals(member, &mut declarations, &mut builtin_types);
+        }
+    }
+    if declarations.is_empty() && builtin_types.is_empty() {
+        return ProjectStdlibNominalPlan::empty();
+    }
+
+    let mut imports = Vec::new();
+    let mut rust_names = HashSet::new();
+    let mut nominal_paths = HashMap::new();
+    for (module, names) in declarations {
+        let mut names = names.into_iter().collect::<Vec<_>>();
+        names.sort();
+        for name in &names {
+            let identity = format!("{module}.{name}");
+            let rust_name = class_rust_name(Some(&identity), name);
+            rust_names.insert(rust_name.clone());
+            nominal_paths.insert(identity, format!("crate::{rust_name}"));
+        }
+        imports.push(HirImport {
+            module,
+            names,
+            aliases: Vec::new(),
+        });
+    }
+    let mut probe_names = HashSet::new();
+    let mut functions = Vec::new();
+    for (index, (name, ty)) in builtin_types.into_iter().enumerate() {
+        let probe_name = format!("__sifr_project_builtin_nominal_{index}");
+        probe_names.insert(probe_name.clone());
+        let rust_name = class_rust_name(None, &name);
+        rust_names.insert(rust_name.clone());
+        let rust_path = format!("crate::{rust_name}");
+        if let Type::Class {
+            identity: Some(identity),
+            ..
+        } = &ty
+        {
+            nominal_paths.insert(identity.clone(), rust_path.clone());
+        }
+        nominal_paths.insert(name, rust_path);
+        functions.push(HirFunction {
+            name: probe_name,
+            params: Vec::new(),
+            return_type: ty.clone(),
+            body: vec![HirStmt::Raise {
+                value: HirExpr::Name {
+                    name: "__sifr_project_builtin_probe_value".to_string(),
+                    binding_id: None,
+                    ty,
+                },
+            }],
+            is_async: false,
+            method_kind: MethodKind::Regular,
+            receiver: None,
+            decorators: Vec::new(),
+            rust_interop: Vec::new(),
+            python_interop: Vec::new(),
+            compiler_intrinsic: None,
+            type_params: Vec::new(),
+        });
+    }
+    let synthetic_module = HirModule {
+        functions,
+        classes: Vec::new(),
+        imports,
+        constants: Vec::new(),
+        generic_functions: HashMap::new(),
+        type_param_bounds: HashMap::new(),
+    };
+    let generated = generate_rust_with_stdlib_for_module_with_structural_policy(
+        &synthetic_module,
+        stdlib_code,
+        Some("main"),
+        false,
+    );
+    let probe_name_refs = probe_names.iter().map(String::as_str).collect();
+    let shared_source = strip_rust_items_by_name(&generated.rust_source, &probe_name_refs);
+    let shared_source = publicize_generated_module_source(&shared_source);
+    let mut prelude = format!("mod {SHARED_STDLIB_NOMINAL_MODULE} {{\n");
+    for line in shared_source.lines() {
+        prelude.push_str("    ");
+        prelude.push_str(line);
+        prelude.push('\n');
+    }
+    prelude.push_str("}\n");
+    let mut ordered_names = rust_names.iter().collect::<Vec<_>>();
+    ordered_names.sort();
+    for name in ordered_names {
+        prelude.push_str("pub use ");
+        prelude.push_str(SHARED_STDLIB_NOMINAL_MODULE);
+        prelude.push_str("::");
+        prelude.push_str(name);
+        prelude.push_str(";\n");
+    }
+
+    ProjectStdlibNominalPlan {
+        prelude,
+        rust_names,
+        nominal_paths,
+        used_stdlib_modules: generated.used_stdlib_modules,
+        required_features: generated.required_features,
+    }
+}
+
+fn collect_function_nominals(
+    function: &FunctionType,
+    declarations: &mut BTreeMap<String, HashSet<String>>,
+    builtin_types: &mut BTreeMap<String, Type>,
+) {
+    for (_, parameter, _) in &function.params {
+        collect_shared_nominals(parameter, declarations, builtin_types);
+    }
+    collect_shared_nominals(&function.return_type, declarations, builtin_types);
+}
+
+fn collect_shared_nominals(
+    ty: &Type,
+    declarations: &mut BTreeMap<String, HashSet<String>>,
+    builtin_types: &mut BTreeMap<String, Type>,
+) {
+    match ty.resolve_alias() {
+        class @ Type::Class {
+            identity,
+            type_args,
+            name,
+            ..
+        } => {
+            if crate::BUILTIN_ERROR_CLASSES.contains(&name.as_str()) {
+                builtin_types
+                    .entry(name.clone())
+                    .or_insert_with(|| class.clone());
+            }
+            if !class.is_python_object_contract() && !class.is_python_resource_identity_contract() {
+                collect_nominal_identity(identity.as_deref(), declarations);
+            }
+            for type_arg in type_args {
+                collect_shared_nominals(type_arg, declarations, builtin_types);
+            }
+        }
+        Type::Protocol {
+            identity, methods, ..
+        } => {
+            collect_nominal_identity(identity.as_deref(), declarations);
+            for (_, method) in methods {
+                collect_function_nominals(method, declarations, builtin_types);
+            }
+        }
+        Type::Newtype {
+            identity, inner, ..
+        } => {
+            collect_nominal_identity(identity.as_deref(), declarations);
+            collect_shared_nominals(inner, declarations, builtin_types);
+        }
+        Type::Enum { identity, .. } => collect_nominal_identity(identity.as_deref(), declarations),
+        Type::List(inner)
+        | Type::Set(inner)
+        | Type::Iterable(inner)
+        | Type::Iterator(inner)
+        | Type::Awaitable(inner)
+        | Type::Failure(inner)
+        | Type::TimeoutResult(inner)
+        | Type::PythonBuffer(inner)
+        | Type::PythonDlpackTensor(inner) => {
+            collect_shared_nominals(inner, declarations, builtin_types);
+        }
+        Type::Dict(left, right)
+        | Type::Result(left, right)
+        | Type::Coroutine(left, right)
+        | Type::Task(left, right)
+        | Type::TaskResult(left, right)
+        | Type::Select2(left, right)
+        | Type::BlockingTask(left, right)
+        | Type::JoinSet(left, right)
+        | Type::AsyncIterator(left, right)
+        | Type::AsyncGenerator(left, right) => {
+            collect_shared_nominals(left, declarations, builtin_types);
+            collect_shared_nominals(right, declarations, builtin_types);
+        }
+        Type::Tuple(items) | Type::Union(items) | Type::Intersection(items) => {
+            for item in items {
+                collect_shared_nominals(item, declarations, builtin_types);
+            }
+        }
+        Type::Function(function) | Type::AsyncFunction(function) => {
+            collect_function_nominals(function, declarations, builtin_types);
+        }
+        Type::Callable(parameters, _, result) | Type::AsyncCallable(parameters, _, result) => {
+            for parameter in parameters {
+                collect_shared_nominals(parameter, declarations, builtin_types);
+            }
+            collect_shared_nominals(result, declarations, builtin_types);
+        }
+        _ => {}
+    }
+}
+
+fn collect_nominal_identity(
+    identity: Option<&str>,
+    declarations: &mut BTreeMap<String, HashSet<String>>,
+) {
+    let Some(identity) = identity else {
+        return;
+    };
+    if is_global_rust_nominal_identity(identity)
+        || (!identity.starts_with("sifr.") && !identity.starts_with("_sifr."))
+    {
+        return;
+    }
+    let Some((module, name)) = identity.rsplit_once('.') else {
+        return;
+    };
+    if crate::BUILTIN_ERROR_CLASSES.contains(&name) {
+        return;
+    }
+    declarations
+        .entry(module.to_string())
+        .or_default()
+        .insert(name.to_string());
+}

--- a/crates/sifr_codegen/src/project_stdlib_nominals.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals.rs
@@ -34,13 +34,14 @@ pub(crate) fn relocate_project_stdlib_nominals(
     source: &str,
     module_name: &str,
     plan: &ProjectStdlibNominalPlan,
+    crate_root_modules: &HashSet<&str>,
 ) -> String {
     if plan.rust_names.is_empty() {
         return source.to_string();
     }
     let names = plan.rust_names.iter().map(String::as_str).collect();
     let stripped = strip_rust_items_by_name(source, &names);
-    if module_name == "main" {
+    if crate_root_modules.contains(module_name) {
         return stripped;
     }
     let mut ordered_names = plan.rust_names.iter().collect::<Vec<_>>();

--- a/crates/sifr_codegen/src/project_union_prelude.rs
+++ b/crates/sifr_codegen/src/project_union_prelude.rs
@@ -1,0 +1,84 @@
+use crate::ir_imports::collect_import_needs_from_items;
+use crate::lib_project_codegen::ProjectUnionUsage;
+use crate::{publicize_generated_module_source, HashMap, Renderer, RustFile, RustItem};
+use std::fmt::Write;
+
+const PROJECT_UNION_MODULE: &str = "__sifr_project_unions";
+
+pub(crate) fn render_project_union_prelude(
+    usage: &ProjectUnionUsage,
+    nominal_type_paths: &HashMap<String, String>,
+) -> String {
+    if usage.unions.is_empty() {
+        return String::new();
+    }
+    let mut emitter = crate::RustEmitter::new();
+    emitter.union_enums.clone_from(&usage.unions);
+    emitter
+        .ordinary_union_enums
+        .clone_from(&usage.ordinary_unions);
+    emitter
+        .try_error_carrier_enums
+        .clone_from(&usage.try_error_unions);
+    emitter
+        .project_nominal_type_paths
+        .clone_from(nominal_type_paths);
+    emitter.generate_enum_definitions();
+
+    let import_needs = collect_import_needs_from_items(&emitter.enum_items);
+    let mut imports = Vec::new();
+    let mut add_import = |needed: bool, path: &[&str]| {
+        if needed {
+            imports.push(RustItem::Use(
+                path.iter().map(|part| (*part).to_string()).collect(),
+            ));
+        }
+    };
+    add_import(
+        import_needs.collections.needs_hashmap,
+        &["std", "collections", "HashMap"],
+    );
+    add_import(
+        import_needs.collections.needs_hashset,
+        &["std", "collections", "HashSet"],
+    );
+    add_import(
+        import_needs.collections.needs_vecdeque,
+        &["std", "collections", "VecDeque"],
+    );
+    add_import(
+        import_needs.runtime.numeric.needs_bigint,
+        &["num_bigint", "BigInt"],
+    );
+    add_import(
+        import_needs.runtime.numeric.needs_decimal,
+        &["rust_decimal", "Decimal"],
+    );
+    add_import(
+        import_needs.runtime.numeric.needs_bigdecimal,
+        &["bigdecimal", "BigDecimal"],
+    );
+    add_import(
+        import_needs.runtime.needs_sifr_int,
+        &["", "sifr_runtime", "SifrInt"],
+    );
+    add_import(import_needs.runtime.needs_mutex, &["std", "sync", "Mutex"]);
+
+    let import_source = Renderer::new().render_file(&RustFile { items: imports });
+    let enum_source = publicize_generated_module_source(&Renderer::new().render_file(&RustFile {
+        items: emitter.enum_items,
+    }));
+    let mut prelude = format!("mod {PROJECT_UNION_MODULE} {{\n");
+    for line in import_source.lines().chain(enum_source.lines()) {
+        prelude.push_str("    ");
+        prelude.push_str(line);
+        prelude.push('\n');
+    }
+    prelude.push_str("}\n");
+    let mut names = usage.unions.keys().collect::<Vec<_>>();
+    names.sort();
+    for name in names {
+        let _ = writeln!(prelude, "pub use {PROJECT_UNION_MODULE}::{name};");
+    }
+    prelude
+}

--- a/crates/sifr_codegen/src/python_interop_common.rs
+++ b/crates/sifr_codegen/src/python_interop_common.rs
@@ -31,7 +31,13 @@ pub(crate) fn rust_source_uses_python_runtime(source: &str) -> bool {
 pub(crate) fn python_error_contract_rust_types(
     module: &HirModule,
 ) -> std::collections::BTreeSet<String> {
-    let mut rust_types = std::collections::BTreeSet::new();
+    python_error_contract_types(module).into_keys().collect()
+}
+
+pub(crate) fn python_error_contract_types(
+    module: &HirModule,
+) -> std::collections::BTreeMap<String, Type> {
+    let mut rust_types = std::collections::BTreeMap::new();
     for function in module
         .functions
         .iter()
@@ -44,7 +50,10 @@ pub(crate) fn python_error_contract_rust_types(
     rust_types
 }
 
-fn record_python_error_contract(ty: &Type, rust_types: &mut std::collections::BTreeSet<String>) {
+fn record_python_error_contract(
+    ty: &Type,
+    rust_types: &mut std::collections::BTreeMap<String, Type>,
+) {
     match ty.resolve_alias() {
         Type::Result(_, error) => record_python_error_contract(error, rust_types),
         Type::Union(members) => {
@@ -53,7 +62,9 @@ fn record_python_error_contract(ty: &Type, rust_types: &mut std::collections::BT
             }
         }
         class @ Type::Class { .. } if class.is_python_error_contract() => {
-            rust_types.insert(class.rust_type());
+            rust_types
+                .entry(class.rust_type())
+                .or_insert_with(|| class.clone());
         }
         _ => {}
     }

--- a/crates/sifr_codegen/src/rust_interop_bridge_contract.rs
+++ b/crates/sifr_codegen/src/rust_interop_bridge_contract.rs
@@ -547,7 +547,7 @@ pub(crate) fn bridge_type_contract(
                 }
             }
         }
-        Type::Enum { name, variants } => {
+        Type::Enum { name, variants, .. } => {
             let declaration_module =
                 match bridge_type_definition_module(name, module_name, module_catalogs, true) {
                     Ok(module_name) => module_name,

--- a/crates/sifr_codegen/src/rust_interop_bridge_contract/generated_types.rs
+++ b/crates/sifr_codegen/src/rust_interop_bridge_contract/generated_types.rs
@@ -137,7 +137,7 @@ impl GeneratedTypeCollector {
                 );
                 generated_class_bridge_type_path(definition_module.as_ref(), class_type)
             }
-            Type::Enum { name, variants } => {
+            Type::Enum { name, variants, .. } => {
                 let definition_module =
                     bridge_type_definition_module(name, module_name, module_catalogs, true)
                         .unwrap_or_else(|_| module_name.cloned());

--- a/crates/sifr_codegen/src/rust_interop_plan_tests.rs
+++ b/crates/sifr_codegen/src/rust_interop_plan_tests.rs
@@ -625,6 +625,7 @@ fn interop_bridge_generated_field_paths_use_declaring_module() {
 #[test]
 fn interop_bridge_rejects_enum_discriminants_outside_repr_u32() {
     let bad_enum = Type::Enum {
+        identity: None,
         name: "Status".to_string(),
         variants: vec![("Broken".to_string(), Some(-1))],
     };

--- a/crates/sifr_codegen/src/stdlib_filter/implementation.rs
+++ b/crates/sifr_codegen/src/stdlib_filter/implementation.rs
@@ -541,6 +541,15 @@ pub(super) fn is_shared_use_path(path: &[String]) -> bool {
         [runtime, symbol]
             if runtime == "sifr_runtime"
                 && symbol == "SifrInt"
+    ) || matches!(
+        path,
+        [numeric_crate, symbol]
+            if matches!(
+                (numeric_crate.as_str(), symbol.as_str()),
+                ("num_bigint", "BigInt")
+                    | ("rust_decimal", "Decimal")
+                    | ("bigdecimal", "BigDecimal")
+            )
     )
 }
 

--- a/crates/sifr_codegen/src/stdlib_filter/tests.rs
+++ b/crates/sifr_codegen/src/stdlib_filter/tests.rs
@@ -355,6 +355,25 @@ fn keep_me() {}
 }
 
 #[test]
+fn strips_numeric_imports_centralized_by_module_codegen() {
+    let input = r#"
+use num_bigint::BigInt;
+use rust_decimal::Decimal;
+use bigdecimal::BigDecimal;
+fn keep_me(value: Decimal) -> (BigInt, BigDecimal) { todo!() }
+"#;
+    let prepared = collect_and_strip_shared_prelude(input);
+    assert!(!prepared.stripped_code.contains("use num_bigint::BigInt;"));
+    assert!(!prepared
+        .stripped_code
+        .contains("use rust_decimal::Decimal;"));
+    assert!(!prepared
+        .stripped_code
+        .contains("use bigdecimal::BigDecimal;"));
+    assert!(prepared.stripped_code.contains("fn keep_me"));
+}
+
+#[test]
 fn canonical_stdlib_names_are_sealed_across_declarations_and_uses() {
     let input = r#"
 struct FileHandle {}

--- a/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
@@ -147,7 +147,7 @@ impl RustEmitter {
             let rendered_target = if index == target_index {
                 self.rust_type_with_generics(target_ty)
             } else {
-                ancestor.replace('.', "::")
+                render_ancestor_rust_type(self.current_module_name.as_deref(), ancestor)
             };
             lowered = crate::RustExpr::FnCall {
                 func: Box::new(crate::RustExpr::Verbatim(format!(
@@ -158,6 +158,23 @@ impl RustEmitter {
         }
         lowered
     }
+}
+
+fn render_ancestor_rust_type(current_module: Option<&str>, ancestor: &str) -> String {
+    let Some((module, name)) = ancestor.rsplit_once('.') else {
+        return sifr_type_system::source_class_rust_name(ancestor);
+    };
+    if current_module == Some(module) {
+        return sifr_type_system::source_class_rust_name(name);
+    }
+    if module.starts_with("sifr.") || module.starts_with("_sifr.") {
+        return sifr_type_system::stdlib_class_rust_name(module, name);
+    }
+    format!(
+        "crate::{}::{}",
+        module.replace('.', "::"),
+        sifr_type_system::source_class_rust_name(name)
+    )
 }
 
 fn map_value(
@@ -182,6 +199,7 @@ fn map_value(
 
 #[cfg(test)]
 mod tests {
+    use super::render_ancestor_rust_type;
     use crate::{RustEmitter, RustExpr};
     use sifr_type_system::Type;
 
@@ -209,6 +227,22 @@ mod tests {
                 value.clone()
             ),
             value
+        );
+    }
+
+    #[test]
+    fn ancestor_paths_are_local_stdlib_or_crate_rooted_by_identity() {
+        assert_eq!(
+            render_ancestor_rust_type(Some("models"), "models.Mid"),
+            "Mid"
+        );
+        assert_eq!(
+            render_ancestor_rust_type(Some("adapter"), "models.Mid"),
+            "crate::models::Mid"
+        );
+        assert_eq!(
+            render_ancestor_rust_type(Some("adapter"), "sifr.resource.NullContext"),
+            sifr_type_system::stdlib_class_rust_name("sifr.resource", "NullContext")
         );
     }
 }

--- a/crates/sifr_codegen/src/stmt_support_emitter/structured_return_if_while.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/structured_return_if_while.rs
@@ -443,7 +443,9 @@ impl RustEmitter {
         if self.union_enums.contains_key(preferred) {
             return preferred.to_string();
         }
-        for (candidate, members) in &self.union_enums {
+        let mut candidates = self.union_enums.iter().collect::<Vec<_>>();
+        candidates.sort_by(|(left, _), (right, _)| left.cmp(right));
+        for (candidate, members) in candidates {
             if needed_variants.iter().all(|needed| {
                 members
                     .iter()

--- a/crates/sifr_codegen/src/union_type_helpers.rs
+++ b/crates/sifr_codegen/src/union_type_helpers.rs
@@ -7,6 +7,87 @@ use sifr_type_system::ParamConvention;
 use sifr_type_system::Type;
 
 impl RustEmitter {
+    fn project_union_member_rust_type(&self, ty: &Type) -> RustType {
+        let resolved = crate::resolve_alias_type_for_plain_call(ty);
+        match resolved {
+            Type::Class {
+                identity,
+                type_args,
+                name,
+                ..
+            } => {
+                let key = identity.as_deref().unwrap_or(name);
+                let Some(path) = self.project_nominal_type_paths.get(key) else {
+                    return sifr_type_to_rust_type(resolved);
+                };
+                if type_args.is_empty() {
+                    RustType::Named(path.clone())
+                } else {
+                    RustType::Generic {
+                        base: path.clone(),
+                        params: type_args
+                            .iter()
+                            .map(|arg| self.project_union_member_rust_type(arg))
+                            .collect(),
+                    }
+                }
+            }
+            Type::Protocol { identity, name, .. } => {
+                let key = identity.as_deref().unwrap_or(name);
+                self.project_nominal_type_paths.get(key).map_or_else(
+                    || sifr_type_to_rust_type(resolved),
+                    |path| RustType::Named(format!("Box<dyn {path}>")),
+                )
+            }
+            Type::Newtype { identity, name, .. } | Type::Enum { identity, name, .. } => {
+                let key = identity.as_deref().unwrap_or(name);
+                self.project_nominal_type_paths
+                    .get(key)
+                    .cloned()
+                    .map_or_else(|| sifr_type_to_rust_type(resolved), RustType::Named)
+            }
+            Type::List(inner) | Type::Iterable(inner) => {
+                RustType::Vec(Box::new(self.project_union_member_rust_type(inner)))
+            }
+            Type::Dict(key, value) => RustType::HashMap(
+                Box::new(self.project_union_member_rust_type(key)),
+                Box::new(self.project_union_member_rust_type(value)),
+            ),
+            Type::Set(inner) => {
+                RustType::HashSet(Box::new(self.project_union_member_rust_type(inner)))
+            }
+            Type::Tuple(items) => RustType::Tuple(
+                items
+                    .iter()
+                    .map(|item| self.project_union_member_rust_type(item))
+                    .collect(),
+            ),
+            Type::Result(ok, error) => RustType::Result(
+                Box::new(self.project_union_member_rust_type(ok)),
+                Box::new(self.project_union_member_rust_type(error)),
+            ),
+            Type::Union(members)
+                if members.iter().any(|member| matches!(member, Type::None))
+                    && members
+                        .iter()
+                        .filter(|member| !matches!(member, Type::None))
+                        .count()
+                        == 1 =>
+            {
+                members
+                    .iter()
+                    .find(|member| !matches!(member, Type::None))
+                    .map_or_else(
+                        || sifr_type_to_rust_type(resolved),
+                        |inner| {
+                            RustType::Option(Box::new(self.project_union_member_rust_type(inner)))
+                        },
+                    )
+            }
+            _ => sifr_type_to_rust_type(resolved),
+        }
+    }
+
     /// Collect all union types from the module that need enum definitions,
     /// and build a map of function signatures for call-site wrapping.
     pub(crate) fn collect_union_types(&mut self, module: &HirModule) {
@@ -201,7 +282,7 @@ impl RustEmitter {
                 .iter()
                 .map(|member| RustEnumVariant {
                     name: member.union_variant_name(),
-                    tuple_fields: vec![sifr_type_to_rust_type(member)],
+                    tuple_fields: vec![self.project_union_member_rust_type(member)],
                     fields: Vec::new(),
                     value: None,
                 })
@@ -230,32 +311,37 @@ impl RustEmitter {
                 variants,
             });
             if is_try_error_carrier {
-                self.enum_items.extend(members.iter().map(|member| {
-                    let variant = member.union_variant_name();
-                    RustItem::Impl {
-                        target: enum_name.clone(),
-                        type_params: Vec::new(),
-                        trait_: Some(format!(
-                            "From<{}>",
-                            crate::render_type(&sifr_type_to_rust_type(member))
-                        )),
-                        items: vec![RustItem::Fn {
-                            name: "from".to_string(),
-                            visibility: Visibility::Private,
+                let conversion_items = members
+                    .iter()
+                    .map(|member| {
+                        let member_type = self.project_union_member_rust_type(member);
+                        let variant = member.union_variant_name();
+                        RustItem::Impl {
+                            target: enum_name.clone(),
                             type_params: Vec::new(),
-                            params: vec![RustParam::Named {
-                                name: "value".to_string(),
-                                ty: sifr_type_to_rust_type(member),
+                            trait_: Some(format!("From<{}>", crate::render_type(&member_type))),
+                            items: vec![RustItem::Fn {
+                                name: "from".to_string(),
+                                visibility: Visibility::Private,
+                                type_params: Vec::new(),
+                                params: vec![RustParam::Named {
+                                    name: "value".to_string(),
+                                    ty: member_type,
+                                }],
+                                ret: Some(RustType::Named("Self".to_string())),
+                                body: vec![RustStmt::Return(Some(RustExpr::FnCall {
+                                    func: Box::new(RustExpr::Path(vec![
+                                        enum_name.clone(),
+                                        variant,
+                                    ])),
+                                    args: vec![RustExpr::Ident("value".to_string())],
+                                }))],
+                                is_async: false,
                             }],
-                            ret: Some(RustType::Named("Self".to_string())),
-                            body: vec![RustStmt::Return(Some(RustExpr::FnCall {
-                                func: Box::new(RustExpr::Path(vec![enum_name.clone(), variant])),
-                                args: vec![RustExpr::Ident("value".to_string())],
-                            }))],
-                            is_async: false,
-                        }],
-                    }
-                }));
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                self.enum_items.extend(conversion_items);
             }
 
             let supports_display = members.iter().all(|member| {

--- a/crates/sifr_codegen/src/union_type_helpers.rs
+++ b/crates/sifr_codegen/src/union_type_helpers.rs
@@ -7,24 +7,41 @@ use sifr_type_system::ParamConvention;
 use sifr_type_system::Type;
 
 impl RustEmitter {
+    fn project_nominal_path(&self, identity: Option<&str>, name: &str) -> Option<&str> {
+        if self.project_nominal_type_paths.is_empty() {
+            return None;
+        }
+        let key = identity.unwrap_or(name);
+        if let Some(path) = self.project_nominal_type_paths.get(key) {
+            return Some(path);
+        }
+        if identity.is_some_and(sifr_type_system::is_global_rust_nominal_identity) {
+            return None;
+        }
+        panic!("missing crate-root path for project union nominal identity '{key}'");
+    }
+
     fn project_union_member_rust_type(&self, ty: &Type) -> RustType {
         let resolved = crate::resolve_alias_type_for_plain_call(ty);
         match resolved {
-            Type::Class {
+            class @ Type::Class {
                 identity,
                 type_args,
                 name,
                 ..
             } => {
-                let key = identity.as_deref().unwrap_or(name);
-                let Some(path) = self.project_nominal_type_paths.get(key) else {
+                if class.is_python_object_contract() || class.is_python_resource_identity_contract()
+                {
+                    return sifr_type_to_rust_type(resolved);
+                }
+                let Some(path) = self.project_nominal_path(identity.as_deref(), name) else {
                     return sifr_type_to_rust_type(resolved);
                 };
                 if type_args.is_empty() {
-                    RustType::Named(path.clone())
+                    RustType::Named(path.to_string())
                 } else {
                     RustType::Generic {
-                        base: path.clone(),
+                        base: path.to_string(),
                         params: type_args
                             .iter()
                             .map(|arg| self.project_union_member_rust_type(arg))
@@ -32,20 +49,18 @@ impl RustEmitter {
                     }
                 }
             }
-            Type::Protocol { identity, name, .. } => {
-                let key = identity.as_deref().unwrap_or(name);
-                self.project_nominal_type_paths.get(key).map_or_else(
+            Type::Protocol { identity, name, .. } => self
+                .project_nominal_path(identity.as_deref(), name)
+                .map_or_else(
                     || sifr_type_to_rust_type(resolved),
                     |path| RustType::Named(format!("Box<dyn {path}>")),
-                )
-            }
-            Type::Newtype { identity, name, .. } | Type::Enum { identity, name, .. } => {
-                let key = identity.as_deref().unwrap_or(name);
-                self.project_nominal_type_paths
-                    .get(key)
-                    .cloned()
-                    .map_or_else(|| sifr_type_to_rust_type(resolved), RustType::Named)
-            }
+                ),
+            Type::Newtype { identity, name, .. } | Type::Enum { identity, name, .. } => self
+                .project_nominal_path(identity.as_deref(), name)
+                .map_or_else(
+                    || sifr_type_to_rust_type(resolved),
+                    |path| RustType::Named(path.to_string()),
+                ),
             Type::List(inner) | Type::Iterable(inner) => {
                 RustType::Vec(Box::new(self.project_union_member_rust_type(inner)))
             }

--- a/crates/sifr_codegen/src/union_type_helpers.rs
+++ b/crates/sifr_codegen/src/union_type_helpers.rs
@@ -40,6 +40,9 @@ impl RustEmitter {
         }
         // Also scan class method bodies and register their signatures
         for class in &module.classes {
+            for (_, field_type) in &class.fields {
+                self.register_union_type(field_type);
+            }
             let mut has_constructor = false;
             for method in &class.methods {
                 // Register method signature under ClassName::method_name
@@ -188,6 +191,9 @@ impl RustEmitter {
 
         self.enum_items.clear();
         for (enum_name, members) in enums {
+            if self.suppressed_union_enum_definitions.contains(&enum_name) {
+                continue;
+            }
             let is_try_error_carrier = self.try_error_carrier_enums.contains(&enum_name);
             let supports_ordinary_value_traits =
                 !is_try_error_carrier || self.ordinary_union_enums.contains(&enum_name);

--- a/crates/sifr_driver/src/build/project_codegen.rs
+++ b/crates/sifr_driver/src/build/project_codegen.rs
@@ -5,7 +5,9 @@ use crate::frontend::FrontendCompiled;
 use crate::project::{
     assemble_project_main_rs, ordered_non_main_module_names, rust_module_file_path, ProjectLowering,
 };
-use sifr_codegen::{generate_rust_multi_with_metadata, generate_rust_with_stdlib, StdlibCode};
+use sifr_codegen::{
+    generate_rust_multi_with_metadata, generate_rust_with_stdlib_for_module, StdlibCode,
+};
 use sifr_ir::HirModule;
 use sifr_stdlib_manifest::StdlibFeature;
 use std::collections::{BTreeMap, HashSet};
@@ -47,7 +49,13 @@ pub(super) fn codegen_single_file_frontend(
     let static_programs = frontend.lowering_result.specialization_outputs.clone();
     let mut generated = run_codegen_with_boundary(
         "internal compiler panic during single-file code generation",
-        || generate_rust_with_stdlib(&frontend.lowering_result.module, &frontend.stdlib.code),
+        || {
+            generate_rust_with_stdlib_for_module(
+                &frontend.lowering_result.module,
+                &frontend.stdlib.code,
+                Some("main"),
+            )
+        },
     )
     .map_err(|error| vec![*error])?;
     generated.static_programs = static_programs;

--- a/crates/sifr_driver/src/build/project_codegen.rs
+++ b/crates/sifr_driver/src/build/project_codegen.rs
@@ -147,7 +147,15 @@ pub(super) fn generated_project_binary_project(
         static_cache.extend(outputs.iter().cloned());
     }
 
-    let main_rs = assemble_project_main_rs(&compile_order, &codegen_result.rust_files);
+    let generated_main_rs = assemble_project_main_rs(&compile_order, &codegen_result.rust_files);
+    let main_rs = if codegen_result.project_union_prelude.is_empty() {
+        generated_main_rs
+    } else {
+        format!(
+            "{}\n{generated_main_rs}",
+            codegen_result.project_union_prelude.trim_end()
+        )
+    };
     let support_modules = ordered_non_main_module_names(&compile_order, &codegen_result.rust_files)
         .into_iter()
         .filter_map(|module_name| {

--- a/crates/sifr_driver/src/test_runner/artifacts.rs
+++ b/crates/sifr_driver/src/test_runner/artifacts.rs
@@ -1,13 +1,16 @@
 use crate::build::{
     generate_dependency_cargo_toml_with_interop, try_generate_sysroot_dependency_plan,
 };
-use crate::project::top_level_module_declarations;
+use crate::project::{rust_module_file_path, top_level_module_declarations};
 use sifr_codegen::InteropBuildPlan;
 #[cfg(test)]
 use sifr_stdlib_manifest::try_sysroot_dependency_plan;
 use sifr_stdlib_manifest::{CargoVendorMode, StdlibFeature, SysrootDependencyPlan};
 use sifr_sysroot::SysrootError;
 use std::collections::HashSet;
+use std::path::PathBuf;
+
+const SUPPORT_MAIN_RUST_FILE: &str = "__sifr_support_main.rs";
 
 pub(crate) struct TestRunnerCargoPlan {
     pub(crate) cargo_toml: String,
@@ -20,6 +23,11 @@ pub(crate) fn compose_test_runner_lib(
 ) -> String {
     let mut test_lib = String::from("#![cfg(test)]\n\n");
     for module_name in top_level_module_declarations(support_module_names) {
+        if module_name == "main" && support_module_names.iter().any(|name| name == "main") {
+            test_lib.push_str("#[path = \"");
+            test_lib.push_str(SUPPORT_MAIN_RUST_FILE);
+            test_lib.push_str("\"]\n");
+        }
         test_lib.push_str("mod ");
         test_lib.push_str(&module_name);
         test_lib.push_str(";\n");
@@ -29,6 +37,13 @@ pub(crate) fn compose_test_runner_lib(
     }
     test_lib.push_str(all_rust_code);
     test_lib
+}
+
+pub(crate) fn test_support_module_file_path(module_name: &str) -> PathBuf {
+    if module_name == "main" {
+        return PathBuf::from(SUPPORT_MAIN_RUST_FILE);
+    }
+    rust_module_file_path(module_name)
 }
 
 #[cfg(test)]

--- a/crates/sifr_driver/src/test_runner/execution.rs
+++ b/crates/sifr_driver/src/test_runner/execution.rs
@@ -1,10 +1,12 @@
-use super::artifacts::{compose_test_runner_lib, try_generate_test_runner_cargo_plan};
+use super::artifacts::{
+    compose_test_runner_lib, test_support_module_file_path, try_generate_test_runner_cargo_plan,
+};
 use super::orchestrator::GeneratedTestRunnerProject;
 use crate::build::{
     prepare_cached_artifact, sysroot_cargo_config_args, ArtifactCacheReport, PreparedArtifactCache,
 };
 use crate::diagnostics::{write_stderr, write_stderr_line, RenderedDiagnostic};
-use crate::project::{namespace_module_files, rust_module_file_path};
+use crate::project::namespace_module_files;
 use sifr_diagnostics::DiagnosticCode;
 use sifr_stdlib_manifest::SysrootDependencyPlan;
 use std::path::Path;
@@ -70,7 +72,7 @@ pub(crate) fn execute_test_runner_project(
 
         for module_name in &generated_project.support_module_names {
             if let Some(code) = generated_project.support_rust_files.get(module_name) {
-                let module_path = rust_module_file_path(module_name);
+                let module_path = test_support_module_file_path(module_name);
                 let output_path = src_dir.join(&module_path);
                 if let Some(parent) = output_path.parent() {
                     std::fs::create_dir_all(parent).map_err(|error| {

--- a/crates/sifr_driver/src/test_runner/orchestrator.rs
+++ b/crates/sifr_driver/src/test_runner/orchestrator.rs
@@ -6,7 +6,7 @@ use crate::project::{
     ParsedProjectModule,
 };
 use crate::stdlib::compile_stdlib;
-use sifr_codegen::{generate_rust_multi_with_metadata, generate_rust_test};
+use sifr_codegen::generate_rust_test_project_with_metadata;
 use sifr_diagnostics::DiagnosticCode;
 use sifr_frontend::{
     compile_module_hir_with_source, FrontendDiagnosticStyle, FrontendSourceContext,
@@ -79,16 +79,7 @@ pub(crate) fn build_test_runner_project(
                 .map(|module| (name.as_str(), module))
         })
         .collect();
-    let support_codegen = run_codegen_with_boundary(
-        "internal compiler panic during support-module code generation",
-        || generate_rust_multi_with_metadata(&support_module_refs, &stdlib_compiled.code),
-    )
-    .map_err(|error| vec![*error])?;
-
-    let mut all_rust_code = String::new();
-    let mut all_stdlib_modules = support_codegen.used_stdlib_modules;
-    let mut all_required_features = support_codegen.required_features;
-
+    let mut lowered_test_modules = BTreeMap::new();
     for (module_name, test_file) in test_files_by_module {
         let Some(parsed) = test_modules.get(module_name.as_str()) else {
             return Err(vec![crate::diagnostics::diagnostic_with_code(
@@ -124,14 +115,35 @@ pub(crate) fn build_test_runner_project(
             }
         };
 
-        let codegen_result = run_codegen_with_boundary(
-            format!(
-                "internal compiler panic during test-module code generation for '{}'",
-                test_file.display()
-            ),
-            || generate_rust_test(&lowering_result.module, module_name),
-        )
-        .map_err(|error| vec![*error])?;
+        lowered_test_modules.insert(module_name.clone(), lowering_result.module);
+    }
+    let test_module_refs = lowered_test_modules
+        .iter()
+        .map(|(name, module)| (name.as_str(), module))
+        .collect::<Vec<_>>();
+    let generated = run_codegen_with_boundary(
+        "internal compiler panic during test-project code generation",
+        || {
+            generate_rust_test_project_with_metadata(
+                &support_module_refs,
+                &test_module_refs,
+                &stdlib_compiled.code,
+            )
+        },
+    )
+    .map_err(|error| vec![*error])?;
+
+    let mut all_rust_code = generated.project_union_prelude;
+    if !all_rust_code.is_empty() {
+        all_rust_code.push('\n');
+    }
+    for (module_name, test_file) in test_files_by_module {
+        let Some(rust_source) = generated.test_rust_files.get(module_name) else {
+            return Err(vec![crate::diagnostics::diagnostic_with_code(
+                format!("missing generated test module '{module_name}'"),
+                DiagnosticCode::INTERNAL_COMPILER_PANIC,
+            )]);
+        };
         all_rust_code.push_str("// Tests from: ");
         if let Some(file_name) = test_file.file_name() {
             all_rust_code.push_str(&file_name.to_string_lossy());
@@ -139,18 +151,16 @@ pub(crate) fn build_test_runner_project(
             all_rust_code.push_str(&test_file.display().to_string());
         }
         all_rust_code.push('\n');
-        all_rust_code.push_str(&codegen_result.rust_source);
+        all_rust_code.push_str(rust_source);
         all_rust_code.push('\n');
-        all_stdlib_modules.extend(codegen_result.used_stdlib_modules);
-        all_required_features.extend(codegen_result.required_features);
     }
 
     Ok(GeneratedTestRunnerProject {
         cache_scope: test_dir.to_path_buf(),
         support_module_names,
-        support_rust_files: support_codegen.rust_files,
+        support_rust_files: generated.support_rust_files,
         all_rust_code,
-        all_stdlib_modules,
-        all_required_features,
+        all_stdlib_modules: generated.used_stdlib_modules,
+        all_required_features: generated.required_features,
     })
 }

--- a/crates/sifr_driver/src/test_runner/orchestrator.rs
+++ b/crates/sifr_driver/src/test_runner/orchestrator.rs
@@ -129,7 +129,7 @@ pub(crate) fn build_test_runner_project(
                 "internal compiler panic during test-module code generation for '{}'",
                 test_file.display()
             ),
-            || generate_rust_test(&lowering_result.module),
+            || generate_rust_test(&lowering_result.module, module_name),
         )
         .map_err(|error| vec![*error])?;
         all_rust_code.push_str("// Tests from: ");

--- a/crates/sifr_driver/src/tests/project_generic_identity.rs
+++ b/crates/sifr_driver/src/tests/project_generic_identity.rs
@@ -1,5 +1,5 @@
 use super::project_build_check::mktemp_dir;
-use crate::{build_project, check_project};
+use crate::{build, build_project, check_project};
 
 #[test]
 fn test_check_project_imports_generic_function_metadata_through_facade() {
@@ -46,6 +46,113 @@ fn test_build_project_imports_generic_function_metadata_through_facade() {
     .expect("main should be written");
     let binary = build_project(&dir.join("main.sifr"), &dir.join("build_out"))
         .expect("generic function facade should build natively");
+    assert!(binary.exists());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn test_build_project_shares_union_identity_across_modules() {
+    let dir = mktemp_dir("shared_project_union_identity");
+    std::fs::write(
+        dir.join("errors.sifr"),
+        "class FirstError(Error):\n    message: str\n\nclass SecondError(Error):\n    message: str\n\nclass Payload:\n    value: bool | int | float | str | bytes | None\n    tag: int | str\n\ndef produce() -> Result[int, FirstError | SecondError]:\n    return 7\n\ndef make_payload() -> Payload:\n    return Payload(True, 3)\n",
+    )
+    .expect("union provider should be written");
+    std::fs::write(
+        dir.join("facade.sifr"),
+        "from errors import FirstError as PublicFirstError, Payload as PublicPayload, SecondError as PublicSecondError, make_payload as public_make_payload, produce as public_produce\n",
+    )
+    .expect("union facade should be written");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from facade import PublicFirstError as E1, PublicPayload as Payload, PublicSecondError as E2, public_make_payload as make_payload, public_produce as produce\n\ndef relay() -> Result[int, E1 | E2]:\n    result: Result[int, E1 | E2] = produce()\n    return result\n\ndef tag_value(payload: Payload) -> int:\n    tag: int | str = payload.tag\n    if isinstance(tag, int):\n        return tag\n    else:\n        return len(tag)\n\ndef main():\n    payload: Payload = make_payload()\n    assert payload.value == True\n    assert tag_value(payload) == 3\n",
+    )
+    .expect("union consumer should be written");
+
+    let binary = build_project(&dir.join("main.sifr"), &dir.join("build_out"))
+        .expect("one project-wide union identity should build natively");
+    assert!(binary.exists());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
+fn test_build_project_keeps_same_basename_enum_and_newtype_unions_distinct() {
+    let dir = mktemp_dir("distinct_enum_newtype_union_identities");
+    let provider = |status_value: i64, token_value: i64| {
+        format!(
+            "from enum import Enum\n\nclass Status(Enum):\n    READY = {status_value}\n\nclass Token(int):\n    pass\n\ndef status() -> Status | int:\n    return Status.READY\n\ndef token() -> Token | str:\n    return Token({token_value})\n"
+        )
+    };
+    std::fs::write(dir.join("left.sifr"), provider(1, 11))
+        .expect("left provider should be written");
+    std::fs::write(dir.join("right.sifr"), provider(2, 22))
+        .expect("right provider should be written");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from left import Status as LeftStatus, Token as LeftToken, status as left_status, token as left_token\nfrom right import Status as RightStatus, Token as RightToken, status as right_status, token as right_token\n\ndef main():\n    first_status: LeftStatus | int = left_status()\n    second_status: RightStatus | int = right_status()\n    first_token: LeftToken | str = left_token()\n    second_token: RightToken | str = right_token()\n",
+    )
+    .expect("union consumer should be written");
+
+    let binary = build_project(&dir.join("main.sifr"), &dir.join("build_out"))
+        .expect("same-basename enum and newtype unions should remain distinct");
+    assert!(binary.exists());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn test_check_project_keeps_same_basename_protocol_unions_distinct() {
+    let dir = mktemp_dir("distinct_protocol_union_identities");
+    let provider = "class Readable(Protocol):\n    def read(self) -> str:\n        pass\n\ndef accept(value: Readable | int) -> int:\n    return 1\n";
+    std::fs::write(dir.join("left.sifr"), provider).expect("left provider should be written");
+    std::fs::write(dir.join("right.sifr"), provider).expect("right provider should be written");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from left import Readable as LeftReadable, accept as accept_left\nfrom right import Readable as RightReadable, accept as accept_right\n\ndef use_left(value: LeftReadable | int) -> int:\n    return accept_left(value)\n\ndef use_right(value: RightReadable | int) -> int:\n    return accept_right(value)\n\ndef main():\n    pass\n",
+    )
+    .expect("protocol consumer should be written");
+
+    let errors = check_project(&dir.join("main.sifr"));
+    assert!(
+        errors.is_empty(),
+        "same-basename protocol unions should remain distinct: {errors:?}"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn test_build_single_file_consumes_three_level_class_upcast() {
+    let dir = mktemp_dir("single_file_three_level_upcast");
+    let source = "class Root:\n    value: int\n\nclass Mid(Root):\n    middle: int\n\n    def __init__(self, value: int, middle: int):\n        super().__init__(value)\n        self.middle = middle\n\nclass Child(Mid):\n    extra: int\n\n    def __init__(self, value: int, middle: int, extra: int):\n        super().__init__(value, middle)\n        self.extra = extra\n\ndef consume(own value: Root) -> int:\n    return value.value\n\ndef as_root(own value: Child) -> Root:\n    return value\n\ndef main():\n    assert consume(Child(1, 2, 3)) == 1\n    root: Root = as_root(Child(4, 5, 6))\n    assert root.value == 4\n";
+
+    let binary = build(source, &dir.join("build_out"))
+        .expect("single-file transitive class upcast should build natively");
+    let status = std::process::Command::new(&binary)
+        .status()
+        .expect("single-file transitive class upcast binary should run");
+    assert!(status.success());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
+fn test_build_project_keeps_same_basename_union_identities_distinct() {
+    let dir = mktemp_dir("distinct_project_union_identities");
+    let provider = |value: i64| {
+        format!(
+            "class PackageError(Error):\n    message: str\n\nclass OtherError(Error):\n    message: str\n\ndef produce() -> Result[int, PackageError | OtherError]:\n    return {value}\n"
+        )
+    };
+    std::fs::write(dir.join("left.sifr"), provider(1)).expect("left provider should be written");
+    std::fs::write(dir.join("right.sifr"), provider(2)).expect("right provider should be written");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from left import PackageError as LeftPackageError, OtherError as LeftOtherError, produce as produce_left\nfrom right import PackageError as RightPackageError, OtherError as RightOtherError, produce as produce_right\n\ndef left_value() -> Result[int, LeftPackageError | LeftOtherError]:\n    return produce_left()\n\ndef right_value() -> Result[int, RightPackageError | RightOtherError]:\n    return produce_right()\n\ndef main():\n    pass\n",
+    )
+    .expect("union consumer should be written");
+
+    let binary = build_project(&dir.join("main.sifr"), &dir.join("build_out"))
+        .expect("same-basename unions should remain nominally distinct");
     assert!(binary.exists());
     let _ = std::fs::remove_dir_all(dir);
 }
@@ -195,6 +302,35 @@ fn test_build_project_consumes_transitive_class_upcasts() {
     let status = std::process::Command::new(&binary)
         .status()
         .expect("consuming class upcast binary should run");
+    assert!(status.success());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
+fn test_build_project_crate_roots_non_main_transitive_upcasts() {
+    let dir = mktemp_dir("non_main_transitive_upcast_native");
+    std::fs::write(
+        dir.join("shapes.sifr"),
+        "class Root:\n    value: int\n\nclass Mid(Root):\n    middle: int\n\n    def __init__(self, value: int, middle: int):\n        super().__init__(value)\n        self.middle = middle\n\nclass Child(Mid):\n    extra: int\n\n    def __init__(self, value: int, middle: int, extra: int):\n        super().__init__(value, middle)\n        self.extra = extra\n",
+    )
+    .expect("shape declarations should be written");
+    std::fs::write(
+        dir.join("adapter.sifr"),
+        "from shapes import Child, Root\n\ndef as_root(own value: Child) -> Root:\n    return value\n",
+    )
+    .expect("non-main adapter should be written");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from adapter import as_root\nfrom shapes import Child, Root\n\ndef main():\n    root: Root = as_root(Child(1, 2, 3))\n    assert root.value == 1\n",
+    )
+    .expect("main consumer should be written");
+
+    let binary = build_project(&dir.join("main.sifr"), &dir.join("build_out"))
+        .expect("non-main transitive upcasts should use crate-rooted paths");
+    let status = std::process::Command::new(&binary)
+        .status()
+        .expect("non-main transitive upcast binary should run");
     assert!(status.success());
     let _ = std::fs::remove_dir_all(dir);
 }

--- a/crates/sifr_driver/src/tests/project_generic_identity.rs
+++ b/crates/sifr_driver/src/tests/project_generic_identity.rs
@@ -99,6 +99,29 @@ fn test_build_project_centralizes_stdlib_nominal_union_payload() {
 }
 
 #[test]
+fn test_build_project_isolates_union_prelude_imports() {
+    let dir = mktemp_dir("isolated_union_prelude_imports");
+    std::fs::write(
+        dir.join("helper.sifr"),
+        "def pick(flag: bool) -> dict[str, int] | int:\n    if flag:\n        return {\"value\": 1}\n    return 2\n",
+    )
+    .expect("helper should be written");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from helper import pick\n\ndef main():\n    local: dict[str, int] = {\"value\": 3}\n    selected: dict[str, int] | int = pick(True)\n    assert local[\"value\"] == 3\n",
+    )
+    .expect("main should be written");
+
+    let binary = build_project(&dir.join("main.sifr"), &dir.join("build_out"))
+        .expect("union prelude imports should not conflict with root imports");
+    let status = std::process::Command::new(&binary)
+        .status()
+        .expect("generated binary should run");
+    assert!(status.success());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 #[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_project_keeps_same_basename_enum_and_newtype_unions_distinct() {
     let dir = mktemp_dir("distinct_enum_newtype_union_identities");

--- a/crates/sifr_driver/src/tests/project_generic_identity.rs
+++ b/crates/sifr_driver/src/tests/project_generic_identity.rs
@@ -76,6 +76,29 @@ fn test_build_project_shares_union_identity_across_modules() {
 }
 
 #[test]
+fn test_build_project_centralizes_stdlib_nominal_union_payload() {
+    let dir = mktemp_dir("shared_stdlib_nominal_union");
+    std::fs::write(
+        dir.join("helper.sifr"),
+        "from sifr.pathlib import Path\n\ndef pick(flag: bool) -> Path | int:\n    if flag:\n        return Path(\"/tmp\")\n    return 1\n\ndef go() -> int:\n    value: Path | int = pick(True)\n    return 1\n",
+    )
+    .expect("helper should be written");
+    std::fs::write(
+        dir.join("main.sifr"),
+        "from helper import go\nfrom sifr.pathlib import Path\n\ndef main():\n    local: Path | int = Path(\"/var\")\n    assert go() == 1\n",
+    )
+    .expect("main should be written");
+
+    let binary = build_project(&dir.join("main.sifr"), &dir.join("build_out"))
+        .expect("stdlib nominal union payload should have one project type");
+    let status = std::process::Command::new(&binary)
+        .status()
+        .expect("generated binary should run");
+    assert!(status.success());
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 #[ignore = "generated build integration coverage runs in full validation profiles"]
 fn test_build_project_keeps_same_basename_enum_and_newtype_unions_distinct() {
     let dir = mktemp_dir("distinct_enum_newtype_union_identities");

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -86,6 +86,39 @@ def test_dotted_import():
 }
 
 #[test]
+fn test_run_tests_uses_declaring_union_owner_and_named_test_module_upcasts() {
+    let unique = format!(
+        "sifr_test_union_owner_upcast_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos()
+    );
+    let test_dir = std::env::temp_dir().join(unique);
+    std::fs::create_dir_all(&test_dir).expect("test dir should be created");
+    std::fs::write(
+        test_dir.join("errors.sifr"),
+        "class FirstError(Error):\n    message: str\n\nclass SecondError(Error):\n    message: str\n\ndef produce() -> Result[int, FirstError | SecondError]:\n    return 1\n",
+    )
+    .expect("union provider should be written");
+    std::fs::write(
+        test_dir.join("app.sifr"),
+        "from errors import produce\n\ndef marker() -> int:\n    return 7\n",
+    )
+    .expect("alphabetically first union consumer should be written");
+    std::fs::write(
+        test_dir.join("test_union_upcast.sifr"),
+        "from app import marker\n\nclass Root:\n    value: int\n\nclass Mid(Root):\n    middle: int\n\n    def __init__(self, value: int, middle: int):\n        super().__init__(value)\n        self.middle = middle\n\nclass Child(Mid):\n    extra: int\n\n    def __init__(self, value: int, middle: int, extra: int):\n        super().__init__(value, middle)\n        self.extra = extra\n\ndef consume(own value: Root) -> int:\n    return value.value\n\ndef test_union_owner_and_upcast():\n    assert marker() == 7\n    assert consume(Child(1, 2, 3)) == 1\n",
+    )
+    .expect("test module should be written");
+
+    let result = run_tests(&test_dir).expect("test runner should compile unions and upcasts");
+    assert!(result, "sifr test run should succeed");
+    let _ = std::fs::remove_dir_all(&test_dir);
+}
+
+#[test]
 fn test_run_tests_reuses_cached_workspace_for_unchanged_project() {
     let unique = format!(
         "sifr_test_cache_reuse_{}_{}",

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -86,7 +86,7 @@ def test_dotted_import():
 }
 
 #[test]
-fn test_run_tests_uses_declaring_union_owner_and_named_test_module_upcasts() {
+fn test_run_tests_shares_root_union_prelude_and_named_test_module_upcasts() {
     let unique = format!(
         "sifr_test_union_owner_upcast_{}_{}",
         std::process::id(),
@@ -104,12 +104,12 @@ fn test_run_tests_uses_declaring_union_owner_and_named_test_module_upcasts() {
     .expect("union provider should be written");
     std::fs::write(
         test_dir.join("app.sifr"),
-        "from errors import produce\n\ndef marker() -> int:\n    return 7\n",
+        "from errors import FirstError, SecondError, produce\n\ndef relay() -> Result[int, FirstError | SecondError]:\n    return produce()\n\ndef marker() -> int:\n    return 7\n",
     )
     .expect("alphabetically first union consumer should be written");
     std::fs::write(
         test_dir.join("test_union_upcast.sifr"),
-        "from app import marker\n\nclass Root:\n    value: int\n\nclass Mid(Root):\n    middle: int\n\n    def __init__(self, value: int, middle: int):\n        super().__init__(value)\n        self.middle = middle\n\nclass Child(Mid):\n    extra: int\n\n    def __init__(self, value: int, middle: int, extra: int):\n        super().__init__(value, middle)\n        self.extra = extra\n\ndef consume(own value: Root) -> int:\n    return value.value\n\ndef test_union_owner_and_upcast():\n    assert marker() == 7\n    assert consume(Child(1, 2, 3)) == 1\n",
+        "from app import marker, relay\nfrom errors import FirstError, SecondError\n\nclass Root:\n    value: int\n\nclass Mid(Root):\n    middle: int\n\n    def __init__(self, value: int, middle: int):\n        super().__init__(value)\n        self.middle = middle\n\nclass Child(Mid):\n    extra: int\n\n    def __init__(self, value: int, middle: int, extra: int):\n        super().__init__(value, middle)\n        self.extra = extra\n\ndef consume(own value: Root) -> int:\n    return value.value\n\ndef consume_result(value: Result[int, FirstError | SecondError]) -> int:\n    return 9\n\ndef test_union_owner_and_upcast():\n    assert marker() == 7\n    assert consume_result(relay()) == 9\n    assert consume(Child(1, 2, 3)) == 1\n",
     )
     .expect("test module should be written");
 

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -104,12 +104,12 @@ fn test_run_tests_shares_root_union_prelude_and_named_test_module_upcasts() {
     .expect("union provider should be written");
     std::fs::write(
         test_dir.join("app.sifr"),
-        "from errors import FirstError, SecondError, produce\n\ndef relay() -> Result[int, FirstError | SecondError]:\n    return produce()\n\ndef marker() -> int:\n    return 7\n",
+        "from errors import FirstError, SecondError, produce\nfrom sifr.pathlib import Path\n\ndef relay() -> Result[int, FirstError | SecondError]:\n    return produce()\n\ndef pick() -> Path | int:\n    return Path(\"/tmp\")\n\ndef marker() -> int:\n    return 7\n",
     )
     .expect("alphabetically first union consumer should be written");
     std::fs::write(
         test_dir.join("test_union_upcast.sifr"),
-        "from app import marker, relay\nfrom errors import FirstError, SecondError\n\nclass Root:\n    value: int\n\nclass Mid(Root):\n    middle: int\n\n    def __init__(self, value: int, middle: int):\n        super().__init__(value)\n        self.middle = middle\n\nclass Child(Mid):\n    extra: int\n\n    def __init__(self, value: int, middle: int, extra: int):\n        super().__init__(value, middle)\n        self.extra = extra\n\ndef consume(own value: Root) -> int:\n    return value.value\n\ndef consume_result(value: Result[int, FirstError | SecondError]) -> int:\n    return 9\n\ndef test_union_owner_and_upcast():\n    assert marker() == 7\n    assert consume_result(relay()) == 9\n    assert consume(Child(1, 2, 3)) == 1\n",
+        "from app import marker, pick, relay\nfrom errors import FirstError, SecondError\nfrom sifr.pathlib import Path\n\nclass Root:\n    value: int\n\nclass Mid(Root):\n    middle: int\n\n    def __init__(self, value: int, middle: int):\n        super().__init__(value)\n        self.middle = middle\n\nclass Child(Mid):\n    extra: int\n\n    def __init__(self, value: int, middle: int, extra: int):\n        super().__init__(value, middle)\n        self.extra = extra\n\ndef consume(own value: Root) -> int:\n    return value.value\n\ndef consume_result(value: Result[int, FirstError | SecondError]) -> int:\n    return 9\n\ndef consume_path(value: Path | int) -> int:\n    return 10\n\ndef test_union_owner_and_upcast():\n    assert marker() == 7\n    assert consume_result(relay()) == 9\n    assert consume_path(pick()) == 10\n    assert consume(Child(1, 2, 3)) == 1\n",
     )
     .expect("test module should be written");
 

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -86,7 +86,7 @@ def test_dotted_import():
 }
 
 #[test]
-fn test_run_tests_shares_root_union_prelude_and_named_test_module_upcasts() {
+fn test_run_tests_support_module_named_main_imports_root_owned_unions() {
     let unique = format!(
         "sifr_test_union_owner_upcast_{}_{}",
         std::process::id(),
@@ -103,13 +103,13 @@ fn test_run_tests_shares_root_union_prelude_and_named_test_module_upcasts() {
     )
     .expect("union provider should be written");
     std::fs::write(
-        test_dir.join("app.sifr"),
+        test_dir.join("main.sifr"),
         "from errors import FirstError, SecondError, produce\nfrom sifr.pathlib import Path\n\ndef relay() -> Result[int, FirstError | SecondError]:\n    return produce()\n\ndef pick() -> Path | int:\n    return Path(\"/tmp\")\n\ndef marker() -> int:\n    return 7\n",
     )
     .expect("alphabetically first union consumer should be written");
     std::fs::write(
         test_dir.join("test_union_upcast.sifr"),
-        "from app import marker, pick, relay\nfrom errors import FirstError, SecondError\nfrom sifr.pathlib import Path\n\nclass Root:\n    value: int\n\nclass Mid(Root):\n    middle: int\n\n    def __init__(self, value: int, middle: int):\n        super().__init__(value)\n        self.middle = middle\n\nclass Child(Mid):\n    extra: int\n\n    def __init__(self, value: int, middle: int, extra: int):\n        super().__init__(value, middle)\n        self.extra = extra\n\ndef consume(own value: Root) -> int:\n    return value.value\n\ndef consume_result(value: Result[int, FirstError | SecondError]) -> int:\n    return 9\n\ndef consume_path(value: Path | int) -> int:\n    return 10\n\ndef test_union_owner_and_upcast():\n    assert marker() == 7\n    assert consume_result(relay()) == 9\n    assert consume_path(pick()) == 10\n    assert consume(Child(1, 2, 3)) == 1\n",
+        "from main import marker, pick, relay\nfrom errors import FirstError, SecondError\nfrom sifr.pathlib import Path\n\nclass Root:\n    value: int\n\nclass Mid(Root):\n    middle: int\n\n    def __init__(self, value: int, middle: int):\n        super().__init__(value)\n        self.middle = middle\n\nclass Child(Mid):\n    extra: int\n\n    def __init__(self, value: int, middle: int, extra: int):\n        super().__init__(value, middle)\n        self.extra = extra\n\ndef consume(own value: Root) -> int:\n    return value.value\n\ndef consume_result(value: Result[int, FirstError | SecondError]) -> int:\n    return 9\n\ndef consume_path(value: Path | int) -> int:\n    return 10\n\ndef test_union_owner_and_upcast():\n    assert marker() == 7\n    assert consume_result(relay()) == 9\n    assert consume_path(pick()) == 10\n    assert consume(Child(1, 2, 3)) == 1\n",
     )
     .expect("test module should be written");
 
@@ -499,4 +499,12 @@ fn test_compose_test_runner_lib_declares_dotted_modules_by_namespace() {
     assert!(lib_source.contains("mod math;\n"));
     assert!(!lib_source.contains("mod helpers.nodes;"));
     assert!(lib_source.contains("#[test]\nfn smoke() {}"));
+}
+
+#[test]
+fn test_compose_test_runner_lib_uses_safe_path_for_support_main() {
+    let support_modules = vec!["main".to_string()];
+    let lib_source = compose_test_runner_lib(&support_modules, "");
+
+    assert!(lib_source.contains("#[path = \"__sifr_support_main.rs\"]\nmod main;"));
 }

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -14,7 +14,7 @@ use crate::{diagnostic_with_code, diagnostic_with_source_range_args_help};
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, RenderedDiagnostic};
 use sifr_lowering::{
     canonicalize_user_export_type, localize_user_import_function_type, localize_user_import_type,
-    ExternalDefs, HirDiagnostic, HirModule, LoweringResult, RustInteropDecoratorKind,
+    ExternalDefs, HirClassKind, HirDiagnostic, HirModule, LoweringResult, RustInteropDecoratorKind,
 };
 use sifr_python_ast::Stmt;
 use sifr_type_system::{FunctionType, ParamConvention, Type};
@@ -269,26 +269,44 @@ pub fn collect_module_exports(
                     },
                 ));
             }
-            let class_ty = canonicalize_user_export_type(
-                &Type::Class {
+            let exported_type = if let Some(inner) = &class.newtype_inner {
+                Type::Newtype {
                     identity: None,
-                    type_args: class
-                        .type_params
-                        .iter()
-                        .cloned()
-                        .map(Type::TypeVar)
-                        .collect(),
                     name: class.name.clone(),
-                    fields: class.fields.clone(),
-                    methods,
-                    parent_class: exported_parent_chain(
-                        class.parent_class.as_deref(),
-                        module,
-                        &imported_ancestry,
-                    ),
-                },
-                &local_classes,
-            );
+                    inner: Box::new(inner.clone()),
+                }
+            } else {
+                match &class.kind {
+                    HirClassKind::Protocol => Type::Protocol {
+                        identity: None,
+                        name: class.name.clone(),
+                        methods,
+                    },
+                    HirClassKind::Enum => Type::Enum {
+                        identity: None,
+                        name: class.name.clone(),
+                        variants: class.enum_variants.clone(),
+                    },
+                    HirClassKind::Regular | HirClassKind::PythonOpaque(_) => Type::Class {
+                        identity: None,
+                        type_args: class
+                            .type_params
+                            .iter()
+                            .cloned()
+                            .map(Type::TypeVar)
+                            .collect(),
+                        name: class.name.clone(),
+                        fields: class.fields.clone(),
+                        methods,
+                        parent_class: exported_parent_chain(
+                            class.parent_class.as_deref(),
+                            module,
+                            &imported_ancestry,
+                        ),
+                    },
+                }
+            };
+            let class_ty = canonicalize_user_export_type(&exported_type, &local_classes);
             class_exports.insert(class.name.clone(), class_ty);
             if let Some(defaults) = lowering_result.class_field_defaults.get(&class.name) {
                 class_field_default_exports.insert(class.name.clone(), defaults.clone());

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -138,7 +138,7 @@ fn describe_node(
         ),
         Type::Union(members) => describe_union(module_name, members, lowering, visiting),
         Type::TypeVar(name) => ShapeNode::TypeParameter(name.clone()),
-        Type::Enum { name, variants } => ShapeNode::Enum {
+        Type::Enum { name, variants, .. } => ShapeNode::Enum {
             identity: format!("{module_name}.{name}"),
             variants: variants
                 .iter()
@@ -150,7 +150,7 @@ fn describe_node(
                 .collect(),
             metadata: Vec::new(),
         },
-        Type::Newtype { name, inner } => ShapeNode::Newtype {
+        Type::Newtype { name, inner, .. } => ShapeNode::Newtype {
             identity: format!("{module_name}.{name}"),
             inner: Box::new(describe_node(module_name, inner, lowering, visiting)),
             metadata: Vec::new(),

--- a/crates/sifr_lowering/src/lower/classes.rs
+++ b/crates/sifr_lowering/src/lower/classes.rs
@@ -19,6 +19,8 @@ use sifr_type_system::{FunctionType, ParamConvention, Type};
 
 mod class_type_collection;
 pub(in crate::lower) use class_type_collection::*;
+mod class_iteration_protocol;
+use class_iteration_protocol::validate_iteration_protocol_methods;
 mod class_semantics;
 mod class_shape_metadata;
 mod class_type_helpers;

--- a/crates/sifr_lowering/src/lower/classes/class_iteration_protocol.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_iteration_protocol.rs
@@ -1,0 +1,147 @@
+use super::class_type_collection::class_method_signature;
+use super::class_type_helpers::option_member_type;
+use super::protocol_diagnostics;
+use super::LowerCtx;
+use sifr_type_system::{FunctionType, Type};
+use std::collections::HashMap;
+
+fn class_next_element_type(class_name: &str, methods: &[(String, FunctionType)]) -> Option<Type> {
+    let next_ft = class_method_signature(methods, "__next__")?;
+    if !next_ft.params.is_empty() {
+        return None;
+    }
+    let elem = option_member_type(next_ft.return_type.as_ref())?;
+    if matches!(elem.resolve_alias(), Type::Class { name, .. } if name == class_name) {
+        return None;
+    }
+    Some(elem)
+}
+
+fn class_iter_element_type(class_name: &str, methods: &[(String, FunctionType)]) -> Option<Type> {
+    let iter_ft = class_method_signature(methods, "__iter__")?;
+    if !iter_ft.params.is_empty() {
+        return None;
+    }
+    match iter_ft.return_type.resolve_alias() {
+        Type::Iterator(elem) | Type::Iterable(elem) => Some(*elem.clone()),
+        Type::Class { name, .. } if name == class_name => {
+            class_next_element_type(class_name, methods)
+        }
+        _ => None,
+    }
+}
+
+fn class_reversed_element_type(
+    class_name: &str,
+    methods: &[(String, FunctionType)],
+) -> Option<Type> {
+    let reversed_ft = class_method_signature(methods, "__reversed__")?;
+    if !reversed_ft.params.is_empty() {
+        return None;
+    }
+    match reversed_ft.return_type.resolve_alias() {
+        Type::Iterator(elem) | Type::Iterable(elem) => Some(*elem.clone()),
+        Type::Class { name, .. } if name == class_name => {
+            class_next_element_type(class_name, methods)
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn validate_iteration_protocol_methods(
+    class_name: &str,
+    methods: &[(String, FunctionType)],
+    method_ranges: &HashMap<String, ruff_text_size::TextRange>,
+    class_range: ruff_text_size::TextRange,
+    ctx: &mut LowerCtx,
+) {
+    if let Some(iter_ft) = class_method_signature(methods, "__iter__") {
+        let range = method_ranges["__iter__"];
+        if !iter_ft.params.is_empty() {
+            protocol_diagnostics::iterator_invalid_parameter_signature(
+                ctx,
+                &format!("{class_name}.__iter__"),
+                range,
+            );
+        } else if class_iter_element_type(class_name, methods).is_none() {
+            protocol_diagnostics::iterator_invalid_return_signature(
+                ctx,
+                &format!("{class_name}.__iter__"),
+                "'Iterator[T]' or 'Iterable[T]'",
+                range,
+            );
+        }
+    }
+
+    if let Some(next_ft) = class_method_signature(methods, "__next__") {
+        let range = method_ranges["__next__"];
+        if !next_ft.params.is_empty() {
+            protocol_diagnostics::iterator_invalid_parameter_signature(
+                ctx,
+                &format!("{class_name}.__next__"),
+                range,
+            );
+        } else if class_next_element_type(class_name, methods).is_none() {
+            protocol_diagnostics::iterator_invalid_return_signature(
+                ctx,
+                &format!("{class_name}.__next__"),
+                "'T | None'",
+                range,
+            );
+        }
+    }
+
+    if let Some(reversed_ft) = class_method_signature(methods, "__reversed__") {
+        let range = method_ranges["__reversed__"];
+        if !reversed_ft.params.is_empty() {
+            protocol_diagnostics::iterator_invalid_parameter_signature(
+                ctx,
+                &format!("{class_name}.__reversed__"),
+                range,
+            );
+        } else if class_reversed_element_type(class_name, methods).is_none() {
+            protocol_diagnostics::iterator_invalid_return_signature(
+                ctx,
+                &format!("{class_name}.__reversed__"),
+                "'Iterator[T]' or 'Iterable[T]'",
+                range,
+            );
+        }
+    }
+
+    if let (Some(iter_elem), Some(next_elem)) = (
+        class_iter_element_type(class_name, methods),
+        class_next_element_type(class_name, methods),
+    ) {
+        if !next_elem.is_assignable_to(&iter_elem) || !iter_elem.is_assignable_to(&next_elem) {
+            protocol_diagnostics::iterator_element_mismatch(
+                ctx,
+                class_name,
+                "__iter__",
+                iter_elem.display_name().as_str(),
+                "__next__",
+                next_elem.display_name().as_str(),
+                class_range,
+            );
+        }
+    }
+
+    if let (Some(iter_elem), Some(reversed_elem)) = (
+        class_iter_element_type(class_name, methods),
+        class_reversed_element_type(class_name, methods),
+    ) {
+        if !reversed_elem.is_assignable_to(&iter_elem)
+            || !iter_elem.is_assignable_to(&reversed_elem)
+        {
+            protocol_diagnostics::iterator_element_mismatch(
+                ctx,
+                class_name,
+                "__iter__",
+                iter_elem.display_name().as_str(),
+                "__reversed__",
+                reversed_elem.display_name().as_str(),
+                class_range,
+            );
+        }
+    }
+}

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -6,9 +6,9 @@ use sifr_python_ast::{Expr, Stmt, StmtClassDef};
 use sifr_type_system::{FunctionType, ParamConvention, Type};
 use std::collections::HashMap;
 
+use super::super::declared_class_identity;
 use super::async_await::coroutine_result_type;
 use super::class_field_inference::collect_constructor_self_field_assignments;
-use super::class_type_helpers::option_member_type;
 use super::diagnostics::{
     collect_enum_variants, get_newtype_inner, get_parent_class, has_decorator, is_enum_class,
     is_error_class, is_protocol_class,
@@ -18,9 +18,9 @@ use super::parameter_conventions::{
     declared_method_receiver_convention, inherit_class_methods,
     record_declared_class_method_metadata, replace_method_signature,
 };
-use super::protocol_diagnostics;
 use super::simple_expr::lower_expr_simple;
 use super::typing_and_functions::resolve_annotation_expr;
+use super::validate_iteration_protocol_methods;
 use super::{parse_typevar_bound_expr, LowerCtx};
 use crate::lower::workload_annotations;
 
@@ -103,153 +103,6 @@ pub(super) fn parent_class_range(class_def: &StmtClassDef, parent_name: &str) ->
         .unwrap_or_else(|| class_def.name.range())
 }
 
-pub(super) fn class_next_element_type(
-    class_name: &str,
-    methods: &[(String, FunctionType)],
-) -> Option<Type> {
-    let next_ft = class_method_signature(methods, "__next__")?;
-    if !next_ft.params.is_empty() {
-        return None;
-    }
-    let elem = option_member_type(next_ft.return_type.as_ref())?;
-    if matches!(elem.resolve_alias(), Type::Class { name, .. } if name == class_name) {
-        return None;
-    }
-    Some(elem)
-}
-
-pub(super) fn class_iter_element_type(
-    class_name: &str,
-    methods: &[(String, FunctionType)],
-) -> Option<Type> {
-    let iter_ft = class_method_signature(methods, "__iter__")?;
-    if !iter_ft.params.is_empty() {
-        return None;
-    }
-    match iter_ft.return_type.resolve_alias() {
-        Type::Iterator(elem) | Type::Iterable(elem) => Some(*elem.clone()),
-        Type::Class { name, .. } if name == class_name => {
-            class_next_element_type(class_name, methods)
-        }
-        _ => None,
-    }
-}
-
-pub(super) fn class_reversed_element_type(
-    class_name: &str,
-    methods: &[(String, FunctionType)],
-) -> Option<Type> {
-    let reversed_ft = class_method_signature(methods, "__reversed__")?;
-    if !reversed_ft.params.is_empty() {
-        return None;
-    }
-    match reversed_ft.return_type.resolve_alias() {
-        Type::Iterator(elem) | Type::Iterable(elem) => Some(*elem.clone()),
-        Type::Class { name, .. } if name == class_name => {
-            class_next_element_type(class_name, methods)
-        }
-        _ => None,
-    }
-}
-
-pub(super) fn validate_iteration_protocol_methods(
-    class_name: &str,
-    methods: &[(String, FunctionType)],
-    method_ranges: &HashMap<String, ruff_text_size::TextRange>,
-    class_range: ruff_text_size::TextRange,
-    ctx: &mut LowerCtx,
-) {
-    if let Some(iter_ft) = class_method_signature(methods, "__iter__") {
-        let range = method_ranges["__iter__"];
-        if !iter_ft.params.is_empty() {
-            protocol_diagnostics::iterator_invalid_parameter_signature(
-                ctx,
-                &format!("{class_name}.__iter__"),
-                range,
-            );
-        } else if class_iter_element_type(class_name, methods).is_none() {
-            protocol_diagnostics::iterator_invalid_return_signature(
-                ctx,
-                &format!("{class_name}.__iter__"),
-                "'Iterator[T]' or 'Iterable[T]'",
-                range,
-            );
-        }
-    }
-
-    if let Some(next_ft) = class_method_signature(methods, "__next__") {
-        let range = method_ranges["__next__"];
-        if !next_ft.params.is_empty() {
-            protocol_diagnostics::iterator_invalid_parameter_signature(
-                ctx,
-                &format!("{class_name}.__next__"),
-                range,
-            );
-        } else if class_next_element_type(class_name, methods).is_none() {
-            protocol_diagnostics::iterator_invalid_return_signature(
-                ctx,
-                &format!("{class_name}.__next__"),
-                "'T | None'",
-                range,
-            );
-        }
-    }
-
-    if let Some(reversed_ft) = class_method_signature(methods, "__reversed__") {
-        let range = method_ranges["__reversed__"];
-        if !reversed_ft.params.is_empty() {
-            protocol_diagnostics::iterator_invalid_parameter_signature(
-                ctx,
-                &format!("{class_name}.__reversed__"),
-                range,
-            );
-        } else if class_reversed_element_type(class_name, methods).is_none() {
-            protocol_diagnostics::iterator_invalid_return_signature(
-                ctx,
-                &format!("{class_name}.__reversed__"),
-                "'Iterator[T]' or 'Iterable[T]'",
-                range,
-            );
-        }
-    }
-
-    if let (Some(iter_elem), Some(next_elem)) = (
-        class_iter_element_type(class_name, methods),
-        class_next_element_type(class_name, methods),
-    ) {
-        if !next_elem.is_assignable_to(&iter_elem) || !iter_elem.is_assignable_to(&next_elem) {
-            protocol_diagnostics::iterator_element_mismatch(
-                ctx,
-                class_name,
-                "__iter__",
-                iter_elem.display_name().as_str(),
-                "__next__",
-                next_elem.display_name().as_str(),
-                class_range,
-            );
-        }
-    }
-
-    if let (Some(iter_elem), Some(reversed_elem)) = (
-        class_iter_element_type(class_name, methods),
-        class_reversed_element_type(class_name, methods),
-    ) {
-        if !reversed_elem.is_assignable_to(&iter_elem)
-            || !iter_elem.is_assignable_to(&reversed_elem)
-        {
-            protocol_diagnostics::iterator_element_mismatch(
-                ctx,
-                class_name,
-                "__iter__",
-                iter_elem.display_name().as_str(),
-                "__reversed__",
-                reversed_elem.display_name().as_str(),
-                class_range,
-            );
-        }
-    }
-}
-
 pub(in crate::lower) fn collect_class_type(
     class_def: &StmtClassDef,
     ctx: &mut LowerCtx,
@@ -297,6 +150,7 @@ pub(in crate::lower) fn collect_class_type(
     // For newtype declarations, register as a Newtype type
     if let Some(ref inner) = newtype_inner {
         let newtype_ty = Type::Newtype {
+            identity: declared_class_identity(ctx.current_module_name.as_deref(), &class_name),
             name: class_name.clone(),
             inner: Box::new(inner.clone()),
         };
@@ -338,6 +192,7 @@ pub(in crate::lower) fn collect_class_type(
             }
         }
         let enum_ty = Type::Enum {
+            identity: declared_class_identity(ctx.current_module_name.as_deref(), &class_name),
             name: class_name.clone(),
             variants: variants
                 .iter()
@@ -445,6 +300,7 @@ pub(in crate::lower) fn collect_class_type(
             }
         }
         let proto_ty = Type::Protocol {
+            identity: declared_class_identity(ctx.current_module_name.as_deref(), &class_name),
             name: class_name.clone(),
             methods: methods.clone(),
         };
@@ -505,7 +361,7 @@ pub(in crate::lower) fn collect_class_type(
     ctx.class_types.insert(
         class_name.clone(),
         Type::Class {
-            identity: None,
+            identity: declared_class_identity(ctx.current_module_name.as_deref(), &class_name),
             type_args: ctx
                 .class_declared_type_params
                 .get(&class_name)
@@ -797,7 +653,7 @@ pub(in crate::lower) fn collect_class_type(
         .map(Type::TypeVar)
         .collect();
     let class_ty = Type::Class {
-        identity: None,
+        identity: declared_class_identity(ctx.current_module_name.as_deref(), &class_name),
         type_args: generic_type_args,
         name: class_name.clone(),
         fields: fields.clone(),

--- a/crates/sifr_lowering/src/lower/expressions/method_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_calls.rs
@@ -402,7 +402,7 @@ pub(in crate::lower) fn resolve_method_type(
         Type::Protocol { name, methods, .. } => {
             resolve_protocol_method_type(name, methods, method, args, arg_ranges, method_range, ctx)
         }
-        Type::Newtype { name, inner } => {
+        Type::Newtype { name, inner, .. } => {
             resolve_newtype_method_type(name, inner, method, args, arg_ranges, method_range, ctx)
         }
         Type::Enum { name, .. } => {

--- a/crates/sifr_lowering/src/lower/expressions_tests/minmax_sorted_sum.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/minmax_sorted_sum.rs
@@ -739,6 +739,7 @@ pub(super) fn test_class_missing_method_has_class_code() {
 #[test]
 pub(super) fn test_protocol_method_wrong_arity_has_call_code() {
     let protocol_ty = Type::Protocol {
+        identity: None,
         name: "Runner".to_string(),
         methods: vec![(
             "run".to_string(),
@@ -761,6 +762,7 @@ pub(super) fn test_protocol_method_wrong_arity_has_call_code() {
 #[test]
 pub(super) fn test_protocol_missing_method_has_protocol_code() {
     let protocol_ty = Type::Protocol {
+        identity: None,
         name: "Runner".to_string(),
         methods: vec![(
             "run".to_string(),

--- a/crates/sifr_lowering/src/lower/imported_class_identity.rs
+++ b/crates/sifr_lowering/src/lower/imported_class_identity.rs
@@ -271,9 +271,46 @@ fn rename_class_identities(ty: &Type, class_aliases: &HashMap<String, String>) -
         Type::AsyncFunction(function) => {
             Type::AsyncFunction(rename_function_type(function, class_aliases))
         }
-        Type::Newtype { name, inner } => Type::Newtype {
-            name: name.clone(),
+        Type::Newtype {
+            identity,
+            name,
+            inner,
+        } => Type::Newtype {
+            identity: identity.clone(),
+            name: class_aliases
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| name.clone()),
             inner: Box::new(rename_class_identities(inner, class_aliases)),
+        },
+        Type::Protocol {
+            identity,
+            name,
+            methods,
+        } => Type::Protocol {
+            identity: identity.clone(),
+            name: class_aliases
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| name.clone()),
+            methods: methods
+                .iter()
+                .map(|(name, function)| {
+                    (name.clone(), rename_function_type(function, class_aliases))
+                })
+                .collect(),
+        },
+        Type::Enum {
+            identity,
+            name,
+            variants,
+        } => Type::Enum {
+            identity: identity.clone(),
+            name: class_aliases
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| name.clone()),
+            variants: variants.clone(),
         },
         Type::Class {
             identity,
@@ -365,8 +402,7 @@ fn set_canonical_identities(ty: &mut Type, local_classes: &HashMap<String, Strin
         | Type::PythonDlpackTensor(inner)
         | Type::Awaitable(inner)
         | Type::Failure(inner)
-        | Type::TimeoutResult(inner)
-        | Type::Newtype { inner, .. } => set_canonical_identities(inner, local_classes),
+        | Type::TimeoutResult(inner) => set_canonical_identities(inner, local_classes),
         Type::Dict(left, right)
         | Type::Result(left, right)
         | Type::Task(left, right)
@@ -443,6 +479,36 @@ fn set_canonical_identities(ty: &mut Type, local_classes: &HashMap<String, Strin
                         .collect::<Vec<_>>()
                         .join("|");
                 }
+            }
+        }
+        Type::Protocol {
+            identity,
+            name,
+            methods,
+        } => {
+            if identity.is_none() {
+                *identity = local_classes.get(name).cloned();
+            }
+            for (_, method) in methods {
+                for (_, param, _) in &mut method.params {
+                    set_canonical_identities(param, local_classes);
+                }
+                set_canonical_identities(&mut method.return_type, local_classes);
+            }
+        }
+        Type::Newtype {
+            identity,
+            name,
+            inner,
+        } => {
+            if identity.is_none() {
+                *identity = local_classes.get(name).cloned();
+            }
+            set_canonical_identities(inner, local_classes);
+        }
+        Type::Enum { identity, name, .. } => {
+            if identity.is_none() {
+                *identity = local_classes.get(name).cloned();
             }
         }
         _ => {}

--- a/crates/sifr_lowering/src/lower/ipc_payload_calls.rs
+++ b/crates/sifr_lowering/src/lower/ipc_payload_calls.rs
@@ -221,6 +221,7 @@ mod tests {
             Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
             Type::Tuple(vec![Type::Int, Type::Str, Type::Bytes]),
             Type::Enum {
+                identity: None,
                 name: "Color".to_string(),
                 variants: vec![("RED".to_string(), Some(1)), ("BLUE".to_string(), Some(2))],
             },

--- a/crates/sifr_lowering/src/lower/ipc_schema_extraction.rs
+++ b/crates/sifr_lowering/src/lower/ipc_schema_extraction.rs
@@ -47,7 +47,7 @@ fn extract_ipc_schema_type_inner(ty: &Type) -> IpcSchemaType {
                 })
                 .collect::<Vec<_>>(),
         },
-        Type::Enum { name, variants } => IpcSchemaType::Enum {
+        Type::Enum { name, variants, .. } => IpcSchemaType::Enum {
             name: name.clone(),
             variants: variants
                 .iter()
@@ -153,6 +153,7 @@ mod tests {
             compatible_version_max: 1,
             request: extract_ipc_schema_type(&request),
             response: extract_ipc_schema_type(&Type::Enum {
+                identity: None,
                 name: "EchoStatus".to_string(),
                 variants: vec![
                     ("Accepted".to_string(), Some(1)),

--- a/crates/sifr_lowering/src/lower/match_lowering.rs
+++ b/crates/sifr_lowering/src/lower/match_lowering.rs
@@ -250,7 +250,7 @@ fn report_enum_exhaustiveness(
     match_stmt: &StmtMatch,
     ctx: &mut LowerCtx,
 ) {
-    let Type::Enum { name, variants } = subject_ty else {
+    let Type::Enum { name, variants, .. } = subject_ty else {
         return;
     };
 

--- a/crates/sifr_lowering/src/lower/method_receiver_analysis.rs
+++ b/crates/sifr_lowering/src/lower/method_receiver_analysis.rs
@@ -442,9 +442,17 @@ pub(super) fn method_signature(
             method,
             class_types,
         ),
-        Type::Protocol { name, methods } => {
-            resolved_nominal_method_signature(None, name, methods, method, class_types)
-        }
+        Type::Protocol {
+            identity,
+            name,
+            methods,
+        } => resolved_nominal_method_signature(
+            identity.as_deref(),
+            name,
+            methods,
+            method,
+            class_types,
+        ),
         Type::Enum { name, .. } => functions.get(&format!("{name}.{method}")).cloned(),
         Type::Alias { body, .. } => method_signature(body, method, class_types, functions),
         Type::TypeVar(name) => class_types

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -222,6 +222,10 @@ pub fn canonicalize_user_export_type(ty: &Type, local_classes: &HashMap<String, 
     imported_class_identity::canonicalize_export_type(ty, local_classes)
 }
 
+fn declared_class_identity(module: Option<&str>, name: &str) -> Option<String> {
+    module.map(|module| format!("{module}.{name}"))
+}
+
 pub fn canonicalize_user_export_type_in_place(
     ty: &mut Type,
     local_classes: &HashMap<String, String>,

--- a/crates/sifr_type_system/src/types/definitions.rs
+++ b/crates/sifr_type_system/src/types/definitions.rs
@@ -151,13 +151,18 @@ pub enum Type {
     /// Protocol type: structural interface that maps to Rust `trait`.
     /// Any class with the required methods satisfies the protocol.
     Protocol {
+        identity: Option<String>,
         name: String,
         methods: Vec<(String, FunctionType)>,
     },
 
     /// Newtype wrapper around a primitive type.
     /// `class Port(int)` -> `struct Port(i64)`
-    Newtype { name: String, inner: Box<Type> },
+    Newtype {
+        identity: Option<String>,
+        name: String,
+        inner: Box<Type>,
+    },
 
     // --- Generics ---
     /// Type variable: a generic type parameter (e.g., `T` in `def first[T](items: list[T]) -> T`)
@@ -175,6 +180,7 @@ pub enum Type {
     /// Enum type: `class Color(Enum): RED = 1; GREEN = 2; BLUE = 3`
     /// Maps to a Rust `#[repr(i64)] enum Color { RED = 1, GREEN = 2, BLUE = 3 }`
     Enum {
+        identity: Option<String>,
         name: String,
         variants: Vec<(String, Option<i64>)>,
     },

--- a/crates/sifr_type_system/src/types/type_rendering.rs
+++ b/crates/sifr_type_system/src/types/type_rendering.rs
@@ -721,10 +721,31 @@ impl Type {
                         && cft.return_type.is_assignable_to(&pft.return_type)
                 })
             }),
-            // Protocol types: same name means same protocol
-            (Self::Protocol { name: a, .. }, Self::Protocol { name: b, .. }) => a == b,
-            // Newtype: same name means same newtype (nominal)
-            (Self::Newtype { name: a, .. }, Self::Newtype { name: b, .. }) => a == b,
+            // Nominal types compare their canonical declaration identity when available.
+            (
+                Self::Protocol {
+                    identity: a_identity,
+                    name: a,
+                    ..
+                },
+                Self::Protocol {
+                    identity: b_identity,
+                    name: b,
+                    ..
+                },
+            ) => a_identity.as_deref().unwrap_or(a) == b_identity.as_deref().unwrap_or(b),
+            (
+                Self::Newtype {
+                    identity: a_identity,
+                    name: a,
+                    ..
+                },
+                Self::Newtype {
+                    identity: b_identity,
+                    name: b,
+                    ..
+                },
+            ) => a_identity.as_deref().unwrap_or(a) == b_identity.as_deref().unwrap_or(b),
             // TypeVar: only assignable to the same type parameter name.
             (Self::TypeVar(a), Self::TypeVar(b)) => a == b,
             // Callable: compatible if param and return types match
@@ -746,8 +767,18 @@ impl Type {
                         .all(|((_, pt, _), ct)| pt.is_assignable_to(ct))
                     && ft.return_type.is_assignable_to(ret)
             }
-            // Enum: nominal typing - same name means same enum
-            (Self::Enum { name: a, .. }, Self::Enum { name: b, .. }) => a == b,
+            (
+                Self::Enum {
+                    identity: a_identity,
+                    name: a,
+                    ..
+                },
+                Self::Enum {
+                    identity: b_identity,
+                    name: b,
+                    ..
+                },
+            ) => a_identity.as_deref().unwrap_or(a) == b_identity.as_deref().unwrap_or(b),
             // BigInt: only assignable to BigInt
             (Self::BigInt, Self::BigInt) => true,
             _ => false,

--- a/crates/sifr_type_system/src/types/union_identity.rs
+++ b/crates/sifr_type_system/src/types/union_identity.rs
@@ -71,12 +71,23 @@ impl Type {
             }
             Self::Unknown => atom("unknown"),
             Self::Result(ok, error) => binary("result", ok, error),
-            class @ Self::Class { type_args, .. } => {
-                named_sequence("class", &class.rust_type(), type_args)
-            }
-            Self::Protocol { name, methods } => nominal_methods("protocol", name, methods),
-            Self::Newtype { name, inner } => {
-                let mut key = component("newtype", name);
+            Self::Class {
+                identity,
+                name,
+                type_args,
+                ..
+            } => named_sequence("class", identity.as_deref().unwrap_or(name), type_args),
+            Self::Protocol {
+                identity,
+                name,
+                methods,
+            } => nominal_methods("protocol", identity.as_deref().unwrap_or(name), methods),
+            Self::Newtype {
+                identity,
+                name,
+                inner,
+            } => {
+                let mut key = component("newtype", identity.as_deref().unwrap_or(name));
                 append(&mut key, &inner.union_identity_key());
                 key
             }
@@ -87,7 +98,11 @@ impl Type {
             Self::AsyncCallable(params, conventions, result) => {
                 callable_key("async_callable", params, conventions, result)
             }
-            Self::Enum { name, variants } => enum_key(name, variants),
+            Self::Enum {
+                identity,
+                name,
+                variants,
+            } => enum_key(identity.as_deref().unwrap_or(name), variants),
             Self::BigInt => atom("bigint"),
             Self::Decimal => atom("decimal"),
             Self::BigDecimal => atom("bigdecimal"),
@@ -247,7 +262,8 @@ mod tests {
             parent_class: None,
         };
         let local_int = class("Int", Some("pkg.Int"));
-        let canonicalized_local_int = class("Int", None);
+        let unqualified_local_int = class("Int", None);
+        let aliased_local_int = class("Integer", Some("pkg.Int"));
         let aliased_other_int = class("OtherInt", Some("other.Int"));
         let union = Type::Union(vec![Type::Int, local_int.clone()]);
 
@@ -260,9 +276,13 @@ mod tests {
             local_int.union_variant_name(),
             aliased_other_int.union_variant_name()
         );
+        assert_ne!(
+            local_int.union_variant_name(),
+            unqualified_local_int.union_variant_name()
+        );
         assert_eq!(
             local_int.union_variant_name(),
-            canonicalized_local_int.union_variant_name()
+            aliased_local_int.union_variant_name()
         );
 
         let callable =
@@ -275,5 +295,59 @@ mod tests {
             Type::Union(vec![Type::Int, Type::Str]).union_enum_name(),
             Type::Union(vec![Type::Str, Type::Int]).union_enum_name()
         );
+
+        let newtype = |name: &str, identity: &str| Type::Newtype {
+            identity: Some(identity.to_string()),
+            name: name.to_string(),
+            inner: Box::new(Type::Int),
+        };
+        let enumeration = |name: &str, identity: &str| Type::Enum {
+            identity: Some(identity.to_string()),
+            name: name.to_string(),
+            variants: vec![("READY".to_string(), Some(1))],
+        };
+        let protocol = |name: &str, identity: &str| Type::Protocol {
+            identity: Some(identity.to_string()),
+            name: name.to_string(),
+            methods: Vec::new(),
+        };
+        for (left, right) in [
+            (
+                newtype("Token", "left.Token"),
+                newtype("Token", "right.Token"),
+            ),
+            (
+                enumeration("Status", "left.Status"),
+                enumeration("Status", "right.Status"),
+            ),
+            (
+                protocol("Readable", "left.Readable"),
+                protocol("Readable", "right.Readable"),
+            ),
+        ] {
+            assert_ne!(
+                Type::Union(vec![Type::Int, left]).union_enum_name(),
+                Type::Union(vec![Type::Int, right]).union_enum_name()
+            );
+        }
+        for (original, alias) in [
+            (
+                newtype("Token", "left.Token"),
+                newtype("PublicToken", "left.Token"),
+            ),
+            (
+                enumeration("Status", "left.Status"),
+                enumeration("PublicStatus", "left.Status"),
+            ),
+            (
+                protocol("Readable", "left.Readable"),
+                protocol("PublicReadable", "left.Readable"),
+            ),
+        ] {
+            assert_eq!(
+                Type::Union(vec![Type::Int, original]).union_enum_name(),
+                Type::Union(vec![Type::Int, alias]).union_enum_name()
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- preserve canonical composite-union identity across binary and test-project code generation
- centralize shared union, numeric, and stdlib nominal imports without duplicate bindings
- map a Sifr main support module injectively into the generated test crate layout
- add native cross-module Result-union and composite-union regressions

## Review

Claude Opus whole-diff review on exact SHA a42d1806e496df0f959011db7659c52f38959903: SATISFIED.

## Validation

- cargo test -p sifr_codegen: 994 passed
- cargo test -p sifr_driver: 466 passed, 77 governed skips
- exact native main-support regression: passed
- no-cache stdlib_json_consolidated E2E: 1/1
- canonical warm create-PR gate: exit 0
- create-PR receipt SHA-256: 4cc51486c1a3ee528f8ce1e44f77a4e3e2ad8374d89d8458430e679f5e09ed83

The required cold-cache create-PR attempt was functionally green and exceeded only the generated-code cold-artifact budget tracked by #3134. The unchanged warm canonical run passed all step budgets.