### PR TITLE
fix: stabilize nominal union tie breaks

### DIFF
--- a/crates/sifr/tests/e2e/pass/nested_optional_safe_operations.sifr
+++ b/crates/sifr/tests/e2e/pass/nested_optional_safe_operations.sifr
@@ -1,0 +1,382 @@
+class OptionalBox:
+    value: str | None
+
+
+def consume_optional(value: str | None) -> bool:
+    return value is None
+
+
+def dict_get_none(d: dict[str, str | None]) -> bool:
+    value = d.get("a")
+    return value is None
+
+
+def dict_pop_none(mut d: dict[str, str | None]) -> bool:
+    value = d.pop("a")
+    return value is None
+
+
+def list_pop_none(mut values: list[str | None]) -> bool:
+    value = values.pop()
+    return value is None
+
+
+def iterator_next_none(values: list[str | None]) -> bool:
+    value = next(iter(values))
+    return value is None
+
+
+def dict_index_none(d: dict[str, str | None]) -> bool:
+    value = d["a"]
+    return value is None
+
+
+def list_index_none(values: list[str | None]) -> bool:
+    value = values[0]
+    return value is None
+
+
+def dict_get_value(d: dict[str, str | None]) -> str | None:
+    return d.get("a")
+
+
+def dict_pop_value(mut d: dict[str, str | None]) -> str | None:
+    return d.pop("a")
+
+
+def list_pop_value(mut values: list[str | None]) -> str | None:
+    return values.pop()
+
+
+def iterator_next_value(values: list[str | None]) -> str | None:
+    return next(iter(values))
+
+
+def dict_safe_union_no_none(mut values: dict[str, int | str]) -> bool:
+    missing_get = values.get("missing")
+    missing_index = values["missing"]
+    missing_pop = values.pop("missing")
+    return missing_get is None and missing_index is None and missing_pop is None
+
+
+def dict_safe_union_with_none(mut values: dict[str, int | str | None]) -> bool:
+    missing_get = values.get("missing")
+    missing_index = values["missing"]
+    missing_pop = values.pop("missing")
+    return missing_get is None and missing_index is None and missing_pop is None
+
+
+def list_safe_union_no_none(mut values: list[int | str]) -> bool:
+    missing_index = values[0]
+    missing_pop = values.pop()
+    return missing_index is None and missing_pop is None
+
+
+def list_safe_union_with_none(mut values: list[int | str | None]) -> bool:
+    missing_index = values[0]
+    missing_pop = values.pop()
+    return missing_index is None and missing_pop is None
+
+
+def set_safe_union_no_none(mut values: set[int | str]) -> bool:
+    return values.pop() is None
+
+
+def set_safe_union_with_none(mut values: set[int | str | None]) -> bool:
+    return values.pop() is None
+
+
+def plain_union_int() -> int | str:
+    return 1
+
+
+def nullable_union_int() -> int | str | None:
+    return 1
+
+
+def dict_safe_union_present(mut values: dict[str, int | str]) -> bool:
+    values["present"] = plain_union_int()
+    return values.get("present") is not None
+
+
+def list_safe_union_present(mut values: list[int | str]) -> bool:
+    values.append(plain_union_int())
+    return values.pop() is not None
+
+
+def list_safe_nullable_union_present(mut values: list[int | str | None]) -> bool:
+    values.append(nullable_union_int())
+    return values.pop() is not None
+
+
+def set_safe_union_present(mut values: set[int | str]) -> bool:
+    values.add(plain_union_int())
+    return values.pop() is not None
+
+
+def set_safe_nullable_union_present(mut values: set[int | str | None]) -> bool:
+    values.add(nullable_union_int())
+    return values.pop() is not None
+
+
+def consume_nullable_union(value: int | str | None) -> bool:
+    return True
+
+
+def observe_present_nullable_union(value: int | str | None) -> bool:
+    return value is not None
+
+
+def dict_get_nullable_union_consumption(values: dict[str, int | str | None]) -> bool:
+    narrowed = values.get("missing")
+    if narrowed is not None:
+        assert observe_present_nullable_union(narrowed)
+    direct = consume_nullable_union(values.get("missing"))
+    annotated: int | str | None = values.get("missing")
+    return direct and consume_nullable_union(annotated)
+
+
+def dict_pop_nullable_union_consumption(mut values: dict[str, int | str | None]) -> bool:
+    narrowed = values.pop("missing")
+    if narrowed is not None:
+        assert observe_present_nullable_union(narrowed)
+    direct = consume_nullable_union(values.pop("missing"))
+    annotated: int | str | None = values.pop("missing")
+    return direct and consume_nullable_union(annotated)
+
+
+def dict_index_nullable_union_consumption(values: dict[str, int | str | None]) -> bool:
+    narrowed = values["missing"]
+    if narrowed is not None:
+        assert observe_present_nullable_union(narrowed)
+    direct = consume_nullable_union(values["missing"])
+    annotated: int | str | None = values["missing"]
+    return direct and consume_nullable_union(annotated)
+
+
+def list_pop_nullable_union_consumption(mut values: list[int | str | None]) -> bool:
+    narrowed = values.pop()
+    if narrowed is not None:
+        assert observe_present_nullable_union(narrowed)
+    direct = consume_nullable_union(values.pop())
+    annotated: int | str | None = values.pop()
+    return direct and consume_nullable_union(annotated)
+
+
+def list_index_nullable_union_consumption(values: list[int | str | None]) -> bool:
+    narrowed = values[0]
+    if narrowed is not None:
+        assert observe_present_nullable_union(narrowed)
+    direct = consume_nullable_union(values[0])
+    annotated: int | str | None = values[0]
+    return direct and consume_nullable_union(annotated)
+
+
+def set_pop_nullable_union_consumption(mut values: set[int | str | None]) -> bool:
+    narrowed = values.pop()
+    if narrowed is not None:
+        assert observe_present_nullable_union(narrowed)
+    direct = consume_nullable_union(values.pop())
+    annotated: int | str | None = values.pop()
+    return direct and consume_nullable_union(annotated)
+
+
+def nullable_union_collection_consumption(mut values: dict[str, int | str | None]) -> bool:
+    values["present"] = nullable_union_int()
+
+    present_list: list[int | str | None] = []
+    present_list.append(values.get("present"))
+    assert present_list.pop() is not None
+    missing_list: list[int | str | None] = []
+    missing_list.append(values.get("missing"))
+    assert consume_nullable_union(missing_list.pop())
+
+    present_set: set[int | str | None] = set()
+    present_set.add(values.get("present"))
+    assert present_set.pop() is not None
+    missing_set: set[int | str | None] = set()
+    missing_set.add(values.get("missing"))
+    assert consume_nullable_union(missing_set.pop())
+
+    present_dict: dict[str, int | str | None] = {}
+    present_dict["value"] = values.get("present")
+    assert present_dict.get("value") is not None
+    missing_dict: dict[str, int | str | None] = {}
+    missing_dict["value"] = values.get("missing")
+    assert consume_nullable_union(missing_dict.get("value"))
+
+    present_literal: list[int | str | None] = [values.get("present")]
+    assert present_literal.pop() is not None
+    missing_literal: list[int | str | None] = [values.get("missing")]
+    assert consume_nullable_union(missing_literal.pop())
+
+    present_set_literal: set[int | str | None] = {values.get("present")}
+    assert len(present_set_literal) == 1
+    missing_dict_literal: dict[str, int | str | None] = {"value": values.get("missing")}
+    return consume_nullable_union(missing_dict_literal.get("value"))
+
+
+def optional_list_index_literal_value(maybe_values: list[str] | None) -> str | None:
+    stored: list[str | None] = [maybe_values[0]]
+    return stored.pop()
+
+
+def guarded_nullable_union_literals(mut values: dict[str, int | str | None]) -> bool:
+    values["present"] = nullable_union_int()
+    if "present" in values:
+        from_dict: list[int | str | None] = [values["present"]]
+        assert len(from_dict) == 1
+
+    list_values: list[int | str | None] = []
+    list_values.append(nullable_union_int())
+    if len(list_values) > 0:
+        from_list: list[int | str | None] = [list_values[0]]
+        assert len(from_list) == 1
+    return True
+
+
+def guarded_dict_literal_return(
+    values: dict[str, int | str | None],
+) -> list[int | str | None]:
+    if "present" in values:
+        return [values["present"]]
+    return []
+
+
+def guarded_list_literal_return(
+    values: list[int | str | None],
+) -> list[int | str | None]:
+    if len(values) > 0:
+        return [values[0]]
+    return []
+
+
+def main():
+    values: list[str | None] = []
+    values.append(None)
+    assert list_pop_none(values)
+
+    get_values: dict[str, str | None] = {}
+    get_values["a"] = None
+    assert dict_get_none(get_values)
+    assert dict_index_none(get_values)
+
+    pop_values: dict[str, str | None] = {}
+    pop_values["a"] = None
+    assert dict_pop_none(pop_values)
+
+    next_values: list[str | None] = []
+    next_values.append(None)
+    assert iterator_next_none(next_values)
+    assert list_index_none(next_values)
+
+    annotated_get_values: dict[str, str | None] = {}
+    annotated_get_values["a"] = None
+    annotated_get: str | None = annotated_get_values.get("a")
+    assert annotated_get is None
+
+    annotated_pop_values: dict[str, str | None] = {}
+    annotated_pop_values["a"] = None
+    annotated_pop: str | None = annotated_pop_values.pop("a")
+    assert annotated_pop is None
+
+    annotated_list_values: list[str | None] = []
+    annotated_list_values.append(None)
+    annotated_list_pop: str | None = annotated_list_values.pop()
+    assert annotated_list_pop is None
+
+    annotated_next_values: list[str | None] = []
+    annotated_next_values.append(None)
+    annotated_next: str | None = next(iter(annotated_next_values))
+    assert annotated_next is None
+
+    returned_get_values: dict[str, str | None] = {}
+    returned_get_values["a"] = None
+    assert dict_get_value(returned_get_values) is None
+
+    returned_pop_values: dict[str, str | None] = {}
+    returned_pop_values["a"] = None
+    assert dict_pop_value(returned_pop_values) is None
+
+    returned_list_values: list[str | None] = []
+    returned_list_values.append(None)
+    assert list_pop_value(returned_list_values) is None
+
+    returned_next_values: list[str | None] = []
+    returned_next_values.append(None)
+    assert iterator_next_value(returned_next_values) is None
+
+    call_values: dict[str, str | None] = {}
+    call_values["a"] = None
+    assert consume_optional(call_values.get("a"))
+    nested_call_value = call_values.get("a")
+    assert consume_optional(nested_call_value)
+    assert nested_call_value is None
+
+    field_values: dict[str, str | None] = {}
+    field_values["a"] = None
+    box: OptionalBox = OptionalBox(None)
+    box.value = field_values.get("a")
+    assert box.value is None
+
+    dict_union_no_none: dict[str, int | str] = {}
+    assert dict_safe_union_no_none(dict_union_no_none)
+    assert dict_safe_union_present(dict_union_no_none)
+
+    dict_union_with_none: dict[str, int | str | None] = {}
+    assert dict_safe_union_with_none(dict_union_with_none)
+
+    list_union_no_none: list[int | str] = []
+    assert list_safe_union_no_none(list_union_no_none)
+    assert list_safe_union_present(list_union_no_none)
+
+    list_union_with_none: list[int | str | None] = []
+    assert list_safe_union_with_none(list_union_with_none)
+    assert list_safe_nullable_union_present(list_union_with_none)
+
+    set_union_no_none: set[int | str] = set()
+    assert set_safe_union_no_none(set_union_no_none)
+    assert set_safe_union_present(set_union_no_none)
+
+    set_union_with_none: set[int | str | None] = set()
+    assert set_safe_union_with_none(set_union_with_none)
+    assert set_safe_nullable_union_present(set_union_with_none)
+
+    dict_get_consumption_values: dict[str, int | str | None] = {}
+    assert dict_get_nullable_union_consumption(dict_get_consumption_values)
+
+    dict_pop_consumption_values: dict[str, int | str | None] = {}
+    assert dict_pop_nullable_union_consumption(dict_pop_consumption_values)
+
+    dict_index_consumption_values: dict[str, int | str | None] = {}
+    assert dict_index_nullable_union_consumption(dict_index_consumption_values)
+
+    list_pop_consumption_values: list[int | str | None] = []
+    assert list_pop_nullable_union_consumption(list_pop_consumption_values)
+
+    list_index_consumption_values: list[int | str | None] = []
+    assert list_index_nullable_union_consumption(list_index_consumption_values)
+
+    set_pop_consumption_values: set[int | str | None] = set()
+    assert set_pop_nullable_union_consumption(set_pop_consumption_values)
+
+    collection_consumption_values: dict[str, int | str | None] = {}
+    assert nullable_union_collection_consumption(collection_consumption_values)
+
+    assert optional_list_index_literal_value(None) is None
+    optional_index_values: list[str] = []
+    optional_index_values.append("present")
+    assert optional_list_index_literal_value(optional_index_values) is not None
+
+    guarded_literal_values: dict[str, int | str | None] = {}
+    assert guarded_nullable_union_literals(guarded_literal_values)
+    assert len(guarded_dict_literal_return(guarded_literal_values)) == 1
+
+    nullable_none_source: dict[str, int | str | None] = {}
+    guarded_none_values: dict[str, int | str | None] = {}
+    guarded_none_values["present"] = nullable_none_source.get("missing")
+    assert len(guarded_dict_literal_return(guarded_none_values)) == 1
+
+    guarded_list_values: list[int | str | None] = []
+    guarded_list_values.append(nullable_union_int())
+    assert len(guarded_list_literal_return(guarded_list_values)) == 1

--- a/crates/sifr_codegen/src/expr_ref_emitter.rs
+++ b/crates/sifr_codegen/src/expr_ref_emitter.rs
@@ -58,17 +58,6 @@ fn uses_debug_display_format(ty: &Type) -> bool {
     }
 }
 
