### PR TITLE
feat: expose annotated method shape metadata

### DIFF
--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -528,6 +528,30 @@ class Model:
             target.specialization_outputs[0].program_identity,
             changed.specialization_outputs[0].program_identity
         );
+        let with_callback = compile(
+            "target",
+            &format!(
+                "{TARGET}    @staticmethod\n    @metadata(\"fixture.callback\", \"after\")\n    def normalize(value: int) -> int:\n        return 0\n"
+            ),
+            &external_defs,
+        )
+        .expect("annotated method specializes");
+        let with_changed_callback = compile(
+            "target",
+            &format!(
+                "{TARGET}    @staticmethod\n    @metadata(\"fixture.callback\", \"after\")\n    def normalize(value: str) -> int:\n        return 0\n"
+            ),
+            &external_defs,
+        )
+        .expect("changed annotated method specializes");
+        assert_ne!(
+            target.specialization_outputs[0].program_identity,
+            with_callback.specialization_outputs[0].program_identity
+        );
+        assert_ne!(
+            with_callback.specialization_outputs[0].program_identity,
+            with_changed_callback.specialization_outputs[0].program_identity
+        );
         let cli = warning_diagnostics(None, &target.warnings);
         let editor = warning_diagnostics(
             Some(FrontendSourceContext {

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -8,6 +8,10 @@ use sifr_lowering::{
 use sifr_type_system::Type;
 use std::collections::{BTreeMap, BTreeSet};
 
+mod methods;
+use methods::described_methods;
+pub use methods::{ShapeMethod, ShapeParameter};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructuralShape {
     pub root: ShapeNode,
@@ -64,6 +68,7 @@ pub enum ShapeNode {
         identity: String,
         type_arguments: Vec<Self>,
         fields: Vec<ShapeField>,
+        methods: Vec<ShapeMethod>,
         metadata: Vec<ShapeMetadata>,
     },
     Enum {
@@ -289,6 +294,16 @@ fn describe_class(
             ),
         })
         .collect();
+    let described_methods = local_class.map_or_else(Vec::new, |class| {
+        described_methods(
+            module_name,
+            local_name,
+            class,
+            type_args,
+            lowering,
+            visiting,
+        )
+    });
     let type_arguments = type_args
         .iter()
         .map(|argument| describe_node(module_name, argument, lowering, visiting))
@@ -298,6 +313,7 @@ fn describe_class(
         identity,
         type_arguments,
         fields: described_fields,
+        methods: described_methods,
         metadata: metadata_for(
             &lowering.declaration_metadata,
             local_name,
@@ -378,6 +394,7 @@ fn canonical_node(node: &ShapeNode) -> String {
             identity,
             type_arguments,
             fields,
+            methods,
             metadata,
         } => {
             let args = canonical_sequence("args", type_arguments);
@@ -397,8 +414,13 @@ fn canonical_node(node: &ShapeNode) -> String {
                 })
                 .collect::<Vec<_>>()
                 .join(",");
+            let methods = methods
+                .iter()
+                .map(canonical_method)
+                .collect::<Vec<_>>()
+                .join(",");
             format!(
-                "class:{identity}:{args}:meta[{}]:fields[{fields}]",
+                "class:{identity}:{args}:meta[{}]:fields[{fields}]:methods[{methods}]",
                 canonical_metadata(metadata)
             )
         }
@@ -439,6 +461,35 @@ fn canonical_node(node: &ShapeNode) -> String {
         ShapeNode::TypeParameter(name) => format!("param:{name}"),
         ShapeNode::Other(name) => format!("other:{name}"),
     }
+}
+
+fn canonical_method(method: &ShapeMethod) -> String {
+    let params = method
+        .params
+        .iter()
+        .map(|param| {
+            format!(
+                "{}:{}:{}:{}:{}:{}",
+                param.name.len(),
+                param.name,
+                param.convention,
+                param.keyword_only,
+                canonical_node(&param.declared_type),
+                canonical_metadata(&param.metadata)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "{}:{}:{}:{}:{}:params[{params}]:result[{}]:meta[{}]",
+        method.name.len(),
+        method.name,
+        method.kind,
+        method.receiver.as_deref().unwrap_or("none"),
+        method.is_async,
+        canonical_node(&method.result),
+        canonical_metadata(&method.metadata)
+    )
 }
 
 fn node_const_value(node: &ShapeNode) -> ConstValue {
@@ -491,6 +542,7 @@ fn node_const_value(node: &ShapeNode) -> ConstValue {
             identity,
             type_arguments,
             fields,
+            methods,
             metadata,
         } => {
             record.insert(
@@ -527,6 +579,10 @@ fn node_const_value(node: &ShapeNode) -> ConstValue {
                         })
                         .collect(),
                 ),
+            );
+            record.insert(
+                "methods".to_string(),
+                ConstValue::List(methods.iter().map(method_const_value).collect()),
             );
             record.insert("metadata".to_string(), metadata_const_value(metadata));
         }
@@ -597,6 +653,54 @@ fn node_const_value(node: &ShapeNode) -> ConstValue {
         }
     }
     ConstValue::Record(record)
+}
+
+fn method_const_value(method: &ShapeMethod) -> ConstValue {
+    ConstValue::Record(BTreeMap::from([
+        ("name".to_string(), ConstValue::String(method.name.clone())),
+        ("kind".to_string(), ConstValue::String(method.kind.clone())),
+        (
+            "receiver".to_string(),
+            method
+                .receiver
+                .clone()
+                .map(ConstValue::String)
+                .unwrap_or(ConstValue::None),
+        ),
+        ("is_async".to_string(), ConstValue::Bool(method.is_async)),
+        (
+            "params".to_string(),
+            ConstValue::List(
+                method
+                    .params
+                    .iter()
+                    .map(|param| {
+                        ConstValue::Record(BTreeMap::from([
+                            ("name".to_string(), ConstValue::String(param.name.clone())),
+                            ("type".to_string(), node_const_value(&param.declared_type)),
+                            (
+                                "convention".to_string(),
+                                ConstValue::String(param.convention.clone()),
+                            ),
+                            (
+                                "keyword_only".to_string(),
+                                ConstValue::Bool(param.keyword_only),
+                            ),
+                            (
+                                "metadata".to_string(),
+                                metadata_const_value(&param.metadata),
+                            ),
+                        ]))
+                    })
+                    .collect(),
+            ),
+        ),
+        ("result".to_string(), node_const_value(&method.result)),
+        (
+            "metadata".to_string(),
+            metadata_const_value(&method.metadata),
+        ),
+    ]))
 }
 
 fn metadata_const_value(metadata: &[ShapeMetadata]) -> ConstValue {
@@ -686,131 +790,4 @@ fn canonical_sequence(kind: &str, elements: &[ShapeNode]) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use sifr_lowering::lower_module;
-    use sifr_syntax::parse_module_suite;
-
-    #[test]
-    fn class_shape_preserves_defaults_generics_and_recursive_identity() {
-        let source = "class Node[T]:\n    value: T\n    label: str = \"root\"\n    next: Node[T] | None = None\n";
-        let parsed = parse_module_suite(source, None).expect("fixture parses");
-        let lowered = lower_module(&parsed).expect("fixture lowers");
-        let class = lowered.module.classes.first().expect("class exists");
-        let ty = Type::Class {
-            identity: None,
-            type_args: vec![Type::Int],
-            name: class.name.clone(),
-            fields: class.fields.clone(),
-            methods: Vec::new(),
-            parent_class: None,
-        };
-        let shape = describe_type("fixture.shapes", &ty, &lowered);
-        assert!(shape.canonical_identity.contains("fixture.shapes.Node"));
-        assert!(shape.canonical_identity.contains("label:str:default"));
-        assert!(shape.canonical_identity.contains("ref:fixture.shapes.Node"));
-    }
-
-    #[test]
-    fn union_description_is_deterministic() {
-        let parsed = parse_module_suite("", None).expect("fixture parses");
-        let lowered = lower_module(&parsed).expect("fixture lowers");
-        let ty = Type::Union(vec![Type::Int, Type::Str]);
-        assert_eq!(
-            describe_type("fixture", &ty, &lowered),
-            describe_type("fixture", &ty, &lowered)
-        );
-    }
-
-    #[test]
-    fn explicit_initializer_does_not_erase_field_default_metadata() {
-        let source = "class Config:\n    retries: int = 3\n\n    def __init__(self, retries: int) -> None:\n        self.retries = retries\n";
-        let parsed = parse_module_suite(source, None).expect("fixture parses");
-        let lowered = lower_module(&parsed).expect("fixture lowers");
-        let class = lowered.module.classes.first().expect("class exists");
-        let ty = Type::Class {
-            identity: None,
-            type_args: Vec::new(),
-            name: class.name.clone(),
-            fields: class.fields.clone(),
-            methods: Vec::new(),
-            parent_class: None,
-        };
-        let shape = describe_type("fixture.defaults", &ty, &lowered);
-        assert!(shape
-            .canonical_identity
-            .contains("retries:int:default=int:3"));
-    }
-
-    #[test]
-    fn enum_and_newtype_shapes_preserve_metadata_and_nominal_identity() {
-        let source = r#"
-from enum import Enum
-
-@metadata("fixture.kind", "color")
-@metadata("enum_variant", "RED", "fixture.label", "red")
-class Color(Enum):
-    RED = 1
-    BLUE = 2
-
-@metadata("fixture.kind", "port")
-class Port(int):
-    pass
-"#;
-        let parsed = parse_module_suite(source, None).expect("fixture parses");
-        let lowered = lower_module(&parsed).expect("fixture lowers");
-        let color = &lowered.module.classes[0];
-        let color_ty = Type::Class {
-            identity: None,
-            type_args: Vec::new(),
-            name: color.name.clone(),
-            fields: color.fields.clone(),
-            methods: Vec::new(),
-            parent_class: None,
-        };
-        let color_shape = describe_type("fixture.nominal", &color_ty, &lowered);
-        assert!(color_shape
-            .canonical_identity
-            .contains("enum:fixture.nominal.Color"));
-        assert!(color_shape.canonical_identity.contains("fixture.label"));
-
-        let port = &lowered.module.classes[1];
-        let port_ty = Type::Class {
-            identity: None,
-            type_args: Vec::new(),
-            name: port.name.clone(),
-            fields: port.fields.clone(),
-            methods: Vec::new(),
-            parent_class: None,
-        };
-        let port_shape = describe_type("fixture.nominal", &port_ty, &lowered);
-        assert!(port_shape
-            .canonical_identity
-            .contains("newtype:fixture.nominal.Port"));
-        assert!(port_shape.canonical_identity.contains("fixture.kind"));
-    }
-
-    #[test]
-    fn canonical_values_bind_record_keys_and_bytes_without_collisions() {
-        let ambiguous_key = ConstValue::Record(BTreeMap::from([(
-            "a=str:1:x,b".to_string(),
-            ConstValue::None,
-        )]));
-        let two_fields = ConstValue::Record(BTreeMap::from([
-            ("a".to_string(), ConstValue::String("x".to_string())),
-            ("b".to_string(), ConstValue::None),
-        ]));
-        assert_ne!(
-            canonical_value(&ambiguous_key),
-            canonical_value(&two_fields)
-        );
-        assert_eq!(
-            canonical_value(&ConstValue::Bytes(vec![0, 255])),
-            "bytes:2:00ff"
-        );
-        assert_ne!(
-            canonical_value(&ConstValue::Bytes(Vec::new())),
-            canonical_value(&ConstValue::String(String::new()))
-        );
-    }
-}
+mod tests;

--- a/crates/sifr_frontend/src/structural_shape/methods.rs
+++ b/crates/sifr_frontend/src/structural_shape/methods.rs
@@ -1,0 +1,161 @@
+use super::{describe_node, metadata_for, ShapeMetadata, ShapeNode};
+use sifr_lowering::{
+    substitute_type_vars, DeclarationMetadataTargetKind, HirClass, HirFunction, LoweringResult,
+    MethodKind,
+};
+use sifr_type_system::{
+    ParamConvention, ParamMutability, ParamOwnership, ReceiverConvention, Type,
+};
+use std::collections::{BTreeSet, HashMap};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShapeMethod {
+    pub name: String,
+    pub kind: String,
+    pub receiver: Option<String>,
+    pub is_async: bool,
+    pub params: Vec<ShapeParameter>,
+    pub result: Box<ShapeNode>,
+    pub metadata: Vec<ShapeMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShapeParameter {
+    pub name: String,
+    pub declared_type: ShapeNode,
+    pub convention: String,
+    pub keyword_only: bool,
+    pub metadata: Vec<ShapeMetadata>,
+}
+
+pub(super) fn described_methods(
+    module_name: &str,
+    class_name: &str,
+    class: &HirClass,
+    type_args: &[Type],
+    lowering: &LoweringResult,
+    visiting: &mut BTreeSet<String>,
+) -> Vec<ShapeMethod> {
+    let mut seen = BTreeSet::new();
+    let owner_prefix = format!("{class_name}.");
+    let bindings = class
+        .type_params
+        .iter()
+        .cloned()
+        .zip(type_args.iter().cloned())
+        .collect::<HashMap<_, _>>();
+    lowering
+        .declaration_metadata
+        .iter()
+        .filter(|entry| {
+            entry.target_kind == DeclarationMetadataTargetKind::Method
+                && entry.owner.starts_with(&owner_prefix)
+                && seen.insert(entry.owner.clone())
+        })
+        .map(|entry| {
+            let declared_name = &entry.owner[owner_prefix.len()..];
+            let hir_name = if declared_name == "__init__" {
+                "new"
+            } else {
+                declared_name
+            };
+            let Some(method) = class
+                .methods
+                .iter()
+                .chain(class.operator_impls.iter().map(|(_, method)| method))
+                .find(|method| method.name == hir_name)
+            else {
+                panic!("validated method metadata must resolve to a lowered method");
+            };
+            described_method(
+                module_name,
+                &entry.owner,
+                declared_name,
+                method,
+                &bindings,
+                metadata_for(
+                    &lowering.declaration_metadata,
+                    &entry.owner,
+                    DeclarationMetadataTargetKind::Method,
+                    None,
+                ),
+                lowering,
+                visiting,
+            )
+        })
+        .collect()
+}
+
+fn described_method(
+    module_name: &str,
+    owner: &str,
+    declared_name: &str,
+    method: &HirFunction,
+    bindings: &HashMap<String, Type>,
+    metadata: Vec<ShapeMetadata>,
+    lowering: &LoweringResult,
+    visiting: &mut BTreeSet<String>,
+) -> ShapeMethod {
+    ShapeMethod {
+        name: declared_name.to_string(),
+        kind: method_kind_name(method.method_kind).to_string(),
+        receiver: method
+            .receiver
+            .map(receiver_convention_name)
+            .map(str::to_string),
+        is_async: method.is_async,
+        params: method
+            .params
+            .iter()
+            .map(|param| ShapeParameter {
+                name: param.name.clone(),
+                declared_type: describe_node(
+                    module_name,
+                    &substitute_type_vars(&param.ty, bindings),
+                    lowering,
+                    visiting,
+                ),
+                convention: param_convention_name(param.convention).to_string(),
+                keyword_only: param.keyword_only,
+                metadata: metadata_for(
+                    &lowering.declaration_metadata,
+                    owner,
+                    DeclarationMetadataTargetKind::Parameter,
+                    Some(&param.name),
+                ),
+            })
+            .collect(),
+        result: Box::new(describe_node(
+            module_name,
+            &substitute_type_vars(&method.return_type, bindings),
+            lowering,
+            visiting,
+        )),
+        metadata,
+    }
+}
+
+const fn method_kind_name(kind: MethodKind) -> &'static str {
+    match kind {
+        MethodKind::Regular => "regular",
+        MethodKind::ClassMethod => "class",
+        MethodKind::StaticMethod => "static",
+    }
+}
+
+const fn receiver_convention_name(convention: ReceiverConvention) -> &'static str {
+    match convention {
+        ReceiverConvention::SharedBorrow => "borrow",
+        ReceiverConvention::MutableBorrow => "mut_borrow",
+        ReceiverConvention::Owned => "own",
+    }
+}
+
+const fn param_convention_name(convention: ParamConvention) -> &'static str {
+    match (convention.ownership(), convention.mutability()) {
+        (ParamOwnership::Borrow, ParamMutability::Immutable) => "borrow",
+        (ParamOwnership::Borrow, ParamMutability::Mutable) => "mut_borrow",
+        (ParamOwnership::Own, ParamMutability::Immutable) => "own",
+        (ParamOwnership::Own, ParamMutability::Mutable) => "own_mut",
+    }
+}

--- a/crates/sifr_frontend/src/structural_shape/tests.rs
+++ b/crates/sifr_frontend/src/structural_shape/tests.rs
@@ -1,0 +1,376 @@
+use super::*;
+use sifr_lowering::lower_module;
+use sifr_syntax::parse_module_suite;
+use sifr_type_system::FunctionType;
+
+fn class_type(class: &sifr_lowering::HirClass, type_args: Vec<Type>) -> Type {
+    Type::Class {
+        identity: None,
+        type_args,
+        name: class.name.clone(),
+        fields: class.fields.clone(),
+        methods: class
+            .methods
+            .iter()
+            .chain(class.operator_impls.iter().map(|(_, method)| method))
+            .map(|method| {
+                (
+                    method.name.clone(),
+                    FunctionType {
+                        receiver: method.receiver,
+                        params: method
+                            .params
+                            .iter()
+                            .map(|param| (param.name.clone(), param.ty.clone(), param.convention))
+                            .collect(),
+                        return_type: Box::new(method.return_type.clone()),
+                    },
+                )
+            })
+            .collect(),
+        parent_class: None,
+    }
+}
+
+#[test]
+fn class_shape_preserves_defaults_generics_and_recursive_identity() {
+    let source = "class Node[T]:\n    value: T\n    label: str = \"root\"\n    next: Node[T] | None = None\n";
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let lowered = lower_module(&parsed).expect("fixture lowers");
+    let class = lowered.module.classes.first().expect("class exists");
+    let shape = describe_type(
+        "fixture.shapes",
+        &class_type(class, vec![Type::Int]),
+        &lowered,
+    );
+    assert!(shape.canonical_identity.contains("fixture.shapes.Node"));
+    assert!(shape.canonical_identity.contains("label:str:default"));
+    assert!(shape.canonical_identity.contains("ref:fixture.shapes.Node"));
+}
+
+#[test]
+fn union_description_is_deterministic() {
+    let parsed = parse_module_suite("", None).expect("fixture parses");
+    let lowered = lower_module(&parsed).expect("fixture lowers");
+    let ty = Type::Union(vec![Type::Int, Type::Str]);
+    assert_eq!(
+        describe_type("fixture", &ty, &lowered),
+        describe_type("fixture", &ty, &lowered)
+    );
+}
+
+#[test]
+fn explicit_initializer_does_not_erase_field_default_metadata() {
+    let source = "class Config:\n    retries: int = 3\n\n    def __init__(self, retries: int) -> None:\n        self.retries = retries\n";
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let lowered = lower_module(&parsed).expect("fixture lowers");
+    let class = lowered.module.classes.first().expect("class exists");
+    let shape = describe_type("fixture.defaults", &class_type(class, Vec::new()), &lowered);
+    assert!(shape
+        .canonical_identity
+        .contains("retries:int:default=int:3"));
+}
+
+#[test]
+fn enum_and_newtype_shapes_preserve_metadata_and_nominal_identity() {
+    let source = r#"
+from enum import Enum
+
+@metadata("fixture.kind", "color")
+@metadata("enum_variant", "RED", "fixture.label", "red")
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+@metadata("fixture.kind", "port")
+class Port(int):
+    pass
+"#;
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let lowered = lower_module(&parsed).expect("fixture lowers");
+    let color = &lowered.module.classes[0];
+    let color_shape = describe_type("fixture.nominal", &class_type(color, Vec::new()), &lowered);
+    assert!(color_shape
+        .canonical_identity
+        .contains("enum:fixture.nominal.Color"));
+    assert!(color_shape.canonical_identity.contains("fixture.label"));
+
+    let port = &lowered.module.classes[1];
+    let port_shape = describe_type("fixture.nominal", &class_type(port, Vec::new()), &lowered);
+    assert!(port_shape
+        .canonical_identity
+        .contains("newtype:fixture.nominal.Port"));
+    assert!(port_shape.canonical_identity.contains("fixture.kind"));
+}
+
+#[test]
+fn annotated_methods_and_parameters_are_exposed_in_source_order() {
+    let source = r#"
+class Model:
+    value: int
+
+    @metadata("fixture.callback", "compare")
+    def __eq__(self, other: Model) -> bool:
+        return True
+
+    @staticmethod
+    @metadata("fixture.callback", "first")
+    @metadata("parameter", "value", "fixture.role", "input")
+    def first(value: int) -> int:
+        return value
+
+    @staticmethod
+    def helper(value: int) -> int:
+        return value
+
+    @classmethod
+    @metadata("fixture.callback", "middle")
+    def middle(cls, value: int) -> int:
+        return value
+
+    @staticmethod
+    @metadata("fixture.callback", "second")
+    async def second(*, mut value: str) -> str:
+        return ""
+"#;
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let lowered = lower_module(&parsed).expect("fixture lowers");
+    let class = lowered.module.classes.first().expect("class exists");
+    let shape = describe_type(
+        "fixture.callbacks",
+        &class_type(class, Vec::new()),
+        &lowered,
+    );
+    let const_shape = shape.to_const_value();
+    let ConstValue::Record(shape_record) = const_shape else {
+        panic!("shape must serialize as a record");
+    };
+    let Some(ConstValue::Record(root_record)) = shape_record.get("root") else {
+        panic!("shape root must serialize as a record");
+    };
+    let Some(ConstValue::List(serialized_methods)) = root_record.get("methods") else {
+        panic!("nominal methods must serialize as a list");
+    };
+    let Some(ConstValue::Record(first_method)) = serialized_methods.get(1) else {
+        panic!("first callback method must serialize as a record");
+    };
+    let Some(ConstValue::List(first_params)) = first_method.get("params") else {
+        panic!("method parameters must serialize as a list");
+    };
+    let Some(ConstValue::Record(first_param)) = first_params.first() else {
+        panic!("first parameter must serialize as a record");
+    };
+    assert_eq!(
+        first_method.get("name"),
+        Some(&ConstValue::String("first".to_string()))
+    );
+    assert_eq!(
+        first_param.get("convention"),
+        Some(&ConstValue::String("borrow".to_string()))
+    );
+    assert!(matches!(
+        first_param.get("metadata"),
+        Some(ConstValue::List(metadata)) if metadata.len() == 1
+    ));
+    let ShapeNode::Nominal { methods, .. } = shape.root else {
+        panic!("model must have a nominal shape");
+    };
+
+    assert_eq!(
+        methods
+            .iter()
+            .map(|method| method.name.as_str())
+            .collect::<Vec<_>>(),
+        ["__eq__", "first", "middle", "second"]
+    );
+    assert_eq!(methods[0].kind, "regular");
+    assert_eq!(methods[0].receiver.as_deref(), Some("borrow"));
+    assert!(matches!(
+        methods[0].params[0].declared_type,
+        ShapeNode::RecursiveReference(_)
+    ));
+    assert_eq!(methods[1].kind, "static");
+    assert_eq!(methods[1].params[0].convention, "borrow");
+    assert_eq!(methods[1].params[0].metadata[0].key, "fixture.role");
+    assert_eq!(methods[2].kind, "class");
+    assert_eq!(methods[2].receiver, None);
+    assert!(methods[3].is_async);
+    assert!(methods[3].params[0].keyword_only);
+    assert_eq!(methods[3].params[0].convention, "mut_borrow");
+}
+
+#[test]
+fn generic_method_contract_uses_concrete_class_arguments() {
+    let source = r#"
+class Box[T]:
+    value: T
+
+    @staticmethod
+    @metadata("fixture.callback", "after")
+    def normalize(value: T) -> T:
+        return value
+
+class Container:
+    item: Box[int]
+"#;
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let lowered = lower_module(&parsed).expect("fixture lowers");
+    let container = &lowered.module.classes[1];
+    let shape = describe_type(
+        "fixture.generics",
+        &class_type(container, Vec::new()),
+        &lowered,
+    );
+    let ShapeNode::Nominal { fields, .. } = shape.root else {
+        panic!("container must have a nominal shape");
+    };
+    let ShapeNode::Nominal { methods, .. } = &fields[0].declared_type else {
+        panic!("container item must preserve its concrete box shape");
+    };
+    assert_eq!(
+        methods[0].params[0].declared_type,
+        ShapeNode::Primitive("int".to_string())
+    );
+    assert_eq!(*methods[0].result, ShapeNode::Primitive("int".to_string()));
+    assert!(!shape.canonical_identity.contains("param:T"));
+}
+
+#[test]
+fn async_method_contract_is_identical_at_root_and_nested_positions() {
+    let source = r#"
+class Inner:
+    value: int
+
+    @metadata("fixture.callback", "run")
+    async def run(self) -> str:
+        return ""
+
+class Outer:
+    inner: Inner
+"#;
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let lowered = lower_module(&parsed).expect("fixture lowers");
+    let inner = &lowered.module.classes[0];
+    let outer = &lowered.module.classes[1];
+
+    let inner_shape = describe_type(
+        "fixture.async_contract",
+        &class_type(inner, Vec::new()),
+        &lowered,
+    );
+    let outer_shape = describe_type(
+        "fixture.async_contract",
+        &class_type(outer, Vec::new()),
+        &lowered,
+    );
+    let ShapeNode::Nominal {
+        methods: root_methods,
+        ..
+    } = inner_shape.root
+    else {
+        panic!("inner must have a nominal shape");
+    };
+    let ShapeNode::Nominal { fields, .. } = outer_shape.root else {
+        panic!("outer must have a nominal shape");
+    };
+    let ShapeNode::Nominal {
+        methods: nested_methods,
+        ..
+    } = &fields[0].declared_type
+    else {
+        panic!("outer field must preserve the nested inner shape");
+    };
+
+    assert_eq!(&root_methods, nested_methods);
+    assert_eq!(
+        *root_methods[0].result,
+        ShapeNode::Primitive("str".to_string())
+    );
+}
+
+#[test]
+fn annotated_constructor_uses_source_name_and_moves_identity() {
+    let source = |parameter_type: &str| {
+        format!(
+            "class Model:\n    @metadata(\"fixture.callback\", \"post_init\")\n    def __init__(self, value: {parameter_type}) -> None:\n        pass\n"
+        )
+    };
+    let describe = |source: &str| {
+        let parsed = parse_module_suite(source, None).expect("fixture parses");
+        let lowered = lower_module(&parsed).expect("fixture lowers");
+        let class = lowered.module.classes.first().expect("class exists");
+        describe_type(
+            "fixture.constructor",
+            &class_type(class, Vec::new()),
+            &lowered,
+        )
+    };
+
+    let integer = describe(&source("int"));
+    let string = describe(&source("str"));
+    let ShapeNode::Nominal { methods, .. } = &integer.root else {
+        panic!("model must have a nominal shape");
+    };
+    assert_eq!(methods[0].name, "__init__");
+    assert_eq!(methods[0].kind, "regular");
+    assert_eq!(methods[0].receiver, None);
+    assert_ne!(integer.canonical_identity, string.canonical_identity);
+}
+
+#[test]
+fn only_annotated_method_contracts_change_canonical_identity() {
+    let plain_source = r#"
+class Model:
+    value: int
+
+    @staticmethod
+    def helper(value: int) -> int:
+        return 0
+"#;
+    let annotated_source = plain_source.replace(
+        "    @staticmethod\n    def helper",
+        "    @staticmethod\n    @metadata(\"fixture.callback\", \"after\")\n    def helper",
+    );
+    let changed_source = annotated_source.replace("value: int) -> int", "value: str) -> int");
+
+    let describe = |source: &str| {
+        let parsed = parse_module_suite(source, None).expect("fixture parses");
+        let lowered = lower_module(&parsed).expect("fixture lowers");
+        let class = lowered.module.classes.first().expect("class exists");
+        describe_type(
+            "fixture.callbacks",
+            &class_type(class, Vec::new()),
+            &lowered,
+        )
+        .canonical_identity
+    };
+
+    let without_helper = describe("class Model:\n    value: int\n");
+    assert_eq!(describe(plain_source), without_helper);
+    assert_ne!(describe(&annotated_source), without_helper);
+    assert_ne!(describe(&changed_source), describe(&annotated_source));
+}
+
+#[test]
+fn canonical_values_bind_record_keys_and_bytes_without_collisions() {
+    let ambiguous_key = ConstValue::Record(BTreeMap::from([(
+        "a=str:1:x,b".to_string(),
+        ConstValue::None,
+    )]));
+    let two_fields = ConstValue::Record(BTreeMap::from([
+        ("a".to_string(), ConstValue::String("x".to_string())),
+        ("b".to_string(), ConstValue::None),
+    ]));
+    assert_ne!(
+        canonical_value(&ambiguous_key),
+        canonical_value(&two_fields)
+    );
+    assert_eq!(
+        canonical_value(&ConstValue::Bytes(vec![0, 255])),
+        "bytes:2:00ff"
+    );
+    assert_ne!(
+        canonical_value(&ConstValue::Bytes(Vec::new())),
+        canonical_value(&ConstValue::String(String::new()))
+    );
+}

--- a/crates/sifr_lowering/src/lib.rs
+++ b/crates/sifr_lowering/src/lib.rs
@@ -26,8 +26,8 @@ pub use lower::{
     lower_module_sysroot_private_declaration_with_externals, lower_module_sysroot_public_stdlib,
     lower_module_sysroot_public_stdlib_with_externals, lower_module_with_externals,
     lower_module_with_externals_and_name, lower_module_with_externals_name_and_options,
-    ExternalDefs, LoweringOptions, LoweringSourceOrigin, PythonBridgeTargetAuthority,
-    PythonTrustPolicy,
+    substitute_type_vars, ExternalDefs, LoweringOptions, LoweringSourceOrigin,
+    PythonBridgeTargetAuthority, PythonTrustPolicy,
 };
 pub use scope::{NarrowingSnapshot, Scope};
 pub use sifr_ir::{

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -241,7 +241,7 @@ pub fn canonicalize_user_export_function_type(
 }
 use generic_inference::infer_type_var_bindings;
 use imports::resolve_imports_early;
-use mod_context::substitute_type_vars;
+pub use mod_context::substitute_type_vars;
 use ruff_text_size::{Ranged, TextRange};
 use sifr_diagnostics::DiagnosticCode;
 use sifr_python_ast::{Expr, Stmt};

--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -602,7 +602,7 @@ impl LoweringSourceOrigin {
     }
 }
 /// Substitute type variables in a type with concrete types.
-pub(in crate::lower) fn substitute_type_vars(ty: &Type, bindings: &HashMap<String, Type>) -> Type {
+pub fn substitute_type_vars(ty: &Type, bindings: &HashMap<String, Type>) -> Type {
     fn substitute_function_type(
         ft: &FunctionType,
         bindings: &HashMap<String, Type>,


### PR DESCRIPTION
## What changed

- expose local metadata-annotated method descriptors through compiler-owned `StructuralShape`
- preserve declaration order, method/receiver/async shape, parameter ownership and metadata, and declared result types
- instantiate generic method contracts from concrete class type arguments
- include operator dunders and preserve source `__init__` identity across its HIR `new` name
- bind method contracts into deterministic const-specialization program identity without changing runtime structural wire identity

## Why

PS7's remaining Native Pydantic validator/context work needs a generated, typed callback substrate. Manual callback tables or erased universal callbacks would duplicate metadata authority and lose static type/ownership evidence.

## Validation

- Claude Opus exact-SHA review round 3: `SATISFIED` on `d42dd6a09a46448bf71d4506fbae46e45b50be6b`
- `CARGO_BUILD_JOBS=6 cargo test -j 6 -p sifr_frontend -p sifr_lowering` (frontend 71/71; lowering 987 passed, 1 ignored)
- canonical create-PR profile: unchanged warm run exit 0; E2E 140/140, Python interop 19/19, Rust interop 10/10, generated-code quality 5/5, all smoke crate/runtime lanes green
- cold create-PR functional checks were green but stopped on the separately tracked #3134 cold generated-artifact step budget; the unchanged warm rerun passed that step in 8.15s
- formatting, maintainability, taxonomy, file-size, and diff checks passed
