### PR TITLE
feat: support distinct structural bridge generics

### DIFF
--- a/crates/sifr_codegen/src/function_emitter/scope_and_function_types.rs
+++ b/crates/sifr_codegen/src/function_emitter/scope_and_function_types.rs
@@ -717,7 +717,11 @@ impl RustEmitter {
                 let structural = func.rust_interop.iter().any(|declaration| {
                     declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural
                 });
-                let base = if structural && self.static_program_functions.contains(&func.name) {
+                let static_program = self
+                    .static_program_type_params
+                    .get(&func.name)
+                    .is_some_and(|params| params.contains(tp));
+                let base = if structural && static_program {
                     "sifr_runtime::interop::structural::StructuralConstruct + sifr_runtime::interop::structural::StructuralProject + sifr_runtime::interop::structural::StaticProgramType"
                 } else if structural {
                     "sifr_runtime::interop::structural::StructuralConstruct + sifr_runtime::interop::structural::StructuralProject"

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -50,8 +50,8 @@ pub struct RustEmitter {
     /// Emit structural bridge implementations only when the project declares
     /// a structural Rust interop boundary.
     pub(crate) structural_interop_enabled: bool,
-    /// Structural bridge functions whose type parameter requires compiler-emitted static data.
-    pub(crate) static_program_functions: HashSet<String>,
+    /// Static-program type parameters for each structural bridge function.
+    pub(crate) static_program_type_params: HashMap<String, HashSet<String>>,
     /// Set of stdlib/intrinsic modules used (for Cargo dependency injection)
     pub used_stdlib_modules: HashSet<String>,
     /// Set of intrinsic function names (for codegen dispatch)
@@ -229,7 +229,7 @@ impl RustEmitter {
             current_class_name: None,
             current_module_name: None,
             structural_interop_enabled: false,
-            static_program_functions: HashSet::new(),
+            static_program_type_params: HashMap::new(),
             used_stdlib_modules: HashSet::new(),
             intrinsic_functions: HashSet::new(),
             intrinsic_registry_features: HashSet::new(),

--- a/crates/sifr_codegen/src/module_prescan.rs
+++ b/crates/sifr_codegen/src/module_prescan.rs
@@ -8,15 +8,17 @@ impl RustEmitter {
         self.collect_display_class_metadata(module);
         self.collect_parent_field_metadata(module);
         self.collect_function_signature_metadata(module);
-        self.static_program_functions = module
+        self.static_program_type_params = module
             .type_param_bounds
             .iter()
-            .filter(|(_, bounds)| {
-                bounds
-                    .values()
-                    .any(|values| values.as_slice() == ["StaticProgram"])
+            .filter_map(|(owner, bounds)| {
+                let params = bounds
+                    .iter()
+                    .filter(|(_, values)| values.as_slice() == ["StaticProgram"])
+                    .map(|(name, _)| name.clone())
+                    .collect::<HashSet<_>>();
+                (!params.is_empty()).then(|| (owner.clone(), params))
             })
-            .map(|(owner, _)| owner.clone())
             .collect();
     }
 

--- a/crates/sifr_codegen/src/rust_interop_bridge_callback_contract.rs
+++ b/crates/sifr_codegen/src/rust_interop_bridge_callback_contract.rs
@@ -12,7 +12,7 @@ pub(crate) struct CallbackSignature<'a> {
     pub(crate) params: &'a [Type],
     pub(crate) conventions: &'a [ParamConvention],
     pub(crate) result: &'a Type,
-    pub(crate) structural_type_param: Option<&'a str>,
+    pub(crate) structural_type_params: &'a [String],
 }
 
 pub(crate) fn bridge_call_scoped_callback_type(
@@ -122,7 +122,7 @@ fn callback_rust_types(
                 catalog,
                 generated_types,
                 BridgeTypePosition::Parameter(CallbackParameterMode::Nested),
-                signature.structural_type_param,
+                signature.structural_type_params,
             )
             .rust_owned_type
         })
@@ -136,7 +136,7 @@ fn callback_rust_types(
             catalog,
             generated_types,
             BridgeTypePosition::Return,
-            signature.structural_type_param,
+            signature.structural_type_params,
         );
         let ok_type = ok_contract.rust_return_type.ok_or(())?;
         format!("Result<{ok_type}, String>")
@@ -148,7 +148,7 @@ fn callback_rust_types(
             catalog,
             generated_types,
             BridgeTypePosition::Return,
-            signature.structural_type_param,
+            signature.structural_type_params,
         );
         result_contract.rust_return_type.ok_or(())?
     };

--- a/crates/sifr_codegen/src/rust_interop_bridge_contract.rs
+++ b/crates/sifr_codegen/src/rust_interop_bridge_contract.rs
@@ -37,8 +37,8 @@ pub struct RustBridgeSignatureContract {
     pub owner: RustInteropOwner,
     pub params: Vec<RustBridgeParamContract>,
     pub return_type: RustBridgeTypeContract,
-    pub structural_type_param: Option<String>,
-    pub static_program_type_param: bool,
+    pub structural_type_params: Vec<String>,
+    pub static_program_type_params: Vec<String>,
     pub panic_error: RustBridgePanicErrorContract,
     pub span: ruff_text_size::TextRange,
 }
@@ -216,7 +216,7 @@ fn signature_contract(
         RustInteropOwner::Class { .. } => (None, None),
     };
     let function = function?;
-    let structural_type_param = function.structural_type_param.as_deref();
+    let structural_type_params = function.structural_type_params.as_slice();
     let params = receiver
         .into_iter()
         .chain(function.params.iter().map(|param| RustBridgeParamContract {
@@ -235,7 +235,7 @@ fn signature_contract(
                         CallbackParameterMode::CallScoped
                     },
                 ),
-                structural_type_param,
+                structural_type_params,
             ),
         }))
         .collect::<Vec<_>>();
@@ -246,7 +246,7 @@ fn signature_contract(
         catalog,
         generated_types,
         BridgeTypePosition::Return,
-        structural_type_param,
+        structural_type_params,
     );
     let panic_error = rust_bridge_panic_error_contract(&function.return_type);
     Some(RustBridgeSignatureContract {
@@ -255,8 +255,8 @@ fn signature_contract(
         owner: declaration.owner.clone(),
         params,
         return_type,
-        structural_type_param: function.structural_type_param.clone(),
-        static_program_type_param: function.static_program_type_param,
+        structural_type_params: function.structural_type_params.clone(),
+        static_program_type_params: function.static_program_type_params.clone(),
         panic_error,
         span: declaration.declaration.span,
     })
@@ -268,8 +268,8 @@ struct ModuleFunction {
     return_type: Type,
     method_kind: Option<sifr_ir::MethodKind>,
     consumes_receiver: bool,
-    structural_type_param: Option<String>,
-    static_program_type_param: bool,
+    structural_type_params: Vec<String>,
+    static_program_type_params: Vec<String>,
 }
 
 pub(crate) struct ModuleCatalog {
@@ -290,6 +290,30 @@ impl ModuleCatalog {
         let mut record_classes = BTreeSet::new();
         let mut enum_classes = BTreeSet::new();
         for function in &module.functions {
+            let has_structural_declaration = function.rust_interop.iter().any(|declaration| {
+                declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural
+            });
+            let structural_type_params = if has_structural_declaration {
+                function
+                    .type_params
+                    .iter()
+                    .filter(|type_param| {
+                        module
+                            .type_param_bounds
+                            .get(&function.name)
+                            .and_then(|bounds| bounds.get(*type_param))
+                            .is_some_and(|bounds| {
+                                matches!(
+                                    bounds.as_slice(),
+                                    [bound] if bound == "Structural" || bound == "StaticProgram"
+                                )
+                            })
+                    })
+                    .cloned()
+                    .collect()
+            } else {
+                Vec::new()
+            };
             functions.insert(
                 function.name.clone(),
                 ModuleFunction {
@@ -297,22 +321,19 @@ impl ModuleCatalog {
                     return_type: function.return_type.clone(),
                     method_kind: None,
                     consumes_receiver: false,
-                    structural_type_param: function
-                        .rust_interop
+                    structural_type_params,
+                    static_program_type_params: function
+                        .type_params
                         .iter()
-                        .any(|declaration| {
-                            declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural
+                        .filter(|type_param| {
+                            module
+                                .type_param_bounds
+                                .get(&function.name)
+                                .and_then(|bounds| bounds.get(*type_param))
+                                .is_some_and(|bounds| bounds.as_slice() == ["StaticProgram"])
                         })
-                        .then(|| function.type_params.first().cloned())
-                        .flatten(),
-                    static_program_type_param: module
-                        .type_param_bounds
-                        .get(&function.name)
-                        .is_some_and(|bounds| {
-                            bounds
-                                .values()
-                                .any(|values| values.as_slice() == ["StaticProgram"])
-                        }),
+                        .cloned()
+                        .collect(),
                 },
             );
         }
@@ -349,8 +370,8 @@ impl ModuleCatalog {
                             .rust_interop
                             .first()
                             .is_some_and(|declaration| declaration.consumes_receiver),
-                        structural_type_param: None,
-                        static_program_type_param: false,
+                        structural_type_params: Vec::new(),
+                        static_program_type_params: Vec::new(),
                     },
                 );
             }
@@ -395,7 +416,7 @@ pub(crate) fn bridge_type_contract(
     catalog: Option<&ModuleCatalog>,
     generated_types: &mut GeneratedTypeCollector,
     position: BridgeTypePosition,
-    structural_type_param: Option<&str>,
+    structural_type_params: &[String],
 ) -> RustBridgeTypeContract {
     let resolved = ty.resolve_alias();
     match resolved {
@@ -438,7 +459,7 @@ pub(crate) fn bridge_type_contract(
             catalog,
             generated_types,
             position,
-            structural_type_param,
+            structural_type_params,
         ),
         Type::Dict(key, value) => bridge_dict_type(
             (key, value),
@@ -447,7 +468,7 @@ pub(crate) fn bridge_type_contract(
             catalog,
             generated_types,
             position,
-            structural_type_param,
+            structural_type_params,
         ),
         Type::Union(members) => bridge_union_type(
             members,
@@ -456,7 +477,7 @@ pub(crate) fn bridge_type_contract(
             catalog,
             generated_types,
             position,
-            structural_type_param,
+            structural_type_params,
         ),
         Type::Tuple(items) => bridge_tuple_type(
             items,
@@ -477,7 +498,7 @@ pub(crate) fn bridge_type_contract(
                     catalog,
                     generated_types,
                     BridgeTypePosition::Return,
-                    structural_type_param,
+                    structural_type_params,
                 );
                 let bridge_error = match recoverable_panic_bridge_error(err) {
                     Ok(Some(ordinary_error)) => ordinary_error,
@@ -493,7 +514,7 @@ pub(crate) fn bridge_type_contract(
                     catalog,
                     generated_types,
                     BridgeTypePosition::Return,
-                    structural_type_param,
+                    structural_type_params,
                 );
                 combine_generic_type(
                     "Result",
@@ -578,7 +599,7 @@ pub(crate) fn bridge_type_contract(
                     params,
                     conventions,
                     result,
-                    structural_type_param,
+                    structural_type_params,
                 },
                 module_name,
                 module_catalogs,
@@ -598,7 +619,7 @@ pub(crate) fn bridge_type_contract(
                     params,
                     conventions,
                     result,
-                    structural_type_param,
+                    structural_type_params,
                 },
                 module_name,
                 module_catalogs,
@@ -618,7 +639,7 @@ pub(crate) fn bridge_type_contract(
             unsupported_type(ty, "dynamic Any/Unknown values are not Rust bridge-compatible")
         }
         Type::Never => unsupported_type(ty, "Never is not a Rust bridge value type"),
-        Type::TypeVar(name) if structural_type_param == Some(name.as_str()) => {
+        Type::TypeVar(name) if structural_type_params.contains(name) => {
             RustBridgeTypeContract {
                 sifr_type: name.clone(),
                 rust_borrowed_type: Some(format!("&{name}")),

--- a/crates/sifr_codegen/src/rust_interop_bridge_contract/type_shapes.rs
+++ b/crates/sifr_codegen/src/rust_interop_bridge_contract/type_shapes.rs
@@ -26,7 +26,7 @@ pub(super) fn bridge_list_type(
     catalog: Option<&ModuleCatalog>,
     generated_types: &mut GeneratedTypeCollector,
     position: BridgeTypePosition,
-    structural_type_param: Option<&str>,
+    structural_type_params: &[String],
 ) -> RustBridgeTypeContract {
     let inner_ty = bridge_type_contract(
         inner,
@@ -35,7 +35,7 @@ pub(super) fn bridge_list_type(
         catalog,
         generated_types,
         position.nested(),
-        structural_type_param,
+        structural_type_params,
     );
     let Some(inner_owned) = inner_ty.rust_owned_type.clone() else {
         return unsupported_type(
@@ -60,7 +60,7 @@ pub(super) fn bridge_dict_type(
     catalog: Option<&ModuleCatalog>,
     generated_types: &mut GeneratedTypeCollector,
     position: BridgeTypePosition,
-    structural_type_param: Option<&str>,
+    structural_type_params: &[String],
 ) -> RustBridgeTypeContract {
     let (key, value) = entries;
     if !matches!(key.resolve_alias(), Type::Str) {
@@ -76,7 +76,7 @@ pub(super) fn bridge_dict_type(
         catalog,
         generated_types,
         position.nested(),
-        structural_type_param,
+        structural_type_params,
     );
     let Some(value_owned) = value_ty.rust_owned_type.clone() else {
         return unsupported_type(
@@ -102,7 +102,7 @@ pub(super) fn bridge_union_type(
     catalog: Option<&ModuleCatalog>,
     generated_types: &mut GeneratedTypeCollector,
     position: BridgeTypePosition,
-    structural_type_param: Option<&str>,
+    structural_type_params: &[String],
 ) -> RustBridgeTypeContract {
     if members.len() == 2 {
         let non_none = members
@@ -120,7 +120,7 @@ pub(super) fn bridge_union_type(
                     catalog,
                     generated_types,
                     position.nested(),
-                    structural_type_param,
+                    structural_type_params,
                 );
                 let Some(inner_owned) = inner.rust_owned_type.clone() else {
                     return unsupported_type(

--- a/crates/sifr_codegen/src/rust_interop_bridge_contract_serialization.rs
+++ b/crates/sifr_codegen/src/rust_interop_bridge_contract_serialization.rs
@@ -44,18 +44,17 @@ fn push_signature(out: &mut String, signature: &RustBridgeSignatureContract) {
     out.push_str("|return=");
     push_type_contract(out, &signature.return_type);
     out.push_str("|structural=");
-    out.push_str(
-        signature
-            .structural_type_param
-            .as_deref()
-            .unwrap_or("<none>"),
-    );
-    out.push_str("|static-program=");
-    out.push_str(if signature.static_program_type_param {
-        "required"
+    if signature.structural_type_params.is_empty() {
+        out.push_str("<none>");
     } else {
-        "absent"
-    });
+        out.push_str(&signature.structural_type_params.join(","));
+    }
+    out.push_str("|static-program=");
+    if signature.static_program_type_params.is_empty() {
+        out.push_str("<none>");
+    } else {
+        out.push_str(&signature.static_program_type_params.join(","));
+    }
     out.push_str("|panic-error=");
     out.push_str(match signature.panic_error {
         crate::rust_interop_bridge_contract::RustBridgePanicErrorContract::None => "none",

--- a/crates/sifr_driver/src/build/rust_interop_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_contract_tests.rs
@@ -481,8 +481,8 @@ pub(super) fn signature_contract(
         },
         params,
         return_type,
-        structural_type_param: None,
-        static_program_type_param: false,
+        structural_type_params: Vec::new(),
+        static_program_type_params: Vec::new(),
         panic_error: sifr_codegen::RustBridgePanicErrorContract::None,
         span: span(),
     }

--- a/crates/sifr_driver/src/build/rust_interop_probe.rs
+++ b/crates/sifr_driver/src/build/rust_interop_probe.rs
@@ -77,7 +77,7 @@ pub(super) fn execute_direct_cargo_probe(
     let requires_structural_runtime = probe
         .signature
         .as_ref()
-        .is_some_and(|signature| signature.structural_type_param.is_some());
+        .is_some_and(|signature| !signature.structural_type_params.is_empty());
     let probe_manifest = probe_cargo_toml(
         &probe.backend.dependency_name,
         &probe.backend.cargo_package_name,
@@ -263,8 +263,8 @@ fn signature_probe_source(
     if is_python_raw_callback_probe(rust_path) {
         return python_raw_callback_probe_source(signature, rust_path);
     }
-    if let Some(type_param) = signature.structural_type_param.as_deref() {
-        return structural_signature_probe_source(signature, rust_path, type_param);
+    if !signature.structural_type_params.is_empty() {
+        return structural_signature_probe_source(signature, rust_path);
     }
     let params = signature
         .params
@@ -355,12 +355,11 @@ fn signature_probe_source(
 fn structural_signature_probe_source(
     signature: &RustBridgeSignatureContract,
     rust_path: &str,
-    type_param: &str,
 ) -> String {
     let mut out = String::from("#![allow(dead_code)]\n");
     out.push_str(&generated_bridge_type_stubs(signature));
     out.push_str("fn __sifr_probe<");
-    out.push_str(type_param);
+    out.push_str(&signature.structural_type_params.join(", "));
     out.push_str(">(");
     out.push_str(
         &signature
@@ -375,13 +374,17 @@ fn structural_signature_probe_source(
             .collect::<Vec<_>>()
             .join(", "),
     );
-    out.push_str(")\nwhere\n    ");
-    out.push_str(type_param);
-    out.push_str(": ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject");
-    if signature.static_program_type_param {
-        out.push_str(" + ::sifr_runtime::interop::structural::StaticProgramType");
+    out.push_str(")\nwhere\n");
+    for type_param in &signature.structural_type_params {
+        out.push_str("    ");
+        out.push_str(type_param);
+        out.push_str(": ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject");
+        if signature.static_program_type_params.contains(type_param) {
+            out.push_str(" + ::sifr_runtime::interop::structural::StaticProgramType");
+        }
+        out.push_str(",\n");
     }
-    out.push_str(",\n{\n    let _: ");
+    out.push_str("{\n    let _: ");
     let return_type = signature_return_probe_type(&signature.return_type);
     let normalized_return_type = if return_type.display_error_generic {
         return_type.ty.replace("__SifrBridgeError", "String")
@@ -395,7 +398,7 @@ fn structural_signature_probe_source(
     }
     out.push_str(rust_path);
     out.push_str("::<");
-    out.push_str(type_param);
+    out.push_str(&signature.structural_type_params.join(", "));
     out.push_str(">(");
     out.push_str(
         &(0..signature.params.len())

--- a/crates/sifr_driver/src/build/rust_interop_probe_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_probe_tests.rs
@@ -134,8 +134,8 @@ fn signature(return_type: RustBridgeTypeContract) -> RustBridgeSignatureContract
         },
         params: Vec::new(),
         return_type,
-        structural_type_param: None,
-        static_program_type_param: false,
+        structural_type_params: Vec::new(),
+        static_program_type_params: Vec::new(),
         panic_error: sifr_codegen::RustBridgePanicErrorContract::None,
         span: TextRange::default(),
     }
@@ -173,16 +173,51 @@ fn structural_probe_normalizes_backend_display_errors_without_erasing_ok_type() 
         kind: RustBridgeTypeKind::Result,
         unsupported_reason: None,
     });
-    signature.structural_type_param = Some("T".to_string());
-    signature.static_program_type_param = true;
+    signature.structural_type_params = vec!["T".to_string()];
+    signature.static_program_type_params = vec!["T".to_string()];
 
-    let source = structural_signature_probe_source(&signature, "bridge::roundtrip", "T");
+    let source = structural_signature_probe_source(&signature, "bridge::roundtrip");
 
     assert!(source.contains("let _: Result<T, String>"));
     assert!(source.contains("bridge::roundtrip::<T>()"));
     assert!(source.contains(".map_err(|error| error.to_string())"));
     assert!(source
         .contains("StructuralProject + ::sifr_runtime::interop::structural::StaticProgramType"));
+}
+
+#[test]
+fn structural_probe_preserves_distinct_input_and_output_generics() {
+    let mut signature = signature(RustBridgeTypeContract {
+        sifr_type: "Result[Output, BridgeError]".to_string(),
+        rust_borrowed_type: None,
+        rust_owned_type: None,
+        rust_return_type: Some(
+            "Result<Output, crate::__sifr_bridge::main::BridgeErrorBridge>".to_string(),
+        ),
+        kind: RustBridgeTypeKind::Result,
+        unsupported_reason: None,
+    });
+    signature.structural_type_params = vec!["Input".to_string(), "Output".to_string()];
+    signature.static_program_type_params = vec!["Output".to_string()];
+    signature.params = vec![sifr_codegen::RustBridgeParamContract {
+        name: "value".to_string(),
+        convention: sifr_codegen::RustBridgeParamConvention::Borrow,
+        ty: RustBridgeTypeContract {
+            sifr_type: "Input".to_string(),
+            rust_borrowed_type: Some("&Input".to_string()),
+            rust_owned_type: Some("Input".to_string()),
+            rust_return_type: Some("Input".to_string()),
+            kind: RustBridgeTypeKind::StructuralTypeParam,
+            unsupported_reason: None,
+        },
+    }];
+
+    let source = structural_signature_probe_source(&signature, "bridge::convert");
+
+    assert!(source.contains("fn __sifr_probe<Input, Output>"));
+    assert!(source.contains("Output: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject + ::sifr_runtime::interop::structural::StaticProgramType"));
+    assert!(source.contains("Input: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject"));
+    assert!(source.contains("bridge::convert::<Input, Output>"));
 }
 
 #[test]

--- a/crates/sifr_lowering/src/lower/rust_interop_structural.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural.rs
@@ -43,105 +43,107 @@ pub(in crate::lower) fn validate_structural_function_contract(
         );
     }
     validate_error_and_panic_contract(return_type, declarations, span, ctx);
-    let [type_param] = type_params else {
+    if type_params.is_empty() {
         structural_type_error(
             ctx,
-            "structural Rust bridge declarations require exactly one type parameter",
+            "structural Rust bridge declarations require at least one type parameter",
             span,
         );
         return;
-    };
-    let exact_bound = ctx
-        .type_param_bounds
-        .get(function_name)
-        .and_then(|bounds| bounds.get(type_param))
-        .and_then(|bounds| match bounds.as_slice() {
-            [bound] if bound == "Structural" || bound == "StaticProgram" => Some(bound.clone()),
-            _ => None,
-        });
-    if exact_bound.is_none() {
-        structural_type_error(
-            ctx,
-            format!(
-                "type parameter `{type_param}` must have the exact `Structural` or `StaticProgram` bound"
-            ),
-            span,
-        );
     }
-    match exact_bound.as_deref() {
-        Some("Structural") => {
-            let imported = ctx.canonical_structural_marker_imported;
-            let local = ctx.local_structural_marker_declared;
-            validate_marker(
+    for type_param in type_params {
+        let exact_bound = ctx
+            .type_param_bounds
+            .get(function_name)
+            .and_then(|bounds| bounds.get(type_param))
+            .and_then(|bounds| match bounds.as_slice() {
+                [bound] if bound == "Structural" || bound == "StaticProgram" => Some(bound.clone()),
+                _ => None,
+            });
+        if exact_bound.is_none() {
+            structural_type_error(
+                ctx,
+                format!(
+                    "type parameter `{type_param}` must have the exact `Structural` or `StaticProgram` bound"
+                ),
+                span,
+            );
+        }
+        match exact_bound.as_deref() {
+            Some("Structural") => validate_marker(
                 ctx,
                 "Structural",
                 "sifr.meta.Structural",
-                imported,
-                local,
+                ctx.canonical_structural_marker_imported,
+                ctx.local_structural_marker_declared,
                 span,
-            );
-        }
-        Some("StaticProgram") => {
-            let imported = ctx.canonical_static_program_marker_imported;
-            let local = ctx.local_static_program_marker_declared;
-            validate_marker(
+            ),
+            Some("StaticProgram") => validate_marker(
                 ctx,
                 "StaticProgram",
                 "sifr.meta.StaticProgram",
-                imported,
-                local,
+                ctx.canonical_static_program_marker_imported,
+                ctx.local_static_program_marker_declared,
+                span,
+            ),
+            _ => {}
+        }
+
+        let mut used = false;
+        for param in params {
+            match structural_type_position(&param.ty, type_param) {
+                StructuralTypePosition::Absent => {}
+                StructuralTypePosition::Direct => {
+                    used = true;
+                    if !param.convention.is_borrowed() || param.convention.is_mutable() {
+                        structural_type_error(
+                            ctx,
+                            format!(
+                                "structural parameter `{}` must be an immutable borrow",
+                                param.name
+                            ),
+                            span,
+                        );
+                    }
+                }
+                StructuralTypePosition::CallScopedCallback => used = true,
+                StructuralTypePosition::Nested => structural_type_error(
+                    ctx,
+                    format!(
+                        "structural type parameter `{type_param}` occurs in an unsupported nested position for `{}`",
+                        param.name
+                    ),
+                    span,
+                ),
+            }
+        }
+        match return_type.resolve_alias() {
+            Type::Result(ok, _) => match structural_type_position(ok, type_param) {
+                StructuralTypePosition::Absent => {}
+                StructuralTypePosition::Direct => used = true,
+                _ => structural_type_error(
+                    ctx,
+                    "a structural return must be the direct successful member of `Result`",
+                    span,
+                ),
+            },
+            other
+                if structural_type_position(other, type_param)
+                    != StructuralTypePosition::Absent =>
+            {
+                structural_type_error(ctx, "a structural return must be inside `Result`", span);
+            }
+            _ => {}
+        }
+        if !used {
+            structural_type_error(
+                ctx,
+                format!(
+                    "structural type parameter `{type_param}` is not used by the bridge signature"
+                ),
                 span,
             );
         }
-        _ => {}
-    }
-
-    let mut used = false;
-    for param in params {
-        match structural_type_position(&param.ty, type_param) {
-            StructuralTypePosition::Absent => {}
-            StructuralTypePosition::Direct => {
-                used = true;
-                if !param.convention.is_borrowed() || param.convention.is_mutable() {
-                    structural_type_error(
-                        ctx,
-                        format!("structural parameter `{}` must be an immutable borrow", param.name),
-                        span,
-                    );
-                }
-            }
-            StructuralTypePosition::CallScopedCallback => used = true,
-            StructuralTypePosition::Nested => structural_type_error(
-                ctx,
-                format!(
-                    "structural type parameter `{type_param}` occurs in an unsupported nested position for `{}`",
-                    param.name
-                ),
-                span,
-            ),
-        }
-    }
-    match return_type.resolve_alias() {
-        Type::Result(ok, _) => match structural_type_position(ok, type_param) {
-            StructuralTypePosition::Absent => {}
-            StructuralTypePosition::Direct => used = true,
-            _ => structural_type_error(
-                ctx,
-                "a structural return must be the direct successful member of `Result`",
-                span,
-            ),
-        },
-        other if structural_type_position(other, type_param) != StructuralTypePosition::Absent => {
-            structural_type_error(ctx, "a structural return must be inside `Result`", span);
-        }
-        _ => {}
-    }
-    if !used {
-        structural_type_error(
-            ctx,
-            format!("structural type parameter `{type_param}` is not used by the bridge signature"),
-            span,
-        );
     }
 }
 

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -57,6 +57,32 @@ def decode[T: StaticProgram]() -> Result[T, CodecError | RustPanicError]: ...
 }
 
 #[test]
+fn rust_interop_accepts_distinct_structural_input_and_static_output() {
+    let source = r"
+from sifr.meta import StaticProgram, Structural
+
+class CodecError(Error):
+    message: str
+
+@rust.structural
+@rust(bridge.codec.convert)
+def convert[Output: StaticProgram, Input: Structural](
+    value: Input,
+) -> Result[Output, CodecError | RustPanicError]: ...
+";
+    let parsed = parse_module(source).expect("source should parse");
+    let module = lower_module_with_externals(parsed.suite(), &structural_externals())
+        .map(|result| result.module)
+        .expect("distinct structural generics should lower");
+    assert_eq!(module.functions[0].type_params, ["Input", "Output"]);
+    assert_eq!(
+        module.type_param_bounds["convert"]["Output"],
+        ["StaticProgram"]
+    );
+    assert_eq!(module.type_param_bounds["convert"]["Input"], ["Structural"]);
+}
+
+#[test]
 fn static_program_bound_requires_a_structural_specialization_owner() {
     let eligible = r#"
 from sifr.meta import StaticProgram

--- a/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/bridges/executor.rs
+++ b/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/bridges/executor.rs
@@ -11,7 +11,7 @@ use sifr_runtime::interop::structural::{
 };
 use sifr_runtime::interop::{Handle, HandleStateError};
 
-const RECORD_IDENTITY: &str = "StaticRecord";
+const RECORD_IDENTITY: &str = "main.StaticRecord";
 static ACTIVE_DOCUMENTS: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug)]
@@ -153,14 +153,25 @@ pub fn execute<T>(document: Handle<ValidatedDocument>, input: &T) -> Result<T, S
 where
     T: StructuralConstruct + StructuralProject + StaticProgramType,
 {
-    let program = T::static_program();
+    execute_distinct::<T, T>(document, input)
+}
+
+pub fn execute_distinct<Input, Output>(
+    document: Handle<ValidatedDocument>,
+    input: &Input,
+) -> Result<Output, StaticProgramError>
+where
+    Input: StructuralConstruct + StructuralProject,
+    Output: StructuralConstruct + StructuralProject + StaticProgramType,
+{
+    let program = Output::static_program();
     let header = program.header();
     program.verify_envelope(
         STATIC_PROGRAM_FORMAT_VERSION,
         header.structural_contract_version(),
         STRUCTURAL_BRIDGE_CONTRACT_VERSION,
         header.identity(),
-        T::shape_identity(),
+        Output::shape_identity(),
     )?;
     verify_typed_program_value(program.value())?;
     let _input = project(input)?;
@@ -169,11 +180,11 @@ where
     }
     let nodes = document.into_inner()?.into_nodes();
     let arena = sifr_runtime::interop::structural::StructuralArena::seal(
-        T::shape_identity(),
+        Output::shape_identity(),
         NodeId::new(0),
         nodes,
     )?;
-    let output = structural_construct::<T, _>(arena)?;
+    let output = structural_construct::<Output, _>(arena)?;
     let observed = project(&output)?;
     LAST_OBSERVATION.with_borrow_mut(|slot| *slot = Some(observed.summary()));
     Ok(output)

--- a/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/main.sifr
+++ b/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/main.sifr
@@ -4,7 +4,7 @@
 # expected-result: static-program-arena-clean
 
 from static_program_runtime.schema_program import derive
-from sifr.meta import StaticProgram
+from sifr.meta import StaticProgram, Structural
 
 
 class StaticProgramError(Error):
@@ -20,6 +20,10 @@ class StaticRecord:
     lookup: dict[str, int]
 
 
+class StructuralInput:
+    label: str
+
+
 @rust.opaque(
     type=bridge.executor.ValidatedDocument,
     send=False,
@@ -33,7 +37,9 @@ class ValidatedDocument:
 
 
 @rust(bridge.executor.open)
-def open_validated_document() -> Result[ValidatedDocument, StaticProgramError | RustPanicError]: ...
+def open_validated_document() -> Result[
+    ValidatedDocument, StaticProgramError | RustPanicError
+]: ...
 
 
 @rust.structural
@@ -45,6 +51,14 @@ def execute_static_program[T: StaticProgram](
 
 
 @rust.structural
+@rust(bridge.executor.execute_distinct)
+def execute_distinct_program[Output: StaticProgram, Input: Structural](
+    own document: ValidatedDocument,
+    value: Input,
+) -> Result[Output, StaticProgramError | RustPanicError]: ...
+
+
+@rust.structural
 @rust(bridge.executor.execute_corrupt)
 def execute_corrupt_program[T: StaticProgram](
     own document: ValidatedDocument,
@@ -53,7 +67,9 @@ def execute_corrupt_program[T: StaticProgram](
 
 
 @rust(bridge.executor.observation)
-def static_program_observation() -> Result[str, StaticProgramError | RustPanicError]: ...
+def static_program_observation() -> Result[
+    str, StaticProgramError | RustPanicError
+]: ...
 
 
 def input_record() -> StaticRecord:
@@ -74,8 +90,18 @@ def verify_static_program_runtime() -> Result[str, StaticProgramError | RustPani
         assert output.tags == ["alpha", "beta"]
         assert output.lookup["left"] == -7
         assert output.lookup["right"] == 9007199254740991
+        distinct_document: ValidatedDocument = open_validated_document()
+        distinct: StaticRecord = execute_distinct_program(
+            distinct_document,
+            StructuralInput("distinct-input"),
+        )
+        assert distinct.exact == 123
+        assert distinct.payload == b"arena-bytes"
         observed: str = static_program_observation()
-        assert observed == "program=sealed;integer=123;fixed=42;bytes=11;tags=alpha,beta;lookup=left:-7,right:9007199254740991;active=0"
+        assert (
+            observed
+            == "program=sealed;integer=123;fixed=42;bytes=11;tags=alpha,beta;lookup=left:-7,right:9007199254740991;active=0"
+        )
         return observed
     except StaticProgramError as error:
         raise error
@@ -83,7 +109,9 @@ def verify_static_program_runtime() -> Result[str, StaticProgramError | RustPani
         raise error
 
 
-def verify_corrupt_program_rejected() -> Result[str, StaticProgramError | RustPanicError]:
+def verify_corrupt_program_rejected() -> Result[
+    str, StaticProgramError | RustPanicError
+]:
     try:
         document: ValidatedDocument = open_validated_document()
         _output: StaticRecord = execute_corrupt_program(document, input_record())


### PR DESCRIPTION
## Summary
- permit multiple compiler-owned Structural and StaticProgram bridge generics
- preserve each generic bound through code generation and Rust probe validation
- add native fixture coverage for a distinct structural input and static-program output

## Validation
- canonical create-PR gate: exit 0
- targeted lowering, codegen, driver probe, and native fixture tests: pass
- Rust interop verification area: 10/10
- affected library Clippy, formatting, HIR, taxonomy, and file-size guardrails: pass

This is a package-neutral compiler prerequisite for PS6 in the active native-Pydantic architecture phase.