### PR TITLE
fix: align project structural nominal identity

### DIFF
--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -42,7 +42,7 @@ pub(crate) fn generate_rust_test_with_project_policy(
     emitter.project_structural_record_identities = project_structural_record_identities.cloned();
     emitter.project_structural_identity_expressions =
         project_structural_identity_expressions.cloned();
-    emitter.structural_identity_module_name = None;
+    emitter.structural_identity_module_name = Some(module_name.to_string());
 
     // First pass: collect all union types used in the module
     emitter.collect_union_types(module);

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -4,6 +4,7 @@ use sifr_ir::{
     HirParam, MethodKind, RustInteropAbiRequirements, RustInteropDeclaration,
     RustInteropDecoratorKind, RustInteropEffect, TypedDeclarationMetadata,
 };
+use sifr_structural_identity::{metadata, nominal_record, primitive, NominalField};
 use sifr_type_system::{ParamConvention, Type};
 
 #[test]
@@ -176,6 +177,26 @@ fn project_root_record_keeps_qualified_structural_identity() {
 
     assert!(main_rust.contains("Some(\"main.Payload\")"), "{main_rust}");
     assert!(!main_rust.contains("Some(\"Payload\")"), "{main_rust}");
+
+    let modules = [("main", &module)];
+    let roots = std::collections::HashSet::from(["main"]);
+    let supported =
+        crate::structural_impl_codegen::structural_record_identities_for_project(&modules);
+    let identities = crate::structural_identity_codegen::static_class_identities_for_project(
+        &modules, &roots, &supported,
+    );
+    let expected = nominal_record(
+        "main.Payload",
+        &[],
+        &[NominalField {
+            name: "value",
+            identity: primitive("i64"),
+            required: true,
+            default_identity: None,
+        }],
+        metadata(&[]),
+    );
+    assert_eq!(identities.get("main.Payload"), Some(&expected));
 }
 
 #[test]
@@ -254,6 +275,7 @@ fn test_project_root_record_keeps_qualified_structural_identity() {
 
     assert!(case_rust.contains("Some(\"case.Payload\")"));
     assert!(case_rust.contains("description.nominal_identity() != Some(\"case.Payload\")"));
+    assert!(!case_rust.contains("Some(\"Payload\")"));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -162,7 +162,7 @@ fn project_record_eligibility_resolves_nested_imported_members() {
 }
 
 #[test]
-fn project_root_record_keeps_unqualified_structural_identity() {
+fn project_root_record_keeps_qualified_structural_identity() {
     let module = module(vec![structural_function()], vec![payload_class()]);
 
     let project = crate::generate_rust_multi_with_metadata(
@@ -174,8 +174,8 @@ fn project_root_record_keeps_unqualified_structural_identity() {
         .get("main")
         .expect("main module is generated");
 
-    assert!(main_rust.contains("Some(\"Payload\")"), "{main_rust}");
-    assert!(!main_rust.contains("Some(\"main.Payload\")"), "{main_rust}");
+    assert!(main_rust.contains("Some(\"main.Payload\")"), "{main_rust}");
+    assert!(!main_rust.contains("Some(\"Payload\")"), "{main_rust}");
 }
 
 #[test]
@@ -237,6 +237,23 @@ fn project_structural_demand_enables_implicit_classes_across_modules() {
     assert!(metadata
         .required_features
         .contains(&sifr_stdlib_manifest::StdlibFeature::StructuralRuntime));
+}
+
+#[test]
+fn test_project_root_record_keeps_qualified_structural_identity() {
+    let case = module(vec![structural_function()], vec![payload_class()]);
+    let generated = crate::lib_test_project_codegen::generate_rust_test_project_with_metadata(
+        &[],
+        &[("case", &case)],
+        &crate::StdlibCode::default(),
+    );
+    let case_rust = generated
+        .test_rust_files
+        .get("case")
+        .expect("test module is generated");
+
+    assert!(case_rust.contains("Some(\"case.Payload\")"));
+    assert!(case_rust.contains("description.nominal_identity() != Some(\"case.Payload\")"));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -179,11 +179,10 @@ fn project_root_record_keeps_qualified_structural_identity() {
     assert!(!main_rust.contains("Some(\"Payload\")"), "{main_rust}");
 
     let modules = [("main", &module)];
-    let roots = std::collections::HashSet::from(["main"]);
     let supported =
         crate::structural_impl_codegen::structural_record_identities_for_project(&modules);
     let identities = crate::structural_identity_codegen::static_class_identities_for_project(
-        &modules, &roots, &supported,
+        &modules, &supported,
     );
     let expected = nominal_record(
         "main.Payload",

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -367,8 +367,7 @@ pub fn generate_rust_multi_with_metadata(
             .cloned()
             .unwrap_or_default();
         let owned_unions = HashSet::new();
-        let structural_identity_module_name =
-            (!crate_root_modules.contains(module_name)).then_some(*module_name);
+        let structural_identity_module_name = Some(*module_name);
         let codegen_result = generate_rust_with_stdlib_for_module_with_project_policy(
             module,
             &module_codegen_code,

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -339,7 +339,6 @@ pub fn generate_rust_multi_with_metadata(
     let structural_identity_expressions = if structural_interop_enabled {
         crate::structural_identity_codegen::class_identity_expressions_for_project(
             modules,
-            &crate_root_modules,
             &structural_record_identities,
         )
     } else {

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -58,7 +58,6 @@ pub fn generate_rust_test_project_with_metadata(
     let structural_identity_expressions = if structural_interop_enabled {
         crate::structural_identity_codegen::class_identity_expressions_for_project(
             &all_modules,
-            &crate_root_modules,
             &structural_record_identities,
         )
     } else {

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -89,8 +89,7 @@ pub fn generate_rust_test_project_with_metadata(
             .get(*module_name)
             .cloned()
             .unwrap_or_default();
-        let structural_identity_module_name =
-            (!crate_root_modules.contains(module_name)).then_some(*module_name);
+        let structural_identity_module_name = Some(*module_name);
         let generated = generate_rust_with_stdlib_for_module_with_project_policy(
             module,
             &module_code,

--- a/crates/sifr_codegen/src/rust_interop_plan.rs
+++ b/crates/sifr_codegen/src/rust_interop_plan.rs
@@ -313,17 +313,10 @@ fn collect_structural_shape_identities_for_project(
         .iter()
         .map(|(module_name, module)| (module_name.unwrap_or(""), *module))
         .collect::<Vec<_>>();
-    let crate_root_modules = modules
-        .iter()
-        .filter_map(|(module_name, _)| {
-            (module_name.is_empty() || *module_name == "main").then_some(*module_name)
-        })
-        .collect::<std::collections::HashSet<_>>();
     let record_identities =
         crate::structural_impl_codegen::structural_record_identities_for_project(&modules);
     let identities = crate::structural_identity_codegen::static_class_identities_for_project(
         &modules,
-        &crate_root_modules,
         &record_identities,
     );
     for ((module_name, module), (module_key, _)) in module_entries.iter().zip(&modules) {

--- a/crates/sifr_codegen/src/rust_interop_plan_tests.rs
+++ b/crates/sifr_codegen/src/rust_interop_plan_tests.rs
@@ -814,10 +814,10 @@ fn interop_cache_fragment_includes_structural_algorithm_and_concrete_identity() 
     assert!(fragment.contains("rust.structural_identity_algorithm_version=1"));
     assert!(fragment.contains("rust.structural_shape_identities=1"));
     assert!(fragment.contains("main:Payload="));
-    assert_eq!(
+    assert_ne!(
         named_plan.rust.structural_shape_identities[0].identity,
         root_plan.rust.structural_shape_identities[0].identity,
-        "naming a crate-root module main must not change its wire shape"
+        "a named project module and an unnamed single-file module have distinct wire identities"
     );
 }
 

--- a/crates/sifr_codegen/src/structural_identity_codegen.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen.rs
@@ -16,7 +16,7 @@ struct IdentityContext<'a> {
 }
 
 impl<'a> IdentityContext<'a> {
-    fn wire_module_name(&self, module_name: &'a str) -> Option<&'a str> {
+    fn wire_module_name(module_name: &'a str) -> Option<&'a str> {
         (!module_name.is_empty()).then_some(module_name)
     }
 
@@ -97,7 +97,6 @@ pub(crate) fn class_identity_expression(
 
 pub(crate) fn class_identity_expressions_for_project(
     modules: &[(&str, &HirModule)],
-    _crate_root_modules: &HashSet<&str>,
     structural_record_identities: &HashSet<String>,
 ) -> HashMap<String, String> {
     let context = IdentityContext { modules };
@@ -114,7 +113,7 @@ pub(crate) fn class_identity_expressions_for_project(
                 };
                 supported.then(|| {
                     let compiled = if class.is_enum() {
-                        compile_enum(class, context.wire_module_name(module_name))
+                        compile_enum(class, IdentityContext::wire_module_name(module_name))
                     } else {
                         compile_class(class, module_name, context)
                     };
@@ -127,7 +126,6 @@ pub(crate) fn class_identity_expressions_for_project(
 
 pub(crate) fn static_class_identities_for_project(
     modules: &[(&str, &HirModule)],
-    _crate_root_modules: &HashSet<&str>,
     structural_record_identities: &HashSet<String>,
 ) -> HashMap<String, ShapeIdentity> {
     let context = IdentityContext { modules };
@@ -144,7 +142,7 @@ pub(crate) fn static_class_identities_for_project(
                 };
                 let compiled = supported.then(|| {
                     if class.is_enum() {
-                        compile_enum(class, context.wire_module_name(module_name))
+                        compile_enum(class, IdentityContext::wire_module_name(module_name))
                     } else {
                         compile_class(class, module_name, context)
                     }
@@ -194,7 +192,7 @@ fn compile_class(
     module_name: &str,
     context: &IdentityContext<'_>,
 ) -> CompiledIdentity {
-    let nominal = class_nominal_identity(class, context.wire_module_name(module_name));
+    let nominal = class_nominal_identity(class, IdentityContext::wire_module_name(module_name));
     let mut stack = vec![nominal.clone()];
     let type_arguments = class
         .type_params
@@ -277,11 +275,10 @@ fn compile_type(
                 .class_candidate(declared_identity.as_deref(), name, scope_module_name)
                 .filter(|(_, _, class)| class.is_enum())
             {
-                compile_enum(class, context.wire_module_name(module_name))
+                compile_enum(class, IdentityContext::wire_module_name(module_name))
             } else {
                 let nominal = declared_identity.clone().unwrap_or_else(|| {
-                    context
-                        .wire_module_name(scope_module_name)
+                    IdentityContext::wire_module_name(scope_module_name)
                         .map_or_else(|| name.clone(), |module| format!("{module}.{name}"))
                 });
                 let members = variants
@@ -307,12 +304,12 @@ fn compile_type(
             let nominal = candidate.map_or_else(
                 || class_identity.clone().unwrap_or_else(|| name.clone()),
                 |(module_name, _, class)| {
-                    class_nominal_identity(class, context.wire_module_name(module_name))
+                    class_nominal_identity(class, IdentityContext::wire_module_name(module_name))
                 },
             );
             if let Some((module_name, _, class)) = candidate {
                 if class.is_enum() {
-                    return compile_enum(class, context.wire_module_name(module_name));
+                    return compile_enum(class, IdentityContext::wire_module_name(module_name));
                 }
             }
             if let Some(index) = stack.iter().position(|entry| entry == &nominal) {
@@ -746,13 +743,12 @@ mod tests {
         let modules = [("models", &models), ("main", &main)];
         let expressions = class_identity_expressions_for_project(
             &modules,
-            &HashSet::from(["main"]),
             &HashSet::from(["models.Payload".to_string(), "main.Envelope".to_string()]),
         );
         let payload_identity =
             static_class_identity(&payload, &models, Some("models")).expect("static payload");
         let expected = identity::nominal_record(
-            "Envelope",
+            "main.Envelope",
             &[],
             &[NominalField {
                 name: "payload",

--- a/crates/sifr_codegen/src/structural_identity_codegen.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen.rs
@@ -13,12 +13,11 @@ enum CompiledIdentity {
 
 struct IdentityContext<'a> {
     modules: &'a [(&'a str, &'a HirModule)],
-    crate_root_modules: &'a HashSet<&'a str>,
 }
 
 impl<'a> IdentityContext<'a> {
     fn wire_module_name(&self, module_name: &'a str) -> Option<&'a str> {
-        (!self.crate_root_modules.contains(module_name)).then_some(module_name)
+        (!module_name.is_empty()).then_some(module_name)
     }
 
     fn class_candidate(
@@ -88,15 +87,7 @@ pub(crate) fn class_identity_expression(
 ) -> String {
     let module_key = module_name.unwrap_or("");
     let modules = [(module_key, module)];
-    let roots = if module_name.is_none() {
-        HashSet::from([module_key])
-    } else {
-        HashSet::new()
-    };
-    let context = IdentityContext {
-        modules: &modules,
-        crate_root_modules: &roots,
-    };
+    let context = IdentityContext { modules: &modules };
     if class.is_enum() {
         compile_enum(class, module_name).expression()
     } else {
@@ -106,13 +97,10 @@ pub(crate) fn class_identity_expression(
 
 pub(crate) fn class_identity_expressions_for_project(
     modules: &[(&str, &HirModule)],
-    crate_root_modules: &HashSet<&str>,
+    _crate_root_modules: &HashSet<&str>,
     structural_record_identities: &HashSet<String>,
 ) -> HashMap<String, String> {
-    let context = IdentityContext {
-        modules,
-        crate_root_modules,
-    };
+    let context = IdentityContext { modules };
     modules
         .iter()
         .flat_map(|(module_name, module)| {
@@ -139,13 +127,10 @@ pub(crate) fn class_identity_expressions_for_project(
 
 pub(crate) fn static_class_identities_for_project(
     modules: &[(&str, &HirModule)],
-    crate_root_modules: &HashSet<&str>,
+    _crate_root_modules: &HashSet<&str>,
     structural_record_identities: &HashSet<String>,
 ) -> HashMap<String, ShapeIdentity> {
-    let context = IdentityContext {
-        modules,
-        crate_root_modules,
-    };
+    let context = IdentityContext { modules };
     modules
         .iter()
         .flat_map(|(module_name, module)| {
@@ -177,15 +162,7 @@ pub(crate) fn static_class_identity(
 ) -> Option<ShapeIdentity> {
     let module_key = module_name.unwrap_or("");
     let modules = [(module_key, module)];
-    let roots = if module_name.is_none() {
-        HashSet::from([module_key])
-    } else {
-        HashSet::new()
-    };
-    let context = IdentityContext {
-        modules: &modules,
-        crate_root_modules: &roots,
-    };
+    let context = IdentityContext { modules: &modules };
     if class.is_enum() {
         compile_enum(class, module_name).static_value()
     } else {

--- a/verification/areas/rust_interop/fixtures/opaque_resource_package_core/examples/package_resource_runtime/src/bridges/package_resource.rs
+++ b/verification/areas/rust_interop/fixtures/opaque_resource_package_core/examples/package_resource_runtime/src/bridges/package_resource.rs
@@ -10,7 +10,7 @@ use sifr_runtime::interop::structural::{
 };
 use sifr_runtime::interop::{Handle, HandleStateError, PoisonOnPanic, SilentPanicBoundary};
 
-const RECORD_IDENTITY: &str = "PackageRecord";
+const RECORD_IDENTITY: &str = "main.PackageRecord";
 
 #[derive(Debug)]
 pub struct PackageResourceError {

--- a/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/bridges/executor.rs
+++ b/verification/areas/rust_interop/fixtures/static_program_arena_bridge/examples/static_program_runtime/src/bridges/executor.rs
@@ -11,7 +11,7 @@ use sifr_runtime::interop::structural::{
 };
 use sifr_runtime::interop::{Handle, HandleStateError};
 
-const RECORD_IDENTITY: &str = "StaticRecord";
+const RECORD_IDENTITY: &str = "main.StaticRecord";
 static ACTIVE_DOCUMENTS: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug)]

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/bridges/structural.rs
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/bridges/structural.rs
@@ -8,9 +8,11 @@ use sifr_runtime::interop::structural::{
 };
 use sifr_runtime::interop::{CallScopedCallbackBridge, Handle, HandleStateError};
 
-const NESTED_IDENTITY: &str = "NestedValue";
-const LEAF_IDENTITY: &str = "Leaf";
-const BOXED_IDENTITY: &str = "Boxed";
+const NESTED_IDENTITY: &str = "main.NestedValue";
+const LEAF_IDENTITY: &str = "main.Leaf";
+const BOXED_IDENTITY: &str = "main.Boxed";
+const STATUS_IDENTITY: &str = "main.Status";
+const SUM_IDENTITY: &str = "main.SumPayload";
 
 #[derive(Debug)]
 pub struct StructuralBridgeError {
@@ -185,7 +187,7 @@ fn union(member: usize, child: u32) -> ArenaNode {
 fn enumeration(name: &'static str, index: usize, child: u32) -> ArenaNode {
     ArenaNode {
         kind: StructuralKind::Enum,
-        nominal_identity: Some("Status"),
+        nominal_identity: Some(STATUS_IDENTITY),
         edges: vec![edge(
             StructuralEdgeKind::ActiveMember { name, index },
             child,
@@ -228,7 +230,7 @@ fn structural_nodes() -> Vec<ArenaNode> {
 
 fn sum_nodes() -> Vec<ArenaNode> {
     vec![
-        record("SumPayload", &[("choice", 1), ("status", 3)]),
+        record(SUM_IDENTITY, &[("choice", 1), ("status", 3)]),
         union(1, 2),
         string("sum"),
         enumeration("WAITING", 1, 4),


### PR DESCRIPTION
Closes #3181.

## Change

Project and test-project roots now keep their wire-module name in generated structural nominal identities. Single-file generation remains unqualified.

This removes the `main.User` versus `User` mismatch between a compiler-sealed schema and generated structural construction. It adds no rewrite, fallback, compatibility path, or legacy mode.

## Review

Claude Opus reviewed three exact candidates. The first two rounds found and verified corrections in the same identity mechanism. The final exact candidate `55210678160b1e43f7aab9245fc12bc9c6698f7d` is SATISFIED with no blocking findings.

Final review SHA-256: `b6d7c534497f8ebf122a2a18287e56f8a34b51c8b4a4014df96d14c3fd5737ea`.

## Evidence

- `cargo test -j 6 -p sifr_codegen --lib`: 1,005 passed.
- `cargo test -j 6 -p sifr_codegen structural_impl_demand_codegen_tests`: 14 passed.
- Three exact ignored Rust interop driver regressions passed.
- `cargo clippy -j 6 -p sifr_codegen --lib -- -D warnings`: passed.
- Formatting, HIR guardrail, and file-size guardrail passed.
- The unchanged `pydantic-sifr` PS6 dependent demo rebuilt and exited zero.
- Canonical create-PR cold run passed all functional checks and stopped only on known cold-artifact budget issue #3134.
- Unchanged warm canonical create-PR exited 0: Python 19/19, Rust interop 10/10, generated quality 5/5, E2E 140/140, and all blocking step budgets passed.
- The all-target codegen Clippy command reports 14 unrelated warnings in current-main test files outside this diff.