### PR TITLE
Add spanned class declaration origins

### DIFF
--- a/crates/sifr_frontend/src/class_declarations.rs
+++ b/crates/sifr_frontend/src/class_declarations.rs
@@ -1,0 +1,581 @@
+//! Pre-finalization class declarations and opaque source-origin registries.
+
+use crate::ConstValue;
+use ruff_text_size::{Ranged, TextRange};
+use sifr_lowering::LoweringResult;
+use sifr_python_ast::{Decorator, Expr, Stmt, StmtClassDef, StmtFunctionDef};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SourceOriginId {
+    namespace: [u8; 32],
+    index: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceOriginKind {
+    Class,
+    Field,
+    ClassItem,
+    Method,
+    Parameter,
+    Annotation,
+    Value,
+    Decorator,
+    Argument,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SourceOriginEntry {
+    pub id: SourceOriginId,
+    pub kind: SourceOriginKind,
+    pub range: TextRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SourceOriginTable {
+    namespace: [u8; 32],
+    entries: BTreeMap<SourceOriginId, SourceOriginEntry>,
+}
+
+impl SourceOriginTable {
+    #[must_use]
+    pub(crate) fn resolve(&self, id: SourceOriginId) -> Option<&SourceOriginEntry> {
+        (id.namespace == self.namespace)
+            .then(|| self.entries.get(&id))
+            .flatten()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DecoratorDeclaration {
+    name: String,
+    origin: SourceOriginId,
+    argument_origins: Vec<SourceOriginId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParameterDeclaration {
+    name: String,
+    origin: SourceOriginId,
+    annotation_origin: Option<SourceOriginId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ClassDeclarationItem {
+    Field {
+        name: String,
+        origin: SourceOriginId,
+        annotation_origin: SourceOriginId,
+        value_origin: Option<SourceOriginId>,
+        value_argument_origins: Vec<SourceOriginId>,
+    },
+    ClassItem {
+        name: String,
+        origin: SourceOriginId,
+        value_origin: SourceOriginId,
+        value_argument_origins: Vec<SourceOriginId>,
+    },
+    Method {
+        name: String,
+        origin: SourceOriginId,
+        decorators: Vec<DecoratorDeclaration>,
+        parameters: Vec<ParameterDeclaration>,
+        return_origin: Option<SourceOriginId>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ClassDeclaration {
+    module: String,
+    name: String,
+    origin: SourceOriginId,
+    decorators: Vec<DecoratorDeclaration>,
+    items: Vec<ClassDeclarationItem>,
+    origins: SourceOriginTable,
+}
+
+impl ClassDeclaration {
+    #[must_use]
+    pub(crate) fn origins(&self) -> &SourceOriginTable {
+        &self.origins
+    }
+
+    pub(crate) fn attach_to_shape(&self, shape: &mut ConstValue, lowering: &LoweringResult) {
+        let ConstValue::Record(fields) = shape else {
+            return;
+        };
+        fields.insert("declaration".to_string(), self.to_const_value(lowering));
+    }
+
+    fn to_const_value(&self, lowering: &LoweringResult) -> ConstValue {
+        ConstValue::Record(BTreeMap::from([
+            (
+                "identity".to_string(),
+                ConstValue::String(format!("{}.{}", self.module, self.name)),
+            ),
+            ("name".to_string(), ConstValue::String(self.name.clone())),
+            ("origin".to_string(), ConstValue::SourceOrigin(self.origin)),
+            (
+                "decorators".to_string(),
+                ConstValue::List(self.decorators.iter().map(decorator_const_value).collect()),
+            ),
+            (
+                "items".to_string(),
+                ConstValue::List(
+                    self.items
+                        .iter()
+                        .enumerate()
+                        .map(|(order, item)| self.item_const_value(order, item, lowering))
+                        .collect(),
+                ),
+            ),
+        ]))
+    }
+
+    fn item_const_value(
+        &self,
+        order: usize,
+        item: &ClassDeclarationItem,
+        lowering: &LoweringResult,
+    ) -> ConstValue {
+        let mut record = BTreeMap::from([
+            (
+                "order".to_string(),
+                ConstValue::Integer(num_bigint::BigInt::from(order)),
+            ),
+            ("annotation_origin".to_string(), ConstValue::None),
+            ("value_origin".to_string(), ConstValue::None),
+            ("return_origin".to_string(), ConstValue::None),
+            ("declared_type".to_string(), ConstValue::None),
+            ("signature".to_string(), ConstValue::None),
+            (
+                "value_argument_origins".to_string(),
+                ConstValue::List(Vec::new()),
+            ),
+            ("decorators".to_string(), ConstValue::List(Vec::new())),
+            ("parameters".to_string(), ConstValue::List(Vec::new())),
+        ]);
+        match item {
+            ClassDeclarationItem::Field {
+                name,
+                origin,
+                annotation_origin,
+                value_origin,
+                value_argument_origins,
+            } => {
+                record.insert("kind".to_string(), ConstValue::String("field".to_string()));
+                record.insert("name".to_string(), ConstValue::String(name.clone()));
+                record.insert("origin".to_string(), ConstValue::SourceOrigin(*origin));
+                record.insert(
+                    "annotation_origin".to_string(),
+                    ConstValue::SourceOrigin(*annotation_origin),
+                );
+                record.insert(
+                    "value_origin".to_string(),
+                    value_origin.map_or(ConstValue::None, ConstValue::SourceOrigin),
+                );
+                record.insert(
+                    "value_argument_origins".to_string(),
+                    origin_list(value_argument_origins),
+                );
+                if let Some(class) = lowering
+                    .module
+                    .classes
+                    .iter()
+                    .find(|class| class.name == self.name)
+                {
+                    if let Some((_, ty)) = class.fields.iter().find(|(field, _)| field == name) {
+                        record.insert(
+                            "declared_type".to_string(),
+                            ConstValue::String(ty.display_name()),
+                        );
+                    }
+                }
+            }
+            ClassDeclarationItem::ClassItem {
+                name,
+                origin,
+                value_origin,
+                value_argument_origins,
+            } => {
+                record.insert(
+                    "kind".to_string(),
+                    ConstValue::String("class_item".to_string()),
+                );
+                record.insert("name".to_string(), ConstValue::String(name.clone()));
+                record.insert("origin".to_string(), ConstValue::SourceOrigin(*origin));
+                record.insert(
+                    "value_origin".to_string(),
+                    ConstValue::SourceOrigin(*value_origin),
+                );
+                record.insert(
+                    "value_argument_origins".to_string(),
+                    origin_list(value_argument_origins),
+                );
+            }
+            ClassDeclarationItem::Method {
+                name,
+                origin,
+                decorators,
+                parameters,
+                return_origin,
+            } => {
+                record.insert("kind".to_string(), ConstValue::String("method".to_string()));
+                record.insert("name".to_string(), ConstValue::String(name.clone()));
+                record.insert("origin".to_string(), ConstValue::SourceOrigin(*origin));
+                record.insert(
+                    "decorators".to_string(),
+                    ConstValue::List(decorators.iter().map(decorator_const_value).collect()),
+                );
+                record.insert(
+                    "parameters".to_string(),
+                    ConstValue::List(parameters.iter().map(parameter_const_value).collect()),
+                );
+                record.insert(
+                    "return_origin".to_string(),
+                    return_origin.map_or(ConstValue::None, ConstValue::SourceOrigin),
+                );
+                let hir_name = if name == "__init__" { "new" } else { name };
+                if let Some(method) = lowering
+                    .module
+                    .classes
+                    .iter()
+                    .find(|class| class.name == self.name)
+                    .and_then(|class| {
+                        class
+                            .methods
+                            .iter()
+                            .chain(class.operator_impls.iter().map(|(_, method)| method))
+                            .find(|method| method.name == hir_name)
+                    })
+                {
+                    let parameters = method
+                        .params
+                        .iter()
+                        .map(|parameter| {
+                            format!(
+                                "{}:{}:{:?}",
+                                parameter.name,
+                                parameter.ty.display_name(),
+                                parameter.convention
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    record.insert(
+                        "signature".to_string(),
+                        ConstValue::String(format!(
+                            "({parameters})->{}",
+                            method.return_type.display_name()
+                        )),
+                    );
+                }
+            }
+        }
+        ConstValue::Record(record)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ClassDeclarationSet {
+    declarations: BTreeMap<String, ClassDeclaration>,
+}
+
+impl ClassDeclarationSet {
+    #[must_use]
+    pub(crate) fn collect(module: &str, statements: &[Stmt]) -> Self {
+        let declarations = statements
+            .iter()
+            .filter_map(|statement| match statement {
+                Stmt::ClassDef(class) => Some((
+                    class.name.to_string(),
+                    DeclarationCollector::new(module, class.name.as_str()).collect(class),
+                )),
+                _ => None,
+            })
+            .collect();
+        Self { declarations }
+    }
+
+    #[must_use]
+    pub(crate) fn get(&self, name: &str) -> Option<&ClassDeclaration> {
+        self.declarations.get(name)
+    }
+}
+
+struct DeclarationCollector {
+    module: String,
+    class_name: String,
+    namespace: [u8; 32],
+    next_origin: u32,
+    entries: BTreeMap<SourceOriginId, SourceOriginEntry>,
+}
+
+impl DeclarationCollector {
+    fn new(module: &str, class_name: &str) -> Self {
+        let namespace = sifr_structural_identity::static_program_identity(
+            sifr_structural_identity::ALGORITHM_VERSION,
+            [
+                ("module", module.as_bytes()),
+                ("class", class_name.as_bytes()),
+                ("contract", b"class-declaration-origin-v1".as_slice()),
+            ],
+        );
+        Self {
+            module: module.to_string(),
+            class_name: class_name.to_string(),
+            namespace: *namespace.as_bytes(),
+            next_origin: 0,
+            entries: BTreeMap::new(),
+        }
+    }
+
+    fn collect(mut self, class: &StmtClassDef) -> ClassDeclaration {
+        let origin = self.add_origin(SourceOriginKind::Class, class.name.range());
+        let decorators = self.decorators(&class.decorator_list);
+        let items = class
+            .body
+            .iter()
+            .filter_map(|statement| self.item(statement))
+            .collect();
+        ClassDeclaration {
+            module: self.module,
+            name: self.class_name,
+            origin,
+            decorators,
+            items,
+            origins: SourceOriginTable {
+                namespace: self.namespace,
+                entries: self.entries,
+            },
+        }
+    }
+
+    fn item(&mut self, statement: &Stmt) -> Option<ClassDeclarationItem> {
+        match statement {
+            Stmt::AnnAssign(assign) => {
+                let Expr::Name(name) = assign.target.as_ref() else {
+                    return None;
+                };
+                let origin = self.add_origin(SourceOriginKind::Field, name.range());
+                let annotation_origin =
+                    self.add_origin(SourceOriginKind::Annotation, assign.annotation.range());
+                let value_origin = assign
+                    .value
+                    .as_deref()
+                    .map(|value| self.add_origin(SourceOriginKind::Value, value.range()));
+                let value_argument_origins = assign
+                    .value
+                    .as_deref()
+                    .map_or_else(Vec::new, |value| self.call_arguments(value));
+                Some(ClassDeclarationItem::Field {
+                    name: name.id.to_string(),
+                    origin,
+                    annotation_origin,
+                    value_origin,
+                    value_argument_origins,
+                })
+            }
+            Stmt::Assign(assign) if assign.targets.len() == 1 => {
+                let Expr::Name(name) = &assign.targets[0] else {
+                    return None;
+                };
+                let origin = self.add_origin(SourceOriginKind::ClassItem, name.range());
+                let value_origin = self.add_origin(SourceOriginKind::Value, assign.value.range());
+                let value_argument_origins = self.call_arguments(&assign.value);
+                Some(ClassDeclarationItem::ClassItem {
+                    name: name.id.to_string(),
+                    origin,
+                    value_origin,
+                    value_argument_origins,
+                })
+            }
+            Stmt::FunctionDef(function) => Some(self.method(function)),
+            _ => None,
+        }
+    }
+
+    fn method(&mut self, function: &StmtFunctionDef) -> ClassDeclarationItem {
+        let origin = self.add_origin(SourceOriginKind::Method, function.name.range());
+        let decorators = self.decorators(&function.decorator_list);
+        let parameters = function
+            .parameters
+            .posonlyargs
+            .iter()
+            .chain(&function.parameters.args)
+            .chain(&function.parameters.kwonlyargs)
+            .map(|parameter| {
+                let origin = self.add_origin(
+                    SourceOriginKind::Parameter,
+                    parameter.parameter.name.range(),
+                );
+                let annotation_origin =
+                    parameter.parameter.annotation.as_deref().map(|annotation| {
+                        self.add_origin(SourceOriginKind::Annotation, annotation.range())
+                    });
+                ParameterDeclaration {
+                    name: parameter.parameter.name.to_string(),
+                    origin,
+                    annotation_origin,
+                }
+            })
+            .collect();
+        let return_origin = function
+            .returns
+            .as_deref()
+            .map(|returns| self.add_origin(SourceOriginKind::Annotation, returns.range()));
+        ClassDeclarationItem::Method {
+            name: function.name.to_string(),
+            origin,
+            decorators,
+            parameters,
+            return_origin,
+        }
+    }
+
+    fn decorators(&mut self, decorators: &[Decorator]) -> Vec<DecoratorDeclaration> {
+        decorators
+            .iter()
+            .map(|decorator| {
+                let origin =
+                    self.add_origin(SourceOriginKind::Decorator, decorator.expression.range());
+                DecoratorDeclaration {
+                    name: expression_name(&decorator.expression),
+                    origin,
+                    argument_origins: self.call_arguments(&decorator.expression),
+                }
+            })
+            .collect()
+    }
+
+    fn call_arguments(&mut self, expression: &Expr) -> Vec<SourceOriginId> {
+        let Expr::Call(call) = expression else {
+            return Vec::new();
+        };
+        call.arguments
+            .args
+            .iter()
+            .chain(call.arguments.keywords.iter().map(|keyword| &keyword.value))
+            .map(|argument| self.add_origin(SourceOriginKind::Argument, argument.range()))
+            .collect()
+    }
+
+    fn add_origin(&mut self, kind: SourceOriginKind, range: TextRange) -> SourceOriginId {
+        let id = SourceOriginId {
+            namespace: self.namespace,
+            index: self.next_origin,
+        };
+        self.next_origin = self.next_origin.saturating_add(1);
+        self.entries
+            .insert(id, SourceOriginEntry { id, kind, range });
+        id
+    }
+}
+
+fn origin_list(origins: &[SourceOriginId]) -> ConstValue {
+    ConstValue::List(
+        origins
+            .iter()
+            .copied()
+            .map(ConstValue::SourceOrigin)
+            .collect(),
+    )
+}
+
+fn decorator_const_value(decorator: &DecoratorDeclaration) -> ConstValue {
+    ConstValue::Record(BTreeMap::from([
+        (
+            "name".to_string(),
+            ConstValue::String(decorator.name.clone()),
+        ),
+        (
+            "origin".to_string(),
+            ConstValue::SourceOrigin(decorator.origin),
+        ),
+        (
+            "argument_origins".to_string(),
+            origin_list(&decorator.argument_origins),
+        ),
+    ]))
+}
+
+fn parameter_const_value(parameter: &ParameterDeclaration) -> ConstValue {
+    ConstValue::Record(BTreeMap::from([
+        (
+            "name".to_string(),
+            ConstValue::String(parameter.name.clone()),
+        ),
+        (
+            "origin".to_string(),
+            ConstValue::SourceOrigin(parameter.origin),
+        ),
+        (
+            "annotation_origin".to_string(),
+            parameter
+                .annotation_origin
+                .map_or(ConstValue::None, ConstValue::SourceOrigin),
+        ),
+    ]))
+}
+
+fn expression_name(expression: &Expr) -> String {
+    match expression {
+        Expr::Name(name) => name.id.to_string(),
+        Expr::Attribute(attribute) => format!(
+            "{}.{}",
+            expression_name(&attribute.value),
+            attribute.attr.as_str()
+        ),
+        Expr::Call(call) => expression_name(&call.func),
+        _ => "<expression>".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sifr_syntax::parse_module_suite;
+
+    #[test]
+    fn declaration_order_and_origin_ids_ignore_source_movement() {
+        let source = r#"
+@metadata("fixture.class", "contract")
+class Command:
+    payload: str = factory("value")
+    config = settings("strict")
+
+    @metadata("fixture.method", "decode")
+    def decode(self, value: str) -> str:
+        return value
+"#;
+        let moved = format!("\n\n{source}");
+        let first = parse_module_suite(source, None).expect("fixture parses");
+        let second = parse_module_suite(&moved, None).expect("moved fixture parses");
+        let first = ClassDeclarationSet::collect("fixture", &first);
+        let second = ClassDeclarationSet::collect("fixture", &second);
+        let first = first.get("Command").expect("declaration exists");
+        let second = second.get("Command").expect("declaration exists");
+
+        assert_eq!(first.items.len(), 3);
+        assert_eq!(first.origin, second.origin);
+        assert_ne!(
+            first.origins.resolve(first.origin).map(|entry| entry.range),
+            second
+                .origins
+                .resolve(second.origin)
+                .map(|entry| entry.range)
+        );
+    }
+
+    #[test]
+    fn origin_registry_rejects_another_class_namespace() {
+        let parsed = parse_module_suite("class A:\n    x: int\nclass B:\n    y: int\n", None)
+            .expect("fixture parses");
+        let declarations = ClassDeclarationSet::collect("fixture", &parsed);
+        let a = declarations.get("A").expect("A exists");
+        let b = declarations.get("B").expect("B exists");
+        assert!(a.origins.resolve(a.origin).is_some());
+        assert!(a.origins.resolve(b.origin).is_none());
+    }
+}

--- a/crates/sifr_frontend/src/const_evaluator.rs
+++ b/crates/sifr_frontend/src/const_evaluator.rs
@@ -694,6 +694,7 @@ fn truthy(value: &ConstValue) -> bool {
         ConstValue::Bytes(value) => !value.is_empty(),
         ConstValue::Tuple(values) | ConstValue::List(values) => !values.is_empty(),
         ConstValue::Record(values) => !values.is_empty(),
+        ConstValue::SourceOrigin(_) => true,
     }
 }
 

--- a/crates/sifr_frontend/src/const_specialization.rs
+++ b/crates/sifr_frontend/src/const_specialization.rs
@@ -26,6 +26,9 @@ pub enum ConstValue {
     Tuple(Vec<Self>),
     List(Vec<Self>),
     Record(BTreeMap<String, Self>),
+    /// Compiler-issued diagnostic token. Package const code can carry this
+    /// value but cannot construct it or retain it in a static program.
+    SourceOrigin(crate::class_declarations::SourceOriginId),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -72,13 +75,14 @@ pub enum ConstSpecializationOutcome<T> {
 /// Decode the closed record returned by a package-owned `@const_eval` specializer.
 ///
 /// The record has exactly `status`, `value`, and `issues`. Issue records have exactly
-/// `package`, `reason_code`, `severity`, `arguments`, and `notes`; the compiler supplies the
-/// primary source span and never executes package rendering code.
-pub fn decode_const_specialization_outcome(
+/// `package`, `reason_code`, `severity`, `arguments`, `primary_origin`, `labels`, and `notes`;
+/// the compiler resolves origins and never executes package rendering code.
+pub(crate) fn decode_const_specialization_outcome(
     value: ConstValue,
     primary_span: TextRange,
+    origins: &crate::class_declarations::SourceOriginTable,
 ) -> Result<ConstSpecializationOutcome<ConstValue>, Vec<HirDiagnostic>> {
-    decode_outcome_record(value, primary_span).map_err(|problem| {
+    decode_outcome_record(value, origins).map_err(|problem| {
         vec![malformed_diagnostic(
             "unknown",
             "outcome_shape",
@@ -90,7 +94,7 @@ pub fn decode_const_specialization_outcome(
 
 fn decode_outcome_record(
     value: ConstValue,
-    primary_span: TextRange,
+    origins: &crate::class_declarations::SourceOriginTable,
 ) -> Result<ConstSpecializationOutcome<ConstValue>, String> {
     let ConstValue::Record(mut fields) = value else {
         return Err("const specialization outcome must be a record".to_string());
@@ -107,7 +111,7 @@ fn decode_outcome_record(
         .ok_or_else(|| "const specialization outcome is missing value".to_string())?;
     let issues = take_list(&mut fields, "issues")?
         .into_iter()
-        .map(|issue| decode_issue(issue, primary_span))
+        .map(|issue| decode_issue(issue, origins))
         .collect::<Result<Vec<_>, _>>()?;
     if !fields.is_empty() {
         return Err("const specialization outcome contains unknown fields".to_string());
@@ -132,13 +136,16 @@ fn decode_outcome_record(
     }
 }
 
-fn decode_issue(value: ConstValue, primary_span: TextRange) -> Result<ConstPackageIssue, String> {
+fn decode_issue(
+    value: ConstValue,
+    origins: &crate::class_declarations::SourceOriginTable,
+) -> Result<ConstPackageIssue, String> {
     let ConstValue::Record(mut fields) = value else {
         return Err("const package issue must be a record".to_string());
     };
-    if fields.len() != 5 {
+    if fields.len() != 7 {
         return Err(
-            "const package issue must contain exactly package, reason_code, severity, arguments, and notes"
+            "const package issue must contain exactly package, reason_code, severity, arguments, primary_origin, labels, and notes"
                 .to_string(),
         );
     }
@@ -154,6 +161,17 @@ fn decode_issue(value: ConstValue, primary_span: TextRange) -> Result<ConstPacka
         Some(_) => return Err("const package issue arguments must be a record".to_string()),
         None => return Err("const package issue is missing arguments".to_string()),
     };
+    let primary_origin = take_source_origin(&mut fields, "primary_origin")?;
+    let primary_span = origins
+        .resolve(primary_origin)
+        .map(|origin| origin.range)
+        .ok_or_else(|| {
+            "const package issue primary_origin is not part of the adapted declaration".to_string()
+        })?;
+    let labels = take_list(&mut fields, "labels")?
+        .into_iter()
+        .map(|label| decode_label(label, origins))
+        .collect::<Result<Vec<_>, _>>()?;
     let notes = take_list(&mut fields, "notes")?
         .into_iter()
         .map(|note| match note {
@@ -167,9 +185,45 @@ fn decode_issue(value: ConstValue, primary_span: TextRange) -> Result<ConstPacka
         severity,
         arguments,
         primary_span,
-        labels: Vec::new(),
+        labels,
         notes,
     })
+}
+
+fn decode_label(
+    value: ConstValue,
+    origins: &crate::class_declarations::SourceOriginTable,
+) -> Result<ConstIssueLabel, String> {
+    let ConstValue::Record(mut fields) = value else {
+        return Err("const package issue label must be a record".to_string());
+    };
+    if fields.len() != 2 {
+        return Err(
+            "const package issue label must contain exactly origin and message".to_string(),
+        );
+    }
+    let origin = take_source_origin(&mut fields, "origin")?;
+    let span = origins
+        .resolve(origin)
+        .map(|origin| origin.range)
+        .ok_or_else(|| {
+            "const package issue label origin is not part of the adapted declaration".to_string()
+        })?;
+    let message = take_string(&mut fields, "message")?;
+    Ok(ConstIssueLabel { span, message })
+}
+
+fn take_source_origin(
+    fields: &mut BTreeMap<String, ConstValue>,
+    name: &str,
+) -> Result<crate::SourceOriginId, String> {
+    match fields.remove(name) {
+        Some(ConstValue::SourceOrigin(value)) => Ok(value),
+        Some(_) => Err(format!(
+            "const field '{name}' must be a compiler-issued source origin"
+        )),
+        None => Err(format!("const record is missing field '{name}'")),
+    }
 }
 
 fn take_string(fields: &mut BTreeMap<String, ConstValue>, name: &str) -> Result<String, String> {
@@ -194,7 +248,7 @@ fn take_list(
 #[derive(Debug, Clone)]
 pub struct ValidatedConstSpecialization<T> {
     pub value: Option<T>,
-    pub diagnostics: Vec<HirDiagnostic>,
+    pub issues: Vec<ConstPackageIssue>,
 }
 
 impl<T> ConstSpecializationOutcome<T> {
@@ -207,6 +261,7 @@ impl<T> ConstSpecializationOutcome<T> {
             Self::Failed { issues } => issues,
         };
         let mut diagnostics = Vec::new();
+        let mut validated_issues = Vec::new();
         if issues.len() > MAX_ISSUES {
             diagnostics.push(malformed_diagnostic(
                 "unknown",
@@ -229,7 +284,7 @@ impl<T> ConstSpecializationOutcome<T> {
             match (&self, issue.severity) {
                 (Self::Produced { .. }, ConstIssueSeverity::Warning)
                 | (Self::Failed { .. }, ConstIssueSeverity::Fatal) => {
-                    diagnostics.push(issue_diagnostic(issue));
+                    validated_issues.push(issue.clone());
                 }
                 (Self::Produced { .. }, ConstIssueSeverity::Fatal) => {
                     diagnostics.push(malformed_diagnostic(
@@ -259,7 +314,10 @@ impl<T> ConstSpecializationOutcome<T> {
                 Self::Produced { value, .. } => Some(value),
                 Self::Failed { .. } => None,
             };
-            Ok(ValidatedConstSpecialization { value, diagnostics })
+            Ok(ValidatedConstSpecialization {
+                value,
+                issues: validated_issues,
+            })
         }
     }
 }
@@ -356,6 +414,9 @@ fn validate_const_value(value: &ConstValue, depth: usize) -> Result<(), String> 
         ConstValue::Bytes(value) if value.len() > 128 => {
             Err("template bytes are limited to 128 values".to_string())
         }
+        ConstValue::SourceOrigin(_) => {
+            Err("source origins cannot be package template arguments".to_string())
+        }
         ConstValue::None
         | ConstValue::Bool(_)
         | ConstValue::Integer(_)
@@ -392,40 +453,8 @@ fn valid_argument_name(value: &str) -> bool {
         && bytes.all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
 }
 
-fn issue_diagnostic(issue: &ConstPackageIssue) -> HirDiagnostic {
-    let code = match issue.severity {
-        ConstIssueSeverity::Fatal => DiagnosticCode::META_SPECIALIZATION_FATAL,
-        ConstIssueSeverity::Warning => DiagnosticCode::META_SPECIALIZATION_WARNING,
-    };
-    let kind = match issue.severity {
-        ConstIssueSeverity::Fatal => "failed",
-        ConstIssueSeverity::Warning => "warning",
-    };
-    HirDiagnostic {
-        code: Some(code),
-        message: format!(
-            "package {} specialization {kind}: {}",
-            issue.package, issue.reason_code
-        ),
-        args: BTreeMap::from([
-            (
-                "package".to_string(),
-                DiagnosticArg::String(issue.package.clone()),
-            ),
-            (
-                "reason_code".to_string(),
-                DiagnosticArg::String(issue.reason_code.clone()),
-            ),
-        ]),
-        help: package_note(issue),
-        primary_range: Some(issue.primary_span),
-        line: None,
-        col: None,
-    }
-}
-
-fn package_note(issue: &ConstPackageIssue) -> Option<String> {
-    if issue.arguments.is_empty() && issue.notes.is_empty() && issue.labels.is_empty() {
+pub(crate) fn package_note(issue: &ConstPackageIssue) -> Option<String> {
+    if issue.arguments.is_empty() && issue.notes.is_empty() {
         return None;
     }
     let mut parts = Vec::new();
@@ -439,12 +468,6 @@ fn package_note(issue: &ConstPackageIssue) -> Option<String> {
         parts.push(format!("package arguments: {arguments}"));
     }
     parts.extend(issue.notes.iter().map(|note| format!("note: {note}")));
-    parts.extend(
-        issue
-            .labels
-            .iter()
-            .map(|label| format!("label {:?}: {}", label.span, label.message)),
-    );
     Some(parts.join("; "))
 }
 

--- a/crates/sifr_frontend/src/graph_cache_and_queries.rs
+++ b/crates/sifr_frontend/src/graph_cache_and_queries.rs
@@ -300,6 +300,10 @@ pub fn compile_module_hir_with_source_and_options(
     source_context: Option<FrontendSourceContext<'_>>,
     lowering_options: LoweringOptions,
 ) -> Result<LoweringResult, Vec<RenderedDiagnostic>> {
+    // Collect source declarations before lowering finalizes class storage and
+    // constructor shape. Later adapter stages consume this same representation.
+    let class_declarations =
+        crate::class_declarations::ClassDeclarationSet::collect(module_name, stmts);
     match lower_module_with_externals_name_and_options(
         module_name,
         stmts,
@@ -310,12 +314,28 @@ pub fn compile_module_hir_with_source_and_options(
             module_name,
             &mut result,
             external_defs,
+            &class_declarations,
         ) {
             Ok(()) => Ok(result),
             Err(errors) => Err(errors
                 .into_iter()
-                .map(|error| {
-                    hir_diagnostic_to_rendered(module_name, diagnostic_style, source_context, error)
+                .map(|error| match error {
+                    crate::package_issues::SpecializationDiagnostic::Hir(error) => {
+                        hir_diagnostic_to_rendered(
+                            module_name,
+                            diagnostic_style,
+                            source_context,
+                            error,
+                        )
+                    }
+                    crate::package_issues::SpecializationDiagnostic::Package(issue) => {
+                        crate::package_issues::render_package_issue(
+                            module_name,
+                            diagnostic_style,
+                            source_context,
+                            &issue,
+                        )
+                    }
                 })
                 .collect()),
         },

--- a/crates/sifr_frontend/src/lib.rs
+++ b/crates/sifr_frontend/src/lib.rs
@@ -7,6 +7,8 @@
 
 mod cache_keys;
 mod callable_exports;
+mod class_declarations;
+pub use class_declarations::SourceOriginId;
 mod const_specialization;
 pub use const_specialization::*;
 mod const_evaluator;
@@ -32,9 +34,11 @@ pub use graph_cache_and_queries::*;
 mod hir_views;
 mod module_export_storage;
 mod module_signatures;
+mod package_issues;
 mod query_diagnostic_rendering;
 pub(crate) use query_diagnostic_rendering::{
     diagnostic_with_code, diagnostic_with_source_range, diagnostic_with_source_range_args_help,
+    diagnostic_with_source_ranges_args_help,
 };
 mod warning_diagnostics;
 pub use warning_diagnostics::{reveal_type_diagnostics, warning_diagnostics};

--- a/crates/sifr_frontend/src/package_issues.rs
+++ b/crates/sifr_frontend/src/package_issues.rs
@@ -1,0 +1,173 @@
+//! Package-issue collection and rendering for deterministic specialization.
+
+use crate::specialization_support::malformed;
+use crate::{
+    diagnostic_with_source_ranges_args_help, package_note, ConstEvalError, ConstIssueSeverity,
+    ConstIssueTemplate, ConstPackageIssue, FrontendDiagnosticStyle, FrontendSourceContext,
+};
+use ruff_text_size::TextRange;
+use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, RenderedDiagnostic};
+use sifr_lowering::{ExternalDefs, HirDiagnostic};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(crate) enum SpecializationDiagnostic {
+    Hir(HirDiagnostic),
+    Package(ConstPackageIssue),
+}
+
+pub(crate) struct SpecializationDiagnostics(Vec<SpecializationDiagnostic>);
+
+impl SpecializationDiagnostics {
+    pub(crate) fn from_hir(diagnostics: Vec<HirDiagnostic>) -> Self {
+        Self(
+            diagnostics
+                .into_iter()
+                .map(SpecializationDiagnostic::Hir)
+                .collect(),
+        )
+    }
+
+    pub(crate) fn push(&mut self, diagnostic: HirDiagnostic) {
+        self.0.push(SpecializationDiagnostic::Hir(diagnostic));
+    }
+
+    pub(crate) fn push_package(&mut self, diagnostic: ConstPackageIssue) {
+        self.0.push(SpecializationDiagnostic::Package(diagnostic));
+    }
+
+    pub(crate) fn extend(&mut self, diagnostics: impl IntoIterator<Item = HirDiagnostic>) {
+        self.0
+            .extend(diagnostics.into_iter().map(SpecializationDiagnostic::Hir));
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn into_vec(self) -> Vec<SpecializationDiagnostic> {
+        self.0
+    }
+}
+
+pub(crate) fn render_package_issue(
+    module_name: &str,
+    diagnostic_style: FrontendDiagnosticStyle,
+    source_context: Option<FrontendSourceContext<'_>>,
+    issue: &ConstPackageIssue,
+) -> RenderedDiagnostic {
+    let code = match issue.severity {
+        ConstIssueSeverity::Fatal => DiagnosticCode::META_SPECIALIZATION_FATAL,
+        ConstIssueSeverity::Warning => DiagnosticCode::META_SPECIALIZATION_WARNING,
+    };
+    let kind = match issue.severity {
+        ConstIssueSeverity::Fatal => "failed",
+        ConstIssueSeverity::Warning => "warning",
+    };
+    let bare_message = format!(
+        "package {} specialization {kind}: {}",
+        issue.package, issue.reason_code
+    );
+    let message = match diagnostic_style {
+        FrontendDiagnosticStyle::Bare => bare_message,
+        FrontendDiagnosticStyle::ModulePrefixed => format!("[{module_name}] {bare_message}"),
+    };
+    let args = BTreeMap::from([
+        (
+            "package".to_string(),
+            DiagnosticArg::String(issue.package.clone()),
+        ),
+        (
+            "reason_code".to_string(),
+            DiagnosticArg::String(issue.reason_code.clone()),
+        ),
+    ]);
+    let related = issue
+        .labels
+        .iter()
+        .map(|label| (label.span, label.message.clone()))
+        .collect::<Vec<_>>();
+    if let Some(context) = source_context {
+        return diagnostic_with_source_ranges_args_help(
+            code,
+            context,
+            issue.primary_span,
+            &related,
+            "{message}",
+            BTreeMap::from([("message".to_string(), DiagnosticArg::String(message))]),
+            args,
+            package_note(issue),
+        );
+    }
+    let mut rendered = crate::diagnostic_with_code(message, code);
+    rendered.args.extend(args);
+    rendered.help = package_note(issue);
+    rendered
+}
+
+pub(crate) fn issue_templates(
+    external_defs: &ExternalDefs,
+    package: &str,
+    function: &str,
+) -> Vec<ConstIssueTemplate> {
+    external_defs
+        .declaration_metadata
+        .get(package)
+        .into_iter()
+        .flatten()
+        .filter(|metadata| metadata.owner == function && metadata.key == "sifr.meta.issue_template")
+        .filter_map(|metadata| {
+            let value = crate::structural_shape::const_value_from_hir(&metadata.value)?;
+            let crate::ConstValue::Tuple(mut parts) = value else {
+                return None;
+            };
+            if parts.len() != 2 {
+                return None;
+            }
+            let crate::ConstValue::List(arguments) = parts.pop()? else {
+                return None;
+            };
+            let crate::ConstValue::String(reason_code) = parts.pop()? else {
+                return None;
+            };
+            let argument_names = arguments
+                .into_iter()
+                .map(|argument| match argument {
+                    crate::ConstValue::String(argument) => Some(argument),
+                    _ => None,
+                })
+                .collect::<Option<BTreeSet<_>>>()?;
+            Some(ConstIssueTemplate {
+                package: package.to_string(),
+                reason_code,
+                argument_names,
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn evaluation_error(
+    package: &str,
+    error: &ConstEvalError,
+    range: TextRange,
+) -> HirDiagnostic {
+    malformed(
+        package,
+        "const_evaluation",
+        format!("{:?}: {}", error.kind, error.detail),
+        range,
+    )
+}
+
+pub(crate) fn replace_unknown_package(diagnostic: &mut HirDiagnostic, package: &str) {
+    if matches!(diagnostic.args.get("package"), Some(DiagnosticArg::String(value)) if value == "unknown")
+    {
+        diagnostic.args.insert(
+            "package".to_string(),
+            DiagnosticArg::String(package.to_string()),
+        );
+        diagnostic.message =
+            diagnostic
+                .message
+                .replacen("package unknown", &format!("package {package}"), 1);
+    }
+}

--- a/crates/sifr_frontend/src/query_diagnostic_rendering.rs
+++ b/crates/sifr_frontend/src/query_diagnostic_rendering.rs
@@ -1,6 +1,6 @@
 use sifr_diagnostics::{
-    DiagnosticArg, DiagnosticBuilder, DiagnosticCode, DiagnosticSink, RenderedDiagnostic, Severity,
-    SourceMap, SourceSpan,
+    DiagnosticArg, DiagnosticBuilder, DiagnosticCode, DiagnosticSink, RelatedKind,
+    RenderedDiagnostic, Severity, SourceMap, SourceSpan,
 };
 use std::collections::BTreeMap;
 
@@ -47,6 +47,29 @@ pub(crate) fn diagnostic_with_source_range_args_help(
     source_context: FrontendSourceContext<'_>,
     range: TextRange,
     message_template: &'static str,
+    args: BTreeMap<String, DiagnosticArg>,
+    extra_args: BTreeMap<String, DiagnosticArg>,
+    help: Option<String>,
+) -> RenderedDiagnostic {
+    diagnostic_with_source_ranges_args_help(
+        code,
+        source_context,
+        range,
+        &[],
+        message_template,
+        args,
+        extra_args,
+        help,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn diagnostic_with_source_ranges_args_help(
+    code: DiagnosticCode,
+    source_context: FrontendSourceContext<'_>,
+    range: TextRange,
+    related_ranges: &[(TextRange, String)],
+    message_template: &'static str,
     mut args: BTreeMap<String, DiagnosticArg>,
     extra_args: BTreeMap<String, DiagnosticArg>,
     help: Option<String>,
@@ -59,6 +82,13 @@ pub(crate) fn diagnostic_with_source_range_args_help(
         .message_template(message_template);
     for (name, value) in args {
         builder = builder.arg_owned(&name, value);
+    }
+    for (range, label) in related_ranges {
+        builder = builder.related(
+            SourceSpan::new(source_id, *range),
+            RelatedKind::Note,
+            Some(label.clone()),
+        );
     }
     if let Some(help) = help {
         builder = builder.help(help);

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -1,24 +1,28 @@
+use crate::package_issues::{
+    evaluation_error, issue_templates, replace_unknown_package, SpecializationDiagnostic,
+    SpecializationDiagnostics,
+};
 use crate::specialization_support::{malformed, method_slot_diagnostic, static_program_value};
 use crate::{
-    decode_const_specialization_outcome, describe_type_with_externals,
-    verify_json_integer_boundary, ConstEvalError, ConstIssueTemplate, DeterministicConstEvaluator,
+    decode_const_specialization_outcome, describe_type_with_externals, package_note,
+    verify_json_integer_boundary, ConstIssueSeverity, DeterministicConstEvaluator,
     JsonIntegerBoundaryDescriptor, JsonIntegerKind, JsonIntegerProfile, JsonIntegerRepresentation,
 };
-use ruff_text_size::TextRange;
-use sifr_diagnostics::{DiagnosticArg, DiagnosticCode};
 use sifr_lowering::{
     ExternalDefs, HirDiagnostic, HirModule, LoweringResult, LoweringWarningDiagnostic,
     StaticSpecializationOutput,
 };
 use sifr_type_system::Type;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 
 pub(crate) fn run_specializations(
     module_name: &str,
     result: &mut LoweringResult,
     external_defs: &ExternalDefs,
-) -> Result<(), Vec<HirDiagnostic>> {
-    let mut errors = verify_integer_boundaries(module_name, result);
+    class_declarations: &crate::class_declarations::ClassDeclarationSet,
+) -> Result<(), Vec<SpecializationDiagnostic>> {
+    let mut errors =
+        SpecializationDiagnostics::from_hir(verify_integer_boundaries(module_name, result));
     for request in result.specialization_requests.clone() {
         let Some(class) = result
             .module
@@ -58,8 +62,18 @@ pub(crate) fn run_specializations(
         }
         let described_shape =
             describe_type_with_externals(module_name, &target_type, result, external_defs);
-        let shape = described_shape.to_const_value();
+        let mut shape = described_shape.to_const_value();
         let canonical_shape = crate::structural_shape::canonical_value(&shape);
+        let Some(declaration) = class_declarations.get(&request.owner) else {
+            errors.push(malformed(
+                &request.package_module,
+                "class_declaration",
+                "specialization target has no pre-finalization declaration",
+                request.range,
+            ));
+            continue;
+        };
+        declaration.attach_to_shape(&mut shape, result);
         let Some(functions) = external_defs.const_functions.get(&request.package_module) else {
             errors.push(malformed(
                 &request.package_module,
@@ -104,7 +118,11 @@ pub(crate) fn run_specializations(
                 continue;
             }
         };
-        let outcome = match decode_const_specialization_outcome(evaluated, request.range) {
+        let outcome = match decode_const_specialization_outcome(
+            evaluated,
+            request.range,
+            declaration.origins(),
+        ) {
             Ok(outcome) => outcome,
             Err(mut diagnostics) => {
                 for diagnostic in &mut diagnostics {
@@ -134,8 +152,19 @@ pub(crate) fn run_specializations(
                                 continue;
                             }
                         };
+                    let static_value = match static_program_value(value) {
+                        Ok(value) => value,
+                        Err(problem) => {
+                            errors.push(malformed(
+                                &request.package_module,
+                                "static_program_value",
+                                problem,
+                                request.range,
+                            ));
+                            continue;
+                        }
+                    };
                     let canonical_value = crate::structural_shape::canonical_value(value);
-                    let static_value = static_program_value(value);
                     let structural_contract_version = sifr_structural_identity::ALGORITHM_VERSION;
                     let program_identity = sifr_structural_identity::static_program_identity(
                         structural_contract_version,
@@ -162,25 +191,25 @@ pub(crate) fn run_specializations(
                             method_slot_context,
                         });
                 }
-                for diagnostic in validated.diagnostics {
-                    match diagnostic.code {
-                        Some(DiagnosticCode::META_SPECIALIZATION_WARNING) => {
+                for issue in validated.issues {
+                    match issue.severity {
+                        ConstIssueSeverity::Warning => {
+                            let related_ranges = issue
+                                .labels
+                                .iter()
+                                .map(|label| (label.span, label.message.clone()))
+                                .collect();
                             result
                                 .warnings
                                 .push(LoweringWarningDiagnostic::MetaPackageIssue {
-                                    package: diagnostic_arg(&diagnostic, "package"),
-                                    reason_code: diagnostic_arg(&diagnostic, "reason_code"),
-                                    help: diagnostic.help,
-                                    primary_range: diagnostic.primary_range,
+                                    package: issue.package.clone(),
+                                    reason_code: issue.reason_code.clone(),
+                                    help: package_note(&issue),
+                                    primary_range: Some(issue.primary_span),
+                                    related_ranges,
                                 });
                         }
-                        Some(DiagnosticCode::META_SPECIALIZATION_FATAL) => errors.push(diagnostic),
-                        _ => errors.push(malformed(
-                            &request.package_module,
-                            "diagnostic_mapping",
-                            "specialization produced a non-metaprogramming diagnostic",
-                            request.range,
-                        )),
+                        ConstIssueSeverity::Fatal => errors.push_package(issue),
                     }
                 }
             }
@@ -189,7 +218,7 @@ pub(crate) fn run_specializations(
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(errors)
+        Err(errors.into_vec())
     }
 }
 
@@ -290,77 +319,6 @@ fn verify_integer_boundaries(module_name: &str, result: &LoweringResult) -> Vec<
     errors
 }
 
-fn issue_templates(
-    external_defs: &ExternalDefs,
-    package: &str,
-    function: &str,
-) -> Vec<ConstIssueTemplate> {
-    external_defs
-        .declaration_metadata
-        .get(package)
-        .into_iter()
-        .flatten()
-        .filter(|metadata| metadata.owner == function && metadata.key == "sifr.meta.issue_template")
-        .filter_map(|metadata| {
-            let value = crate::structural_shape::const_value_from_hir(&metadata.value)?;
-            let crate::ConstValue::Tuple(mut parts) = value else {
-                return None;
-            };
-            if parts.len() != 2 {
-                return None;
-            }
-            let crate::ConstValue::List(arguments) = parts.pop()? else {
-                return None;
-            };
-            let crate::ConstValue::String(reason_code) = parts.pop()? else {
-                return None;
-            };
-            let argument_names = arguments
-                .into_iter()
-                .map(|argument| match argument {
-                    crate::ConstValue::String(argument) => Some(argument),
-                    _ => None,
-                })
-                .collect::<Option<BTreeSet<_>>>()?;
-            Some(ConstIssueTemplate {
-                package: package.to_string(),
-                reason_code,
-                argument_names,
-            })
-        })
-        .collect()
-}
-
-fn evaluation_error(package: &str, error: &ConstEvalError, range: TextRange) -> HirDiagnostic {
-    malformed(
-        package,
-        "const_evaluation",
-        format!("{:?}: {}", error.kind, error.detail),
-        range,
-    )
-}
-
-fn diagnostic_arg(diagnostic: &HirDiagnostic, name: &str) -> String {
-    match diagnostic.args.get(name) {
-        Some(DiagnosticArg::String(value)) => value.clone(),
-        _ => "unknown".to_string(),
-    }
-}
-
-fn replace_unknown_package(diagnostic: &mut HirDiagnostic, package: &str) {
-    if matches!(diagnostic.args.get("package"), Some(DiagnosticArg::String(value)) if value == "unknown")
-    {
-        diagnostic.args.insert(
-            "package".to_string(),
-            DiagnosticArg::String(package.to_string()),
-        );
-        diagnostic.message =
-            diagnostic
-                .message
-                .replacen("package unknown", &format!("package {package}"), 1);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -368,6 +326,7 @@ mod tests {
         collect_module_exports, compile_module_hir, warning_diagnostics, FrontendDiagnosticStyle,
         FrontendSourceContext,
     };
+    use sifr_diagnostics::DiagnosticArg;
     use sifr_lowering::StaticMethodSlotContext;
     use sifr_syntax::parse_module_suite;
 
@@ -416,11 +375,27 @@ mod tests {
 class IssueArgs:
     field: str
 
+class SourceOrigin:
+    pass
+
+class SourceDeclaration:
+    origin: SourceOrigin
+
+class ShapeInput:
+    canonical_identity: str
+    declaration: SourceDeclaration
+
+class Label:
+    origin: SourceOrigin
+    message: str
+
 class Issue:
     package: str
     reason_code: str
     severity: str
     arguments: IssueArgs
+    primary_origin: SourceOrigin
+    labels: list[Label]
     notes: list[str]
 
 class Outcome:
@@ -429,14 +404,12 @@ class Outcome:
     issues: list[Issue]
 
 @const_eval
-{template}def describe(shape: dict[str, str]) -> Outcome:
-    issue: Issue = Issue("fixture.meta", "{reason}", "{severity}", IssueArgs("value"), ["package note"])
+{template}def describe(shape: ShapeInput) -> Outcome:
+    labels: list[Label] = [Label(shape.declaration.origin, "class declared here")]
+    issue: Issue = Issue("fixture.meta", "{reason}", "{severity}", IssueArgs("value"), shape.declaration.origin, labels, ["package note"])
     issues: list[Issue] = [issue]
     if "{severity}" == "warning":
-        identity: str | None = shape["canonical_identity"]
-        if identity is not None:
-            return Outcome("produced", identity, issues)
-        return Outcome("failed", None, issues)
+        return Outcome("produced", shape.canonical_identity, issues)
     return Outcome("failed", None, issues)
 "#
         )
@@ -494,6 +467,19 @@ class Model:
             target.specialization_outputs[0].program_identity,
             unrelated.specialization_outputs[0].program_identity
         );
+        let moved = compile("target", &format!("\n\n{TARGET}"), &external_defs)
+            .expect("source movement compiles");
+        assert_eq!(
+            target.specialization_outputs[0].program_identity,
+            moved.specialization_outputs[0].program_identity
+        );
+        let primary_range = |result: &LoweringResult| match result.warnings.last() {
+            Some(LoweringWarningDiagnostic::MetaPackageIssue { primary_range, .. }) => {
+                *primary_range
+            }
+            other => panic!("expected package warning, got {other:?}"),
+        };
+        assert_ne!(primary_range(&target), primary_range(&moved));
         let changed = compile(
             "target",
             &TARGET.replace("value: int", "value: str"),
@@ -541,6 +527,11 @@ class Model:
         assert_eq!(cli[0].args, editor[0].args);
         assert_eq!(cli[0].url, editor[0].url);
         assert_eq!(cli[0].message_template, editor[0].message_template);
+        assert_eq!(editor[0].spans.len(), 2);
+        assert!(editor[0]
+            .spans
+            .iter()
+            .any(|span| span.label.as_deref() == Some("class declared here")));
     }
 
     #[test]
@@ -847,6 +838,20 @@ class ImportedUse:
 
         let diagnostics = errors(compile("target", TARGET, &external_defs));
         assert_eq!(diagnostics[0].code, "SIFR-META-0003");
+    }
+
+    #[test]
+    fn package_cannot_forge_a_source_origin() {
+        let mut external_defs = ExternalDefs::default();
+        let forged = package_source("fatal", "shape_rejected", true)
+            .replace("shape.declaration.origin", "SourceOrigin()");
+        let package = compile("fixture.meta", &forged, &external_defs)
+            .expect("forging package compiles before origin validation");
+        collect_module_exports("fixture.meta", &package, &mut external_defs);
+
+        let diagnostics = errors(compile("target", TARGET, &external_defs));
+        assert_eq!(diagnostics[0].code, "SIFR-META-0003");
+        assert!(diagnostics[0].message.contains("primary_origin"));
     }
 
     #[test]

--- a/crates/sifr_frontend/src/specialization_support.rs
+++ b/crates/sifr_frontend/src/specialization_support.rs
@@ -3,27 +3,38 @@ use sifr_diagnostics::{DiagnosticArg, DiagnosticCode};
 use sifr_lowering::{HirDiagnostic, StaticProgramValue};
 use std::collections::BTreeMap;
 
-pub(crate) fn static_program_value(value: &crate::ConstValue) -> StaticProgramValue {
-    match value {
+pub(crate) fn static_program_value(
+    value: &crate::ConstValue,
+) -> Result<StaticProgramValue, &'static str> {
+    Ok(match value {
         crate::ConstValue::None => StaticProgramValue::None,
         crate::ConstValue::Bool(value) => StaticProgramValue::Bool(*value),
         crate::ConstValue::Integer(value) => StaticProgramValue::Integer(value.to_string()),
         crate::ConstValue::FloatBits(value) => StaticProgramValue::FloatBits(*value),
         crate::ConstValue::String(value) => StaticProgramValue::String(value.clone()),
         crate::ConstValue::Bytes(value) => StaticProgramValue::Bytes(value.clone()),
-        crate::ConstValue::Tuple(values) => {
-            StaticProgramValue::Tuple(values.iter().map(static_program_value).collect())
-        }
-        crate::ConstValue::List(values) => {
-            StaticProgramValue::List(values.iter().map(static_program_value).collect())
-        }
+        crate::ConstValue::Tuple(values) => StaticProgramValue::Tuple(
+            values
+                .iter()
+                .map(static_program_value)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        crate::ConstValue::List(values) => StaticProgramValue::List(
+            values
+                .iter()
+                .map(static_program_value)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
         crate::ConstValue::Record(values) => StaticProgramValue::Record(
             values
                 .iter()
-                .map(|(name, value)| (name.clone(), static_program_value(value)))
-                .collect(),
+                .map(|(name, value)| Ok((name.clone(), static_program_value(value)?)))
+                .collect::<Result<Vec<_>, &'static str>>()?,
         ),
-    }
+        crate::ConstValue::SourceOrigin(_) => {
+            return Err("source origins cannot be retained in a static program")
+        }
+    })
 }
 
 pub(crate) fn malformed(

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -837,6 +837,9 @@ pub(crate) fn canonical_value(value: &ConstValue) -> String {
                 .collect::<Vec<_>>()
                 .join(",")
         ),
+        // Origin identity is diagnostic-only. A package result containing an
+        // origin is rejected before static-program canonicalization.
+        ConstValue::SourceOrigin(_) => "source-origin:opaque".to_string(),
     }
 }
 

--- a/crates/sifr_frontend/src/warning_diagnostics.rs
+++ b/crates/sifr_frontend/src/warning_diagnostics.rs
@@ -1,6 +1,8 @@
 //! Rendering for non-fatal lowering diagnostics shared by CLI and editor analysis.
 
-use crate::{diagnostic_with_source_range, FrontendSourceContext};
+use crate::{
+    diagnostic_with_source_range, diagnostic_with_source_ranges_args_help, FrontendSourceContext,
+};
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, RenderedDiagnostic};
 use sifr_lowering::{LoweringWarningDiagnostic, RevealTypeDiagnostic};
 use std::collections::BTreeMap;
@@ -63,6 +65,7 @@ fn warning_diagnostic(
             reason_code,
             help: _,
             primary_range,
+            related_ranges: _,
         } => (
             DiagnosticCode::META_SPECIALIZATION_WARNING,
             format!("package {package} specialization warning: {reason_code}"),
@@ -74,11 +77,29 @@ fn warning_diagnostic(
             *primary_range,
         ),
     };
-    let mut rendered = if let (Some(context), Some(range)) = (source_context, primary_range) {
-        diagnostic_with_source_range(code, context, range, message_template, &args)
-    } else {
-        rendered_spanless_diagnostic(code, message, message_template, &args)
+    let related_ranges = match diagnostic {
+        LoweringWarningDiagnostic::MetaPackageIssue { related_ranges, .. } => {
+            related_ranges.as_slice()
+        }
+        _ => &[],
     };
+    if let (Some(context), Some(range)) = (source_context, primary_range) {
+        let args = args
+            .iter()
+            .map(|(name, value)| ((*name).to_string(), value.clone()))
+            .collect();
+        return diagnostic_with_source_ranges_args_help(
+            code,
+            context,
+            range,
+            related_ranges,
+            message_template,
+            args,
+            BTreeMap::new(),
+            structured_help,
+        );
+    }
+    let mut rendered = rendered_spanless_diagnostic(code, message, message_template, &args);
     rendered.help = structured_help;
     rendered
 }

--- a/crates/sifr_ir/src/diagnostic_types.rs
+++ b/crates/sifr_ir/src/diagnostic_types.rs
@@ -47,5 +47,6 @@ pub enum LoweringWarningDiagnostic {
         reason_code: String,
         help: Option<String>,
         primary_range: Option<TextRange>,
+        related_ranges: Vec<(TextRange, String)>,
     },
 }

--- a/crates/sifr_lsp/src/conversion.rs
+++ b/crates/sifr_lsp/src/conversion.rs
@@ -402,6 +402,7 @@ pub(crate) fn text_edits(
 
 pub(crate) fn diagnostic(
     diagnostic: RenderedDiagnostic,
+    uri: &str,
     source: &str,
     encoding: PositionEncoding,
 ) -> LspResult<Value> {
@@ -412,6 +413,20 @@ pub(crate) fn diagnostic(
         .or_else(|| diagnostic.spans.first());
     let class = diagnostic_class(&diagnostic);
     let rule_id = diagnostic_rule_id(&diagnostic);
+    let related_information = diagnostic
+        .spans
+        .iter()
+        .filter(|span| !span.is_primary)
+        .map(|span| {
+            Ok(json!({
+                "location": {
+                    "uri": uri,
+                    "range": diagnostic_span_range(span, source, encoding)?,
+                },
+                "message": span.label.as_deref().unwrap_or("related declaration"),
+            }))
+        })
+        .collect::<LspResult<Vec<_>>>()?;
     Ok(json!({
         "range": primary.map_or_else(|| Ok(default_range()), |span| diagnostic_span_range(span, source, encoding))?,
         "severity": diagnostic_severity(diagnostic.severity),
@@ -419,6 +434,7 @@ pub(crate) fn diagnostic(
         "codeDescription": { "href": diagnostic.url },
         "source": "sifr",
         "message": diagnostic.message,
+        "relatedInformation": related_information,
         "data": {
             "code": diagnostic.code,
             "diagnosticClass": class,
@@ -569,12 +585,15 @@ fn token_modifier_bits(modifiers: &[String]) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::{
-        completion_item, lsp_range_with_encoding, signature_help, text_range_with_encoding,
+        completion_item, diagnostic, lsp_range_with_encoding, signature_help,
+        text_range_with_encoding,
     };
     use ruff_text_size::{TextRange, TextSize};
     use serde_json::json;
     use sifr_analysis::{CompletionItem, SignatureHelp};
+    use sifr_diagnostics::{DiagnosticSpan, RenderedDiagnostic, Severity};
     use sifr_source::PositionEncoding;
+    use std::collections::BTreeMap;
 
     #[test]
     fn utf16_ranges_round_trip_through_conversion_layer() {
@@ -632,5 +651,50 @@ mod tests {
         assert_eq!(signature["parameters"][0]["label"], "left: int");
         assert_eq!(signature["parameters"][1]["label"], "right: int");
         assert_eq!(help["activeParameter"], 1);
+    }
+
+    #[test]
+    fn diagnostic_conversion_preserves_related_source_locations() {
+        let span = |byte_start, byte_end, is_primary, label| DiagnosticSpan {
+            file: Some("model.sifr".to_string()),
+            byte_start,
+            byte_end,
+            line: None,
+            column: None,
+            end_line: None,
+            end_column: None,
+            is_primary,
+            label,
+            lines: Vec::new(),
+        };
+        let rendered = RenderedDiagnostic {
+            code: "SIFR-META-0001".to_string(),
+            severity: Severity::Error,
+            message: "package fixture.meta specialization failed: rejected".to_string(),
+            message_template: "{message}".to_string(),
+            args: BTreeMap::new(),
+            url: "https://docs.sifr.sh/errors/SIFR-META-0001".to_string(),
+            spans: vec![
+                span(0, 5, true, None),
+                span(6, 11, false, Some("declared here".to_string())),
+            ],
+            children: Vec::new(),
+            help: Some("note: retained".to_string()),
+            suggestions: Vec::new(),
+        };
+        let value = diagnostic(
+            rendered,
+            "file:///workspace/model.sifr",
+            "class field\n",
+            PositionEncoding::Utf16,
+        )
+        .unwrap();
+        assert_eq!(value["code"], "SIFR-META-0001");
+        assert_eq!(value["data"]["help"], "note: retained");
+        assert_eq!(
+            value["relatedInformation"][0]["location"]["uri"],
+            "file:///workspace/model.sifr"
+        );
+        assert_eq!(value["relatedInformation"][0]["message"], "declared here");
     }
 }

--- a/crates/sifr_lsp/src/diagnostics.rs
+++ b/crates/sifr_lsp/src/diagnostics.rs
@@ -134,7 +134,7 @@ pub(crate) fn document_diagnostics(session: &mut Session, uri: &str) -> LspResul
             .load_diagnostics(uri)
             .iter()
             .cloned()
-            .map(|diagnostic| conversion::diagnostic(diagnostic, &source, position_encoding))
+            .map(|diagnostic| conversion::diagnostic(diagnostic, uri, &source, position_encoding))
             .collect::<LspResult<Vec<_>>>();
     }
     let mut diagnostics = session.with_document_analysis(uri, |snapshot, host, file, source| {
@@ -144,7 +144,7 @@ pub(crate) fn document_diagnostics(session: &mut Session, uri: &str) -> LspResul
             .into_value();
         diagnostics
             .into_iter()
-            .map(|diagnostic| conversion::diagnostic(diagnostic, source, position_encoding))
+            .map(|diagnostic| conversion::diagnostic(diagnostic, uri, source, position_encoding))
             .collect::<LspResult<Vec<_>>>()
     })?;
     match session.python_declaration_snapshot(uri) {
@@ -152,7 +152,9 @@ pub(crate) fn document_diagnostics(session: &mut Session, uri: &str) -> LspResul
             python
                 .diagnostics
                 .into_iter()
-                .map(|diagnostic| conversion::diagnostic(diagnostic, &source, position_encoding))
+                .map(|diagnostic| {
+                    conversion::diagnostic(diagnostic, uri, &source, position_encoding)
+                })
                 .collect::<LspResult<Vec<_>>>()?,
         ),
         Err(error) => session.trace(

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -22,10 +22,20 @@ their specialization functions and the meaning of the static values they produce
   package-neutral integer JSON boundary. `profile` is `exact`, `web`, `string_ints`, or `None`;
   representation is `default`, `number`, or `decimal_string`.
 
-The public `sifr.meta` module contains `ConstIssueTemplate`, generic `ConstPackageIssue[A]`,
-generic `ConstSpecializationOutcome[T, A]`, and `JsonIntegerBoundaryDescriptor` value types.
-Package argument records remain statically typed package code; the compiler converts them to a
-closed const record only at the specialization boundary.
+The public `sifr.meta` module contains `SourceOrigin`, `ClassDeclaration`,
+`ClassDecoratorDeclaration`, `ClassParameterDeclaration`, `ClassDeclarationItem`,
+`ConstIssueLabel`, `ConstIssueTemplate`, generic `ConstPackageIssue[A]`, generic
+`ConstSpecializationOutcome[T, A]`, and `JsonIntegerBoundaryDescriptor` value types. Package
+argument records remain statically typed package code; the compiler converts them to a closed
+const record only at the specialization boundary.
+
+Every specialization input also contains one `declaration: ClassDeclaration`. The compiler
+collects this declaration before class lowering finalizes storage. It preserves class decorators,
+fields, annotated values, class items, methods, method decorators and parameters, and source
+order. Declaration and decorator-argument locations are represented only by `SourceOrigin`.
+`SourceOrigin` is an opaque compiler value: package code can forward an origin supplied in the
+current declaration, but cannot construct, inspect, serialize, return, or select an origin from a
+different class declaration.
 
 ## Structural shape
 
@@ -45,10 +55,13 @@ static derivation and rejects runtime effects, unsupported expressions, missing 
 budget exhaustion, and escaping loop control.
 
 A package result is a closed record with exactly `status`, `value`, and `issues`. Each issue has
-exactly `package`, `reason_code`, `severity`, `arguments`, and `notes`; the compiler supplies the
-source span. Produced values may carry only warnings. Failed outcomes contain at least one fatal
-issue and no value. Package/reason namespaces, template arguments, text, issue counts, nesting,
-labels, and notes are bounded and validated before rendering.
+exactly `package`, `reason_code`, `severity`, `arguments`, `primary_origin`, `labels`, and `notes`.
+Each label has exactly `origin` and `message`. The compiler resolves the primary and related
+origins against the current declaration and owns the resulting source spans. Produced values may
+carry only warnings. Failed outcomes contain at least one fatal issue and no value.
+Package/reason namespaces, template arguments, text, issue counts, nesting, labels, and notes are
+bounded and validated before rendering. A missing, forged, or unrelated origin fails closed with
+`SIFR-META-0003` at the specialization request.
 
 The frontend maps fatal, warning, and malformed results to `SIFR-META-0001`,
 `SIFR-META-0002`, and `SIFR-META-0003`. Package text never becomes a top-level compiler code or
@@ -66,6 +79,9 @@ concrete owner, package module, specializer function, canonical structural shape
 and structural-contract identity. Check and editor analysis retain this identity. Build and run emit
 the canonical bytes. For a structural static program, they also emit an allocation-free borrowed
 view of the same closed value. The generated-project cache key includes the same identity.
+Source origins and byte locations are excluded from both the canonical structural shape and the
+retained static value. Moving an otherwise unchanged declaration therefore updates diagnostic
+locations without changing the static-program identity.
 
 For a structural Rust call with the compiler-owned `sifr.meta.StaticProgram` bound, the compiler
 also emits a sealed typed `StaticProgram[T]` envelope and implements `StaticProgramType` for the

--- a/stdlib/sifr/meta.sifr
+++ b/stdlib/sifr/meta.sifr
@@ -27,11 +27,57 @@ class ConstIssueTemplate:
     argument_names: list[str]
 
 
+class SourceOrigin:
+    pass
+
+
+class ClassDecoratorDeclaration:
+    name: str
+    origin: SourceOrigin
+    argument_origins: list[SourceOrigin]
+
+
+class ClassParameterDeclaration:
+    name: str
+    origin: SourceOrigin
+    annotation_origin: SourceOrigin | None
+
+
+class ClassDeclarationItem:
+    order: int
+    kind: str
+    name: str
+    origin: SourceOrigin
+    annotation_origin: SourceOrigin | None
+    value_origin: SourceOrigin | None
+    return_origin: SourceOrigin | None
+    declared_type: str | None
+    signature: str | None
+    value_argument_origins: list[SourceOrigin]
+    decorators: list[ClassDecoratorDeclaration]
+    parameters: list[ClassParameterDeclaration]
+
+
+class ClassDeclaration:
+    identity: str
+    name: str
+    origin: SourceOrigin
+    decorators: list[ClassDecoratorDeclaration]
+    items: list[ClassDeclarationItem]
+
+
+class ConstIssueLabel:
+    origin: SourceOrigin
+    message: str
+
+
 class ConstPackageIssue[A]:
     package: str
     reason_code: str
     severity: str
     arguments: A
+    primary_origin: SourceOrigin
+    labels: list[ConstIssueLabel]
     notes: list[str]
 
 

--- a/verification/areas/core_language/fixtures/const_specialization_general/fixture/meta.sifr
+++ b/verification/areas/core_language/fixtures/const_specialization_general/fixture/meta.sifr
@@ -1,24 +1,28 @@
-from sifr.meta import ConstPackageIssue, ConstSpecializationOutcome
+from sifr.meta import ClassDeclaration, ConstIssueLabel, ConstPackageIssue, ConstSpecializationOutcome
 
 
 class ShapeArguments:
     identity: str
 
 
+class ShapeInput:
+    canonical_identity: str
+    declaration: ClassDeclaration
+
+
 @const_eval
 @metadata("sifr.meta.issue_template", ("shape_derived", ["identity"]))
-def describe(shape: dict[str, str]) -> ConstSpecializationOutcome[str, ShapeArguments]:
-    identity: str | None = shape["canonical_identity"]
-    if identity is not None:
-        arguments: ShapeArguments = ShapeArguments("concrete shape")
-        warning: ConstPackageIssue[ShapeArguments] = ConstPackageIssue(
-            "fixture.meta",
-            "shape_derived",
-            "warning",
-            arguments,
-            ["static description derived from the concrete structural shape"],
-        )
-        warnings: list[ConstPackageIssue[ShapeArguments]] = [warning]
-        return ConstSpecializationOutcome("produced", identity, warnings)
-    failures: list[ConstPackageIssue[ShapeArguments]] = []
-    return ConstSpecializationOutcome("failed", None, failures)
+def describe(shape: ShapeInput) -> ConstSpecializationOutcome[str, ShapeArguments]:
+    arguments: ShapeArguments = ShapeArguments("concrete shape")
+    labels: list[ConstIssueLabel] = []
+    warning: ConstPackageIssue[ShapeArguments] = ConstPackageIssue(
+        "fixture.meta",
+        "shape_derived",
+        "warning",
+        arguments,
+        shape.declaration.origin,
+        labels,
+        ["static description derived from the concrete structural shape"],
+    )
+    warnings: list[ConstPackageIssue[ShapeArguments]] = [warning]
+    return ConstSpecializationOutcome("produced", shape.canonical_identity, warnings)

--- a/verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_fatal/baselines/check-compact.stderr.txt
+++ b/verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_fatal/baselines/check-compact.stderr.txt
@@ -1,2 +1,2 @@
 1 error, 0 warnings, 0 notes
-E SIFR-META-0001 verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_fatal/main.sifr:4:2 package fixture.meta specialization failed: shape_rejected
+E SIFR-META-0001 verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_fatal/main.sifr:5:7 package fixture.meta specialization failed: shape_rejected

--- a/verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_fatal/fixture/meta.sifr
+++ b/verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_fatal/fixture/meta.sifr
@@ -1,20 +1,28 @@
-from sifr.meta import ConstPackageIssue, ConstSpecializationOutcome
+from sifr.meta import ClassDeclaration, ConstIssueLabel, ConstPackageIssue, ConstSpecializationOutcome
 
 
 class ShapeArguments:
     identity: str
 
 
+class ShapeInput:
+    canonical_identity: str
+    declaration: ClassDeclaration
+
+
 @const_eval
 @metadata("sifr.meta.issue_template", ("shape_rejected", ["identity"]))
-def reject(shape: dict[str, str]) -> ConstSpecializationOutcome[str, ShapeArguments]:
-    identity: str | None = shape["canonical_identity"]
-    if identity is not None:
-        arguments: ShapeArguments = ShapeArguments("concrete shape")
-        issue: ConstPackageIssue[ShapeArguments] = ConstPackageIssue(
-            "fixture.meta", "shape_rejected", "fatal", arguments, ["shape rejected"]
-        )
-        issues: list[ConstPackageIssue[ShapeArguments]] = [issue]
-        return ConstSpecializationOutcome("failed", None, issues)
-    issues: list[ConstPackageIssue[ShapeArguments]] = []
+def reject(shape: ShapeInput) -> ConstSpecializationOutcome[str, ShapeArguments]:
+    arguments: ShapeArguments = ShapeArguments("concrete shape")
+    labels: list[ConstIssueLabel] = []
+    issue: ConstPackageIssue[ShapeArguments] = ConstPackageIssue(
+        "fixture.meta",
+        "shape_rejected",
+        "fatal",
+        arguments,
+        shape.declaration.origin,
+        labels,
+        ["shape rejected"],
+    )
+    issues: list[ConstPackageIssue[ShapeArguments]] = [issue]
     return ConstSpecializationOutcome("failed", None, issues)

--- a/verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_warning/baselines/check-compact.stderr.txt
+++ b/verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_warning/baselines/check-compact.stderr.txt
@@ -1,2 +1,2 @@
 0 errors, 1 warning, 0 notes
-W SIFR-META-0002 verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_warning/main.sifr:4:2 package fixture.meta specialization warning: shape_derived
+W SIFR-META-0002 verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_warning/main.sifr:5:30 package fixture.meta specialization warning: shape_derived

--- a/verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_warning/fixture/meta.sifr
+++ b/verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_warning/fixture/meta.sifr
@@ -1,20 +1,43 @@
-from sifr.meta import ConstPackageIssue, ConstSpecializationOutcome
+from sifr.meta import ClassDeclaration, ConstIssueLabel, ConstPackageIssue, ConstSpecializationOutcome, SourceOrigin
 
 
 class ShapeArguments:
     identity: str
 
 
+class ShapeInput:
+    canonical_identity: str
+    declaration: ClassDeclaration
+
+
 @const_eval
 @metadata("sifr.meta.issue_template", ("shape_derived", ["identity"]))
-def describe(shape: dict[str, str]) -> ConstSpecializationOutcome[str, ShapeArguments]:
-    identity: str | None = shape["canonical_identity"]
-    if identity is not None:
-        arguments: ShapeArguments = ShapeArguments("concrete shape")
-        issue: ConstPackageIssue[ShapeArguments] = ConstPackageIssue(
-            "fixture.meta", "shape_derived", "warning", arguments, ["shape retained"]
-        )
-        issues: list[ConstPackageIssue[ShapeArguments]] = [issue]
-        return ConstSpecializationOutcome("produced", identity, issues)
-    issues: list[ConstPackageIssue[ShapeArguments]] = []
-    return ConstSpecializationOutcome("failed", None, issues)
+def describe(shape: ShapeInput) -> ConstSpecializationOutcome[str, ShapeArguments]:
+    primary_origin: SourceOrigin | None = None
+    for decorator in shape.declaration.decorators:
+        if decorator.name == "metadata":
+            primary_origin = decorator.argument_origins[1]
+    if primary_origin is None:
+        issues: list[ConstPackageIssue[ShapeArguments]] = []
+        return ConstSpecializationOutcome("failed", None, issues)
+
+    arguments: ShapeArguments = ShapeArguments("concrete shape")
+    labels: list[ConstIssueLabel] = [
+        ConstIssueLabel(shape.declaration.origin, "adapted class declared here")
+    ]
+    for item in shape.declaration.items:
+        if item.kind == "field":
+            labels.append(ConstIssueLabel(item.origin, "field declared here"))
+        if item.kind == "method":
+            labels.append(ConstIssueLabel(item.origin, "method declared here"))
+    issue: ConstPackageIssue[ShapeArguments] = ConstPackageIssue(
+        "fixture.meta",
+        "shape_derived",
+        "warning",
+        arguments,
+        primary_origin,
+        labels,
+        ["shape retained"],
+    )
+    issues: list[ConstPackageIssue[ShapeArguments]] = [issue]
+    return ConstSpecializationOutcome("produced", shape.canonical_identity, issues)

--- a/verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_warning/main.sifr
+++ b/verification/areas/diagnostics/fixtures/diagnostics/meta_specialization_warning/main.sifr
@@ -2,5 +2,9 @@ from fixture.meta import describe
 
 
 @const_specialize("fixture.meta", "describe")
+@metadata("fixture.adapter", "rejected")
 class Model:
     value: int
+
+    def normalize(self, value: int) -> int:
+        return value


### PR DESCRIPTION
Implements M1 of the static class-adapter phase.

- captures pre-finalization class declarations and opaque source origins
- lets package issues select primary and related declaration locations
- excludes locations from static identities and rejects forged origins
- preserves related information through CLI/frontend/LSP diagnostics
- adds a non-Pydantic argument-level conformance fixture

Validation before review:
- cargo check -p sifr_frontend -p sifr_lsp
- cargo test -p sifr_frontend specialization_runner::tests
- cargo test -p sifr_lsp conversion::tests
- cargo clippy -p sifr_frontend -p sifr_lsp -- -D warnings
- cargo fmt --check
- HIR maintainability and file-size guardrails

The full diagnostics baseline suite was attempted but is externally obstructed by the absent algorithmic-compatibility LeetCode corpus; focused M1 fixtures were reproduced directly and their expected baselines updated.