### PR TITLE
feat: implement structural sum bridge

### DIFF
--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -19,6 +19,8 @@ pub fn generate_rust_test(module: &HirModule, module_name: &str) -> CodegenResul
         None,
         None,
         None,
+        crate::rust_interop_plan::module_uses_structural_interop(module),
+        None,
     )
 }
 
@@ -29,8 +31,12 @@ pub(crate) fn generate_rust_test_with_project_policy(
     project_union_enums: Option<&HashSet<String>>,
     project_ordinary_union_enums: Option<&HashSet<String>>,
     project_try_error_carrier_enums: Option<&HashSet<String>>,
+    structural_interop_enabled: bool,
+    project_structural_record_identities: Option<&HashSet<String>>,
 ) -> CodegenResult {
     let mut emitter = RustEmitter::new();
+    emitter.structural_interop_enabled = structural_interop_enabled;
+    emitter.project_structural_record_identities = project_structural_record_identities.cloned();
 
     // First pass: collect all union types used in the module
     emitter.collect_union_types(module);

--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -37,6 +37,7 @@ pub(crate) fn generate_rust_test_with_project_policy(
     let mut emitter = RustEmitter::new();
     emitter.structural_interop_enabled = structural_interop_enabled;
     emitter.project_structural_record_identities = project_structural_record_identities.cloned();
+    emitter.structural_identity_module_name = None;
 
     // First pass: collect all union types used in the module
     emitter.collect_union_types(module);

--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -21,9 +21,11 @@ pub fn generate_rust_test(module: &HirModule, module_name: &str) -> CodegenResul
         None,
         crate::rust_interop_plan::module_uses_structural_interop(module),
         None,
+        None,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn generate_rust_test_with_project_policy(
     module: &HirModule,
     module_name: &str,
@@ -33,10 +35,13 @@ pub(crate) fn generate_rust_test_with_project_policy(
     project_try_error_carrier_enums: Option<&HashSet<String>>,
     structural_interop_enabled: bool,
     project_structural_record_identities: Option<&HashSet<String>>,
+    project_structural_identity_expressions: Option<&super::HashMap<String, String>>,
 ) -> CodegenResult {
     let mut emitter = RustEmitter::new();
     emitter.structural_interop_enabled = structural_interop_enabled;
     emitter.project_structural_record_identities = project_structural_record_identities.cloned();
+    emitter.project_structural_identity_expressions =
+        project_structural_identity_expressions.cloned();
     emitter.structural_identity_module_name = None;
 
     // First pass: collect all union types used in the module

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -1,8 +1,8 @@
 use crate::{generate_rust, generate_rust_multi};
 use sifr_ir::{
-    HirClass, HirClassKind, HirFunction, HirModule, HirParam, MethodKind,
-    RustInteropAbiRequirements, RustInteropDeclaration, RustInteropDecoratorKind,
-    RustInteropEffect,
+    DeclarationMetadataTargetKind, HirClass, HirClassKind, HirExpr, HirFunction, HirModule,
+    HirParam, MethodKind, RustInteropAbiRequirements, RustInteropDeclaration,
+    RustInteropDecoratorKind, RustInteropEffect, TypedDeclarationMetadata,
 };
 use sifr_type_system::{ParamConvention, Type};
 
@@ -179,6 +179,21 @@ fn project_root_record_keeps_unqualified_structural_identity() {
 }
 
 #[test]
+fn named_single_file_record_keeps_unqualified_structural_identity() {
+    let module = module(vec![structural_function()], vec![payload_class()]);
+
+    let generated = crate::generate_rust_with_stdlib_for_module(
+        &module,
+        &crate::StdlibCode::default(),
+        Some("main"),
+    )
+    .rust_source;
+
+    assert!(generated.contains("Some(\"Payload\")"), "{generated}");
+    assert!(!generated.contains("Some(\"main.Payload\")"), "{generated}");
+}
+
+#[test]
 fn platform_integer_union_does_not_receive_structural_impls() {
     let union = Type::Union(vec![
         Type::Int,
@@ -278,6 +293,37 @@ fn structural_demand_emits_checked_enum_and_ordinary_union_impls() {
     assert!(generated.contains("::structural::union"), "{generated}");
     assert!(
         generated.contains("ShapeIdentity::from_bytes"),
+        "{generated}"
+    );
+}
+
+#[test]
+fn enum_with_unrepresentable_identity_metadata_gets_no_structural_impl() {
+    let mut enumeration = payload_class();
+    enumeration.name = "Status".to_string();
+    enumeration.kind = HirClassKind::Enum;
+    enumeration.fields = Vec::new();
+    enumeration.enum_variants = vec![("READY".to_string(), Some(1))];
+    enumeration.declaration_metadata = vec![TypedDeclarationMetadata {
+        owner: "Status".to_string(),
+        target_kind: DeclarationMetadataTargetKind::Type,
+        target_name: None,
+        key: "example.policy".to_string(),
+        value_type: Type::Int,
+        value: HirExpr::BinOp {
+            left: Box::new(HirExpr::IntLiteral(1)),
+            op: "+".to_string(),
+            right: Box::new(HirExpr::IntLiteral(1)),
+            ty: Type::Int,
+        },
+        range: Default::default(),
+    }];
+    let module = module(vec![structural_function()], vec![enumeration]);
+
+    let generated = generate_rust(&module);
+
+    assert!(
+        !generated.contains("StructuralType for Status"),
         "{generated}"
     );
 }

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -101,6 +101,67 @@ fn project_union_resolves_structural_members_from_their_defining_module() {
 }
 
 #[test]
+fn project_record_eligibility_resolves_nested_imported_members() {
+    let mut leaf = payload_class();
+    leaf.name = "Leaf".to_string();
+    leaf.identity = Some("models.Leaf".to_string());
+    let models = module(Vec::new(), vec![leaf]);
+
+    let leaf_type = Type::Class {
+        identity: Some("models.Leaf".to_string()),
+        type_args: Vec::new(),
+        name: "Leaf".to_string(),
+        fields: vec![("value".to_string(), Type::Int)],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let mut payload = payload_class();
+    payload.identity = Some("records.Payload".to_string());
+    payload.fields = vec![("leaf".to_string(), leaf_type.clone())];
+    let payload_type = Type::Class {
+        identity: Some("records.Payload".to_string()),
+        type_args: Vec::new(),
+        name: "Payload".to_string(),
+        fields: vec![("leaf".to_string(), leaf_type)],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let records = module(
+        vec![ordinary_function(
+            "choose",
+            Type::Union(vec![payload_type, Type::Str]),
+        )],
+        vec![payload],
+    );
+    let api = module(vec![structural_function()], Vec::new());
+
+    let project = crate::generate_rust_multi_with_metadata(
+        &[("models", &models), ("records", &records), ("main", &api)],
+        &crate::StdlibCode::default(),
+    );
+    let records_rust = project
+        .rust_files
+        .get("records")
+        .expect("records module is generated");
+
+    assert!(
+        records_rust.contains("StructuralType for Payload"),
+        "{records_rust}"
+    );
+    assert!(
+        records_rust.contains("StructuralConstruct for Payload"),
+        "{records_rust}"
+    );
+    assert!(
+        project
+            .project_union_prelude
+            .contains("crate::records::Payload"),
+        "{}",
+        project.project_union_prelude
+    );
+}
+
+#[test]
 fn platform_integer_union_does_not_receive_structural_impls() {
     let union = Type::Union(vec![
         Type::Int,

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -1,9 +1,10 @@
 use crate::{generate_rust, generate_rust_multi};
 use sifr_ir::{
-    HirClass, HirClassKind, HirFunction, HirModule, MethodKind, RustInteropAbiRequirements,
-    RustInteropDeclaration, RustInteropDecoratorKind, RustInteropEffect,
+    HirClass, HirClassKind, HirFunction, HirModule, HirParam, MethodKind,
+    RustInteropAbiRequirements, RustInteropDeclaration, RustInteropDecoratorKind,
+    RustInteropEffect,
 };
-use sifr_type_system::Type;
+use sifr_type_system::{ParamConvention, Type};
 
 #[test]
 fn ordinary_class_codegen_skips_structural_impls() {
@@ -19,6 +20,53 @@ fn ordinary_class_codegen_skips_structural_impls() {
     assert!(!metadata
         .required_features
         .contains(&sifr_stdlib_manifest::StdlibFeature::StructuralRuntime));
+}
+
+#[test]
+fn ordinary_union_codegen_skips_structural_impls_without_demand() {
+    let union = Type::Union(vec![Type::Int, Type::Str]);
+    let module = module(vec![ordinary_function("choose", union)], Vec::new());
+
+    let generated = generate_rust(&module);
+
+    assert!(generated.contains("enum __SifrUnion"));
+    assert!(!generated.contains("StructuralType"));
+    assert!(!generated.contains("StructuralConstruct"));
+    assert!(!generated.contains("StructuralProject"));
+
+    let project = crate::generate_rust_multi_with_metadata(
+        &[("main", &module)],
+        &crate::StdlibCode::default(),
+    );
+    let prelude = project.project_union_prelude;
+    assert!(prelude.contains("enum __SifrUnion"));
+    assert!(!prelude.contains("StructuralType"));
+    assert!(!prelude.contains("StructuralConstruct"));
+    assert!(!prelude.contains("StructuralProject"));
+}
+
+#[test]
+fn direct_ordinary_union_gets_structural_impls_when_demanded() {
+    let union = Type::Union(vec![Type::Int, Type::Str]);
+    let module = module(
+        vec![structural_function(), ordinary_function("choose", union)],
+        Vec::new(),
+    );
+
+    let generated = generate_rust(&module);
+
+    assert!(generated.contains("StructuralKind::Union"), "{generated}");
+    assert!(generated.contains("ActiveMember"), "{generated}");
+    assert!(generated.contains("StructuralConstruct"), "{generated}");
+    assert!(generated.contains("StructuralProject"), "{generated}");
+
+    let project = crate::generate_rust_multi_with_metadata(
+        &[("main", &module)],
+        &crate::StdlibCode::default(),
+    );
+    let prelude = project.project_union_prelude;
+    assert!(prelude.contains("StructuralKind::Union"), "{prelude}");
+    assert!(prelude.contains("ActiveMember"), "{prelude}");
 }
 
 #[test]
@@ -60,6 +108,46 @@ fn structural_impls_escape_rust_keyword_field_identifiers() {
     assert!(models_rust.contains("&self.r#type"));
     assert!(models_rust.contains("RecordField"));
     assert!(models_rust.contains("\"type\""));
+}
+
+#[test]
+fn structural_demand_emits_checked_enum_and_ordinary_union_impls() {
+    let mut enumeration = payload_class();
+    enumeration.name = "Status".to_string();
+    enumeration.kind = HirClassKind::Enum;
+    enumeration.fields = Vec::new();
+    enumeration.enum_variants = vec![
+        ("READY".to_string(), Some(4)),
+        ("WAITING".to_string(), None),
+    ];
+    let enum_type = Type::Enum {
+        identity: Some("main.Status".to_string()),
+        name: "Status".to_string(),
+        variants: enumeration.enum_variants.clone(),
+    };
+    let mut container = payload_class();
+    container.name = "SumPayload".to_string();
+    container.fields = vec![
+        (
+            "choice".to_string(),
+            Type::Union(vec![Type::Int, Type::Str]),
+        ),
+        ("status".to_string(), enum_type),
+    ];
+    let module = module(vec![structural_function()], vec![enumeration, container]);
+
+    let generated = generate_rust(&module);
+
+    assert!(generated.contains("StructuralKind::Union"), "{generated}");
+    assert!(generated.contains("ActiveMember"), "{generated}");
+    assert!(generated.contains("StructuralKind::Enum"), "{generated}");
+    assert!(generated.contains("Self::READY"), "{generated}");
+    assert!(generated.contains("Self::WAITING"), "{generated}");
+    assert!(generated.contains("::structural::union"), "{generated}");
+    assert!(
+        generated.contains("ShapeIdentity::from_bytes"),
+        "{generated}"
+    );
 }
 
 #[test]
@@ -139,6 +227,29 @@ fn structural_function() -> HirFunction {
             abi_requirements: RustInteropAbiRequirements::default(),
             consumes_receiver: false,
         }],
+        python_interop: Vec::new(),
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    }
+}
+
+fn ordinary_function(name: &str, parameter_type: Type) -> HirFunction {
+    HirFunction {
+        name: name.to_string(),
+        params: vec![HirParam {
+            name: "value".to_string(),
+            ty: parameter_type,
+            default: None,
+            keyword_only: false,
+            convention: ParamConvention::borrow(),
+        }],
+        return_type: Type::None,
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        receiver: None,
+        decorators: Vec::new(),
+        rust_interop: Vec::new(),
         python_interop: Vec::new(),
         compiler_intrinsic: None,
         type_params: Vec::new(),

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -162,6 +162,23 @@ fn project_record_eligibility_resolves_nested_imported_members() {
 }
 
 #[test]
+fn project_root_record_keeps_unqualified_structural_identity() {
+    let module = module(vec![structural_function()], vec![payload_class()]);
+
+    let project = crate::generate_rust_multi_with_metadata(
+        &[("main", &module)],
+        &crate::StdlibCode::default(),
+    );
+    let main_rust = project
+        .rust_files
+        .get("main")
+        .expect("main module is generated");
+
+    assert!(main_rust.contains("Some(\"Payload\")"), "{main_rust}");
+    assert!(!main_rust.contains("Some(\"main.Payload\")"), "{main_rust}");
+}
+
+#[test]
 fn platform_integer_union_does_not_receive_structural_impls() {
     let union = Type::Union(vec![
         Type::Int,

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -70,6 +70,60 @@ fn direct_ordinary_union_gets_structural_impls_when_demanded() {
 }
 
 #[test]
+fn project_union_resolves_structural_members_from_their_defining_module() {
+    let models = module(Vec::new(), vec![payload_class()]);
+    let payload = Type::Class {
+        identity: Some("models.Payload".to_string()),
+        type_args: Vec::new(),
+        name: "Payload".to_string(),
+        fields: vec![("value".to_string(), Type::Int)],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let api = module(
+        vec![
+            structural_function(),
+            ordinary_function("choose", Type::Union(vec![payload, Type::Str])),
+        ],
+        Vec::new(),
+    );
+
+    let project = crate::generate_rust_multi_with_metadata(
+        &[("models", &models), ("main", &api)],
+        &crate::StdlibCode::default(),
+    );
+    let prelude = project.project_union_prelude;
+
+    assert!(prelude.contains("crate::models::Payload"), "{prelude}");
+    assert!(prelude.contains("StructuralKind::Union"), "{prelude}");
+    assert!(prelude.contains("StructuralConstruct"), "{prelude}");
+    assert!(prelude.contains("StructuralProject"), "{prelude}");
+}
+
+#[test]
+fn platform_integer_union_does_not_receive_structural_impls() {
+    let union = Type::Union(vec![
+        Type::Int,
+        Type::FixedInt(sifr_type_system::FixedIntType::USize),
+    ]);
+    let module = module(
+        vec![structural_function(), ordinary_function("choose", union)],
+        Vec::new(),
+    );
+
+    let project = crate::generate_rust_multi_with_metadata(
+        &[("main", &module)],
+        &crate::StdlibCode::default(),
+    );
+    let prelude = project.project_union_prelude;
+
+    assert!(prelude.contains("enum __SifrUnion"));
+    assert!(!prelude.contains("StructuralType"));
+    assert!(!prelude.contains("StructuralConstruct"));
+    assert!(!prelude.contains("StructuralProject"));
+}
+
+#[test]
 fn project_structural_demand_enables_implicit_classes_across_modules() {
     let models = module(Vec::new(), vec![payload_class()]);
     let api = module(vec![structural_function()], Vec::new());

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -16,6 +16,8 @@ pub struct RustEmitter {
     pub(crate) try_error_carrier_enums: HashSet<String>,
     /// Union enums also used as ordinary source-level values.
     pub(crate) ordinary_union_enums: HashSet<String>,
+    /// Ordinary union enums that participate in a structural bridge shape.
+    pub(crate) structural_union_enums: HashSet<String>,
     /// Project-owned union enums whose definition is emitted by the crate-root prelude.
     /// The complete union map remains available to lowering and exhaustiveness checks.
     pub(crate) suppressed_union_enum_definitions: HashSet<String>,
@@ -214,6 +216,7 @@ impl RustEmitter {
             union_enums: HashMap::new(),
             try_error_carrier_enums: HashSet::new(),
             ordinary_union_enums: HashSet::new(),
+            structural_union_enums: HashSet::new(),
             suppressed_union_enum_definitions: HashSet::new(),
             project_nominal_type_paths: HashMap::new(),
             enum_items: Vec::new(),

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -55,6 +55,9 @@ pub struct RustEmitter {
     /// Canonical record identities proven structurally supported against the
     /// complete project module graph. `None` keeps single-module eligibility.
     pub(crate) project_structural_record_identities: Option<HashSet<String>>,
+    /// Module qualifier used by structural wire identities. Crate-root modules
+    /// have no qualifier even when project analysis names them `main`.
+    pub(crate) structural_identity_module_name: Option<String>,
     /// Static-program type parameters for each structural bridge function.
     pub(crate) static_program_type_params: HashMap<String, HashSet<String>>,
     /// Set of stdlib/intrinsic modules used (for Cargo dependency injection)
@@ -236,6 +239,7 @@ impl RustEmitter {
             current_module_name: None,
             structural_interop_enabled: false,
             project_structural_record_identities: None,
+            structural_identity_module_name: None,
             static_program_type_params: HashMap::new(),
             used_stdlib_modules: HashSet::new(),
             intrinsic_functions: HashSet::new(),

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -55,6 +55,9 @@ pub struct RustEmitter {
     /// Canonical record identities proven structurally supported against the
     /// complete project module graph. `None` keeps single-module eligibility.
     pub(crate) project_structural_record_identities: Option<HashSet<String>>,
+    /// Compiler-owned structural shape expressions computed against the complete
+    /// project graph, keyed by canonical source identity.
+    pub(crate) project_structural_identity_expressions: Option<HashMap<String, String>>,
     /// Module qualifier used by structural wire identities. Crate-root modules
     /// have no qualifier even when project analysis names them `main`.
     pub(crate) structural_identity_module_name: Option<String>,
@@ -239,6 +242,7 @@ impl RustEmitter {
             current_module_name: None,
             structural_interop_enabled: false,
             project_structural_record_identities: None,
+            project_structural_identity_expressions: None,
             structural_identity_module_name: None,
             static_program_type_params: HashMap::new(),
             used_stdlib_modules: HashSet::new(),

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -52,6 +52,9 @@ pub struct RustEmitter {
     /// Emit structural bridge implementations only when the project declares
     /// a structural Rust interop boundary.
     pub(crate) structural_interop_enabled: bool,
+    /// Canonical record identities proven structurally supported against the
+    /// complete project module graph. `None` keeps single-module eligibility.
+    pub(crate) project_structural_record_identities: Option<HashSet<String>>,
     /// Static-program type parameters for each structural bridge function.
     pub(crate) static_program_type_params: HashMap<String, HashSet<String>>,
     /// Set of stdlib/intrinsic modules used (for Cargo dependency injection)
@@ -232,6 +235,7 @@ impl RustEmitter {
             current_class_name: None,
             current_module_name: None,
             structural_interop_enabled: false,
+            project_structural_record_identities: None,
             static_program_type_params: HashMap::new(),
             used_stdlib_modules: HashSet::new(),
             intrinsic_functions: HashSet::new(),

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -233,8 +233,9 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_structural_policy(
         module,
         stdlib_code,
         module_name,
-        module_name,
+        None,
         structural_interop_enabled,
+        None,
         None,
         None,
         None,
@@ -242,6 +243,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_structural_policy(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
     module: &HirModule,
     stdlib_code: &StdlibCode,
@@ -252,10 +254,13 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
     project_ordinary_union_enums: Option<&HashSet<String>>,
     project_try_error_carrier_enums: Option<&HashSet<String>>,
     project_structural_record_identities: Option<&HashSet<String>>,
+    project_structural_identity_expressions: Option<&HashMap<String, String>>,
 ) -> CodegenResult {
     let mut emitter = RustEmitter::new();
     emitter.structural_interop_enabled = structural_interop_enabled;
     emitter.project_structural_record_identities = project_structural_record_identities.cloned();
+    emitter.project_structural_identity_expressions =
+        project_structural_identity_expressions.cloned();
     emitter.structural_identity_module_name = structural_identity_module_name.map(str::to_string);
     // Register stdlib generic classes so user code skips explicit type annotations
     emitter

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -237,6 +237,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_structural_policy(
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -248,9 +249,11 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
     owned_union_enums: Option<&HashSet<String>>,
     project_ordinary_union_enums: Option<&HashSet<String>>,
     project_try_error_carrier_enums: Option<&HashSet<String>>,
+    project_structural_record_identities: Option<&HashSet<String>>,
 ) -> CodegenResult {
     let mut emitter = RustEmitter::new();
     emitter.structural_interop_enabled = structural_interop_enabled;
+    emitter.project_structural_record_identities = project_structural_record_identities.cloned();
     // Register stdlib generic classes so user code skips explicit type annotations
     emitter
         .generic_classes

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -340,6 +340,11 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
             .try_error_carrier_enums
             .extend(project_try_error_carrier_enums.iter().cloned());
     }
+    if structural_interop_enabled {
+        emitter.structural_union_enums.extend(
+            crate::structural_impl_codegen::structural_union_names(module, &emitter.union_enums),
+        );
+    }
     if let Some(owned_union_enums) = owned_union_enums {
         emitter.suppressed_union_enum_definitions = emitter
             .union_enums

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -233,6 +233,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_structural_policy(
         module,
         stdlib_code,
         module_name,
+        module_name,
         structural_interop_enabled,
         None,
         None,
@@ -245,6 +246,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
     module: &HirModule,
     stdlib_code: &StdlibCode,
     module_name: Option<&str>,
+    structural_identity_module_name: Option<&str>,
     structural_interop_enabled: bool,
     owned_union_enums: Option<&HashSet<String>>,
     project_ordinary_union_enums: Option<&HashSet<String>>,
@@ -254,6 +256,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
     let mut emitter = RustEmitter::new();
     emitter.structural_interop_enabled = structural_interop_enabled;
     emitter.project_structural_record_identities = project_structural_record_identities.cloned();
+    emitter.structural_identity_module_name = structural_identity_module_name.map(str::to_string);
     // Register stdlib generic classes so user code skips explicit type annotations
     emitter
         .generic_classes

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -340,7 +340,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
             .try_error_carrier_enums
             .extend(project_try_error_carrier_enums.iter().cloned());
     }
-    if structural_interop_enabled {
+    if structural_interop_enabled && owned_union_enums.is_none() {
         emitter.structural_union_enums.extend(
             crate::structural_impl_codegen::structural_union_names(module, &emitter.union_enums),
         );

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -47,22 +47,31 @@ pub(crate) struct ProjectUnionUsage {
     pub(crate) module_unions: HashMap<String, HashSet<String>>,
     pub(crate) ordinary_unions: HashSet<String>,
     pub(crate) try_error_unions: HashSet<String>,
+    pub(crate) structural_unions: HashSet<String>,
 }
 
 pub(crate) fn project_union_usage(
     modules: &[(&str, &HirModule)],
     project_code: &StdlibCode,
+    structural_interop_enabled: bool,
 ) -> ProjectUnionUsage {
     let mut unions = HashMap::new();
     let mut module_unions = HashMap::new();
     let mut ordinary_unions = HashSet::new();
     let mut try_error_unions = HashSet::new();
+    let mut structural_unions = HashSet::new();
     for (module_name, module) in modules {
         let mut emitter = super::RustEmitter::new();
         emitter.collect_union_types(module);
         register_imported_union_types(&mut emitter, module, project_code);
         ordinary_unions.extend(emitter.ordinary_union_enums.iter().cloned());
         try_error_unions.extend(emitter.try_error_carrier_enums.iter().cloned());
+        if structural_interop_enabled {
+            structural_unions.extend(crate::structural_impl_codegen::structural_union_names(
+                module,
+                &emitter.union_enums,
+            ));
+        }
         let names = emitter.union_enums.keys().cloned().collect::<HashSet<_>>();
         for (name, members) in emitter.union_enums {
             unions.entry(name).or_insert(members);
@@ -74,6 +83,7 @@ pub(crate) fn project_union_usage(
         module_unions,
         ordinary_unions,
         try_error_unions,
+        structural_unions,
     }
 }
 
@@ -318,7 +328,8 @@ pub fn generate_rust_multi_with_metadata(
     project_codegen_code
         .module_class_fields
         .extend(project_class_fields(modules));
-    let union_usage = project_union_usage(modules, &project_codegen_code);
+    let union_usage =
+        project_union_usage(modules, &project_codegen_code, structural_interop_enabled);
     let stdlib_nominal_plan =
         project_stdlib_nominal_plan(&union_usage.unions, stdlib_code, modules);
     let crate_root_modules = HashSet::from(["main"]);
@@ -754,6 +765,7 @@ mod tests {
             let usage = project_union_usage(
                 &[("left", &left), ("right", &right)],
                 &StdlibCode::default(),
+                false,
             );
 
             assert_eq!(usage.unions.len(), 2, "{:?}", usage.unions);

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -356,10 +356,13 @@ pub fn generate_rust_multi_with_metadata(
             .cloned()
             .unwrap_or_default();
         let owned_unions = HashSet::new();
+        let structural_identity_module_name =
+            (!crate_root_modules.contains(module_name)).then_some(*module_name);
         let codegen_result = generate_rust_with_stdlib_for_module_with_project_policy(
             module,
             &module_codegen_code,
             Some(module_name),
+            structural_identity_module_name,
             structural_interop_enabled,
             Some(&owned_unions),
             Some(&union_usage.ordinary_unions),

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -328,6 +328,9 @@ pub fn generate_rust_multi_with_metadata(
         .extend(project_class_fields(modules));
     let union_usage =
         project_union_usage(modules, &project_codegen_code, structural_interop_enabled);
+    let structural_record_identities = structural_interop_enabled
+        .then(|| crate::structural_impl_codegen::structural_record_identities_for_project(modules))
+        .unwrap_or_default();
     let stdlib_nominal_plan =
         project_stdlib_nominal_plan(&union_usage.unions, stdlib_code, modules);
     let crate_root_modules = HashSet::from(["main"]);
@@ -361,6 +364,7 @@ pub fn generate_rust_multi_with_metadata(
             Some(&owned_unions),
             Some(&union_usage.ordinary_unions),
             Some(&union_usage.try_error_unions),
+            Some(&structural_record_identities),
         );
         let local_imports = render_local_module_imports(module, &project_modules);
         let union_imports =

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -66,17 +66,15 @@ pub(crate) fn project_union_usage(
         register_imported_union_types(&mut emitter, module, project_code);
         ordinary_unions.extend(emitter.ordinary_union_enums.iter().cloned());
         try_error_unions.extend(emitter.try_error_carrier_enums.iter().cloned());
-        if structural_interop_enabled {
-            structural_unions.extend(crate::structural_impl_codegen::structural_union_names(
-                module,
-                &emitter.union_enums,
-            ));
-        }
         let names = emitter.union_enums.keys().cloned().collect::<HashSet<_>>();
         for (name, members) in emitter.union_enums {
             unions.entry(name).or_insert(members);
         }
         module_unions.insert((*module_name).to_string(), names);
+    }
+    if structural_interop_enabled {
+        structural_unions =
+            crate::structural_impl_codegen::structural_union_names_for_project(&unions, modules);
     }
     ProjectUnionUsage {
         unions,

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -328,12 +328,23 @@ pub fn generate_rust_multi_with_metadata(
         .extend(project_class_fields(modules));
     let union_usage =
         project_union_usage(modules, &project_codegen_code, structural_interop_enabled);
-    let structural_record_identities = structural_interop_enabled
-        .then(|| crate::structural_impl_codegen::structural_record_identities_for_project(modules))
-        .unwrap_or_default();
+    let structural_record_identities = if structural_interop_enabled {
+        crate::structural_impl_codegen::structural_record_identities_for_project(modules)
+    } else {
+        HashSet::new()
+    };
     let stdlib_nominal_plan =
         project_stdlib_nominal_plan(&union_usage.unions, stdlib_code, modules);
     let crate_root_modules = HashSet::from(["main"]);
+    let structural_identity_expressions = if structural_interop_enabled {
+        crate::structural_identity_codegen::class_identity_expressions_for_project(
+            modules,
+            &crate_root_modules,
+            &structural_record_identities,
+        )
+    } else {
+        HashMap::new()
+    };
     let mut nominal_type_paths = project_nominal_type_paths(modules, &crate_root_modules);
     nominal_type_paths.extend(stdlib_nominal_plan.nominal_paths.clone());
     let union_prelude = render_project_union_prelude(&union_usage, &nominal_type_paths);
@@ -368,6 +379,7 @@ pub fn generate_rust_multi_with_metadata(
             Some(&union_usage.ordinary_unions),
             Some(&union_usage.try_error_unions),
             Some(&structural_record_identities),
+            Some(&structural_identity_expressions),
         );
         let local_imports = render_local_module_imports(module, &project_modules);
         let union_imports =

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -44,17 +44,26 @@ pub fn generate_rust_test_project_with_metadata(
         .iter()
         .any(|(_, module)| crate::rust_interop_plan::module_uses_structural_interop(module));
     let union_usage = project_union_usage(&all_modules, &project_code, structural_interop_enabled);
-    let structural_record_identities = structural_interop_enabled
-        .then(|| {
-            crate::structural_impl_codegen::structural_record_identities_for_project(&all_modules)
-        })
-        .unwrap_or_default();
+    let structural_record_identities = if structural_interop_enabled {
+        crate::structural_impl_codegen::structural_record_identities_for_project(&all_modules)
+    } else {
+        HashSet::new()
+    };
     let stdlib_nominal_plan =
         project_stdlib_nominal_plan(&union_usage.unions, stdlib_code, &all_modules);
     let crate_root_modules = test_modules
         .iter()
         .map(|(module_name, _)| *module_name)
         .collect::<HashSet<_>>();
+    let structural_identity_expressions = if structural_interop_enabled {
+        crate::structural_identity_codegen::class_identity_expressions_for_project(
+            &all_modules,
+            &crate_root_modules,
+            &structural_record_identities,
+        )
+    } else {
+        HashMap::new()
+    };
     let mut nominal_type_paths = project_nominal_type_paths(&all_modules, &crate_root_modules);
     nominal_type_paths.extend(stdlib_nominal_plan.nominal_paths.clone());
     let union_prelude = render_project_union_prelude(&union_usage, &nominal_type_paths);
@@ -92,6 +101,7 @@ pub fn generate_rust_test_project_with_metadata(
             Some(&union_usage.ordinary_unions),
             Some(&union_usage.try_error_unions),
             Some(&structural_record_identities),
+            Some(&structural_identity_expressions),
         );
         let imports = [
             render_local_module_imports(module, &project_modules),
@@ -131,6 +141,7 @@ pub fn generate_rust_test_project_with_metadata(
             Some(&union_usage.try_error_unions),
             structural_interop_enabled,
             Some(&structural_record_identities),
+            Some(&structural_identity_expressions),
         );
         test_rust_files.insert((*module_name).to_string(), generated.rust_source);
         used_stdlib_modules.extend(generated.used_stdlib_modules);

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -40,7 +40,10 @@ pub fn generate_rust_test_project_with_metadata(
     project_code
         .module_class_fields
         .extend(project_class_fields(&all_modules));
-    let union_usage = project_union_usage(&all_modules, &project_code);
+    let structural_interop_enabled = all_modules
+        .iter()
+        .any(|(_, module)| crate::rust_interop_plan::module_uses_structural_interop(module));
+    let union_usage = project_union_usage(&all_modules, &project_code, structural_interop_enabled);
     let stdlib_nominal_plan =
         project_stdlib_nominal_plan(&union_usage.unions, stdlib_code, &all_modules);
     let crate_root_modules = test_modules
@@ -57,9 +60,6 @@ pub fn generate_rust_test_project_with_metadata(
         .collect::<Vec<_>>()
         .join("\n\n");
     let project_modules = all_modules.iter().copied().collect::<HashMap<_, _>>();
-    let structural_interop_enabled = all_modules
-        .iter()
-        .any(|(_, module)| crate::rust_interop_plan::module_uses_structural_interop(module));
     let all_union_names = union_usage.unions.keys().cloned().collect::<HashSet<_>>();
 
     let mut support_rust_files = HashMap::new();

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -44,6 +44,11 @@ pub fn generate_rust_test_project_with_metadata(
         .iter()
         .any(|(_, module)| crate::rust_interop_plan::module_uses_structural_interop(module));
     let union_usage = project_union_usage(&all_modules, &project_code, structural_interop_enabled);
+    let structural_record_identities = structural_interop_enabled
+        .then(|| {
+            crate::structural_impl_codegen::structural_record_identities_for_project(&all_modules)
+        })
+        .unwrap_or_default();
     let stdlib_nominal_plan =
         project_stdlib_nominal_plan(&union_usage.unions, stdlib_code, &all_modules);
     let crate_root_modules = test_modules
@@ -83,6 +88,7 @@ pub fn generate_rust_test_project_with_metadata(
             Some(&HashSet::new()),
             Some(&union_usage.ordinary_unions),
             Some(&union_usage.try_error_unions),
+            Some(&structural_record_identities),
         );
         let imports = [
             render_local_module_imports(module, &project_modules),
@@ -120,6 +126,8 @@ pub fn generate_rust_test_project_with_metadata(
             Some(&all_union_names),
             Some(&union_usage.ordinary_unions),
             Some(&union_usage.try_error_unions),
+            structural_interop_enabled,
+            Some(&structural_record_identities),
         );
         test_rust_files.insert((*module_name).to_string(), generated.rust_source);
         used_stdlib_modules.extend(generated.used_stdlib_modules);

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -80,10 +80,13 @@ pub fn generate_rust_test_project_with_metadata(
             .get(*module_name)
             .cloned()
             .unwrap_or_default();
+        let structural_identity_module_name =
+            (!crate_root_modules.contains(module_name)).then_some(*module_name);
         let generated = generate_rust_with_stdlib_for_module_with_project_policy(
             module,
             &module_code,
             Some(module_name),
+            structural_identity_module_name,
             structural_interop_enabled,
             Some(&HashSet::new()),
             Some(&union_usage.ordinary_unions),

--- a/crates/sifr_codegen/src/project_union_prelude.rs
+++ b/crates/sifr_codegen/src/project_union_prelude.rs
@@ -21,6 +21,9 @@ pub(crate) fn render_project_union_prelude(
         .try_error_carrier_enums
         .clone_from(&usage.try_error_unions);
     emitter
+        .structural_union_enums
+        .clone_from(&usage.structural_unions);
+    emitter
         .project_nominal_type_paths
         .clone_from(nominal_type_paths);
     emitter.generate_enum_definitions();

--- a/crates/sifr_codegen/src/rust_interop_plan.rs
+++ b/crates/sifr_codegen/src/rust_interop_plan.rs
@@ -283,9 +283,7 @@ pub fn interop_build_plan_for_named_modules<'a>(
     if rust.declarations.iter().any(|declaration| {
         declaration.declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural
     }) {
-        for (module_name, module) in &module_entries {
-            collect_structural_shape_identities(*module_name, module, &mut rust);
-        }
+        collect_structural_shape_identities_for_project(&module_entries, &mut rust);
     }
     rust.bridge_contracts =
         bridge_contract_plan_for_named_modules(module_entries, &rust.declarations);
@@ -307,28 +305,48 @@ pub(crate) fn module_uses_structural_interop(module: &HirModule) -> bool {
         .any(|declaration| declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural)
 }
 
-fn collect_structural_shape_identities(
-    module_name: Option<&str>,
-    module: &HirModule,
+fn collect_structural_shape_identities_for_project(
+    module_entries: &[(Option<&str>, &HirModule)],
     plan: &mut RustInteropPlan,
 ) {
-    for class in &module.classes {
-        if !crate::structural_impl_codegen::structural_record_supported(class, module) {
-            continue;
-        }
-        plan.structural_identity_algorithm_version =
-            Some(crate::structural_identity_codegen::algorithm_version());
-        let Some(identity) =
-            crate::structural_identity_codegen::static_class_identity(class, module, module_name)
-        else {
-            continue;
-        };
-        plan.structural_shape_identities
-            .push(RustStructuralShapeIdentity {
-                module_name: module_name.map(str::to_string),
-                type_name: class.name.clone(),
-                identity: *identity.as_bytes(),
+    let modules = module_entries
+        .iter()
+        .map(|(module_name, module)| (module_name.unwrap_or(""), *module))
+        .collect::<Vec<_>>();
+    let crate_root_modules = modules
+        .iter()
+        .filter_map(|(module_name, _)| {
+            (module_name.is_empty() || *module_name == "main").then_some(*module_name)
+        })
+        .collect::<std::collections::HashSet<_>>();
+    let record_identities =
+        crate::structural_impl_codegen::structural_record_identities_for_project(&modules);
+    let identities = crate::structural_identity_codegen::static_class_identities_for_project(
+        &modules,
+        &crate_root_modules,
+        &record_identities,
+    );
+    for ((module_name, module), (module_key, _)) in module_entries.iter().zip(&modules) {
+        for class in &module.classes {
+            let key = class.identity.clone().unwrap_or_else(|| {
+                if module_key.is_empty() {
+                    class.name.clone()
+                } else {
+                    format!("{module_key}.{}", class.name)
+                }
             });
+            let Some(identity) = identities.get(&key) else {
+                continue;
+            };
+            plan.structural_identity_algorithm_version =
+                Some(crate::structural_identity_codegen::algorithm_version());
+            plan.structural_shape_identities
+                .push(RustStructuralShapeIdentity {
+                    module_name: module_name.map(str::to_string),
+                    type_name: class.name.clone(),
+                    identity: *identity.as_bytes(),
+                });
+        }
     }
     plan.structural_shape_identities.sort();
 }

--- a/crates/sifr_codegen/src/rust_interop_plan_tests.rs
+++ b/crates/sifr_codegen/src/rust_interop_plan_tests.rs
@@ -807,12 +807,18 @@ fn interop_cache_fragment_includes_structural_algorithm_and_concrete_identity() 
         type_param_bounds: std::collections::HashMap::new(),
     };
 
-    let fragment =
-        interop_build_plan_for_named_modules([(Some("main"), &module)]).cache_key_fragment();
+    let named_plan = interop_build_plan_for_named_modules([(Some("main"), &module)]);
+    let root_plan = interop_build_plan_for_named_modules([(None, &module)]);
+    let fragment = named_plan.cache_key_fragment();
 
     assert!(fragment.contains("rust.structural_identity_algorithm_version=1"));
     assert!(fragment.contains("rust.structural_shape_identities=1"));
     assert!(fragment.contains("main:Payload="));
+    assert_eq!(
+        named_plan.rust.structural_shape_identities[0].identity,
+        root_plan.rust.structural_shape_identities[0].identity,
+        "naming a crate-root module main must not change its wire shape"
+    );
 }
 
 fn python_error_fields() -> Vec<(String, Type)> {

--- a/crates/sifr_codegen/src/structural_identity_codegen.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen.rs
@@ -1,7 +1,7 @@
-use sifr_ir::{HirClass, HirExpr, HirModule};
+use sifr_ir::{canonical_structural_identity_value, HirClass, HirModule};
 use sifr_structural_identity::{self as identity, NominalField, ShapeIdentity, ALGORITHM_VERSION};
 use sifr_type_system::Type;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 const STRUCTURAL: &str = "::sifr_runtime::interop::structural";
 
@@ -9,6 +9,60 @@ const STRUCTURAL: &str = "::sifr_runtime::interop::structural";
 enum CompiledIdentity {
     Static(ShapeIdentity),
     Dynamic(String),
+}
+
+struct IdentityContext<'a> {
+    modules: &'a [(&'a str, &'a HirModule)],
+    crate_root_modules: &'a HashSet<&'a str>,
+}
+
+impl<'a> IdentityContext<'a> {
+    fn wire_module_name(&self, module_name: &'a str) -> Option<&'a str> {
+        (!self.crate_root_modules.contains(module_name)).then_some(module_name)
+    }
+
+    fn class_candidate(
+        &self,
+        identity: Option<&str>,
+        name: &str,
+        scope_module_name: &str,
+    ) -> Option<(&'a str, &'a HirModule, &'a HirClass)> {
+        if let Some(identity) = identity {
+            if let Some(candidate) = self.modules.iter().find_map(|(module_name, module)| {
+                module
+                    .classes
+                    .iter()
+                    .find(|class| {
+                        class.identity.as_deref() == Some(identity)
+                            || format!("{module_name}.{}", class.name) == identity
+                    })
+                    .map(|class| (*module_name, *module, class))
+            }) {
+                return Some(candidate);
+            }
+            if self.modules.len() != 1 || !self.modules[0].0.is_empty() {
+                return None;
+            }
+        }
+        if let Some((module_name, module)) = self
+            .modules
+            .iter()
+            .find(|(module_name, _)| *module_name == scope_module_name)
+        {
+            if let Some(class) = module.classes.iter().find(|class| class.name == name) {
+                return Some((*module_name, *module, class));
+            }
+        }
+        let mut candidates = self.modules.iter().filter_map(|(module_name, module)| {
+            module
+                .classes
+                .iter()
+                .find(|class| class.name == name)
+                .map(|class| (*module_name, *module, class))
+        });
+        let candidate = candidates.next()?;
+        candidates.next().is_none().then_some(candidate)
+    }
 }
 
 impl CompiledIdentity {
@@ -32,11 +86,88 @@ pub(crate) fn class_identity_expression(
     module: &HirModule,
     module_name: Option<&str>,
 ) -> String {
+    let module_key = module_name.unwrap_or("");
+    let modules = [(module_key, module)];
+    let roots = if module_name.is_none() {
+        HashSet::from([module_key])
+    } else {
+        HashSet::new()
+    };
+    let context = IdentityContext {
+        modules: &modules,
+        crate_root_modules: &roots,
+    };
     if class.is_enum() {
         compile_enum(class, module_name).expression()
     } else {
-        compile_class(class, module, module_name).expression()
+        compile_class(class, module_key, &context).expression()
     }
+}
+
+pub(crate) fn class_identity_expressions_for_project(
+    modules: &[(&str, &HirModule)],
+    crate_root_modules: &HashSet<&str>,
+    structural_record_identities: &HashSet<String>,
+) -> HashMap<String, String> {
+    let context = IdentityContext {
+        modules,
+        crate_root_modules,
+    };
+    modules
+        .iter()
+        .flat_map(|(module_name, module)| {
+            let context = &context;
+            module.classes.iter().filter_map(move |class| {
+                let key = project_class_identity(class, module_name);
+                let supported = if class.is_enum() {
+                    crate::structural_impl_codegen::structural_enum_supported(class)
+                } else {
+                    structural_record_identities.contains(&key)
+                };
+                supported.then(|| {
+                    let compiled = if class.is_enum() {
+                        compile_enum(class, context.wire_module_name(module_name))
+                    } else {
+                        compile_class(class, module_name, context)
+                    };
+                    (key, compiled.expression())
+                })
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn static_class_identities_for_project(
+    modules: &[(&str, &HirModule)],
+    crate_root_modules: &HashSet<&str>,
+    structural_record_identities: &HashSet<String>,
+) -> HashMap<String, ShapeIdentity> {
+    let context = IdentityContext {
+        modules,
+        crate_root_modules,
+    };
+    modules
+        .iter()
+        .flat_map(|(module_name, module)| {
+            let context = &context;
+            module.classes.iter().filter_map(move |class| {
+                let key = project_class_identity(class, module_name);
+                let supported = if class.is_enum() {
+                    crate::structural_impl_codegen::structural_enum_supported(class)
+                } else {
+                    structural_record_identities.contains(&key)
+                };
+                let compiled = supported.then(|| {
+                    if class.is_enum() {
+                        compile_enum(class, context.wire_module_name(module_name))
+                    } else {
+                        compile_class(class, module_name, context)
+                    }
+                })?;
+                compiled.static_value().map(|identity| (key, identity))
+            })
+        })
+        .collect()
 }
 
 pub(crate) fn static_class_identity(
@@ -44,10 +175,21 @@ pub(crate) fn static_class_identity(
     module: &HirModule,
     module_name: Option<&str>,
 ) -> Option<ShapeIdentity> {
+    let module_key = module_name.unwrap_or("");
+    let modules = [(module_key, module)];
+    let roots = if module_name.is_none() {
+        HashSet::from([module_key])
+    } else {
+        HashSet::new()
+    };
+    let context = IdentityContext {
+        modules: &modules,
+        crate_root_modules: &roots,
+    };
     if class.is_enum() {
         compile_enum(class, module_name).static_value()
     } else {
-        compile_class(class, module, module_name).static_value()
+        compile_class(class, module_key, &context).static_value()
     }
 }
 
@@ -63,19 +205,19 @@ pub(crate) fn class_identity_inputs_supported(class: &HirClass) -> bool {
     class
         .field_defaults
         .iter()
-        .all(|(_, value)| canonical_hir_value(value).is_some())
+        .all(|(_, value)| canonical_structural_identity_value(value).is_some())
         && class
             .declaration_metadata
             .iter()
-            .all(|metadata| canonical_hir_value(&metadata.value).is_some())
+            .all(|metadata| canonical_structural_identity_value(&metadata.value).is_some())
 }
 
 fn compile_class(
     class: &HirClass,
-    module: &HirModule,
-    module_name: Option<&str>,
+    module_name: &str,
+    context: &IdentityContext<'_>,
 ) -> CompiledIdentity {
-    let nominal = class_nominal_identity(class, module_name);
+    let nominal = class_nominal_identity(class, context.wire_module_name(module_name));
     let mut stack = vec![nominal.clone()];
     let type_arguments = class
         .type_params
@@ -91,8 +233,8 @@ fn compile_class(
         &type_arguments,
         &class.fields,
         Some(class),
-        module,
         module_name,
+        context,
         &mut stack,
     )
 }
@@ -113,8 +255,8 @@ fn compile_enum(class: &HirClass, module_name: Option<&str>) -> CompiledIdentity
 
 fn compile_type(
     ty: &Type,
-    module: &HirModule,
-    module_name: Option<&str>,
+    scope_module_name: &str,
+    context: &IdentityContext<'_>,
     stack: &mut Vec<String>,
 ) -> CompiledIdentity {
     match ty.resolve_alias() {
@@ -128,11 +270,11 @@ fn compile_type(
         Type::TypeVar(name) => CompiledIdentity::Dynamic(format!(
             "<{name} as {STRUCTURAL}::StructuralType>::shape_identity()"
         )),
-        Type::List(value) => compile_unary("list", value, module, module_name, stack),
-        Type::Set(value) => compile_unary("set", value, module, module_name, stack),
+        Type::List(value) => compile_unary("list", value, scope_module_name, context, stack),
+        Type::Set(value) => compile_unary("set", value, scope_module_name, context, stack),
         Type::Dict(key, value) => {
-            let key = compile_type(key, module, module_name, stack);
-            let value = compile_type(value, module, module_name, stack);
+            let key = compile_type(key, scope_module_name, context, stack);
+            let value = compile_type(value, scope_module_name, context, stack);
             match (key.static_value(), value.static_value()) {
                 (Some(key), Some(value)) => {
                     CompiledIdentity::Static(identity::binary_container("mapping", key, value))
@@ -144,25 +286,26 @@ fn compile_type(
                 )),
             }
         }
-        Type::Tuple(values) => compile_many("tuple", values, module, module_name, stack),
+        Type::Tuple(values) => compile_many("tuple", values, scope_module_name, context, stack),
         Type::Union(values) => match optional_member(values) {
-            Some(member) => compile_unary("optional", member, module, module_name, stack),
-            None => compile_many("union", values, module, module_name, stack),
+            Some(member) => compile_unary("optional", member, scope_module_name, context, stack),
+            None => compile_many("union", values, scope_module_name, context, stack),
         },
         Type::Enum {
             identity: declared_identity,
             name,
             variants,
         } => {
-            if let Some(class) = module
-                .classes
-                .iter()
-                .find(|class| class.name == *name && class.is_enum())
+            if let Some((module_name, _, class)) = context
+                .class_candidate(declared_identity.as_deref(), name, scope_module_name)
+                .filter(|(_, _, class)| class.is_enum())
             {
-                compile_enum(class, module_name)
+                compile_enum(class, context.wire_module_name(module_name))
             } else {
                 let nominal = declared_identity.clone().unwrap_or_else(|| {
-                    module_name.map_or_else(|| name.clone(), |module| format!("{module}.{name}"))
+                    context
+                        .wire_module_name(scope_module_name)
+                        .map_or_else(|| name.clone(), |module| format!("{module}.{name}"))
                 });
                 let members = variants
                     .iter()
@@ -182,16 +325,17 @@ fn compile_type(
             fields,
             ..
         } => {
-            let candidate = module.classes.iter().find(|class| class.name == *name);
-            let nominal = class_identity.clone().unwrap_or_else(|| {
-                candidate.map_or_else(
-                    || name.clone(),
-                    |class| class_nominal_identity(class, module_name),
-                )
-            });
-            if let Some(class) = candidate {
+            let candidate =
+                context.class_candidate(class_identity.as_deref(), name, scope_module_name);
+            let nominal = candidate.map_or_else(
+                || class_identity.clone().unwrap_or_else(|| name.clone()),
+                |(module_name, _, class)| {
+                    class_nominal_identity(class, context.wire_module_name(module_name))
+                },
+            );
+            if let Some((module_name, _, class)) = candidate {
                 if class.is_enum() {
-                    return compile_enum(class, module_name);
+                    return compile_enum(class, context.wire_module_name(module_name));
                 }
             }
             if let Some(index) = stack.iter().position(|entry| entry == &nominal) {
@@ -205,11 +349,11 @@ fn compile_type(
             stack.push(nominal.clone());
             let arguments = type_args
                 .iter()
-                .map(|argument| compile_type(argument, module, module_name, stack))
+                .map(|argument| compile_type(argument, scope_module_name, context, stack))
                 .collect::<Vec<_>>();
             let concrete_fields = candidate.map_or_else(
                 || fields.clone(),
-                |class| {
+                |(_, _, class)| {
                     let bindings = class
                         .type_params
                         .iter()
@@ -227,9 +371,9 @@ fn compile_type(
                 &nominal,
                 &arguments,
                 &concrete_fields,
-                candidate,
-                module,
-                module_name,
+                candidate.map(|(_, _, class)| class),
+                candidate.map_or(scope_module_name, |(module_name, _, _)| module_name),
+                context,
                 stack,
             );
             stack.pop();
@@ -304,15 +448,15 @@ fn compile_record(
     type_arguments: &[CompiledIdentity],
     fields: &[(String, Type)],
     class: Option<&HirClass>,
-    module: &HirModule,
-    module_name: Option<&str>,
+    scope_module_name: &str,
+    context: &IdentityContext<'_>,
     stack: &mut Vec<String>,
 ) -> CompiledIdentity {
     let field_identities = fields
         .iter()
         .enumerate()
         .map(|(index, (name, ty))| {
-            let shape = compile_type(ty, module, module_name, stack);
+            let shape = compile_type(ty, scope_module_name, context, stack);
             let default = class.and_then(|class| field_default_identity(class, index));
             (name, shape, default)
         })
@@ -369,11 +513,11 @@ fn compile_record(
 fn compile_unary(
     tag: &str,
     value: &Type,
-    module: &HirModule,
-    module_name: Option<&str>,
+    scope_module_name: &str,
+    context: &IdentityContext<'_>,
     stack: &mut Vec<String>,
 ) -> CompiledIdentity {
-    let value = compile_type(value, module, module_name, stack);
+    let value = compile_type(value, scope_module_name, context, stack);
     value.static_value().map_or_else(
         || {
             CompiledIdentity::Dynamic(format!(
@@ -388,13 +532,13 @@ fn compile_unary(
 fn compile_many(
     tag: &str,
     values: &[Type],
-    module: &HirModule,
-    module_name: Option<&str>,
+    scope_module_name: &str,
+    context: &IdentityContext<'_>,
     stack: &mut Vec<String>,
 ) -> CompiledIdentity {
     let values = values
         .iter()
-        .map(|value| compile_type(value, module, module_name, stack))
+        .map(|value| compile_type(value, scope_module_name, context, stack))
         .collect::<Vec<_>>();
     let static_values = values
         .iter()
@@ -433,7 +577,7 @@ fn field_default_identity(class: &HirClass, field_index: usize) -> Option<ShapeI
         .field_defaults
         .iter()
         .find(|(index, _)| *index == field_index)
-        .and_then(|(_, value)| canonical_hir_value(value))
+        .and_then(|(_, value)| canonical_structural_identity_value(value))
         .map(|value| identity::default_value(&value))
 }
 
@@ -442,7 +586,7 @@ fn class_metadata_identity(class: Option<&HirClass>) -> ShapeIdentity {
         .into_iter()
         .flat_map(|class| &class.declaration_metadata)
         .filter_map(|metadata| {
-            canonical_hir_value(&metadata.value).map(|value| {
+            canonical_structural_identity_value(&metadata.value).map(|value| {
                 format!(
                     "{:?}|{}|{}|{:?}|{}",
                     metadata.target_kind,
@@ -458,57 +602,22 @@ fn class_metadata_identity(class: Option<&HirClass>) -> ShapeIdentity {
     identity::metadata(&entries.iter().map(String::as_str).collect::<Vec<_>>())
 }
 
-fn canonical_hir_value(value: &HirExpr) -> Option<String> {
-    match value {
-        HirExpr::IntLiteral(value) => Some(format!("int:{value}")),
-        HirExpr::LargeIntLiteral(value) => Some(format!("int:{value}")),
-        HirExpr::FloatLiteral(value) => Some(format!("float:{:016x}", value.to_bits())),
-        HirExpr::StringLiteral(value) => Some(format!("str:{}:{value}", value.len())),
-        HirExpr::BoolLiteral(value) => Some(format!("bool:{value}")),
-        HirExpr::NoneLiteral => Some("none".to_string()),
-        HirExpr::ListLiteral { elements, .. } => canonical_sequence("list", elements),
-        HirExpr::TupleLiteral { elements, .. } => canonical_sequence("tuple", elements),
-        HirExpr::SetLiteral { elements, .. } => {
-            let mut elements = elements
-                .iter()
-                .map(canonical_hir_value)
-                .collect::<Option<Vec<_>>>()?;
-            elements.sort();
-            Some(format!("set[{}]", elements.join(",")))
-        }
-        HirExpr::DictLiteral { keys, values, .. } if keys.len() == values.len() => {
-            let mut entries = keys
-                .iter()
-                .zip(values)
-                .map(|(key, value)| {
-                    Some(format!(
-                        "{}={}",
-                        canonical_hir_value(key)?,
-                        canonical_hir_value(value)?
-                    ))
-                })
-                .collect::<Option<Vec<_>>>()?;
-            entries.sort();
-            Some(format!("dict[{}]", entries.join(",")))
-        }
-        _ => None,
-    }
-}
-
-fn canonical_sequence(tag: &str, values: &[HirExpr]) -> Option<String> {
-    let values = values
-        .iter()
-        .map(canonical_hir_value)
-        .collect::<Option<Vec<_>>>()?;
-    Some(format!("{tag}[{}]", values.join(",")))
-}
-
 fn class_nominal_identity(class: &HirClass, module_name: Option<&str>) -> String {
     class.identity.clone().unwrap_or_else(|| {
         module_name.map_or_else(
             || class.name.clone(),
             |module| format!("{module}.{}", class.name),
         )
+    })
+}
+
+fn project_class_identity(class: &HirClass, module_name: &str) -> String {
+    class.identity.clone().unwrap_or_else(|| {
+        if module_name.is_empty() {
+            class.name.clone()
+        } else {
+            format!("{module_name}.{}", class.name)
+        }
     })
 }
 
@@ -525,7 +634,7 @@ fn static_expression(value: ShapeIdentity) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sifr_ir::{DeclarationMetadataTargetKind, HirClassKind, TypedDeclarationMetadata};
+    use sifr_ir::{DeclarationMetadataTargetKind, HirClassKind, HirExpr, TypedDeclarationMetadata};
 
     fn class(name: &str, fields: Vec<(String, Type)>) -> HirClass {
         HirClass {
@@ -611,5 +720,75 @@ mod tests {
         assert_ne!(plain_identity, default_identity);
         assert_ne!(plain_identity, metadata_identity);
         assert_ne!(default_identity, metadata_identity);
+    }
+
+    #[test]
+    fn project_identity_preserves_imported_defaults_and_metadata_inside_union() {
+        let mut payload = class("Payload", vec![("value".to_string(), Type::Int)]);
+        payload.field_defaults = vec![(0, HirExpr::IntLiteral(7))];
+        payload.declaration_metadata = vec![TypedDeclarationMetadata {
+            owner: "Payload".to_string(),
+            target_kind: DeclarationMetadataTargetKind::Type,
+            target_name: None,
+            key: "example.policy".to_string(),
+            value_type: Type::Str,
+            value: HirExpr::StringLiteral("strict".to_string()),
+            range: Default::default(),
+        }];
+        let models = HirModule {
+            functions: Vec::new(),
+            classes: vec![payload.clone()],
+            imports: Vec::new(),
+            constants: Vec::new(),
+            generic_functions: HashMap::new(),
+            type_param_bounds: HashMap::new(),
+        };
+        let payload_type = Type::Class {
+            identity: Some("models.Payload".to_string()),
+            type_args: Vec::new(),
+            name: "Payload".to_string(),
+            fields: vec![("value".to_string(), Type::Int)],
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let envelope = class(
+            "Envelope",
+            vec![(
+                "payload".to_string(),
+                Type::Union(vec![payload_type, Type::Str]),
+            )],
+        );
+        let main = HirModule {
+            functions: Vec::new(),
+            classes: vec![envelope],
+            imports: Vec::new(),
+            constants: Vec::new(),
+            generic_functions: HashMap::new(),
+            type_param_bounds: HashMap::new(),
+        };
+        let modules = [("models", &models), ("main", &main)];
+        let expressions = class_identity_expressions_for_project(
+            &modules,
+            &HashSet::from(["main"]),
+            &HashSet::from(["models.Payload".to_string(), "main.Envelope".to_string()]),
+        );
+        let payload_identity =
+            static_class_identity(&payload, &models, Some("models")).expect("static payload");
+        let expected = identity::nominal_record(
+            "Envelope",
+            &[],
+            &[NominalField {
+                name: "payload",
+                identity: identity::union(&[payload_identity, identity::primitive("str")]),
+                required: true,
+                default_identity: None,
+            }],
+            identity::metadata(&[]),
+        );
+
+        assert_eq!(
+            expressions.get("main.Envelope"),
+            Some(&static_expression(expected))
+        );
     }
 }

--- a/crates/sifr_codegen/src/structural_identity_codegen.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen.rs
@@ -32,7 +32,11 @@ pub(crate) fn class_identity_expression(
     module: &HirModule,
     module_name: Option<&str>,
 ) -> String {
-    compile_class(class, module, module_name).expression()
+    if class.is_enum() {
+        compile_enum(class, module_name).expression()
+    } else {
+        compile_class(class, module, module_name).expression()
+    }
 }
 
 pub(crate) fn static_class_identity(
@@ -40,7 +44,15 @@ pub(crate) fn static_class_identity(
     module: &HirModule,
     module_name: Option<&str>,
 ) -> Option<ShapeIdentity> {
-    compile_class(class, module, module_name).static_value()
+    if class.is_enum() {
+        compile_enum(class, module_name).static_value()
+    } else {
+        compile_class(class, module, module_name).static_value()
+    }
+}
+
+pub(crate) fn enum_identity_expression(class: &HirClass, module_name: Option<&str>) -> String {
+    compile_enum(class, module_name).expression()
 }
 
 pub(crate) const fn algorithm_version() -> u32 {
@@ -85,6 +97,20 @@ fn compile_class(
     )
 }
 
+fn compile_enum(class: &HirClass, module_name: Option<&str>) -> CompiledIdentity {
+    let nominal = class_nominal_identity(class, module_name);
+    let members = class
+        .enum_variants
+        .iter()
+        .map(|(name, value)| (name.as_str(), *value))
+        .collect::<Vec<_>>();
+    CompiledIdentity::Static(identity::enum_shape(
+        &nominal,
+        &members,
+        class_metadata_identity(Some(class)),
+    ))
+}
+
 fn compile_type(
     ty: &Type,
     module: &HirModule,
@@ -119,11 +145,35 @@ fn compile_type(
             }
         }
         Type::Tuple(values) => compile_many("tuple", values, module, module_name, stack),
-        Type::Union(values) if optional_member(values).is_some() => {
-            let Some(member) = optional_member(values) else {
-                unreachable!("guarded optional union must contain one value member");
-            };
-            compile_unary("optional", member, module, module_name, stack)
+        Type::Union(values) => match optional_member(values) {
+            Some(member) => compile_unary("optional", member, module, module_name, stack),
+            None => compile_many("union", values, module, module_name, stack),
+        },
+        Type::Enum {
+            identity: declared_identity,
+            name,
+            variants,
+        } => {
+            if let Some(class) = module
+                .classes
+                .iter()
+                .find(|class| class.name == *name && class.is_enum())
+            {
+                compile_enum(class, module_name)
+            } else {
+                let nominal = declared_identity.clone().unwrap_or_else(|| {
+                    module_name.map_or_else(|| name.clone(), |module| format!("{module}.{name}"))
+                });
+                let members = variants
+                    .iter()
+                    .map(|(name, value)| (name.as_str(), *value))
+                    .collect::<Vec<_>>();
+                CompiledIdentity::Static(identity::enum_shape(
+                    &nominal,
+                    &members,
+                    identity::metadata(&[]),
+                ))
+            }
         }
         Type::Class {
             identity: class_identity,
@@ -139,6 +189,11 @@ fn compile_type(
                     |class| class_nominal_identity(class, module_name),
                 )
             });
+            if let Some(class) = candidate {
+                if class.is_enum() {
+                    return compile_enum(class, module_name);
+                }
+            }
             if let Some(index) = stack.iter().position(|entry| entry == &nominal) {
                 let Ok(index) = u32::try_from(index) else {
                     unreachable!(

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -33,7 +33,11 @@ impl RustEmitter {
     }
 
     pub(crate) fn emit_structural_enum_impls(&mut self, class: &HirClass) {
-        if !self.structural_interop_enabled || !class.is_enum() {
+        if !self.structural_interop_enabled
+            || !class.is_enum()
+            || class.enum_variants.is_empty()
+            || !crate::structural_identity_codegen::class_identity_inputs_supported(class)
+        {
             return;
         }
         let target = Self::class_impl_target(class);
@@ -52,6 +56,11 @@ impl RustEmitter {
 }
 
 pub(crate) fn structural_record_supported(class: &HirClass, module: &HirModule) -> bool {
+    let modules = [("", module)];
+    structural_record_supported_in(class, &modules)
+}
+
+fn structural_record_supported_in(class: &HirClass, modules: &[(&str, &HirModule)]) -> bool {
     let mut visiting = BTreeSet::from([class.name.clone()]);
     class.parent_class.is_none()
         && !class.is_error_type
@@ -66,52 +75,50 @@ pub(crate) fn structural_record_supported(class: &HirClass, module: &HirModule) 
         && class
             .fields
             .iter()
-            .all(|(_, ty)| structural_record_field_supported(ty, module, &mut visiting))
+            .all(|(_, ty)| structural_record_field_supported(ty, modules, &mut visiting))
 }
 
 fn structural_record_field_supported(
     ty: &Type,
-    module: &HirModule,
+    modules: &[(&str, &HirModule)],
     visiting: &mut BTreeSet<String>,
 ) -> bool {
-    matches!(ty.resolve_alias(), Type::Bytes) || structural_type_supported(ty, module, visiting)
+    matches!(ty.resolve_alias(), Type::Bytes) || structural_type_supported(ty, modules, visiting)
 }
 
 fn structural_type_supported(
     ty: &Type,
-    module: &HirModule,
+    modules: &[(&str, &HirModule)],
     visiting: &mut BTreeSet<String>,
 ) -> bool {
     match ty.resolve_alias() {
         Type::Int | Type::Float | Type::Bool | Type::Str | Type::None | Type::TypeVar(_) => true,
-        Type::Enum { .. } => true,
+        Type::Enum { variants, .. } => !variants.is_empty(),
         Type::Bytes => false,
         Type::FixedInt(value) => !matches!(
             value,
             sifr_type_system::FixedIntType::ISize | sifr_type_system::FixedIntType::USize
         ),
-        Type::List(value) | Type::Set(value) => structural_type_supported(value, module, visiting),
+        Type::List(value) | Type::Set(value) => structural_type_supported(value, modules, visiting),
         Type::Dict(key, value) => {
-            structural_type_supported(key, module, visiting)
-                && structural_type_supported(value, module, visiting)
+            structural_type_supported(key, modules, visiting)
+                && structural_type_supported(value, modules, visiting)
         }
         Type::Tuple(values) => {
             values.len() <= 4
                 && values
                     .iter()
-                    .all(|value| structural_type_supported(value, module, visiting))
+                    .all(|value| structural_type_supported(value, modules, visiting))
         }
         Type::Union(values) => values
             .iter()
-            .all(|value| structural_type_supported(value, module, visiting)),
-        Type::Class { name, .. } => {
-            if visiting.contains(name) {
+            .all(|value| structural_type_supported(value, modules, visiting)),
+        Type::Class { identity, name, .. } => {
+            let key = identity.as_deref().unwrap_or(name);
+            if visiting.contains(key) {
                 return true;
             }
-            let Some(candidate) = module
-                .classes
-                .iter()
-                .find(|candidate| candidate.name == *name)
+            let Some(candidate) = structural_class_candidate(identity.as_deref(), name, modules)
             else {
                 return false;
             };
@@ -132,12 +139,12 @@ fn structural_type_supported(
             {
                 return false;
             }
-            visiting.insert(name.clone());
+            visiting.insert(key.to_string());
             let supported = candidate
                 .fields
                 .iter()
-                .all(|(_, field)| structural_record_field_supported(field, module, visiting));
-            visiting.remove(name);
+                .all(|(_, field)| structural_record_field_supported(field, modules, visiting));
+            visiting.remove(key);
             supported
         }
         Type::Newtype { .. } => false,
@@ -145,66 +152,57 @@ fn structural_type_supported(
     }
 }
 
+fn structural_class_candidate<'a>(
+    identity: Option<&str>,
+    name: &str,
+    modules: &'a [(&'a str, &'a HirModule)],
+) -> Option<&'a HirClass> {
+    if let Some(identity) = identity {
+        if let Some(candidate) = modules.iter().find_map(|(module_name, module)| {
+            module.classes.iter().find(|class| {
+                class.identity.as_deref() == Some(identity)
+                    || format!("{module_name}.{}", class.name) == identity
+            })
+        }) {
+            return Some(candidate);
+        }
+    }
+    let mut candidates = modules
+        .iter()
+        .flat_map(|(_, module)| &module.classes)
+        .filter(|class| class.name == name);
+    let candidate = candidates.next()?;
+    candidates.next().is_none().then_some(candidate)
+}
+
 pub(crate) fn structural_union_names(
     module: &HirModule,
     unions: &std::collections::HashMap<String, Vec<Type>>,
 ) -> HashSet<String> {
+    structural_union_names_in(unions, &[("", module)])
+}
+
+pub(crate) fn structural_union_names_for_project(
+    unions: &std::collections::HashMap<String, Vec<Type>>,
+    modules: &[(&str, &HirModule)],
+) -> HashSet<String> {
+    structural_union_names_in(unions, modules)
+}
+
+fn structural_union_names_in(
+    unions: &std::collections::HashMap<String, Vec<Type>>,
+    modules: &[(&str, &HirModule)],
+) -> HashSet<String> {
     let mut names = HashSet::new();
-    for class in &module.classes {
-        if structural_record_supported(class, module) {
-            for (_, field) in &class.fields {
-                collect_structural_union_names(field, &mut names);
-            }
-        }
-    }
     for (name, members) in unions {
         if members
             .iter()
-            .all(|member| structural_type_supported(member, module, &mut BTreeSet::new()))
+            .all(|member| structural_type_supported(member, modules, &mut BTreeSet::new()))
         {
             names.insert(name.clone());
         }
     }
     names
-}
-
-fn collect_structural_union_names(ty: &Type, names: &mut HashSet<String>) {
-    match ty.resolve_alias() {
-        Type::Union(values) if !is_optional_union(values) => {
-            names.insert(ty.union_enum_name());
-            for value in values {
-                collect_structural_union_names(value, names);
-            }
-        }
-        Type::Union(values) | Type::Tuple(values) => {
-            for value in values {
-                collect_structural_union_names(value, names);
-            }
-        }
-        Type::List(value) | Type::Set(value) => collect_structural_union_names(value, names),
-        Type::Dict(key, value) => {
-            collect_structural_union_names(key, names);
-            collect_structural_union_names(value, names);
-        }
-        Type::Class {
-            type_args, fields, ..
-        } => {
-            for value in type_args {
-                collect_structural_union_names(value, names);
-            }
-            for (_, value) in fields {
-                collect_structural_union_names(value, names);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn is_optional_union(values: &[Type]) -> bool {
-    values.len() == 2
-        && values
-            .iter()
-            .any(|value| matches!(value.resolve_alias(), Type::None))
 }
 
 fn structural_impl_type_params(class: &HirClass) -> Vec<RustTypeParam> {
@@ -429,12 +427,12 @@ fn structural_enum_impls(
     nominal_identity: &str,
     shape: &str,
 ) -> Vec<RustItem> {
-    let mut next_value = 1_i64;
     let mut construct_arms = Vec::with_capacity(class.enum_variants.len());
     let mut project_arms = Vec::with_capacity(class.enum_variants.len());
-    for (index, (name, declared)) in class.enum_variants.iter().enumerate() {
-        let value = declared.unwrap_or(next_value);
-        next_value = value.saturating_add(1);
+    for (index, (name, value)) in crate::type_emitters::resolved_enum_variants(class)
+        .into_iter()
+        .enumerate()
+    {
         construct_arms.push(format!(
             "{STRUCTURAL}::StructuralEdgeKind::ActiveMember {{ name: \"{name}\", index: {index} }} => match <i64 as {STRUCTURAL}::StructuralConstruct>::structural_construct_at(source, child, token) {{ Ok({value}) => Ok(Self::{name}), Ok(_) => Err({STRUCTURAL}::StructuralContractError::MemberMismatch), Err(error) => Err(error), }},"
         ));

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -33,10 +33,7 @@ impl RustEmitter {
     }
 
     pub(crate) fn emit_structural_enum_impls(&mut self, class: &HirClass) {
-        if !self.structural_interop_enabled
-            || !class.is_enum()
-            || class.enum_variants.is_empty()
-            || !crate::structural_identity_codegen::class_identity_inputs_supported(class)
+        if !self.structural_interop_enabled || !class.is_enum() || !structural_enum_supported(class)
         {
             return;
         }
@@ -123,9 +120,7 @@ fn structural_type_supported(
                 return false;
             };
             if candidate.is_enum() {
-                return crate::structural_identity_codegen::class_identity_inputs_supported(
-                    candidate,
-                );
+                return structural_enum_supported(candidate);
             }
             if candidate.parent_class.is_some()
                 || candidate.is_error_type
@@ -166,6 +161,9 @@ fn structural_class_candidate<'a>(
         }) {
             return Some(candidate);
         }
+        if modules.len() != 1 || !modules[0].0.is_empty() {
+            return None;
+        }
     }
     let mut candidates = modules
         .iter()
@@ -173,6 +171,11 @@ fn structural_class_candidate<'a>(
         .filter(|class| class.name == name);
     let candidate = candidates.next()?;
     candidates.next().is_none().then_some(candidate)
+}
+
+fn structural_enum_supported(class: &HirClass) -> bool {
+    !class.enum_variants.is_empty()
+        && crate::structural_identity_codegen::class_identity_inputs_supported(class)
 }
 
 pub(crate) fn structural_union_names(

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -7,7 +7,19 @@ const STRUCTURAL: &str = "::sifr_runtime::interop::structural";
 
 impl RustEmitter {
     pub(crate) fn emit_structural_record_impls(&mut self, class: &HirClass, module: &HirModule) {
-        if !self.structural_interop_enabled || !structural_record_supported(class, module) {
+        let supported = self
+            .project_structural_record_identities
+            .as_ref()
+            .map_or_else(
+                || structural_record_supported(class, module),
+                |identities| {
+                    identities.contains(&structural_record_identity(
+                        class,
+                        self.current_module_name.as_deref(),
+                    ))
+                },
+            );
+        if !self.structural_interop_enabled || !supported {
             return;
         }
         let target = Self::class_impl_target(class);
@@ -55,6 +67,30 @@ impl RustEmitter {
 pub(crate) fn structural_record_supported(class: &HirClass, module: &HirModule) -> bool {
     let modules = [("", module)];
     structural_record_supported_in(class, &modules)
+}
+
+pub(crate) fn structural_record_identities_for_project(
+    modules: &[(&str, &HirModule)],
+) -> HashSet<String> {
+    modules
+        .iter()
+        .flat_map(|(module_name, module)| {
+            module
+                .classes
+                .iter()
+                .filter(|class| structural_record_supported_in(class, modules))
+                .map(|class| structural_record_identity(class, Some(module_name)))
+        })
+        .collect()
+}
+
+fn structural_record_identity(class: &HirClass, module_name: Option<&str>) -> String {
+    class.identity.clone().unwrap_or_else(|| {
+        module_name.map_or_else(
+            || class.name.clone(),
+            |module_name| format!("{module_name}.{}", class.name),
+        )
+    })
 }
 
 fn structural_record_supported_in(class: &HirClass, modules: &[(&str, &HirModule)]) -> bool {

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -24,13 +24,14 @@ impl RustEmitter {
         }
         let target = Self::class_impl_target(class);
         let type_params = structural_impl_type_params(class);
-        let nominal_identity = nominal_identity(class, self.current_module_name.as_deref());
+        let structural_module_name = self.structural_identity_module_name.as_deref();
+        let nominal_identity = nominal_identity(class, structural_module_name);
         let type_impl = structural_type_impl(
             class,
             module,
             &target,
             type_params.clone(),
-            self.current_module_name.as_deref(),
+            structural_module_name,
         );
         let construct_impl =
             structural_construct_impl(class, &target, type_params.clone(), &nominal_identity, self);
@@ -50,10 +51,11 @@ impl RustEmitter {
             return;
         }
         let target = Self::class_impl_target(class);
-        let nominal_identity = nominal_identity(class, self.current_module_name.as_deref());
+        let structural_module_name = self.structural_identity_module_name.as_deref();
+        let nominal_identity = nominal_identity(class, structural_module_name);
         let shape = crate::structural_identity_codegen::enum_identity_expression(
             class,
-            self.current_module_name.as_deref(),
+            structural_module_name,
         );
         self.body_items.extend(structural_enum_impls(
             class,

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -1,7 +1,7 @@
 use crate::{RustEmitter, RustItem, RustParam, RustStmt, RustType, RustTypeParam, Visibility};
 use sifr_ir::{HirClass, HirModule, RustInteropDecoratorKind};
 use sifr_type_system::Type;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 
 const STRUCTURAL: &str = "::sifr_runtime::interop::structural";
 
@@ -29,6 +29,24 @@ impl RustEmitter {
             &target,
             type_params,
             &nominal_identity,
+        ));
+    }
+
+    pub(crate) fn emit_structural_enum_impls(&mut self, class: &HirClass) {
+        if !self.structural_interop_enabled || !class.is_enum() {
+            return;
+        }
+        let target = Self::class_impl_target(class);
+        let nominal_identity = nominal_identity(class, self.current_module_name.as_deref());
+        let shape = crate::structural_identity_codegen::enum_identity_expression(
+            class,
+            self.current_module_name.as_deref(),
+        );
+        self.body_items.extend(structural_enum_impls(
+            class,
+            &target,
+            &nominal_identity,
+            &shape,
         ));
     }
 }
@@ -66,6 +84,7 @@ fn structural_type_supported(
 ) -> bool {
     match ty.resolve_alias() {
         Type::Int | Type::Float | Type::Bool | Type::Str | Type::None | Type::TypeVar(_) => true,
+        Type::Enum { .. } => true,
         Type::Bytes => false,
         Type::FixedInt(value) => !matches!(
             value,
@@ -82,17 +101,9 @@ fn structural_type_supported(
                     .iter()
                     .all(|value| structural_type_supported(value, module, visiting))
         }
-        Type::Union(values)
-            if values.len() == 2
-                && values
-                    .iter()
-                    .any(|value| matches!(value.resolve_alias(), Type::None)) =>
-        {
-            values
-                .iter()
-                .filter(|value| !matches!(value.resolve_alias(), Type::None))
-                .all(|value| structural_type_supported(value, module, visiting))
-        }
+        Type::Union(values) => values
+            .iter()
+            .all(|value| structural_type_supported(value, module, visiting)),
         Type::Class { name, .. } => {
             if visiting.contains(name) {
                 return true;
@@ -104,11 +115,15 @@ fn structural_type_supported(
             else {
                 return false;
             };
+            if candidate.is_enum() {
+                return crate::structural_identity_codegen::class_identity_inputs_supported(
+                    candidate,
+                );
+            }
             if candidate.parent_class.is_some()
                 || candidate.is_error_type
                 || candidate.newtype_inner.is_some()
                 || !crate::structural_identity_codegen::class_identity_inputs_supported(candidate)
-                || candidate.is_enum()
                 || candidate.python_opaque_declaration().is_some()
                 || candidate
                     .rust_interop
@@ -128,6 +143,68 @@ fn structural_type_supported(
         Type::Newtype { .. } => false,
         _ => false,
     }
+}
+
+pub(crate) fn structural_union_names(
+    module: &HirModule,
+    unions: &std::collections::HashMap<String, Vec<Type>>,
+) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for class in &module.classes {
+        if structural_record_supported(class, module) {
+            for (_, field) in &class.fields {
+                collect_structural_union_names(field, &mut names);
+            }
+        }
+    }
+    for (name, members) in unions {
+        if members
+            .iter()
+            .all(|member| structural_type_supported(member, module, &mut BTreeSet::new()))
+        {
+            names.insert(name.clone());
+        }
+    }
+    names
+}
+
+fn collect_structural_union_names(ty: &Type, names: &mut HashSet<String>) {
+    match ty.resolve_alias() {
+        Type::Union(values) if !is_optional_union(values) => {
+            names.insert(ty.union_enum_name());
+            for value in values {
+                collect_structural_union_names(value, names);
+            }
+        }
+        Type::Union(values) | Type::Tuple(values) => {
+            for value in values {
+                collect_structural_union_names(value, names);
+            }
+        }
+        Type::List(value) | Type::Set(value) => collect_structural_union_names(value, names),
+        Type::Dict(key, value) => {
+            collect_structural_union_names(key, names);
+            collect_structural_union_names(value, names);
+        }
+        Type::Class {
+            type_args, fields, ..
+        } => {
+            for value in type_args {
+                collect_structural_union_names(value, names);
+            }
+            for (_, value) in fields {
+                collect_structural_union_names(value, names);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_optional_union(values: &[Type]) -> bool {
+    values.len() == 2
+        && values
+            .iter()
+            .any(|value| matches!(value.resolve_alias(), Type::None))
 }
 
 fn structural_impl_type_params(class: &HirClass) -> Vec<RustTypeParam> {
@@ -344,4 +421,130 @@ fn structural_project_impl(
             is_async: false,
         }],
     }
+}
+
+fn structural_enum_impls(
+    class: &HirClass,
+    target: &str,
+    nominal_identity: &str,
+    shape: &str,
+) -> Vec<RustItem> {
+    let mut next_value = 1_i64;
+    let mut construct_arms = Vec::with_capacity(class.enum_variants.len());
+    let mut project_arms = Vec::with_capacity(class.enum_variants.len());
+    for (index, (name, declared)) in class.enum_variants.iter().enumerate() {
+        let value = declared.unwrap_or(next_value);
+        next_value = value.saturating_add(1);
+        construct_arms.push(format!(
+            "{STRUCTURAL}::StructuralEdgeKind::ActiveMember {{ name: \"{name}\", index: {index} }} => match <i64 as {STRUCTURAL}::StructuralConstruct>::structural_construct_at(source, child, token) {{ Ok({value}) => Ok(Self::{name}), Ok(_) => Err({STRUCTURAL}::StructuralContractError::MemberMismatch), Err(error) => Err(error), }},"
+        ));
+        project_arms.push(format!(
+            "Self::{name} => {{ visitor.edge({STRUCTURAL}::StructuralEdge::new({STRUCTURAL}::StructuralEdgeKind::ActiveMember {{ name: \"{name}\", index: {index} }}))?; visitor.scalar({STRUCTURAL}::StructuralScalarRef::SignedInteger {{ value: i128::from({value}_i64), width: 64 }})?; }}"
+        ));
+    }
+    let construct_body = format!(
+        "let description = source.node(node)?;\nif description.kind() != {STRUCTURAL}::StructuralKind::Enum {{ return Err({STRUCTURAL}::StructuralContractError::KindMismatch); }}\nif description.nominal_identity() != Some({nominal_identity}) {{ return Err({STRUCTURAL}::StructuralContractError::MemberMismatch); }}\nlet [edge] = description.edges() else {{ return Err({STRUCTURAL}::StructuralContractError::ArityMismatch); }};\nlet edge_kind = edge.kind();\nlet child = edge.node();\nmatch edge_kind {{\n{}\n_ => Err({STRUCTURAL}::StructuralContractError::MemberMismatch),\n}}",
+        construct_arms.join("\n")
+    );
+    let project_body = format!(
+        "let control = visitor.enter({STRUCTURAL}::StructuralEnter::new({STRUCTURAL}::StructuralKind::Enum, Some({nominal_identity}), 1))?;\nif control == {STRUCTURAL}::VisitControl::Continue {{\nmatch self {{\n{}\n}}\n}}\nvisitor.exit({STRUCTURAL}::StructuralKind::Enum)",
+        project_arms.join("\n")
+    );
+    vec![
+        RustItem::Impl {
+            target: target.to_string(),
+            type_params: Vec::new(),
+            trait_: Some(format!("{STRUCTURAL}::StructuralType")),
+            items: vec![
+                RustItem::Fn {
+                    name: "shape_identity".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: Vec::new(),
+                    params: Vec::new(),
+                    ret: Some(RustType::Named(format!("{STRUCTURAL}::ShapeIdentity"))),
+                    body: vec![RustStmt::Verbatim(shape.to_string())],
+                    is_async: false,
+                },
+                RustItem::Fn {
+                    name: "nominal_identity".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: Vec::new(),
+                    params: Vec::new(),
+                    ret: Some(RustType::Named("Option<&'static str>".to_string())),
+                    body: vec![RustStmt::Verbatim(format!("Some({nominal_identity})"))],
+                    is_async: false,
+                },
+            ],
+        },
+        RustItem::Impl {
+            target: target.to_string(),
+            type_params: Vec::new(),
+            trait_: Some(format!("{STRUCTURAL}::StructuralConstruct")),
+            items: vec![RustItem::Fn {
+                name: "structural_construct_at".to_string(),
+                visibility: Visibility::Private,
+                type_params: vec![RustTypeParam {
+                    name: "S".to_string(),
+                    bounds: vec![format!("{STRUCTURAL}::StructuralSource")],
+                }],
+                params: vec![
+                    RustParam::Named {
+                        name: "source".to_string(),
+                        ty: RustType::Ref {
+                            mutable: true,
+                            inner: Box::new(RustType::Named("S".to_string())),
+                        },
+                    },
+                    RustParam::Named {
+                        name: "node".to_string(),
+                        ty: RustType::Named(format!("{STRUCTURAL}::NodeId")),
+                    },
+                    RustParam::Named {
+                        name: "token".to_string(),
+                        ty: RustType::Named(format!("{STRUCTURAL}::ConstructToken")),
+                    },
+                ],
+                ret: Some(RustType::Named(format!(
+                    "Result<Self, {STRUCTURAL}::StructuralContractError>"
+                ))),
+                body: vec![RustStmt::Verbatim(construct_body)],
+                is_async: false,
+            }],
+        },
+        RustItem::Impl {
+            target: target.to_string(),
+            type_params: Vec::new(),
+            trait_: Some(format!("{STRUCTURAL}::StructuralProject")),
+            items: vec![RustItem::Fn {
+                name: "structural_project".to_string(),
+                visibility: Visibility::Private,
+                type_params: vec![
+                    RustTypeParam {
+                        name: "'value".to_string(),
+                        bounds: Vec::new(),
+                    },
+                    RustTypeParam {
+                        name: "V".to_string(),
+                        bounds: vec![format!("{STRUCTURAL}::StructuralVisitor<'value>")],
+                    },
+                ],
+                params: vec![
+                    RustParam::SelfParamWithLifetime {
+                        mutable: false,
+                        lifetime: "'value".to_string(),
+                    },
+                    RustParam::Named {
+                        name: "visitor".to_string(),
+                        ty: RustType::Ref {
+                            mutable: true,
+                            inner: Box::new(RustType::Named("V".to_string())),
+                        },
+                    },
+                ],
+                ret: Some(RustType::Named("Result<(), V::Error>".to_string())),
+                body: vec![RustStmt::Verbatim(project_body)],
+                is_async: false,
+            }],
+        },
+    ]
 }

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -26,12 +26,25 @@ impl RustEmitter {
         let type_params = structural_impl_type_params(class);
         let structural_module_name = self.structural_identity_module_name.as_deref();
         let nominal_identity = nominal_identity(class, structural_module_name);
+        let identity_key = structural_record_identity(class, self.current_module_name.as_deref());
+        let shape = self
+            .project_structural_identity_expressions
+            .as_ref()
+            .and_then(|expressions| expressions.get(&identity_key))
+            .cloned()
+            .unwrap_or_else(|| {
+                crate::structural_identity_codegen::class_identity_expression(
+                    class,
+                    module,
+                    structural_module_name,
+                )
+            });
         let type_impl = structural_type_impl(
             class,
-            module,
             &target,
             type_params.clone(),
             structural_module_name,
+            shape,
         );
         let construct_impl =
             structural_construct_impl(class, &target, type_params.clone(), &nominal_identity, self);
@@ -53,10 +66,18 @@ impl RustEmitter {
         let target = Self::class_impl_target(class);
         let structural_module_name = self.structural_identity_module_name.as_deref();
         let nominal_identity = nominal_identity(class, structural_module_name);
-        let shape = crate::structural_identity_codegen::enum_identity_expression(
-            class,
-            structural_module_name,
-        );
+        let identity_key = structural_record_identity(class, self.current_module_name.as_deref());
+        let shape = self
+            .project_structural_identity_expressions
+            .as_ref()
+            .and_then(|expressions| expressions.get(&identity_key))
+            .cloned()
+            .unwrap_or_else(|| {
+                crate::structural_identity_codegen::enum_identity_expression(
+                    class,
+                    structural_module_name,
+                )
+            });
         self.body_items.extend(structural_enum_impls(
             class,
             &target,
@@ -88,10 +109,12 @@ pub(crate) fn structural_record_identities_for_project(
 
 fn structural_record_identity(class: &HirClass, module_name: Option<&str>) -> String {
     class.identity.clone().unwrap_or_else(|| {
-        module_name.map_or_else(
-            || class.name.clone(),
-            |module_name| format!("{module_name}.{}", class.name),
-        )
+        module_name
+            .filter(|module_name| !module_name.is_empty())
+            .map_or_else(
+                || class.name.clone(),
+                |module_name| format!("{module_name}.{}", class.name),
+            )
     })
 }
 
@@ -128,7 +151,14 @@ fn structural_type_supported(
 ) -> bool {
     match ty.resolve_alias() {
         Type::Int | Type::Float | Type::Bool | Type::Str | Type::None | Type::TypeVar(_) => true,
-        Type::Enum { variants, .. } => !variants.is_empty(),
+        Type::Enum {
+            identity,
+            name,
+            variants,
+        } => structural_class_candidate(identity.as_deref(), name, modules).map_or_else(
+            || sifr_ir::structural_identity_enum_variants_supported(variants),
+            structural_enum_supported,
+        ),
         Type::Bytes => false,
         Type::FixedInt(value) => !matches!(
             value,
@@ -211,9 +241,15 @@ fn structural_class_candidate<'a>(
     candidates.next().is_none().then_some(candidate)
 }
 
-fn structural_enum_supported(class: &HirClass) -> bool {
-    !class.enum_variants.is_empty()
+pub(crate) fn structural_enum_supported(class: &HirClass) -> bool {
+    sifr_ir::structural_identity_enum_variants_supported(&class.enum_variants)
         && crate::structural_identity_codegen::class_identity_inputs_supported(class)
+        && !class.is_error_type
+        && class.python_opaque_declaration().is_none()
+        && !class
+            .rust_interop
+            .iter()
+            .any(|declaration| declaration.kind == RustInteropDecoratorKind::Opaque)
 }
 
 pub(crate) fn structural_union_names(
@@ -275,13 +311,11 @@ fn nominal_identity(class: &HirClass, module_name: Option<&str>) -> String {
 
 fn structural_type_impl(
     class: &HirClass,
-    module: &HirModule,
     target: &str,
     type_params: Vec<RustTypeParam>,
     module_name: Option<&str>,
+    identity: String,
 ) -> RustItem {
-    let identity =
-        crate::structural_identity_codegen::class_identity_expression(class, module, module_name);
     let nominal_identity = nominal_identity(class, module_name);
     RustItem::Impl {
         target: target.to_string(),

--- a/crates/sifr_codegen/src/type_emitters.rs
+++ b/crates/sifr_codegen/src/type_emitters.rs
@@ -48,19 +48,13 @@ impl RustEmitter {
         } else {
             Visibility::Private
         };
-        let mut auto_value = 1_i64;
-        let variants = class
-            .enum_variants
-            .iter()
-            .map(|(name, value)| {
-                let resolved = value.unwrap_or(auto_value);
-                auto_value = resolved + 1;
-                crate::RustEnumVariant {
-                    name: name.clone(),
-                    tuple_fields: Vec::new(),
-                    fields: Vec::new(),
-                    value: Some(RustExpr::Literal(RustLiteral::Int(resolved))),
-                }
+        let variants = resolved_enum_variants(class)
+            .into_iter()
+            .map(|(name, resolved)| crate::RustEnumVariant {
+                name: name.to_string(),
+                tuple_fields: Vec::new(),
+                fields: Vec::new(),
+                value: Some(RustExpr::Literal(RustLiteral::Int(resolved))),
             })
             .collect::<Vec<_>>();
         self.body_items.push(RustItem::Enum {
@@ -332,4 +326,17 @@ impl RustEmitter {
             |_, _| Option::<Vec<RustStmt>>::None,
         )
     }
+}
+
+pub(crate) fn resolved_enum_variants(class: &HirClass) -> Vec<(&str, i64)> {
+    let mut next_value = 1_i64;
+    class
+        .enum_variants
+        .iter()
+        .map(|(name, declared)| {
+            let value = declared.unwrap_or(next_value);
+            next_value = value.saturating_add(1);
+            (name.as_str(), value)
+        })
+        .collect()
 }

--- a/crates/sifr_codegen/src/type_emitters.rs
+++ b/crates/sifr_codegen/src/type_emitters.rs
@@ -151,6 +151,7 @@ impl RustEmitter {
             trait_: None,
             items: impl_items,
         });
+        self.emit_structural_enum_impls(class);
     }
 
     pub(crate) fn emit_newtype(&mut self, class: &HirClass, inner: &Type, module_public: bool) {

--- a/crates/sifr_codegen/src/union_type_helpers.rs
+++ b/crates/sifr_codegen/src/union_type_helpers.rs
@@ -1,6 +1,6 @@
 use crate::{
     sifr_type_to_rust_type, RustEmitter, RustEnumVariant, RustExpr, RustItem, RustLiteral,
-    RustMatchArm, RustParam, RustStmt, RustType, Visibility,
+    RustMatchArm, RustParam, RustStmt, RustType, RustTypeParam, Visibility,
 };
 use sifr_ir::HirModule;
 use sifr_type_system::ParamConvention;
@@ -325,6 +325,10 @@ impl RustEmitter {
                 repr: None,
                 variants,
             });
+            if self.structural_union_enums.contains(&enum_name) {
+                self.enum_items
+                    .extend(self.structural_union_impls(&enum_name, &members));
+            }
             if is_try_error_carrier {
                 let conversion_items = members
                     .iter()
@@ -419,6 +423,138 @@ impl RustEmitter {
                 }],
             });
         }
+    }
+
+    fn structural_union_impls(&self, enum_name: &str, members: &[Type]) -> Vec<RustItem> {
+        const STRUCTURAL: &str = "::sifr_runtime::interop::structural";
+        let member_types = members
+            .iter()
+            .map(|member| {
+                crate::Renderer::render_type_string(&self.project_union_member_rust_type(member))
+            })
+            .collect::<Vec<_>>();
+        let shape_members = member_types
+            .iter()
+            .map(|member| format!("<{member} as {STRUCTURAL}::StructuralType>::shape_identity()"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let construct_arms = members
+            .iter()
+            .zip(&member_types)
+            .enumerate()
+            .map(|(index, (member, member_type))| {
+                let variant = member.union_variant_name();
+                format!(
+                    "{STRUCTURAL}::StructuralEdgeKind::ActiveMember {{ name: \"member\", index: {index} }} => <{member_type} as {STRUCTURAL}::StructuralConstruct>::structural_construct_at(source, child, token).map(Self::{variant}),"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let project_arms = members
+            .iter()
+            .enumerate()
+            .map(|(index, member)| {
+                let variant = member.union_variant_name();
+                format!(
+                    "Self::{variant}(value) => {{ visitor.edge({STRUCTURAL}::StructuralEdge::new({STRUCTURAL}::StructuralEdgeKind::ActiveMember {{ name: \"member\", index: {index} }}))?; {STRUCTURAL}::StructuralProject::structural_project(value, visitor)?; }}"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let construct_body = format!(
+            "let description = source.node(node)?;\nif description.kind() != {STRUCTURAL}::StructuralKind::Union {{ return Err({STRUCTURAL}::StructuralContractError::KindMismatch); }}\nlet [edge] = description.edges() else {{ return Err({STRUCTURAL}::StructuralContractError::ArityMismatch); }};\nlet edge_kind = edge.kind();\nlet child = edge.node();\nmatch edge_kind {{\n{construct_arms}\n_ => Err({STRUCTURAL}::StructuralContractError::MemberMismatch),\n}}"
+        );
+        let project_body = format!(
+            "let control = visitor.enter({STRUCTURAL}::StructuralEnter::new({STRUCTURAL}::StructuralKind::Union, None, 1))?;\nif control == {STRUCTURAL}::VisitControl::Continue {{\nmatch self {{\n{project_arms}\n}}\n}}\nvisitor.exit({STRUCTURAL}::StructuralKind::Union)"
+        );
+        vec![
+            RustItem::Impl {
+                target: enum_name.to_string(),
+                type_params: Vec::new(),
+                trait_: Some(format!("{STRUCTURAL}::StructuralType")),
+                items: vec![RustItem::Fn {
+                    name: "shape_identity".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: Vec::new(),
+                    params: Vec::new(),
+                    ret: Some(RustType::Named(format!("{STRUCTURAL}::ShapeIdentity"))),
+                    body: vec![RustStmt::Verbatim(format!(
+                        "{STRUCTURAL}::union(&[{shape_members}])"
+                    ))],
+                    is_async: false,
+                }],
+            },
+            RustItem::Impl {
+                target: enum_name.to_string(),
+                type_params: Vec::new(),
+                trait_: Some(format!("{STRUCTURAL}::StructuralConstruct")),
+                items: vec![RustItem::Fn {
+                    name: "structural_construct_at".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![RustTypeParam {
+                        name: "S".to_string(),
+                        bounds: vec![format!("{STRUCTURAL}::StructuralSource")],
+                    }],
+                    params: vec![
+                        RustParam::Named {
+                            name: "source".to_string(),
+                            ty: RustType::Ref {
+                                mutable: true,
+                                inner: Box::new(RustType::Named("S".to_string())),
+                            },
+                        },
+                        RustParam::Named {
+                            name: "node".to_string(),
+                            ty: RustType::Named(format!("{STRUCTURAL}::NodeId")),
+                        },
+                        RustParam::Named {
+                            name: "token".to_string(),
+                            ty: RustType::Named(format!("{STRUCTURAL}::ConstructToken")),
+                        },
+                    ],
+                    ret: Some(RustType::Named(format!(
+                        "Result<Self, {STRUCTURAL}::StructuralContractError>"
+                    ))),
+                    body: vec![RustStmt::Verbatim(construct_body)],
+                    is_async: false,
+                }],
+            },
+            RustItem::Impl {
+                target: enum_name.to_string(),
+                type_params: Vec::new(),
+                trait_: Some(format!("{STRUCTURAL}::StructuralProject")),
+                items: vec![RustItem::Fn {
+                    name: "structural_project".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![
+                        RustTypeParam {
+                            name: "'value".to_string(),
+                            bounds: Vec::new(),
+                        },
+                        RustTypeParam {
+                            name: "V".to_string(),
+                            bounds: vec![format!("{STRUCTURAL}::StructuralVisitor<'value>")],
+                        },
+                    ],
+                    params: vec![
+                        RustParam::SelfParamWithLifetime {
+                            mutable: false,
+                            lifetime: "'value".to_string(),
+                        },
+                        RustParam::Named {
+                            name: "visitor".to_string(),
+                            ty: RustType::Ref {
+                                mutable: true,
+                                inner: Box::new(RustType::Named("V".to_string())),
+                            },
+                        },
+                    ],
+                    ret: Some(RustType::Named("Result<(), V::Error>".to_string())),
+                    body: vec![RustStmt::Verbatim(project_body)],
+                    is_async: false,
+                }],
+            },
+        ]
     }
 }
 

--- a/crates/sifr_codegen/src/union_type_helpers.rs
+++ b/crates/sifr_codegen/src/union_type_helpers.rs
@@ -462,7 +462,7 @@ impl RustEmitter {
             .collect::<Vec<_>>()
             .join("\n");
         let construct_body = format!(
-            "let description = source.node(node)?;\nif description.kind() != {STRUCTURAL}::StructuralKind::Union {{ return Err({STRUCTURAL}::StructuralContractError::KindMismatch); }}\nlet [edge] = description.edges() else {{ return Err({STRUCTURAL}::StructuralContractError::ArityMismatch); }};\nlet edge_kind = edge.kind();\nlet child = edge.node();\nmatch edge_kind {{\n{construct_arms}\n_ => Err({STRUCTURAL}::StructuralContractError::MemberMismatch),\n}}"
+            "let description = source.node(node)?;\nif description.kind() != {STRUCTURAL}::StructuralKind::Union {{ return Err({STRUCTURAL}::StructuralContractError::KindMismatch); }}\nif description.nominal_identity().is_some() {{ return Err({STRUCTURAL}::StructuralContractError::MemberMismatch); }}\nlet [edge] = description.edges() else {{ return Err({STRUCTURAL}::StructuralContractError::ArityMismatch); }};\nlet edge_kind = edge.kind();\nlet child = edge.node();\nmatch edge_kind {{\n{construct_arms}\n_ => Err({STRUCTURAL}::StructuralContractError::MemberMismatch),\n}}"
         );
         let project_body = format!(
             "let control = visitor.enter({STRUCTURAL}::StructuralEnter::new({STRUCTURAL}::StructuralKind::Union, None, 1))?;\nif control == {STRUCTURAL}::VisitControl::Continue {{\nmatch self {{\n{project_arms}\n}}\n}}\nvisitor.exit({STRUCTURAL}::StructuralKind::Union)"

--- a/crates/sifr_driver/src/tests/package_rust_interop_build_tests.rs
+++ b/crates/sifr_driver/src/tests/package_rust_interop_build_tests.rs
@@ -394,7 +394,7 @@ fn test_build_structural_bridge_runtime() {
     );
     assert_eq!(
         run_built_package(&entrypoint),
-        "records=3;sequences=1;optionals=1;strings=input,x,input-box;construction=root/a,b/boxed/tail;callback=typed"
+        "records=3;sequences=1;optionals=1;strings=input,x,input-box;construction=root/a,b/boxed/tail;callback=typed;sums=sum/WAITING"
     );
     let _ = std::fs::remove_dir_all(package_root);
 }

--- a/crates/sifr_ir/src/specialization_metadata.rs
+++ b/crates/sifr_ir/src/specialization_metadata.rs
@@ -3,6 +3,7 @@
 use crate::HirExpr;
 use ruff_text_size::TextRange;
 use sifr_type_system::Type;
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum DeclarationMetadataTargetKind {
@@ -27,6 +28,75 @@ pub struct TypedDeclarationMetadata {
     pub value_type: Type,
     pub value: HirExpr,
     pub range: TextRange,
+}
+
+/// Return the canonical structural-identity spelling for a closed HIR value.
+///
+/// Lowering and code generation use this one predicate so a type cannot satisfy
+/// the `Structural` bound unless code generation can preserve all of its
+/// defaults and declaration metadata in the wire identity.
+pub fn canonical_structural_identity_value(value: &HirExpr) -> Option<String> {
+    match value {
+        HirExpr::IntLiteral(value) => Some(format!("int:{value}")),
+        HirExpr::LargeIntLiteral(value) => Some(format!("int:{value}")),
+        HirExpr::FloatLiteral(value) => Some(format!("float:{:016x}", value.to_bits())),
+        HirExpr::StringLiteral(value) => Some(format!("str:{}:{value}", value.len())),
+        HirExpr::BoolLiteral(value) => Some(format!("bool:{value}")),
+        HirExpr::NoneLiteral => Some("none".to_string()),
+        HirExpr::ListLiteral { elements, .. } => canonical_sequence("list", elements),
+        HirExpr::TupleLiteral { elements, .. } => canonical_sequence("tuple", elements),
+        HirExpr::SetLiteral { elements, .. } => {
+            let mut elements = elements
+                .iter()
+                .map(canonical_structural_identity_value)
+                .collect::<Option<Vec<_>>>()?;
+            elements.sort();
+            Some(format!("set[{}]", elements.join(",")))
+        }
+        HirExpr::DictLiteral { keys, values, .. } if keys.len() == values.len() => {
+            let mut entries = keys
+                .iter()
+                .zip(values)
+                .map(|(key, value)| {
+                    Some(format!(
+                        "{}={}",
+                        canonical_structural_identity_value(key)?,
+                        canonical_structural_identity_value(value)?
+                    ))
+                })
+                .collect::<Option<Vec<_>>>()?;
+            entries.sort();
+            Some(format!("dict[{}]", entries.join(",")))
+        }
+        _ => None,
+    }
+}
+
+fn canonical_sequence(tag: &str, values: &[HirExpr]) -> Option<String> {
+    let values = values
+        .iter()
+        .map(canonical_structural_identity_value)
+        .collect::<Option<Vec<_>>>()?;
+    Some(format!("{tag}[{}]", values.join(",")))
+}
+
+/// Return whether enum discriminants have one exact, non-overflowing structural encoding.
+pub fn structural_identity_enum_variants_supported(variants: &[(String, Option<i64>)]) -> bool {
+    if variants.is_empty() {
+        return false;
+    }
+    let mut next = Some(1_i64);
+    let mut seen = HashSet::new();
+    for (_, declared) in variants {
+        let Some(value) = declared.or(next) else {
+            return false;
+        };
+        if !seen.insert(value) {
+            return false;
+        }
+        next = value.checked_add(1);
+    }
+    true
 }
 
 #[derive(Debug, Clone)]

--- a/crates/sifr_lowering/src/lower/diagnostics.rs
+++ b/crates/sifr_lowering/src/lower/diagnostics.rs
@@ -320,7 +320,7 @@ pub(in crate::lower) fn collect_enum_variants(class_def: &StmtClassDef) -> Vec<E
                             None
                         };
                         let v = value.unwrap_or(auto_value);
-                        auto_value = v + 1;
+                        auto_value = v.checked_add(1).unwrap_or(v);
                         variants.push(EnumVariantInfo {
                             name: variant_name,
                             value,
@@ -347,7 +347,7 @@ pub(in crate::lower) fn collect_enum_variants(class_def: &StmtClassDef) -> Vec<E
                         None
                     };
                     let v = value.unwrap_or(auto_value);
-                    auto_value = v + 1;
+                    auto_value = v.checked_add(1).unwrap_or(v);
                     variants.push(EnumVariantInfo {
                         name: variant_name,
                         value,

--- a/crates/sifr_lowering/src/lower/imports.rs
+++ b/crates/sifr_lowering/src/lower/imports.rs
@@ -247,6 +247,13 @@ pub(in crate::lower) fn resolve_imports_early(
                             );
                             ctx.class_types
                                 .insert(local.clone(), imported_class_ty.clone());
+                            register_imported_structural_identity_inputs(
+                                ctx,
+                                externals,
+                                &module_key,
+                                name,
+                                &local,
+                            );
                             register_imported_class_instance_methods(
                                 ctx,
                                 externals,
@@ -393,4 +400,31 @@ pub(in crate::lower) fn resolve_imports_early(
             }
         }
     }
+}
+
+fn register_imported_structural_identity_inputs(
+    ctx: &mut LowerCtx,
+    externals: &ExternalDefs,
+    module_name: &str,
+    external_name: &str,
+    local_name: &str,
+) {
+    let defaults_supported = externals
+        .class_field_defaults
+        .get(module_name)
+        .and_then(|classes| classes.get(external_name))
+        .into_iter()
+        .flatten()
+        .all(|(_, value)| sifr_ir::canonical_structural_identity_value(value).is_some());
+    let metadata_supported = externals
+        .declaration_metadata
+        .get(module_name)
+        .into_iter()
+        .flatten()
+        .filter(|metadata| metadata.owner == external_name)
+        .all(|metadata| sifr_ir::canonical_structural_identity_value(&metadata.value).is_some());
+    ctx.imported_structural_identity_inputs.insert(
+        local_name.to_string(),
+        defaults_supported && metadata_supported,
+    );
 }

--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -35,6 +35,9 @@ pub(in crate::lower) struct LowerCtx {
     /// Class declaration defaults, independent of constructor signatures.
     pub(in crate::lower) class_field_defaults: HashMap<String, Vec<(usize, HirExpr)>>,
     pub(in crate::lower) declaration_metadata: Vec<sifr_ir::TypedDeclarationMetadata>,
+    /// Whether each imported class can preserve all defaults and metadata in a
+    /// compiler-owned structural identity.
+    pub(in crate::lower) imported_structural_identity_inputs: HashMap<String, bool>,
     pub(in crate::lower) specialization_requests: Vec<sifr_ir::ConstSpecializationRequest>,
     pub(in crate::lower) json_integer_boundary_requests: Vec<sifr_ir::JsonIntegerBoundaryRequest>,
     /// Whether the exact compiler-owned `sifr.meta.Structural` spelling was imported.
@@ -205,6 +208,7 @@ impl LowerCtx {
             function_defaults: HashMap::new(),
             class_field_defaults: HashMap::new(),
             declaration_metadata: Vec::new(),
+            imported_structural_identity_inputs: HashMap::new(),
             specialization_requests: Vec::new(),
             json_integer_boundary_requests: Vec::new(),
             canonical_structural_marker_imported: false,

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -254,6 +254,26 @@ def use(value: int | list[bytes]) -> None:
 }
 
 #[test]
+fn structural_bound_rejects_platform_integer_union_members() {
+    let errors = lower_errors(
+        r"
+def accept[T: Structural](value: T) -> None:
+    pass
+
+def use(value: int | usize) -> None:
+    accept(value)
+",
+    );
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
+            && error
+                .message
+                .contains("does not implement protocol 'Structural'")
+    }));
+}
+
+#[test]
 fn rust_interop_rejects_incomplete_structural_error_and_panic_contracts() {
     let panic_only = lower_errors(
         r"

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -214,6 +214,46 @@ def encode[T: Structural](value: T) -> Result[bytes, CodecError | RustPanicError
 }
 
 #[test]
+fn structural_bound_accepts_enums_and_supported_ordinary_unions() {
+    lower_ok(
+        r"
+from enum import Enum
+
+class Status(Enum):
+    READY = 4
+    WAITING = 5
+
+def accept[T: Structural](value: T) -> None:
+    pass
+
+def use(choice: int | str, status: Status) -> None:
+    accept(choice)
+    accept(status)
+",
+    );
+}
+
+#[test]
+fn structural_bound_rejects_an_ordinary_union_with_an_unsupported_member() {
+    let errors = lower_errors(
+        r"
+def accept[T: Structural](value: T) -> None:
+    pass
+
+def use(value: int | list[bytes]) -> None:
+    accept(value)
+",
+    );
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
+            && error
+                .message
+                .contains("does not implement protocol 'Structural'")
+    }));
+}
+
+#[test]
 fn rust_interop_rejects_incomplete_structural_error_and_panic_contracts() {
     let panic_only = lower_errors(
         r"

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -1,6 +1,8 @@
 use crate::{lower_module_with_externals, ExternalDefs, HirDiagnostic, HirModule};
 use sifr_diagnostics::DiagnosticCode;
-use sifr_ir::RustInteropDecoratorKind;
+use sifr_ir::{
+    DeclarationMetadataTargetKind, HirExpr, RustInteropDecoratorKind, TypedDeclarationMetadata,
+};
 use sifr_python_parser::parse_module;
 use sifr_type_system::Type;
 use std::collections::HashMap;
@@ -231,6 +233,87 @@ def use(choice: int | str, status: Status) -> None:
     accept(status)
 ",
     );
+}
+
+#[test]
+fn structural_bound_rejects_enum_discriminant_overflow() {
+    let errors = lower_errors(
+        r"
+from enum import Enum
+
+class Status(Enum):
+    LAST = 9223372036854775807
+    OVERFLOW = 'auto'
+
+def accept[T: Structural](value: T) -> None:
+    pass
+
+def use(status: Status) -> None:
+    accept(status)
+",
+    );
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
+            && error
+                .message
+                .contains("does not implement protocol 'Structural'")
+    }));
+}
+
+#[test]
+fn structural_bound_rejects_imported_enum_with_unrepresentable_metadata() {
+    let mut externals = structural_externals();
+    externals.classes.insert(
+        "models".to_string(),
+        HashMap::from([(
+            "Status".to_string(),
+            Type::Enum {
+                identity: Some("models.Status".to_string()),
+                name: "Status".to_string(),
+                variants: vec![("READY".to_string(), Some(1))],
+            },
+        )]),
+    );
+    externals.declaration_metadata.insert(
+        "models".to_string(),
+        vec![TypedDeclarationMetadata {
+            owner: "Status".to_string(),
+            target_kind: DeclarationMetadataTargetKind::Type,
+            target_name: None,
+            key: "example.policy".to_string(),
+            value_type: Type::Int,
+            value: HirExpr::BinOp {
+                left: Box::new(HirExpr::IntLiteral(1)),
+                op: "+".to_string(),
+                right: Box::new(HirExpr::IntLiteral(1)),
+                ty: Type::Int,
+            },
+            range: Default::default(),
+        }],
+    );
+    let source = r"
+from sifr.meta import Structural
+from models import Status
+
+def accept[T: Structural](value: T) -> None:
+    pass
+
+def use(status: Status) -> None:
+    accept(status)
+";
+    let parsed = parse_module(source).expect("source should parse");
+    let errors = match lower_module_with_externals(parsed.suite(), &externals) {
+        Ok(_) => panic!("unrepresentable imported metadata must fail lowering"),
+        Err(errors) => errors,
+    };
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
+            && error
+                .message
+                .contains("does not implement protocol 'Structural'")
+    }));
 }
 
 #[test]

--- a/crates/sifr_lowering/src/lower/type_bounds.rs
+++ b/crates/sifr_lowering/src/lower/type_bounds.rs
@@ -137,17 +137,10 @@ fn supports_structural_bridge_type_inner(
                     .iter()
                     .all(|value| supports_structural_bridge_type_inner(value, ctx, visiting, false))
         }
-        Type::Union(values)
-            if values.len() == 2
-                && values
-                    .iter()
-                    .any(|value| matches!(value.resolve_alias(), Type::None)) =>
-        {
-            values
-                .iter()
-                .filter(|value| !matches!(value.resolve_alias(), Type::None))
-                .all(|value| supports_structural_bridge_type_inner(value, ctx, visiting, false))
-        }
+        Type::Union(values) => values
+            .iter()
+            .all(|value| supports_structural_bridge_type_inner(value, ctx, visiting, false)),
+        Type::Enum { .. } => true,
         Type::Class {
             identity,
             type_args,

--- a/crates/sifr_lowering/src/lower/type_bounds.rs
+++ b/crates/sifr_lowering/src/lower/type_bounds.rs
@@ -111,6 +111,22 @@ fn supports_structural_bridge_type(ty: &Type, ctx: &LowerCtx) -> bool {
     supports_structural_bridge_type_inner(ty, ctx, &mut std::collections::HashSet::new(), false)
 }
 
+fn structural_identity_inputs_supported(class_name: &str, ctx: &LowerCtx) -> bool {
+    if let Some(supported) = ctx.imported_structural_identity_inputs.get(class_name) {
+        return *supported;
+    }
+    ctx.class_field_defaults
+        .get(class_name)
+        .into_iter()
+        .flatten()
+        .all(|(_, value)| sifr_ir::canonical_structural_identity_value(value).is_some())
+        && ctx
+            .declaration_metadata
+            .iter()
+            .filter(|metadata| metadata.owner == class_name)
+            .all(|metadata| sifr_ir::canonical_structural_identity_value(&metadata.value).is_some())
+}
+
 fn supports_structural_bridge_type_inner(
     ty: &Type,
     ctx: &LowerCtx,
@@ -144,7 +160,13 @@ fn supports_structural_bridge_type_inner(
         Type::Union(values) => values
             .iter()
             .all(|value| supports_structural_bridge_type_inner(value, ctx, visiting, false)),
-        Type::Enum { variants, .. } => !variants.is_empty(),
+        Type::Enum { name, variants, .. } => {
+            sifr_ir::structural_identity_enum_variants_supported(variants)
+                && structural_identity_inputs_supported(name, ctx)
+                && !ctx.error_types.contains(name)
+                && !ctx.python_opaque_classes.contains_key(name)
+                && !ctx.rust_opaque_classes.contains(name)
+        }
         Type::Class {
             identity,
             type_args,
@@ -157,6 +179,7 @@ fn supports_structural_bridge_type_inner(
                 || ctx.error_types.contains(name)
                 || ctx.python_opaque_classes.contains_key(name)
                 || ctx.rust_opaque_classes.contains(name)
+                || !structural_identity_inputs_supported(name, ctx)
             {
                 return false;
             }

--- a/crates/sifr_lowering/src/lower/type_bounds.rs
+++ b/crates/sifr_lowering/src/lower/type_bounds.rs
@@ -118,7 +118,11 @@ fn supports_structural_bridge_type_inner(
     direct_record_field: bool,
 ) -> bool {
     match ty.resolve_alias() {
-        Type::Int | Type::FixedInt(_) | Type::Float | Type::Bool | Type::Str | Type::None => true,
+        Type::Int | Type::Float | Type::Bool | Type::Str | Type::None => true,
+        Type::FixedInt(value) => !matches!(
+            value,
+            sifr_type_system::FixedIntType::ISize | sifr_type_system::FixedIntType::USize
+        ),
         Type::Bytes => direct_record_field,
         Type::TypeVar(name) => typevar_satisfies_spec(name, "Structural", ctx),
         Type::List(value) => supports_structural_bridge_type_inner(value, ctx, visiting, false),
@@ -140,7 +144,7 @@ fn supports_structural_bridge_type_inner(
         Type::Union(values) => values
             .iter()
             .all(|value| supports_structural_bridge_type_inner(value, ctx, visiting, false)),
-        Type::Enum { .. } => true,
+        Type::Enum { variants, .. } => !variants.is_empty(),
         Type::Class {
             identity,
             type_args,

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -622,6 +622,17 @@ exact integers, while `StructuralScalarRef` borrows them for projection. The
 fixed-width integer variant records signedness and width, so no narrowing is
 implicit.
 
+An ordinary union is an aggregate `Union` node with one `ActiveMember` edge.
+The edge name is `member`. Its index selects the stored union-member order, and
+its child contains the active value. Construction rejects unknown indices or
+additional edges. Projection emits the same edge before the active value.
+
+A C-like enum is a nominal aggregate `Enum` node with one `ActiveMember` edge.
+The edge contains the declared variant name and declaration index. Its child is
+a signed 64-bit scalar with the declared value. Construction checks the nominal
+identity, variant name, index, and scalar value. Projection emits this same
+shape. Data-carrying variants remain ordinary unions of records.
+
 `StructuralSource` is implementable by a native backend, but its values remain
 sealed behind an opaque resource declared by that package. Sifr code cannot
 name a node, forge a source, call `take_scalar`, or construct a structural value

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -441,7 +441,7 @@ path at the declaration or specialization site.
 
 `bytes` has one structural encoding: a scalar byte buffer. The compiler supports
 that encoding for a direct record field. It rejects `bytes` inside a list, set,
-mapping, tuple, optional value, or generic type argument. It does not
+mapping, tuple, optional value, union member, or generic type argument. It does not
 reinterpret nested `bytes` as a sequence of integers.
 
 `sifr.meta.StaticProgram` is the stricter compiler-owned bound for a structural
@@ -629,7 +629,8 @@ additional edges. Projection emits the same edge before the active value.
 
 A C-like enum is a nominal aggregate `Enum` node with one `ActiveMember` edge.
 The edge contains the declared variant name and declaration index. Its child is
-a signed 64-bit scalar with the declared value. Construction checks the nominal
+a signed 64-bit scalar with the resolved value. Implicit values start at one and
+advance from the previous resolved value. Construction checks the nominal
 identity, variant name, index, and scalar value. Projection emits this same
 shape. Data-carrying variants remain ordinary unions of records.
 

--- a/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/bridges/executor.rs
+++ b/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/bridges/executor.rs
@@ -11,7 +11,7 @@ use sifr_runtime::interop::structural::{
 };
 use sifr_runtime::interop::{Handle, HandleStateError};
 
-const RECORD_IDENTITY: &str = "main.StaticRecord";
+const RECORD_IDENTITY: &str = "StaticRecord";
 static ACTIVE_DOCUMENTS: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug)]

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/README.md
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/README.md
@@ -1,5 +1,6 @@
 # Structural bridge runtime scenario
 
 Generated-package evidence for checked construction, allocation-free projection,
-recursive and generic nominal identity, opaque source ownership, and a typed
-call-scoped callback over one monomorphized structural Rust target.
+recursive and generic nominal identity, enum and ordinary-union values, opaque
+source ownership, and a typed call-scoped callback over one monomorphized
+structural Rust target.

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/bridges/structural.rs
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/bridges/structural.rs
@@ -8,9 +8,9 @@ use sifr_runtime::interop::structural::{
 };
 use sifr_runtime::interop::{CallScopedCallbackBridge, Handle, HandleStateError};
 
-const NESTED_IDENTITY: &str = "main.NestedValue";
-const LEAF_IDENTITY: &str = "main.Leaf";
-const BOXED_IDENTITY: &str = "main.Boxed";
+const NESTED_IDENTITY: &str = "NestedValue";
+const LEAF_IDENTITY: &str = "Leaf";
+const BOXED_IDENTITY: &str = "Boxed";
 
 #[derive(Debug)]
 pub struct StructuralBridgeError {
@@ -185,7 +185,7 @@ fn union(member: usize, child: u32) -> ArenaNode {
 fn enumeration(name: &'static str, index: usize, child: u32) -> ArenaNode {
     ArenaNode {
         kind: StructuralKind::Enum,
-        nominal_identity: Some("main.Status"),
+        nominal_identity: Some("Status"),
         edges: vec![edge(
             StructuralEdgeKind::ActiveMember { name, index },
             child,
@@ -228,7 +228,7 @@ fn structural_nodes() -> Vec<ArenaNode> {
 
 fn sum_nodes() -> Vec<ArenaNode> {
     vec![
-        record("main.SumPayload", &[("choice", 1), ("status", 3)]),
+        record("SumPayload", &[("choice", 1), ("status", 3)]),
         union(1, 2),
         string("sum"),
         enumeration("WAITING", 1, 4),

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/bridges/structural.rs
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/bridges/structural.rs
@@ -102,10 +102,7 @@ fn edge(kind: StructuralEdgeKind<'static>, node: u32) -> StructuralNodeEdge<'sta
     StructuralNodeEdge::new(kind, NodeId::new(node))
 }
 
-fn record(
-    nominal_identity: &'static str,
-    fields: &[(&'static str, u32)],
-) -> ArenaNode {
+fn record(nominal_identity: &'static str, fields: &[(&'static str, u32)]) -> ArenaNode {
     ArenaNode {
         kind: StructuralKind::Record,
         nominal_identity: Some(nominal_identity),
@@ -214,7 +211,12 @@ fn structural_nodes() -> Vec<ArenaNode> {
         optional(Some(10)),
         record(
             NESTED_IDENTITY,
-            &[("label", 11), ("leaves", 12), ("payload", 13), ("child", 15)],
+            &[
+                ("label", 11),
+                ("leaves", 12),
+                ("payload", 13),
+                ("child", 15),
+            ],
         ),
         string("tail"),
         sequence(&[]),
@@ -328,10 +330,7 @@ where
     ))
 }
 
-pub fn roundtrip<T>(
-    source: Handle<StructuralArena>,
-    value: &T,
-) -> Result<T, StructuralBridgeError>
+pub fn roundtrip<T>(source: Handle<StructuralArena>, value: &T) -> Result<T, StructuralBridgeError>
 where
     T: StructuralConstruct + StructuralProject,
 {
@@ -366,7 +365,9 @@ where
 {
     let _input_projection = project(value)?;
     let input = structural_construct::<T, _>(into_source::<T>(source)?)?;
-    let output = callback.call((input,)).map_err(StructuralBridgeError::new)?;
+    let output = callback
+        .call((input,))
+        .map_err(StructuralBridgeError::new)?;
     let _output_projection = project(&output)?;
     Ok(output)
 }

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/bridges/structural.rs
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/bridges/structural.rs
@@ -8,9 +8,9 @@ use sifr_runtime::interop::structural::{
 };
 use sifr_runtime::interop::{CallScopedCallbackBridge, Handle, HandleStateError};
 
-const NESTED_IDENTITY: &str = "NestedValue";
-const LEAF_IDENTITY: &str = "Leaf";
-const BOXED_IDENTITY: &str = "Boxed";
+const NESTED_IDENTITY: &str = "main.NestedValue";
+const LEAF_IDENTITY: &str = "main.Leaf";
+const BOXED_IDENTITY: &str = "main.Boxed";
 
 #[derive(Debug)]
 pub struct StructuralBridgeError {
@@ -126,6 +126,18 @@ fn string(value: &str) -> ArenaNode {
     }
 }
 
+fn signed_integer(value: i64) -> ArenaNode {
+    ArenaNode {
+        kind: StructuralKind::SignedInteger,
+        nominal_identity: None,
+        edges: Vec::new(),
+        scalar: Some(StructuralScalar::SignedInteger {
+            value: i128::from(value),
+            width: 64,
+        }),
+    }
+}
+
 fn sequence(children: &[u32]) -> ArenaNode {
     ArenaNode {
         kind: StructuralKind::Sequence,
@@ -158,6 +170,33 @@ fn optional(child: Option<u32>) -> ArenaNode {
     }
 }
 
+fn union(member: usize, child: u32) -> ArenaNode {
+    ArenaNode {
+        kind: StructuralKind::Union,
+        nominal_identity: None,
+        edges: vec![edge(
+            StructuralEdgeKind::ActiveMember {
+                name: "member",
+                index: member,
+            },
+            child,
+        )],
+        scalar: None,
+    }
+}
+
+fn enumeration(name: &'static str, index: usize, child: u32) -> ArenaNode {
+    ArenaNode {
+        kind: StructuralKind::Enum,
+        nominal_identity: Some("main.Status"),
+        edges: vec![edge(
+            StructuralEdgeKind::ActiveMember { name, index },
+            child,
+        )],
+        scalar: None,
+    }
+}
+
 fn structural_nodes() -> Vec<ArenaNode> {
     vec![
         record(
@@ -185,9 +224,35 @@ fn structural_nodes() -> Vec<ArenaNode> {
     ]
 }
 
+fn sum_nodes() -> Vec<ArenaNode> {
+    vec![
+        record("main.SumPayload", &[("choice", 1), ("status", 3)]),
+        union(1, 2),
+        string("sum"),
+        enumeration("WAITING", 1, 4),
+        signed_integer(5),
+    ]
+}
+
 pub fn open() -> Result<Handle<StructuralArena>, StructuralBridgeError> {
     Ok(Handle::new(StructuralArena {
         nodes: structural_nodes(),
+    }))
+}
+
+pub fn open_sum() -> Result<Handle<StructuralArena>, StructuralBridgeError> {
+    Ok(Handle::new(StructuralArena { nodes: sum_nodes() }))
+}
+
+pub fn open_union() -> Result<Handle<StructuralArena>, StructuralBridgeError> {
+    Ok(Handle::new(StructuralArena {
+        nodes: vec![union(1, 1), string("sum")],
+    }))
+}
+
+pub fn open_enum() -> Result<Handle<StructuralArena>, StructuralBridgeError> {
+    Ok(Handle::new(StructuralArena {
+        nodes: vec![enumeration("WAITING", 1, 1), signed_integer(5)],
     }))
 }
 
@@ -283,7 +348,12 @@ where
             "structural construction accepted a mismatched root identity",
         ));
     }
-    structural_construct::<T, _>(into_source::<T>(source)?).map_err(Into::into)
+    structural_construct::<T, _>(into_source::<T>(source)?).map_err(|error| {
+        StructuralBridgeError::new(format!(
+            "{} construction failed: {error}",
+            std::any::type_name::<T>()
+        ))
+    })
 }
 
 pub fn transform<T>(

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/main.sifr
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/main.sifr
@@ -4,6 +4,7 @@
 # expected-result: structural-roundtrip-clean
 
 from sifr.meta import Structural
+from enum import Enum
 from typing import Callable
 
 
@@ -30,6 +31,16 @@ class NestedValue:
     child: NestedValue | None
 
 
+class Status(Enum):
+    READY = 4
+    WAITING = 5
+
+
+class SumPayload:
+    choice: int | str
+    status: Status
+
+
 @rust.opaque(
     type=bridge.structural.StructuralArena,
     send=False,
@@ -44,6 +55,18 @@ class StructuralArena:
 
 @rust(bridge.structural.open)
 def open_structural_arena() -> Result[StructuralArena, StructuralBridgeError | RustPanicError]: ...
+
+
+@rust(bridge.structural.open_sum)
+def open_sum_arena() -> Result[StructuralArena, StructuralBridgeError | RustPanicError]: ...
+
+
+@rust(bridge.structural.open_union)
+def open_union_arena() -> Result[StructuralArena, StructuralBridgeError | RustPanicError]: ...
+
+
+@rust(bridge.structural.open_enum)
+def open_enum_arena() -> Result[StructuralArena, StructuralBridgeError | RustPanicError]: ...
 
 
 @rust.structural
@@ -107,9 +130,21 @@ def verify_structural_bridge_runtime() -> Result[str, StructuralBridgeError | Ru
         )
         assert transformed.label == "root"
         assert transformed.child is not None
+        union_source: StructuralArena = open_union_arena()
+        union_input: int | str = 1
+        union_value: int | str = structural_roundtrip(union_source, union_input)
+        assert str(union_value) == "sum"
+        enum_source: StructuralArena = open_enum_arena()
+        status: Status = structural_roundtrip(enum_source, Status.READY)
+        assert status == Status.WAITING
+        sum_source: StructuralArena = open_sum_arena()
+        sum_input: SumPayload = SumPayload(1, Status.READY)
+        sum_value: SumPayload = structural_roundtrip(sum_source, sum_input)
+        assert str(sum_value.choice) == "sum"
+        assert sum_value.status == Status.WAITING
         cleanup_source: StructuralArena = open_structural_arena()
         closed: None = cleanup_source.close()
-        return projection + ";construction=root/a,b/boxed/tail;callback=typed"
+        return projection + ";construction=root/a,b/boxed/tail;callback=typed;sums=sum/WAITING"
     except StructuralBridgeError as error:
         raise error
     except RustPanicError as error:


### PR DESCRIPTION
Closes #3172.

## Summary

- add package-neutral structural identities and checked construction/projection for Sifr enums
- add one project-owned ordinary-union structural representation with deterministic ownership
- align lowering, codegen eligibility, demand gating, and project-wide nested-record resolution
- extend the structural bridge fixture with direct and nested enum/union round trips

No compatibility path, fallback, legacy surface, versioned alternate, or Pydantic-specific compiler path is included.

## Review

Claude Opus reviewed the complete exact candidate in four rounds. Final verdict: SATISFIED.

- exact candidate: 73fa61248c484b6fab4849210882028a13810fb9
- final response digest: 1f8bdaafedef572a79fc9b92aed43c821fc90453114b4d28f58440b304ad26c9

## Validation

- `cargo test -j 6 -p sifr_codegen`: 1000/1000
- `cargo test -j 6 -p sifr_driver --lib test_build_structural_bridge_runtime -- --ignored --test-threads=1 --nocapture`: 1/1
- generated structural runtime output: `records=3;sequences=1;optionals=1;strings=input,x,input-box;construction=root/a,b/boxed/tail;callback=typed;sums=sum/WAITING`
- governed file-size, HIR maintainability, verification taxonomy, and formatting guards: pass
- canonical create-PR gate: exit 0; E2E 140/140, Python 19/19, Rust 10/10, generated quality 5/5
- create-PR report SHA-256: 28954386a702e0b2d74310bfe71410529920b9842f3da4cb4c4e203430c47c95

The required post-clean cold create-PR attempt was functionally green but exceeded only the tracked #3134 generated-artifact cold budget. The unchanged warm canonical run passed.