### PR TITLE
docs: lock implemented integer JSON schemas

### DIFF
--- a/internal_docs/integer_model.md
+++ b/internal_docs/integer_model.md
@@ -331,13 +331,17 @@ Example:
 
 ```python
 class UserOut:
-    id: int64           # database identifier, string-encoded by default under json.web
+    id: int64           # database identifier; needs safe bounds or string_ints
     balance_cents: int  # exact app value; public JSON policy decides number vs string
 ```
 
 The framework must not infer persistence or storage width from a source-level `int` field. Models that back SQL, Arrow, or external wire schemas must choose width or serialization policy explicitly.
 
-Under `json.web`, schema-driven public models default to JSON numbers only when the field's static range is inside JavaScript's safe integer range. Wider fields such as `int64`, `uint64`, and exact `int` default to decimal string encoding unless the field is explicitly annotated with a runtime range-checked number policy or an exact-client policy.
+Under `json.web`, schema-driven public models use JSON numbers only when the
+field's complete static range is inside the JavaScript-safe range. Wider fields
+such as `int64`, `uint64`, and exact `int` fail schema generation unless bounds
+prove that range. Select `json.string_ints` explicitly for decimal-string
+encoding, or select `json.exact` with an exact-client policy.
 
 ## Serialization and External Boundaries
 
@@ -376,6 +380,15 @@ OpenAPI/JSON Schema generation must reflect the chosen boundary:
 - fixed-width integer fields map to bounded integer schema with minimum and maximum.
 - `int` fields in `json.web` either declare safe-integer bounds or use `type: string`, `pattern: "^-?[0-9]+$"`, and a Sifr extension marker such as `x-sifr-format: integer-decimal-string`.
 - exact arbitrary `int` fields must not be emitted as ordinary unbounded `type: integer` for browser-targeted clients without an explicit precision policy.
+
+The implemented exact-profile schema marker is
+`x-sifr-integer-profile: exact`. The schema also includes
+`x-sifr-generated-client-warning` so a generated-client backend can require an
+exact JSON integer parser. The backend owns presenting that client warning;
+the compiler continues to own `SIFR-INT-0009` for an unsafe or ambiguous
+boundary. `pydantic_sifr_core::generate_json_schema` consumes the sealed Core
+Schema and the `SerializationPlan` profile. It does not infer another profile
+or fall back from `json.web` to `json.string_ints`.
 
 ### Databases
 