-fn option_inner_type(ty: &Type) -> Option<&Type> {
-    let resolved = crate::resolve_alias_type_for_plain_call(ty);
-    let Type::Union(members) = resolved else {
-        return None;
-    };
-    if members.len() != 2 || !members.iter().any(|member| matches!(member, Type::None)) {
-        return None;
-    }
-    members.iter().find(|member| !matches!(member, Type::None))
-}
-
 fn option_inner_from_rust_type(ty: &Type) -> Option<Type> {
     let rust_ty = ty.rust_type();
     if !rust_ty.starts_with("Option<") {
@@ -90,8 +79,8 @@ fn option_inner_from_rust_type(ty: &Type) -> Option<Type> {
 }
 
 fn display_option_inner_type(expr: &HirExpr) -> Option<Type> {
-    if let Some(inner) = option_inner_type(expr.ty()) {
-        return Some(inner.clone());
+    if let Some(inner) = expr.ty().optional_member_type() {
+        return Some(inner);
     }
     if let HirExpr::Index { object, .. } = expr {
         match crate::resolve_alias_type_for_plain_call(object.ty()) {

--- a/crates/sifr_codegen/src/expr_render_helpers/operator_rewrites.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/operator_rewrites.rs
@@ -196,22 +196,7 @@ impl RustEmitter {
                             method: projection_method.to_string(),
                             args: vec![],
                         };
-                        if crate::helpers::is_option_type(value_ty.as_ref()) {
-                            crate::RustExpr::MethodCall {
-                                receiver: Box::new(lowered_get),
-                                method: "and_then".to_string(),
-                                args: vec![crate::RustExpr::Closure {
-                                    params: vec![crate::RustParam::Named {
-                                        name: "__v".to_string(),
-                                        ty: crate::RustType::Named("_".to_string()),
-                                    }],
-                                    body: Box::new(crate::RustExpr::Ident("__v".to_string())),
-                                    is_move: false,
-                                }],
-                            }
-                        } else {
-                            lowered_get
-                        }
+                        crate::helpers::normalize_safe_option_result(value_ty.as_ref(), lowered_get)
                     }
                     Type::List(element_ty) => {
                         let projection_method =
@@ -221,7 +206,7 @@ impl RustEmitter {
                         let object_name = "__sifr_index_list".to_string();
                         let index_name = "__sifr_index_i".to_string();
                         let normalized_name = "__sifr_index_norm".to_string();
-                        crate::RustExpr::Block {
+                        let lowered_index = crate::RustExpr::Block {
                             stmts: vec![
                                 crate::RustStmt::Let {
                                     mutable: false,
@@ -287,7 +272,11 @@ impl RustEmitter {
                                 method: projection_method.to_string(),
                                 args: vec![],
                             })),
-                        }
+                        };
+                        crate::helpers::normalize_safe_option_result(
+                            element_ty.as_ref(),
+                            lowered_index,
+                        )
                     }
                     Type::Bytes => {
                         let object_name = "__sifr_index_bytes".to_string();

--- a/crates/sifr_codegen/src/field_analysis_helpers.rs
+++ b/crates/sifr_codegen/src/field_analysis_helpers.rs
@@ -22,19 +22,12 @@ impl RustEmitter {
         same_scc_classes: &HashSet<String>,
     ) -> String {
         match ty {
-            sifr_type_system::Type::Union(members) => {
-                let non_none: Vec<&sifr_type_system::Type> = members
-                    .iter()
-                    .filter(|member| !matches!(member, sifr_type_system::Type::None))
-                    .collect();
-                let has_none = members
-                    .iter()
-                    .any(|member| matches!(member, sifr_type_system::Type::None));
-                if has_none && non_none.len() == 1 {
-                    if type_references_any_class(non_none[0], same_scc_classes) {
+            sifr_type_system::Type::Union(_) => {
+                if let Some(member) = ty.optional_member_type() {
+                    if type_references_any_class(&member, same_scc_classes) {
                         format!(
                             "Option<Box<{}>>",
-                            self.recursive_target_rust_type_for_field(non_none[0])
+                            self.recursive_target_rust_type_for_field(&member)
                         )
                     } else {
                         self.rust_type_with_generics(ty)

--- a/crates/sifr_codegen/src/generic_bounds_helpers.rs
+++ b/crates/sifr_codegen/src/generic_bounds_helpers.rs
@@ -186,14 +186,9 @@ impl RustEmitter {
                 self.rust_type_with_generics(ok),
                 self.rust_generator_error_type_with_generics(err)
             ),
-            Type::Union(members) => {
-                let non_none: Vec<&Type> = members
-                    .iter()
-                    .filter(|member| !matches!(member, Type::None))
-                    .collect();
-                let has_none = members.iter().any(|member| matches!(member, Type::None));
-                if has_none && non_none.len() == 1 {
-                    format!("Option<{}>", self.rust_type_with_generics(non_none[0]))
+            Type::Union(_) => {
+                if let Some(member) = ty.optional_member_type() {
+                    format!("Option<{}>", self.rust_type_with_generics(&member))
                 } else {
                     ty.rust_type()
                 }

--- a/crates/sifr_codegen/src/helpers.rs
+++ b/crates/sifr_codegen/src/helpers.rs
@@ -1,6 +1,8 @@
-use super::{IsNoneUnionMatch, IsinstanceUnionMatch, ModuleFuncSignatures};
+use super::{IsinstanceUnionMatch, ModuleFuncSignatures};
 
+mod collection_storage;
 mod helpers_impl;
+pub(crate) use collection_storage::*;
 pub(crate) use helpers_impl::*;
 #[cfg(test)]
 mod tests;

--- a/crates/sifr_codegen/src/helpers/collection_storage.rs
+++ b/crates/sifr_codegen/src/helpers/collection_storage.rs
@@ -1,0 +1,111 @@
+use crate::RustExpr;
+use sifr_ir::HirExpr;
+use sifr_type_system::Type;
+
+use super::flatten_option_value_for_target;
+
+/// Adapt a collection operation whose HIR type was contextually narrowed to its target.
+///
+/// Safe reads still produce a representation-significant outer `Option` at runtime. Collection
+/// literal inference can replace the expression's HIR type with the enclosing element type, so
+/// recover the operation payload before adapting the lowered value.
+pub(crate) fn adapt_collection_value_for_target(
+    target: &Type,
+    source_expr: &HirExpr,
+    value: RustExpr,
+) -> RustExpr {
+    flatten_option_value_for_target(target, source_expr.ty(), value)
+}
+
+/// Adapt representation-significant optional wrappers inside an owned collection value.
+pub(crate) fn adapt_collection_storage_for_target(
+    target: &Type,
+    source: &Type,
+    value: RustExpr,
+) -> RustExpr {
+    let (target, source) = (
+        crate::resolve_alias_type_for_plain_call(target),
+        crate::resolve_alias_type_for_plain_call(source),
+    );
+    match (target, source) {
+        (Type::List(target_element), Type::List(source_element)) => adapt_iterable_storage(
+            target_element.as_ref(),
+            source_element.as_ref(),
+            value,
+            "collect::<Vec<_>>",
+        ),
+        (Type::Set(target_element), Type::Set(source_element)) => adapt_iterable_storage(
+            target_element.as_ref(),
+            source_element.as_ref(),
+            value,
+            "collect::<std::collections::HashSet<_>>",
+        ),
+        (Type::Dict(target_key, target_value), Type::Dict(source_key, source_value)) => {
+            let key_ident = RustExpr::Ident("__sifr_collection_key".to_string());
+            let value_ident = RustExpr::Ident("__sifr_collection_value".to_string());
+            let adapted_key = flatten_option_value_for_target(
+                target_key.as_ref(),
+                source_key.as_ref(),
+                key_ident.clone(),
+            );
+            let adapted_value = flatten_option_value_for_target(
+                target_value.as_ref(),
+                source_value.as_ref(),
+                value_ident.clone(),
+            );
+            if adapted_key == key_ident && adapted_value == value_ident {
+                return value;
+            }
+            collect_mapped_storage(
+                value,
+                "(__sifr_collection_key, __sifr_collection_value)",
+                RustExpr::Tuple(vec![adapted_key, adapted_value]),
+                "collect::<std::collections::HashMap<_, _>>",
+            )
+        }
+        _ => value,
+    }
+}
+
+fn adapt_iterable_storage(
+    target_element: &Type,
+    source_element: &Type,
+    value: RustExpr,
+    collect_method: &str,
+) -> RustExpr {
+    let element_ident = RustExpr::Ident("__sifr_collection_value".to_string());
+    let adapted =
+        flatten_option_value_for_target(target_element, source_element, element_ident.clone());
+    if adapted == element_ident {
+        return value;
+    }
+    collect_mapped_storage(value, "__sifr_collection_value", adapted, collect_method)
+}
+
+fn collect_mapped_storage(
+    value: RustExpr,
+    parameter: &str,
+    body: RustExpr,
+    collect_method: &str,
+) -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::MethodCall {
+                receiver: Box::new(value),
+                method: "into_iter".to_string(),
+                args: Vec::new(),
+            }),
+            method: "map".to_string(),
+            args: vec![RustExpr::Closure {
+                params: vec![crate::RustParam::Named {
+                    name: parameter.to_string(),
+                    ty: crate::RustType::Named("_".to_string()),
+                }],
+                body: Box::new(body),
+                is_move: false,
+            }],
+        }),
+        method: collect_method.to_string(),
+        args: Vec::new(),
+    }
+}

--- a/crates/sifr_codegen/src/helpers/helpers_impl.rs
+++ b/crates/sifr_codegen/src/helpers/helpers_impl.rs
@@ -1,4 +1,4 @@
-use super::{IsNoneUnionMatch, IsinstanceUnionMatch, ModuleFuncSignatures};
+use super::{IsinstanceUnionMatch, ModuleFuncSignatures};
 use crate::hir_analysis::{
     queries,
     traversal::{self, TraversalConfig},
@@ -202,17 +202,89 @@ pub(crate) fn default_param_convention(ty: &Type) -> ParamConvention {
 }
 
 pub(crate) fn is_option_type(ty: &Type) -> bool {
-    let resolved = crate::resolve_alias_type_for_plain_call(ty);
-    if let Type::Union(members) = resolved {
-        let non_none: Vec<&Type> = members
-            .iter()
-            .filter(|m| !matches!(m, Type::None))
-            .collect();
-        let has_none = members.iter().any(|m| matches!(m, Type::None));
-        has_none && non_none.len() == 1
-    } else {
-        false
+    ty.optional_member_type().is_some()
+}
+
+fn option_wrapper_depth(ty: &Type) -> usize {
+    let mut current = ty.clone();
+    let mut depth = 0;
+    while let Some(payload) = current.optional_member_type() {
+        depth += 1;
+        current = payload;
     }
+    depth
+}
+
+/// Adapt a representation-significant optional wrapper to its assignable target.
+pub(crate) fn flatten_option_value_for_target(
+    target: &Type,
+    source: &Type,
+    mut value: RustExpr,
+) -> RustExpr {
+    let target_depth = option_wrapper_depth(target);
+    let source_depth = option_wrapper_depth(source);
+    if target_depth == 0 && source_depth == 1 {
+        let Some(source_payload) = source.optional_member_type() else {
+            return value;
+        };
+        let canonical_source_payload =
+            match crate::resolve_alias_type_for_plain_call(&source_payload) {
+                Type::Union(members) => sifr_type_system::make_union(members.clone()),
+                other => other.clone(),
+            };
+        let canonical_target = match crate::resolve_alias_type_for_plain_call(target) {
+            Type::Union(members) => sifr_type_system::make_union(members.clone()),
+            other => other.clone(),
+        };
+        let Type::Union(target_members) = &canonical_target else {
+            return value;
+        };
+        if canonical_source_payload != canonical_target
+            || !target_members
+                .iter()
+                .any(|member| matches!(member.resolve_alias(), Type::None))
+        {
+            return value;
+        }
+        return RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Paren(Box::new(value))),
+            method: "unwrap_or".to_string(),
+            args: vec![RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec![
+                    canonical_target.union_enum_name(),
+                    Type::None.union_variant_name(),
+                ])),
+                args: vec![RustExpr::Literal(crate::RustLiteral::Unit)],
+            }],
+        };
+    }
+    if target_depth == 0 || source_depth <= target_depth || !source.is_assignable_to(target) {
+        return value;
+    }
+    for _ in target_depth..source_depth {
+        value = RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Paren(Box::new(value))),
+            method: "flatten".to_string(),
+            args: Vec::new(),
+        };
+    }
+    value
+}
+
+/// Normalize nested absence produced by a safe collection operation.
+pub(crate) fn normalize_safe_option_result(payload: &Type, value: RustExpr) -> RustExpr {
+    let canonical_payload = match crate::resolve_alias_type_for_plain_call(payload) {
+        Type::Union(members) => sifr_type_system::make_union(members.clone()),
+        _ => return value,
+    };
+    if is_option_type(&canonical_payload) {
+        return RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Paren(Box::new(value))),
+            method: "flatten".to_string(),
+            args: Vec::new(),
+        };
+    }
+    value
 }
 
 /// Detect truthiness check on an Option variable: `if x:` where x has type T | None.
@@ -313,8 +385,13 @@ pub(crate) fn detect_isinstance_union(expr: &HirExpr) -> Option<IsinstanceUnionM
         if func == "isinstance" && args.len() == 2 {
             if let HirExpr::Name { name, ty, .. } = &args[0] {
                 let resolved_ty = crate::resolve_alias_type_for_plain_call(ty);
-                if let Type::Union(members) = resolved_ty {
+                if let Type::Union(raw_members) = resolved_ty {
                     if !is_option_type(resolved_ty) {
+                        let Type::Union(members) =
+                            sifr_type_system::make_union(raw_members.clone())
+                        else {
+                            return None;
+                        };
                         let type_name = match &args[1] {
                             HirExpr::StringLiteral(type_name) => type_name.as_str(),
                             HirExpr::Name { name, .. } => name.as_str(),
@@ -339,7 +416,7 @@ pub(crate) fn detect_isinstance_union(expr: &HirExpr) -> Option<IsinstanceUnionM
                         // Check that this type is a member of the union
                         if members.contains(&target_ty) {
                             let variant = target_ty.union_variant_name();
-                            let enum_name = resolved_ty.union_enum_name();
+                            let enum_name = Type::Union(members.clone()).union_enum_name();
                             // Collect other variants for else branch destructuring
                             let other_variants: Vec<(String, Type)> = members
                                 .iter()
@@ -439,40 +516,6 @@ pub(crate) fn detect_is_none_var(expr: &HirExpr) -> Option<String> {
             if let HirExpr::Name { name, ty, .. } = left.as_ref() {
                 if is_option_type(ty) {
                     return Some(name.clone());
-                }
-            }
-        }
-    }
-    None
-}
-
-/// Detect `x is None` pattern for 3+ member unions containing None.
-/// Returns (`var_name`, `enum_name`, `non_none_variants`).
-pub(crate) fn detect_is_none_union_var(expr: &HirExpr) -> Option<IsNoneUnionMatch> {
-    if let HirExpr::Compare {
-        left,
-        ops,
-        comparators,
-        ..
-    } = expr
-    {
-        if ops.len() == 1 && ops[0] == "is" && matches!(comparators[0], HirExpr::NoneLiteral) {
-            if let HirExpr::Name { name, ty, .. } = left.as_ref() {
-                if let Type::Union(members) = ty {
-                    let has_none = members.iter().any(|m| matches!(m, Type::None));
-                    let non_none: Vec<&Type> = members
-                        .iter()
-                        .filter(|m| !matches!(m, Type::None))
-                        .collect();
-                    // Only match for 3+ member unions (not simple Option)
-                    if has_none && non_none.len() >= 2 {
-                        let enum_name = ty.union_enum_name();
-                        let non_none_variants: Vec<(String, Type)> = non_none
-                            .iter()
-                            .map(|t| (t.union_variant_name(), (*t).clone()))
-                            .collect();
-                        return Some((name.clone(), enum_name, non_none_variants));
-                    }
                 }
             }
         }

--- a/crates/sifr_codegen/src/helpers/tests.rs
+++ b/crates/sifr_codegen/src/helpers/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::RustExpr;
 use sifr_ir::{HirExceptHandler, HirExpr, HirFunction, HirModule, HirParam, HirStmt, MethodKind};
 use sifr_type_system::{OwnershipKind, ParamConvention, Type};
 use std::collections::HashMap;
@@ -553,4 +554,153 @@ fn module_uses_bigint_false_without_bigint() {
     }]);
 
     assert!(!module_uses_bigint(&module));
+}
+
+#[test]
+fn option_target_coercion_flattens_only_excess_wrapper_layers() {
+    let flat = Type::Union(vec![Type::Str, Type::None]);
+    let nested = Type::Union(vec![flat.clone(), Type::None]);
+    let twice_nested = Type::Union(vec![nested.clone(), Type::None]);
+    let value = RustExpr::Ident("value".to_string());
+
+    assert_eq!(
+        flatten_option_value_for_target(&flat, &nested, value.clone()),
+        RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Paren(Box::new(value.clone()))),
+            method: "flatten".to_string(),
+            args: Vec::new(),
+        }
+    );
+    let twice_flattened = flatten_option_value_for_target(&flat, &twice_nested, value.clone());
+    assert!(matches!(
+        twice_flattened,
+        RustExpr::MethodCall { method, receiver, .. }
+            if method == "flatten"
+                && matches!(receiver.as_ref(), RustExpr::Paren(inner)
+                    if matches!(inner.as_ref(), RustExpr::MethodCall { method, .. } if method == "flatten"))
+    ));
+    assert_eq!(
+        flatten_option_value_for_target(&nested, &nested, value.clone()),
+        value.clone()
+    );
+    assert_eq!(
+        flatten_option_value_for_target(&Type::Any, &nested, value.clone()),
+        value.clone()
+    );
+    assert_eq!(
+        flatten_option_value_for_target(&Type::Unknown, &nested, value.clone()),
+        value
+    );
+}
+
+#[test]
+fn option_target_coercion_maps_outer_absence_to_nullable_union_variant() {
+    let target = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
+    let source = Type::Union(vec![target.clone(), Type::None]);
+    let rendered = crate::render_expr(&flatten_option_value_for_target(
+        &target,
+        &source,
+        RustExpr::Ident("value".to_string()),
+    ));
+    assert!(rendered.contains(".unwrap_or("), "{rendered}");
+    assert!(rendered.contains(&target.union_enum_name()), "{rendered}");
+    assert!(
+        rendered.contains(&Type::None.union_variant_name()),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn collection_target_coercion_recovers_contextually_narrowed_safe_get() {
+    let target = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
+    let runtime_source = sifr_type_system::safe_optional_result(target.clone());
+    let expr = HirExpr::MethodCall {
+        object: Box::new(HirExpr::Name {
+            name: "values".to_string(),
+            binding_id: None,
+            ty: Type::Dict(Box::new(Type::Str), Box::new(target.clone())),
+        }),
+        method: "get".to_string(),
+        args: vec![HirExpr::StringLiteral("key".to_string())],
+        receiver_convention: None,
+        receiver_target: None,
+        mutable_arg_places: Vec::new(),
+        source: None,
+        ty: runtime_source,
+    };
+    let rendered = crate::render_expr(&adapt_collection_value_for_target(
+        &target,
+        &expr,
+        RustExpr::Ident("value".to_string()),
+    ));
+    assert!(rendered.contains(".unwrap_or("), "{rendered}");
+}
+
+#[test]
+fn collection_target_coercion_does_not_flatten_a_simple_optional_index() {
+    let target = sifr_type_system::make_union(vec![Type::Str, Type::None]);
+    let expr = HirExpr::Index {
+        object: Box::new(HirExpr::Name {
+            name: "maybe_values".to_string(),
+            binding_id: None,
+            ty: sifr_type_system::make_union(vec![Type::List(Box::new(Type::Str)), Type::None]),
+        }),
+        index: Box::new(HirExpr::IntLiteral(0)),
+        ty: target.clone(),
+    };
+    let value = RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::Ident("maybe_values".to_string())),
+        method: "and_then".to_string(),
+        args: Vec::new(),
+    };
+    assert_eq!(
+        adapt_collection_value_for_target(&target, &expr, value.clone()),
+        value
+    );
+}
+
+#[test]
+fn collection_storage_coercion_maps_nested_optional_elements() {
+    let target_element = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
+    let source_element = Type::Union(vec![target_element.clone(), Type::None]);
+    let rendered = crate::render_expr(&adapt_collection_storage_for_target(
+        &Type::List(Box::new(target_element.clone())),
+        &Type::List(Box::new(source_element)),
+        RustExpr::Ident("values".to_string()),
+    ));
+    assert!(rendered.contains(".into_iter().map("), "{rendered}");
+    assert!(rendered.contains(".unwrap_or("), "{rendered}");
+    assert!(
+        rendered.contains(&target_element.union_enum_name()),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn safe_option_result_flattens_simple_option_and_preserves_nullable_union() {
+    let value = RustExpr::Ident("value".to_string());
+    assert_eq!(
+        normalize_safe_option_result(&Type::Union(vec![Type::Str, Type::None]), value.clone()),
+        RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Paren(Box::new(value.clone()))),
+            method: "flatten".to_string(),
+            args: Vec::new(),
+        }
+    );
+    assert_eq!(
+        normalize_safe_option_result(&Type::Str, value.clone()),
+        value
+    );
+
+    let plain_union = sifr_type_system::make_union(vec![Type::Int, Type::Str]);
+    assert_eq!(
+        normalize_safe_option_result(&plain_union, value.clone()),
+        value
+    );
+
+    let nullable_union = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
+    assert_eq!(
+        normalize_safe_option_result(&nullable_union, value.clone()),
+        value
+    );
 }

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/builtin_core_methods.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/builtin_core_methods.rs
@@ -186,11 +186,17 @@ impl RustEmitter {
                             args: vec![],
                         })
                     }
-                    _ => Some(RustExpr::MethodCall {
-                        receiver: Box::new(lowered_arg),
-                        method: "next".to_string(),
-                        args: vec![],
-                    }),
+                    _ => {
+                        let next_expr = RustExpr::MethodCall {
+                            receiver: Box::new(lowered_arg),
+                            method: "next".to_string(),
+                            args: vec![],
+                        };
+                        let payload = args[0].ty().iterator_element_type()?;
+                        Some(crate::helpers::normalize_safe_option_result(
+                            &payload, next_expr,
+                        ))
+                    }
                 }
             }
             "anext" if args.len() == 1 => {

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/builtin_numeric.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/builtin_numeric.rs
@@ -743,7 +743,7 @@ impl RustEmitter {
                 };
                 let str_arg_ty = call_return_ty.as_ref().unwrap_or_else(|| args[0].ty());
                 if let Some(inner) = registry_option_inner_type(str_arg_ty) {
-                    let format_str = if registry_uses_debug_display_format(inner) {
+                    let format_str = if registry_uses_debug_display_format(&inner) {
                         "{:?}".to_string()
                     } else {
                         "{}".to_string()

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/collection_methods.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/collection_methods.rs
@@ -261,6 +261,25 @@ impl RustEmitter {
             );
         }
 
+        let collection_element_target = match (object_ty, method) {
+            (Type::List(element_ty), "append" | "appendleft") => Some((0, element_ty.as_ref())),
+            (Type::List(element_ty), "insert") => Some((1, element_ty.as_ref())),
+            (Type::Set(element_ty), "add") => Some((0, element_ty.as_ref())),
+            (Type::Dict(_, value_ty), "setdefault") => Some((1, value_ty.as_ref())),
+            _ => None,
+        };
+        if let Some((index, target_ty)) = collection_element_target {
+            if let (Some(argument), Some(lowered_arg)) = (args.get(index), arg_exprs.get_mut(index))
+            {
+                let source_ty = self.effective_registry_expr_ty(argument);
+                *lowered_arg = crate::helpers::flatten_option_value_for_target(
+                    target_ty,
+                    &source_ty,
+                    lowered_arg.clone(),
+                );
+            }
+        }
+
         if matches!(object_ty, Type::List(_))
             && matches!(method, "append" | "appendleft")
             && !args.is_empty()

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/literal_and_intrinsic_exprs.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/literal_and_intrinsic_exprs.rs
@@ -1,4 +1,4 @@
-use super::{intrinsics, HirExpr, RustEmitter};
+use super::{intrinsics, HirExpr, RustEmitter, Type};
 use sifr_ir::CompilerIntrinsicId;
 
 impl RustEmitter {
@@ -6,6 +6,7 @@ impl RustEmitter {
         &mut self,
         keys: &[HirExpr],
         values: &[HirExpr],
+        ty: &Type,
     ) -> Option<crate::RustExpr> {
         if keys.len() != values.len() {
             return None;
@@ -28,13 +29,27 @@ impl RustEmitter {
         }];
 
         for (key, value) in keys.iter().zip(values.iter()) {
+            let lowered_key = self.try_lower_registry_expr_strict(key)?;
+            let lowered_value = self.try_lower_registry_expr_strict(value)?;
+            let (lowered_key, lowered_value) = match ty.resolve_alias() {
+                Type::Dict(key_ty, value_ty) => (
+                    crate::helpers::adapt_collection_value_for_target(
+                        key_ty.as_ref(),
+                        key,
+                        lowered_key,
+                    ),
+                    crate::helpers::adapt_collection_value_for_target(
+                        value_ty.as_ref(),
+                        value,
+                        lowered_value,
+                    ),
+                ),
+                _ => (lowered_key, lowered_value),
+            };
             stmts.push(crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                 receiver: Box::new(crate::RustExpr::Ident(map_ident.clone())),
                 method: "insert".to_string(),
-                args: vec![
-                    self.try_lower_registry_expr_strict(key)?,
-                    self.try_lower_registry_expr_strict(value)?,
-                ],
+                args: vec![lowered_key, lowered_value],
             }));
         }
 
@@ -47,6 +62,7 @@ impl RustEmitter {
     pub(crate) fn try_lower_registry_set_literal_expr(
         &mut self,
         elements: &[HirExpr],
+        ty: &Type,
     ) -> Option<crate::RustExpr> {
         let set_ident = "__sifr_registry_set_literal".to_string();
         let mut stmts = vec![crate::RustStmt::Let {
@@ -66,6 +82,14 @@ impl RustEmitter {
 
         for element in elements {
             let lowered = self.try_lower_registry_expr_strict(element)?;
+            let lowered = match ty.resolve_alias() {
+                Type::Set(element_ty) => crate::helpers::adapt_collection_value_for_target(
+                    element_ty.as_ref(),
+                    element,
+                    lowered,
+                ),
+                _ => lowered,
+            };
             stmts.push(crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                 receiver: Box::new(crate::RustExpr::Ident(set_ident.clone())),
                 method: "insert".to_string(),

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
@@ -4,6 +4,36 @@ use super::{
     HirExpr, ParamConvention, RustEmitter, RustExpr, Type,
 };
 impl RustEmitter {
+    pub(crate) fn flatten_option_argument_for_ir(
+        arg: &HirExpr,
+        param_ty: &Type,
+        effective_arg_ty: &Type,
+        convention: ParamConvention,
+        lowered_arg: RustExpr,
+    ) -> RustExpr {
+        let adapted = crate::helpers::flatten_option_value_for_target(
+            param_ty,
+            effective_arg_ty,
+            lowered_arg.clone(),
+        );
+        if adapted == lowered_arg {
+            return lowered_arg;
+        }
+        let value = if convention.is_borrowed()
+            && matches!(arg, HirExpr::Name { .. })
+            && !crate::helpers::is_copy_type_for_codegen(effective_arg_ty)
+        {
+            RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Paren(Box::new(lowered_arg))),
+                method: "clone".to_string(),
+                args: Vec::new(),
+            }
+        } else {
+            lowered_arg
+        };
+        crate::helpers::flatten_option_value_for_target(param_ty, effective_arg_ty, value)
+    }
+
     pub(crate) fn try_lower_registry_plain_call_with_signature(
         &mut self,
         func: &str,
@@ -114,6 +144,16 @@ impl RustEmitter {
                 }
             }
 
+            let unadapted_option_arg = lowered_arg.clone();
+            lowered_arg = Self::flatten_option_argument_for_ir(
+                arg,
+                param_ty,
+                &effective_arg_ty,
+                *convention,
+                lowered_arg,
+            );
+            let option_value_adapted = lowered_arg != unadapted_option_arg;
+
             let mut recursive_option_adapted = false;
             if crate::helpers::is_option_type(resolved_param) {
                 if let Some(adapted) = self.try_adapt_recursive_option_constructor_arg_for_ir(
@@ -149,7 +189,7 @@ impl RustEmitter {
                         args: vec![lowered_arg],
                     };
                 }
-            } else if arg_is_option {
+            } else if arg_is_option && !option_value_adapted {
                 if !crate::helpers::is_copy_type_for_codegen(&effective_arg_ty) {
                     lowered_arg = crate::RustExpr::MethodCall {
                         receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),
@@ -444,6 +484,15 @@ impl RustEmitter {
         }
         let effective_arg_ty = self.effective_registry_expr_ty(arg);
         let arg_is_option = crate::helpers::is_option_type(&effective_arg_ty);
+        let unadapted_option_arg = lowered_arg.clone();
+        lowered_arg = Self::flatten_option_argument_for_ir(
+            arg,
+            param_ty,
+            &effective_arg_ty,
+            convention,
+            lowered_arg,
+        );
+        let option_value_adapted = lowered_arg != unadapted_option_arg;
         if crate::helpers::is_option_type(param_ty)
             && !arg_is_option
             && !matches!(arg, HirExpr::NoneLiteral)
@@ -459,7 +508,10 @@ impl RustEmitter {
                 func: Box::new(crate::RustExpr::Path(vec!["Some".to_string()])),
                 args: vec![lowered_arg],
             };
-        } else if arg_is_option && !crate::helpers::is_option_type(param_ty) {
+        } else if arg_is_option
+            && !crate::helpers::is_option_type(param_ty)
+            && !option_value_adapted
+        {
             if !crate::helpers::is_copy_type_for_codegen(&effective_arg_ty) {
                 lowered_arg = crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/recursive_exprs.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/recursive_exprs.rs
@@ -160,13 +160,20 @@ impl RustEmitter {
                         let expects_option = crate::helpers::is_option_type(element_ty.as_ref());
                         let has_option = crate::helpers::is_option_type(&arg_ty);
                         let mut adjusted = arg_exprs[0].clone();
+                        let adapted = crate::helpers::flatten_option_value_for_target(
+                            element_ty.as_ref(),
+                            &arg_ty,
+                            adjusted.clone(),
+                        );
+                        let option_value_adapted = adapted != adjusted;
+                        adjusted = adapted;
                         if expects_option && !has_option && !matches!(args[0], HirExpr::NoneLiteral)
                         {
                             adjusted = crate::RustExpr::FnCall {
                                 func: Box::new(crate::RustExpr::Path(vec!["Some".to_string()])),
                                 args: vec![adjusted],
                             };
-                        } else if !expects_option && has_option {
+                        } else if !expects_option && has_option && !option_value_adapted {
                             if !crate::helpers::is_copy_type_for_codegen(&arg_ty) {
                                 adjusted = crate::RustExpr::MethodCall {
                                     receiver: Box::new(crate::RustExpr::Paren(Box::new(adjusted))),
@@ -604,7 +611,7 @@ impl RustEmitter {
                             let lowered_expr = self.try_lower_registry_expr_strict(expr)?;
                             if let Some(inner_ty) = registry_option_inner_type(expr.ty()) {
                                 let inner_format_str =
-                                    if registry_uses_debug_display_format(inner_ty) {
+                                    if registry_uses_debug_display_format(&inner_ty) {
                                         "{:?}".to_string()
                                     } else {
                                         "{}".to_string()
@@ -805,8 +812,8 @@ impl RustEmitter {
                     step.as_deref(),
                 )
             }
-            HirExpr::DictLiteral { keys, values, .. } => {
-                self.try_lower_registry_dict_literal_expr(keys, values)
+            HirExpr::DictLiteral { keys, values, ty } => {
+                self.try_lower_registry_dict_literal_expr(keys, values, ty)
             }
             HirExpr::ListLiteral { elements, ty } => {
                 if elements.is_empty() {
@@ -817,7 +824,18 @@ impl RustEmitter {
                 let list_ty = crate::resolve_alias_type_for_plain_call(ty);
                 let mut lowered = elements
                     .iter()
-                    .map(|element| self.try_lower_registry_expr_strict(element))
+                    .map(|element| {
+                        let lowered = self.try_lower_registry_expr_strict(element)?;
+                        Some(if let Type::List(element_ty) = list_ty {
+                            crate::helpers::adapt_collection_value_for_target(
+                                element_ty.as_ref(),
+                                element,
+                                lowered,
+                            )
+                        } else {
+                            lowered
+                        })
+                    })
                     .collect::<Option<Vec<_>>>()?;
                 if matches!(list_ty, Type::Bytes) {
                     lowered = lowered
@@ -841,8 +859,8 @@ impl RustEmitter {
                     Some(crate::RustExpr::Tuple(lowered))
                 }
             }
-            HirExpr::SetLiteral { elements, .. } => {
-                self.try_lower_registry_set_literal_expr(elements)
+            HirExpr::SetLiteral { elements, ty } => {
+                self.try_lower_registry_set_literal_expr(elements, ty)
             }
             _ => None,
         }

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/registry_helpers.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/registry_helpers.rs
@@ -58,15 +58,8 @@ pub(super) fn registry_uses_debug_display_format(ty: &Type) -> bool {
     }
 }
 
-pub(super) fn registry_option_inner_type(ty: &Type) -> Option<&Type> {
-    let resolved = crate::resolve_alias_type_for_plain_call(ty);
-    let Type::Union(members) = resolved else {
-        return None;
-    };
-    if members.len() != 2 || !members.iter().any(|member| matches!(member, Type::None)) {
-        return None;
-    }
-    members.iter().find(|member| !matches!(member, Type::None))
+pub(super) fn registry_option_inner_type(ty: &Type) -> Option<Type> {
+    ty.optional_member_type()
 }
 
 pub(super) fn registry_is_string_like_type(ty: &Type) -> bool {
@@ -173,17 +166,7 @@ pub(super) fn registry_class_method_signature<'a>(
 
 pub(super) fn registry_class_has_next(methods: &[(String, FunctionType)]) -> bool {
     registry_class_method_signature(methods, "__next__").is_some_and(|next_ft| {
-        next_ft.params.is_empty()
-            && matches!(next_ft.return_type.as_ref().resolve_alias(), Type::Union(members) if {
-                let has_none = members
-                    .iter()
-                    .any(|member| matches!(member.resolve_alias(), Type::None));
-                let non_none = members
-                    .iter()
-                    .filter(|member| !matches!(member.resolve_alias(), Type::None))
-                    .count();
-                has_none && non_none == 1
-            })
+        next_ft.params.is_empty() && next_ft.return_type.optional_member_type().is_some()
     })
 }
 
@@ -569,12 +552,16 @@ pub(super) fn registry_call_callable_with_owned_args(
         let mut lowered_arg = RustExpr::Ident(name.clone());
         let arg_is_option = crate::helpers::is_option_type(arg_ty);
         let param_is_option = crate::helpers::is_option_type(param_ty);
+        let adapted_arg =
+            crate::helpers::flatten_option_value_for_target(param_ty, arg_ty, lowered_arg.clone());
+        let option_value_adapted = adapted_arg != lowered_arg;
+        lowered_arg = adapted_arg;
         if param_is_option && !arg_is_option {
             lowered_arg = RustExpr::FnCall {
                 func: Box::new(RustExpr::Path(vec!["Some".to_string()])),
                 args: vec![lowered_arg],
             };
-        } else if !param_is_option && arg_is_option {
+        } else if !param_is_option && arg_is_option && !option_value_adapted {
             lowered_arg = RustEmitter::force_unwrap_option_expr_for_ir(
                 lowered_arg,
                 "compiler-verified callable argument should be Some",

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -63,7 +63,7 @@ mod ir_optimize;
 mod ir_validate;
 mod lib_support;
 pub(crate) use lib_modules_and_codegen::{
-    IsNoneUnionMatch, IsinstanceUnionMatch, ModuleFuncSignatures, NestedFnCapture,
+    IsinstanceUnionMatch, ModuleFuncSignatures, NestedFnCapture,
 };
 pub(crate) use lib_support::{
     homogeneous_large_tuple_backing_array, resolve_alias_type_for_plain_call,

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -189,7 +189,7 @@ fn project_root_record_keeps_qualified_structural_identity() {
         &[],
         &[NominalField {
             name: "value",
-            identity: primitive("i64"),
+            identity: primitive("int"),
             required: true,
             default_identity: None,
         }],

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -38,7 +38,6 @@ pub(crate) type ModuleFuncSignatures = HashMap<String, FuncSignature>;
 type StdlibFuncSignatures = HashMap<String, ModuleFuncSignatures>;
 pub(crate) type UnionVariantTypes = Vec<(String, Type)>;
 pub(crate) type IsinstanceUnionMatch = (String, String, String, UnionVariantTypes);
-pub(crate) type IsNoneUnionMatch = (String, String, UnionVariantTypes);
 
 pub use crate::entrypoints::{generate_rust, generate_rust_test, generate_rust_with_metadata};
 

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -20,14 +20,17 @@ use collections_and_comprehensions::{
     is_option_like_simple, is_promoted_fixed_width_integer_binop, is_reserved_builtin_call_func,
     is_safe_simple_binop, is_safe_simple_compare, is_simple_int_true_division_binop,
     is_string_like_simple, normalize_binop_op, normalize_compare_op, resolve_alias_type,
-    try_lower_guarded_option_compare_expr, try_lower_mixed_float_operand_expr,
-    try_lower_none_identity_compare_expr, try_lower_option_none_compare_expr,
-    try_lower_promoted_integer_operand_expr, try_lower_simple_binop_operand_expr,
-    try_lower_simple_compare_operand_expr, try_lower_simple_dict_comp_expr,
-    try_lower_simple_dict_literal_expr, try_lower_simple_fstring_expr,
-    try_lower_simple_generator_expr, try_lower_simple_index_expr, try_lower_simple_lambda_expr,
-    try_lower_simple_list_comp_expr, try_lower_simple_range_operand_expr,
-    try_lower_simple_set_comp_expr, try_lower_simple_set_literal_expr, try_lower_simple_slice_expr,
+    try_lower_guarded_option_compare_expr, try_lower_none_identity_compare_expr,
+    try_lower_option_none_compare_expr, try_lower_simple_compare_operand_expr,
+    try_lower_simple_dict_comp_expr, try_lower_simple_dict_literal_expr,
+    try_lower_simple_fstring_expr, try_lower_simple_generator_expr, try_lower_simple_index_expr,
+    try_lower_simple_lambda_expr, try_lower_simple_list_comp_expr, try_lower_simple_set_comp_expr,
+    try_lower_simple_set_literal_expr, try_lower_simple_slice_expr,
+};
+mod scalar_operands;
+use scalar_operands::{
+    try_lower_mixed_float_operand_expr, try_lower_promoted_integer_operand_expr,
+    try_lower_simple_binop_operand_expr, try_lower_simple_range_operand_expr,
 };
 
 pub(crate) fn typed_empty_list_expr(ty: &Type) -> Option<RustExpr> {

--- a/crates/sifr_codegen/src/lower_expr/collections_and_comprehensions.rs
+++ b/crates/sifr_codegen/src/lower_expr/collections_and_comprehensions.rs
@@ -24,6 +24,8 @@ pub(super) fn try_lower_simple_index_expr(
                 method: projection_method.to_string(),
                 args: vec![],
             };
+            let projected =
+                crate::helpers::normalize_safe_option_result(value_ty.as_ref(), projected);
             if is_option_like_simple(result_ty) {
                 Some(projected)
             } else {
@@ -79,7 +81,7 @@ pub(super) fn try_lower_simple_slice_expr(
 pub(super) fn try_lower_simple_dict_literal_expr(
     keys: &[HirExpr],
     values: &[HirExpr],
-    _ty: &Type,
+    ty: &Type,
 ) -> Option<RustExpr> {
     if keys.len() != values.len() {
         return None;
@@ -88,6 +90,21 @@ pub(super) fn try_lower_simple_dict_literal_expr(
     for (key, value) in keys.iter().zip(values.iter()) {
         let lowered_key = try_lower_leaf_or_name_expr(key)?;
         let lowered_value = try_lower_leaf_or_name_expr(value)?;
+        let (lowered_key, lowered_value) = match resolve_alias_type(ty) {
+            Type::Dict(key_ty, value_ty) => (
+                crate::helpers::adapt_collection_value_for_target(
+                    key_ty.as_ref(),
+                    key,
+                    lowered_key,
+                ),
+                crate::helpers::adapt_collection_value_for_target(
+                    value_ty.as_ref(),
+                    value,
+                    lowered_value,
+                ),
+            ),
+            _ => (lowered_key, lowered_value),
+        };
         entries.push(RustExpr::Tuple(vec![lowered_key, lowered_value]));
     }
 
@@ -102,14 +119,21 @@ pub(super) fn try_lower_simple_dict_literal_expr(
 
 pub(super) fn try_lower_simple_set_literal_expr(
     elements: &[HirExpr],
-    _ty: &Type,
+    ty: &Type,
 ) -> Option<RustExpr> {
     let mut lowered_elements = Vec::with_capacity(elements.len());
     for element in elements {
         let lowered = try_lower_leaf_or_name_expr(element)?;
-        lowered_elements.push(crate::RustEmitter::clone_non_copy_name_expr_for_ir(
-            element, lowered,
-        ));
+        let lowered = crate::RustEmitter::clone_non_copy_name_expr_for_ir(element, lowered);
+        let lowered = match resolve_alias_type(ty) {
+            Type::Set(element_ty) => crate::helpers::adapt_collection_value_for_target(
+                element_ty.as_ref(),
+                element,
+                lowered,
+            ),
+            _ => lowered,
+        };
+        lowered_elements.push(lowered);
     }
 
     Some(RustExpr::FnCall {
@@ -131,10 +155,19 @@ pub(super) fn try_lower_simple_list_comp_expr(
     }
 
     let result_ident = "__sifr_list_comp".to_string();
+    let lowered_expr = try_lower_leaf_or_name_expr(expr)?;
+    let lowered_expr = match resolve_alias_type(ty) {
+        Type::List(element_ty) => crate::helpers::adapt_collection_value_for_target(
+            element_ty.as_ref(),
+            expr,
+            lowered_expr,
+        ),
+        _ => lowered_expr,
+    };
     let mut nested_body = vec![RustStmt::Expr(RustExpr::MethodCall {
         receiver: Box::new(RustExpr::Ident(result_ident.clone())),
         method: "push".to_string(),
-        args: vec![try_lower_leaf_or_name_expr(expr)?],
+        args: vec![lowered_expr],
     })];
 
     for (var, iter_expr, maybe_filter) in generators.iter().rev() {
@@ -190,13 +223,27 @@ pub(super) fn try_lower_simple_dict_comp_expr(
     let iter = try_lower_simple_iter_source_expr(iter_expr)?;
 
     let result_ident = "__sifr_dict_comp".to_string();
+    let lowered_key = try_lower_leaf_or_name_expr(key_expr)?;
+    let lowered_value = try_lower_leaf_or_name_expr(val_expr)?;
+    let (lowered_key, lowered_value) = match resolve_alias_type(ty) {
+        Type::Dict(key_ty, value_ty) => (
+            crate::helpers::adapt_collection_value_for_target(
+                key_ty.as_ref(),
+                key_expr,
+                lowered_key,
+            ),
+            crate::helpers::adapt_collection_value_for_target(
+                value_ty.as_ref(),
+                val_expr,
+                lowered_value,
+            ),
+        ),
+        _ => (lowered_key, lowered_value),
+    };
     let insert_stmt = RustStmt::Expr(RustExpr::MethodCall {
         receiver: Box::new(RustExpr::Ident(result_ident.clone())),
         method: "insert".to_string(),
-        args: vec![
-            try_lower_leaf_or_name_expr(key_expr)?,
-            try_lower_leaf_or_name_expr(val_expr)?,
-        ],
+        args: vec![lowered_key, lowered_value],
     });
 
     let loop_body = if let Some(filter) = maybe_filter {
@@ -252,10 +299,19 @@ pub(super) fn try_lower_simple_set_comp_expr(
     let iter = try_lower_simple_iter_source_expr(iter_expr)?;
 
     let result_ident = "__sifr_set_comp".to_string();
+    let lowered_expr = try_lower_leaf_or_name_expr(expr)?;
+    let lowered_expr = match resolve_alias_type(ty) {
+        Type::Set(element_ty) => crate::helpers::adapt_collection_value_for_target(
+            element_ty.as_ref(),
+            expr,
+            lowered_expr,
+        ),
+        _ => lowered_expr,
+    };
     let insert_stmt = RustStmt::Expr(RustExpr::MethodCall {
         receiver: Box::new(RustExpr::Ident(result_ident.clone())),
         method: "insert".to_string(),
-        args: vec![try_lower_leaf_or_name_expr(expr)?],
+        args: vec![lowered_expr],
     });
 
     let loop_body = if let Some(filter) = maybe_filter {
@@ -461,13 +517,7 @@ pub(super) fn is_enum_like_simple(ty: &Type) -> bool {
 }
 
 pub(super) fn is_option_like_simple(ty: &Type) -> bool {
-    if let Type::Union(members) = resolve_alias_type(ty) {
-        let non_none = members.iter().filter(|m| !matches!(m, Type::None)).count();
-        let has_none = members.iter().any(|m| matches!(m, Type::None));
-        has_none && non_none == 1
-    } else {
-        false
-    }
+    ty.optional_member_type().is_some()
 }
 
 pub(super) fn detect_is_some_guard_name(expr: &HirExpr) -> Option<String> {
@@ -768,57 +818,6 @@ pub(super) fn try_lower_guarded_option_compare_expr(
         op: normalized_op.to_string(),
         right: Box::new(lowered_right),
     })
-}
-
-pub(super) fn try_lower_simple_range_operand_expr(expr: &HirExpr) -> Option<RustExpr> {
-    if let HirExpr::Name { name, ty, .. } = expr {
-        if is_int_like_simple(ty) {
-            return Some(RustExpr::Ident(name.clone()));
-        }
-        return None;
-    }
-    if matches!(expr, HirExpr::RangeLiteral { .. }) {
-        return None;
-    }
-    try_lower_leaf_expr(expr)
-}
-
-pub(super) fn try_lower_mixed_float_operand_expr(expr: &HirExpr) -> Option<RustExpr> {
-    let lowered = try_lower_simple_binop_operand_expr(expr)?;
-    if is_int_like_simple(expr.ty()) {
-        return Some(RustExpr::Cast {
-            expr: Box::new(lowered),
-            ty: RustType::F64,
-        });
-    }
-    Some(lowered)
-}
-
-pub(super) fn try_lower_promoted_integer_operand_expr(expr: &HirExpr) -> Option<RustExpr> {
-    let lowered = match expr {
-        HirExpr::Name { name, ty, .. }
-            if is_int_like_simple(ty) || is_fixed_width_int_like_simple(ty) =>
-        {
-            RustExpr::Ident(name.clone())
-        }
-        _ => try_lower_simple_binop_operand_expr(expr)?,
-    };
-    if is_fixed_width_int_like_simple(expr.ty()) {
-        return Some(RustExpr::Cast {
-            expr: Box::new(lowered),
-            ty: RustType::I64,
-        });
-    }
-    Some(lowered)
-}
-
-pub(super) fn try_lower_simple_binop_operand_expr(expr: &HirExpr) -> Option<RustExpr> {
-    if let HirExpr::Name { name, ty, .. } = expr {
-        if is_numeric_simple(ty) {
-            return Some(RustExpr::Ident(name.clone()));
-        }
-    }
-    try_lower_leaf_expr(expr)
 }
 
 pub(super) fn try_lower_simple_compare_operand_expr(expr: &HirExpr) -> Option<RustExpr> {

--- a/crates/sifr_codegen/src/lower_expr/iterators_and_callables.rs
+++ b/crates/sifr_codegen/src/lower_expr/iterators_and_callables.rs
@@ -259,6 +259,7 @@ pub(super) fn adapt_simple_map_callable_arg(
 ) -> RustExpr {
     let resolved_param = resolve_alias_type(param_ty);
     let arg_is_option = is_option_like_simple(arg_ty);
+    lowered_arg = crate::helpers::flatten_option_value_for_target(param_ty, arg_ty, lowered_arg);
     if is_option_like_simple(resolved_param) && !arg_is_option {
         lowered_arg = RustExpr::FnCall {
             func: Box::new(RustExpr::Path(vec!["Some".to_string()])),

--- a/crates/sifr_codegen/src/lower_expr/leaves_and_plain_calls.rs
+++ b/crates/sifr_codegen/src/lower_expr/leaves_and_plain_calls.rs
@@ -353,7 +353,17 @@ pub fn try_lower_leaf_expr(expr: &HirExpr) -> Option<RustExpr> {
                 .iter()
                 .map(|element| {
                     try_lower_leaf_expr(element).map(|lowered| {
-                        crate::RustEmitter::clone_non_copy_name_expr_for_ir(element, lowered)
+                        let lowered =
+                            crate::RustEmitter::clone_non_copy_name_expr_for_ir(element, lowered);
+                        if let Type::List(element_ty) = list_ty {
+                            crate::helpers::adapt_collection_value_for_target(
+                                element_ty.as_ref(),
+                                element,
+                                lowered,
+                            )
+                        } else {
+                            lowered
+                        }
                     })
                 })
                 .collect::<Option<Vec<_>>>()?;

--- a/crates/sifr_codegen/src/lower_expr/scalar_operands.rs
+++ b/crates/sifr_codegen/src/lower_expr/scalar_operands.rs
@@ -1,0 +1,57 @@
+use super::{
+    collections_and_comprehensions::{
+        is_fixed_width_int_like_simple, is_int_like_simple, is_numeric_simple,
+    },
+    try_lower_leaf_expr, HirExpr, RustExpr, RustType,
+};
+
+pub(super) fn try_lower_simple_range_operand_expr(expr: &HirExpr) -> Option<RustExpr> {
+    if let HirExpr::Name { name, ty, .. } = expr {
+        if is_int_like_simple(ty) {
+            return Some(RustExpr::Ident(name.clone()));
+        }
+        return None;
+    }
+    if matches!(expr, HirExpr::RangeLiteral { .. }) {
+        return None;
+    }
+    try_lower_leaf_expr(expr)
+}
+
+pub(super) fn try_lower_mixed_float_operand_expr(expr: &HirExpr) -> Option<RustExpr> {
+    let lowered = try_lower_simple_binop_operand_expr(expr)?;
+    if is_int_like_simple(expr.ty()) {
+        return Some(RustExpr::Cast {
+            expr: Box::new(lowered),
+            ty: RustType::F64,
+        });
+    }
+    Some(lowered)
+}
+
+pub(super) fn try_lower_promoted_integer_operand_expr(expr: &HirExpr) -> Option<RustExpr> {
+    let lowered = match expr {
+        HirExpr::Name { name, ty, .. }
+            if is_int_like_simple(ty) || is_fixed_width_int_like_simple(ty) =>
+        {
+            RustExpr::Ident(name.clone())
+        }
+        _ => try_lower_simple_binop_operand_expr(expr)?,
+    };
+    if is_fixed_width_int_like_simple(expr.ty()) {
+        return Some(RustExpr::Cast {
+            expr: Box::new(lowered),
+            ty: RustType::I64,
+        });
+    }
+    Some(lowered)
+}
+
+pub(super) fn try_lower_simple_binop_operand_expr(expr: &HirExpr) -> Option<RustExpr> {
+    if let HirExpr::Name { name, ty, .. } = expr {
+        if is_numeric_simple(ty) {
+            return Some(RustExpr::Ident(name.clone()));
+        }
+    }
+    try_lower_leaf_expr(expr)
+}

--- a/crates/sifr_codegen/src/lower_stmt/condition_type_and_expr_helpers.rs
+++ b/crates/sifr_codegen/src/lower_stmt/condition_type_and_expr_helpers.rs
@@ -10,13 +10,7 @@ pub(super) fn resolve_alias_type(ty: &Type) -> &Type {
 }
 
 pub(super) fn is_option_like_type(ty: &Type) -> bool {
-    if let Type::Union(members) = resolve_alias_type(ty) {
-        let non_none = members.iter().filter(|m| !matches!(m, Type::None)).count();
-        let has_none = members.iter().any(|m| matches!(m, Type::None));
-        has_none && non_none == 1
-    } else {
-        false
-    }
+    ty.optional_member_type().is_some()
 }
 
 pub(super) fn detect_option_truthiness_alias(expr: &HirExpr) -> Option<String> {

--- a/crates/sifr_codegen/src/lower_stmt/loop_lowering.rs
+++ b/crates/sifr_codegen/src/lower_stmt/loop_lowering.rs
@@ -176,17 +176,7 @@ pub(super) fn try_lower_simple_for_iter_expr(iter: &HirExpr, target_ty: &Type) -
 
     fn class_has_next(methods: &[(String, FunctionType)]) -> bool {
         class_method_signature(methods, "__next__").is_some_and(|next_ft| {
-            next_ft.params.is_empty()
-                && matches!(next_ft.return_type.as_ref().resolve_alias(), Type::Union(members) if {
-                    let has_none = members
-                        .iter()
-                        .any(|member| matches!(member.resolve_alias(), Type::None));
-                    let non_none = members
-                        .iter()
-                        .filter(|member| !matches!(member.resolve_alias(), Type::None))
-                        .count();
-                    has_none && non_none == 1
-                })
+            next_ft.params.is_empty() && next_ft.return_type.optional_member_type().is_some()
         })
     }
 

--- a/crates/sifr_codegen/src/lower_stmt/return_and_assignment_values.rs
+++ b/crates/sifr_codegen/src/lower_stmt/return_and_assignment_values.rs
@@ -49,9 +49,13 @@ pub(super) fn try_lower_simple_return_stmt(
 
     if option_return {
         if is_option_like_type(value.ty()) && !is_none_type(value.ty()) {
-            return Some(vec![RustStmt::Return(Some(try_lower_name_ident_expr(
-                value,
-            )?))]);
+            let lowered = try_lower_name_ident_expr(value)?;
+            let lowered = crate::helpers::flatten_option_value_for_target(
+                ctx.return_type?,
+                value.ty(),
+                lowered,
+            );
+            return Some(vec![RustStmt::Return(Some(lowered))]);
         }
         if matches!(value, HirExpr::NoneLiteral) {
             return Some(vec![RustStmt::Return(Some(RustExpr::Literal(
@@ -117,11 +121,24 @@ pub(super) fn try_lower_simple_let_value(ty: &Type, value: &HirExpr) -> Option<R
     if let Some(lowered) = crate::fixed_width_literal_expr_for_target(ty, value) {
         return Some(lowered);
     }
+    if is_option_like_type(value.ty()) {
+        let lowered = try_lower_name_ident_expr(value)?;
+        let adapted =
+            crate::helpers::flatten_option_value_for_target(ty, value.ty(), lowered.clone());
+        if adapted != lowered {
+            return Some(adapted);
+        }
+    }
     if is_option_like_type(ty) && matches!(value, HirExpr::NoneLiteral) {
         return Some(RustExpr::Literal(RustLiteral::None));
     }
     if is_option_like_type(ty) && is_option_like_type(value.ty()) && !is_none_type(value.ty()) {
-        return try_lower_name_ident_expr(value);
+        let lowered = try_lower_name_ident_expr(value)?;
+        return Some(crate::helpers::flatten_option_value_for_target(
+            ty,
+            value.ty(),
+            lowered,
+        ));
     }
     if is_option_like_type(ty) && !is_option_like_type(value.ty()) && !is_none_type(value.ty()) {
         return Some(RustExpr::FnCall {
@@ -155,7 +172,12 @@ pub(super) fn try_lower_simple_let_value(ty: &Type, value: &HirExpr) -> Option<R
     if !is_alias_equivalent_type(ty, value.ty()) {
         return None;
     }
-    try_lower_leaf_or_name_expr(value)
+    let lowered = try_lower_leaf_or_name_expr(value)?;
+    Some(crate::helpers::adapt_collection_storage_for_target(
+        ty,
+        value.ty(),
+        lowered,
+    ))
 }
 
 fn value_requires_consuming_class_upcast(target: &Type, value: &HirExpr) -> bool {

--- a/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
+++ b/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
@@ -388,6 +388,14 @@ pub(super) fn coerce_simple_assign_value_for_target_type(
     let Some(target_ty) = target_ty else {
         return lowered_value;
     };
+    let adapted_value = crate::helpers::flatten_option_value_for_target(
+        target_ty,
+        value.ty(),
+        lowered_value.clone(),
+    );
+    if adapted_value != lowered_value {
+        return adapted_value;
+    }
     if !crate::helpers::is_option_type(target_ty) {
         return lowered_value;
     }
@@ -395,7 +403,11 @@ pub(super) fn coerce_simple_assign_value_for_target_type(
         return RustExpr::Literal(RustLiteral::None);
     }
     if crate::helpers::is_option_type(value.ty()) {
-        return lowered_value;
+        return crate::helpers::flatten_option_value_for_target(
+            target_ty,
+            value.ty(),
+            lowered_value,
+        );
     }
     RustExpr::FnCall {
         func: Box::new(RustExpr::Path(vec!["Some".to_string()])),

--- a/crates/sifr_codegen/src/lower_stmt/subscript_assignment.rs
+++ b/crates/sifr_codegen/src/lower_stmt/subscript_assignment.rs
@@ -111,15 +111,23 @@ pub(super) fn try_lower_simple_subscript_assign_stmt(
     let lowered_value =
         maybe_clone_subscript_assignment_name(value, try_lower_leaf_or_name_expr(value)?);
     match resolve_alias_type(object_ty) {
-        Type::List(_) => Some(vec![build_list_subscript_assign_stmt(
+        Type::List(element_ty) => Some(vec![build_list_subscript_assign_stmt(
             RustExpr::Ident(object.to_string()),
             lowered_index,
-            lowered_value,
+            crate::helpers::flatten_option_value_for_target(
+                element_ty.as_ref(),
+                value.ty(),
+                lowered_value,
+            ),
         )]),
-        Type::Dict(_, _) => Some(vec![build_dict_subscript_assign_stmt(
+        Type::Dict(_, value_ty) => Some(vec![build_dict_subscript_assign_stmt(
             RustExpr::Ident(object.to_string()),
             lowered_index,
-            lowered_value,
+            crate::helpers::flatten_option_value_for_target(
+                value_ty.as_ref(),
+                value.ty(),
+                lowered_value,
+            ),
         )]),
         _ => None,
     }
@@ -238,22 +246,30 @@ pub(super) fn try_lower_simple_nested_subscript_assign_stmt(
     let inner_index_is_option = is_option_like_type(inner_index.ty());
     let target_elem_is_option = is_option_like_type(target_elem_ty);
     let lowered_value = try_lower_leaf_or_name_expr(value)?;
-    let assign_elem_stmt = if is_option_like_type(value.ty()) && !target_elem_is_option {
-        RustStmt::IfLet {
-            pattern: "Some(__nested_assign_value)".to_string(),
-            expr: lowered_value,
-            then_body: vec![RustStmt::Assign {
+    let adapted_value = crate::helpers::flatten_option_value_for_target(
+        target_elem_ty,
+        value.ty(),
+        lowered_value.clone(),
+    );
+    let option_value_adapted = adapted_value != lowered_value;
+    let lowered_value = adapted_value;
+    let assign_elem_stmt =
+        if is_option_like_type(value.ty()) && !target_elem_is_option && !option_value_adapted {
+            RustStmt::IfLet {
+                pattern: "Some(__nested_assign_value)".to_string(),
+                expr: lowered_value,
+                then_body: vec![RustStmt::Assign {
+                    target: RustExpr::Deref(Box::new(RustExpr::Ident("__elem".to_string()))),
+                    value: RustExpr::Ident("__nested_assign_value".to_string()),
+                }],
+                else_body: None,
+            }
+        } else {
+            RustStmt::Assign {
                 target: RustExpr::Deref(Box::new(RustExpr::Ident("__elem".to_string()))),
-                value: RustExpr::Ident("__nested_assign_value".to_string()),
-            }],
-            else_body: None,
-        }
-    } else {
-        RustStmt::Assign {
-            target: RustExpr::Deref(Box::new(RustExpr::Ident("__elem".to_string()))),
-            value: lowered_value,
-        }
-    };
+                value: lowered_value,
+            }
+        };
 
     let mut inner_then_body = vec![RustStmt::Let {
         mutable: false,
@@ -378,24 +394,30 @@ pub(super) fn try_lower_simple_attribute_subscript_assign_stmt(
     value: &HirExpr,
     field_ty: &Type,
 ) -> Option<Vec<RustStmt>> {
-    let lowered_value = try_lower_leaf_or_name_expr(value)?;
-
     match resolve_alias_type(field_ty) {
-        Type::List(_) => Some(vec![build_list_subscript_assign_stmt(
+        Type::List(element_ty) => Some(vec![build_list_subscript_assign_stmt(
             RustExpr::Field {
                 expr: Box::new(RustExpr::Ident(object.to_string())),
                 field: field.to_string(),
             },
             try_lower_leaf_or_name_expr(index)?,
-            lowered_value,
+            crate::helpers::flatten_option_value_for_target(
+                element_ty.as_ref(),
+                value.ty(),
+                try_lower_leaf_or_name_expr(value)?,
+            ),
         )]),
-        Type::Dict(_, _) => Some(vec![build_dict_subscript_assign_stmt(
+        Type::Dict(_, value_ty) => Some(vec![build_dict_subscript_assign_stmt(
             RustExpr::Field {
                 expr: Box::new(RustExpr::Ident(object.to_string())),
                 field: field.to_string(),
             },
             try_lower_attribute_dict_insert_key_expr(index, field_ty)?,
-            lowered_value,
+            crate::helpers::flatten_option_value_for_target(
+                value_ty.as_ref(),
+                value.ty(),
+                try_lower_leaf_or_name_expr(value)?,
+            ),
         )]),
         _ => None,
     }
@@ -421,22 +443,30 @@ pub(super) fn try_lower_simple_attribute_nested_subscript_assign_stmt(
     let inner_index_is_option = is_option_like_type(inner_index.ty());
     let target_elem_is_option = is_option_like_type(target_elem_ty);
     let lowered_value = try_lower_leaf_or_name_expr(value)?;
-    let assign_elem_stmt = if is_option_like_type(value.ty()) && !target_elem_is_option {
-        RustStmt::IfLet {
-            pattern: "Some(__nested_assign_value)".to_string(),
-            expr: lowered_value,
-            then_body: vec![RustStmt::Assign {
+    let adapted_value = crate::helpers::flatten_option_value_for_target(
+        target_elem_ty,
+        value.ty(),
+        lowered_value.clone(),
+    );
+    let option_value_adapted = adapted_value != lowered_value;
+    let lowered_value = adapted_value;
+    let assign_elem_stmt =
+        if is_option_like_type(value.ty()) && !target_elem_is_option && !option_value_adapted {
+            RustStmt::IfLet {
+                pattern: "Some(__nested_assign_value)".to_string(),
+                expr: lowered_value,
+                then_body: vec![RustStmt::Assign {
+                    target: RustExpr::Deref(Box::new(RustExpr::Ident("__elem".to_string()))),
+                    value: RustExpr::Ident("__nested_assign_value".to_string()),
+                }],
+                else_body: None,
+            }
+        } else {
+            RustStmt::Assign {
                 target: RustExpr::Deref(Box::new(RustExpr::Ident("__elem".to_string()))),
-                value: RustExpr::Ident("__nested_assign_value".to_string()),
-            }],
-            else_body: None,
-        }
-    } else {
-        RustStmt::Assign {
-            target: RustExpr::Deref(Box::new(RustExpr::Ident("__elem".to_string()))),
-            value: lowered_value,
-        }
-    };
+                value: lowered_value,
+            }
+        };
     let receiver = || RustExpr::Field {
         expr: Box::new(RustExpr::Ident(object.to_string())),
         field: field.to_string(),

--- a/crates/sifr_codegen/src/methods/mod.rs
+++ b/crates/sifr_codegen/src/methods/mod.rs
@@ -106,8 +106,10 @@ pub(crate) fn lower_method_with_context(
         (Type::List(_), "appendleft") if is_deque_data_field => {
             deque::lower_appendleft(object, args)
         }
-        (Type::List(_), "pop") if is_deque_data_field => deque::lower_pop(object, args),
-        (Type::List(_), "popleft") if is_deque_data_field => deque::lower_popleft(object, args),
+        (Type::List(elem), "pop") if is_deque_data_field => deque::lower_pop(object, args)
+            .map(|expr| crate::helpers::normalize_safe_option_result(elem, expr)),
+        (Type::List(elem), "popleft") if is_deque_data_field => deque::lower_popleft(object, args)
+            .map(|expr| crate::helpers::normalize_safe_option_result(elem, expr)),
         (Type::List(_), "append") => list::lower_append(object, args),
         (Type::List(_), "extend") => list::lower_extend(object, args),
         (Type::List(_), "insert") => list::lower_insert(object, args),
@@ -117,7 +119,8 @@ pub(crate) fn lower_method_with_context(
         (Type::List(_), "sort") => list::lower_sort(object, args),
         (Type::List(_), "count") => list::lower_count(object, args),
         (Type::List(_), "contains") => list::lower_contains(object, args),
-        (Type::List(_), "pop") => list::lower_pop(object, args),
+        (Type::List(elem), "pop") => list::lower_pop(object, args)
+            .map(|expr| crate::helpers::normalize_safe_option_result(elem, expr)),
         (Type::List(_), "remove") => list::lower_remove(object, args),
         (Type::List(_), "index") => list::lower_index(object, args),
         (Type::Bytes, "count") => bytes::lower_count(object, args),
@@ -143,8 +146,20 @@ pub(crate) fn lower_method_with_context(
         (Type::Dict(_, _), "clear") => dict::lower_clear(object, args),
         (Type::Dict(_, _), "copy") => dict::lower_copy(object, args),
         (Type::Dict(_, _), "contains") => dict::lower_contains(object, args),
-        (Type::Dict(_, _), "get") => dict::lower_get(object, args),
-        (Type::Dict(_, _), "pop") => dict::lower_pop(object, args),
+        (Type::Dict(_, value), "get") => dict::lower_get(object, args).map(|expr| {
+            if args.len() == 1 {
+                crate::helpers::normalize_safe_option_result(value, expr)
+            } else {
+                expr
+            }
+        }),
+        (Type::Dict(_, value), "pop") => dict::lower_pop(object, args).map(|expr| {
+            if args.len() == 1 {
+                crate::helpers::normalize_safe_option_result(value, expr)
+            } else {
+                expr
+            }
+        }),
         (Type::Dict(_, _), "setdefault") => dict::lower_setdefault(object, args),
         (Type::Set(_), "add") => set::lower_add(object, args),
         (Type::Set(_), "remove") => set::lower_remove(object, args),
@@ -155,7 +170,8 @@ pub(crate) fn lower_method_with_context(
         (Type::Set(_), "issubset") => set::lower_issubset(object, args),
         (Type::Set(_), "issuperset") => set::lower_issuperset(object, args),
         (Type::Set(_), "isdisjoint") => set::lower_isdisjoint(object, args),
-        (Type::Set(_), "pop") => set::lower_pop(object, args),
+        (Type::Set(elem), "pop") => set::lower_pop(object, args)
+            .map(|expr| crate::helpers::normalize_safe_option_result(elem, expr)),
         (Type::Set(_), "union") => set::lower_union(object, args),
         (Type::Set(_), "intersection") => set::lower_intersection(object, args),
         (Type::Set(_), "difference") => set::lower_difference(object, args),
@@ -675,6 +691,44 @@ mod tests {
         assert!(rendered.contains("if desc"));
         assert!(rendered.contains("xs.sort()"));
         assert!(rendered.contains("xs.reverse()"));
+    }
+
+    #[test]
+    fn safe_collection_methods_flatten_optional_payload_absence() {
+        let optional_string = Type::Union(vec![Type::Str, Type::None]);
+
+        let list_pop = lower_method(
+            &Type::List(Box::new(optional_string.clone())),
+            "pop",
+            "values",
+            &[],
+        )
+        .expect("optional list pop lowers");
+        assert_eq!(render_expr(&list_pop.expr), "(values.pop()).flatten()");
+
+        let dict_get = lower_method(
+            &Type::Dict(Box::new(Type::Str), Box::new(optional_string.clone())),
+            "get",
+            "values",
+            &["key".to_string()],
+        )
+        .expect("optional dict get lowers");
+        assert_eq!(
+            render_expr(&dict_get.expr),
+            "(values.get(&key).cloned()).flatten()"
+        );
+
+        let dict_pop = lower_method(
+            &Type::Dict(Box::new(Type::Str), Box::new(optional_string)),
+            "pop",
+            "values",
+            &["key".to_string()],
+        )
+        .expect("optional dict pop lowers");
+        assert_eq!(
+            render_expr(&dict_pop.expr),
+            "(values.remove(&key)).flatten()"
+        );
     }
 
     #[test]

--- a/crates/sifr_codegen/src/operator_protocol_emitters.rs
+++ b/crates/sifr_codegen/src/operator_protocol_emitters.rs
@@ -675,12 +675,7 @@ impl RustEmitter {
     }
 
     pub(crate) fn is_option_like_for_operator(ty: &Type) -> bool {
-        if let Type::Union(members) = Self::resolve_alias_type_for_operator_loop_iter(ty) {
-            let non_none = members.iter().filter(|m| !matches!(m, Type::None)).count();
-            let has_none = members.iter().any(|m| matches!(m, Type::None));
-            return has_none && non_none == 1;
-        }
-        false
+        ty.optional_member_type().is_some()
     }
 
     pub(crate) fn resolve_alias_type_for_operator_loop_iter(ty: &Type) -> &Type {

--- a/crates/sifr_codegen/src/option_binding_mutability.rs
+++ b/crates/sifr_codegen/src/option_binding_mutability.rs
@@ -21,7 +21,7 @@ pub(crate) fn option_binding_requires_mut(
     let Some(inner_ty) = option_inner_type(option_ty) else {
         return false;
     };
-    let Type::Class { name, .. } = crate::resolve_alias_type_for_plain_call(inner_ty) else {
+    let Type::Class { name, .. } = crate::resolve_alias_type_for_plain_call(&inner_ty) else {
         return false;
     };
     recursive_fields
@@ -29,20 +29,6 @@ pub(crate) fn option_binding_requires_mut(
         .any(|(class_name, _)| class_name == name)
 }
 
-fn option_inner_type(ty: &Type) -> Option<&Type> {
-    let Type::Union(members) = crate::resolve_alias_type_for_plain_call(ty) else {
-        return None;
-    };
-    let mut non_none = members
-        .iter()
-        .filter(|member| !matches!(crate::resolve_alias_type_for_plain_call(member), Type::None));
-    let inner = non_none.next()?;
-    if non_none.next().is_some()
-        || !members
-            .iter()
-            .any(|member| matches!(crate::resolve_alias_type_for_plain_call(member), Type::None))
-    {
-        return None;
-    }
-    Some(inner)
+fn option_inner_type(ty: &Type) -> Option<Type> {
+    ty.optional_member_type()
 }

--- a/crates/sifr_codegen/src/preamble/types_and_errors.rs
+++ b/crates/sifr_codegen/src/preamble/types_and_errors.rs
@@ -82,14 +82,9 @@ pub fn sifr_type_to_rust_type(ty: &Type) -> RustType {
                 task_error_type_to_rust_type(err),
             ],
         },
-        Type::Union(members) => {
-            let non_none: Vec<&Type> = members
-                .iter()
-                .filter(|m| !matches!(m, Type::None))
-                .collect();
-            let has_none = members.iter().any(|m| matches!(m, Type::None));
-            if has_none && non_none.len() == 1 {
-                RustType::Option(Box::new(sifr_type_to_rust_type(non_none[0])))
+        Type::Union(_) => {
+            if let Some(member) = ty.optional_member_type() {
+                RustType::Option(Box::new(sifr_type_to_rust_type(&member)))
             } else {
                 RustType::Named(ty.rust_type())
             }

--- a/crates/sifr_codegen/src/project_stdlib_nominals.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals.rs
@@ -1,18 +1,23 @@
-use crate::stdlib_filter::strip_rust_items_by_name;
+use crate::stdlib_filter::{
+    partition_rust_items_by_name, rust_source_defines_item_name, rust_source_references_item_name,
+    strip_rust_items_by_name,
+};
 use crate::{
     build_error_into_error_impl, generate_rust_with_stdlib_for_module_with_structural_policy,
     publicize_generated_module_source, HirModule, Renderer, RustFile, StdlibCode,
 };
 use sifr_ir::{HirExpr, HirFunction, HirImport, HirStmt, MethodKind};
 use sifr_stdlib_manifest::StdlibFeature;
-use sifr_type_system::{class_rust_name, is_global_rust_nominal_identity, FunctionType, Type};
+use sifr_type_system::{class_rust_name, is_crate_root_rust_nominal_identity, FunctionType, Type};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 const SHARED_STDLIB_NOMINAL_MODULE: &str = "__sifr_project_nominals";
+const SHARED_MODULE_CRATE_ROOT_NOMINAL_IDENTITIES: &[&str] = &["_sifr.fs.NativeFileHandle"];
 
 pub(crate) struct ProjectStdlibNominalPlan {
     pub(crate) prelude: String,
     pub(crate) rust_names: HashSet<String>,
+    pub(crate) crate_root_rust_names: HashSet<String>,
     pub(crate) nominal_paths: HashMap<String, String>,
     pub(crate) used_stdlib_modules: HashSet<String>,
     pub(crate) required_features: HashSet<StdlibFeature>,
@@ -23,6 +28,7 @@ impl ProjectStdlibNominalPlan {
         Self {
             prelude: String::new(),
             rust_names: HashSet::new(),
+            crate_root_rust_names: HashSet::new(),
             nominal_paths: HashMap::new(),
             used_stdlib_modules: HashSet::new(),
             required_features: HashSet::new(),
@@ -39,16 +45,25 @@ pub(crate) fn relocate_project_stdlib_nominals(
     if plan.rust_names.is_empty() {
         return source.to_string();
     }
-    let names = plan.rust_names.iter().map(String::as_str).collect();
+    let names = plan
+        .rust_names
+        .iter()
+        .chain(&plan.crate_root_rust_names)
+        .map(String::as_str)
+        .collect();
     let stripped = strip_rust_items_by_name(source, &names);
     if crate_root_modules.contains(module_name) {
         return stripped;
     }
-    let mut ordered_names = plan.rust_names.iter().collect::<Vec<_>>();
+    let mut ordered_names = plan
+        .rust_names
+        .iter()
+        .chain(&plan.crate_root_rust_names)
+        .collect::<Vec<_>>();
     ordered_names.sort();
     let mut imports = String::new();
     for name in ordered_names {
-        if !stripped.contains(name) {
+        if !rust_source_references_item_name(&stripped, name) {
             continue;
         }
         imports.push_str("use crate::");
@@ -158,6 +173,25 @@ pub(crate) fn project_stdlib_nominal_plan(
     );
     let probe_name_refs = probe_names.iter().map(String::as_str).collect();
     let shared_source = strip_rust_items_by_name(&generated.rust_source, &probe_name_refs);
+    let crate_root_candidates = SHARED_MODULE_CRATE_ROOT_NOMINAL_IDENTITIES
+        .iter()
+        .filter_map(|identity| {
+            identity
+                .rsplit_once('.')
+                .map(|(_, name)| class_rust_name(Some(identity), name))
+        })
+        .collect::<HashSet<_>>();
+    let crate_root_name_refs = crate_root_candidates
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let (crate_root_source, shared_source) =
+        partition_rust_items_by_name(&shared_source, &crate_root_name_refs);
+    let crate_root_rust_names = crate_root_candidates
+        .into_iter()
+        .filter(|name| rust_source_defines_item_name(&crate_root_source, name))
+        .collect::<HashSet<_>>();
+    let crate_root_source = publicize_generated_module_source(&crate_root_source);
     let mut shared_source = publicize_generated_module_source(&shared_source);
     if !python_error_rust_names.is_empty() {
         let mut names = python_error_rust_names.into_iter().collect::<Vec<_>>();
@@ -168,7 +202,23 @@ pub(crate) fn project_stdlib_nominal_plan(
             .collect();
         shared_source.push_str(&Renderer::new().render_file(&RustFile { items }));
     }
-    let mut prelude = format!("mod {SHARED_STDLIB_NOMINAL_MODULE} {{\n");
+    let mut prelude = crate_root_source;
+    if !prelude.is_empty() {
+        prelude.push('\n');
+    }
+    prelude.push_str("mod ");
+    prelude.push_str(SHARED_STDLIB_NOMINAL_MODULE);
+    prelude.push_str(" {\n");
+    let mut crate_root_imports = crate_root_rust_names
+        .iter()
+        .filter(|name| rust_source_references_item_name(&shared_source, name))
+        .collect::<Vec<_>>();
+    crate_root_imports.sort();
+    for name in crate_root_imports {
+        prelude.push_str("    use crate::");
+        prelude.push_str(name);
+        prelude.push_str(";\n");
+    }
     for line in shared_source.lines() {
         prelude.push_str("    ");
         prelude.push_str(line);
@@ -188,6 +238,7 @@ pub(crate) fn project_stdlib_nominal_plan(
     ProjectStdlibNominalPlan {
         prelude,
         rust_names,
+        crate_root_rust_names,
         nominal_paths,
         used_stdlib_modules: generated.used_stdlib_modules,
         required_features: generated.required_features,
@@ -293,7 +344,7 @@ fn collect_nominal_identity(
     let Some(identity) = identity else {
         return;
     };
-    if is_global_rust_nominal_identity(identity)
+    if is_crate_root_rust_nominal_identity(identity)
         || (!identity.starts_with("sifr.") && !identity.starts_with("_sifr."))
     {
         return;
@@ -308,4 +359,44 @@ fn collect_nominal_identity(
         .entry(module.to_string())
         .or_default()
         .insert(name.to_string());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_error_union_keeps_its_shared_module_definition() {
+        let timeout_error = Type::Class {
+            identity: Some("sifr.builtin.TimeoutError".to_string()),
+            type_args: Vec::new(),
+            name: "TimeoutError".to_string(),
+            fields: vec![("message".to_string(), Type::Str)],
+            methods: Vec::new(),
+            parent_class: Some("Error".to_string()),
+        };
+        let unions = HashMap::from([(
+            "TimeoutOrValueError".to_string(),
+            vec![
+                timeout_error,
+                Type::Class {
+                    identity: None,
+                    type_args: Vec::new(),
+                    name: "ValueError".to_string(),
+                    fields: vec![("message".to_string(), Type::Str)],
+                    methods: Vec::new(),
+                    parent_class: Some("Error".to_string()),
+                },
+            ],
+        )]);
+
+        let plan = project_stdlib_nominal_plan(&unions, &StdlibCode::default(), &[]);
+
+        assert!(plan.prelude.contains("pub struct TimeoutError"));
+        assert!(plan
+            .prelude
+            .contains("pub use __sifr_project_nominals::TimeoutError"));
+        assert!(!plan.prelude.contains("use crate::TimeoutError"));
+        assert!(plan.crate_root_rust_names.is_empty());
+    }
 }

--- a/crates/sifr_codegen/src/stdlib_filter/implementation.rs
+++ b/crates/sifr_codegen/src/stdlib_filter/implementation.rs
@@ -324,6 +324,43 @@ pub(crate) fn strip_rust_items_by_name(rust_code: &str, names: &HashSet<&str>) -
     render_items(&kept_items)
 }
 
+pub(crate) fn partition_rust_items_by_name(
+    rust_code: &str,
+    names: &HashSet<&str>,
+) -> (String, String) {
+    let Ok(parsed) = syn::parse_file(rust_code) else {
+        return (String::new(), rust_code.to_string());
+    };
+    let (selected, remaining): (Vec<_>, Vec<_>) = parsed.items.into_iter().partition(|item| {
+        parse_item_name(item)
+            .as_deref()
+            .is_some_and(|name| names.contains(name))
+    });
+    (render_items(&selected), render_items(&remaining))
+}
+
+pub(crate) fn rust_source_references_item_name(rust_code: &str, name: &str) -> bool {
+    let Ok(parsed) = syn::parse_file(rust_code) else {
+        return false;
+    };
+    let item_names = HashSet::from([name.to_string()]);
+    let global_types = HashSet::new();
+    parsed.items.iter().any(|item| {
+        let current_name = parse_item_name(item).unwrap_or_default();
+        referenced_item_names_via_ast(item, &item_names, &current_name, &global_types)
+            .contains(name)
+    })
+}
+
+pub(crate) fn rust_source_defines_item_name(rust_code: &str, name: &str) -> bool {
+    syn::parse_file(rust_code).is_ok_and(|parsed| {
+        parsed
+            .items
+            .iter()
+            .any(|item| parse_item_name(item).as_deref() == Some(name))
+    })
+}
+
 fn parse_stdlib_ir_file(rust_code: &str) -> Option<StdlibIrFile> {
     let Ok(parsed) = syn::parse_file(rust_code) else {
         return None;

--- a/crates/sifr_codegen/src/stdlib_filter/tests.rs
+++ b/crates/sifr_codegen/src/stdlib_filter/tests.rs
@@ -485,3 +485,41 @@ fn value() -> SifrInt { sifr_runtime::SifrInt::from_i64(1) }
     assert!(absolute.contains("impl ::sifr_runtime::python::PythonResourceIdentity"));
     assert!(absolute.contains("::sifr_runtime::SifrInt::from_i64"));
 }
+
+#[test]
+fn parsed_item_reference_detection_ignores_basename_substrings() {
+    let source = r#"
+struct MyTimeoutError {}
+struct Holder { value: __SifrIoNativeFileHandle }
+fn label() -> &'static str { "TimeoutError" }
+"#;
+
+    assert!(rust_source_references_item_name(
+        source,
+        "__SifrIoNativeFileHandle"
+    ));
+    assert!(!rust_source_references_item_name(source, "TimeoutError"));
+}
+
+#[test]
+fn item_partition_moves_only_exact_named_items() {
+    let source = r#"
+struct __SifrIoNativeFileHandle { value: i64 }
+impl __SifrIoNativeFileHandle { fn value(&self) -> i64 { self.value } }
+struct Holder { value: __SifrIoNativeFileHandle }
+"#;
+    let names = HashSet::from(["__SifrIoNativeFileHandle"]);
+
+    let (selected, remaining) = partition_rust_items_by_name(source, &names);
+
+    assert!(selected.contains("struct __SifrIoNativeFileHandle"));
+    assert!(selected.contains("impl __SifrIoNativeFileHandle"));
+    assert!(!selected.contains("struct Holder"));
+    assert!(remaining.contains("struct Holder"));
+    assert!(!remaining.contains("struct __SifrIoNativeFileHandle"));
+    assert!(rust_source_defines_item_name(
+        &selected,
+        "__SifrIoNativeFileHandle"
+    ));
+    assert!(!rust_source_defines_item_name(&selected, "Holder"));
+}

--- a/crates/sifr_codegen/src/stmt_support_emitter/await_and_async_comprehension.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/await_and_async_comprehension.rs
@@ -165,6 +165,10 @@ impl RustEmitter {
         }
         let lowered_value = self.consuming_value_upcast_for_ir(target_ty, value_ty, lowered_value);
         let lowered_value =
+            crate::helpers::flatten_option_value_for_target(target_ty, value_ty, lowered_value);
+        let lowered_value =
+            crate::helpers::adapt_collection_storage_for_target(target_ty, value_ty, lowered_value);
+        let lowered_value =
             Self::wrap_option_local_value_for_ir(target_ty, value, value_ty, lowered_value);
         if crate::helpers::is_option_type(target_ty) {
             return Ok(lowered_value);
@@ -249,15 +253,8 @@ impl RustEmitter {
         }
     }
 
-    pub(crate) fn option_inner_type_for_ir(ty: &Type) -> Option<&Type> {
-        let resolved = crate::resolve_alias_type_for_plain_call(ty);
-        let Type::Union(members) = resolved else {
-            return None;
-        };
-        if members.len() != 2 || !members.iter().any(|member| matches!(member, Type::None)) {
-            return None;
-        }
-        members.iter().find(|member| !matches!(member, Type::None))
+    pub(crate) fn option_inner_type_for_ir(ty: &Type) -> Option<Type> {
+        ty.optional_member_type()
     }
 
     pub(crate) fn collect_stmt_string_concat_parts_for_ir<'a>(
@@ -473,6 +470,7 @@ impl RustEmitter {
         &mut self,
         value_expr: &HirExpr,
         generators: &[(String, HirExpr, Option<HirExpr>)],
+        result_ty: &Type,
     ) -> Result<Option<RustExpr>, crate::CodegenError> {
         let Some((var, iter_expr, maybe_filter)) = generators.first() else {
             return Ok(None);
@@ -486,9 +484,16 @@ impl RustEmitter {
         let Some(lowered_iter) = self.lower_stmt_expr_for_ir(iter_expr)? else {
             return Ok(None);
         };
-        let Some(lowered_value) = self.lower_stmt_expr_for_ir(value_expr)? else {
+        let Some(mut lowered_value) = self.lower_stmt_expr_for_ir(value_expr)? else {
             return Ok(None);
         };
+        if let Type::List(element_ty) = Self::resolve_alias_type_for_loop_iter(result_ty) {
+            lowered_value = crate::helpers::adapt_collection_value_for_target(
+                element_ty.as_ref(),
+                value_expr,
+                lowered_value,
+            );
+        }
 
         let result_ident = "__sifr_async_list_comp".to_string();
         let iter_ident = "__sifr_async_list_iter".to_string();
@@ -573,6 +578,7 @@ impl RustEmitter {
         &mut self,
         value_expr: &HirExpr,
         generators: &[(String, HirExpr, Option<HirExpr>)],
+        result_ty: &Type,
     ) -> Result<Option<RustExpr>, crate::CodegenError> {
         let Some((var, iter_expr, maybe_filter)) = generators.first() else {
             return Ok(None);
@@ -586,9 +592,16 @@ impl RustEmitter {
         let Some(lowered_iter) = self.lower_stmt_expr_for_ir(iter_expr)? else {
             return Ok(None);
         };
-        let Some(lowered_value) = self.lower_stmt_expr_for_ir(value_expr)? else {
+        let Some(mut lowered_value) = self.lower_stmt_expr_for_ir(value_expr)? else {
             return Ok(None);
         };
+        if let Type::Set(element_ty) = Self::resolve_alias_type_for_loop_iter(result_ty) {
+            lowered_value = crate::helpers::adapt_collection_value_for_target(
+                element_ty.as_ref(),
+                value_expr,
+                lowered_value,
+            );
+        }
 
         let result_ident = "__sifr_async_set_comp".to_string();
         let iter_ident = "__sifr_async_set_iter".to_string();
@@ -680,6 +693,7 @@ impl RustEmitter {
         key_expr: &HirExpr,
         val_expr: &HirExpr,
         generators: &[(String, HirExpr, Option<HirExpr>)],
+        result_ty: &Type,
     ) -> Result<Option<RustExpr>, crate::CodegenError> {
         let Some((var, iter_expr, maybe_filter)) = generators.first() else {
             return Ok(None);
@@ -693,12 +707,24 @@ impl RustEmitter {
         let Some(lowered_iter) = self.lower_stmt_expr_for_ir(iter_expr)? else {
             return Ok(None);
         };
-        let Some(lowered_key) = self.lower_stmt_expr_for_ir(key_expr)? else {
+        let Some(mut lowered_key) = self.lower_stmt_expr_for_ir(key_expr)? else {
             return Ok(None);
         };
-        let Some(lowered_value) = self.lower_stmt_expr_for_ir(val_expr)? else {
+        let Some(mut lowered_value) = self.lower_stmt_expr_for_ir(val_expr)? else {
             return Ok(None);
         };
+        if let Type::Dict(key_ty, value_ty) = Self::resolve_alias_type_for_loop_iter(result_ty) {
+            lowered_key = crate::helpers::adapt_collection_value_for_target(
+                key_ty.as_ref(),
+                key_expr,
+                lowered_key,
+            );
+            lowered_value = crate::helpers::adapt_collection_value_for_target(
+                value_ty.as_ref(),
+                val_expr,
+                lowered_value,
+            );
+        }
 
         let result_ident = "__sifr_async_dict_comp".to_string();
         let iter_ident = "__sifr_async_dict_iter".to_string();

--- a/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
@@ -66,6 +66,16 @@ impl RustEmitter {
                     || self.mut_borrowed_params.contains(name)
                     || ty.rust_type().starts_with('&'));
 
+            let unadapted_option_arg = lowered_arg.clone();
+            lowered_arg = Self::flatten_option_argument_for_ir(
+                hir_arg,
+                param_ty,
+                &effective_arg_ty,
+                *convention,
+                lowered_arg,
+            );
+            let option_value_adapted = lowered_arg != unadapted_option_arg;
+
             if matches!(hir_arg, HirExpr::NoneLiteral)
                 && matches!(resolved_param, Type::None | Type::TypeVar(_))
             {
@@ -111,7 +121,7 @@ impl RustEmitter {
                         args: vec![wrapped_inner],
                     };
                 }
-            } else if arg_is_option {
+            } else if arg_is_option && !option_value_adapted {
                 if !crate::helpers::is_copy_type_for_codegen(&effective_arg_ty) {
                     lowered_arg = crate::RustExpr::MethodCall {
                         receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),

--- a/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
@@ -17,14 +17,14 @@ impl RustEmitter {
             if let Some(source_inner) = Self::option_inner_type_for_ir(source_ty) {
                 let value = crate::RustExpr::Ident("__sifr_option_value".to_string());
                 let converted =
-                    self.consuming_value_upcast_for_ir(target_inner, source_inner, value.clone());
+                    self.consuming_value_upcast_for_ir(&target_inner, &source_inner, value.clone());
                 if converted == value {
                     return lowered;
                 }
                 return map_value(lowered, "map", "__sifr_option_value", converted);
             }
             // The ordinary option adapter wraps the converted payload in Some.
-            return self.consuming_value_upcast_for_ir(target_inner, source_ty, lowered);
+            return self.consuming_value_upcast_for_ir(&target_inner, source_ty, lowered);
         }
 
         if let (Type::Result(source_ok, source_error), Type::Result(target_ok, target_error)) =
@@ -111,7 +111,8 @@ impl RustEmitter {
         source_ty: &Type,
         mut lowered: crate::RustExpr,
     ) -> crate::RustExpr {
-        let target_ty = Self::option_inner_type_for_ir(target_ty).unwrap_or(target_ty);
+        let target_inner = Self::option_inner_type_for_ir(target_ty);
+        let target_ty = target_inner.as_ref().unwrap_or(target_ty);
         let (
             Type::Class {
                 identity: source_identity,

--- a/crates/sifr_codegen/src/stmt_support_emitter/comprehension_exprs.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/comprehension_exprs.rs
@@ -20,13 +20,20 @@ impl RustEmitter {
                 if generators.iter().any(|(_, iter_expr, _)| {
                     Self::async_iterator_error_type_for_ir(iter_expr).is_some()
                 }) {
-                    return self.try_lower_async_list_comp_for_ir(expr, generators);
+                    return self.try_lower_async_list_comp_for_ir(expr, generators, ty);
                 }
 
                 let result_ident = "__sifr_list_comp".to_string();
-                let Some(lowered_expr) = self.lower_stmt_expr_for_ir(expr)? else {
+                let Some(mut lowered_expr) = self.lower_stmt_expr_for_ir(expr)? else {
                     return Ok(None);
                 };
+                if let Type::List(element_ty) = Self::resolve_alias_type_for_loop_iter(ty) {
+                    lowered_expr = crate::helpers::adapt_collection_value_for_target(
+                        element_ty.as_ref(),
+                        expr,
+                        lowered_expr,
+                    );
+                }
                 let mut nested_body = vec![RustStmt::Expr(RustExpr::MethodCall {
                     receiver: Box::new(RustExpr::Ident(result_ident.clone())),
                     method: "push".to_string(),
@@ -87,17 +94,30 @@ impl RustEmitter {
                     return Ok(None);
                 }
                 if Self::async_iterator_error_type_for_ir(iter_expr).is_some() {
-                    return self.try_lower_async_dict_comp_for_ir(key_expr, val_expr, generators);
+                    return self
+                        .try_lower_async_dict_comp_for_ir(key_expr, val_expr, generators, ty);
                 }
                 let Some(iter) = self.lower_comprehension_iter_for_ir(iter_expr)? else {
                     return Ok(None);
                 };
-                let Some(lowered_key) = self.lower_stmt_expr_for_ir(key_expr)? else {
+                let Some(mut lowered_key) = self.lower_stmt_expr_for_ir(key_expr)? else {
                     return Ok(None);
                 };
-                let Some(lowered_value) = self.lower_stmt_expr_for_ir(val_expr)? else {
+                let Some(mut lowered_value) = self.lower_stmt_expr_for_ir(val_expr)? else {
                     return Ok(None);
                 };
+                if let Type::Dict(key_ty, value_ty) = Self::resolve_alias_type_for_loop_iter(ty) {
+                    lowered_key = crate::helpers::adapt_collection_value_for_target(
+                        key_ty.as_ref(),
+                        key_expr,
+                        lowered_key,
+                    );
+                    lowered_value = crate::helpers::adapt_collection_value_for_target(
+                        value_ty.as_ref(),
+                        val_expr,
+                        lowered_value,
+                    );
+                }
 
                 let result_ident = "__sifr_dict_comp".to_string();
                 let insert_stmt = RustStmt::Expr(RustExpr::MethodCall {
@@ -159,14 +179,21 @@ impl RustEmitter {
                     return Ok(None);
                 }
                 if Self::async_iterator_error_type_for_ir(iter_expr).is_some() {
-                    return self.try_lower_async_set_comp_for_ir(expr, generators);
+                    return self.try_lower_async_set_comp_for_ir(expr, generators, ty);
                 }
                 let Some(iter) = self.lower_comprehension_iter_for_ir(iter_expr)? else {
                     return Ok(None);
                 };
-                let Some(lowered_expr) = self.lower_stmt_expr_for_ir(expr)? else {
+                let Some(mut lowered_expr) = self.lower_stmt_expr_for_ir(expr)? else {
                     return Ok(None);
                 };
+                if let Type::Set(element_ty) = Self::resolve_alias_type_for_loop_iter(ty) {
+                    lowered_expr = crate::helpers::adapt_collection_value_for_target(
+                        element_ty.as_ref(),
+                        expr,
+                        lowered_expr,
+                    );
+                }
 
                 let result_ident = "__sifr_set_comp".to_string();
                 let insert_stmt = RustStmt::Expr(RustExpr::MethodCall {

--- a/crates/sifr_codegen/src/stmt_support_emitter/condition_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/condition_lowering.rs
@@ -61,7 +61,7 @@ impl RustEmitter {
                 return Ok(None);
             };
             if matches!(
-                crate::resolve_alias_type_for_plain_call(option_inner_ty),
+                crate::resolve_alias_type_for_plain_call(&option_inner_ty),
                 Type::Bool | Type::LiteralBool(_)
             ) {
                 return Ok(Some(crate::RustExpr::MethodCall {
@@ -78,11 +78,11 @@ impl RustEmitter {
                 }));
             }
             if matches!(
-                crate::resolve_alias_type_for_plain_call(option_inner_ty),
+                crate::resolve_alias_type_for_plain_call(&option_inner_ty),
                 Type::Int | Type::LiteralInt(_) | Type::BigInt | Type::Float
             ) {
                 let Some(zero_literal) =
-                    Self::zero_literal_for_numeric_truthiness_type_for_ir(option_inner_ty)
+                    Self::zero_literal_for_numeric_truthiness_type_for_ir(&option_inner_ty)
                 else {
                     unreachable!("numeric Option truthiness guard must have a zero literal");
                 };

--- a/crates/sifr_codegen/src/stmt_support_emitter/expr_call_and_literal_helpers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/expr_call_and_literal_helpers.rs
@@ -399,6 +399,13 @@ macro_rules! stmt_expr_literals_and_calls {
                     lowered_element =
                         Self::clone_non_copy_name_expr_for_ir(element, lowered_element);
                 }
+                if let Type::List(element_ty) = list_ty {
+                    lowered_element = crate::helpers::adapt_collection_value_for_target(
+                        element_ty.as_ref(),
+                        element,
+                        lowered_element,
+                    );
+                }
                 if matches!(list_ty, Type::Bytes) {
                     lowered_element = crate::RustExpr::Cast {
                         expr: Box::new(lowered_element),
@@ -504,7 +511,7 @@ macro_rules! stmt_expr_literals_and_calls {
             }
             return Ok(Some(crate::RustExpr::Tuple(lowered_elements)));
         }
-        if let HirExpr::DictLiteral { keys, values, .. } = $expr {
+        if let HirExpr::DictLiteral { keys, values, ty } = $expr {
             if keys.len() != values.len() {
                 return Ok(None);
             }
@@ -522,12 +529,24 @@ macro_rules! stmt_expr_literals_and_calls {
                 },
             });
             for (key, value) in keys.iter().zip(values.iter()) {
-                let Some(lowered_key) = $emitter.lower_stmt_expr_for_ir(key)? else {
+                let Some(mut lowered_key) = $emitter.lower_stmt_expr_for_ir(key)? else {
                     return Ok(None);
                 };
-                let Some(lowered_value) = $emitter.lower_stmt_expr_for_ir(value)? else {
+                let Some(mut lowered_value) = $emitter.lower_stmt_expr_for_ir(value)? else {
                     return Ok(None);
                 };
+                if let Type::Dict(key_ty, value_ty) = crate::resolve_alias_type_for_plain_call(ty) {
+                    lowered_key = crate::helpers::adapt_collection_value_for_target(
+                        key_ty.as_ref(),
+                        key,
+                        lowered_key,
+                    );
+                    lowered_value = crate::helpers::adapt_collection_value_for_target(
+                        value_ty.as_ref(),
+                        value,
+                        lowered_value,
+                    );
+                }
                 stmts.push(crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::Ident("__dict".to_string())),
                     method: "insert".to_string(),
@@ -539,7 +558,7 @@ macro_rules! stmt_expr_literals_and_calls {
                 expr: Some(Box::new(crate::RustExpr::Ident("__dict".to_string()))),
             }));
         }
-        if let HirExpr::SetLiteral { elements, .. } = $expr {
+        if let HirExpr::SetLiteral { elements, ty } = $expr {
             let mut stmts = Vec::with_capacity(elements.len() + 1);
             stmts.push(crate::RustStmt::Let {
                 mutable: true,
@@ -554,9 +573,16 @@ macro_rules! stmt_expr_literals_and_calls {
                 },
             });
             for element in elements {
-                let Some(lowered_element) = $emitter.lower_stmt_expr_for_ir(element)? else {
+                let Some(mut lowered_element) = $emitter.lower_stmt_expr_for_ir(element)? else {
                     return Ok(None);
                 };
+                if let Type::Set(element_ty) = crate::resolve_alias_type_for_plain_call(ty) {
+                    lowered_element = crate::helpers::adapt_collection_value_for_target(
+                        element_ty.as_ref(),
+                        element,
+                        lowered_element,
+                    );
+                }
                 stmts.push(crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::Ident("__set".to_string())),
                     method: "insert".to_string(),
@@ -629,11 +655,17 @@ macro_rules! stmt_expr_literals_and_calls {
                 let Some(lowered_iterator) = $emitter.lower_stmt_expr_for_ir(&args[0])? else {
                     return Ok(None);
                 };
-                return Ok(Some(crate::RustExpr::MethodCall {
+                let next_expr = crate::RustExpr::MethodCall {
                     receiver: Box::new(lowered_iterator),
                     method: "next".to_string(),
                     args: vec![],
-                }));
+                };
+                let Some(payload) = args[0].ty().iterator_element_type() else {
+                    return Ok(None);
+                };
+                return Ok(Some(crate::helpers::normalize_safe_option_result(
+                    &payload, next_expr,
+                )));
             }
             if func == "anext" && args.len() == 1 {
                 let Some(lowered_iterator) = $emitter.lower_stmt_expr_for_ir(&args[0])? else {
@@ -660,7 +692,7 @@ macro_rules! stmt_expr_literals_and_calls {
                     return Ok(None);
                 };
                 if let Some(inner) = Self::option_inner_type_for_ir(arg.ty()) {
-                    let format_str = if Self::uses_debug_display_format_for_ir(inner) {
+                    let format_str = if Self::uses_debug_display_format_for_ir(&inner) {
                         "{:?}".to_string()
                     } else {
                         "{}".to_string()

--- a/crates/sifr_codegen/src/stmt_support_emitter/expr_call_metadata.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/expr_call_metadata.rs
@@ -167,16 +167,7 @@ pub(crate) fn should_force_mutable_binding(
         methods.iter().any(|(name, ft)| {
             name == "__next__"
                 && ft.params.is_empty()
-                && matches!(ft.return_type.as_ref().resolve_alias(), Type::Union(members) if {
-                    let has_none = members
-                        .iter()
-                        .any(|member| matches!(member.resolve_alias(), Type::None));
-                    let non_none = members
-                        .iter()
-                        .filter(|member| !matches!(member.resolve_alias(), Type::None))
-                        .count();
-                    has_none && non_none == 1
-                })
+                && ft.return_type.optional_member_type().is_some()
         })
     }
 

--- a/crates/sifr_codegen/src/stmt_support_emitter/field_assignment.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/field_assignment.rs
@@ -54,6 +54,8 @@ impl RustEmitter {
         let Some(value_expr) = self.lower_stmt_expr_for_ir(value)? else {
             return Ok(false);
         };
+        let value_expr =
+            crate::helpers::flatten_option_value_for_target(field_ty, value.ty(), value_expr);
         let value_expr = self.adapt_field_assign_value_for_recursive_storage(
             object,
             field,
@@ -81,6 +83,11 @@ impl RustEmitter {
         let Some(value_expr) = self.lower_stmt_expr_for_ir(value)? else {
             return Ok(None);
         };
+        let value_expr = crate::helpers::flatten_option_value_for_target(
+            nested_field_ty,
+            value.ty(),
+            value_expr,
+        );
         let value_expr = self.adapt_field_assign_value_for_recursive_storage(
             object,
             nested_field,
@@ -150,46 +157,19 @@ impl RustEmitter {
     }
 
     pub(crate) fn optional_recursive_class_name(field_ty: &Type) -> Option<String> {
-        let Type::Union(members) = field_ty.resolve_alias() else {
+        let member = field_ty.optional_member_type()?;
+        let Type::Class { name, .. } = member.resolve_alias() else {
             return None;
         };
-        let mut class_name: Option<String> = None;
-        let mut has_none = false;
-        for member in members {
-            match member.resolve_alias() {
-                Type::Class { name, .. } => class_name = Some(name.clone()),
-                Type::None => has_none = true,
-                _ => {}
-            }
-        }
-        if has_none {
-            class_name
-        } else {
-            None
-        }
+        Some(name.clone())
     }
 
     pub(crate) fn optional_class_name(ty: &Type) -> Option<String> {
-        let Type::Union(members) = ty.resolve_alias() else {
+        let member = ty.optional_member_type()?;
+        let Type::Class { name, .. } = member.resolve_alias() else {
             return None;
         };
-        if members.len() != 2 {
-            return None;
-        }
-        let mut class_name: Option<String> = None;
-        let mut has_none = false;
-        for member in members {
-            match member.resolve_alias() {
-                Type::Class { name, .. } => class_name = Some(name.clone()),
-                Type::None => has_none = true,
-                _ => return None,
-            }
-        }
-        if has_none {
-            class_name
-        } else {
-            None
-        }
+        Some(name.clone())
     }
 
     pub(crate) fn recursive_field_needs_boxing(
@@ -300,13 +280,21 @@ impl RustEmitter {
             field: field.clone(),
         };
         let lowered = match field_ty {
-            Type::List(_) => {
+            Type::List(element_ty) => {
                 let Some(index_expr) = self.lower_stmt_expr_for_ir(index)? else {
                     return Ok(false);
                 };
-                crate::build_list_subscript_assign_stmt(receiver, index_expr, value_expr)
+                crate::build_list_subscript_assign_stmt(
+                    receiver,
+                    index_expr,
+                    crate::helpers::flatten_option_value_for_target(
+                        element_ty.as_ref(),
+                        value.ty(),
+                        value_expr,
+                    ),
+                )
             }
-            Type::Dict(key_ty, _) => {
+            Type::Dict(key_ty, value_ty) => {
                 let key_needs_clone = matches!(key_ty.as_ref(), Type::Str | Type::TypeVar(_))
                     && matches!(index, HirExpr::Name { name, .. }
                         if self.borrowed_params.contains(name.as_str()) || self.mut_borrowed_params.contains(name.as_str()));
@@ -325,7 +313,14 @@ impl RustEmitter {
                 crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                     receiver: Box::new(receiver),
                     method: "insert".to_string(),
-                    args: vec![index_expr, value_expr],
+                    args: vec![
+                        index_expr,
+                        crate::helpers::flatten_option_value_for_target(
+                            value_ty.as_ref(),
+                            value.ty(),
+                            value_expr,
+                        ),
+                    ],
                 })
             }
             _ => return Ok(false),

--- a/crates/sifr_codegen/src/stmt_support_emitter/iterator_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/iterator_lowering.rs
@@ -159,17 +159,7 @@ impl RustEmitter {
         methods: &[(String, sifr_type_system::FunctionType)],
     ) -> bool {
         Self::class_method_signature_for_iter_for_ir(methods, "__next__").is_some_and(|next_ft| {
-            next_ft.params.is_empty()
-                && matches!(next_ft.return_type.as_ref().resolve_alias(), Type::Union(members) if {
-                    let has_none = members
-                        .iter()
-                        .any(|member| matches!(member.resolve_alias(), Type::None));
-                    let non_none = members
-                        .iter()
-                        .filter(|member| !matches!(member.resolve_alias(), Type::None))
-                        .count();
-                    has_none && non_none == 1
-                })
+            next_ft.params.is_empty() && next_ft.return_type.optional_member_type().is_some()
         })
     }
 

--- a/crates/sifr_codegen/src/stmt_support_emitter/nested_subscript_assignment.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/nested_subscript_assignment.rs
@@ -40,6 +40,13 @@ impl RustEmitter {
         } else {
             lowered_value
         };
+        let adapted_value = crate::helpers::flatten_option_value_for_target(
+            target_elem_ty,
+            value.ty(),
+            lowered_value.clone(),
+        );
+        let option_value_adapted = adapted_value != lowered_value;
+        let lowered_value = adapted_value;
 
         let value_is_option = if crate::helpers::is_option_type(value.ty()) {
             true
@@ -54,7 +61,9 @@ impl RustEmitter {
         } else {
             false
         };
-        let assign_into_elem = if value_is_option && !crate::helpers::is_option_type(target_elem_ty)
+        let assign_into_elem = if value_is_option
+            && !crate::helpers::is_option_type(target_elem_ty)
+            && !option_value_adapted
         {
             RustStmt::IfLet {
                 pattern: "Some(__nested_assign_value)".to_string(),
@@ -253,6 +262,11 @@ impl RustEmitter {
         } else {
             lowered_value
         };
+        let lowered_value = crate::helpers::flatten_option_value_for_target(
+            target_elem_ty,
+            value.ty(),
+            lowered_value,
+        );
 
         let index_is_option = |expr: &HirExpr| {
             if crate::helpers::is_option_type(expr.ty()) {
@@ -419,6 +433,13 @@ impl RustEmitter {
         } else {
             lowered_value
         };
+        let adapted_value = crate::helpers::flatten_option_value_for_target(
+            target_elem_ty.as_ref(),
+            value.ty(),
+            lowered_value.clone(),
+        );
+        let option_value_adapted = adapted_value != lowered_value;
+        let lowered_value = adapted_value;
 
         let value_is_option = if crate::helpers::is_option_type(value.ty()) {
             true
@@ -433,23 +454,25 @@ impl RustEmitter {
         } else {
             false
         };
-        let assign_into_elem =
-            if value_is_option && !crate::helpers::is_option_type(target_elem_ty.as_ref()) {
-                RustStmt::IfLet {
-                    pattern: "Some(__nested_assign_value)".to_string(),
-                    expr: RustExpr::Ident("__nested_assign_value".to_string()),
-                    then_body: vec![RustStmt::Assign {
-                        target: RustExpr::Deref(Box::new(RustExpr::Ident("__elem".to_string()))),
-                        value: RustExpr::Ident("__nested_assign_value".to_string()),
-                    }],
-                    else_body: None,
-                }
-            } else {
-                RustStmt::Assign {
+        let assign_into_elem = if value_is_option
+            && !crate::helpers::is_option_type(target_elem_ty.as_ref())
+            && !option_value_adapted
+        {
+            RustStmt::IfLet {
+                pattern: "Some(__nested_assign_value)".to_string(),
+                expr: RustExpr::Ident("__nested_assign_value".to_string()),
+                then_body: vec![RustStmt::Assign {
                     target: RustExpr::Deref(Box::new(RustExpr::Ident("__elem".to_string()))),
                     value: RustExpr::Ident("__nested_assign_value".to_string()),
-                }
-            };
+                }],
+                else_body: None,
+            }
+        } else {
+            RustStmt::Assign {
+                target: RustExpr::Deref(Box::new(RustExpr::Ident("__elem".to_string()))),
+                value: RustExpr::Ident("__nested_assign_value".to_string()),
+            }
+        };
         let field_receiver = || RustExpr::Field {
             expr: Box::new(Self::object_name_expr_for_ir(object)),
             field: field.to_string(),
@@ -637,6 +660,11 @@ impl RustEmitter {
         } else {
             lowered_value
         };
+        let lowered_value = crate::helpers::flatten_option_value_for_target(
+            target_elem_ty,
+            value.ty(),
+            lowered_value,
+        );
 
         let field_receiver = || RustExpr::Field {
             expr: Box::new(Self::object_name_expr_for_ir(object)),
@@ -780,12 +808,16 @@ impl RustEmitter {
         };
 
         match Self::resolve_alias_type_for_loop_iter(object_ty) {
-            Type::List(_) => Ok(Some(RustStmt::Block(vec![
+            Type::List(element_ty) => Ok(Some(RustStmt::Block(vec![
                 RustStmt::Let {
                     mutable: false,
                     name: "__assign_value".to_string(),
                     ty: None,
-                    value: clone_non_copy_name(value, lowered_value),
+                    value: crate::helpers::flatten_option_value_for_target(
+                        element_ty.as_ref(),
+                        value.ty(),
+                        clone_non_copy_name(value, lowered_value),
+                    ),
                 },
                 crate::build_list_subscript_assign_stmt(
                     RustExpr::Ident(object.to_string()),
@@ -793,7 +825,7 @@ impl RustEmitter {
                     RustExpr::Ident("__assign_value".to_string()),
                 ),
             ]))),
-            Type::Dict(key_ty, _) => {
+            Type::Dict(key_ty, value_ty) => {
                 let key_needs_clone = matches!(key_ty.as_ref(), Type::Str | Type::TypeVar(_))
                     && matches!(index, HirExpr::Name { name, .. }
                         if self.borrowed_params.contains(name.as_str())
@@ -814,7 +846,11 @@ impl RustEmitter {
                         mutable: false,
                         name: "__assign_value".to_string(),
                         ty: None,
-                        value: clone_non_copy_name(value, lowered_value),
+                        value: crate::helpers::flatten_option_value_for_target(
+                            value_ty.as_ref(),
+                            value.ty(),
+                            clone_non_copy_name(value, lowered_value),
+                        ),
                     },
                     crate::build_dict_subscript_assign_stmt(
                         RustExpr::Ident(object.to_string()),

--- a/crates/sifr_codegen/src/stmt_support_emitter/print_calls.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/print_calls.rs
@@ -57,11 +57,17 @@ impl RustEmitter {
                 let Some(lowered_iterator) = self.lower_stmt_expr_for_ir(&args[0])? else {
                     return Ok(None);
                 };
-                return Ok(Some(crate::RustExpr::MethodCall {
+                let next_expr = crate::RustExpr::MethodCall {
                     receiver: Box::new(lowered_iterator),
                     method: "next".to_string(),
                     args: vec![],
-                }));
+                };
+                let Some(payload) = args[0].ty().iterator_element_type() else {
+                    return Ok(None);
+                };
+                return Ok(Some(crate::helpers::normalize_safe_option_result(
+                    &payload, next_expr,
+                )));
             }
             if func == "anext" && args.len() == 1 {
                 let Some(lowered_iterator) = self.lower_stmt_expr_for_ir(&args[0])? else {
@@ -184,7 +190,7 @@ impl RustEmitter {
                                 Self::option_inner_type_for_ir(inner.ty())
                             {
                                 let option_format_str =
-                                    if Self::uses_debug_display_format_for_ir(option_inner_ty) {
+                                    if Self::uses_debug_display_format_for_ir(&option_inner_ty) {
                                         "{:?}".to_string()
                                     } else {
                                         "{}".to_string()
@@ -235,7 +241,7 @@ impl RustEmitter {
                 return Ok(None);
             };
             if let Some(inner) = Self::option_inner_type_for_ir(arg.ty()) {
-                let option_format_str = if Self::uses_debug_display_format_for_ir(inner) {
+                let option_format_str = if Self::uses_debug_display_format_for_ir(&inner) {
                     "{:?}".to_string()
                 } else {
                     "{}".to_string()
@@ -313,7 +319,7 @@ impl RustEmitter {
                 return Ok(None);
             };
             if let Some(inner) = Self::option_inner_type_for_ir(arg.ty()) {
-                let option_format_str = if Self::uses_debug_display_format_for_ir(inner) {
+                let option_format_str = if Self::uses_debug_display_format_for_ir(&inner) {
                     "{:?}".to_string()
                 } else {
                     "{}".to_string()

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
@@ -405,13 +405,21 @@ impl RustEmitter {
                     field: field.clone(),
                 };
                 let lowered_stmt = match field_ty {
-                    Type::List(_) => {
+                    Type::List(element_ty) => {
                         let Some(index_expr) = self.lower_rendered_expr_for_ir(index)? else {
                             return Ok(None);
                         };
-                        crate::build_list_subscript_assign_stmt(receiver, index_expr, value_expr)
+                        crate::build_list_subscript_assign_stmt(
+                            receiver,
+                            index_expr,
+                            crate::helpers::flatten_option_value_for_target(
+                                element_ty.as_ref(),
+                                value.ty(),
+                                value_expr,
+                            ),
+                        )
                     }
-                    Type::Dict(key_ty, _) => {
+                    Type::Dict(key_ty, value_ty) => {
                         let key_needs_clone = matches!(
                             key_ty.as_ref(),
                             Type::Str | Type::TypeVar(_)
@@ -431,7 +439,14 @@ impl RustEmitter {
                         crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                             receiver: Box::new(receiver),
                             method: "insert".to_string(),
-                            args: vec![index_expr, value_expr],
+                            args: vec![
+                                index_expr,
+                                crate::helpers::flatten_option_value_for_target(
+                                    value_ty.as_ref(),
+                                    value.ty(),
+                                    value_expr,
+                                ),
+                            ],
                         })
                     }
                     _ => return Ok(None),

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_wrappers_and_compare.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_wrappers_and_compare.rs
@@ -106,19 +106,8 @@ macro_rules! stmt_expr_wrappers_range_index {
             if let Some(lowered) = $emitter.try_lower_structured_index_expr(object, index, ty)? {
                 return Ok(Some(lowered));
             }
-            let object_ty = crate::resolve_alias_type_for_plain_call(object.ty());
             let index_returns_option = crate::helpers::is_option_type(ty);
-            let option_inner_ty = if let Type::Union(members) = object_ty {
-                let mut non_none = members.iter().filter(|m| !matches!(m, Type::None));
-                let first = non_none.next();
-                if non_none.next().is_none() && members.iter().any(|m| matches!(m, Type::None)) {
-                    first
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
+            let option_inner_ty = object.ty().optional_member_type();
             if let Some(inner_ty) = option_inner_ty {
                 let Some(lowered_object) = $emitter.lower_stmt_expr_for_ir(object)? else {
                     return Ok(None);
@@ -245,6 +234,7 @@ macro_rules! stmt_expr_wrappers_range_index {
             let Some(lowered_index) = $emitter.lower_stmt_expr_for_ir(index)? else {
                 return Ok(None);
             };
+            let object_ty = crate::resolve_alias_type_for_plain_call(object.ty());
             match object_ty {
                 Type::Dict(_, value_ty) => {
                     let key_arg = if matches!(index.as_ref(), HirExpr::StringLiteral(_)) {

--- a/crates/sifr_codegen/src/structural_identity_codegen.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen.rs
@@ -235,7 +235,7 @@ fn compile_type(
     stack: &mut Vec<String>,
 ) -> CompiledIdentity {
     match ty.resolve_alias() {
-        Type::Int => CompiledIdentity::Static(identity::primitive("i64")),
+        Type::Int => CompiledIdentity::Static(identity::primitive("int")),
         Type::FixedInt(value) => CompiledIdentity::Static(identity::primitive(value.rust_name())),
         Type::Float => CompiledIdentity::Static(identity::primitive("f64")),
         Type::Bool => CompiledIdentity::Static(identity::primitive("bool")),
@@ -644,6 +644,118 @@ mod tests {
     }
 
     #[test]
+    fn structural_substitution_preserves_generic_union_grouping() {
+        let template =
+            sifr_type_system::make_union(vec![Type::Int, Type::TypeVar("T".to_string())]);
+        let bindings = HashMap::from([("T".to_string(), Type::Bool)]);
+        let actual = substitute_structural_type(&template, &bindings);
+
+        assert_eq!(actual, Type::Union(vec![Type::Int, Type::Bool]));
+    }
+
+    #[test]
+    fn generic_union_identity_matches_reordered_collapsed_and_nested_substitutions() {
+        let modules = Vec::new();
+        let context = IdentityContext { modules: &modules };
+        let template =
+            sifr_type_system::make_union(vec![Type::Str, Type::TypeVar("T".to_string())]);
+        assert_eq!(
+            compile_type(&template, "main", &context, &mut Vec::new()).expression(),
+            format!(
+                "{STRUCTURAL}::union(&[{STRUCTURAL}::ShapeIdentity::from_bytes({:?}), <T as {STRUCTURAL}::StructuralType>::shape_identity()])",
+                identity::primitive("str").as_bytes()
+            )
+        );
+
+        let reordered =
+            substitute_structural_type(&template, &HashMap::from([("T".to_string(), Type::Int)]));
+        let reordered_identity =
+            compile_type(&reordered, "main", &context, &mut Vec::new()).static_value();
+        assert_eq!(
+            reordered_identity,
+            Some(identity::union(&[
+                identity::primitive("str"),
+                identity::primitive("int"),
+            ]))
+        );
+
+        let collapsed =
+            substitute_structural_type(&template, &HashMap::from([("T".to_string(), Type::Str)]));
+        let collapsed_identity =
+            compile_type(&collapsed, "main", &context, &mut Vec::new()).static_value();
+        assert_eq!(collapsed, Type::Union(vec![Type::Str, Type::Str]));
+        assert_eq!(collapsed_identity, Some(identity::primitive("str")));
+
+        let nested_argument = sifr_type_system::make_union(vec![Type::Int, Type::Bool]);
+        let nested = substitute_structural_type(
+            &template,
+            &HashMap::from([("T".to_string(), nested_argument)]),
+        );
+        let nested_identity =
+            compile_type(&nested, "main", &context, &mut Vec::new()).static_value();
+        assert_eq!(
+            nested_identity,
+            Some(identity::union(&[
+                identity::primitive("str"),
+                identity::union(&[identity::primitive("bool"), identity::primitive("int"),]),
+            ]))
+        );
+
+        let optional_template =
+            sifr_type_system::make_union(vec![Type::None, Type::TypeVar("T".to_string())]);
+        assert_eq!(
+            compile_type(&optional_template, "main", &context, &mut Vec::new()).expression(),
+            format!(
+                "{STRUCTURAL}::unary_container(\"optional\", <T as {STRUCTURAL}::StructuralType>::shape_identity())"
+            )
+        );
+        let optional_argument = sifr_type_system::make_union(vec![Type::None, Type::Str]);
+        let nested_optional = substitute_structural_type(
+            &optional_template,
+            &HashMap::from([("T".to_string(), optional_argument)]),
+        );
+        let nested_optional_identity =
+            compile_type(&nested_optional, "main", &context, &mut Vec::new()).static_value();
+        assert_eq!(
+            nested_optional_identity,
+            Some(identity::unary_container(
+                "optional",
+                identity::unary_container("optional", identity::primitive("str")),
+            ))
+        );
+    }
+
+    #[test]
+    fn exact_and_fixed_width_integer_identities_are_distinct() {
+        let modules = Vec::new();
+        let context = IdentityContext { modules: &modules };
+        let exact = compile_type(&Type::Int, "main", &context, &mut Vec::new()).static_value();
+        let fixed = compile_type(
+            &Type::FixedInt(sifr_type_system::FixedIntType::I64),
+            "main",
+            &context,
+            &mut Vec::new(),
+        )
+        .static_value();
+
+        assert_eq!(exact, Some(identity::primitive("int")));
+        assert_eq!(fixed, Some(identity::primitive("i64")));
+        assert_ne!(exact, fixed);
+    }
+
+    #[test]
+    fn structural_identity_recanonicalizes_raw_union_members() {
+        let modules = Vec::new();
+        let context = IdentityContext { modules: &modules };
+        let raw = Type::Union(vec![Type::Int, Type::Bool]);
+        let canonical = sifr_type_system::make_union(vec![Type::Int, Type::Bool]);
+        let actual = compile_type(&raw, "main", &context, &mut Vec::new()).static_value();
+        let expected = compile_type(&canonical, "main", &context, &mut Vec::new()).static_value();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn mutually_recursive_records_compile_to_static_numbered_identity() {
         let a_to_b = class_type("B", vec![("a".to_string(), class_type("A", Vec::new()))]);
         let b_to_a = class_type("A", vec![("b".to_string(), class_type("B", Vec::new()))]);
@@ -752,7 +864,7 @@ mod tests {
             &[],
             &[NominalField {
                 name: "payload",
-                identity: identity::union(&[payload_identity, identity::primitive("str")]),
+                identity: identity::union(&[identity::primitive("str"), payload_identity]),
                 required: true,
                 default_identity: None,
             }],

--- a/crates/sifr_codegen/src/try_error_carrier.rs
+++ b/crates/sifr_codegen/src/try_error_carrier.rs
@@ -1,5 +1,5 @@
 use sifr_ir::HirExceptHandler;
-use sifr_type_system::Type;
+use sifr_type_system::{make_union, Type};
 
 pub(crate) fn timeout_error_type() -> Type {
     Type::Class {
@@ -13,13 +13,10 @@ pub(crate) fn timeout_error_type() -> Type {
 }
 
 pub(crate) fn exact_try_error_carrier(types: &[Type]) -> Option<Type> {
-    let mut members = types.to_vec();
-    members.sort_by_key(Type::union_variant_name);
-    members.dedup_by(|left, right| left.union_variant_name() == right.union_variant_name());
-    match members.len() {
-        0 => None,
-        1 => members.pop(),
-        _ => Some(Type::Union(members)),
+    if types.is_empty() {
+        None
+    } else {
+        Some(make_union(types.to_vec()))
     }
 }
 
@@ -75,6 +72,25 @@ mod tests {
     }
 
     #[test]
+    fn carrier_uses_the_canonical_union_member_order() {
+        let named_error = |name: &str| Type::Class {
+            identity: Some(format!("a.{name}")),
+            type_args: Vec::new(),
+            name: name.to_string(),
+            fields: vec![("message".to_string(), Type::Str)],
+            methods: Vec::new(),
+            parent_class: Some("Error".to_string()),
+        };
+        let os_error = named_error("OSError");
+        let zero_division = named_error("ZeroDivisionError");
+        let ordinary = make_union(vec![os_error.clone(), zero_division.clone()]);
+        let carrier = exact_try_error_carrier(&[zero_division, os_error])
+            .expect("carrier should contain both errors");
+
+        assert_eq!(carrier, ordinary);
+    }
+
+    #[test]
     fn carrier_collapses_structural_snapshots_of_one_nominal_identity() {
         let first = error("sifr.io.IOError");
         let mut second = first.clone();
@@ -83,10 +99,10 @@ mod tests {
         };
         fields.push(("kind".to_string(), Type::Str));
 
-        assert_eq!(
-            exact_try_error_carrier(&[first.clone(), second]),
-            Some(first)
-        );
+        let forward = exact_try_error_carrier(&[first.clone(), second.clone()]);
+        let reverse = exact_try_error_carrier(&[second.clone(), first]);
+        assert_eq!(forward, reverse);
+        assert_eq!(forward, Some(second));
     }
 
     #[test]

--- a/crates/sifr_codegen/src/union_type_helpers.rs
+++ b/crates/sifr_codegen/src/union_type_helpers.rs
@@ -15,7 +15,7 @@ impl RustEmitter {
         if let Some(path) = self.project_nominal_type_paths.get(key) {
             return Some(path);
         }
-        if identity.is_some_and(sifr_type_system::is_global_rust_nominal_identity) {
+        if identity.is_some_and(sifr_type_system::is_crate_root_rust_nominal_identity) {
             return None;
         }
         panic!("missing crate-root path for project union nominal identity '{key}'");
@@ -23,6 +23,9 @@ impl RustEmitter {
 
     fn project_union_member_rust_type(&self, ty: &Type) -> RustType {
         let resolved = crate::resolve_alias_type_for_plain_call(ty);
+        if let Some(member) = resolved.optional_member_type() {
+            return RustType::Option(Box::new(self.project_union_member_rust_type(&member)));
+        }
         match resolved {
             class @ Type::Class {
                 identity,
@@ -81,24 +84,6 @@ impl RustEmitter {
                 Box::new(self.project_union_member_rust_type(ok)),
                 Box::new(self.project_union_member_rust_type(error)),
             ),
-            Type::Union(members)
-                if members.iter().any(|member| matches!(member, Type::None))
-                    && members
-                        .iter()
-                        .filter(|member| !matches!(member, Type::None))
-                        .count()
-                        == 1 =>
-            {
-                members
-                    .iter()
-                    .find(|member| !matches!(member, Type::None))
-                    .map_or_else(
-                        || sifr_type_to_rust_type(resolved),
-                        |inner| {
-                            RustType::Option(Box::new(self.project_union_member_rust_type(inner)))
-                        },
-                    )
-            }
             _ => sifr_type_to_rust_type(resolved),
         }
     }
@@ -205,14 +190,21 @@ impl RustEmitter {
 
     fn register_union_type_with_usage(&mut self, ty: &Type, ordinary_value: bool) {
         let resolved = crate::resolve_alias_type_for_plain_call(ty);
+        // A raw `T | None` is an Option wrapper whose payload grouping is
+        // significant. Only canonicalize unions that are represented by an
+        // enum; the payload union is registered during the recursive walk.
+        if resolved.optional_member_type().is_none() {
+            if let Type::Union(members) = resolved {
+                let canonical = sifr_type_system::make_union(members.clone());
+                if canonical != *resolved {
+                    self.register_union_type_with_usage(&canonical, ordinary_value);
+                    return;
+                }
+            }
+        }
         match resolved {
             Type::Union(members) => {
-                let non_none = members
-                    .iter()
-                    .filter(|member| !matches!(member, Type::None))
-                    .count();
-                let is_option =
-                    members.iter().any(|member| matches!(member, Type::None)) && non_none == 1;
+                let is_option = resolved.optional_member_type().is_some();
                 if !is_option {
                     let enum_name = resolved.union_enum_name();
                     if ordinary_value {
@@ -273,8 +265,12 @@ impl RustEmitter {
     }
 
     fn register_try_error_carrier(&mut self, ty: &Type) {
-        if matches!(ty.resolve_alias(), Type::Union(_)) {
-            self.try_error_carrier_enums.insert(ty.union_enum_name());
+        if let Type::Union(members) = ty.resolve_alias() {
+            let canonical = sifr_type_system::make_union(members.clone());
+            if matches!(canonical, Type::Union(_)) {
+                self.try_error_carrier_enums
+                    .insert(canonical.union_enum_name());
+            }
         }
         self.register_union_type_with_usage(ty, false);
     }
@@ -634,6 +630,36 @@ mod tests {
     }
 
     #[test]
+    fn try_carrier_and_ordinary_union_registration_keep_one_member_order() {
+        let error = |name: &str| Type::Class {
+            identity: Some(format!("a.{name}")),
+            type_args: Vec::new(),
+            name: name.to_string(),
+            fields: vec![("message".to_string(), Type::Str)],
+            methods: Vec::new(),
+            parent_class: Some("Error".to_string()),
+        };
+        let os_error = error("OSError");
+        let zero_division = error("ZeroDivisionError");
+        let ordinary = sifr_type_system::make_union(vec![os_error.clone(), zero_division.clone()]);
+        let raw = Type::Union(vec![zero_division.clone(), os_error.clone()]);
+        let carrier = crate::try_error_carrier::exact_try_error_carrier(&[zero_division, os_error])
+            .expect("carrier should contain both errors");
+
+        let render = |first: &Type| {
+            let mut emitter = RustEmitter::new();
+            emitter.register_union_type(first);
+            emitter.register_try_error_carrier(&carrier);
+            emitter.register_union_type(&ordinary);
+            emitter.generate_enum_definitions();
+            crate::render::render_items(&emitter.enum_items)
+        };
+
+        assert_eq!(render(&raw), render(&ordinary));
+        assert_eq!(render(&carrier), render(&ordinary));
+    }
+
+    #[test]
     fn carrier_only_union_omits_unneeded_value_traits() {
         let union = Type::Union(vec![Type::Int, Type::Str]);
         let mut emitter = RustEmitter::new();
@@ -644,6 +670,45 @@ mod tests {
             panic!("first generated item should be the union enum");
         };
         assert_eq!(derives, &["Debug", "Clone"]);
+    }
+
+    #[test]
+    fn collapsed_try_carrier_does_not_record_a_plain_type_as_an_enum() {
+        let class = Type::Class {
+            identity: Some("tests.Error".to_string()),
+            type_args: Vec::new(),
+            name: "Error".to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: Some("Error".to_string()),
+        };
+        let snapshot = Type::Class {
+            identity: Some("tests.Error".to_string()),
+            type_args: Vec::new(),
+            name: "Error".to_string(),
+            fields: vec![("message".to_string(), Type::Str)],
+            methods: Vec::new(),
+            parent_class: Some("Error".to_string()),
+        };
+        let mut emitter = RustEmitter::new();
+
+        emitter.register_try_error_carrier(&Type::Union(vec![class, snapshot]));
+
+        assert!(emitter.try_error_carrier_enums.is_empty());
+    }
+
+    #[test]
+    fn nested_optional_union_registers_its_grouped_payload_enum() {
+        let inner = sifr_type_system::make_union(vec![Type::Int, Type::Str]);
+        let raw = Type::Union(vec![inner.clone(), Type::None]);
+        let expected_name = inner.union_enum_name();
+        let mut emitter = RustEmitter::new();
+
+        emitter.register_union_type(&raw);
+
+        assert_eq!(raw.rust_type(), format!("Option<{expected_name}>"));
+        assert!(emitter.union_enums.contains_key(&expected_name));
+        assert_eq!(emitter.union_enums.len(), 1);
     }
 
     #[test]

--- a/crates/sifr_driver/src/tests/package_python_async_runtime_tests.rs
+++ b/crates/sifr_driver/src/tests/package_python_async_runtime_tests.rs
@@ -114,6 +114,62 @@ def main() -> None:
 
 #[test]
 #[ignore = "generated build integration coverage runs in full validation profiles"]
+fn unrelated_project_union_keeps_module_local_native_file_handle() {
+    let dir = mktemp_dir("package_unrelated_union_native_handle");
+    let app = production_package(&dir, "app", "sifr-union-fs-app", "union_fs_app");
+    write_package_source(
+        &app,
+        "errors.sifr",
+        r#"class FirstError(Error):
+    message: str
+
+class SecondError(Error):
+    message: str
+
+def produce() -> Result[int, FirstError | SecondError]:
+    return 1
+"#,
+    );
+    write_package_source(
+        &app,
+        "reader.sifr",
+        r#"def read_it() -> str:
+    path: str = "/tmp/sifr_union_fs_probe.txt"
+    try:
+        f = open(path, "r", encoding="utf-8")
+        content: str = f.read()
+        f.close()
+        return content
+    except IOError as error:
+        return error.message
+"#,
+    );
+    write_package_source(
+        &app,
+        "main.sifr",
+        r#"from .errors import FirstError, SecondError, produce
+from .reader import read_it
+
+def relay() -> Result[int, FirstError | SecondError]:
+    return produce()
+
+def main() -> None:
+    print(read_it())
+"#,
+    );
+
+    let graph = package_graph(&dir, &[&app], &[]);
+    let source_map = sifr_package::PackageSourceMap::build(&graph).expect("source map builds");
+    let entrypoint = package_entrypoint(&graph, &source_map, &app, app.root.join("src/main.sifr"));
+    let artifact = build_cached_package_project(&entrypoint)
+        .expect("an unrelated union must not relocate the filesystem native handle");
+
+    assert!(artifact.binary_path().exists());
+    let _ignored = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+#[ignore = "generated build integration coverage runs in full validation profiles"]
 fn canonical_open_handles_build_beside_local_same_basename_classes() {
     let dir = mktemp_dir("package_open_handle_identity_collision");
     let app = production_package(&dir, "app", "sifr-open-app", "open_app");

--- a/crates/sifr_lowering/src/lower/async_for.rs
+++ b/crates/sifr_lowering/src/lower/async_for.rs
@@ -32,25 +32,7 @@ fn async_result_parts(ty: &Type) -> Option<(Type, Type)> {
 }
 
 fn option_value_type(ty: &Type) -> Option<Type> {
-    let Type::Union(members) = ty.resolve_alias() else {
-        return None;
-    };
-    let has_none = members
-        .iter()
-        .any(|member| matches!(member.resolve_alias(), Type::None));
-    if !has_none {
-        return None;
-    }
-    let non_none = members
-        .iter()
-        .filter(|member| !matches!(member.resolve_alias(), Type::None))
-        .cloned()
-        .collect::<Vec<_>>();
-    if non_none.len() == 1 {
-        non_none.into_iter().next()
-    } else {
-        None
-    }
+    ty.optional_member_type()
 }
 
 pub(in crate::lower) fn async_iterator_parts(ty: &Type) -> Option<(Type, Type)> {

--- a/crates/sifr_lowering/src/lower/builtin_calls/bytes_len_range.rs
+++ b/crates/sifr_lowering/src/lower/builtin_calls/bytes_len_range.rs
@@ -111,19 +111,9 @@ pub(in crate::lower) fn lower_len_call(call: &ExprCall, ctx: &mut LowerCtx) -> O
     let arg = lower_expr(&call.arguments.args[0], ctx)?;
     let arg_ty = arg.ty().clone();
 
-    let effective_ty = if let Type::Union(members) = &arg_ty {
-        let non_none: Vec<&Type> = members
-            .iter()
-            .filter(|m| !matches!(m, Type::None))
-            .collect();
-        if non_none.len() == 1 {
-            non_none[0].clone()
-        } else {
-            arg_ty.clone()
-        }
-    } else {
-        arg_ty.clone()
-    };
+    let effective_ty = arg_ty
+        .optional_member_type()
+        .unwrap_or_else(|| arg_ty.clone());
     match effective_ty.resolve_alias() {
         Type::Str
         | Type::Bytes

--- a/crates/sifr_lowering/src/lower/class_field_inference.rs
+++ b/crates/sifr_lowering/src/lower/class_field_inference.rs
@@ -1,5 +1,5 @@
 use sifr_python_ast::{Expr, Operator, Stmt, UnaryOp};
-use sifr_type_system::Type;
+use sifr_type_system::{make_union, Type};
 use std::collections::HashMap;
 
 use super::{simple_expr::lower_expr_simple, LowerCtx};
@@ -19,10 +19,7 @@ fn merge_inferred_types(existing: Type, inferred: Type) -> Type {
     if existing.is_assignable_to(&inferred) {
         return inferred;
     }
-    let mut members = vec![existing, inferred];
-    members.sort_by_key(Type::display_name);
-    members.dedup_by(|left, right| left.display_name() == right.display_name());
-    Type::Union(members)
+    make_union(vec![existing, inferred])
 }
 
 fn upsert_inferred_field(fields: &mut Vec<(String, Type)>, field_name: String, inferred_ty: Type) {
@@ -299,5 +296,32 @@ pub(in crate::lower) fn collect_constructor_self_field_assignments(
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn imported_class(local_name: &str, identity: &str) -> Type {
+        Type::Class {
+            identity: Some(identity.to_string()),
+            type_args: Vec::new(),
+            name: local_name.to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        }
+    }
+
+    #[test]
+    fn inferred_field_union_uses_declaration_identity_not_local_spelling() {
+        let alpha = imported_class("Zeta", "pkg.Alpha");
+        let beta = imported_class("Beta", "pkg.Beta");
+
+        assert_eq!(
+            merge_inferred_types(beta.clone(), alpha.clone()),
+            sifr_type_system::make_union(vec![alpha, beta])
+        );
     }
 }

--- a/crates/sifr_lowering/src/lower/classes/class_type_helpers.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_helpers.rs
@@ -1,20 +1,5 @@
 use super::Type;
 
 pub(super) fn option_member_type(ty: &Type) -> Option<Type> {
-    let Type::Union(members) = ty.resolve_alias() else {
-        return None;
-    };
-    let has_none = members
-        .iter()
-        .any(|member| matches!(member.resolve_alias(), Type::None));
-    let non_none: Vec<Type> = members
-        .iter()
-        .filter(|member| !matches!(member.resolve_alias(), Type::None))
-        .cloned()
-        .collect();
-    if has_none && non_none.len() == 1 {
-        non_none.first().cloned()
-    } else {
-        None
-    }
+    ty.optional_member_type()
 }

--- a/crates/sifr_lowering/src/lower/expressions/call_builtins.rs
+++ b/crates/sifr_lowering/src/lower/expressions/call_builtins.rs
@@ -12,6 +12,7 @@ use super::{
     Ranged, Type,
 };
 use crate::lower::type_bounds::supports_print_formatting;
+use sifr_type_system::safe_optional_result;
 pub(super) enum CallLowering {
     Lowered(HirExpr),
     NoMatch,
@@ -176,7 +177,7 @@ pub(super) fn lower_unshadowed_builtin_call(
         ) {
             return None;
         }
-        let result_ty = Type::Union(vec![elem_ty, Type::None]);
+        let result_ty = safe_optional_result(elem_ty);
         let signature = sifr_type_system::FunctionType {
             receiver: None,
             params: vec![(
@@ -701,7 +702,7 @@ pub(super) fn lower_unshadowed_builtin_call(
                 mutable_arg_places: Vec::new(),
                 func: "min".to_string(),
                 args: vec![arg],
-                ty: Type::Union(vec![elem_ty, Type::None]),
+                ty: safe_optional_result(elem_ty),
             }));
         }
         expression_diagnostics::call_wrong_positional_count(
@@ -774,7 +775,7 @@ pub(super) fn lower_unshadowed_builtin_call(
                 mutable_arg_places: Vec::new(),
                 func: "max".to_string(),
                 args: vec![arg],
-                ty: Type::Union(vec![elem_ty, Type::None]),
+                ty: safe_optional_result(elem_ty),
             }));
         }
         expression_diagnostics::call_wrong_positional_count(

--- a/crates/sifr_lowering/src/lower/expressions/method_type_collections.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_type_collections.rs
@@ -8,6 +8,7 @@ use super::{
 use crate::lower::type_bounds::{
     supports_structural_equality_in_context, supports_total_order_in_context,
 };
+use sifr_type_system::safe_optional_result;
 pub(super) fn resolve_list_method_type(
     elem_ty: &Type,
     method: &str,
@@ -215,14 +216,14 @@ pub(super) fn resolve_list_method_type(
                 }
             }
             // pop() returns Option[T] = T | None
-            Some(Type::Union(vec![elem_ty.clone(), Type::None]))
+            Some(safe_optional_result(elem_ty.clone()))
         }
         "popleft" => {
             if !args.is_empty() {
                 reject_no_method_args(ctx, "list.popleft", arg_ranges, method_range);
                 return None;
             }
-            Some(Type::Union(vec![elem_ty.clone(), Type::None]))
+            Some(safe_optional_result(elem_ty.clone()))
         }
         "appendleft" => {
             if args.len() != 1 {
@@ -487,7 +488,7 @@ pub(super) fn resolve_dict_method_type(
                 }
             } else {
                 // dict.get(key) -> V | None
-                Some(Type::Union(vec![val_ty.clone(), Type::None]))
+                Some(safe_optional_result(val_ty.clone()))
             }
         }
         "pop" => {
@@ -525,7 +526,7 @@ pub(super) fn resolve_dict_method_type(
                 Some(val_ty.clone())
             } else {
                 // pop() returns Option[V] = V | None
-                Some(Type::Union(vec![val_ty.clone(), Type::None]))
+                Some(safe_optional_result(val_ty.clone()))
             }
         }
         "setdefault" => {
@@ -734,7 +735,7 @@ pub(super) fn resolve_set_method_type(
                 return None;
             }
             // Returns Option[T] = T | None (safe: no panic on empty set)
-            Some(Type::Union(vec![elem_ty.clone(), Type::None]))
+            Some(safe_optional_result(elem_ty.clone()))
         }
         _ => {
             ctx.error_with_code_at(

--- a/crates/sifr_lowering/src/lower/expressions_tests/callable_and_builtin_diagnostics.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/callable_and_builtin_diagnostics.rs
@@ -644,7 +644,7 @@ pub(super) fn test_bytes_index_and_iteration_expose_uint8() {
     };
     assert_eq!(
         first_ty,
-        &Type::Union(vec![Type::FixedInt(FixedIntType::U8), Type::None])
+        &sifr_type_system::make_union(vec![Type::FixedInt(FixedIntType::U8), Type::None])
     );
 
     let Some(HirStmt::For { target_ty, .. }) = function

--- a/crates/sifr_lowering/src/lower/function_flow.rs
+++ b/crates/sifr_lowering/src/lower/function_flow.rs
@@ -1,5 +1,5 @@
 use crate::hir_nodes::HirStmt;
-use sifr_type_system::Type;
+use sifr_type_system::{make_union, Type};
 
 /// Collect all return types from a list of HIR statements (recursively).
 pub(in crate::lower) fn collect_return_types(stmts: &[HirStmt]) -> Vec<Type> {
@@ -93,17 +93,7 @@ pub(in crate::lower) fn collapse_types(types: Vec<Type>, empty_type: Type) -> Ty
     if types.is_empty() {
         return empty_type;
     }
-    if types.len() == 1 {
-        return types.into_iter().next().unwrap_or(Type::Any);
-    }
-    let mut members = types;
-    members.sort_by_key(Type::display_name);
-    members.dedup();
-    if members.len() == 1 {
-        members.into_iter().next().unwrap_or(Type::Any)
-    } else {
-        Type::Union(members)
-    }
+    make_union(types)
 }
 
 pub(in crate::lower) fn infer_function_return_type(
@@ -194,21 +184,41 @@ pub(in crate::lower) fn infer_function_return_type(
 }
 
 fn normalize_generator_yield_type(yielded_type: Type) -> Type {
+    if let Some(member) = yielded_type.optional_member_type() {
+        return member;
+    }
     let Type::Union(members) = yielded_type else {
         return yielded_type;
     };
     if members.is_empty() {
         return Type::Union(members);
     }
-    let non_none: Vec<Type> = members
-        .iter()
-        .filter(|member| !matches!(member, Type::None))
-        .cloned()
-        .collect();
-    let has_none = members.iter().any(|member| matches!(member, Type::None));
-    if has_none && non_none.len() == 1 {
-        non_none.into_iter().next().unwrap_or(Type::Any)
-    } else {
-        Type::Union(members)
+    sifr_type_system::make_union(members)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn imported_class(local_name: &str, identity: &str) -> Type {
+        Type::Class {
+            identity: Some(identity.to_string()),
+            type_args: Vec::new(),
+            name: local_name.to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        }
+    }
+
+    #[test]
+    fn inferred_return_union_uses_declaration_identity_not_local_spelling() {
+        let alpha = imported_class("Zeta", "pkg.Alpha");
+        let beta = imported_class("Beta", "pkg.Beta");
+
+        assert_eq!(
+            collapse_types(vec![beta.clone(), alpha.clone()], Type::Any),
+            sifr_type_system::make_union(vec![alpha, beta])
+        );
     }
 }

--- a/crates/sifr_lowering/src/lower/guarded_index.rs
+++ b/crates/sifr_lowering/src/lower/guarded_index.rs
@@ -390,7 +390,7 @@ mod tests {
         assert!(errors.iter().any(|error| {
             error
                 .message
-                .contains("type mismatch: expected 'int', got 'int | None'")
+                .contains("type mismatch: expected 'int', got 'None | int'")
         }));
     }
 
@@ -533,7 +533,7 @@ mod tests {
         assert!(errors.iter().any(|error| {
             error
                 .message
-                .contains("type mismatch: expected 'int', got 'int | None'")
+                .contains("type mismatch: expected 'int', got 'None | int'")
         }));
     }
 
@@ -605,7 +605,7 @@ mod tests {
         assert!(errors.iter().any(|error| {
             error
                 .message
-                .contains("type mismatch: expected 'str', got 'str | None'")
+                .contains("type mismatch: expected 'str', got 'None | str'")
         }));
     }
 
@@ -673,7 +673,7 @@ mod tests {
         assert!(errors.iter().any(|error| {
             error
                 .message
-                .contains("type mismatch: expected 'int', got 'int | None'")
+                .contains("type mismatch: expected 'int', got 'None | int'")
         }));
     }
 }

--- a/crates/sifr_lowering/src/lower/imported_class_identity.rs
+++ b/crates/sifr_lowering/src/lower/imported_class_identity.rs
@@ -1,4 +1,4 @@
-use sifr_type_system::{FunctionType, OwnershipKind, ParamConvention, Type};
+use sifr_type_system::{make_union, FunctionType, OwnershipKind, ParamConvention, Type};
 use std::collections::HashMap;
 
 pub(super) fn imported_constructor_function_type(class_ty: &Type) -> Option<FunctionType> {
@@ -184,7 +184,7 @@ fn rename_class_identities(ty: &Type, class_aliases: &HashMap<String, String>) -
                 .map(|item| rename_class_identities(item, class_aliases))
                 .collect(),
         ),
-        Type::Union(items) => Type::Union(
+        Type::Union(items) => make_union(
             items
                 .iter()
                 .map(|item| rename_class_identities(item, class_aliases))
@@ -416,10 +416,16 @@ fn set_canonical_identities(ty: &mut Type, local_classes: &HashMap<String, Strin
             set_canonical_identities(left, local_classes);
             set_canonical_identities(right, local_classes);
         }
-        Type::Tuple(items) | Type::Union(items) | Type::Intersection(items) => {
+        Type::Tuple(items) | Type::Intersection(items) => {
             for item in items {
                 set_canonical_identities(item, local_classes);
             }
+        }
+        Type::Union(items) => {
+            for item in &mut *items {
+                set_canonical_identities(item, local_classes);
+            }
+            *ty = make_union(std::mem::take(items));
         }
         Type::Callable(params, _, result) | Type::AsyncCallable(params, _, result) => {
             for param in params {
@@ -512,5 +518,56 @@ fn set_canonical_identities(ty: &mut Type, local_classes: &HashMap<String, Strin
             }
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn class(name: &str, identity: Option<&str>) -> Type {
+        Type::Class {
+            identity: identity.map(str::to_string),
+            type_args: Vec::new(),
+            name: name.to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        }
+    }
+
+    fn member_identities(ty: Type) -> Vec<String> {
+        let Type::Union(members) = ty else {
+            panic!("expected union");
+        };
+        members.iter().map(Type::union_variant_name).collect()
+    }
+
+    #[test]
+    fn imported_alias_renaming_keeps_union_identity_order() {
+        let original = make_union(vec![
+            class("Alpha", Some("pkg.Alpha")),
+            class("Beta", Some("pkg.Beta")),
+        ]);
+        let aliases = HashMap::from([("Alpha".to_string(), "Zeta".to_string())]);
+        let renamed = rename_class_identities(&original, &aliases);
+
+        assert_eq!(member_identities(original), member_identities(renamed));
+    }
+
+    #[test]
+    fn canonical_identity_insertion_reorders_union_members() {
+        let mut actual = Type::Union(vec![class("Zeta", None), class("Beta", None)]);
+        let identities = HashMap::from([
+            ("Zeta".to_string(), "pkg.Alpha".to_string()),
+            ("Beta".to_string(), "pkg.Beta".to_string()),
+        ]);
+        set_canonical_identities(&mut actual, &identities);
+        let expected = make_union(vec![
+            class("Zeta", Some("pkg.Alpha")),
+            class("Beta", Some("pkg.Beta")),
+        ]);
+
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/sifr_lowering/src/lower/ipc_payload_calls.rs
+++ b/crates/sifr_lowering/src/lower/ipc_payload_calls.rs
@@ -72,8 +72,8 @@ fn non_ipc_serializable_reason_inner(ty: &Type, visiting: &mut HashSet<String>) 
         Type::Tuple(elems) => elems
             .iter()
             .find_map(|elem| non_ipc_serializable_reason_inner(elem.resolve_alias(), visiting)),
-        Type::Union(members) => {
-            if let Some(non_none) = option_payload_member(members) {
+        Type::Union(_) => {
+            if let Some(non_none) = ty.optional_member_type() {
                 non_ipc_serializable_reason_inner(non_none.resolve_alias(), visiting)
             } else {
                 Some(
@@ -160,13 +160,6 @@ fn non_ipc_serializable_reason_inner(ty: &Type, visiting: &mut HashSet<String>) 
             Some("structural protocol payloads need generated concrete schemas".to_string())
         }
     }
-}
-
-fn option_payload_member(members: &[Type]) -> Option<&Type> {
-    if members.len() != 2 || !members.iter().any(|member| matches!(member, Type::None)) {
-        return None;
-    }
-    members.iter().find(|member| !matches!(member, Type::None))
 }
 
 fn class_has_non_send_marker(name: &str, parent_chain: Option<&str>) -> bool {

--- a/crates/sifr_lowering/src/lower/ipc_schema_extraction.rs
+++ b/crates/sifr_lowering/src/lower/ipc_schema_extraction.rs
@@ -29,8 +29,8 @@ fn extract_ipc_schema_type_inner(ty: &Type) -> IpcSchemaType {
                 .map(extract_ipc_schema_type)
                 .collect::<Vec<_>>(),
         ),
-        Type::Union(members) => {
-            extract_option_schema_type(members).unwrap_or_else(|| IpcSchemaType::Unsupported {
+        Type::Union(_) => {
+            extract_option_schema_type(ty).unwrap_or_else(|| IpcSchemaType::Unsupported {
                 type_name: ty.display_name(),
             })
         }
@@ -91,15 +91,10 @@ fn extract_ipc_schema_type_inner(ty: &Type) -> IpcSchemaType {
     }
 }
 
-fn extract_option_schema_type(members: &[Type]) -> Option<IpcSchemaType> {
-    if members.len() != 2 || !members.iter().any(|member| matches!(member, Type::None)) {
-        return None;
-    }
-    let payload = members
-        .iter()
-        .find(|member| !matches!(member, Type::None))?;
+fn extract_option_schema_type(ty: &Type) -> Option<IpcSchemaType> {
+    let payload = ty.optional_member_type()?;
     Some(IpcSchemaType::Option(Box::new(extract_ipc_schema_type(
-        payload,
+        &payload,
     ))))
 }
 

--- a/crates/sifr_lowering/src/lower/nested_function_inference/type_unification.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/type_unification.rs
@@ -78,7 +78,7 @@ pub(super) fn replace_inference_holes_with_any(ty: Type) -> Type {
                 .map(replace_inference_holes_with_any)
                 .collect(),
         ),
-        Type::Union(elements) => Type::Union(
+        Type::Union(elements) => sifr_type_system::make_union(
             elements
                 .into_iter()
                 .map(replace_inference_holes_with_any)
@@ -134,5 +134,17 @@ fn collapse_literal(ty: Type) -> Type {
             body: Box::new(collapse_literal(*body)),
         },
         other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inference_hole_replacement_recanonicalizes_and_deduplicates_unions() {
+        let ty = Type::Union(vec![Type::Unknown, Type::Any]);
+
+        assert_eq!(replace_inference_holes_with_any(ty), Type::Any);
     }
 }

--- a/crates/sifr_lowering/src/lower/type_bounds.rs
+++ b/crates/sifr_lowering/src/lower/type_bounds.rs
@@ -336,13 +336,8 @@ fn supports_total_order(ty: &Type) -> bool {
 /// Whether `print` can use the exact Display/Debug strategy selected by codegen.
 pub(in crate::lower) fn supports_print_formatting(ty: &Type) -> bool {
     let resolved = ty.resolve_alias();
-    if let Type::Union(members) = resolved {
-        if members.len() == 2 && members.iter().any(|member| matches!(member, Type::None)) {
-            return members
-                .iter()
-                .find(|member| !matches!(member, Type::None))
-                .is_some_and(supports_print_formatting);
-        }
+    if let Some(member) = resolved.optional_member_type() {
+        return supports_print_formatting(&member);
     }
     match resolved {
         Type::List(_)

--- a/crates/sifr_structural_identity/src/lib.rs
+++ b/crates/sifr_structural_identity/src/lib.rs
@@ -89,7 +89,14 @@ pub fn tuple(members: &[ShapeIdentity]) -> ShapeIdentity {
 
 #[must_use]
 pub fn union(members: &[ShapeIdentity]) -> ShapeIdentity {
-    compose_identities("union", members)
+    let mut canonical = members.to_vec();
+    canonical.sort_unstable();
+    canonical.dedup();
+    match canonical.as_slice() {
+        [] => primitive("never"),
+        [member] => *member,
+        _ => compose_identities("union", &canonical),
+    }
 }
 
 #[must_use]
@@ -223,7 +230,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn identities_are_ordered_length_delimited_and_deterministic() {
+    fn identities_are_length_delimited_and_deterministic() {
         let string = primitive("str");
         assert_eq!(string, primitive("str"));
         assert_ne!(string, primitive("bytes"));
@@ -231,10 +238,18 @@ mod tests {
             tuple(&[primitive("a"), primitive("bc")]),
             tuple(&[primitive("ab"), primitive("c")])
         );
-        assert_ne!(
+        assert_eq!(
             union(&[primitive("a"), primitive("b")]),
             union(&[primitive("b"), primitive("a")])
         );
+    }
+
+    #[test]
+    fn union_identity_normalizes_empty_singleton_and_duplicate_members() {
+        let integer = primitive("int");
+        assert_eq!(union(&[]), primitive("never"));
+        assert_eq!(union(&[integer]), integer);
+        assert_eq!(union(&[integer, integer]), integer);
     }
 
     #[test]

--- a/crates/sifr_type_system/src/lib.rs
+++ b/crates/sifr_type_system/src/lib.rs
@@ -10,24 +10,29 @@ mod check_equality_capability_tests;
 mod collection_capabilities;
 pub mod infer;
 pub mod literal;
+mod safe_optional;
 #[cfg(test)]
 mod type_capability_identity_tests;
 mod types;
 pub mod union;
+#[cfg(test)]
+mod union_operation_tests;
 
 pub use check::{
     type_check_binary_op, type_check_bool_op, type_check_comparison, type_check_unary_op,
 };
 pub use infer::infer_literal_type;
 pub use types::{
-    class_rust_name, is_global_rust_nominal_identity, source_class_rust_name,
-    stdlib_class_rust_name, FixedIntType, FunctionType, IterationCapability, IterationMetadata,
-    OwnershipKind, ParamConvention, ParamMutability, ParamOwnership, PythonArrowKind,
-    ReceiverConvention, Type, COMPILER_RUST_PATH_ROOTS, GLOBAL_RUST_NOMINAL_IDENTITIES,
+    class_rust_name, is_crate_root_rust_nominal_identity, is_global_rust_nominal_identity,
+    source_class_rust_name, stdlib_class_rust_name, FixedIntType, FunctionType,
+    IterationCapability, IterationMetadata, OwnershipKind, ParamConvention, ParamMutability,
+    ParamOwnership, PythonArrowKind, ReceiverConvention, Type, COMPILER_RUST_PATH_ROOTS,
+    CRATE_ROOT_RUST_NOMINAL_IDENTITIES, GLOBAL_RUST_NOMINAL_IDENTITIES,
 };
 pub mod narrow;
 pub use literal::{widen as widen_literal, LiteralValue};
 pub use narrow::{narrow_type, NarrowingCondition};
+pub use safe_optional::safe_optional_result;
 pub use union::{
     intersect_with_union, make_union, remove_none_from_union, subtract_from_union, union_contains,
     union_contains_none,

--- a/crates/sifr_type_system/src/safe_optional.rs
+++ b/crates/sifr_type_system/src/safe_optional.rs
@@ -1,0 +1,53 @@
+use crate::{make_union, Type};
+
+/// Return the result type of an operation that can produce no value.
+///
+/// A multi-member payload remains inside a representation-significant outer
+/// optional wrapper. A simple optional payload is flattened because both
+/// absence layers have the same observable Sifr value.
+#[must_use]
+pub fn safe_optional_result(payload: Type) -> Type {
+    match payload.resolve_alias() {
+        Type::Union(members) if members.len() > 1 && payload.optional_member_type().is_none() => {
+            Type::Union(vec![payload, Type::None])
+        }
+        _ => make_union(vec![payload, Type::None]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_multi_member_payload_inside_outer_optional() {
+        let payload = make_union(vec![Type::Int, Type::Str]);
+        assert_eq!(
+            safe_optional_result(payload.clone()),
+            Type::Union(vec![payload, Type::None])
+        );
+    }
+
+    #[test]
+    fn preserves_nullable_multi_member_payload_inside_outer_optional() {
+        let payload = make_union(vec![Type::Int, Type::Str, Type::None]);
+        assert_eq!(
+            safe_optional_result(payload.clone()),
+            Type::Union(vec![payload, Type::None])
+        );
+    }
+
+    #[test]
+    fn flattens_simple_optional_payload() {
+        let payload = make_union(vec![Type::Str, Type::None]);
+        assert_eq!(safe_optional_result(payload.clone()), payload);
+    }
+
+    #[test]
+    fn canonicalizes_non_union_payload() {
+        assert_eq!(
+            safe_optional_result(Type::Int),
+            make_union(vec![Type::Int, Type::None])
+        );
+    }
+}

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -8,8 +8,9 @@ mod python_interop;
 mod rust_trait_capabilities;
 mod source_names;
 pub use source_names::{
-    class_rust_name, is_global_rust_nominal_identity, source_class_rust_name,
-    stdlib_class_rust_name, COMPILER_RUST_PATH_ROOTS, GLOBAL_RUST_NOMINAL_IDENTITIES,
+    class_rust_name, is_crate_root_rust_nominal_identity, is_global_rust_nominal_identity,
+    source_class_rust_name, stdlib_class_rust_name, COMPILER_RUST_PATH_ROOTS,
+    CRATE_ROOT_RUST_NOMINAL_IDENTITIES, GLOBAL_RUST_NOMINAL_IDENTITIES,
 };
 mod type_queries;
 mod type_rendering;

--- a/crates/sifr_type_system/src/types/display_impl.rs
+++ b/crates/sifr_type_system/src/types/display_impl.rs
@@ -9,7 +9,9 @@ impl std::fmt::Display for Type {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{FixedIntType, FunctionType, IterationCapability, OwnershipKind, ParamConvention};
+    use crate::{
+        make_union, FixedIntType, FunctionType, IterationCapability, OwnershipKind, ParamConvention,
+    };
 
     #[test]
     fn test_ownership_primitives_are_copy() {
@@ -162,7 +164,7 @@ mod tests {
         );
         assert_eq!(
             Type::Bytes.index_result_type(&Type::Int),
-            Some(Type::Union(vec![uint8.clone(), Type::None]))
+            Some(make_union(vec![uint8.clone(), Type::None]))
         );
         assert!(Type::Bytes.is_assignable_to(&Type::Iterable(Box::new(uint8))));
         assert!(!Type::Bytes.is_assignable_to(&Type::Iterable(Box::new(Type::Int))));
@@ -611,14 +613,21 @@ mod tests {
         // Safe indexing returns Option[T] = T | None
         assert_eq!(
             list_int.index_result_type(&Type::Int),
-            Some(Type::Union(vec![Type::Int, Type::None]))
+            Some(make_union(vec![Type::Int, Type::None]))
         );
         assert_eq!(list_int.index_result_type(&Type::Str), None);
 
         let dict_any_int = Type::Dict(Box::new(Type::Any), Box::new(Type::Int));
         assert_eq!(
             dict_any_int.index_result_type(&Type::Str),
-            Some(Type::Union(vec![Type::Int, Type::None]))
+            Some(make_union(vec![Type::Int, Type::None]))
+        );
+
+        let optional_int = make_union(vec![Type::Int, Type::None]);
+        let list_optional_int = Type::List(Box::new(optional_int.clone()));
+        assert_eq!(
+            list_optional_int.index_result_type(&Type::Int),
+            Some(optional_int)
         );
     }
 
@@ -703,6 +712,21 @@ mod tests {
     fn test_union_rust_type_option() {
         let optional_str = Type::Union(vec![Type::None, Type::Str]);
         assert_eq!(optional_str.rust_type(), "Option<String>");
+
+        let nested_optional = Type::Union(vec![Type::None, optional_str.clone()]);
+        assert_eq!(nested_optional.optional_member_type(), Some(optional_str));
+        assert_eq!(nested_optional.rust_type(), "Option<Option<String>>");
+
+        let inner_union = Type::Union(vec![Type::Int, Type::Str]);
+        let nested_general = Type::Union(vec![Type::None, inner_union.clone()]);
+        assert_eq!(
+            nested_general.optional_member_type(),
+            Some(inner_union.clone())
+        );
+        assert_eq!(
+            nested_general.rust_type(),
+            format!("Option<{}>", inner_union.rust_type())
+        );
     }
 
     #[test]

--- a/crates/sifr_type_system/src/types/source_names.rs
+++ b/crates/sifr_type_system/src/types/source_names.rs
@@ -35,9 +35,25 @@ pub const GLOBAL_RUST_NOMINAL_IDENTITIES: &[&str] = &[
     "sifr.parallel.WorkerError",
 ];
 
+/// Canonical declarations that have exactly one compiler-generated Rust type
+/// at the crate root. Project-wide union support must reference these types;
+/// it must not reproduce them inside the shared nominal module.
+pub const CRATE_ROOT_RUST_NOMINAL_IDENTITIES: &[&str] = &[
+    "_sifr.fs.NativeFileHandle",
+    "sifr.builtin.CancellationError",
+    "sifr.builtin.TimeoutError",
+    "sifr.parallel.WorkerRuntimeError",
+    "sifr.parallel.WorkerError",
+];
+
 #[must_use]
 pub fn is_global_rust_nominal_identity(identity: &str) -> bool {
     GLOBAL_RUST_NOMINAL_IDENTITIES.contains(&identity)
+}
+
+#[must_use]
+pub fn is_crate_root_rust_nominal_identity(identity: &str) -> bool {
+    CRATE_ROOT_RUST_NOMINAL_IDENTITIES.contains(&identity)
 }
 
 /// Return a collision-free Rust identifier for a source-declared nominal type.
@@ -110,7 +126,10 @@ fn push_hex_byte(target: &mut String, byte: u8) {
 
 #[cfg(test)]
 mod tests {
-    use super::{class_rust_name, source_class_rust_name, stdlib_class_rust_name};
+    use super::{
+        class_rust_name, is_crate_root_rust_nominal_identity, is_global_rust_nominal_identity,
+        source_class_rust_name, stdlib_class_rust_name,
+    };
 
     #[test]
     fn escapes_compiler_namespaces_injectively() {
@@ -156,6 +175,20 @@ mod tests {
         assert_ne!(
             class_rust_name(Some("sifr.json.JsonValue"), "JsonValue"),
             class_rust_name(None, "JsonValue")
+        );
+    }
+
+    #[test]
+    fn native_file_handle_is_crate_root_owned_but_still_sealed() {
+        assert!(is_crate_root_rust_nominal_identity(
+            "_sifr.fs.NativeFileHandle"
+        ));
+        assert!(!is_global_rust_nominal_identity(
+            "_sifr.fs.NativeFileHandle"
+        ));
+        assert_eq!(
+            class_rust_name(Some("_sifr.fs.NativeFileHandle"), "NativeFileHandle"),
+            "__SifrIoNativeFileHandle"
         );
     }
 }

--- a/crates/sifr_type_system/src/types/type_queries.rs
+++ b/crates/sifr_type_system/src/types/type_queries.rs
@@ -297,8 +297,10 @@ impl Type {
         )
     }
 
-    fn option_like_member_type(ty: &Type) -> Option<Type> {
-        let Type::Union(members) = ty.resolve_alias() else {
+    /// Return the payload of a raw `T | None` wrapper without flattening `T`.
+    #[must_use]
+    pub fn optional_member_type(&self) -> Option<Type> {
+        let Type::Union(members) = self.resolve_alias() else {
             return None;
         };
         let has_none = members
@@ -310,7 +312,7 @@ impl Type {
             .cloned()
             .collect();
         if has_none && non_none.len() == 1 {
-            non_none.first().cloned()
+            non_none.into_iter().next()
         } else {
             None
         }
@@ -324,7 +326,7 @@ impl Type {
         if !next_ft.params.is_empty() {
             return None;
         }
-        let elem = Self::option_like_member_type(next_ft.return_type.as_ref())?;
+        let elem = next_ft.return_type.optional_member_type()?;
         if matches!(elem.resolve_alias(), Type::Class { name, .. } if name == class_name) {
             return None;
         }
@@ -666,17 +668,13 @@ impl Type {
             Self::LiteralBool(_) => "bool".to_string(),
             // Union: special case for T | None -> Option<T>
             Self::Union(members) => {
-                let non_none: Vec<&Type> = members
-                    .iter()
-                    .filter(|m| !matches!(m, Type::None))
-                    .collect();
-                let has_none = members.iter().any(|m| matches!(m, Type::None));
-                if has_none && non_none.len() == 1 {
-                    // T | None -> Option<T>
-                    format!("Option<{}>", non_none[0].rust_type())
+                if let Some(member) = self.optional_member_type() {
+                    format!("Option<{}>", member.rust_type())
                 } else {
-                    // General union -> generated enum name
-                    self.union_enum_name()
+                    match crate::make_union(members.clone()) {
+                        canonical @ Self::Union(_) => canonical.union_enum_name(),
+                        canonical => canonical.rust_type(),
+                    }
                 }
             }
             Self::Intersection(_) => "Box<dyn std::any::Any>".to_string(),

--- a/crates/sifr_type_system/src/types/type_rendering.rs
+++ b/crates/sifr_type_system/src/types/type_rendering.rs
@@ -298,7 +298,7 @@ impl Type {
             Self::List(elem) => {
                 if index_ty == &Type::Int {
                     // Safe indexing: returns Option[T] = T | None
-                    Some(Type::Union(vec![*elem.clone(), Type::None]))
+                    Some(crate::safe_optional_result(*elem.clone()))
                 } else {
                     None
                 }
@@ -309,7 +309,7 @@ impl Type {
                     || key.is_assignable_to(index_ty)
                 {
                     // Safe indexing: returns Option[V] = V | None
-                    Some(Type::Union(vec![*val.clone(), Type::None]))
+                    Some(crate::safe_optional_result(*val.clone()))
                 } else {
                     None
                 }
@@ -326,7 +326,7 @@ impl Type {
             Self::Str => {
                 if index_ty == &Type::Int {
                     // Safe indexing: returns Option[str] = str | None
-                    Some(Type::Union(vec![Type::Str, Type::None]))
+                    Some(make_union(vec![Type::Str, Type::None]))
                 } else {
                     None
                 }
@@ -334,7 +334,7 @@ impl Type {
             Self::Bytes => {
                 if index_ty == &Type::Int {
                     // Safe indexing: returns Option[uint8] = uint8 | None
-                    Some(Type::Union(vec![
+                    Some(make_union(vec![
                         Type::FixedInt(FixedIntType::U8),
                         Type::None,
                     ]))
@@ -358,17 +358,7 @@ impl Type {
                 }
             }
             // Union type: if T|None where T is indexable, unwrap and delegate
-            Self::Union(members) => {
-                let non_none: Vec<&Type> = members
-                    .iter()
-                    .filter(|m| !matches!(m, Type::None))
-                    .collect();
-                if non_none.len() == 1 {
-                    non_none[0].index_result_type(index_ty)
-                } else {
-                    None
-                }
-            }
+            Self::Union(_) => self.optional_member_type()?.index_result_type(index_ty),
             _ => None,
         }
     }
@@ -393,17 +383,7 @@ impl Type {
             Self::Range => Some(Type::Int),
             Self::Str => Some(Type::Str),
             Self::Bytes => Some(Type::FixedInt(FixedIntType::U8)),
-            Self::Union(members) => {
-                let non_none: Vec<&Type> = members
-                    .iter()
-                    .filter(|member| !matches!(member, Type::None))
-                    .collect();
-                if non_none.len() == 1 {
-                    non_none[0].contains_element_type()
-                } else {
-                    None
-                }
-            }
+            Self::Union(_) => self.optional_member_type()?.contains_element_type(),
             _ => None,
         }
     }

--- a/crates/sifr_type_system/src/types/union_identity.rs
+++ b/crates/sifr_type_system/src/types/union_identity.rs
@@ -9,7 +9,12 @@ impl Type {
     #[must_use]
     pub fn union_enum_name(&self) -> String {
         match self {
-            Self::Union(_) => compiler_identifier("__SifrUnion_", &self.union_identity_key()),
+            Self::Union(members) => match crate::make_union(members.clone()) {
+                canonical @ Self::Union(_) => {
+                    compiler_identifier("__SifrUnion_", &canonical.union_identity_key())
+                }
+                collapsed => collapsed.rust_type(),
+            },
             _ => self.rust_type(),
         }
     }
@@ -20,7 +25,7 @@ impl Type {
         compiler_identifier("__SifrUnionVariant_", &self.union_identity_key())
     }
 
-    fn union_identity_key(&self) -> String {
+    pub(crate) fn union_identity_key(&self) -> String {
         match self {
             Self::Int => atom("int"),
             Self::FixedInt(fixed) => component("fixed", fixed.source_name()),
@@ -43,7 +48,7 @@ impl Type {
             Self::AsyncIterator(item, error) => binary("async_iterator", item, error),
             Self::AsyncGenerator(item, error) => binary("async_generator", item, error),
             Self::PythonBuffer(element) => unary("python_buffer", element),
-            Self::PythonArrow(kind) => format!("python_arrow:{}", kind.source_name()),
+            Self::PythonArrow(kind) => component("python_arrow", kind.source_name()),
             Self::PythonDlpackTensor(element) => unary("python_dlpack_tensor", element),
             Self::PythonDlpackStream => atom("python_dlpack_stream"),
             Self::List(element) => unary("list", element),
@@ -55,7 +60,7 @@ impl Type {
             Self::Iterator(element) => unary("iterator", element),
             Self::Any => atom("any"),
             Self::Never => atom("never"),
-            Self::Union(members) => unordered_sequence("union", members),
+            Self::Union(members) => union_sequence("union", members),
             Self::Intersection(members) => sequence("intersection", members),
             Self::LiteralInt(value) => component("literal_int", &value.to_string()),
             Self::LiteralStr(value) => component("literal_str", value),
@@ -64,11 +69,10 @@ impl Type {
                 name,
                 type_args,
                 body,
-            } => {
-                let mut key = named_sequence("alias", name, type_args);
-                append(&mut key, &body.union_identity_key());
-                key
+            } if matches!(body.as_ref(), Self::Unknown) => {
+                named_sequence("recursive_alias", name, type_args)
             }
+            Self::Alias { body, .. } => body.union_identity_key(),
             Self::Unknown => atom("unknown"),
             Self::Result(ok, error) => binary("result", ok, error),
             Self::Class {
@@ -149,18 +153,34 @@ fn sequence(tag: &str, values: &[Type]) -> String {
     key
 }
 
-fn unordered_sequence(tag: &str, values: &[Type]) -> String {
-    let mut identities = values
-        .iter()
-        .map(Type::union_identity_key)
-        .collect::<Vec<_>>();
+fn union_sequence(tag: &str, values: &[Type]) -> String {
+    let mut identities = Vec::new();
+    collect_union_identities(values, &mut identities);
     identities.sort_unstable();
+    identities.dedup();
+    if identities.len() == 1 {
+        if let Some(identity) = identities.pop() {
+            return identity;
+        }
+    }
     let mut key = component("sequence", tag);
     append(&mut key, &identities.len().to_string());
     for identity in identities {
         append(&mut key, &identity);
     }
     key
+}
+
+fn collect_union_identities(values: &[Type], identities: &mut Vec<String>) {
+    for value in values {
+        match value {
+            Type::Union(nested) => collect_union_identities(nested, identities),
+            Type::Alias { body, .. } if matches!(body.as_ref(), Type::Union(_)) => {
+                collect_union_identities(std::slice::from_ref(body.as_ref()), identities);
+            }
+            other => identities.push(other.union_identity_key()),
+        }
+    }
 }
 
 fn named_sequence(tag: &str, name: &str, values: &[Type]) -> String {
@@ -349,5 +369,33 @@ mod tests {
                 Type::Union(vec![Type::Int, alias]).union_enum_name()
             );
         }
+    }
+
+    #[test]
+    fn raw_identity_duplicate_union_renders_as_its_canonical_member() {
+        let class = Type::Class {
+            identity: Some("pkg.Item".to_string()),
+            type_args: Vec::new(),
+            name: "Item".to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let snapshot = Type::Class {
+            identity: Some("pkg.Item".to_string()),
+            type_args: Vec::new(),
+            name: "Item".to_string(),
+            fields: vec![("value".to_string(), Type::Int)],
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        assert_eq!(
+            Type::Union(vec![class.clone(), snapshot]).union_enum_name(),
+            class.rust_type()
+        );
+        assert_eq!(
+            Type::Union(vec![class.clone(), class.clone()]).union_identity_key(),
+            class.union_identity_key()
+        );
     }
 }

--- a/crates/sifr_type_system/src/union.rs
+++ b/crates/sifr_type_system/src/union.rs
@@ -17,8 +17,7 @@ use crate::types::Type;
 pub fn make_union(types: Vec<Type>) -> Type {
     let mut members = Vec::new();
     flatten_into(&mut members, types);
-    deduplicate(&mut members);
-    sort_members(&mut members);
+    normalize_members(&mut members);
 
     match members.len() {
         0 => Type::Never,
@@ -47,6 +46,11 @@ pub fn union_contains(union: &Type, ty: &Type) -> bool {
 /// Used for narrowing: if `x: int | str` and we know `x` is `int`,
 /// the else branch has `x: str`.
 pub fn subtract_from_union(union: &Type, to_remove: &Type) -> Type {
+    if matches!(to_remove.resolve_alias(), Type::None) {
+        if let Some(payload) = union.optional_member_type() {
+            return payload;
+        }
+    }
     match union {
         // Unknown minus a specific type is still Unknown (we can't enumerate what's left)
         Type::Unknown => Type::Unknown,
@@ -152,32 +156,287 @@ fn flatten_into(out: &mut Vec<Type>, types: Vec<Type>) {
     for ty in types {
         match ty {
             Type::Union(inner) => flatten_into(out, inner),
+            Type::Alias { body, .. } if matches!(body.as_ref(), Type::Union(_)) => {
+                flatten_into(out, vec![*body]);
+            }
             other => out.push(other),
         }
     }
 }
 
-/// Remove duplicate types.
-fn deduplicate(types: &mut Vec<Type>) {
-    let mut seen = Vec::new();
-    types.retain(|ty| {
-        if seen.contains(ty) {
-            false
-        } else {
-            seen.push(ty.clone());
-            true
+fn normalize_members(types: &mut Vec<Type>) {
+    if types.len() < 2 {
+        return;
+    }
+    // Remove common exact duplicates before allocating canonical identity keys.
+    let mut exact = Vec::with_capacity(types.len());
+    for ty in types.drain(..) {
+        if !exact.contains(&ty) {
+            exact.push(ty);
         }
-    });
+    }
+    *types = exact;
+    if types.len() < 2 {
+        return;
+    }
+    let mut keyed = types
+        .drain(..)
+        .map(|ty| (type_source_sort_key(&ty), ty))
+        .collect::<Vec<_>>();
+    keyed.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+
+    let mut normalized = Vec::with_capacity(keyed.len());
+    let mut keyed = keyed.into_iter().peekable();
+    while let Some((primary_key, ty)) = keyed.next() {
+        if keyed
+            .peek()
+            .is_none_or(|(next_key, _)| next_key != &primary_key)
+        {
+            normalized.push(ty);
+            continue;
+        }
+        let mut group = vec![ty];
+        while keyed
+            .peek()
+            .is_some_and(|(next_key, _)| next_key == &primary_key)
+        {
+            if let Some((_, member)) = keyed.next() {
+                group.push(member);
+            }
+        }
+        append_normalized_group(&mut normalized, group);
+    }
+    *types = normalized;
 }
 
-/// Sort types for consistent ordering.
-/// Order: None, Bool, Int, fixed-width ints, Float, Str, `LiteralBool`, `LiteralInt`, `LiteralStr`,
-///        List, Dict, Tuple, Range, Iterable, Iterator, Function, Unknown, Any, Never, Union, Intersection, Alias
-fn sort_members(types: &mut [Type]) {
-    types.sort_by_key(type_sort_key);
+fn append_normalized_group(normalized: &mut Vec<Type>, group: Vec<Type>) {
+    if group.len() == 1 {
+        normalized.extend(group);
+        return;
+    }
+
+    let mut unique = Vec::with_capacity(group.len());
+    for ty in group {
+        if !unique.contains(&ty) {
+            unique.push(ty);
+        }
+    }
+    if unique.len() == 1 {
+        normalized.extend(unique);
+        return;
+    }
+
+    let mut keyed = unique
+        .into_iter()
+        .map(|ty| (ty.union_identity_key(), ty))
+        .collect::<Vec<_>>();
+    keyed.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    let mut deduplicated: Vec<(String, Type)> = Vec::with_capacity(keyed.len());
+    for (identity, ty) in keyed {
+        if let Some((current_identity, current)) = deduplicated.last_mut() {
+            if current_identity == &identity {
+                if representative_key(&ty) > representative_key(current) {
+                    *current = ty;
+                }
+                continue;
+            }
+        }
+        deduplicated.push((identity, ty));
+    }
+    normalized.extend(deduplicated.into_iter().map(|(_, ty)| ty));
 }
 
-fn type_sort_key(ty: &Type) -> (u8, String) {
+fn representative_key(ty: &Type) -> (u8, usize, usize, String, String, String) {
+    let representation = format!("{ty:?}");
+    let (kind, completeness, details, local_name) = match ty {
+        Type::Class {
+            name,
+            fields,
+            methods,
+            parent_class,
+            ..
+        } => (
+            2,
+            (fields.len() + methods.len(), fields.len()),
+            nominal_member_details(fields, methods, parent_class.as_deref()),
+            name.clone(),
+        ),
+        Type::Protocol { name, methods, .. } => (
+            2,
+            (methods.len(), 0),
+            nominal_member_details(&[], methods, None),
+            name.clone(),
+        ),
+        Type::Enum { name, variants, .. } => (
+            2,
+            (variants.len(), 0),
+            enum_member_details(variants),
+            name.clone(),
+        ),
+        Type::Newtype { name, .. } => (1, (0, 0), ty.union_identity_key(), name.clone()),
+        Type::Alias { name, .. } => (
+            1,
+            (type_information_score(ty), 0),
+            ty.union_identity_key(),
+            name.clone(),
+        ),
+        _ => (
+            1,
+            (type_information_score(ty), 0),
+            ty.union_identity_key(),
+            String::new(),
+        ),
+    };
+    (
+        kind,
+        completeness.0,
+        completeness.1,
+        details,
+        local_name,
+        representation,
+    )
+}
+
+fn type_information_score(ty: &Type) -> usize {
+    match ty {
+        Type::List(inner)
+        | Type::Set(inner)
+        | Type::Iterable(inner)
+        | Type::Iterator(inner)
+        | Type::Failure(inner)
+        | Type::TimeoutResult(inner)
+        | Type::Awaitable(inner)
+        | Type::PythonBuffer(inner)
+        | Type::PythonDlpackTensor(inner)
+        | Type::Alias { body: inner, .. }
+        | Type::Newtype { inner, .. } => type_information_score(inner),
+        Type::Dict(left, right)
+        | Type::Result(left, right)
+        | Type::Coroutine(left, right)
+        | Type::Task(left, right)
+        | Type::TaskResult(left, right)
+        | Type::Select2(left, right)
+        | Type::BlockingTask(left, right)
+        | Type::JoinSet(left, right)
+        | Type::AsyncIterator(left, right)
+        | Type::AsyncGenerator(left, right) => {
+            type_information_score(left) + type_information_score(right)
+        }
+        Type::Tuple(items) | Type::Union(items) | Type::Intersection(items) => {
+            items.iter().map(type_information_score).sum()
+        }
+        Type::Function(function) | Type::AsyncFunction(function) => {
+            function_information_score(function)
+        }
+        Type::Class {
+            type_args,
+            fields,
+            methods,
+            parent_class,
+            ..
+        } => {
+            fields.len()
+                + methods.len()
+                + usize::from(parent_class.is_some())
+                + type_args.iter().map(type_information_score).sum::<usize>()
+                + fields
+                    .iter()
+                    .map(|(_, field)| type_information_score(field))
+                    .sum::<usize>()
+                + methods
+                    .iter()
+                    .map(|(_, method)| function_information_score(method))
+                    .sum::<usize>()
+        }
+        Type::Protocol { methods, .. } => {
+            methods.len()
+                + methods
+                    .iter()
+                    .map(|(_, method)| function_information_score(method))
+                    .sum::<usize>()
+        }
+        Type::Callable(parameters, _, result) | Type::AsyncCallable(parameters, _, result) => {
+            parameters.iter().map(type_information_score).sum::<usize>()
+                + type_information_score(result)
+        }
+        Type::Enum { variants, .. } => variants.len(),
+        Type::None
+        | Type::Bool
+        | Type::Int
+        | Type::FixedInt(_)
+        | Type::Float
+        | Type::Str
+        | Type::Bytes
+        | Type::Range
+        | Type::Any
+        | Type::Never
+        | Type::LiteralInt(_)
+        | Type::LiteralStr(_)
+        | Type::LiteralBool(_)
+        | Type::Unknown
+        | Type::TypeVar(_)
+        | Type::PythonArrow(_)
+        | Type::PythonDlpackStream
+        | Type::BigInt
+        | Type::Decimal
+        | Type::BigDecimal => 0,
+    }
+}
+
+fn function_information_score(function: &crate::types::FunctionType) -> usize {
+    function
+        .params
+        .iter()
+        .map(|(_, parameter, _)| type_information_score(parameter))
+        .sum::<usize>()
+        + type_information_score(&function.return_type)
+}
+
+fn nominal_member_details(
+    fields: &[(String, Type)],
+    methods: &[(String, crate::types::FunctionType)],
+    parent_class: Option<&str>,
+) -> String {
+    let mut details = String::new();
+    for (name, ty) in fields {
+        append_representative_component(&mut details, "field");
+        append_representative_component(&mut details, name);
+        append_representative_component(&mut details, &ty.union_identity_key());
+    }
+    for (name, function) in methods {
+        append_representative_component(&mut details, "method");
+        append_representative_component(&mut details, name);
+        append_representative_component(
+            &mut details,
+            &Type::Function(function.clone()).union_identity_key(),
+        );
+    }
+    if let Some(parent) = parent_class {
+        append_representative_component(&mut details, "parent");
+        append_representative_component(&mut details, parent);
+    }
+    details
+}
+
+fn enum_member_details(variants: &[(String, Option<i64>)]) -> String {
+    let mut details = String::new();
+    for (name, value) in variants {
+        append_representative_component(&mut details, name);
+        append_representative_component(
+            &mut details,
+            &value.map_or_else(|| "implicit".to_string(), |value| value.to_string()),
+        );
+    }
+    details
+}
+
+fn append_representative_component(target: &mut String, value: &str) {
+    target.push_str(&value.len().to_string());
+    target.push(':');
+    target.push_str(value);
+}
+
+fn type_source_sort_key(ty: &Type) -> (u8, String) {
     match ty {
         Type::None => (0, String::new()),
         Type::Bool => (1, String::new()),
@@ -209,43 +468,24 @@ fn type_sort_key(ty: &Type) -> (u8, String) {
         Type::Awaitable(_) => (26, String::new()),
         Type::AsyncIterator(_, _) => (27, String::new()),
         Type::AsyncGenerator(_, _) => (28, String::new()),
-        Type::PythonBuffer(element) => (29, format!("buffer:{}", element.display_name())),
+        Type::PythonBuffer(_) => (29, "buffer".to_string()),
         Type::PythonArrow(kind) => (29, format!("arrow:{}", kind.source_name())),
-        Type::PythonDlpackTensor(element) => {
-            (29, format!("dlpack_tensor:{}", element.display_name()))
-        }
+        Type::PythonDlpackTensor(_) => (29, "dlpack_tensor".to_string()),
         Type::PythonDlpackStream => (29, "dlpack_stream".to_string()),
         Type::Unknown => (29, String::new()),
         Type::Any => (29, String::new()),
         Type::Never => (29, String::new()),
         Type::Union(_) => (30, String::new()),
         Type::Intersection(_) => (31, String::new()),
-        Type::Alias {
-            name, type_args, ..
-        } => (
-            31,
-            if type_args.is_empty() {
-                name.clone()
-            } else {
-                format!(
-                    "{}[{}]",
-                    name,
-                    type_args
-                        .iter()
-                        .map(Type::display_name)
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            },
-        ),
-        Type::Class { .. } => (31, ty.display_name()),
+        Type::Alias { body, .. } => type_source_sort_key(body),
+        Type::Class { identity, name, .. } => (31, identity.as_ref().unwrap_or(name).clone()),
         Type::Result(_, _) => (32, String::new()),
-        Type::Protocol { name, .. } => (33, name.clone()),
-        Type::Newtype { name, .. } => (34, name.clone()),
+        Type::Protocol { identity, name, .. } => (33, identity.as_ref().unwrap_or(name).clone()),
+        Type::Newtype { identity, name, .. } => (34, identity.as_ref().unwrap_or(name).clone()),
         Type::TypeVar(name) => (35, name.clone()),
         Type::Callable(..) => (36, String::new()),
         Type::AsyncCallable(..) => (37, String::new()),
-        Type::Enum { name, .. } => (38, name.clone()),
+        Type::Enum { identity, name, .. } => (38, identity.as_ref().unwrap_or(name).clone()),
         Type::BigInt => (39, String::new()),
         Type::Decimal => (40, String::new()),
         Type::BigDecimal => (41, String::new()),
@@ -336,54 +576,278 @@ mod tests {
     }
 
     #[test]
-    fn test_subtract_from_union() {
-        let u = Type::Union(vec![Type::Int, Type::Str]);
-        let result = subtract_from_union(&u, &Type::Int);
-        assert_eq!(result, Type::Str);
+    fn python_resource_union_dedup_uses_alias_transparent_element_identity() {
+        let byte_alias = Type::Alias {
+            name: "Byte".to_string(),
+            type_args: Vec::new(),
+            body: Box::new(Type::FixedInt(crate::types::FixedIntType::U8)),
+        };
+        let uint8 = Type::FixedInt(crate::types::FixedIntType::U8);
+
+        for (left, right) in [
+            (
+                Type::PythonBuffer(Box::new(byte_alias.clone())),
+                Type::PythonBuffer(Box::new(uint8.clone())),
+            ),
+            (
+                Type::PythonDlpackTensor(Box::new(byte_alias)),
+                Type::PythonDlpackTensor(Box::new(uint8)),
+            ),
+        ] {
+            let forward = make_union(vec![left.clone(), right.clone()]);
+            let reverse = make_union(vec![right, left]);
+            assert!(!matches!(forward, Type::Union(_)));
+            assert_eq!(forward, reverse);
+        }
     }
 
     #[test]
-    fn test_subtract_none_from_optional() {
-        let u = Type::Union(vec![Type::None, Type::Str]);
-        let result = remove_none_from_union(&u);
-        assert_eq!(result, Type::Str);
+    fn nested_nominal_snapshot_dedup_keeps_the_complete_member_in_each_order() {
+        let incomplete = Type::List(Box::new(Type::Class {
+            identity: Some("pkg.Item".to_string()),
+            type_args: Vec::new(),
+            name: "Item".to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        }));
+        let complete = Type::List(Box::new(Type::Class {
+            identity: Some("pkg.Item".to_string()),
+            type_args: Vec::new(),
+            name: "Item".to_string(),
+            fields: vec![("value".to_string(), Type::Int)],
+            methods: Vec::new(),
+            parent_class: None,
+        }));
+
+        assert_eq!(
+            make_union(vec![incomplete.clone(), complete.clone()]),
+            complete
+        );
+        assert_eq!(make_union(vec![complete.clone(), incomplete]), complete);
     }
 
     #[test]
-    fn test_intersect_with_union() {
-        let u = Type::Union(vec![Type::Bool, Type::Int, Type::Str]);
-        let result = intersect_with_union(&u, &Type::Int);
-        assert_eq!(result, Type::Int);
+    fn narrowing_preserves_non_union_alias_semantics() {
+        let mapping = Type::Dict(Box::new(Type::Str), Box::new(Type::Int));
+        let alias = Type::Alias {
+            name: "__sifr_defaultdict_str_int".to_string(),
+            type_args: Vec::new(),
+            body: Box::new(mapping.clone()),
+        };
+        let optional = make_union(vec![alias.clone(), Type::None]);
+
+        assert_eq!(make_union(vec![mapping, alias.clone()]), alias);
+        assert_eq!(remove_none_from_union(&optional), alias);
     }
 
     #[test]
-    fn test_union_contains() {
-        let u = Type::Union(vec![Type::Int, Type::Str]);
-        assert!(union_contains(&u, &Type::Int));
-        assert!(union_contains(&u, &Type::Str));
-        assert!(!union_contains(&u, &Type::Bool));
+    fn nominal_union_order_uses_declaration_identity_for_equal_source_names() {
+        let class = |identity: &str| Type::Class {
+            identity: Some(identity.to_string()),
+            type_args: Vec::new(),
+            name: "Record".to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let enumeration = |identity: &str| Type::Enum {
+            identity: Some(identity.to_string()),
+            name: "Status".to_string(),
+            variants: vec![("READY".to_string(), Some(1))],
+        };
+        let newtype = |identity: &str| Type::Newtype {
+            identity: Some(identity.to_string()),
+            name: "Token".to_string(),
+            inner: Box::new(Type::Int),
+        };
+
+        for (left, right) in [
+            (class("alpha.Record"), class("zoo.Record")),
+            (enumeration("alpha.Status"), enumeration("zoo.Status")),
+            (newtype("alpha.Token"), newtype("zoo.Token")),
+        ] {
+            let expected = make_union(vec![left.clone(), right.clone()]);
+            assert_eq!(make_union(vec![right, left]), expected);
+        }
     }
 
     #[test]
-    fn test_union_contains_none() {
-        let u = Type::Union(vec![Type::None, Type::Str]);
-        assert!(union_contains_none(&u));
-        let u2 = Type::Union(vec![Type::Int, Type::Str]);
-        assert!(!union_contains_none(&u2));
+    fn nominal_union_order_ignores_local_import_spellings() {
+        let class = |name: &str, identity: &str| Type::Class {
+            identity: Some(identity.to_string()),
+            type_args: Vec::new(),
+            name: name.to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let member_names = |union: Type| {
+            let Type::Union(members) = union else {
+                panic!("expected union");
+            };
+            members
+                .iter()
+                .map(Type::union_variant_name)
+                .collect::<Vec<_>>()
+        };
+        let original = make_union(vec![class("Alpha", "pkg.Alpha"), class("Beta", "pkg.Beta")]);
+        let aliased = make_union(vec![class("Zeta", "pkg.Alpha"), class("Beta", "pkg.Beta")]);
+
+        assert_eq!(member_names(original), member_names(aliased));
     }
 
     #[test]
-    fn test_is_assignable_to_union() {
-        let members = vec![Type::Int, Type::Str];
-        assert!(is_assignable_to_union(&Type::Int, &members));
-        assert!(is_assignable_to_union(&Type::Str, &members));
-        assert!(!is_assignable_to_union(&Type::Bool, &members));
+    fn nominal_snapshot_dedup_keeps_the_same_complete_member_in_each_order() {
+        let complete = Type::Class {
+            identity: Some("pkg.Record".to_string()),
+            type_args: Vec::new(),
+            name: "Record".to_string(),
+            fields: vec![("value".to_string(), Type::Int)],
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let incomplete = Type::Class {
+            identity: Some("pkg.Record".to_string()),
+            type_args: Vec::new(),
+            name: "Record".to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let forward = make_union(vec![incomplete.clone(), complete.clone()]);
+        let reverse = make_union(vec![complete.clone(), incomplete]);
+
+        assert_eq!(forward, reverse);
+        assert_eq!(forward, complete);
     }
 
     #[test]
-    fn test_literal_overlap_with_base() {
-        let u = Type::Union(vec![Type::Int, Type::Str]);
-        let result = intersect_with_union(&u, &Type::LiteralInt(42));
-        assert_eq!(result, Type::Int);
+    fn nominal_snapshot_dedup_is_independent_of_local_spelling_order() {
+        let class = |name: &str| Type::Class {
+            identity: Some("pkg.Record".to_string()),
+            type_args: Vec::new(),
+            name: name.to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let protocol = |name: &str| Type::Protocol {
+            identity: Some("pkg.Readable".to_string()),
+            name: name.to_string(),
+            methods: Vec::new(),
+        };
+        let newtype = |name: &str| Type::Newtype {
+            identity: Some("pkg.Token".to_string()),
+            name: name.to_string(),
+            inner: Box::new(Type::Int),
+        };
+        let enumeration = |name: &str| Type::Enum {
+            identity: Some("pkg.Status".to_string()),
+            name: name.to_string(),
+            variants: Vec::new(),
+        };
+
+        for (left, right) in [
+            (class("LocalRecord"), class("Record")),
+            (protocol("LocalReadable"), protocol("Readable")),
+            (newtype("LocalToken"), newtype("Token")),
+            (enumeration("LocalStatus"), enumeration("Status")),
+        ] {
+            assert_eq!(
+                make_union(vec![left.clone(), right.clone()]),
+                make_union(vec![right, left])
+            );
+        }
+    }
+
+    #[test]
+    fn nominal_snapshot_completeness_counts_fields_and_methods_together() {
+        let method = crate::types::FunctionType::new(Vec::new(), Type::None);
+        let method_snapshot = Type::Class {
+            identity: Some("pkg.Record".to_string()),
+            type_args: Vec::new(),
+            name: "Record".to_string(),
+            fields: vec![("first".to_string(), Type::Int)],
+            methods: vec![("render".to_string(), method)],
+            parent_class: None,
+        };
+        let field_snapshot = Type::Class {
+            identity: Some("pkg.Record".to_string()),
+            type_args: Vec::new(),
+            name: "Record".to_string(),
+            fields: vec![
+                ("first".to_string(), Type::Int),
+                ("second".to_string(), Type::Str),
+            ],
+            methods: Vec::new(),
+            parent_class: None,
+        };
+
+        assert_eq!(
+            make_union(vec![method_snapshot, field_snapshot.clone()]),
+            field_snapshot
+        );
+    }
+
+    #[test]
+    fn union_order_is_permutation_independent_for_equal_primary_keys() {
+        let error = |identity: &str| Type::Class {
+            identity: Some(identity.to_string()),
+            type_args: Vec::new(),
+            name: "Failure".to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: Some("Error".to_string()),
+        };
+        let protocol = |identity: &str| Type::Protocol {
+            identity: Some(identity.to_string()),
+            name: "Readable".to_string(),
+            methods: Vec::new(),
+        };
+        let alias = |body| Type::Alias {
+            name: "Value".to_string(),
+            type_args: Vec::new(),
+            body: Box::new(body),
+        };
+
+        for (left, right) in [
+            (
+                Type::List(Box::new(Type::Int)),
+                Type::List(Box::new(Type::Str)),
+            ),
+            (
+                Type::Dict(Box::new(Type::Int), Box::new(Type::Str)),
+                Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+            ),
+            (
+                Type::Set(Box::new(Type::Int)),
+                Type::Set(Box::new(Type::Str)),
+            ),
+            (Type::Tuple(vec![Type::Int]), Type::Range),
+            (
+                Type::Result(Box::new(Type::Int), Box::new(error("alpha.Failure"))),
+                Type::Result(Box::new(Type::Int), Box::new(error("zoo.Failure"))),
+            ),
+            (protocol("alpha.Readable"), protocol("zoo.Readable")),
+            (alias(Type::Int), alias(Type::Str)),
+            (
+                Type::Callable(
+                    vec![Type::Int],
+                    vec![crate::ParamConvention::own()],
+                    Box::new(Type::Bool),
+                ),
+                Type::Callable(
+                    vec![Type::Str],
+                    vec![crate::ParamConvention::own()],
+                    Box::new(Type::Bool),
+                ),
+            ),
+        ] {
+            assert_eq!(
+                make_union(vec![left.clone(), right.clone()]),
+                make_union(vec![right, left])
+            );
+        }
     }
 }

--- a/crates/sifr_type_system/src/union_operation_tests.rs
+++ b/crates/sifr_type_system/src/union_operation_tests.rs
@@ -1,0 +1,63 @@
+use crate::{
+    intersect_with_union, remove_none_from_union, subtract_from_union, union_contains,
+    union_contains_none, Type,
+};
+
+#[test]
+fn subtracts_a_member_from_a_union() {
+    let union = Type::Union(vec![Type::Int, Type::Str]);
+    assert_eq!(subtract_from_union(&union, &Type::Int), Type::Str);
+}
+
+#[test]
+fn subtracts_none_from_an_optional() {
+    let optional = Type::Union(vec![Type::None, Type::Str]);
+    assert_eq!(remove_none_from_union(&optional), Type::Str);
+}
+
+#[test]
+fn subtracts_only_the_outer_none_from_a_nested_optional_union() {
+    let payload = crate::make_union(vec![Type::Int, Type::Str, Type::None]);
+    let nested = Type::Union(vec![payload.clone(), Type::None]);
+    assert_eq!(remove_none_from_union(&nested), payload);
+}
+
+#[test]
+fn intersects_a_union_with_a_member() {
+    let union = Type::Union(vec![Type::Bool, Type::Int, Type::Str]);
+    assert_eq!(intersect_with_union(&union, &Type::Int), Type::Int);
+}
+
+#[test]
+fn reports_union_membership() {
+    let union = Type::Union(vec![Type::Int, Type::Str]);
+    assert!(union_contains(&union, &Type::Int));
+    assert!(union_contains(&union, &Type::Str));
+    assert!(!union_contains(&union, &Type::Bool));
+}
+
+#[test]
+fn reports_none_membership() {
+    let optional = Type::Union(vec![Type::None, Type::Str]);
+    assert!(union_contains_none(&optional));
+
+    let union = Type::Union(vec![Type::Int, Type::Str]);
+    assert!(!union_contains_none(&union));
+}
+
+#[test]
+fn reports_assignability_to_union_members() {
+    let members = vec![Type::Int, Type::Str];
+    assert!(Type::Int.is_assignable_to(&Type::Union(members.clone())));
+    assert!(Type::Str.is_assignable_to(&Type::Union(members.clone())));
+    assert!(!Type::Bool.is_assignable_to(&Type::Union(members)));
+}
+
+#[test]
+fn intersects_a_literal_with_its_union_base() {
+    let union = Type::Union(vec![Type::Int, Type::Str]);
+    assert_eq!(
+        intersect_with_union(&union, &Type::LiteralInt(42)),
+        Type::Int
+    );
+}

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -626,6 +626,11 @@ An ordinary union is an aggregate `Union` node with one `ActiveMember` edge.
 The edge name is `member`. Its index selects the stored union-member order, and
 its child contains the active value. Construction rejects unknown indices or
 additional edges. Projection emits the same edge before the active value.
+Canonical member order uses the type category. Nominal types then use their
+stable declaration identity. The compiler-owned member identity resolves all
+remaining ties and merges repeated snapshots of one member.
+Structural union identity sorts and deduplicates member identities. This keeps
+generic and concrete union identities equal after type substitution.
 
 A C-like enum is a nominal aggregate `Enum` node with one `ActiveMember` edge.
 The edge contains the declared variant name and declaration index. Its child is

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/main.sifr
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/main.sifr
@@ -24,6 +24,10 @@ class Boxed[T]:
     value: T
 
 
+class OptionalBox[T]:
+    value: T | None
+
+
 class NestedValue:
     label: str
     leaves: list[Leaf]
@@ -105,6 +109,9 @@ def verify_structural_bridge_runtime() -> Result[str, StructuralBridgeError | Ru
     try:
         projection: str = observe_structural(original)
         assert projection == "records=3;sequences=1;optionals=1;strings=input,x,input-box"
+        nested_optional: OptionalBox[str | None] = OptionalBox(None)
+        nested_optional_projection: str = observe_structural(nested_optional)
+        assert nested_optional_projection == "records=1;sequences=0;optionals=1;strings="
 
         roundtrip_source: StructuralArena = open_structural_arena()
         decoded: NestedValue = structural_roundtrip(roundtrip_source, original)


### PR DESCRIPTION
## Summary
- canonicalize union members using stable nominal, structural, protocol, newtype, and enum identities
- resolve same-bare-name union ties deterministically across modules and generic substitutions
- preserve nested optionality in raw generic and structural wrappers while flattening only at typed optional boundaries
- make safe container operations and `next` follow Python-consistent `None` semantics without legacy or fallback paths

## Review
- Claude Opus round 9: SATISFIED on exact SHA `85671d6258cc15b31be424d205b9bf20c6d64ce1`
- review response SHA-256: `d9e73c5604630563d755236a5b3a4467f91ab149b973344e775fe4b848c27324`
- no blocking findings remain

## Targeted validation
- `sifr_type_system`: 129/129
- `sifr_lowering`: 987 passed, 1 intentional ignore
- `sifr_codegen`: 1016/1016
- focused nested optional E2E: 1/1 with cache disabled
- release compiler build: pass
- structural generated-build driver: 1/1
- Rust interop verification area: 10/10
- strict affected-library Clippy, fmt, HIR maintainability, and 900-line file-size guard: pass
- controlled work-mode performance subset: 3/3 budgets passed; receipt SHA-256 `84a023390236eb42d1ef1f0301fc19465da2abf501622580b3f0fee9f1d27ae4`

## Canonical create-PR gate
- exact candidate: `85671d6258cc15b31be424d205b9bf20c6d64ce1`
- unchanged warm canonical rerun: exit 0
- E2E: 140/140
- Python interop: 19/19 with zero mutations
- Rust interop: 10/10
- generated-code quality: 5/5
- runtime platform: 28 variants, zero failures, one declared capability skip
- receipt SHA-256: `a87ff5bb08de17c157886dda9e6bbb286abf53b0f3d98891a93891f41057eeb0`

The initial cold gate passed every functional lane but exceeded only the known #3134 generated-artifact cold-cache step budget. The unchanged warm canonical rerun exited 0. This change does not alter timeouts or budgets and adds no backward compatibility, fallback, legacy path, or versioned API name.
