### PR TITLE
fix: preserve imported structural shape contracts

### DIFF
--- a/crates/sifr_frontend/src/class_method_exports.rs
+++ b/crates/sifr_frontend/src/class_method_exports.rs
@@ -1,7 +1,8 @@
 use sifr_lowering::{
-    canonicalize_user_export_type, ExternalDefs, HirClass, MethodKind, StructuralMethodExport,
+    canonicalize_user_export_type, DeclarationMetadataTargetKind, ExternalDefs, HirClass,
+    MethodKind, StructuralMethodExport, TypedDeclarationMetadata,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 #[derive(Default)]
 pub(crate) struct ClassMethodExports {
@@ -45,38 +46,66 @@ fn imported_instance_methods(
         .unwrap_or_default()
 }
 
-pub(crate) fn exported_structural_methods(
+fn exported_structural_methods(
     class: &HirClass,
     local_classes: &HashMap<String, String>,
+    declaration_metadata: &[TypedDeclarationMetadata],
 ) -> Option<Vec<StructuralMethodExport>> {
-    let methods = class
-        .methods
+    let owner_prefix = format!("{}.", class.name);
+    let mut seen = BTreeSet::new();
+    let methods = declaration_metadata
         .iter()
-        .map(|method| (method.name.as_str(), method))
-        .chain(
-            class
-                .operator_impls
+        .filter(|entry| {
+            entry.target_kind == DeclarationMetadataTargetKind::Method
+                && entry.owner.starts_with(&owner_prefix)
+                && seen.insert(entry.owner.clone())
+        })
+        .filter_map(|entry| {
+            let declared_name = &entry.owner[owner_prefix.len()..];
+            let hir_name = if declared_name == "__init__" {
+                "new"
+            } else {
+                declared_name
+            };
+            let method = class
+                .methods
                 .iter()
-                .map(|(name, method)| (name.as_str(), method)),
-        )
-        .map(|(name, method)| StructuralMethodExport {
-            name: name.to_string(),
-            params: method
-                .params
-                .iter()
-                .cloned()
-                .map(|mut param| {
-                    param.ty = canonicalize_user_export_type(&param.ty, local_classes);
-                    param
-                })
-                .collect(),
-            return_type: canonicalize_user_export_type(&method.return_type, local_classes),
-            is_async: method.is_async,
-            method_kind: method.method_kind,
-            receiver: method.receiver,
+                .chain(class.operator_impls.iter().map(|(_, method)| method))
+                .find(|method| method.name == hir_name)?;
+            Some(StructuralMethodExport {
+                name: declared_name.to_string(),
+                params: method
+                    .params
+                    .iter()
+                    .cloned()
+                    .map(|mut param| {
+                        param.ty = canonicalize_user_export_type(&param.ty, local_classes);
+                        param
+                    })
+                    .collect(),
+                return_type: canonicalize_user_export_type(&method.return_type, local_classes),
+                is_async: method.is_async,
+                method_kind: method.method_kind,
+                receiver: method.receiver,
+            })
         })
         .collect::<Vec<_>>();
     (!methods.is_empty()).then_some(methods)
+}
+
+pub(crate) fn structural_method_map(
+    module: &sifr_lowering::HirModule,
+    local_classes: &HashMap<String, String>,
+    lowering: &sifr_lowering::LoweringResult,
+) -> HashMap<String, Vec<StructuralMethodExport>> {
+    module
+        .classes
+        .iter()
+        .filter_map(|class| {
+            exported_structural_methods(class, local_classes, &lowering.declaration_metadata)
+                .map(|methods| (class.name.clone(), methods))
+        })
+        .collect()
 }
 
 impl ClassMethodExports {

--- a/crates/sifr_frontend/src/class_method_exports.rs
+++ b/crates/sifr_frontend/src/class_method_exports.rs
@@ -90,7 +90,12 @@ pub(crate) fn structural_method_map(
     local_classes: &HashMap<String, String>,
     lowering: &sifr_lowering::LoweringResult,
 ) -> HashMap<String, Vec<StructuralMethodExport>> {
-    if module.classes.is_empty() {
+    if module.classes.is_empty()
+        || !lowering
+            .declaration_metadata
+            .iter()
+            .any(|entry| entry.target_kind == DeclarationMetadataTargetKind::Method)
+    {
         return HashMap::new();
     }
     let mut names_by_class: HashMap<&str, Vec<&str>> = HashMap::new();

--- a/crates/sifr_frontend/src/class_method_exports.rs
+++ b/crates/sifr_frontend/src/class_method_exports.rs
@@ -1,8 +1,8 @@
 use sifr_lowering::{
     canonicalize_user_export_type, DeclarationMetadataTargetKind, ExternalDefs, HirClass,
-    MethodKind, StructuralMethodExport, TypedDeclarationMetadata,
+    MethodKind, StructuralMethodExport,
 };
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 #[derive(Default)]
 pub(crate) struct ClassMethodExports {
@@ -49,20 +49,12 @@ fn imported_instance_methods(
 fn exported_structural_methods(
     class: &HirClass,
     local_classes: &HashMap<String, String>,
-    declaration_metadata: &[TypedDeclarationMetadata],
+    declared_names: &[&str],
 ) -> Option<Vec<StructuralMethodExport>> {
-    let owner_prefix = format!("{}.", class.name);
-    let mut seen = BTreeSet::new();
-    let methods = declaration_metadata
+    let methods = declared_names
         .iter()
-        .filter(|entry| {
-            entry.target_kind == DeclarationMetadataTargetKind::Method
-                && entry.owner.starts_with(&owner_prefix)
-                && seen.insert(entry.owner.clone())
-        })
-        .filter_map(|entry| {
-            let declared_name = &entry.owner[owner_prefix.len()..];
-            let hir_name = if declared_name == "__init__" {
+        .filter_map(|declared_name| {
+            let hir_name = if *declared_name == "__init__" {
                 "new"
             } else {
                 declared_name
@@ -98,11 +90,34 @@ pub(crate) fn structural_method_map(
     local_classes: &HashMap<String, String>,
     lowering: &sifr_lowering::LoweringResult,
 ) -> HashMap<String, Vec<StructuralMethodExport>> {
+    if module.classes.is_empty() {
+        return HashMap::new();
+    }
+    let mut names_by_class: HashMap<&str, Vec<&str>> = HashMap::new();
+    let mut seen = HashSet::new();
+    for entry in &lowering.declaration_metadata {
+        if entry.target_kind != DeclarationMetadataTargetKind::Method
+            || !seen.insert(entry.owner.as_str())
+        {
+            continue;
+        }
+        let Some((class_name, method_name)) = entry.owner.rsplit_once('.') else {
+            continue;
+        };
+        names_by_class
+            .entry(class_name)
+            .or_default()
+            .push(method_name);
+    }
+    if names_by_class.is_empty() {
+        return HashMap::new();
+    }
     module
         .classes
         .iter()
         .filter_map(|class| {
-            exported_structural_methods(class, local_classes, &lowering.declaration_metadata)
+            let declared_names = names_by_class.get(class.name.as_str())?;
+            exported_structural_methods(class, local_classes, declared_names)
                 .map(|methods| (class.name.clone(), methods))
         })
         .collect()

--- a/crates/sifr_frontend/src/class_method_exports.rs
+++ b/crates/sifr_frontend/src/class_method_exports.rs
@@ -1,4 +1,6 @@
-use sifr_lowering::{ExternalDefs, HirClass, MethodKind};
+use sifr_lowering::{
+    canonicalize_user_export_type, ExternalDefs, HirClass, MethodKind, StructuralMethodExport,
+};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Default)]
@@ -41,6 +43,40 @@ fn imported_instance_methods(
         .and_then(|classes| classes.get(class_name))
         .cloned()
         .unwrap_or_default()
+}
+
+pub(crate) fn exported_structural_methods(
+    class: &HirClass,
+    local_classes: &HashMap<String, String>,
+) -> Option<Vec<StructuralMethodExport>> {
+    let methods = class
+        .methods
+        .iter()
+        .map(|method| (method.name.as_str(), method))
+        .chain(
+            class
+                .operator_impls
+                .iter()
+                .map(|(name, method)| (name.as_str(), method)),
+        )
+        .map(|(name, method)| StructuralMethodExport {
+            name: name.to_string(),
+            params: method
+                .params
+                .iter()
+                .cloned()
+                .map(|mut param| {
+                    param.ty = canonicalize_user_export_type(&param.ty, local_classes);
+                    param
+                })
+                .collect(),
+            return_type: canonicalize_user_export_type(&method.return_type, local_classes),
+            is_async: method.is_async,
+            method_kind: method.method_kind,
+            receiver: method.receiver,
+        })
+        .collect::<Vec<_>>();
+    (!methods.is_empty()).then_some(methods)
 }
 
 impl ClassMethodExports {

--- a/crates/sifr_frontend/src/lib.rs
+++ b/crates/sifr_frontend/src/lib.rs
@@ -26,6 +26,7 @@ pub use frontend_reuse::{FrontendCacheEntryIdentity, FrontendReuseStats};
 mod graph_cache_and_queries;
 pub use graph_cache_and_queries::*;
 mod hir_views;
+mod module_export_storage;
 mod module_signatures;
 mod query_diagnostic_rendering;
 pub(crate) use query_diagnostic_rendering::{
@@ -40,6 +41,8 @@ mod query_diagnostics_behavior_tests;
 #[cfg(test)]
 mod query_diagnostics_equivalence_tests;
 mod source_provider;
+#[cfg(test)]
+mod structural_shape_import_tests;
 pub use source_provider::*;
 mod source_maps;
 pub use source_maps::*;

--- a/crates/sifr_frontend/src/module_export_storage.rs
+++ b/crates/sifr_frontend/src/module_export_storage.rs
@@ -1,0 +1,14 @@
+use std::collections::HashMap;
+
+pub(crate) fn replace_module_entry<T>(
+    modules: &mut HashMap<String, T>,
+    module_name: &str,
+    value: T,
+    is_empty: impl FnOnce(&T) -> bool,
+) {
+    if is_empty(&value) {
+        modules.remove(module_name);
+    } else {
+        modules.insert(module_name.to_string(), value);
+    }
+}

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -3,7 +3,7 @@ use super::{
     SourceHash, SourcePath, SourceText, SymbolKind, SymbolView,
 };
 use crate::callable_exports::{exported_function_type, RustCallbackExports};
-use crate::class_method_exports::ClassMethodExports;
+use crate::class_method_exports::{exported_structural_methods, ClassMethodExports};
 pub(crate) use crate::export_type_localization::should_export_callable;
 use crate::export_type_localization::{
     copy_class_generic_metadata, copy_function_generic_metadata, declared_generic_metadata,
@@ -175,6 +175,7 @@ pub fn collect_module_exports(
     let mut class_exports = HashMap::new();
     let mut class_method_exports = ClassMethodExports::default();
     let mut class_type_param_exports = HashMap::new();
+    let mut structural_method_exports = HashMap::new();
     let mut rust_opaque_exports = std::collections::HashSet::new();
     let mut class_field_default_exports = HashMap::new();
     let mut const_exports = HashMap::new();
@@ -308,6 +309,9 @@ pub fn collect_module_exports(
             };
             let class_ty = canonicalize_user_export_type(&exported_type, &local_classes);
             class_exports.insert(class.name.clone(), class_ty);
+            if let Some(methods) = exported_structural_methods(class, &local_classes) {
+                structural_method_exports.insert(class.name.clone(), methods);
+            }
             if let Some(defaults) = lowering_result.class_field_defaults.get(&class.name) {
                 class_field_default_exports.insert(class.name.clone(), defaults.clone());
             }
@@ -316,7 +320,6 @@ pub fn collect_module_exports(
             }
         }
     }
-
     for (name, ty, _) in &module.constants {
         if !name.starts_with('_') {
             const_exports.insert(
@@ -458,6 +461,11 @@ pub fn collect_module_exports(
     external_defs
         .classes
         .insert(module_name.to_string(), class_exports);
+    if !structural_method_exports.is_empty() {
+        external_defs
+            .structural_methods
+            .insert(module_name.to_string(), structural_method_exports);
+    }
     if error_exports.is_empty() {
         external_defs.error_types.remove(module_name);
     } else {

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -9,6 +9,7 @@ use crate::export_type_localization::{
     copy_class_generic_metadata, copy_function_generic_metadata, declared_generic_metadata,
     exported_parent_chain, imported_class_ancestry, reexport_class_aliases,
 };
+use crate::module_export_storage::replace_module_entry;
 use crate::module_signatures::ModuleSignature;
 use crate::{diagnostic_with_code, diagnostic_with_source_range_args_help};
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, RenderedDiagnostic};
@@ -472,17 +473,18 @@ pub fn collect_module_exports(
             .rust_opaque_classes
             .insert(module_name.to_string(), rust_opaque_exports);
     }
-    if !class_field_default_exports.is_empty() {
-        external_defs
-            .class_field_defaults
-            .insert(module_name.to_string(), class_field_default_exports);
-    }
-    if !lowering_result.declaration_metadata.is_empty() {
-        external_defs.declaration_metadata.insert(
-            module_name.to_string(),
-            lowering_result.declaration_metadata.clone(),
-        );
-    }
+    replace_module_entry(
+        &mut external_defs.class_field_defaults,
+        module_name,
+        class_field_default_exports,
+        HashMap::is_empty,
+    );
+    replace_module_entry(
+        &mut external_defs.declaration_metadata,
+        module_name,
+        lowering_result.declaration_metadata.clone(),
+        Vec::is_empty,
+    );
     if !lowering_result.specialization_requests.is_empty() {
         external_defs.specialization_requests.insert(
             module_name.to_string(),
@@ -502,11 +504,12 @@ pub fn collect_module_exports(
         );
     }
     class_method_exports.store(external_defs, module_name);
-    if !class_type_param_exports.is_empty() {
-        external_defs
-            .class_type_params
-            .insert(module_name.to_string(), class_type_param_exports);
-    }
+    replace_module_entry(
+        &mut external_defs.class_type_params,
+        module_name,
+        class_type_param_exports,
+        HashMap::is_empty,
+    );
     if !generic_exports.is_empty() {
         external_defs
             .generic_functions

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -3,7 +3,7 @@ use super::{
     SourceHash, SourcePath, SourceText, SymbolKind, SymbolView,
 };
 use crate::callable_exports::{exported_function_type, RustCallbackExports};
-use crate::class_method_exports::{exported_structural_methods, ClassMethodExports};
+use crate::class_method_exports::{structural_method_map, ClassMethodExports};
 pub(crate) use crate::export_type_localization::should_export_callable;
 use crate::export_type_localization::{
     copy_class_generic_metadata, copy_function_generic_metadata, declared_generic_metadata,
@@ -19,6 +19,7 @@ use sifr_lowering::{
 use sifr_python_ast::Stmt;
 use sifr_type_system::{FunctionType, ParamConvention, Type};
 use std::collections::{BTreeMap, HashMap};
+
 pub(super) fn module_state(
     id: ModuleId,
     file: FileId,
@@ -175,7 +176,6 @@ pub fn collect_module_exports(
     let mut class_exports = HashMap::new();
     let mut class_method_exports = ClassMethodExports::default();
     let mut class_type_param_exports = HashMap::new();
-    let mut structural_method_exports = HashMap::new();
     let mut rust_opaque_exports = std::collections::HashSet::new();
     let mut class_field_default_exports = HashMap::new();
     let mut const_exports = HashMap::new();
@@ -188,6 +188,7 @@ pub fn collect_module_exports(
     let mut rust_callback_exports = RustCallbackExports::default();
     let (mut generic_exports, mut type_param_bound_exports, local_classes) =
         declared_generic_metadata(module_name, module);
+    let structural_method_exports = structural_method_map(module, &local_classes, lowering_result);
     let imported_ancestry = imported_class_ancestry(module, external_defs);
 
     for func in &module.functions {
@@ -309,9 +310,6 @@ pub fn collect_module_exports(
             };
             let class_ty = canonicalize_user_export_type(&exported_type, &local_classes);
             class_exports.insert(class.name.clone(), class_ty);
-            if let Some(methods) = exported_structural_methods(class, &local_classes) {
-                structural_method_exports.insert(class.name.clone(), methods);
-            }
             if let Some(defaults) = lowering_result.class_field_defaults.get(&class.name) {
                 class_field_default_exports.insert(class.name.clone(), defaults.clone());
             }
@@ -461,7 +459,9 @@ pub fn collect_module_exports(
     external_defs
         .classes
         .insert(module_name.to_string(), class_exports);
-    if !structural_method_exports.is_empty() {
+    if structural_method_exports.is_empty() {
+        external_defs.structural_methods.remove(module_name);
+    } else {
         external_defs
             .structural_methods
             .insert(module_name.to_string(), structural_method_exports);

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -459,13 +459,7 @@ pub fn collect_module_exports(
     external_defs
         .classes
         .insert(module_name.to_string(), class_exports);
-    if structural_method_exports.is_empty() {
-        external_defs.structural_methods.remove(module_name);
-    } else {
-        external_defs
-            .structural_methods
-            .insert(module_name.to_string(), structural_method_exports);
-    }
+    external_defs.replace_structural_methods(module_name, structural_method_exports);
     if error_exports.is_empty() {
         external_defs.error_types.remove(module_name);
     } else {

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -224,6 +224,12 @@ pub fn collect_module_exports(
     }
 
     for class in &module.classes {
+        if let Some(defaults) = lowering_result.class_field_defaults.get(&class.name) {
+            class_field_default_exports.insert(class.name.clone(), defaults.clone());
+        }
+        if !class.type_params.is_empty() {
+            class_type_param_exports.insert(class.name.clone(), class.type_params.clone());
+        }
         if !class.name.starts_with('_') {
             if class.is_error_type {
                 error_exports.insert(class.name.clone());
@@ -310,12 +316,6 @@ pub fn collect_module_exports(
             };
             let class_ty = canonicalize_user_export_type(&exported_type, &local_classes);
             class_exports.insert(class.name.clone(), class_ty);
-            if let Some(defaults) = lowering_result.class_field_defaults.get(&class.name) {
-                class_field_default_exports.insert(class.name.clone(), defaults.clone());
-            }
-            if !class.type_params.is_empty() {
-                class_type_param_exports.insert(class.name.clone(), class.type_params.clone());
-            }
         }
     }
     for (name, ty, _) in &module.constants {

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -1,7 +1,7 @@
 use crate::{
-    decode_const_specialization_outcome, describe_type, verify_json_integer_boundary,
-    ConstEvalError, ConstIssueTemplate, DeterministicConstEvaluator, JsonIntegerBoundaryDescriptor,
-    JsonIntegerKind, JsonIntegerProfile, JsonIntegerRepresentation,
+    decode_const_specialization_outcome, describe_type_with_externals,
+    verify_json_integer_boundary, ConstEvalError, ConstIssueTemplate, DeterministicConstEvaluator,
+    JsonIntegerBoundaryDescriptor, JsonIntegerKind, JsonIntegerProfile, JsonIntegerRepresentation,
 };
 use ruff_text_size::TextRange;
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode};
@@ -55,7 +55,8 @@ pub(crate) fn run_specializations(
             ));
             continue;
         }
-        let shape = describe_type(module_name, &target_type, result).to_const_value();
+        let shape = describe_type_with_externals(module_name, &target_type, result, external_defs)
+            .to_const_value();
         let canonical_shape = crate::structural_shape::canonical_value(&shape);
         let Some(functions) = external_defs.const_functions.get(&request.package_module) else {
             errors.push(malformed(
@@ -565,6 +566,68 @@ class Model:
         assert_eq!(cli[0].args, editor[0].args);
         assert_eq!(cli[0].url, editor[0].url);
         assert_eq!(cli[0].message_template, editor[0].message_template);
+    }
+
+    #[test]
+    fn imported_annotated_methods_preserve_nested_program_identity() {
+        fn compile_consumer(method_return: &str) -> StaticSpecializationOutput {
+            let mut external_defs = ExternalDefs::default();
+            let package = compile(
+                "fixture.meta",
+                &package_source("warning", "shape_notice", true),
+                &external_defs,
+            )
+            .expect("package compiles");
+            collect_module_exports("fixture.meta", &package, &mut external_defs);
+
+            let return_expression = if method_return == "T" {
+                "value"
+            } else {
+                "\"\""
+            };
+            let model_source = format!(
+                r#"
+class Box[T]:
+    value: T
+
+    @staticmethod
+    @metadata("fixture.callback", "normalize")
+    @metadata("parameter", "value", "fixture.role", "input")
+    def normalize(value: T) -> {method_return}:
+        return {return_expression}
+"#
+            );
+            let models =
+                compile("models", &model_source, &external_defs).expect("model module compiles");
+            collect_module_exports("models", &models, &mut external_defs);
+
+            let consumer = compile(
+                "consumer",
+                r#"
+from fixture.meta import describe
+from models import Box
+
+@const_specialize("fixture.meta", "describe")
+class Container:
+    item: Box[int]
+"#,
+                &external_defs,
+            )
+            .expect("consumer specializes imported model");
+            consumer
+                .specialization_outputs
+                .into_iter()
+                .next()
+                .expect("consumer emits a static program")
+        }
+
+        let integer = compile_consumer("T");
+        assert!(integer.canonical_value.contains("normalize:static"));
+        assert!(integer.canonical_value.contains("fixture.callback"));
+        assert!(integer.canonical_value.contains("5:value:borrow:false:int"));
+
+        let string = compile_consumer("str");
+        assert_ne!(integer.program_identity, string.program_identity);
     }
 
     #[test]

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -763,24 +763,34 @@ class ImportedUse:
     }
 
     #[test]
-    fn public_import_can_describe_annotated_private_nested_type() {
+    fn public_import_preserves_private_generic_nested_shape() {
         let mut external_defs = ExternalDefs::default();
         let models = compile(
             "models",
             r#"
-class _Hidden:
-    value: int
+class _Hidden[T]:
+    value: T = 0
 
     @metadata("fixture.callback", "read")
-    def read(self) -> int:
+    def read(self) -> T:
         return self.value
 
 class Box:
-    hidden: _Hidden
+    hidden: _Hidden[int]
+
+class LocalUse:
+    item: Box
 "#,
             &external_defs,
         )
         .expect("models compile");
+        let local_use = models
+            .module
+            .classes
+            .iter()
+            .find(|class| class.name == "LocalUse")
+            .expect("local use exists");
+        let local_shape = crate::describe_type("models", &local_use.fields[0].1, &models);
         collect_module_exports("models", &models, &mut external_defs);
         assert!(!external_defs.classes["models"].contains_key("_Hidden"));
         assert!(external_defs.structural_methods["models"].contains_key("_Hidden"));
@@ -803,8 +813,11 @@ class Box:
             &consumer,
             &external_defs,
         );
+        assert_eq!(local_shape.canonical_identity, shape.canonical_identity);
         assert!(shape.canonical_identity.contains("models._Hidden"));
+        assert!(shape.canonical_identity.contains("value:int:default=int:0"));
         assert!(shape.canonical_identity.contains("read:regular"));
+        assert!(shape.canonical_identity.contains("result[int]"));
         assert!(shape.canonical_identity.contains("fixture.callback"));
     }
 

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -631,6 +631,184 @@ class Container:
     }
 
     #[test]
+    fn reexported_nominal_shapes_match_local_shapes_without_consumer_fallbacks() {
+        fn field_type<'a>(result: &'a LoweringResult, class_name: &str, field: &str) -> &'a Type {
+            result
+                .module
+                .classes
+                .iter()
+                .find(|class| class.name == class_name)
+                .and_then(|class| class.fields.iter().find(|(name, _)| name == field))
+                .map(|(_, ty)| ty)
+                .expect("fixture field exists")
+        }
+
+        let mut external_defs = ExternalDefs::default();
+        let models = compile(
+            "models",
+            r#"
+from enum import Enum
+
+@metadata("fixture.kind", "color")
+@metadata("enum_variant", "RED", "fixture.label", "red")
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+@metadata("fixture.kind", "port")
+class Port(int):
+    pass
+
+class Box[T]:
+    value: T
+
+    @metadata("fixture.callback", "construct")
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+    @metadata("fixture.callback", "compare")
+    def __eq__(self, other: Box[T]) -> bool:
+        return True
+
+    @classmethod
+    @metadata("fixture.callback", "from_value")
+    def from_value(cls, value: T) -> Box[T]:
+        return Box(value)
+
+    @staticmethod
+    @metadata("fixture.callback", "normalize")
+    @metadata("parameter", "value", "fixture.role", "input")
+    async def normalize(*, value: T) -> T:
+        return value
+
+class LocalUse:
+    item: Box[int]
+    color: Color
+    port: Port
+"#,
+            &external_defs,
+        )
+        .expect("models compile");
+        let local_box =
+            crate::describe_type("models", field_type(&models, "LocalUse", "item"), &models);
+        let local_color =
+            crate::describe_type("models", field_type(&models, "LocalUse", "color"), &models);
+        let local_port =
+            crate::describe_type("models", field_type(&models, "LocalUse", "port"), &models);
+        collect_module_exports("models", &models, &mut external_defs);
+
+        let facade = compile(
+            "facade",
+            "from models import Box as Renamed\nfrom models import Color\nfrom models import Port\n",
+            &external_defs,
+        )
+        .expect("facade reexports compile");
+        collect_module_exports("facade", &facade, &mut external_defs);
+        let consumer = compile(
+            "consumer",
+            r#"
+from facade import Renamed, Color, Port
+
+class ImportedUse:
+    item: Renamed[int]
+    color: Color
+    port: Port
+"#,
+            &external_defs,
+        )
+        .expect("consumer compiles");
+
+        let imported_box = crate::describe_type_with_externals(
+            "consumer",
+            field_type(&consumer, "ImportedUse", "item"),
+            &consumer,
+            &external_defs,
+        );
+        let imported_color = crate::describe_type_with_externals(
+            "consumer",
+            field_type(&consumer, "ImportedUse", "color"),
+            &consumer,
+            &external_defs,
+        );
+        let imported_port = crate::describe_type_with_externals(
+            "consumer",
+            field_type(&consumer, "ImportedUse", "port"),
+            &consumer,
+            &external_defs,
+        );
+
+        assert_eq!(
+            local_box.canonical_identity,
+            imported_box.canonical_identity
+        );
+        assert_eq!(
+            local_color.canonical_identity,
+            imported_color.canonical_identity
+        );
+        assert_eq!(
+            local_port.canonical_identity,
+            imported_port.canonical_identity
+        );
+        assert!(imported_box.canonical_identity.contains("__init__:regular"));
+        assert!(imported_box.canonical_identity.contains("__eq__:regular"));
+        assert!(imported_box.canonical_identity.contains("from_value:class"));
+        assert!(imported_box
+            .canonical_identity
+            .contains("normalize:static:none:true"));
+        assert!(imported_box.canonical_identity.contains("fixture.role"));
+        assert!(imported_color.canonical_identity.contains("models.Color"));
+        assert!(imported_color.canonical_identity.contains("fixture.label"));
+        assert!(imported_port.canonical_identity.contains("models.Port"));
+        assert!(imported_port.canonical_identity.contains("fixture.kind"));
+    }
+
+    #[test]
+    fn public_import_can_describe_annotated_private_nested_type() {
+        let mut external_defs = ExternalDefs::default();
+        let models = compile(
+            "models",
+            r#"
+class _Hidden:
+    value: int
+
+    @metadata("fixture.callback", "read")
+    def read(self) -> int:
+        return self.value
+
+class Box:
+    hidden: _Hidden
+"#,
+            &external_defs,
+        )
+        .expect("models compile");
+        collect_module_exports("models", &models, &mut external_defs);
+        assert!(!external_defs.classes["models"].contains_key("_Hidden"));
+        assert!(external_defs.structural_methods["models"].contains_key("_Hidden"));
+
+        let consumer = compile(
+            "consumer",
+            "from models import Box\n\nclass Container:\n    item: Box\n",
+            &external_defs,
+        )
+        .expect("consumer compiles");
+        let container = consumer
+            .module
+            .classes
+            .iter()
+            .find(|class| class.name == "Container")
+            .expect("container exists");
+        let shape = crate::describe_type_with_externals(
+            "consumer",
+            &container.fields[0].1,
+            &consumer,
+            &external_defs,
+        );
+        assert!(shape.canonical_identity.contains("models._Hidden"));
+        assert!(shape.canonical_identity.contains("read:regular"));
+        assert!(shape.canonical_identity.contains("fixture.callback"));
+    }
+
+    #[test]
     fn package_fatal_flows_through_registry_owned_frontend_error() {
         let mut external_defs = ExternalDefs::default();
         let package = compile(

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -421,6 +421,17 @@ mod tests {
         )
     }
 
+    fn field_type<'a>(result: &'a LoweringResult, class_name: &str, field: &str) -> &'a Type {
+        result
+            .module
+            .classes
+            .iter()
+            .find(|class| class.name == class_name)
+            .and_then(|class| class.fields.iter().find(|(name, _)| name == field))
+            .map(|(_, ty)| ty)
+            .expect("fixture field exists")
+    }
+
     fn errors(
         result: Result<LoweringResult, Vec<sifr_diagnostics::RenderedDiagnostic>>,
     ) -> Vec<sifr_diagnostics::RenderedDiagnostic> {
@@ -632,17 +643,6 @@ class Container:
 
     #[test]
     fn reexported_nominal_shapes_match_local_shapes_without_consumer_fallbacks() {
-        fn field_type<'a>(result: &'a LoweringResult, class_name: &str, field: &str) -> &'a Type {
-            result
-                .module
-                .classes
-                .iter()
-                .find(|class| class.name == class_name)
-                .and_then(|class| class.fields.iter().find(|(name, _)| name == field))
-                .map(|(_, ty)| ty)
-                .expect("fixture field exists")
-        }
-
         let mut external_defs = ExternalDefs::default();
         let models = compile(
             "models",
@@ -689,12 +689,17 @@ class LocalUse:
             &external_defs,
         )
         .expect("models compile");
-        let local_box =
-            crate::describe_type("models", field_type(&models, "LocalUse", "item"), &models);
-        let local_color =
-            crate::describe_type("models", field_type(&models, "LocalUse", "color"), &models);
-        let local_port =
-            crate::describe_type("models", field_type(&models, "LocalUse", "port"), &models);
+        let describe_local = |field| {
+            crate::describe_type_with_externals(
+                "models",
+                field_type(&models, "LocalUse", field),
+                &models,
+                &external_defs,
+            )
+        };
+        let local_box = describe_local("item");
+        let local_color = describe_local("color");
+        let local_port = describe_local("port");
         collect_module_exports("models", &models, &mut external_defs);
 
         let facade = compile(
@@ -760,67 +765,6 @@ class ImportedUse:
         assert!(imported_color.canonical_identity.contains("fixture.label"));
         assert!(imported_port.canonical_identity.contains("models.Port"));
         assert!(imported_port.canonical_identity.contains("fixture.kind"));
-    }
-
-    #[test]
-    fn public_import_preserves_private_generic_nested_shape() {
-        let mut external_defs = ExternalDefs::default();
-        let models = compile(
-            "models",
-            r#"
-class _Hidden[T]:
-    value: T = 0
-
-    @metadata("fixture.callback", "read")
-    def read(self) -> T:
-        return self.value
-
-class Box:
-    hidden: _Hidden[int]
-
-class LocalUse:
-    item: Box
-"#,
-            &external_defs,
-        )
-        .expect("models compile");
-        let local_use = models
-            .module
-            .classes
-            .iter()
-            .find(|class| class.name == "LocalUse")
-            .expect("local use exists");
-        let local_shape = crate::describe_type("models", &local_use.fields[0].1, &models);
-        collect_module_exports("models", &models, &mut external_defs);
-        assert!(!external_defs.classes["models"].contains_key("_Hidden"));
-        assert!(external_defs
-            .structural_methods_for("models")
-            .is_some_and(|classes| classes.contains_key("_Hidden")));
-
-        let consumer = compile(
-            "consumer",
-            "from models import Box\n\nclass Container:\n    item: Box\n",
-            &external_defs,
-        )
-        .expect("consumer compiles");
-        let container = consumer
-            .module
-            .classes
-            .iter()
-            .find(|class| class.name == "Container")
-            .expect("container exists");
-        let shape = crate::describe_type_with_externals(
-            "consumer",
-            &container.fields[0].1,
-            &consumer,
-            &external_defs,
-        );
-        assert_eq!(local_shape.canonical_identity, shape.canonical_identity);
-        assert!(shape.canonical_identity.contains("models._Hidden"));
-        assert!(shape.canonical_identity.contains("value:int:default=int:0"));
-        assert!(shape.canonical_identity.contains("read:regular"));
-        assert!(shape.canonical_identity.contains("result[int]"));
-        assert!(shape.canonical_identity.contains("fixture.callback"));
     }
 
     #[test]

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -793,7 +793,9 @@ class LocalUse:
         let local_shape = crate::describe_type("models", &local_use.fields[0].1, &models);
         collect_module_exports("models", &models, &mut external_defs);
         assert!(!external_defs.classes["models"].contains_key("_Hidden"));
-        assert!(external_defs.structural_methods["models"].contains_key("_Hidden"));
+        assert!(external_defs
+            .structural_methods_for("models")
+            .is_some_and(|classes| classes.contains_key("_Hidden")));
 
         let consumer = compile(
             "consumer",

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -91,21 +91,6 @@ pub enum ShapeNode {
     Other(String),
 }
 
-/// Describe a concrete type as seen from one lowered module.
-///
-/// The output uses only declaration identity and ordered vectors. It therefore remains stable
-/// across hash-map seeds and process boundaries and can be used directly as an incremental query
-/// key or serialized static description.
-#[must_use]
-#[cfg(test)]
-pub(crate) fn describe_type(
-    module_name: &str,
-    ty: &Type,
-    lowering: &LoweringResult,
-) -> StructuralShape {
-    describe_type_inner(module_name, ty, lowering, None)
-}
-
 /// Describe a type with project export metadata available for imported nominals.
 #[must_use]
 pub fn describe_type_with_externals(

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -3,13 +3,14 @@
 use crate::ConstValue;
 use num_bigint::BigInt;
 use sifr_lowering::{
-    DeclarationMetadataTargetKind, HirClassKind, HirExpr, LoweringResult, TypedDeclarationMetadata,
+    DeclarationMetadataTargetKind, ExternalDefs, HirClassKind, HirExpr, LoweringResult,
+    TypedDeclarationMetadata,
 };
 use sifr_type_system::Type;
 use std::collections::{BTreeMap, BTreeSet};
 
 mod methods;
-use methods::described_methods;
+use methods::{described_exported_methods, described_methods};
 pub use methods::{ShapeMethod, ShapeParameter};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,8 +94,34 @@ pub enum ShapeNode {
 /// key or serialized static description.
 #[must_use]
 pub fn describe_type(module_name: &str, ty: &Type, lowering: &LoweringResult) -> StructuralShape {
+    describe_type_inner(module_name, ty, lowering, None)
+}
+
+/// Describe a type with project export metadata available for imported nominals.
+#[must_use]
+pub fn describe_type_with_externals(
+    module_name: &str,
+    ty: &Type,
+    lowering: &LoweringResult,
+    external_defs: &ExternalDefs,
+) -> StructuralShape {
+    describe_type_inner(module_name, ty, lowering, Some(external_defs))
+}
+
+fn describe_type_inner(
+    module_name: &str,
+    ty: &Type,
+    lowering: &LoweringResult,
+    external_defs: Option<&ExternalDefs>,
+) -> StructuralShape {
     let mut visiting = BTreeSet::new();
-    let root = describe_node(module_name, ty.resolve_alias(), lowering, &mut visiting);
+    let root = describe_node(
+        module_name,
+        ty.resolve_alias(),
+        lowering,
+        external_defs,
+        &mut visiting,
+    );
     let canonical_identity = canonical_node(&root);
     StructuralShape {
         root,
@@ -106,6 +133,7 @@ fn describe_node(
     module_name: &str,
     ty: &Type,
     lowering: &LoweringResult,
+    external_defs: Option<&ExternalDefs>,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeNode {
     match ty {
@@ -123,25 +151,43 @@ fn describe_node(
             module_name,
             element,
             lowering,
+            external_defs,
             visiting,
         ))),
         Type::Dict(key, value) => ShapeNode::Dictionary(
-            Box::new(describe_node(module_name, key, lowering, visiting)),
-            Box::new(describe_node(module_name, value, lowering, visiting)),
+            Box::new(describe_node(
+                module_name,
+                key,
+                lowering,
+                external_defs,
+                visiting,
+            )),
+            Box::new(describe_node(
+                module_name,
+                value,
+                lowering,
+                external_defs,
+                visiting,
+            )),
         ),
         Type::Set(element) => ShapeNode::Set(Box::new(describe_node(
             module_name,
             element,
             lowering,
+            external_defs,
             visiting,
         ))),
         Type::Tuple(elements) => ShapeNode::Tuple(
             elements
                 .iter()
-                .map(|element| describe_node(module_name, element, lowering, visiting))
+                .map(|element| {
+                    describe_node(module_name, element, lowering, external_defs, visiting)
+                })
                 .collect(),
         ),
-        Type::Union(members) => describe_union(module_name, members, lowering, visiting),
+        Type::Union(members) => {
+            describe_union(module_name, members, lowering, external_defs, visiting)
+        }
         Type::TypeVar(name) => ShapeNode::TypeParameter(name.clone()),
         Type::Enum { name, variants, .. } => ShapeNode::Enum {
             identity: format!("{module_name}.{name}"),
@@ -157,7 +203,13 @@ fn describe_node(
         },
         Type::Newtype { name, inner, .. } => ShapeNode::Newtype {
             identity: format!("{module_name}.{name}"),
-            inner: Box::new(describe_node(module_name, inner, lowering, visiting)),
+            inner: Box::new(describe_node(
+                module_name,
+                inner,
+                lowering,
+                external_defs,
+                visiting,
+            )),
             metadata: Vec::new(),
         },
         Type::Class {
@@ -173,6 +225,7 @@ fn describe_node(
             type_args,
             fields,
             lowering,
+            external_defs,
             visiting,
         ),
         other => ShapeNode::Other(other.display_name()),
@@ -187,6 +240,7 @@ fn describe_union(
     module_name: &str,
     members: &[Type],
     lowering: &LoweringResult,
+    external_defs: Option<&ExternalDefs>,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeNode {
     let non_none = members
@@ -198,13 +252,14 @@ fn describe_union(
             module_name,
             non_none[0],
             lowering,
+            external_defs,
             visiting,
         )));
     }
     ShapeNode::Union(
         members
             .iter()
-            .map(|member| describe_node(module_name, member, lowering, visiting))
+            .map(|member| describe_node(module_name, member, lowering, external_defs, visiting))
             .collect(),
     )
 }
@@ -217,6 +272,7 @@ fn describe_class(
     type_args: &[Type],
     fields: &[(String, Type)],
     lowering: &LoweringResult,
+    external_defs: Option<&ExternalDefs>,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeNode {
     let identity = if declared_identity.contains('.') {
@@ -261,7 +317,7 @@ fn describe_class(
             };
         }
         if let Some(inner) = &class.newtype_inner {
-            let inner = describe_node(module_name, inner, lowering, visiting);
+            let inner = describe_node(module_name, inner, lowering, external_defs, visiting);
             visiting.remove(&identity);
             return ShapeNode::Newtype {
                 identity,
@@ -276,47 +332,95 @@ fn describe_class(
         }
     }
 
-    let defaults = lowering.class_field_defaults.get(local_name);
+    let external_class = local_class
+        .is_none()
+        .then(|| {
+            let (source_module, source_name) = identity.rsplit_once('.')?;
+            let external_defs = external_defs?;
+            Some((source_module, source_name, external_defs))
+        })
+        .flatten();
+    let declaration_metadata = external_class
+        .and_then(|(source_module, _, external_defs)| {
+            external_defs.declaration_metadata.get(source_module)
+        })
+        .map_or(lowering.declaration_metadata.as_slice(), Vec::as_slice);
+    let metadata_owner = external_class.map_or(local_name, |(_, source_name, _)| source_name);
+    let defaults = external_class
+        .and_then(|(source_module, source_name, external_defs)| {
+            external_defs
+                .class_field_defaults
+                .get(source_module)
+                .and_then(|classes| classes.get(source_name))
+        })
+        .or_else(|| lowering.class_field_defaults.get(local_name));
     let described_fields = fields
         .iter()
         .enumerate()
         .map(|(index, (name, ty))| ShapeField {
             name: name.clone(),
-            declared_type: describe_node(module_name, ty, lowering, visiting),
+            declared_type: describe_node(module_name, ty, lowering, external_defs, visiting),
             default: defaults
                 .and_then(|values| values.iter().find(|(field, _)| *field == index))
                 .and_then(|(_, value)| const_value_from_hir(value)),
             metadata: metadata_for(
-                &lowering.declaration_metadata,
-                local_name,
+                declaration_metadata,
+                metadata_owner,
                 DeclarationMetadataTargetKind::Field,
                 Some(name),
             ),
         })
         .collect();
-    let described_methods = local_class.map_or_else(Vec::new, |class| {
+    let described_methods = if let Some(class) = local_class {
         described_methods(
             module_name,
             local_name,
             class,
             type_args,
             lowering,
+            external_defs,
             visiting,
         )
-    });
+    } else if let Some((source_module, source_name, external_defs)) = external_class {
+        let methods = external_defs
+            .structural_methods
+            .get(source_module)
+            .and_then(|classes| classes.get(source_name))
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let type_params = external_defs
+            .class_type_params
+            .get(source_module)
+            .and_then(|classes| classes.get(source_name))
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        described_exported_methods(
+            module_name,
+            source_name,
+            methods,
+            type_params,
+            type_args,
+            declaration_metadata,
+            lowering,
+            Some(external_defs),
+            visiting,
+        )
+    } else {
+        Vec::new()
+    };
     let type_arguments = type_args
         .iter()
-        .map(|argument| describe_node(module_name, argument, lowering, visiting))
+        .map(|argument| describe_node(module_name, argument, lowering, external_defs, visiting))
         .collect();
     visiting.remove(&identity);
     ShapeNode::Nominal {
-        identity,
+        identity: identity.clone(),
         type_arguments,
         fields: described_fields,
         methods: described_methods,
         metadata: metadata_for(
-            &lowering.declaration_metadata,
-            local_name,
+            declaration_metadata,
+            metadata_owner,
             DeclarationMetadataTargetKind::Type,
             None,
         ),

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -13,7 +13,7 @@ mod methods;
 use methods::{described_exported_methods, described_methods};
 pub use methods::{ShapeMethod, ShapeParameter};
 mod nominal_types;
-use nominal_types::{describe_enum, describe_newtype, qualified_identity};
+use nominal_types::{describe_enum, describe_newtype};
 mod canonical_helpers;
 use canonical_helpers::{canonical_bytes, canonical_sequence, canonical_values};
 
@@ -99,14 +99,14 @@ pub fn describe_type_with_externals(
     lowering: &LoweringResult,
     external_defs: &ExternalDefs,
 ) -> StructuralShape {
-    describe_type_inner(module_name, ty, lowering, Some(external_defs))
+    describe_type_inner(module_name, ty, lowering, external_defs)
 }
 
 fn describe_type_inner(
     module_name: &str,
     ty: &Type,
     lowering: &LoweringResult,
-    external_defs: Option<&ExternalDefs>,
+    external_defs: &ExternalDefs,
 ) -> StructuralShape {
     let mut visiting = BTreeSet::new();
     let root = describe_node(
@@ -127,7 +127,7 @@ fn describe_node(
     module_name: &str,
     ty: &Type,
     lowering: &LoweringResult,
-    external_defs: Option<&ExternalDefs>,
+    external_defs: &ExternalDefs,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeNode {
     match ty {
@@ -236,7 +236,7 @@ fn describe_union(
     module_name: &str,
     members: &[Type],
     lowering: &LoweringResult,
-    external_defs: Option<&ExternalDefs>,
+    external_defs: &ExternalDefs,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeNode {
     let non_none = members
@@ -268,10 +268,13 @@ fn describe_class(
     type_args: &[Type],
     fields: &[(String, Type)],
     lowering: &LoweringResult,
-    external_defs: Option<&ExternalDefs>,
+    external_defs: &ExternalDefs,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeNode {
-    let identity = qualified_identity(module_name, declared_identity);
+    let (source_module, source_name) = declared_identity
+        .rsplit_once('.')
+        .unwrap_or((module_name, declared_identity));
+    let identity = format!("{source_module}.{source_name}");
     if !visiting.insert(identity.clone()) {
         return ShapeNode::RecursiveReference(identity);
     }
@@ -314,21 +317,13 @@ fn describe_class(
         }
     }
 
-    let external_class = local_class
-        .is_none()
-        .then(|| {
-            let (source_module, source_name) = identity.rsplit_once('.')?;
-            let external_defs = external_defs?;
-            Some((source_module, source_name, external_defs))
-        })
-        .flatten();
     let (declaration_metadata, metadata_owner, defaults) = if local_class.is_some() {
         (
             lowering.declaration_metadata.as_slice(),
             local_name,
             lowering.class_field_defaults.get(local_name),
         )
-    } else if let Some((source_module, source_name, external_defs)) = external_class {
+    } else {
         (
             external_defs
                 .declaration_metadata
@@ -340,8 +335,6 @@ fn describe_class(
                 .get(source_module)
                 .and_then(|classes| classes.get(source_name)),
         )
-    } else {
-        (&[][..], local_name, None)
     };
     let described_fields = fields
         .iter()
@@ -370,7 +363,7 @@ fn describe_class(
             external_defs,
             visiting,
         )
-    } else if let Some((source_module, source_name, external_defs)) = external_class {
+    } else {
         let methods = external_defs
             .structural_methods_for(source_module)
             .and_then(|classes| classes.get(source_name))
@@ -390,11 +383,9 @@ fn describe_class(
             type_args,
             declaration_metadata,
             lowering,
-            Some(external_defs),
+            external_defs,
             visiting,
         )
-    } else {
-        Vec::new()
     };
     let type_arguments = type_args
         .iter()

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -12,6 +12,10 @@ use std::collections::{BTreeMap, BTreeSet};
 mod methods;
 use methods::{described_exported_methods, described_methods};
 pub use methods::{ShapeMethod, ShapeParameter};
+mod nominal_types;
+use nominal_types::{describe_enum, describe_newtype, qualified_identity};
+mod canonical_helpers;
+use canonical_helpers::{canonical_bytes, canonical_sequence, canonical_values};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructuralShape {
@@ -93,7 +97,12 @@ pub enum ShapeNode {
 /// across hash-map seeds and process boundaries and can be used directly as an incremental query
 /// key or serialized static description.
 #[must_use]
-pub fn describe_type(module_name: &str, ty: &Type, lowering: &LoweringResult) -> StructuralShape {
+#[cfg(test)]
+pub(crate) fn describe_type(
+    module_name: &str,
+    ty: &Type,
+    lowering: &LoweringResult,
+) -> StructuralShape {
     describe_type_inner(module_name, ty, lowering, None)
 }
 
@@ -189,29 +198,31 @@ fn describe_node(
             describe_union(module_name, members, lowering, external_defs, visiting)
         }
         Type::TypeVar(name) => ShapeNode::TypeParameter(name.clone()),
-        Type::Enum { name, variants, .. } => ShapeNode::Enum {
-            identity: format!("{module_name}.{name}"),
-            variants: variants
-                .iter()
-                .map(|(name, value)| ShapeEnumVariant {
-                    name: name.clone(),
-                    value: *value,
-                    metadata: Vec::new(),
-                })
-                .collect(),
-            metadata: Vec::new(),
-        },
-        Type::Newtype { name, inner, .. } => ShapeNode::Newtype {
-            identity: format!("{module_name}.{name}"),
-            inner: Box::new(describe_node(
-                module_name,
-                inner,
-                lowering,
-                external_defs,
-                visiting,
-            )),
-            metadata: Vec::new(),
-        },
+        Type::Enum {
+            identity,
+            name,
+            variants,
+        } => describe_enum(
+            module_name,
+            identity.as_deref(),
+            name,
+            variants,
+            lowering,
+            external_defs,
+        ),
+        Type::Newtype {
+            identity,
+            name,
+            inner,
+        } => describe_newtype(
+            module_name,
+            identity.as_deref(),
+            name,
+            inner,
+            lowering,
+            external_defs,
+            visiting,
+        ),
         Type::Class {
             identity,
             type_args,
@@ -275,11 +286,7 @@ fn describe_class(
     external_defs: Option<&ExternalDefs>,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeNode {
-    let identity = if declared_identity.contains('.') {
-        declared_identity.to_string()
-    } else {
-        format!("{module_name}.{declared_identity}")
-    };
+    let identity = qualified_identity(module_name, declared_identity);
     if !visiting.insert(identity.clone()) {
         return ShapeNode::RecursiveReference(identity);
     }
@@ -340,20 +347,27 @@ fn describe_class(
             Some((source_module, source_name, external_defs))
         })
         .flatten();
-    let declaration_metadata = external_class
-        .and_then(|(source_module, _, external_defs)| {
-            external_defs.declaration_metadata.get(source_module)
-        })
-        .map_or(lowering.declaration_metadata.as_slice(), Vec::as_slice);
-    let metadata_owner = external_class.map_or(local_name, |(_, source_name, _)| source_name);
-    let defaults = external_class
-        .and_then(|(source_module, source_name, external_defs)| {
+    let (declaration_metadata, metadata_owner, defaults) = if local_class.is_some() {
+        (
+            lowering.declaration_metadata.as_slice(),
+            local_name,
+            lowering.class_field_defaults.get(local_name),
+        )
+    } else if let Some((source_module, source_name, external_defs)) = external_class {
+        (
+            external_defs
+                .declaration_metadata
+                .get(source_module)
+                .map_or(&[][..], Vec::as_slice),
+            source_name,
             external_defs
                 .class_field_defaults
                 .get(source_module)
-                .and_then(|classes| classes.get(source_name))
-        })
-        .or_else(|| lowering.class_field_defaults.get(local_name));
+                .and_then(|classes| classes.get(source_name)),
+        )
+    } else {
+        (&[][..], local_name, None)
+    };
     let described_fields = fields
         .iter()
         .enumerate()
@@ -859,38 +873,6 @@ pub(crate) fn canonical_value(value: &ConstValue) -> String {
                 .join(",")
         ),
     }
-}
-
-fn canonical_bytes(value: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut encoded = String::with_capacity(value.len() * 2);
-    for byte in value {
-        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
-        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
-    }
-    encoded
-}
-
-fn canonical_values(kind: &str, values: &[ConstValue]) -> String {
-    format!(
-        "{kind}[{}]",
-        values
-            .iter()
-            .map(canonical_value)
-            .collect::<Vec<_>>()
-            .join(",")
-    )
-}
-
-fn canonical_sequence(kind: &str, elements: &[ShapeNode]) -> String {
-    format!(
-        "{kind}[{}]",
-        elements
-            .iter()
-            .map(canonical_node)
-            .collect::<Vec<_>>()
-            .join(",")
-    )
 }
 
 #[cfg(test)]

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -291,51 +291,41 @@ fn describe_class(
         return ShapeNode::RecursiveReference(identity);
     }
 
-    let local_class = lowering
-        .module
-        .classes
-        .iter()
-        .find(|class| class.name == local_name);
+    let local_identity = format!("{module_name}.{local_name}");
+    let local_class = (identity == local_identity)
+        .then(|| {
+            lowering
+                .module
+                .classes
+                .iter()
+                .find(|class| class.name == local_name)
+        })
+        .flatten();
     if let Some(class) = local_class {
         if matches!(class.kind, HirClassKind::Enum) {
+            let described = describe_enum(
+                module_name,
+                Some(&identity),
+                local_name,
+                &class.enum_variants,
+                lowering,
+                external_defs,
+            );
             visiting.remove(&identity);
-            return ShapeNode::Enum {
-                identity,
-                variants: class
-                    .enum_variants
-                    .iter()
-                    .map(|(name, value)| ShapeEnumVariant {
-                        name: name.clone(),
-                        value: *value,
-                        metadata: metadata_for(
-                            &lowering.declaration_metadata,
-                            local_name,
-                            DeclarationMetadataTargetKind::EnumVariant,
-                            Some(name),
-                        ),
-                    })
-                    .collect(),
-                metadata: metadata_for(
-                    &lowering.declaration_metadata,
-                    local_name,
-                    DeclarationMetadataTargetKind::Type,
-                    None,
-                ),
-            };
+            return described;
         }
         if let Some(inner) = &class.newtype_inner {
-            let inner = describe_node(module_name, inner, lowering, external_defs, visiting);
+            let described = describe_newtype(
+                module_name,
+                Some(&identity),
+                local_name,
+                inner,
+                lowering,
+                external_defs,
+                visiting,
+            );
             visiting.remove(&identity);
-            return ShapeNode::Newtype {
-                identity,
-                inner: Box::new(inner),
-                metadata: metadata_for(
-                    &lowering.declaration_metadata,
-                    local_name,
-                    DeclarationMetadataTargetKind::Type,
-                    None,
-                ),
-            };
+            return described;
         }
     }
 

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -387,8 +387,7 @@ fn describe_class(
         )
     } else if let Some((source_module, source_name, external_defs)) = external_class {
         let methods = external_defs
-            .structural_methods
-            .get(source_module)
+            .structural_methods_for(source_module)
             .and_then(|classes| classes.get(source_name))
             .map(Vec::as_slice)
             .unwrap_or_default();

--- a/crates/sifr_frontend/src/structural_shape/canonical_helpers.rs
+++ b/crates/sifr_frontend/src/structural_shape/canonical_helpers.rs
@@ -1,0 +1,34 @@
+use super::{canonical_node, canonical_value, ShapeNode};
+use crate::ConstValue;
+
+pub(super) fn canonical_bytes(value: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(value.len() * 2);
+    for byte in value {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+pub(super) fn canonical_values(kind: &str, values: &[ConstValue]) -> String {
+    format!(
+        "{kind}[{}]",
+        values
+            .iter()
+            .map(canonical_value)
+            .collect::<Vec<_>>()
+            .join(",")
+    )
+}
+
+pub(super) fn canonical_sequence(kind: &str, elements: &[ShapeNode]) -> String {
+    format!(
+        "{kind}[{}]",
+        elements
+            .iter()
+            .map(canonical_node)
+            .collect::<Vec<_>>()
+            .join(",")
+    )
+}

--- a/crates/sifr_frontend/src/structural_shape/methods.rs
+++ b/crates/sifr_frontend/src/structural_shape/methods.rs
@@ -34,7 +34,7 @@ pub(super) fn described_methods(
     class: &HirClass,
     type_args: &[Type],
     lowering: &LoweringResult,
-    external_defs: Option<&sifr_lowering::ExternalDefs>,
+    external_defs: &sifr_lowering::ExternalDefs,
     visiting: &mut BTreeSet<String>,
 ) -> Vec<ShapeMethod> {
     let mut seen = BTreeSet::new();
@@ -99,7 +99,7 @@ pub(super) fn described_exported_methods(
     type_args: &[Type],
     declaration_metadata: &[TypedDeclarationMetadata],
     lowering: &LoweringResult,
-    external_defs: Option<&sifr_lowering::ExternalDefs>,
+    external_defs: &sifr_lowering::ExternalDefs,
     visiting: &mut BTreeSet<String>,
 ) -> Vec<ShapeMethod> {
     let bindings = type_params
@@ -150,7 +150,7 @@ fn described_method(
     metadata: Vec<ShapeMetadata>,
     declaration_metadata: &[TypedDeclarationMetadata],
     lowering: &LoweringResult,
-    external_defs: Option<&sifr_lowering::ExternalDefs>,
+    external_defs: &sifr_lowering::ExternalDefs,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeMethod {
     ShapeMethod {

--- a/crates/sifr_frontend/src/structural_shape/methods.rs
+++ b/crates/sifr_frontend/src/structural_shape/methods.rs
@@ -53,22 +53,19 @@ pub(super) fn described_methods(
                 && entry.owner.starts_with(&owner_prefix)
                 && seen.insert(entry.owner.clone())
         })
-        .map(|entry| {
+        .filter_map(|entry| {
             let declared_name = &entry.owner[owner_prefix.len()..];
             let hir_name = if declared_name == "__init__" {
                 "new"
             } else {
                 declared_name
             };
-            let Some(method) = class
+            let method = class
                 .methods
                 .iter()
                 .chain(class.operator_impls.iter().map(|(_, method)| method))
-                .find(|method| method.name == hir_name)
-            else {
-                panic!("validated method metadata must resolve to a lowered method");
-            };
-            described_method(
+                .find(|method| method.name == hir_name)?;
+            Some(described_method(
                 module_name,
                 &entry.owner,
                 declared_name,
@@ -88,11 +85,12 @@ pub(super) fn described_methods(
                 lowering,
                 external_defs,
                 visiting,
-            )
+            ))
         })
         .collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn described_exported_methods(
     module_name: &str,
     class_name: &str,
@@ -104,34 +102,19 @@ pub(super) fn described_exported_methods(
     external_defs: Option<&sifr_lowering::ExternalDefs>,
     visiting: &mut BTreeSet<String>,
 ) -> Vec<ShapeMethod> {
-    let mut seen = BTreeSet::new();
-    let owner_prefix = format!("{class_name}.");
     let bindings = type_params
         .iter()
         .cloned()
         .zip(type_args.iter().cloned())
         .collect::<HashMap<_, _>>();
-    declaration_metadata
+    methods
         .iter()
-        .filter(|entry| {
-            entry.target_kind == DeclarationMetadataTargetKind::Method
-                && entry.owner.starts_with(&owner_prefix)
-                && seen.insert(entry.owner.clone())
-        })
-        .map(|entry| {
-            let declared_name = &entry.owner[owner_prefix.len()..];
-            let hir_name = if declared_name == "__init__" {
-                "new"
-            } else {
-                declared_name
-            };
-            let Some(method) = methods.iter().find(|method| method.name == hir_name) else {
-                panic!("validated imported method metadata must resolve to an exported method");
-            };
+        .map(|method| {
+            let owner = format!("{class_name}.{}", method.name);
             described_method(
                 module_name,
-                &entry.owner,
-                declared_name,
+                &owner,
+                &method.name,
                 &method.params,
                 &method.return_type,
                 method.method_kind,
@@ -140,7 +123,7 @@ pub(super) fn described_exported_methods(
                 &bindings,
                 metadata_for(
                     declaration_metadata,
-                    &entry.owner,
+                    &owner,
                     DeclarationMetadataTargetKind::Method,
                     None,
                 ),
@@ -153,6 +136,7 @@ pub(super) fn described_exported_methods(
         .collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn described_method(
     module_name: &str,
     owner: &str,

--- a/crates/sifr_frontend/src/structural_shape/methods.rs
+++ b/crates/sifr_frontend/src/structural_shape/methods.rs
@@ -1,7 +1,7 @@
 use super::{describe_node, metadata_for, ShapeMetadata, ShapeNode};
 use sifr_lowering::{
-    substitute_type_vars, DeclarationMetadataTargetKind, HirClass, HirFunction, LoweringResult,
-    MethodKind,
+    substitute_type_vars, DeclarationMetadataTargetKind, HirClass, HirParam, LoweringResult,
+    MethodKind, StructuralMethodExport, TypedDeclarationMetadata,
 };
 use sifr_type_system::{
     ParamConvention, ParamMutability, ParamOwnership, ReceiverConvention, Type,
@@ -34,6 +34,7 @@ pub(super) fn described_methods(
     class: &HirClass,
     type_args: &[Type],
     lowering: &LoweringResult,
+    external_defs: Option<&sifr_lowering::ExternalDefs>,
     visiting: &mut BTreeSet<String>,
 ) -> Vec<ShapeMethod> {
     let mut seen = BTreeSet::new();
@@ -71,7 +72,11 @@ pub(super) fn described_methods(
                 module_name,
                 &entry.owner,
                 declared_name,
-                method,
+                &method.params,
+                &method.return_type,
+                method.method_kind,
+                method.receiver,
+                method.is_async,
                 &bindings,
                 metadata_for(
                     &lowering.declaration_metadata,
@@ -79,7 +84,69 @@ pub(super) fn described_methods(
                     DeclarationMetadataTargetKind::Method,
                     None,
                 ),
+                &lowering.declaration_metadata,
                 lowering,
+                external_defs,
+                visiting,
+            )
+        })
+        .collect()
+}
+
+pub(super) fn described_exported_methods(
+    module_name: &str,
+    class_name: &str,
+    methods: &[StructuralMethodExport],
+    type_params: &[String],
+    type_args: &[Type],
+    declaration_metadata: &[TypedDeclarationMetadata],
+    lowering: &LoweringResult,
+    external_defs: Option<&sifr_lowering::ExternalDefs>,
+    visiting: &mut BTreeSet<String>,
+) -> Vec<ShapeMethod> {
+    let mut seen = BTreeSet::new();
+    let owner_prefix = format!("{class_name}.");
+    let bindings = type_params
+        .iter()
+        .cloned()
+        .zip(type_args.iter().cloned())
+        .collect::<HashMap<_, _>>();
+    declaration_metadata
+        .iter()
+        .filter(|entry| {
+            entry.target_kind == DeclarationMetadataTargetKind::Method
+                && entry.owner.starts_with(&owner_prefix)
+                && seen.insert(entry.owner.clone())
+        })
+        .map(|entry| {
+            let declared_name = &entry.owner[owner_prefix.len()..];
+            let hir_name = if declared_name == "__init__" {
+                "new"
+            } else {
+                declared_name
+            };
+            let Some(method) = methods.iter().find(|method| method.name == hir_name) else {
+                panic!("validated imported method metadata must resolve to an exported method");
+            };
+            described_method(
+                module_name,
+                &entry.owner,
+                declared_name,
+                &method.params,
+                &method.return_type,
+                method.method_kind,
+                method.receiver,
+                method.is_async,
+                &bindings,
+                metadata_for(
+                    declaration_metadata,
+                    &entry.owner,
+                    DeclarationMetadataTargetKind::Method,
+                    None,
+                ),
+                declaration_metadata,
+                lowering,
+                external_defs,
                 visiting,
             )
         })
@@ -90,22 +157,24 @@ fn described_method(
     module_name: &str,
     owner: &str,
     declared_name: &str,
-    method: &HirFunction,
+    params: &[HirParam],
+    return_type: &Type,
+    method_kind: MethodKind,
+    receiver: Option<ReceiverConvention>,
+    is_async: bool,
     bindings: &HashMap<String, Type>,
     metadata: Vec<ShapeMetadata>,
+    declaration_metadata: &[TypedDeclarationMetadata],
     lowering: &LoweringResult,
+    external_defs: Option<&sifr_lowering::ExternalDefs>,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeMethod {
     ShapeMethod {
         name: declared_name.to_string(),
-        kind: method_kind_name(method.method_kind).to_string(),
-        receiver: method
-            .receiver
-            .map(receiver_convention_name)
-            .map(str::to_string),
-        is_async: method.is_async,
-        params: method
-            .params
+        kind: method_kind_name(method_kind).to_string(),
+        receiver: receiver.map(receiver_convention_name).map(str::to_string),
+        is_async,
+        params: params
             .iter()
             .map(|param| ShapeParameter {
                 name: param.name.clone(),
@@ -113,12 +182,13 @@ fn described_method(
                     module_name,
                     &substitute_type_vars(&param.ty, bindings),
                     lowering,
+                    external_defs,
                     visiting,
                 ),
                 convention: param_convention_name(param.convention).to_string(),
                 keyword_only: param.keyword_only,
                 metadata: metadata_for(
-                    &lowering.declaration_metadata,
+                    declaration_metadata,
                     owner,
                     DeclarationMetadataTargetKind::Parameter,
                     Some(&param.name),
@@ -127,8 +197,9 @@ fn described_method(
             .collect(),
         result: Box::new(describe_node(
             module_name,
-            &substitute_type_vars(&method.return_type, bindings),
+            &substitute_type_vars(return_type, bindings),
             lowering,
+            external_defs,
             visiting,
         )),
         metadata,

--- a/crates/sifr_frontend/src/structural_shape/nominal_types.rs
+++ b/crates/sifr_frontend/src/structural_shape/nominal_types.rs
@@ -15,7 +15,7 @@ pub(super) fn describe_enum(
 ) -> ShapeNode {
     let identity = qualified_identity(module_name, declared_identity.unwrap_or(local_name));
     let (metadata, owner) =
-        declaration_metadata_for(&identity, local_name, lowering, external_defs);
+        declaration_metadata_for(module_name, &identity, local_name, lowering, external_defs);
     ShapeNode::Enum {
         identity,
         variants: variants
@@ -47,7 +47,7 @@ pub(super) fn describe_newtype(
 ) -> ShapeNode {
     let identity = qualified_identity(module_name, declared_identity.unwrap_or(local_name));
     let (metadata, owner) =
-        declaration_metadata_for(&identity, local_name, lowering, external_defs);
+        declaration_metadata_for(module_name, &identity, local_name, lowering, external_defs);
     ShapeNode::Newtype {
         identity,
         inner: Box::new(describe_node(
@@ -70,16 +70,18 @@ pub(super) fn qualified_identity(module_name: &str, declared_identity: &str) -> 
 }
 
 fn declaration_metadata_for<'a>(
+    module_name: &str,
     identity: &str,
     local_name: &str,
     lowering: &'a LoweringResult,
     external_defs: Option<&'a ExternalDefs>,
 ) -> (&'a [TypedDeclarationMetadata], String) {
-    if lowering
-        .module
-        .classes
-        .iter()
-        .any(|class| class.name == local_name)
+    if identity == format!("{module_name}.{local_name}")
+        && lowering
+            .module
+            .classes
+            .iter()
+            .any(|class| class.name == local_name)
     {
         return (&lowering.declaration_metadata, local_name.to_string());
     }

--- a/crates/sifr_frontend/src/structural_shape/nominal_types.rs
+++ b/crates/sifr_frontend/src/structural_shape/nominal_types.rs
@@ -11,11 +11,19 @@ pub(super) fn describe_enum(
     local_name: &str,
     variants: &[(String, Option<i64>)],
     lowering: &LoweringResult,
-    external_defs: Option<&ExternalDefs>,
+    external_defs: &ExternalDefs,
 ) -> ShapeNode {
-    let identity = qualified_identity(module_name, declared_identity.unwrap_or(local_name));
-    let (metadata, owner) =
-        declaration_metadata_for(module_name, &identity, local_name, lowering, external_defs);
+    let (source_module, source_name) =
+        identity_parts(module_name, declared_identity.unwrap_or(local_name));
+    let identity = format!("{source_module}.{source_name}");
+    let (metadata, owner) = declaration_metadata_for(
+        module_name,
+        source_module,
+        source_name,
+        local_name,
+        lowering,
+        external_defs,
+    );
     ShapeNode::Enum {
         identity,
         variants: variants
@@ -42,12 +50,20 @@ pub(super) fn describe_newtype(
     local_name: &str,
     inner: &Type,
     lowering: &LoweringResult,
-    external_defs: Option<&ExternalDefs>,
+    external_defs: &ExternalDefs,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeNode {
-    let identity = qualified_identity(module_name, declared_identity.unwrap_or(local_name));
-    let (metadata, owner) =
-        declaration_metadata_for(module_name, &identity, local_name, lowering, external_defs);
+    let (source_module, source_name) =
+        identity_parts(module_name, declared_identity.unwrap_or(local_name));
+    let identity = format!("{source_module}.{source_name}");
+    let (metadata, owner) = declaration_metadata_for(
+        module_name,
+        source_module,
+        source_name,
+        local_name,
+        lowering,
+        external_defs,
+    );
     ShapeNode::Newtype {
         identity,
         inner: Box::new(describe_node(
@@ -61,22 +77,22 @@ pub(super) fn describe_newtype(
     }
 }
 
-pub(super) fn qualified_identity(module_name: &str, declared_identity: &str) -> String {
-    if declared_identity.contains('.') {
-        declared_identity.to_string()
-    } else {
-        format!("{module_name}.{declared_identity}")
-    }
+fn identity_parts<'a>(module_name: &'a str, declared_identity: &'a str) -> (&'a str, &'a str) {
+    declared_identity
+        .rsplit_once('.')
+        .unwrap_or((module_name, declared_identity))
 }
 
 fn declaration_metadata_for<'a>(
     module_name: &str,
-    identity: &str,
+    source_module: &str,
+    source_name: &str,
     local_name: &str,
     lowering: &'a LoweringResult,
-    external_defs: Option<&'a ExternalDefs>,
+    external_defs: &'a ExternalDefs,
 ) -> (&'a [TypedDeclarationMetadata], String) {
-    if identity == format!("{module_name}.{local_name}")
+    if source_module == module_name
+        && source_name == local_name
         && lowering
             .module
             .classes
@@ -85,11 +101,9 @@ fn declaration_metadata_for<'a>(
     {
         return (&lowering.declaration_metadata, local_name.to_string());
     }
-    let Some((source_module, source_name)) = identity.rsplit_once('.') else {
-        return (&[], local_name.to_string());
-    };
     let metadata = external_defs
-        .and_then(|defs| defs.declaration_metadata.get(source_module))
+        .declaration_metadata
+        .get(source_module)
         .map_or(&[][..], Vec::as_slice);
     (metadata, source_name.to_string())
 }

--- a/crates/sifr_frontend/src/structural_shape/nominal_types.rs
+++ b/crates/sifr_frontend/src/structural_shape/nominal_types.rs
@@ -1,0 +1,93 @@
+use super::{describe_node, metadata_for, ShapeEnumVariant, ShapeNode};
+use sifr_lowering::{
+    DeclarationMetadataTargetKind, ExternalDefs, LoweringResult, TypedDeclarationMetadata,
+};
+use sifr_type_system::Type;
+use std::collections::BTreeSet;
+
+pub(super) fn describe_enum(
+    module_name: &str,
+    declared_identity: Option<&str>,
+    local_name: &str,
+    variants: &[(String, Option<i64>)],
+    lowering: &LoweringResult,
+    external_defs: Option<&ExternalDefs>,
+) -> ShapeNode {
+    let identity = qualified_identity(module_name, declared_identity.unwrap_or(local_name));
+    let (metadata, owner) =
+        declaration_metadata_for(&identity, local_name, lowering, external_defs);
+    ShapeNode::Enum {
+        identity,
+        variants: variants
+            .iter()
+            .map(|(name, value)| ShapeEnumVariant {
+                name: name.clone(),
+                value: *value,
+                metadata: metadata_for(
+                    metadata,
+                    &owner,
+                    DeclarationMetadataTargetKind::EnumVariant,
+                    Some(name),
+                ),
+            })
+            .collect(),
+        metadata: metadata_for(metadata, &owner, DeclarationMetadataTargetKind::Type, None),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn describe_newtype(
+    module_name: &str,
+    declared_identity: Option<&str>,
+    local_name: &str,
+    inner: &Type,
+    lowering: &LoweringResult,
+    external_defs: Option<&ExternalDefs>,
+    visiting: &mut BTreeSet<String>,
+) -> ShapeNode {
+    let identity = qualified_identity(module_name, declared_identity.unwrap_or(local_name));
+    let (metadata, owner) =
+        declaration_metadata_for(&identity, local_name, lowering, external_defs);
+    ShapeNode::Newtype {
+        identity,
+        inner: Box::new(describe_node(
+            module_name,
+            inner,
+            lowering,
+            external_defs,
+            visiting,
+        )),
+        metadata: metadata_for(metadata, &owner, DeclarationMetadataTargetKind::Type, None),
+    }
+}
+
+pub(super) fn qualified_identity(module_name: &str, declared_identity: &str) -> String {
+    if declared_identity.contains('.') {
+        declared_identity.to_string()
+    } else {
+        format!("{module_name}.{declared_identity}")
+    }
+}
+
+fn declaration_metadata_for<'a>(
+    identity: &str,
+    local_name: &str,
+    lowering: &'a LoweringResult,
+    external_defs: Option<&'a ExternalDefs>,
+) -> (&'a [TypedDeclarationMetadata], String) {
+    if lowering
+        .module
+        .classes
+        .iter()
+        .any(|class| class.name == local_name)
+    {
+        return (&lowering.declaration_metadata, local_name.to_string());
+    }
+    let Some((source_module, source_name)) = identity.rsplit_once('.') else {
+        return (&[], local_name.to_string());
+    };
+    let metadata = external_defs
+        .and_then(|defs| defs.declaration_metadata.get(source_module))
+        .map_or(&[][..], Vec::as_slice);
+    (metadata, source_name.to_string())
+}

--- a/crates/sifr_frontend/src/structural_shape/tests.rs
+++ b/crates/sifr_frontend/src/structural_shape/tests.rs
@@ -3,6 +3,10 @@ use sifr_lowering::lower_module;
 use sifr_syntax::parse_module_suite;
 use sifr_type_system::FunctionType;
 
+fn describe_type(module_name: &str, ty: &Type, lowering: &LoweringResult) -> StructuralShape {
+    describe_type_with_externals(module_name, ty, lowering, &ExternalDefs::default())
+}
+
 fn class_type(class: &sifr_lowering::HirClass, type_args: Vec<Type>) -> Type {
     Type::Class {
         identity: None,

--- a/crates/sifr_frontend/src/structural_shape_import_tests.rs
+++ b/crates/sifr_frontend/src/structural_shape_import_tests.rs
@@ -1,0 +1,202 @@
+use crate::{
+    collect_module_exports, compile_module_hir, describe_type_with_externals,
+    FrontendDiagnosticStyle,
+};
+use sifr_lowering::{ExternalDefs, LoweringResult};
+use sifr_syntax::parse_module_suite;
+use sifr_type_system::Type;
+
+fn compile(module: &str, source: &str, external_defs: &ExternalDefs) -> LoweringResult {
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    compile_module_hir(
+        module,
+        &parsed,
+        external_defs,
+        FrontendDiagnosticStyle::Bare,
+    )
+    .expect("fixture compiles")
+}
+
+fn field_type<'a>(result: &'a LoweringResult, class_name: &str, field: &str) -> &'a Type {
+    result
+        .module
+        .classes
+        .iter()
+        .find(|class| class.name == class_name)
+        .and_then(|class| class.fields.iter().find(|(name, _)| name == field))
+        .map(|(_, ty)| ty)
+        .expect("field exists")
+}
+
+#[test]
+fn recollection_removes_stale_structural_shape_exports() {
+    let mut external_defs = ExternalDefs::default();
+    let annotated = compile(
+        "models",
+        r#"
+@metadata("fixture.kind", "hidden")
+class _Hidden[T]:
+    value: T = 0
+
+    @metadata("fixture.callback", "read")
+    def read(self) -> T:
+        return self.value
+"#,
+        &external_defs,
+    );
+    collect_module_exports("models", &annotated, &mut external_defs);
+    assert!(external_defs.class_field_defaults.contains_key("models"));
+    assert!(external_defs.declaration_metadata.contains_key("models"));
+    assert!(external_defs.class_type_params.contains_key("models"));
+    assert!(external_defs.structural_methods_for("models").is_some());
+
+    let plain = compile("models", "class _Hidden:\n    value: int\n", &external_defs);
+    collect_module_exports("models", &plain, &mut external_defs);
+    assert!(!external_defs.class_field_defaults.contains_key("models"));
+    assert!(!external_defs.declaration_metadata.contains_key("models"));
+    assert!(!external_defs.class_type_params.contains_key("models"));
+    assert!(external_defs.structural_methods_for("models").is_none());
+}
+
+#[test]
+fn structural_method_storage_is_allocated_only_while_demanded() {
+    let mut external_defs = ExternalDefs::default();
+    let plain = compile("first", "class Plain:\n    value: int\n", &external_defs);
+    collect_module_exports("first", &plain, &mut external_defs);
+    assert!(!external_defs.has_structural_methods());
+
+    let annotated_source = r#"
+class Model:
+    @metadata("fixture.callback", "read")
+    def read(self) -> int:
+        return 1
+"#;
+    let first = compile("first", annotated_source, &external_defs);
+    collect_module_exports("first", &first, &mut external_defs);
+    assert!(external_defs.has_structural_methods());
+
+    let first_plain = compile("first", "class Model:\n    pass\n", &external_defs);
+    collect_module_exports("first", &first_plain, &mut external_defs);
+    assert!(!external_defs.has_structural_methods());
+
+    let first = compile("first", annotated_source, &external_defs);
+    let second = compile("second", annotated_source, &external_defs);
+    collect_module_exports("first", &first, &mut external_defs);
+    collect_module_exports("second", &second, &mut external_defs);
+    collect_module_exports("first", &first_plain, &mut external_defs);
+    assert!(external_defs.has_structural_methods());
+    let second_plain = compile("second", "class Model:\n    pass\n", &external_defs);
+    collect_module_exports("second", &second_plain, &mut external_defs);
+    assert!(!external_defs.has_structural_methods());
+}
+
+#[test]
+fn imported_nominal_ignores_colliding_local_class_shape() {
+    let mut external_defs = ExternalDefs::default();
+    let models = compile(
+        "models",
+        r#"
+class Box:
+    model_value: int = 1
+
+    @metadata("fixture.callback", "model")
+    def model_method(self) -> int:
+        return self.model_value
+
+class Wrapper:
+    item: Box
+
+class LocalUse:
+    value: Wrapper
+"#,
+        &external_defs,
+    );
+    let local = describe_type_with_externals(
+        "models",
+        field_type(&models, "LocalUse", "value"),
+        &models,
+        &external_defs,
+    );
+    collect_module_exports("models", &models, &mut external_defs);
+
+    let consumer = compile(
+        "consumer",
+        r#"
+from models import Wrapper
+
+class Box:
+    consumer_only: str = "wrong"
+
+    @metadata("fixture.callback", "consumer")
+    def consumer_method(self) -> str:
+        return self.consumer_only
+
+class Use:
+    value: Wrapper
+"#,
+        &external_defs,
+    );
+    let imported = describe_type_with_externals(
+        "consumer",
+        field_type(&consumer, "Use", "value"),
+        &consumer,
+        &external_defs,
+    );
+
+    assert_eq!(local.canonical_identity, imported.canonical_identity);
+    assert!(imported.canonical_identity.contains("models.Box"));
+    assert!(!imported.canonical_identity.contains("consumer_only"));
+    assert!(!imported.canonical_identity.contains("consumer_method"));
+}
+
+#[test]
+fn public_import_preserves_private_generic_nested_shape() {
+    let mut external_defs = ExternalDefs::default();
+    let models = compile(
+        "models",
+        r#"
+class _Hidden[T]:
+    value: T = 0
+
+    @metadata("fixture.callback", "read")
+    def read(self) -> T:
+        return self.value
+
+class Box:
+    hidden: _Hidden[int]
+
+class LocalUse:
+    item: Box
+"#,
+        &external_defs,
+    );
+    let local_shape = describe_type_with_externals(
+        "models",
+        field_type(&models, "LocalUse", "item"),
+        &models,
+        &external_defs,
+    );
+    collect_module_exports("models", &models, &mut external_defs);
+    assert!(!external_defs.classes["models"].contains_key("_Hidden"));
+    assert!(external_defs
+        .structural_methods_for("models")
+        .is_some_and(|classes| classes.contains_key("_Hidden")));
+
+    let consumer = compile(
+        "consumer",
+        "from models import Box\n\nclass Container:\n    item: Box\n",
+        &external_defs,
+    );
+    let shape = describe_type_with_externals(
+        "consumer",
+        field_type(&consumer, "Container", "item"),
+        &consumer,
+        &external_defs,
+    );
+    assert_eq!(local_shape.canonical_identity, shape.canonical_identity);
+    assert!(shape.canonical_identity.contains("models._Hidden"));
+    assert!(shape.canonical_identity.contains("value:int:default=int:0"));
+    assert!(shape.canonical_identity.contains("read:regular"));
+    assert!(shape.canonical_identity.contains("result[int]"));
+    assert!(shape.canonical_identity.contains("fixture.callback"));
+}

--- a/crates/sifr_lowering/src/lib.rs
+++ b/crates/sifr_lowering/src/lib.rs
@@ -27,7 +27,7 @@ pub use lower::{
     lower_module_sysroot_public_stdlib_with_externals, lower_module_with_externals,
     lower_module_with_externals_and_name, lower_module_with_externals_name_and_options,
     substitute_type_vars, ExternalDefs, LoweringOptions, LoweringSourceOrigin,
-    PythonBridgeTargetAuthority, PythonTrustPolicy,
+    PythonBridgeTargetAuthority, PythonTrustPolicy, StructuralMethodExport,
 };
 pub use scope::{NarrowingSnapshot, Scope};
 pub use sifr_ir::{

--- a/crates/sifr_lowering/src/lib.rs
+++ b/crates/sifr_lowering/src/lib.rs
@@ -28,6 +28,7 @@ pub use lower::{
     lower_module_with_externals_and_name, lower_module_with_externals_name_and_options,
     substitute_type_vars, ExternalDefs, LoweringOptions, LoweringSourceOrigin,
     PythonBridgeTargetAuthority, PythonTrustPolicy, StructuralMethodExport,
+    StructuralMethodExports,
 };
 pub use scope::{NarrowingSnapshot, Scope};
 pub use sifr_ir::{

--- a/crates/sifr_lowering/src/lower/external_defs.rs
+++ b/crates/sifr_lowering/src/lower/external_defs.rs
@@ -13,6 +13,9 @@ pub struct StructuralMethodExport {
     pub receiver: Option<ReceiverConvention>,
 }
 
+pub type StructuralMethodExports = std::collections::HashMap<String, Vec<StructuralMethodExport>>;
+type StructuralMethodModules = std::collections::HashMap<String, StructuralMethodExports>;
+
 #[derive(Debug, Clone, Default)]
 pub struct ModuleSpecializationMetadata {
     pub class_field_defaults: std::collections::HashMap<String, Vec<(usize, HirExpr)>>,
@@ -52,10 +55,7 @@ pub struct ExternalDefs {
     ///
     /// These are compiler-internal exports. They preserve declaration details that
     /// `Type::Class::methods` intentionally does not carry.
-    pub structural_methods: std::collections::HashMap<
-        String,
-        std::collections::HashMap<String, Vec<StructuralMethodExport>>,
-    >,
+    pub structural_methods: Option<Box<StructuralMethodModules>>,
     /// Map of `module_name` -> (`class_name` -> declaration-order field defaults).
     ///
     /// Constructor defaults intentionally remain separate because an explicit constructor is
@@ -111,6 +111,31 @@ pub struct ExternalDefs {
 }
 
 impl ExternalDefs {
+    pub fn replace_structural_methods(
+        &mut self,
+        module_name: &str,
+        methods: StructuralMethodExports,
+    ) {
+        if methods.is_empty() {
+            let remove_storage = self.structural_methods.as_mut().is_some_and(|modules| {
+                modules.remove(module_name);
+                modules.is_empty()
+            });
+            if remove_storage {
+                self.structural_methods = None;
+            }
+        } else {
+            self.structural_methods
+                .get_or_insert_with(Box::default)
+                .insert(module_name.to_string(), methods);
+        }
+    }
+
+    #[must_use]
+    pub fn structural_methods_for(&self, module_name: &str) -> Option<&StructuralMethodExports> {
+        self.structural_methods.as_deref()?.get(module_name)
+    }
+
     pub fn insert_error_type(&mut self, module_name: &str, class_name: &str) {
         self.error_types
             .entry(module_name.to_string())

--- a/crates/sifr_lowering/src/lower/external_defs.rs
+++ b/crates/sifr_lowering/src/lower/external_defs.rs
@@ -55,7 +55,7 @@ pub struct ExternalDefs {
     ///
     /// These are compiler-internal exports. They preserve declaration details that
     /// `Type::Class::methods` intentionally does not carry.
-    pub structural_methods: Option<Box<StructuralMethodModules>>,
+    structural_methods: Option<Box<StructuralMethodModules>>,
     /// Map of `module_name` -> (`class_name` -> declaration-order field defaults).
     ///
     /// Constructor defaults intentionally remain separate because an explicit constructor is
@@ -134,6 +134,11 @@ impl ExternalDefs {
     #[must_use]
     pub fn structural_methods_for(&self, module_name: &str) -> Option<&StructuralMethodExports> {
         self.structural_methods.as_deref()?.get(module_name)
+    }
+
+    #[must_use]
+    pub fn has_structural_methods(&self) -> bool {
+        self.structural_methods.is_some()
     }
 
     pub fn insert_error_type(&mut self, module_name: &str, class_name: &str) {

--- a/crates/sifr_lowering/src/lower/external_defs.rs
+++ b/crates/sifr_lowering/src/lower/external_defs.rs
@@ -1,6 +1,17 @@
-use crate::hir_nodes::HirExpr;
-use sifr_ir::CompilerIntrinsicId;
-use sifr_type_system::{FunctionType, Type};
+use crate::hir_nodes::{HirExpr, HirParam};
+use sifr_ir::{CompilerIntrinsicId, MethodKind};
+use sifr_type_system::{FunctionType, ReceiverConvention, Type};
+
+/// Package-neutral method contract retained for imported structural shape descriptions.
+#[derive(Debug, Clone)]
+pub struct StructuralMethodExport {
+    pub name: String,
+    pub params: Vec<HirParam>,
+    pub return_type: Type,
+    pub is_async: bool,
+    pub method_kind: MethodKind,
+    pub receiver: Option<ReceiverConvention>,
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct ModuleSpecializationMetadata {
@@ -37,6 +48,14 @@ pub struct ExternalDefs {
     /// Map of `module_name` -> (`class_name` -> `type_param_names`)
     pub class_type_params:
         std::collections::HashMap<String, std::collections::HashMap<String, Vec<String>>>,
+    /// Map of `module_name` -> (`class_name` -> annotated-method-capable contracts).
+    ///
+    /// These are compiler-internal exports. They preserve declaration details that
+    /// `Type::Class::methods` intentionally does not carry.
+    pub structural_methods: std::collections::HashMap<
+        String,
+        std::collections::HashMap<String, Vec<StructuralMethodExport>>,
+    >,
     /// Map of `module_name` -> (`class_name` -> declaration-order field defaults).
     ///
     /// Constructor defaults intentionally remain separate because an explicit constructor is

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -200,7 +200,7 @@ use default_args::collect_function_defaults;
 pub(in crate::lower) use diagnostic_types::{
     fallback_error_type, HirDiagnostic, LoweringWarningDiagnostic, RevealTypeDiagnostic,
 };
-pub use external_defs::{ExternalDefs, StructuralMethodExport};
+pub use external_defs::{ExternalDefs, StructuralMethodExport, StructuralMethodExports};
 
 pub fn localize_user_import_type(
     ty: &Type,

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -200,7 +200,7 @@ use default_args::collect_function_defaults;
 pub(in crate::lower) use diagnostic_types::{
     fallback_error_type, HirDiagnostic, LoweringWarningDiagnostic, RevealTypeDiagnostic,
 };
-pub use external_defs::ExternalDefs;
+pub use external_defs::{ExternalDefs, StructuralMethodExport};
 
 pub fn localize_user_import_type(
     ty: &Type,


### PR DESCRIPTION
## Summary

- preserve annotated method contracts and source metadata across imports and re-exports
- retain private nested generic shape metadata needed by public structural records
- resolve local versus imported structural identities by fully qualified identity
- remove production fallback shape description paths

## Validation

- `cargo test -j6 -p sifr_frontend -p sifr_lowering`
- `cargo clippy -j6 -p sifr_frontend -p sifr_lowering --lib -- -D warnings`
- `cargo fmt --check`
- HIR maintainability, file-size, taxonomy, and diff checks
- canonical create-PR profile: PASS; receipt SHA-256 `11762eff2b59abbef32b072e5687739405519253794a55ad3ede9e4c00835ee2`

## Review

Claude Opus reviewed exact SHA `32ca67b439326a56a5c07fd170b3902e004eb25a` and returned SATISFIED. Review response SHA-256: `5e39ea926a19bf4d3d961b87d978a569440975bbf800ee1a1d54516f0a9f4c4f`.

## External validation records

- cold generated-artifact budget: #3134
- isolated LSP watchdog flake: #3195