### PR TITLE
fix: allow typed programs without method slots

### DIFF
--- a/crates/sifr_frontend/src/slot_table.rs
+++ b/crates/sifr_frontend/src/slot_table.rs
@@ -47,6 +47,9 @@ pub(crate) fn resolve_method_slots(
     let Some(references) = method_slot_references(value)? else {
         return Ok((Vec::new(), None));
     };
+    if references.is_empty() {
+        return Ok((Vec::new(), None));
+    }
     let mut owner_types = HashMap::new();
     collect_nominal_types(
         target_type,
@@ -138,15 +141,9 @@ fn method_slot_references(
     let crate::ConstValue::List(values) = value else {
         return Err(MethodSlotError::new(
             MethodSlotErrorKind::List,
-            "reserved `sifr_method_slots` must be a nonempty list of strings",
+            "reserved `sifr_method_slots` must be a list of strings",
         ));
     };
-    if values.is_empty() {
-        return Err(MethodSlotError::new(
-            MethodSlotErrorKind::List,
-            "reserved `sifr_method_slots` must not be empty",
-        ));
-    }
     let mut seen = BTreeSet::new();
     let mut references = Vec::with_capacity(values.len());
     for value in values {

--- a/crates/sifr_frontend/src/slot_table_tests.rs
+++ b/crates/sifr_frontend/src/slot_table_tests.rs
@@ -24,19 +24,43 @@ fn install_specializer(external_defs: &mut ExternalDefs, slot_references: &[&str
         .join(", ");
     let source = format!(
         r#"
+class SlotProgram:
+    sifr_method_slots: list[str]
+
 class Outcome:
     status: str
-    value: dict[str, list[str]] | None
+    value: SlotProgram | None
     issues: list[str]
 
 @const_eval
 def describe(shape: dict[str, str]) -> Outcome:
-    return Outcome("produced", {{"sifr_method_slots": [{slots}]}}, [])
+    return Outcome("produced", SlotProgram([{slots}]), [])
 "#
     );
     let package =
         compile("fixture.slots", &source, external_defs).expect("slot specializer compiles");
     collect_module_exports("fixture.slots", &package, external_defs);
+}
+
+#[test]
+fn typed_empty_method_slot_field_emits_no_table() {
+    let mut external_defs = ExternalDefs::default();
+    install_specializer(&mut external_defs, &[]);
+    let result = compile(
+        "target",
+        r#"
+from fixture.slots import describe
+
+@const_specialize("fixture.slots", "describe")
+class Record:
+    value: str
+"#,
+        &external_defs,
+    )
+    .expect("typed empty method-slot field specializes");
+    let output = &result.specialization_outputs[0];
+    assert!(output.method_slots.is_empty());
+    assert_eq!(output.method_slot_context, None);
 }
 
 fn diagnostic_codes(

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -662,17 +662,16 @@ class Record:
             r#"
 class Outcome:
     status: str
-    value: dict[str, list[str]] | None
+    value: dict[str, str] | None
     issues: list[str]
 
 @const_eval
 def describe(shape: dict[str, str]) -> Outcome:
-    slots: list[str] = []
-    return Outcome("produced", {"sifr_method_slots": slots}, [])
+    return Outcome("produced", {"sifr_method_slots": "target.Record::normalize"}, [])
 "#,
             &external_defs,
         )
-        .expect("invalid-slot package declaration compiles");
+        .expect("malformed-slot package declaration compiles");
         collect_module_exports("fixture.invalid_slots", &package, &mut external_defs);
         let diagnostics = errors(compile(
             "target",

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -75,13 +75,14 @@ program, runtime compiler, compatibility path, or fallback to the ordinary `Stru
 is closed for this contract. A new variant requires a contract and cache-identity review.
 
 A produced value can request a method-slot table through exactly one reserved entry:
-`sifr_method_slots: list[str]`. The field is ordered and nonempty. Each value is an exact
+`sifr_method_slots: list[str]`. The field is ordered. An empty list emits no slot table, which
+lets one typed specialization payload cover types with and without callbacks. Each value is an exact
 `module.Type::method` identity, including for imported or re-exported owners. Duplicate,
 unqualified, missing, unannotated, asynchronous, constructor, class-method, non-`Result`, or
 nonstructural method contracts fail with `SIFR-RUST-SLOT-####`. The compiler derives one context
 type and borrow mode from the selected methods and emits the table only when a Rust declaration
 uses the package-neutral `MethodSlots` and `Context` bounds. Programs without caller-owned
-context use `NoContext`. The table identity includes slot order, structural signatures, receiver
+context use `NoContext`. A nonempty table identity includes slot order, structural signatures, receiver
 mode, context shape and borrow mode, handler shapes, and the static-program identity.
 
 ## Integer boundary verification

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -476,7 +476,9 @@ constants. It does not copy private compiler literals.
 declares an ordered method-slot table. The produced specialization value must
 contain the one reserved field `sifr_method_slots: list[str]`. Each string has
 the exact identity-qualified form `module.Type::method`. The list must be
-nonempty and contain no duplicate. A selected method must be present in the
+ordered and contain no duplicate. An empty list emits no method-slot table, so
+a typed specialization payload does not need a second no-callback record. A
+selected method must be present in the
 concrete structural shape, including through an imported or re-exported owner.
 There is no bare-name lookup or runtime registry.
 


### PR DESCRIPTION
## Summary
- define an empty `sifr_method_slots` list as a typed specialization payload with no emitted method-slot table
- preserve every nonempty ordered/duplicate/signature/context contract and diagnostic
- retain a real malformed-list negative for `SIFR-RUST-SLOT-0001` and add typed empty-list fast-lane coverage
- add no alias, fallback, compatibility, legacy spelling, versioned name, or package-specific compiler path

## Review
- exact candidate: `514c018c09176fc9456e6f4b34530de2669497c2`
- first review: NOT SATISFIED; evidence/diagnostic coverage blockers remediated
- remediation review: SATISFIED, no blockers
- final response SHA-256: `76bda413860ef97ff631a3992dc469f8122c44c190845f672f06c928a93abe66`

## Focused validation
- frontend slot-table suite and restored malformed-list diagnostic
- generated method-slot driver fixtures 2/2
- Rust-interop fixture and compatibility matrices
- diagnostics rules 5/5
- strict frontend Clippy, formatting, HIR maintainability, file-size, and diff checks

Canonical create-PR and one merge gate are pending on this exact candidate.