--- a/plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md
+++ b/plans/issues/active/ad-hoc-native-pydantic-sifr-architecture.md
@@ -964,6 +964,27 @@ Milestone delivery records:
 - The remediation review's later alias-key mechanism defect is recorded in
   companion [issue #20](https://github.com/sifr-lang/pydantic-sifr/issues/20)
   for the explicit PS9 aliases and mode-representation row.
+- The PS9 integer-profile JSON Schema item merged in companion
+  [PR #22](https://github.com/sifr-lang/pydantic-sifr/pull/22) at merge commit
+  `d7620bcaef75580d548f00dfd7bcafb523efbf2a`. The exact final reviewed and
+  gated candidate was `62b22ea7ea530d6fabde33f6d09afb351f3071ea`.
+- Exact, web, and string-integer schemas now preserve their selected profile
+  and complete static range. Web schemas require a wholly JavaScript-safe
+  range and otherwise expose compiler-owned `SIFR-INT-0009` provenance.
+  Integer literals and enum inputs use the same profile path as ordinary
+  integer nodes. No profile fallback or implicit string encoding was added.
+- The first exact-SHA review found integer literals and enum inputs bypassed
+  the profile path. The bounded remediation made those representations
+  profile-aware, and the one permitted remediation review returned
+  `SATISFIED`; its response SHA-256 is
+  `ca9ae1d6b69920eb98b44b41b73e3f28a200f0e5b6ea80d1097e0f68e048ae93`.
+- Thirteen focused JSON Schema tests, the full core suite, strict Clippy,
+  formatting, and file-size guard passed. The exact-pin companion create-PR
+  and single merge gates passed all package, release, provenance, demo, fuzz,
+  benchmark-smoke, and merge-only checks.
+- The coordinated Sifr boundary artifact now names the implemented consumer,
+  generated-client warning ownership, fail-closed web behavior, exact-profile
+  marker, and four exact bounded JSON Schema snapshots.
 - `milestone_ps_9` is now active in the companion repository.
 - Deferred follow-up work: align registry representative-fixture paths with diagnostic
   baselines; align the pre-existing lowering and codegen structural-eligibility
@@ -3212,9 +3233,9 @@ JSON; every `serializers/*` fixture family named in the baseline and
 - [x] Implement native, JSON, and strings-profile validation plus serialization
   modes.
 - [x] Generate JSON Schema from the same Core Schema.
-- Reflect the selected Sifr integer JSON profile and static range in every
+- [x] Reflect the selected Sifr integer JSON profile and static range in every
   integer schema, failing closed with `SIFR-INT-0009` when ambiguous.
-- Before the external package release, merge a coordinated `sifr-lang/sifr`
+- [x] Before the external package release, merge a coordinated `sifr-lang/sifr`
   documentation/verification PR updating
   `verification/areas/core_language/data/integer_model/serialization_boundary_rules.md`
   with the implemented descriptor consumer, generated-client warning

--- a/verification/areas/core_language/data/integer_model/serialization_boundary_rules.md
+++ b/verification/areas/core_language/data/integer_model/serialization_boundary_rules.md
@@ -7,11 +7,14 @@ and generated serde implementations must satisfy. Runtime JSON profile helpers
 live in `sifr_runtime::json`; framework layers may wrap that API, but must not
 reimplement or weaken the policy.
 
-The planned external `sifr-lang/pydantic-sifr` package is a consumer of this
-contract, not a second integer-schema authority. Its compile-time Core Schema
-must provide a general compiler-owned `JsonIntegerBoundaryDescriptor`; the
-compiler validates the descriptor and owns `SIFR-INT-0009`, while the package
-and native core route execution through `sifr_runtime::json`.
+The external `sifr-lang/pydantic-sifr` package consumes this contract. It is not
+a second integer-schema authority. The compiler validates the general
+`JsonIntegerBoundaryDescriptor` before it seals the Core Schema program and
+owns `SIFR-INT-0009`. The implemented native consumer builds one
+`SerializationPlan` from that sealed schema and its selected profile.
+`TypeAdapter::json_schema` passes the same Core Schema and plan profile to
+`pydantic_sifr_core::generate_json_schema`. Runtime output continues to route
+through `sifr_runtime::json`.
 
 ## JSON Profiles
 
@@ -37,8 +40,8 @@ Sifr `int`.
 | Sifr field | Selected profile | Schema rules |
 | --- | --- | --- |
 | `int8`, `int16`, `int32`, `uint8`, `uint16`, `uint32` | `json.web` | `type: integer` with exact `minimum` and `maximum`; may be TypeScript `number` |
-| `int64`, `uint64` | `json.web` | decimal string by default: `type: string`, `pattern: "^-?[0-9]+$"`, `x-sifr-format: integer-decimal-string`; numeric schema requires an explicit safe-range constraint |
-| `int` | `json.web` | decimal string by default or a typed `JsonIntegerRangeError` policy; numeric schema requires a static safe range |
+| `int64`, `uint64` | `json.web` | numeric schema only with a statically proven safe range; otherwise schema generation fails with `SIFR-INT-0009` |
+| `int` | `json.web` | numeric schema only with a statically proven safe range; otherwise schema generation fails with `SIFR-INT-0009` |
 | any integer | `json.string_ints` | decimal string schema with `x-sifr-format: integer-decimal-string` |
 | any integer | `json.exact` | `type: integer`, `x-sifr-integer-profile: exact`, and a generated-client warning unless the client target supports exact integer parsing |
 
@@ -46,6 +49,65 @@ If a route or model lacks enough policy to select one of these mappings, schema
 generation must fail closed with `SIFR-INT-0009` and include the field path plus
 suggested policies (`json.web` string encoding, explicit safe range,
 `json.string_ints`, or exact-client support).
+
+`pydantic_sifr_core` exposes the compiler-owned code through
+`JsonSchemaError::diagnostic_code` when a `json.web` range is insufficient. It
+does not emit the top-level compiler diagnostic. The exact profile emits
+`x-sifr-generated-client-warning`; each generated-client backend owns turning
+that annotation into its actionable warning and selecting an exact integer
+parser. The package does not silently choose a client representation.
+
+The following objects are the implemented bounded serialization-mode snapshots.
+Object keys are deterministic. An `int32` under `json.web` is:
+
+```json
+{
+  "maximum": 2147483647,
+  "minimum": -2147483648,
+  "type": "integer",
+  "x-sifr-integer-profile": "web"
+}
+```
+
+An `int64` under `json.exact` is:
+
+```json
+{
+  "maximum": 9223372036854775807,
+  "minimum": -9223372036854775808,
+  "type": "integer",
+  "x-sifr-generated-client-warning": "client must use an exact integer JSON parser for this field",
+  "x-sifr-integer-profile": "exact"
+}
+```
+
+An `int32` under `json.string_ints` is:
+
+```json
+{
+  "pattern": "^-?[0-9]+$",
+  "type": "string",
+  "x-sifr-format": "integer-decimal-string",
+  "x-sifr-integer-profile": "string_ints",
+  "x-sifr-maximum": 2147483647,
+  "x-sifr-minimum": -2147483648
+}
+```
+
+An exact `int` constrained to the JavaScript-safe range under `json.web` is:
+
+```json
+{
+  "maximum": 9007199254740991,
+  "minimum": -9007199254740991,
+  "type": "integer",
+  "x-sifr-integer-profile": "web"
+}
+```
+
+Without both safe bounds, the last request returns `IntegerPolicy` with
+diagnostic code `SIFR-INT-0009`. Selecting `json.string_ints` is the explicit
+decimal-string alternative; `json.web` does not fall back to it.
 
 ## TypeScript Client Mapping
 
@@ -57,9 +119,10 @@ Generated TypeScript clients must make precision visible in the type:
 | decimal integer string | branded `SifrDecimalIntString` unless the user opts into plain `string` |
 | exact-client integer profile | `bigint` only when the target runtime and JSON parser strategy are explicitly configured |
 
-`int64`, `uint64`, and exact `int` response fields under `json.web` default to
-decimal strings. A generated TypeScript `number` for those fields is valid only
-when the schema also carries a static safe range.
+`int64`, `uint64`, and exact `int` response fields under `json.web` require a
+static safe range. A generated TypeScript `number` is valid only when the schema
+carries that range. Select `json.string_ints` explicitly for a decimal-string
+wire representation.
 
 ## Generated Serde
 


### PR DESCRIPTION
Records companion PR #22 and updates the coordinated integer boundary artifact with the implemented consumer, warning ownership, fail-closed web policy, exact profile marker, and bounded JSON Schema snapshots. Documentation-only; diff/taxonomy checks passed.