### PR TITLE
fix: use legal method slot program field

### DIFF
--- a/crates/sifr_frontend/src/slot_table.rs
+++ b/crates/sifr_frontend/src/slot_table.rs
@@ -132,19 +132,19 @@ fn method_slot_references(
     let crate::ConstValue::Record(fields) = value else {
         return Ok(None);
     };
-    let Some(value) = fields.get("sifr.meta.slots") else {
+    let Some(value) = fields.get("sifr_method_slots") else {
         return Ok(None);
     };
     let crate::ConstValue::List(values) = value else {
         return Err(MethodSlotError::new(
             MethodSlotErrorKind::List,
-            "reserved `sifr.meta.slots` must be a nonempty list of strings",
+            "reserved `sifr_method_slots` must be a nonempty list of strings",
         ));
     };
     if values.is_empty() {
         return Err(MethodSlotError::new(
             MethodSlotErrorKind::List,
-            "reserved `sifr.meta.slots` must not be empty",
+            "reserved `sifr_method_slots` must not be empty",
         ));
     }
     let mut seen = BTreeSet::new();
@@ -153,7 +153,7 @@ fn method_slot_references(
         let crate::ConstValue::String(reference) = value else {
             return Err(MethodSlotError::new(
                 MethodSlotErrorKind::List,
-                "reserved `sifr.meta.slots` must contain only strings",
+                "reserved `sifr_method_slots` must contain only strings",
             ));
         };
         if !seen.insert(reference.clone()) {

--- a/crates/sifr_frontend/src/slot_table_tests.rs
+++ b/crates/sifr_frontend/src/slot_table_tests.rs
@@ -31,7 +31,7 @@ class Outcome:
 
 @const_eval
 def describe(shape: dict[str, str]) -> Outcome:
-    return Outcome("produced", {{"sifr.meta.slots": [{slots}]}}, [])
+    return Outcome("produced", {{"sifr_method_slots": [{slots}]}}, [])
 "#
     );
     let package =

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -618,7 +618,7 @@ class Outcome:
 
 @const_eval
 def describe(shape: dict[str, str]) -> Outcome:
-    return Outcome("produced", {"sifr.meta.slots": ["target.Record::normalize"]}, [])
+    return Outcome("produced", {"sifr_method_slots": ["target.Record::normalize"]}, [])
 "#,
             &external_defs,
         )
@@ -668,7 +668,7 @@ class Outcome:
 @const_eval
 def describe(shape: dict[str, str]) -> Outcome:
     slots: list[str] = []
-    return Outcome("produced", {"sifr.meta.slots": slots}, [])
+    return Outcome("produced", {"sifr_method_slots": slots}, [])
 "#,
             &external_defs,
         )

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -75,7 +75,7 @@ program, runtime compiler, compatibility path, or fallback to the ordinary `Stru
 is closed for this contract. A new variant requires a contract and cache-identity review.
 
 A produced value can request a method-slot table through exactly one reserved entry:
-`"sifr.meta.slots": list[str]`. The list is ordered and nonempty. Each value is an exact
+`sifr_method_slots: list[str]`. The field is ordered and nonempty. Each value is an exact
 `module.Type::method` identity, including for imported or re-exported owners. Duplicate,
 unqualified, missing, unannotated, asynchronous, constructor, class-method, non-`Result`, or
 nonstructural method contracts fail with `SIFR-RUST-SLOT-####`. The compiler derives one context

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -474,7 +474,7 @@ constants. It does not copy private compiler literals.
 
 `sifr.meta.MethodSlots` is the compiler-owned bound for a static program that
 declares an ordered method-slot table. The produced specialization value must
-contain the one reserved entry `"sifr.meta.slots": list[str]`. Each string has
+contain the one reserved field `sifr_method_slots: list[str]`. Each string has
 the exact identity-qualified form `module.Type::method`. The list must be
 nonempty and contain no duplicate. A selected method must be present in the
 concrete structural shape, including through an imported or re-exported owner.

--- a/verification/areas/rust_interop/checks/_scenario_registry.py
+++ b/verification/areas/rust_interop/checks/_scenario_registry.py
@@ -82,7 +82,7 @@ REQUIRED_SCENARIO_EXAMPLES = {
         "method_slot_runtime": {
             "tokens": (
                 "MethodSlotTable",
-                "sifr.meta.slots",
+                "sifr_method_slots",
                 "MethodSlots",
                 "Context",
             ),

--- a/verification/areas/rust_interop/fixtures/method_slot_table/examples/method_slot_runtime/src/schema_program.sifr
+++ b/verification/areas/rust_interop/fixtures/method_slot_table/examples/method_slot_runtime/src/schema_program.sifr
@@ -1,6 +1,10 @@
+class SlotProgram:
+    sifr_method_slots: list[str]
+
+
 class ProgramOutcome:
     status: str
-    value: dict[str, list[str]] | None
+    value: SlotProgram | None
     issues: list[str]
 
 
@@ -8,12 +12,12 @@ class ProgramOutcome:
 def derive(shape: dict[str, str]) -> ProgramOutcome:
     return ProgramOutcome(
         "produced",
-        {
-            "sifr.meta.slots": [
+        SlotProgram(
+            [
                 "main.Record::normalize",
                 "main.Record::finalize",
             ]
-        },
+        ),
         [],
     )
 
@@ -21,12 +25,12 @@ def derive(shape: dict[str, str]) -> ProgramOutcome:
 @const_eval
 def derive_no_context(shape: dict[str, str]) -> ProgramOutcome:
     return ProgramOutcome(
-        "produced", {"sifr.meta.slots": ["main.NoContextRecord::normalize"]}, []
+        "produced", SlotProgram(["main.NoContextRecord::normalize"]), []
     )
 
 
 @const_eval
 def derive_shared(shape: dict[str, str]) -> ProgramOutcome:
     return ProgramOutcome(
-        "produced", {"sifr.meta.slots": ["main.SharedRecord::normalize"]}, []
+        "produced", SlotProgram(["main.SharedRecord::normalize"]), []
     )


### PR DESCRIPTION
## Summary
- replace the illegal dotted MethodSlots specialization record key with the single legal compiler-owned field `sifr_method_slots`
- update the typed fixture, diagnostics, verification registry, and durable architecture docs
- retain no legacy alias, fallback, or compatibility path

## Review
- exact reviewed candidate: `4eb576a46df7e9b9198abc26280152ff9b74ef78`
- Claude Opus verdict: SATISFIED, no blockers
- response SHA-256: `440da0c5a279dd580d505d5879fc2c3303a6a3f3921ca1d4acc716ffe5299572`

## Focused validation
- `cargo test -j6 -p sifr_frontend slot_table`
- `cargo test -j6 -p sifr_driver test_method_slot -- --ignored --nocapture`
- `cargo clippy -j6 -p sifr_frontend --all-targets -- -D warnings`
- Rust interop fixture/compatibility/tier/stable-claim checks
- verification taxonomy, file-size, maintainability, fmt and diff checks

Canonical create-PR and merge gates are pending on this exact candidate.