### PR TITLE
M4: normalize adapter defaults, inheritance, and identity

### DIFF
--- a/crates/sifr_driver/src/tests/adapter_defaults.rs
+++ b/crates/sifr_driver/src/tests/adapter_defaults.rs
@@ -120,8 +120,8 @@ class Model(Contract):
 
 #[test]
 fn adapter_identities_ignore_source_movement_and_distinguish_default_states() {
-    fn identities(source: &str) -> ([u8; 32], [u8; 32]) {
-        let compiled = compile(source);
+    fn identities(source: &str, contract: &str) -> ([u8; 32], [u8; 32]) {
+        let compiled = compile_with_contract(source, contract);
         let selection = compiled
             .external_defs
             .class_adapter_selections
@@ -134,13 +134,12 @@ fn adapter_identities_ignore_source_movement_and_distinguish_default_states() {
         )
     }
 
-    let constant = identities(
-        r#"
+    let constant_source = r#"
 from fixture.defaults import Contract, contract_field
 class Model(Contract):
     tags: list[str] = contract_field(default=[])
-"#,
-    );
+"#;
+    let constant = identities(constant_source, CONTRACT);
     let moved = identities(
         r#"
 
@@ -150,6 +149,7 @@ from fixture.defaults import Contract, contract_field
 class Model(Contract):
     tags: list[str] = contract_field(default=[])
 "#,
+        CONTRACT,
     );
     let factory = identities(
         r#"
@@ -157,8 +157,13 @@ from fixture.defaults import Contract, contract_field
 class Model(Contract):
     tags: list[str] = contract_field(default_factory=list)
 "#,
+        CONTRACT,
     );
     assert_eq!(constant, moved);
+    assert_eq!(
+        constant,
+        identities(constant_source, &format!("\n\n{CONTRACT}"))
+    );
     assert_ne!(constant, factory);
 }
 
@@ -287,6 +292,30 @@ class Child(Parent):
         error.code == sifr_diagnostics::DiagnosticCode::TYPE_MISMATCH.code()
             && error.message.contains("cannot be re-annotated")
     }));
+}
+
+#[test]
+fn compatible_inherited_reannotation_preserves_local_default_ordering() {
+    let compiled = compile(
+        r#"
+from fixture.defaults import Contract, contract_field
+
+class Parent(Contract):
+    value: int
+
+class Child(Parent):
+    value: int
+    enabled: bool = contract_field(default=True)
+"#,
+    );
+    let defaults = compiled
+        .external_defs
+        .function_defaults
+        .get("main")
+        .and_then(|functions| functions.get("Child"))
+        .expect("compatible override keeps the local default on enabled");
+    assert_eq!(defaults.len(), 1);
+    assert_eq!(defaults[0].0, 1);
 }
 
 #[test]

--- a/crates/sifr_driver/src/tests/adapter_defaults.rs
+++ b/crates/sifr_driver/src/tests/adapter_defaults.rs
@@ -1,0 +1,415 @@
+use super::support::parse_suite;
+use crate::project::ProjectLowering;
+use crate::{collect_project_hir_modules, compile_stdlib};
+use sifr_ir::{AdapterFieldDefault, StaticProgramValue};
+use sifr_type_system::Type;
+use std::collections::HashMap;
+
+const CONTRACT: &str = r#"
+from sifr.meta import CallableIdentity, DeclarationInput, DeclarationPlan, PlannedField, PlannedIssue, PlannedMetadata, StaticValue
+
+class DefaultDescriptor:
+    default_kind: str
+    default_value: StaticValue | None
+    default_factory: CallableIdentity | None
+
+@class_adapter_provider("fixture.defaults", "DefaultDescriptor")
+@const_eval
+def adapt_defaults(declaration: DeclarationInput[DefaultDescriptor]) -> DeclarationPlan[DefaultDescriptor]:
+    fields: list[PlannedField] = []
+    metadata: list[PlannedMetadata[DefaultDescriptor]] = []
+    issues: list[PlannedIssue[DefaultDescriptor]] = []
+    for item in declaration.declaration.items:
+        if item.kind == "field":
+            declared_type: str | None = item.declared_type
+            if declared_type is not None:
+                identity: str = item.identity
+                default_kind: str = item.default_kind
+                default_value: StaticValue | None = item.default_value
+                default_factory: CallableIdentity | None = None
+                for descriptor in declaration.descriptors:
+                    if descriptor.target_identity == identity:
+                        default_kind = descriptor.value.default_kind
+                        default_value = descriptor.value.default_value
+                        default_factory = descriptor.value.default_factory
+                fields.append(PlannedField(identity, declared_type, default_kind, default_value, default_factory, "package"))
+        if item.kind == "method" and item.name == "inherited_method":
+            if item.identity != "main.Parent.inherited_method":
+                raise ValueError("inherited method identity was not preserved")
+    return DeclarationPlan(fields, metadata, None, None, issues)
+
+@class_adapter_marker("fixture.defaults", "adapt_defaults")
+class Contract:
+    pass
+
+@field_descriptor("fixture.defaults", "adapt_defaults")
+def contract_field(
+    default: StaticValue | None = None,
+    default_factory: CallableIdentity | None = None,
+) -> DefaultDescriptor:
+    if default_factory is not None:
+        return DefaultDescriptor("factory", None, default_factory)
+    if default is not None:
+        return DefaultDescriptor("const", default, None)
+    return DefaultDescriptor("required", None, None)
+"#;
+
+fn compile(main: &str) -> ProjectLowering {
+    compile_with_contract(main, CONTRACT)
+}
+
+fn compile_with_contract(main: &str, contract: &str) -> ProjectLowering {
+    let modules = HashMap::from([
+        ("fixture.defaults".to_string(), parse_suite(contract)),
+        ("main".to_string(), parse_suite(main)),
+    ]);
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    collect_project_hir_modules(&modules, stdlib_defs)
+        .expect("adapted defaults project should compile")
+}
+
+#[test]
+fn required_const_and_factory_defaults_finalize_constructor_parameters() {
+    let compiled = compile(
+        r#"
+from fixture.defaults import Contract, contract_field
+
+class Model(Contract):
+    value: int
+    enabled: bool = contract_field(default=True)
+    tags: list[str] = contract_field(default_factory=list)
+    count: int = 3
+"#,
+    );
+    let defaults = compiled
+        .external_defs
+        .function_defaults
+        .get("main")
+        .and_then(|functions| functions.get("Model"))
+        .expect("normalized constructor defaults are exported");
+    assert_eq!(defaults.len(), 3);
+    assert_eq!(defaults[0].0, 1);
+    assert_eq!(defaults[1].0, 2);
+    assert_eq!(defaults[2].0, 3);
+
+    let selection = compiled
+        .external_defs
+        .class_adapter_selections
+        .get("main")
+        .and_then(|classes| classes.get("Model"))
+        .expect("applied field plan is retained");
+    assert!(matches!(
+        selection.field_plans[0].default,
+        AdapterFieldDefault::Required
+    ));
+    assert!(matches!(
+        selection.field_plans[1].default,
+        AdapterFieldDefault::Const(StaticProgramValue::Bool(true))
+    ));
+    assert!(matches!(
+        selection.field_plans[2].default,
+        AdapterFieldDefault::Factory(_)
+    ));
+    assert!(matches!(
+        selection.field_plans[3].default,
+        AdapterFieldDefault::Const(StaticProgramValue::Integer(ref value)) if value == "3"
+    ));
+    assert_ne!(selection.adapter_invocation_identity, [0; 32]);
+    assert_ne!(selection.post_adapter_identity, [0; 32]);
+}
+
+#[test]
+fn adapter_identities_ignore_source_movement_and_distinguish_default_states() {
+    fn identities(source: &str) -> ([u8; 32], [u8; 32]) {
+        let compiled = compile(source);
+        let selection = compiled
+            .external_defs
+            .class_adapter_selections
+            .get("main")
+            .and_then(|classes| classes.get("Model"))
+            .expect("adapter identity is exported");
+        (
+            selection.adapter_invocation_identity,
+            selection.post_adapter_identity,
+        )
+    }
+
+    let constant = identities(
+        r#"
+from fixture.defaults import Contract, contract_field
+class Model(Contract):
+    tags: list[str] = contract_field(default=[])
+"#,
+    );
+    let moved = identities(
+        r#"
+
+
+from fixture.defaults import Contract, contract_field
+
+class Model(Contract):
+    tags: list[str] = contract_field(default=[])
+"#,
+    );
+    let factory = identities(
+        r#"
+from fixture.defaults import Contract, contract_field
+class Model(Contract):
+    tags: list[str] = contract_field(default_factory=list)
+"#,
+    );
+    assert_eq!(constant, moved);
+    assert_ne!(constant, factory);
+}
+
+#[test]
+fn relevant_adapter_edits_invalidate_invocation_and_post_adapter_identity() {
+    let source = r#"
+from fixture.defaults import Contract
+class Model(Contract):
+    value: int
+"#;
+    let base = compile_with_contract(source, CONTRACT);
+    let changed_contract = CONTRACT.replace(
+        "fields.append(PlannedField(identity, declared_type, default_kind, default_value, default_factory, \"package\"))",
+        "fields.append(PlannedField(identity, declared_type, default_kind, default_value, default_factory, \"changed\"))",
+    );
+    let changed = compile_with_contract(source, &changed_contract);
+    let identities = |compiled: &ProjectLowering| {
+        let selection = compiled
+            .external_defs
+            .class_adapter_selections
+            .get("main")
+            .and_then(|classes| classes.get("Model"))
+            .expect("adapter identity exists");
+        (
+            selection.adapter_invocation_identity,
+            selection.post_adapter_identity,
+        )
+    };
+    assert_ne!(identities(&base), identities(&changed));
+}
+
+#[test]
+fn inherited_fields_keep_parent_identity_and_concrete_generic_types() {
+    let compiled = compile(
+        r#"
+from fixture.defaults import Contract
+
+class Parent[T](Contract):
+    inherited: T
+
+    def inherited_method(self, value: T) -> T:
+        return value
+
+class Child(Parent[int]):
+    local: str
+"#,
+    );
+    let selection = compiled
+        .external_defs
+        .class_adapter_selections
+        .get("main")
+        .and_then(|classes| classes.get("Child"))
+        .expect("generic adapted child is selected");
+    assert_eq!(selection.data_parent.as_deref(), Some("Parent"));
+    assert_eq!(selection.provider_module, "fixture.defaults");
+    assert_eq!(selection.field_plans.len(), 2);
+    assert_eq!(selection.field_plans[0].identity, "main.Parent.inherited");
+    assert_eq!(selection.field_plans[0].declared_type, Type::Int);
+    assert_eq!(selection.field_plans[1].identity, "main.Child.local");
+}
+
+#[test]
+fn imported_concrete_generic_parent_keeps_provider_and_field_identity() {
+    let modules = HashMap::from([
+        ("fixture.defaults".to_string(), parse_suite(CONTRACT)),
+        (
+            "base".to_string(),
+            parse_suite(
+                r#"
+from fixture.defaults import Contract
+class Parent[T](Contract):
+    inherited: T
+"#,
+            ),
+        ),
+        (
+            "main".to_string(),
+            parse_suite(
+                r#"
+from base import Parent
+class Child(Parent[int]):
+    local: str
+"#,
+            ),
+        ),
+    ]);
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let compiled = collect_project_hir_modules(&modules, stdlib_defs)
+        .expect("imported generic adapted parent should compile");
+    let selection = compiled
+        .external_defs
+        .class_adapter_selections
+        .get("main")
+        .and_then(|classes| classes.get("Child"))
+        .expect("imported adapted child is selected");
+    assert_eq!(selection.provider_module, "fixture.defaults");
+    assert_eq!(selection.field_plans[0].identity, "base.Parent.inherited");
+    assert_eq!(selection.field_plans[0].declared_type, Type::Int);
+}
+
+#[test]
+fn incompatible_inherited_field_reannotation_is_rejected() {
+    let modules = HashMap::from([
+        ("fixture.defaults".to_string(), parse_suite(CONTRACT)),
+        (
+            "main".to_string(),
+            parse_suite(
+                r#"
+from fixture.defaults import Contract
+
+class Parent(Contract):
+    value: int
+
+class Child(Parent):
+    value: str
+"#,
+            ),
+        ),
+    ]);
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let errors = match collect_project_hir_modules(&modules, stdlib_defs) {
+        Ok(_) => panic!("an incompatible inherited field override must fail"),
+        Err(errors) => errors,
+    };
+    assert!(errors.iter().any(|error| {
+        error.code == sifr_diagnostics::DiagnosticCode::TYPE_MISMATCH.code()
+            && error.message.contains("cannot be re-annotated")
+    }));
+}
+
+#[test]
+fn reexported_default_descriptors_finalize_constructor_parameters() {
+    let modules = HashMap::from([
+        (
+            "fixture.contract_types".to_string(),
+            parse_suite(include_str!(
+                "../../../../verification/areas/core_language/fixtures/static_class_adapter/fixture/contract_types.sifr"
+            )),
+        ),
+        (
+            "fixture.contract".to_string(),
+            parse_suite(include_str!(
+                "../../../../verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr"
+            )),
+        ),
+        (
+            "fixture.facade".to_string(),
+            parse_suite(include_str!(
+                "../../../../verification/areas/core_language/fixtures/static_class_adapter/fixture/facade.sifr"
+            )),
+        ),
+        (
+            "main".to_string(),
+            parse_suite(
+                r#"
+from fixture.facade import Contract, contract_config, contract_field
+class Model(Contract):
+    _config = contract_config(True)
+    value: int
+    enabled: bool = contract_field(default=True)
+    tags: list[str] = contract_field(default_factory=list)
+"#,
+            ),
+        ),
+    ]);
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let compiled = collect_project_hir_modules(&modules, stdlib_defs)
+        .expect("reexported default descriptors should compile");
+    let defaults = compiled
+        .external_defs
+        .function_defaults
+        .get("main")
+        .and_then(|functions| functions.get("Model"))
+        .expect("adapted constructor defaults are exported");
+    assert_eq!(
+        defaults.iter().map(|(index, _)| *index).collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+}
+
+#[test]
+fn checked_default_factories_support_functions_static_methods_and_constructors() {
+    let compiled = compile(
+        r#"
+from fixture.defaults import Contract, contract_field
+
+def make_tags() -> list[str]:
+    return []
+
+class Factory:
+    @staticmethod
+    def make_tags() -> list[str]:
+        return []
+
+class Token:
+    pass
+
+class Model(Contract):
+    first: list[str] = contract_field(default_factory=make_tags)
+    second: list[str] = contract_field(default_factory=Factory.make_tags)
+    token: Token = contract_field(default_factory=Token)
+"#,
+    );
+    let fields = &compiled
+        .external_defs
+        .class_adapter_selections
+        .get("main")
+        .and_then(|classes| classes.get("Model"))
+        .expect("factory plans are retained")
+        .field_plans;
+    assert!(fields
+        .iter()
+        .all(|field| matches!(field.default, AdapterFieldDefault::Factory(_))));
+}
+
+#[test]
+fn invalid_constant_and_factory_defaults_are_rejected_by_the_adapter_boundary() {
+    for (declaration, expected) in [
+        (
+            "value: int = contract_field(default=\"bad\")",
+            "constant default",
+        ),
+        (
+            "value: int = contract_field(default_factory=needs_arg)",
+            "must accept no arguments",
+        ),
+        (
+            "value: int = contract_field(default_factory=wrong_result)",
+            "does not return its declared type",
+        ),
+    ] {
+        let source = format!(
+            r#"
+from fixture.defaults import Contract, contract_field
+def needs_arg(value: int) -> int:
+    return value
+def wrong_result() -> str:
+    return "bad"
+class Invalid(Contract):
+    {declaration}
+"#
+        );
+        let modules = HashMap::from([
+            ("fixture.defaults".to_string(), parse_suite(CONTRACT)),
+            ("main".to_string(), parse_suite(&source)),
+        ]);
+        let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+        let errors = match collect_project_hir_modules(&modules, stdlib_defs) {
+            Ok(_) => panic!("invalid adapter default should fail"),
+            Err(errors) => errors,
+        };
+        assert!(errors.iter().any(|error| error.message.contains(expected)));
+    }
+}

--- a/crates/sifr_driver/src/tests/early_adapters.rs
+++ b/crates/sifr_driver/src/tests/early_adapters.rs
@@ -26,7 +26,7 @@ def adapt_contract(declaration: DeclarationInput[ContractDescriptor]) -> Declara
         if item.kind == "field":
             declared_type: str | None = item.declared_type
             if declared_type is not None:
-                fields.append(PlannedField(declaration.declaration.identity + "." + item.name, declared_type))
+                fields.append(PlannedField(item.identity, declared_type))
         if item.kind == "method" and item.name == "parse":
             signature: str | None = item.signature
             if signature is None:
@@ -228,7 +228,7 @@ class Invalid(Contract):
 
 #[test]
 fn adapter_plan_cannot_remove_or_retype_fields() {
-    let field_append = "fields.append(PlannedField(declaration.declaration.identity + \".\" + item.name, declared_type))";
+    let field_append = "fields.append(PlannedField(item.identity, declared_type))";
     for contract in [
         CONTRACT.replace(
             field_append,
@@ -437,4 +437,85 @@ class Invalid(Contract):
         error.code == sifr_diagnostics::DiagnosticCode::META_MALFORMED_DECLARATION.code()
             && error.message.contains("at most 32 issues")
     }));
+}
+
+#[test]
+fn marker_is_rejected_in_annotation_position() {
+    let modules = project(
+        r#"
+from fixture.contract import Contract
+
+class Invalid:
+    value: Contract
+"#,
+        CONTRACT,
+    );
+    let errors = compile_errors(&modules, "marker annotations must fail locally");
+    assert!(errors.iter().any(|error| {
+        error.code == sifr_diagnostics::DiagnosticCode::META_MALFORMED_DECLARATION.code()
+            && error.message.contains("base-only declarations")
+    }));
+}
+
+#[test]
+fn private_markers_are_not_exported() {
+    let contract = CONTRACT.replace("class Contract:", "class _Contract:");
+    let modules = project(
+        r#"
+from fixture.contract import _Contract
+
+class Invalid(_Contract):
+    value: int
+"#,
+        &contract,
+    );
+    let errors = compile_errors(&modules, "private markers must not cross module exports");
+    assert!(
+        errors.iter().any(|error| {
+            error.message.contains("_Contract")
+                && (error.message.contains("cannot import private")
+                    || error.message.contains("unknown type"))
+        }),
+        "{errors:#?}"
+    );
+}
+
+#[test]
+fn adapter_edits_but_not_consumer_source_movement_invalidate_program_identity() {
+    fn identities(main: &str, contract: &str) -> ([u8; 32], [u8; 32]) {
+        let modules = project(main, contract);
+        let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+        let compiled = collect_project_hir_modules(&modules, stdlib_defs)
+            .expect("adapter identity project should compile");
+        let invocation = compiled
+            .external_defs
+            .class_adapter_selections
+            .get("main")
+            .and_then(|classes| classes.get("Model"))
+            .expect("adapter selection exists")
+            .adapter_invocation_identity;
+        let program = compiled
+            .external_defs
+            .specialization_outputs
+            .get("main")
+            .and_then(|outputs| outputs.first())
+            .expect("adapter-requested program exists")
+            .program_identity;
+        (invocation, program)
+    }
+
+    let source = r#"
+from fixture.contract import Contract, contract_config
+class Model(Contract):
+    _config = contract_config(True)
+    value: int
+"#;
+    let moved = format!("\n\n{source}");
+    let edited = CONTRACT.replace(
+        "    fields: list[PlannedField] = []",
+        "    adapter_revision: int = 2\n    fields: list[PlannedField] = []",
+    );
+    let base = identities(source, CONTRACT);
+    assert_eq!(base, identities(&moved, CONTRACT));
+    assert_ne!(base, identities(source, &edited));
 }

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod adapter_defaults;
 mod diagnostics;
 mod discovery_and_workspace;
 mod early_adapters;

--- a/crates/sifr_driver/src/tests/typed_descriptors.rs
+++ b/crates/sifr_driver/src/tests/typed_descriptors.rs
@@ -267,6 +267,40 @@ class Contract:
 }
 
 #[test]
+fn nested_annotated_descriptors_flatten_inner_to_outer_before_rhs() {
+    let modules = descriptor_project(
+        r#"
+from typing import Annotated
+from fixture.contract import bounded, option
+
+class Contract:
+    value: Annotated[Annotated[int, bounded(1)], bounded(2)] | None = option(3, [], None)
+"#,
+    );
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let project = collect_project_hir_modules(&modules, stdlib_defs)
+        .expect("nested Annotated descriptor project should compile");
+    let descriptors = project
+        .external_defs
+        .declaration_descriptors
+        .get("main")
+        .expect("descriptor uses are exported");
+    let limits = descriptors
+        .iter()
+        .map(|descriptor| {
+            let StaticProgramValue::Record(fields) = &descriptor.value else {
+                panic!("descriptor should preserve its record value");
+            };
+            match fields.iter().find(|(name, _)| name == "limit") {
+                Some((_, StaticProgramValue::Integer(value))) => value.clone(),
+                value => panic!("expected integer limit, got {value:?}"),
+            }
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(limits, vec!["1", "2", "3"]);
+}
+
+#[test]
 fn unrelated_same_basename_is_not_a_descriptor() {
     let mut modules = descriptor_project(
         r#"

--- a/crates/sifr_frontend/src/adapter_program_identity.rs
+++ b/crates/sifr_frontend/src/adapter_program_identity.rs
@@ -1,7 +1,379 @@
 //! Cache-key bridge from early class adaptation to static specialization.
 
-use sifr_lowering::LoweringResult;
+use sifr_lowering::{
+    HirAsyncWithKind, HirExpr, HirFunction, HirModule, HirPattern, HirStmt, LoweringResult,
+};
 use std::fmt::Write;
+
+pub(crate) fn canonical_const_functions(module: &HirModule) -> String {
+    let mut canonical = module.clone();
+    for function in &mut canonical.functions {
+        strip_function_locations(function);
+    }
+    format!("{canonical:#?}")
+}
+
+fn strip_function_locations(function: &mut HirFunction) {
+    for parameter in &mut function.params {
+        if let Some(default) = &mut parameter.default {
+            strip_expr_locations(default);
+        }
+    }
+    strip_stmt_locations(&mut function.body);
+    // Interop declarations do not participate in deterministic const evaluation,
+    // and their diagnostic spans are intentionally source-relative.
+    function.rust_interop.clear();
+    function.python_interop.clear();
+}
+
+fn strip_stmt_locations(statements: &mut [HirStmt]) {
+    for statement in statements {
+        match statement {
+            HirStmt::Let { value, .. }
+            | HirStmt::Assign { value, .. }
+            | HirStmt::AugAssign { value, .. }
+            | HirStmt::Raise { value }
+            | HirStmt::Yield { value } => strip_expr_locations(value),
+            HirStmt::Return { value } => {
+                if let Some(value) = value {
+                    strip_expr_locations(value);
+                }
+            }
+            HirStmt::Expr { expr } => strip_expr_locations(expr),
+            HirStmt::If {
+                condition,
+                then_body,
+                elif_clauses,
+                else_body,
+            } => {
+                strip_expr_locations(condition);
+                strip_stmt_locations(then_body);
+                for (condition, body) in elif_clauses {
+                    strip_expr_locations(condition);
+                    strip_stmt_locations(body);
+                }
+                if let Some(body) = else_body {
+                    strip_stmt_locations(body);
+                }
+            }
+            HirStmt::While {
+                condition,
+                body,
+                else_body,
+            } => {
+                strip_expr_locations(condition);
+                strip_stmt_locations(body);
+                if let Some(body) = else_body {
+                    strip_stmt_locations(body);
+                }
+            }
+            HirStmt::For {
+                iter,
+                body,
+                else_body,
+                ..
+            }
+            | HirStmt::AsyncFor {
+                iter,
+                body,
+                else_body,
+                ..
+            } => {
+                strip_expr_locations(iter);
+                strip_stmt_locations(body);
+                if let Some(body) = else_body {
+                    strip_stmt_locations(body);
+                }
+            }
+            HirStmt::TupleUnpack { value, .. } | HirStmt::StarUnpack { value, .. } => {
+                strip_expr_locations(value);
+            }
+            HirStmt::Assert { test, msg } => {
+                strip_expr_locations(test);
+                if let Some(message) = msg {
+                    strip_expr_locations(message);
+                }
+            }
+            HirStmt::TryExcept { body, handlers, .. } => {
+                strip_stmt_locations(body);
+                for handler in handlers {
+                    strip_stmt_locations(&mut handler.body);
+                }
+            }
+            HirStmt::TryFinally { body, finalbody } => {
+                strip_stmt_locations(body);
+                strip_stmt_locations(finalbody);
+            }
+            HirStmt::FieldAssign { value, .. }
+            | HirStmt::NestedFieldAssign { value, .. }
+            | HirStmt::AttributeAugAssign { value, .. } => strip_expr_locations(value),
+            HirStmt::SubscriptAssign { index, value, .. }
+            | HirStmt::SubscriptAugAssign { index, value, .. }
+            | HirStmt::AttributeSubscriptAssign { index, value, .. } => {
+                strip_expr_locations(index);
+                strip_expr_locations(value);
+            }
+            HirStmt::NestedSubscriptAssign {
+                outer_index,
+                inner_index,
+                value,
+                ..
+            }
+            | HirStmt::AttributeNestedSubscriptAssign {
+                outer_index,
+                inner_index,
+                value,
+                ..
+            } => {
+                strip_expr_locations(outer_index);
+                strip_expr_locations(inner_index);
+                strip_expr_locations(value);
+            }
+            HirStmt::Delete { object, index } => {
+                strip_expr_locations(object);
+                strip_expr_locations(index);
+            }
+            HirStmt::With { items, body } => {
+                for item in items {
+                    strip_expr_locations(&mut item.context);
+                }
+                strip_stmt_locations(body);
+            }
+            HirStmt::AsyncWith { kind, body, .. } => {
+                strip_async_with_locations(kind);
+                strip_stmt_locations(body);
+            }
+            HirStmt::NestedFunction { func, .. } => strip_function_locations(func),
+            HirStmt::Match { subject, arms, .. } => {
+                strip_expr_locations(subject);
+                for arm in arms {
+                    strip_pattern_locations(&mut arm.pattern);
+                    if let Some(guard) = &mut arm.guard {
+                        strip_expr_locations(guard);
+                    }
+                    strip_stmt_locations(&mut arm.body);
+                }
+            }
+            HirStmt::Break | HirStmt::Continue | HirStmt::Pass => {}
+        }
+    }
+}
+
+fn strip_expr_locations(expression: &mut HirExpr) {
+    match expression {
+        HirExpr::IntLiteral(_)
+        | HirExpr::LargeIntLiteral(_)
+        | HirExpr::FloatLiteral(_)
+        | HirExpr::StringLiteral(_)
+        | HirExpr::BoolLiteral(_)
+        | HirExpr::NoneLiteral
+        | HirExpr::Name { .. }
+        | HirExpr::EnumVariant { .. } => {}
+        HirExpr::BinOp { left, right, .. } => {
+            strip_expr_locations(left);
+            strip_expr_locations(right);
+        }
+        HirExpr::UnaryOp { operand, .. }
+        | HirExpr::Await { value: operand, .. }
+        | HirExpr::QuestionMark { expr: operand, .. }
+        | HirExpr::OkWrap { value: operand, .. }
+        | HirExpr::ErrWrap { value: operand, .. } => strip_expr_locations(operand),
+        HirExpr::Compare {
+            left, comparators, ..
+        } => {
+            strip_expr_locations(left);
+            strip_expr_list_locations(comparators);
+        }
+        HirExpr::BoolOp { values, .. }
+        | HirExpr::ListLiteral {
+            elements: values, ..
+        }
+        | HirExpr::SetLiteral {
+            elements: values, ..
+        }
+        | HirExpr::TupleLiteral {
+            elements: values, ..
+        } => strip_expr_list_locations(values),
+        HirExpr::Call { args, .. }
+        | HirExpr::IteratorCall { args, .. }
+        | HirExpr::ConstructorCall { args, .. }
+        | HirExpr::SuperCall { args, .. } => strip_expr_list_locations(args),
+        HirExpr::PythonCall {
+            args,
+            record_expansions,
+            ..
+        } => {
+            strip_expr_list_locations(args);
+            for expansion in record_expansions {
+                expansion.span = ruff_text_size::TextRange::default();
+            }
+        }
+        HirExpr::IntrinsicCall {
+            args,
+            call_range,
+            arg_ranges,
+            ..
+        } => {
+            strip_expr_list_locations(args);
+            *call_range = ruff_text_size::TextRange::default();
+            arg_ranges.clear();
+        }
+        HirExpr::IfExpr {
+            condition,
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            strip_expr_locations(condition);
+            strip_expr_locations(then_expr);
+            strip_expr_locations(else_expr);
+        }
+        HirExpr::RangeLiteral {
+            start, end, step, ..
+        } => {
+            strip_expr_locations(start);
+            strip_expr_locations(end);
+            if let Some(step) = step {
+                strip_expr_locations(step);
+            }
+        }
+        HirExpr::DictLiteral { keys, values, .. } => {
+            strip_expr_list_locations(keys);
+            strip_expr_list_locations(values);
+        }
+        HirExpr::Index { object, index, .. }
+        | HirExpr::ContainsOp {
+            element: object,
+            collection: index,
+            ..
+        } => {
+            strip_expr_locations(object);
+            strip_expr_locations(index);
+        }
+        HirExpr::MethodCall {
+            object,
+            args,
+            source,
+            ..
+        } => {
+            strip_expr_locations(object);
+            strip_expr_list_locations(args);
+            *source = None;
+        }
+        HirExpr::FString { parts, .. } => {
+            for part in parts {
+                if let sifr_lowering::HirFStringPart::Expr(expression) = part {
+                    strip_expr_locations(expression);
+                }
+            }
+        }
+        HirExpr::Slice {
+            object,
+            start,
+            stop,
+            step,
+            ..
+        } => {
+            strip_expr_locations(object);
+            for bound in [start, stop, step].into_iter().flatten() {
+                strip_expr_locations(bound);
+            }
+        }
+        HirExpr::WalrusExpr { value, .. } | HirExpr::FieldAccess { object: value, .. } => {
+            strip_expr_locations(value);
+        }
+        HirExpr::Lambda { params, body, .. } => {
+            for parameter in params {
+                if let Some(default) = &mut parameter.default {
+                    strip_expr_locations(default);
+                }
+            }
+            strip_expr_locations(body);
+        }
+        HirExpr::ListComp {
+            expr, generators, ..
+        }
+        | HirExpr::SetComp {
+            expr, generators, ..
+        } => {
+            strip_expr_locations(expr);
+            strip_generator_locations(generators);
+        }
+        HirExpr::DictComp {
+            key_expr,
+            val_expr,
+            generators,
+            ..
+        } => {
+            strip_expr_locations(key_expr);
+            strip_expr_locations(val_expr);
+            strip_generator_locations(generators);
+        }
+        HirExpr::GeneratorExpr {
+            expr, iter, filter, ..
+        } => {
+            strip_expr_locations(expr);
+            strip_expr_locations(iter);
+            if let Some(filter) = filter {
+                strip_expr_locations(filter);
+            }
+        }
+    }
+}
+
+fn strip_expr_list_locations(expressions: &mut [HirExpr]) {
+    for expression in expressions {
+        strip_expr_locations(expression);
+    }
+}
+
+fn strip_generator_locations(generators: &mut [(String, HirExpr, Option<HirExpr>)]) {
+    for (_, iter, filter) in generators {
+        strip_expr_locations(iter);
+        if let Some(filter) = filter {
+            strip_expr_locations(filter);
+        }
+    }
+}
+
+fn strip_async_with_locations(kind: &mut HirAsyncWithKind) {
+    match kind {
+        HirAsyncWithKind::TaskScope => {}
+        HirAsyncWithKind::TaskGroup { context } => {
+            if let Some(context) = context {
+                strip_expr_locations(context);
+            }
+        }
+        HirAsyncWithKind::TaskTimeout { duration } => strip_expr_locations(duration),
+        HirAsyncWithKind::UserDefined { context, .. }
+        | HirAsyncWithKind::Python { context, .. } => strip_expr_locations(context),
+    }
+}
+
+fn strip_pattern_locations(pattern: &mut HirPattern) {
+    match pattern {
+        HirPattern::Literal { value } => strip_expr_locations(value),
+        HirPattern::Or { patterns } => {
+            for pattern in patterns {
+                strip_pattern_locations(pattern);
+            }
+        }
+        HirPattern::Class { fields, .. } => {
+            for (_, pattern) in fields {
+                strip_pattern_locations(pattern);
+            }
+        }
+        HirPattern::Tuple { elements } => {
+            for pattern in elements {
+                strip_pattern_locations(pattern);
+            }
+        }
+        HirPattern::Wildcard
+        | HirPattern::Capture { .. }
+        | HirPattern::None
+        | HirPattern::Value { .. } => {}
+    }
+}
 
 pub(crate) fn post_adapter_hex(result: &LoweringResult, owner: &str) -> String {
     result

--- a/crates/sifr_frontend/src/adapter_program_identity.rs
+++ b/crates/sifr_frontend/src/adapter_program_identity.rs
@@ -1,0 +1,20 @@
+//! Cache-key bridge from early class adaptation to static specialization.
+
+use sifr_lowering::LoweringResult;
+use std::fmt::Write;
+
+pub(crate) fn post_adapter_hex(result: &LoweringResult, owner: &str) -> String {
+    result
+        .class_adapter_selections
+        .iter()
+        .find(|selection| selection.owner == owner)
+        .map_or_else(String::new, |selection| {
+            selection.post_adapter_identity.iter().fold(
+                String::with_capacity(64),
+                |mut encoded, byte| {
+                    let _ = write!(encoded, "{byte:02x}");
+                    encoded
+                },
+            )
+        })
+}

--- a/crates/sifr_frontend/src/callable_identities.rs
+++ b/crates/sifr_frontend/src/callable_identities.rs
@@ -45,6 +45,20 @@ pub(crate) fn resolve(
     }
 }
 
+pub(crate) fn contract_for_identity(
+    module_name: &str,
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    identity: &CallableIdentity,
+) -> Option<FunctionType> {
+    Resolver {
+        module_name,
+        result,
+        external_defs,
+    }
+    .contract(identity)
+}
+
 struct Resolver<'a> {
     module_name: &'a str,
     result: &'a LoweringResult,
@@ -110,7 +124,137 @@ impl Resolver<'_> {
                 }
             }
         }
-        None
+        builtin_factory_type(local).map(|function| CallableIdentity {
+            module: "sifr.builtins".to_string(),
+            owner: None,
+            symbol: local.to_string(),
+            generic_arguments,
+            signature: signature(&function),
+        })
+    }
+
+    fn contract(&self, identity: &CallableIdentity) -> Option<FunctionType> {
+        if identity.module == "sifr.builtins" && identity.owner.is_none() {
+            return builtin_factory_type(&identity.symbol)
+                .filter(|function| signature(function) == identity.signature);
+        }
+        if identity.module == self.module_name {
+            if let Some(owner) = &identity.owner {
+                let owner_name = owner
+                    .rsplit_once('.')
+                    .map_or(owner.as_str(), |(_, name)| name);
+                let class = self
+                    .result
+                    .module
+                    .classes
+                    .iter()
+                    .find(|class| class.name == owner_name)?;
+                let function = if identity.symbol == "__init__" {
+                    let return_type = class_type(self.module_name, class);
+                    class
+                        .methods
+                        .iter()
+                        .find(|method| method.name == "new")
+                        .map_or_else(
+                            || constructor_type(&class.fields, return_type.clone()),
+                            |method| {
+                                let mut function = self.canonical_local_function_type(method);
+                                function.return_type = Box::new(return_type.clone());
+                                function
+                            },
+                        )
+                } else {
+                    let method = class
+                        .methods
+                        .iter()
+                        .find(|method| method.name == identity.symbol)?;
+                    if method.method_kind == MethodKind::Regular {
+                        return None;
+                    }
+                    self.canonical_local_function_type(method)
+                };
+                return (signature(&function) == identity.signature).then_some(function);
+            }
+            let function = self
+                .result
+                .module
+                .functions
+                .iter()
+                .find(|function| function.name == identity.symbol)
+                .map(|function| self.canonical_local_function_type(function))?;
+            return (signature(&function) == identity.signature).then_some(function);
+        }
+        if let Some(owner) = &identity.owner {
+            let owner_name = owner
+                .rsplit_once('.')
+                .map_or(owner.as_str(), |(_, name)| name);
+            if identity.symbol == "__init__" {
+                let ty = self
+                    .external_defs
+                    .classes
+                    .get(&identity.module)?
+                    .get(owner_name)?;
+                let Type::Class { fields, .. } = ty.resolve_alias() else {
+                    return None;
+                };
+                let function = self
+                    .external_defs
+                    .structural_methods_for(&identity.module)
+                    .and_then(|classes| classes.get(owner_name))
+                    .and_then(|methods| methods.iter().find(|method| method.name == "__init__"))
+                    .map_or_else(
+                        || constructor_type(fields, ty.clone()),
+                        |method| FunctionType {
+                            receiver: method.receiver,
+                            params: method
+                                .params
+                                .iter()
+                                .map(|parameter| {
+                                    (
+                                        parameter.name.clone(),
+                                        parameter.ty.clone(),
+                                        parameter.convention,
+                                    )
+                                })
+                                .collect(),
+                            return_type: Box::new(ty.clone()),
+                        },
+                    );
+                return (signature(&function) == identity.signature).then_some(function);
+            }
+            let method = self
+                .external_defs
+                .structural_methods_for(&identity.module)?
+                .get(owner_name)?
+                .iter()
+                .find(|method| method.name == identity.symbol)?;
+            if method.method_kind == MethodKind::Regular {
+                return None;
+            }
+            let function = FunctionType {
+                receiver: method.receiver,
+                params: method
+                    .params
+                    .iter()
+                    .map(|parameter| {
+                        (
+                            parameter.name.clone(),
+                            parameter.ty.clone(),
+                            parameter.convention,
+                        )
+                    })
+                    .collect(),
+                return_type: Box::new(method.return_type.clone()),
+            };
+            return (signature(&function) == identity.signature).then_some(function);
+        }
+        let function = self
+            .external_defs
+            .functions
+            .get(&identity.module)?
+            .get(&identity.symbol)?
+            .clone();
+        (signature(&function) == identity.signature).then_some(function)
     }
 
     fn method(&self, owner: &str, method_name: &str) -> Option<CallableIdentity> {
@@ -365,6 +509,21 @@ fn constructor_type(fields: &[(String, Type)], return_type: Type) -> FunctionTyp
             .collect(),
         return_type: Box::new(return_type),
     }
+}
+
+fn builtin_factory_type(name: &str) -> Option<FunctionType> {
+    let return_type = match name {
+        "list" => Type::List(Box::new(Type::Any)),
+        "set" => Type::Set(Box::new(Type::Any)),
+        "dict" => Type::Dict(Box::new(Type::Any), Box::new(Type::Any)),
+        "str" => Type::Str,
+        "bytes" => Type::Bytes,
+        "int" => Type::Int,
+        "float" => Type::Float,
+        "bool" => Type::Bool,
+        _ => return None,
+    };
+    Some(FunctionType::new(Vec::new(), return_type))
 }
 
 fn function_type(function: &HirFunction) -> FunctionType {

--- a/crates/sifr_frontend/src/class_declarations.rs
+++ b/crates/sifr_frontend/src/class_declarations.rs
@@ -158,39 +158,35 @@ impl ClassDeclaration {
             .map(|entry| entry.id)
     }
 
-    #[must_use]
-    pub(crate) fn field_contracts(&self, lowering: &LoweringResult) -> Vec<(String, String)> {
-        lowering
-            .module
-            .classes
-            .iter()
-            .find(|class| class.name == self.name)
-            .into_iter()
-            .flat_map(|class| &class.fields)
-            .map(|(name, ty)| {
-                (
-                    format!("{}.{}.{name}", self.module, self.name),
-                    crate::canonical_types::type_identity(ty),
-                )
-            })
-            .collect()
-    }
-
     fn item_const_value(
         &self,
         order: usize,
         item: &ClassDeclarationItem,
         lowering: &LoweringResult,
     ) -> ConstValue {
+        let item_name = match item {
+            ClassDeclarationItem::Field { name, .. }
+            | ClassDeclarationItem::ClassItem { name, .. }
+            | ClassDeclarationItem::Method { name, .. } => name,
+        };
         let mut record = BTreeMap::from([
             (
                 "order".to_string(),
                 ConstValue::Integer(num_bigint::BigInt::from(order)),
             ),
+            (
+                "identity".to_string(),
+                ConstValue::String(format!("{}.{}.{}", self.module, self.name, item_name)),
+            ),
             ("annotation_origin".to_string(), ConstValue::None),
             ("value_origin".to_string(), ConstValue::None),
             ("return_origin".to_string(), ConstValue::None),
             ("declared_type".to_string(), ConstValue::None),
+            (
+                "default_kind".to_string(),
+                ConstValue::String("required".to_string()),
+            ),
+            ("default_value".to_string(), ConstValue::None),
             ("signature".to_string(), ConstValue::None),
             (
                 "value_argument_origins".to_string(),
@@ -239,6 +235,30 @@ impl ClassDeclaration {
                             "declared_type".to_string(),
                             ConstValue::String(crate::canonical_types::type_identity(ty)),
                         );
+                    }
+                    if let Some(index) = class
+                        .fields
+                        .iter()
+                        .enumerate()
+                        .rev()
+                        .find_map(|(index, (field, _))| (field == name).then_some(index))
+                    {
+                        if let Some(value) = lowering
+                            .class_field_defaults
+                            .get(&self.name)
+                            .into_iter()
+                            .flatten()
+                            .find(|(field, _)| *field == index)
+                            .and_then(|(_, value)| {
+                                crate::structural_shape::const_value_from_hir(value)
+                            })
+                        {
+                            record.insert(
+                                "default_kind".to_string(),
+                                ConstValue::String("const".to_string()),
+                            );
+                            record.insert("default_value".to_string(), value);
+                        }
                     }
                 }
             }

--- a/crates/sifr_frontend/src/class_declarations.rs
+++ b/crates/sifr_frontend/src/class_declarations.rs
@@ -230,19 +230,33 @@ impl ClassDeclaration {
                     .iter()
                     .find(|class| class.name == self.name)
                 {
-                    if let Some((_, ty)) = class.fields.iter().find(|(field, _)| field == name) {
+                    let parent_fields =
+                        class.parent_type.as_ref().and_then(|parent| match parent {
+                            sifr_type_system::Type::Class { fields, .. } => Some(fields.as_slice()),
+                            _ => None,
+                        });
+                    let parent_field = parent_fields.and_then(|fields| {
+                        fields
+                            .iter()
+                            .enumerate()
+                            .find(|(_, (field, _))| field == name)
+                    });
+                    let own_field = class
+                        .fields
+                        .iter()
+                        .enumerate()
+                        .find(|(_, (field, _))| field == name);
+                    if let Some((_, (_, ty))) = parent_field.or(own_field) {
                         record.insert(
                             "declared_type".to_string(),
                             ConstValue::String(crate::canonical_types::type_identity(ty)),
                         );
                     }
-                    if let Some(index) = class
-                        .fields
-                        .iter()
-                        .enumerate()
-                        .rev()
-                        .find_map(|(index, (field, _))| (field == name).then_some(index))
-                    {
+                    let parent_field_count = parent_fields.map_or(0, <[_]>::len);
+                    let field_index = parent_field
+                        .map(|(index, _)| index)
+                        .or_else(|| own_field.map(|(index, _)| parent_field_count + index));
+                    if let Some(index) = field_index {
                         if let Some(value) = lowering
                             .class_field_defaults
                             .get(&self.name)

--- a/crates/sifr_frontend/src/descriptor_exports.rs
+++ b/crates/sifr_frontend/src/descriptor_exports.rs
@@ -23,19 +23,25 @@ pub(crate) fn add_aliases(
     local_classes: &HashMap<String, String>,
     exports: &mut HashMap<String, Type>,
 ) {
-    exports.extend(lowering.class_adapter_markers.iter().map(|marker| {
-        (
-            marker.symbol.clone(),
-            Type::Class {
-                identity: Some(format!("{}.{}", marker.module, marker.symbol)),
-                type_args: Vec::new(),
-                name: marker.symbol.clone(),
-                fields: Vec::new(),
-                methods: Vec::new(),
-                parent_class: None,
-            },
-        )
-    }));
+    exports.extend(
+        lowering
+            .class_adapter_markers
+            .iter()
+            .filter(|marker| !marker.symbol.starts_with('_'))
+            .map(|marker| {
+                (
+                    marker.symbol.clone(),
+                    Type::Class {
+                        identity: Some(format!("{}.{}", marker.module, marker.symbol)),
+                        type_args: Vec::new(),
+                        name: marker.symbol.clone(),
+                        fields: Vec::new(),
+                        methods: Vec::new(),
+                        parent_class: None,
+                    },
+                )
+            }),
+    );
     exports.extend(
         lowering
             .type_aliases

--- a/crates/sifr_frontend/src/early_adapters.rs
+++ b/crates/sifr_frontend/src/early_adapters.rs
@@ -110,7 +110,7 @@ fn run_one(
         return;
     };
     let canonical_input = crate::const_canonical::canonical_value(&input);
-    let canonical_provider = format!("{functions:#?}");
+    let canonical_provider = crate::adapter_program_identity::canonical_const_functions(&functions);
     let invocation_identity = sifr_structural_identity::static_program_identity(
         sifr_structural_identity::ALGORITHM_VERSION,
         [
@@ -713,6 +713,15 @@ fn normalized_field_types(
                     .iter()
                     .find(|(field, _)| field == &name)
                     .map(|(_, ty)| ty.clone())
+                    .or_else(|| {
+                        class.parent_type.as_ref().and_then(|parent| match parent {
+                            Type::Class { fields, .. } => fields
+                                .iter()
+                                .find(|(field, _)| field == &name)
+                                .map(|(_, ty)| ty.clone()),
+                            _ => None,
+                        })
+                    })
             } else {
                 parent
                     .into_iter()
@@ -767,7 +776,16 @@ fn expected_field_contracts(
                     (Some(ConstValue::String(identity)), Some(ConstValue::String(ty))) => {
                         Ok((identity.clone(), ty.clone()))
                     }
-                    _ => Err("declared field identity or type is unavailable".to_string()),
+                    _ => Err(format!(
+                        "declared field identity or type is unavailable for '{}'",
+                        fields
+                            .get("name")
+                            .and_then(|name| match name {
+                                ConstValue::String(name) => Some(name.as_str()),
+                                _ => None,
+                            })
+                            .unwrap_or("<unknown>")
+                    )),
                 },
             )
         })

--- a/crates/sifr_frontend/src/early_adapters.rs
+++ b/crates/sifr_frontend/src/early_adapters.rs
@@ -1,5 +1,7 @@
 //! Erased marker selection and bounded early class-adapter execution.
 
+mod inheritance;
+
 use crate::package_issues::{
     evaluation_error, issue_templates, replace_unknown_package, SpecializationDiagnostic,
     SpecializationDiagnostics,
@@ -10,11 +12,12 @@ use crate::{
     ConstValue, DeterministicConstEvaluator,
 };
 use sifr_lowering::{
-    AppliedAdapterMetadata, ClassAdapterSelection, ConstSpecializationRequest,
-    DeclarationDescriptorKind, DeclarationMetadataTargetKind, LoweringWarningDiagnostic,
-    TypedDeclarationDescriptor,
+    AdapterFieldDefault, AdapterFieldPlan, AppliedAdapterMetadata, ClassAdapterSelection,
+    ConstSpecializationRequest, DeclarationDescriptorKind, DeclarationMetadataTargetKind,
+    LoweringWarningDiagnostic, TypedDeclarationDescriptor,
 };
 use sifr_lowering::{ExternalDefs, HirModule, LoweringResult};
+use sifr_type_system::Type;
 use std::collections::{BTreeMap, HashMap};
 
 const MAX_PLAN_METADATA: usize = 1024;
@@ -78,7 +81,14 @@ fn run_one(
         ));
         return;
     }
-    let input = match adapter_input(module_name, result, declaration, selection, &descriptors) {
+    let input = match adapter_input(
+        module_name,
+        result,
+        external_defs,
+        declaration,
+        selection,
+        &descriptors,
+    ) {
         Ok(input) => input,
         Err(problem) => {
             diagnostics.push(malformed(
@@ -99,6 +109,18 @@ fn run_one(
         ));
         return;
     };
+    let canonical_input = crate::const_canonical::canonical_value(&input);
+    let canonical_provider = format!("{functions:#?}");
+    let invocation_identity = sifr_structural_identity::static_program_identity(
+        sifr_structural_identity::ALGORITHM_VERSION,
+        [
+            ("contract", b"class-adapter-invocation-v1".as_slice()),
+            ("provider_module", selection.provider_module.as_bytes()),
+            ("provider_function", selection.provider_function.as_bytes()),
+            ("provider_hir", canonical_provider.as_bytes()),
+            ("input", canonical_input.as_bytes()),
+        ],
+    );
     let evaluated = DeterministicConstEvaluator::new(&functions)
         .evaluate_function(&selection.provider_function, vec![input]);
     let plan = match evaluated {
@@ -112,6 +134,15 @@ fn run_one(
             return;
         }
     };
+    let canonical_output = crate::const_canonical::canonical_value(&plan);
+    let post_adapter_identity = sifr_structural_identity::static_program_identity(
+        sifr_structural_identity::ALGORITHM_VERSION,
+        [
+            ("contract", b"class-adapter-post-v1".as_slice()),
+            ("invocation", invocation_identity.as_bytes().as_slice()),
+            ("output", canonical_output.as_bytes()),
+        ],
+    );
     let (plan, issues) =
         match validate_issues(plan, declaration, external_defs, selection, diagnostics) {
             Some(plan) => plan,
@@ -134,8 +165,21 @@ fn run_one(
                 });
         }
     }
-    match validate_plan(module_name, result, declaration, selection, plan) {
-        Ok(validated) => apply_plan(result, selection, validated),
+    match validate_plan(
+        module_name,
+        result,
+        external_defs,
+        declaration,
+        selection,
+        plan,
+    ) {
+        Ok(validated) => apply_plan(
+            result,
+            selection,
+            validated,
+            *invocation_identity.as_bytes(),
+            *post_adapter_identity.as_bytes(),
+        ),
         Err(problem) => diagnostics.push(malformed(
             &selection.provider_module,
             "adapter_plan",
@@ -148,6 +192,7 @@ fn run_one(
 fn adapter_input(
     module_name: &str,
     result: &LoweringResult,
+    external_defs: &ExternalDefs,
     declaration: &crate::class_declarations::ClassDeclaration,
     selection: &ClassAdapterSelection,
     descriptors: &[&TypedDeclarationDescriptor],
@@ -186,11 +231,10 @@ fn adapter_input(
         .map_or(ConstValue::None, |parent| {
             ConstValue::String(crate::canonical_types::type_identity(parent))
         });
+    let declaration =
+        inheritance::declaration_value(module_name, result, external_defs, declaration, selection)?;
     Ok(ConstValue::Record(BTreeMap::from([
-        (
-            "declaration".to_string(),
-            declaration.to_const_value(result),
-        ),
+        ("declaration".to_string(), declaration),
         ("descriptors".to_string(), ConstValue::List(descriptors)),
         (
             "provider_module".to_string(),
@@ -262,7 +306,7 @@ fn validate_issues(
         diagnostics.push(malformed(
             &selection.provider_module,
             "adapter_plan",
-            "adapter plan must contain exactly fields, metadata, specialization_module, specialization_function, and issues",
+            "adapter plan must contain exactly these fields: fields, metadata, specialization_module, specialization_function, and issues",
             selection.range,
         ));
         return None;
@@ -335,6 +379,7 @@ fn validate_issues(
 }
 
 struct ValidatedPlan {
+    fields: Vec<AdapterFieldPlan>,
     metadata: Vec<AppliedAdapterMetadata>,
     specialization: Option<(String, String)>,
 }
@@ -342,6 +387,7 @@ struct ValidatedPlan {
 fn validate_plan(
     module_name: &str,
     result: &LoweringResult,
+    external_defs: &ExternalDefs,
     declaration: &crate::class_declarations::ClassDeclaration,
     selection: &ClassAdapterSelection,
     value: ConstValue,
@@ -353,7 +399,14 @@ fn validate_plan(
         return Err("adapter plan contains unknown output fields".to_string());
     }
     let planned_fields = take_list(&mut fields, "fields")?;
-    validate_fields(declaration, result, planned_fields)?;
+    let planned_fields = validate_fields(
+        module_name,
+        selection,
+        declaration,
+        result,
+        external_defs,
+        planned_fields,
+    )?;
     let metadata = take_list(&mut fields, "metadata")?;
     if metadata.len() > MAX_PLAN_METADATA {
         return Err(format!(
@@ -362,7 +415,16 @@ fn validate_plan(
     }
     let metadata = metadata
         .into_iter()
-        .map(|value| parse_metadata(module_name, declaration, result, selection, value))
+        .map(|value| {
+            parse_metadata(
+                module_name,
+                declaration,
+                result,
+                external_defs,
+                selection,
+                value,
+            )
+        })
         .collect::<Result<Vec<_>, _>>()?;
     let module = take_optional_string(&mut fields, "specialization_module")?;
     let function = take_optional_string(&mut fields, "specialization_function")?;
@@ -388,46 +450,151 @@ fn validate_plan(
         return Err("an adapted class may request exactly one specialization".to_string());
     }
     Ok(ValidatedPlan {
+        fields: planned_fields,
         metadata,
         specialization,
     })
 }
 
 fn validate_fields(
+    module_name: &str,
+    selection: &ClassAdapterSelection,
     declaration: &crate::class_declarations::ClassDeclaration,
     result: &LoweringResult,
+    external_defs: &ExternalDefs,
     values: Vec<ConstValue>,
-) -> Result<(), String> {
+) -> Result<Vec<AdapterFieldPlan>, String> {
     let actual = values
         .into_iter()
         .map(|value| {
             let ConstValue::Record(mut fields) = value else {
                 return Err("planned field must be a record".to_string());
             };
-            if fields.len() != 2 {
-                return Err(
-                    "planned field must contain exactly identity and declared_type".to_string(),
-                );
+            if fields.len() != 6 {
+                return Err("planned field must contain exactly identity, declared_type, default_kind, default_value, default_factory, and validation_policy".to_string());
             }
             let identity = take_string(&mut fields, "identity")?;
             let declared_type = take_string(&mut fields, "declared_type")?;
-            Ok((identity, declared_type))
+            let default_kind = take_string(&mut fields, "default_kind")?;
+            let default_value = fields
+                .remove("default_value")
+                .ok_or_else(|| "planned field is missing default_value".to_string())?;
+            let default_factory = fields
+                .remove("default_factory")
+                .ok_or_else(|| "planned field is missing default_factory".to_string())?;
+            let validation_policy = fields
+                .remove("validation_policy")
+                .ok_or_else(|| "planned field is missing validation_policy".to_string())?;
+            Ok((
+                identity,
+                declared_type,
+                default_kind,
+                default_value,
+                default_factory,
+                validation_policy,
+            ))
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let expected = declaration.field_contracts(result);
-    if actual != expected {
+    let expected =
+        expected_field_contracts(module_name, result, external_defs, declaration, selection)?;
+    if actual.len() != expected.len()
+        || actual
+            .iter()
+            .zip(&expected)
+            .any(|(actual, expected)| (&actual.0, &actual.1) != (&expected.0, &expected.1))
+    {
         return Err(
             "adapter plan fields must preserve every declared field identity, order, and type"
                 .to_string(),
         );
     }
-    Ok(())
+    let class = result
+        .module
+        .classes
+        .iter()
+        .find(|class| class.name == selection.owner)
+        .ok_or_else(|| "adapted class fields are unavailable".to_string())?;
+    let normalized_types = normalized_field_types(
+        module_name,
+        result,
+        external_defs,
+        selection,
+        class,
+        &expected,
+    )?;
+    actual
+        .into_iter()
+        .zip(normalized_types)
+        .map(
+            |((identity, _, kind, value, factory, policy), (name, ty))| {
+                let default = match (kind.as_str(), value, factory) {
+                    ("required", ConstValue::None, ConstValue::None) => {
+                        AdapterFieldDefault::Required
+                    }
+                    ("const", value, ConstValue::None) => {
+                        if !crate::typed_descriptors::const_value_assignable(&value, &ty) {
+                            return Err(format!(
+                                "planned constant default for field '{name}' is not assignable to its declared type"
+                            ));
+                        }
+                        AdapterFieldDefault::Const(
+                            static_program_value(&value).map_err(str::to_string)?,
+                        )
+                    }
+                    ("factory", ConstValue::None, ConstValue::CallableIdentity(factory)) => {
+                        let contract = crate::callable_identities::contract_for_identity(
+                            module_name,
+                            result,
+                            external_defs,
+                            &factory,
+                        )
+                        .ok_or_else(|| {
+                            format!(
+                                "planned default factory for field '{name}' is not a checked callable"
+                            )
+                        })?;
+                        if !contract.params.is_empty() {
+                            return Err(format!(
+                                "planned default factory for field '{name}' must accept no arguments"
+                            ));
+                        }
+                        if !contract.return_type.is_assignable_to(&ty) {
+                            return Err(format!(
+                                "planned default factory for field '{name}' does not return its declared type"
+                            ));
+                        }
+                        AdapterFieldDefault::Factory(factory)
+                    }
+                    _ => {
+                        return Err(format!(
+                            "planned field '{name}' must use a valid required, const, or factory default state"
+                        ));
+                    }
+                };
+                let validation_policy = match policy {
+                    ConstValue::None => None,
+                    ConstValue::String(value) => Some(sifr_lowering::StaticProgramValue::String(value)),
+                    _ => return Err(format!(
+                        "planned default validation policy for field '{name}' must be a string or None"
+                    )),
+                };
+                Ok(AdapterFieldPlan {
+                    identity,
+                    name: name.clone(),
+                    declared_type: ty,
+                    default,
+                    validation_policy,
+                })
+            },
+        )
+        .collect()
 }
 
 fn parse_metadata(
     module_name: &str,
     declaration: &crate::class_declarations::ClassDeclaration,
     result: &LoweringResult,
+    external_defs: &ExternalDefs,
     selection: &ClassAdapterSelection,
     value: ConstValue,
 ) -> Result<AppliedAdapterMetadata, String> {
@@ -460,7 +627,13 @@ fn parse_metadata(
     let (target_kind, target_name) = match target_kind.as_str() {
         "class" if target_identity == owner_identity => (DeclarationMetadataTargetKind::Type, None),
         "field" => {
-            let fields = declaration.field_contracts(result);
+            let fields = expected_field_contracts(
+                module_name,
+                result,
+                external_defs,
+                declaration,
+                selection,
+            )?;
             let Some((identity, _)) = fields
                 .iter()
                 .find(|(identity, _)| identity == &target_identity)
@@ -486,7 +659,137 @@ fn parse_metadata(
     })
 }
 
-fn apply_plan(result: &mut LoweringResult, selection: &ClassAdapterSelection, plan: ValidatedPlan) {
+fn normalized_field_types(
+    module_name: &str,
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    selection: &ClassAdapterSelection,
+    class: &sifr_lowering::HirClass,
+    expected: &[(String, String)],
+) -> Result<Vec<(String, Type)>, String> {
+    let local_prefix = format!("{module_name}.{}.", selection.owner);
+    let parent_name = selection.data_parent.as_deref();
+    let parent_identity = class
+        .parent_type
+        .as_ref()
+        .and_then(|parent| match parent {
+            Type::Class { identity, name, .. } => {
+                Some(identity.as_deref().unwrap_or(name).to_string())
+            }
+            _ => None,
+        })
+        .or_else(|| parent_name.map(|name| format!("{module_name}.{name}")));
+    let parent = parent_name.and_then(|name| {
+        inheritance::parent_selection(
+            result,
+            external_defs,
+            parent_identity.as_deref().unwrap_or(""),
+            name,
+        )
+    });
+    let type_args = match class.parent_type.as_ref() {
+        Some(Type::Class { type_args, .. }) => type_args.as_slice(),
+        _ => &[],
+    };
+    let bindings = parent_name.map_or_else(HashMap::new, |name| {
+        inheritance::parent_bindings(
+            result,
+            external_defs,
+            parent_identity.as_deref().unwrap_or(""),
+            name,
+            type_args,
+        )
+    });
+    expected
+        .iter()
+        .map(|(identity, _)| {
+            let name = identity
+                .rsplit_once('.')
+                .map(|(_, name)| name.to_string())
+                .ok_or_else(|| "planned field identity is malformed".to_string())?;
+            let ty = if identity.starts_with(&local_prefix) {
+                class
+                    .fields
+                    .iter()
+                    .find(|(field, _)| field == &name)
+                    .map(|(_, ty)| ty.clone())
+            } else {
+                parent
+                    .into_iter()
+                    .flat_map(|parent| parent.field_plans.iter())
+                    .find(|field| field.identity == *identity)
+                    .map(|field| {
+                        sifr_lowering::substitute_type_vars(&field.declared_type, &bindings)
+                    })
+                    .or_else(|| {
+                        class.parent_type.as_ref().and_then(|parent| match parent {
+                            Type::Class { fields, .. } => fields
+                                .iter()
+                                .find(|(field, _)| field == &name)
+                                .map(|(_, ty)| ty.clone()),
+                            _ => None,
+                        })
+                    })
+            }
+            .ok_or_else(|| format!("normalized type for field '{name}' is unavailable"))?;
+            Ok((name, ty))
+        })
+        .collect()
+}
+
+fn expected_field_contracts(
+    module_name: &str,
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    declaration: &crate::class_declarations::ClassDeclaration,
+    selection: &ClassAdapterSelection,
+) -> Result<Vec<(String, String)>, String> {
+    let value =
+        inheritance::declaration_value(module_name, result, external_defs, declaration, selection)
+            .map_err(str::to_string)?;
+    let ConstValue::Record(fields) = value else {
+        return Err("class declaration is not structural".to_string());
+    };
+    let Some(ConstValue::List(items)) = fields.get("items") else {
+        return Err("class declaration items are unavailable".to_string());
+    };
+    items
+        .iter()
+        .filter_map(|item| {
+            let ConstValue::Record(fields) = item else {
+                return None;
+            };
+            if !matches!(fields.get("kind"), Some(ConstValue::String(kind)) if kind == "field") {
+                return None;
+            }
+            Some(
+                match (fields.get("identity"), fields.get("declared_type")) {
+                    (Some(ConstValue::String(identity)), Some(ConstValue::String(ty))) => {
+                        Ok((identity.clone(), ty.clone()))
+                    }
+                    _ => Err("declared field identity or type is unavailable".to_string()),
+                },
+            )
+        })
+        .collect()
+}
+
+fn apply_plan(
+    result: &mut LoweringResult,
+    selection: &ClassAdapterSelection,
+    plan: ValidatedPlan,
+    adapter_invocation_identity: [u8; 32],
+    post_adapter_identity: [u8; 32],
+) {
+    if let Some(applied) = result
+        .class_adapter_selections
+        .iter_mut()
+        .find(|candidate| candidate.owner == selection.owner)
+    {
+        applied.field_plans = plan.fields;
+        applied.adapter_invocation_identity = adapter_invocation_identity;
+        applied.post_adapter_identity = post_adapter_identity;
+    }
     result.applied_adapter_metadata.extend(plan.metadata);
     if let Some((package_module, function)) = plan.specialization {
         result

--- a/crates/sifr_frontend/src/early_adapters/inheritance.rs
+++ b/crates/sifr_frontend/src/early_adapters/inheritance.rs
@@ -35,16 +35,6 @@ pub(super) fn declaration_value(
     let Some(parent_name) = selection.data_parent.as_deref() else {
         return Ok(value);
     };
-    let local_field_count = items
-        .iter()
-        .filter(|item| {
-            matches!(
-                item,
-                ConstValue::Record(fields)
-                    if matches!(fields.get("kind"), Some(ConstValue::String(kind)) if kind == "field")
-            )
-        })
-        .count();
     let (parent_identity, mut parent_fields) = if let Some(Type::Class {
         identity,
         name,
@@ -59,12 +49,12 @@ pub(super) fn declaration_value(
             fields.clone()
         };
         (identity.as_deref().unwrap_or(name).to_string(), fields)
+    } else if let Some(shape) =
+        fallback_parent_shape(module_name, result, external_defs, parent_name)
+    {
+        shape
     } else {
-        let inherited_count = class.fields.len().saturating_sub(local_field_count);
-        (
-            format!("{module_name}.{parent_name}"),
-            class.fields.iter().take(inherited_count).cloned().collect(),
-        )
+        return Err("adapted data parent shape is unavailable");
     };
     let parent_selection = parent_selection(result, external_defs, &parent_identity, parent_name);
     if let Some(parent) = parent_selection.filter(|parent| !parent.field_plans.is_empty()) {
@@ -141,6 +131,51 @@ pub(super) fn declaration_value(
         }
     }
     Ok(value)
+}
+
+fn fallback_parent_shape(
+    module_name: &str,
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    parent_name: &str,
+) -> Option<(String, Vec<(String, Type)>)> {
+    if let Some(parent) = result
+        .module
+        .classes
+        .iter()
+        .find(|candidate| candidate.name == parent_name)
+    {
+        return Some((
+            parent
+                .identity
+                .clone()
+                .unwrap_or_else(|| format!("{module_name}.{}", parent.name)),
+            parent.fields.clone(),
+        ));
+    }
+
+    let mut matches = external_defs
+        .classes
+        .iter()
+        .filter_map(|(module, classes)| {
+            let Type::Class {
+                identity,
+                name,
+                fields,
+                ..
+            } = classes.get(parent_name)?.resolve_alias()
+            else {
+                return None;
+            };
+            Some((
+                identity
+                    .clone()
+                    .unwrap_or_else(|| format!("{module}.{name}")),
+                fields.clone(),
+            ))
+        });
+    let shape = matches.next()?;
+    matches.next().is_none().then_some(shape)
 }
 
 fn local_parent_fields(

--- a/crates/sifr_frontend/src/early_adapters/inheritance.rs
+++ b/crates/sifr_frontend/src/early_adapters/inheritance.rs
@@ -1,0 +1,352 @@
+use crate::ConstValue;
+use sifr_lowering::{
+    AdapterFieldDefault, AdapterFieldPlan, ClassAdapterSelection, ExternalDefs, HirClass,
+    LoweringResult,
+};
+use sifr_type_system::{FunctionType, Type};
+use std::collections::{BTreeMap, HashMap};
+
+pub(super) fn declaration_value(
+    module_name: &str,
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    declaration: &crate::class_declarations::ClassDeclaration,
+    selection: &ClassAdapterSelection,
+) -> Result<ConstValue, &'static str> {
+    let mut value = declaration.to_const_value(result);
+    let ConstValue::Record(fields) = &mut value else {
+        return Err("class declaration is not structural");
+    };
+    let origin = fields
+        .get("origin")
+        .cloned()
+        .ok_or("class declaration origin is unavailable")?;
+    let Some(ConstValue::List(items)) = fields.get_mut("items") else {
+        return Err("class declaration items are unavailable");
+    };
+    let Some(class) = result
+        .module
+        .classes
+        .iter()
+        .find(|class| class.name == selection.owner)
+    else {
+        return Ok(value);
+    };
+    let Some(parent_name) = selection.data_parent.as_deref() else {
+        return Ok(value);
+    };
+    let local_field_count = items
+        .iter()
+        .filter(|item| {
+            matches!(
+                item,
+                ConstValue::Record(fields)
+                    if matches!(fields.get("kind"), Some(ConstValue::String(kind)) if kind == "field")
+            )
+        })
+        .count();
+    let (parent_identity, mut parent_fields) = if let Some(Type::Class {
+        identity,
+        name,
+        fields,
+        type_args,
+        ..
+    }) = class.parent_type.as_ref()
+    {
+        let fields = if fields.is_empty() {
+            local_parent_fields(result, parent_name, type_args)
+        } else {
+            fields.clone()
+        };
+        (identity.as_deref().unwrap_or(name).to_string(), fields)
+    } else {
+        let inherited_count = class.fields.len().saturating_sub(local_field_count);
+        (
+            format!("{module_name}.{parent_name}"),
+            class.fields.iter().take(inherited_count).cloned().collect(),
+        )
+    };
+    let parent_selection = parent_selection(result, external_defs, &parent_identity, parent_name);
+    if let Some(parent) = parent_selection.filter(|parent| !parent.field_plans.is_empty()) {
+        let type_args = match class.parent_type.as_ref() {
+            Some(Type::Class { type_args, .. }) => type_args.as_slice(),
+            _ => &[],
+        };
+        let bindings = parent_bindings(
+            result,
+            external_defs,
+            &parent_identity,
+            parent_name,
+            type_args,
+        );
+        parent_fields = parent
+            .field_plans
+            .iter()
+            .map(|field| {
+                (
+                    field.name.clone(),
+                    sifr_lowering::substitute_type_vars(&field.declared_type, &bindings),
+                )
+            })
+            .collect();
+    }
+    let mut inherited = Vec::with_capacity(parent_fields.len());
+    for (index, (name, ty)) in parent_fields.iter().enumerate() {
+        if let Some(local_index) = items.iter().position(|item| {
+            matches!(
+                item,
+                ConstValue::Record(fields)
+                    if matches!(fields.get("kind"), Some(ConstValue::String(kind)) if kind == "field")
+                        && matches!(fields.get("name"), Some(ConstValue::String(local)) if local == name)
+            )
+        }) {
+            inherited.push(items.remove(local_index));
+        } else {
+            inherited.push(inherited_field_item(
+                index,
+                name,
+                ty,
+                &parent_identity,
+                parent_selection.and_then(|parent| parent.field_plans.get(index)),
+                &origin,
+            )?);
+        }
+    }
+    let local_methods = items
+        .iter()
+        .filter_map(|item| match item {
+            ConstValue::Record(fields)
+                if matches!(fields.get("kind"), Some(ConstValue::String(kind)) if kind == "method") =>
+            {
+                match fields.get("name") {
+                    Some(ConstValue::String(name)) => Some(name.clone()),
+                    _ => None,
+                }
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    inherited.extend(
+        parent_method_contracts(class, result, parent_name)
+            .into_iter()
+            .filter(|(name, _)| !local_methods.contains(name))
+            .map(|(name, signature)| {
+                inherited_method_item(&name, &signature, &parent_identity, &origin)
+            }),
+    );
+    items.splice(0..0, inherited);
+    for (order, item) in items.iter_mut().enumerate() {
+        if let ConstValue::Record(fields) = item {
+            fields.insert("order".to_string(), ConstValue::Integer(order.into()));
+        }
+    }
+    Ok(value)
+}
+
+fn local_parent_fields(
+    result: &LoweringResult,
+    parent_name: &str,
+    type_args: &[Type],
+) -> Vec<(String, Type)> {
+    let bindings = result
+        .module
+        .classes
+        .iter()
+        .find(|candidate| candidate.name == parent_name)
+        .into_iter()
+        .flat_map(|candidate| candidate.type_params.iter())
+        .cloned()
+        .zip(type_args.iter().cloned())
+        .collect::<HashMap<_, _>>();
+    result
+        .module
+        .classes
+        .iter()
+        .find(|parent| parent.name == parent_name)
+        .into_iter()
+        .flat_map(|parent| parent.fields.iter())
+        .map(|(name, ty)| {
+            (
+                name.clone(),
+                sifr_lowering::substitute_type_vars(ty, &bindings),
+            )
+        })
+        .collect()
+}
+
+pub(super) fn parent_bindings(
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    parent_identity: &str,
+    parent_name: &str,
+    type_args: &[Type],
+) -> HashMap<String, Type> {
+    let mut params = result
+        .module
+        .classes
+        .iter()
+        .find(|candidate| candidate.name == parent_name)
+        .into_iter()
+        .flat_map(|candidate| candidate.type_params.iter())
+        .cloned()
+        .collect::<Vec<_>>();
+    if params.is_empty() {
+        if let Some((module, owner)) = parent_identity.rsplit_once('.') {
+            params = external_defs
+                .class_type_params
+                .get(module)
+                .and_then(|classes| classes.get(owner))
+                .cloned()
+                .unwrap_or_default();
+        }
+    }
+    params.into_iter().zip(type_args.iter().cloned()).collect()
+}
+
+fn parent_method_contracts(
+    class: &HirClass,
+    result: &LoweringResult,
+    parent_name: &str,
+) -> Vec<(String, FunctionType)> {
+    if let Some(Type::Class { methods, .. }) = class.parent_type.as_ref() {
+        if !methods.is_empty() {
+            return methods.clone();
+        }
+    }
+    result
+        .module
+        .classes
+        .iter()
+        .find(|parent| parent.name == parent_name)
+        .into_iter()
+        .flat_map(|parent| parent.methods.iter())
+        .map(|method| {
+            (
+                method.name.clone(),
+                FunctionType {
+                    receiver: method.receiver,
+                    params: method
+                        .params
+                        .iter()
+                        .map(|parameter| {
+                            (
+                                parameter.name.clone(),
+                                parameter.ty.clone(),
+                                parameter.convention,
+                            )
+                        })
+                        .collect(),
+                    return_type: Box::new(method.return_type.clone()),
+                },
+            )
+        })
+        .collect()
+}
+
+fn inherited_method_item(
+    name: &str,
+    signature: &FunctionType,
+    parent_identity: &str,
+    origin: &ConstValue,
+) -> ConstValue {
+    ConstValue::Record(BTreeMap::from([
+        ("order".to_string(), ConstValue::Integer(0.into())),
+        ("kind".to_string(), ConstValue::String("method".to_string())),
+        ("name".to_string(), ConstValue::String(name.to_string())),
+        (
+            "identity".to_string(),
+            ConstValue::String(format!("{parent_identity}.{name}")),
+        ),
+        ("origin".to_string(), origin.clone()),
+        ("annotation_origin".to_string(), ConstValue::None),
+        ("value_origin".to_string(), ConstValue::None),
+        ("return_origin".to_string(), origin.clone()),
+        ("declared_type".to_string(), ConstValue::None),
+        (
+            "default_kind".to_string(),
+            ConstValue::String("required".to_string()),
+        ),
+        ("default_value".to_string(), ConstValue::None),
+        (
+            "signature".to_string(),
+            ConstValue::String(crate::canonical_types::function_identity(signature)),
+        ),
+        (
+            "value_argument_origins".to_string(),
+            ConstValue::List(Vec::new()),
+        ),
+        ("value_arguments".to_string(), ConstValue::List(Vec::new())),
+        ("decorators".to_string(), ConstValue::List(Vec::new())),
+        ("parameters".to_string(), ConstValue::List(Vec::new())),
+    ]))
+}
+
+pub(super) fn parent_selection<'a>(
+    result: &'a LoweringResult,
+    external_defs: &'a ExternalDefs,
+    parent_identity: &str,
+    parent_name: &str,
+) -> Option<&'a ClassAdapterSelection> {
+    if let Some(parent) = result
+        .class_adapter_selections
+        .iter()
+        .find(|selection| selection.owner == parent_name)
+    {
+        return Some(parent);
+    }
+    let (module, owner) = parent_identity.rsplit_once('.')?;
+    external_defs
+        .class_adapter_selections
+        .get(module)?
+        .get(owner)
+}
+
+fn inherited_field_item(
+    order: usize,
+    name: &str,
+    ty: &Type,
+    parent_identity: &str,
+    plan: Option<&AdapterFieldPlan>,
+    origin: &ConstValue,
+) -> Result<ConstValue, &'static str> {
+    let (default_kind, default_value) = match plan.map(|plan| &plan.default) {
+        Some(AdapterFieldDefault::Const(value)) => {
+            ("const", crate::specialization_support::const_value(value)?)
+        }
+        Some(AdapterFieldDefault::Factory(_)) => ("factory", ConstValue::None),
+        _ => ("required", ConstValue::None),
+    };
+    Ok(ConstValue::Record(BTreeMap::from([
+        ("order".to_string(), ConstValue::Integer(order.into())),
+        ("kind".to_string(), ConstValue::String("field".to_string())),
+        ("name".to_string(), ConstValue::String(name.to_string())),
+        (
+            "identity".to_string(),
+            ConstValue::String(plan.map_or_else(
+                || format!("{parent_identity}.{name}"),
+                |plan| plan.identity.clone(),
+            )),
+        ),
+        ("origin".to_string(), origin.clone()),
+        ("annotation_origin".to_string(), origin.clone()),
+        ("value_origin".to_string(), ConstValue::None),
+        ("return_origin".to_string(), ConstValue::None),
+        (
+            "declared_type".to_string(),
+            ConstValue::String(crate::canonical_types::type_identity(ty)),
+        ),
+        (
+            "default_kind".to_string(),
+            ConstValue::String(default_kind.to_string()),
+        ),
+        ("default_value".to_string(), default_value),
+        ("signature".to_string(), ConstValue::None),
+        (
+            "value_argument_origins".to_string(),
+            ConstValue::List(Vec::new()),
+        ),
+        ("value_arguments".to_string(), ConstValue::List(Vec::new())),
+        ("decorators".to_string(), ConstValue::List(Vec::new())),
+        ("parameters".to_string(), ConstValue::List(Vec::new())),
+    ])))
+}

--- a/crates/sifr_frontend/src/graph_cache_and_queries.rs
+++ b/crates/sifr_frontend/src/graph_cache_and_queries.rs
@@ -364,16 +364,24 @@ pub fn compile_module_hir_with_source_and_options(
                 let applied_metadata = std::mem::take(&mut result.applied_adapter_metadata);
                 let specialization_requests = std::mem::take(&mut result.specialization_requests);
                 let adapter_warnings = result.warnings[lowering_warning_count..].to_vec();
+                let mut final_options = lowering_options;
+                final_options.adapter_field_plans = result
+                    .class_adapter_selections
+                    .iter()
+                    .map(|selection| (selection.owner.clone(), selection.field_plans.clone()))
+                    .collect();
+                let applied_selections = result.class_adapter_selections.clone();
                 result = match lower_module_with_externals_name_and_options(
                     module_name,
                     stmts,
                     external_defs,
-                    lowering_options,
+                    final_options,
                 ) {
                     Ok(mut finalized) => {
                         finalized.declaration_descriptors = descriptors;
                         finalized.applied_adapter_metadata = applied_metadata;
                         finalized.specialization_requests = specialization_requests;
+                        finalized.class_adapter_selections = applied_selections;
                         finalized.warnings.extend(adapter_warnings);
                         finalized
                     }

--- a/crates/sifr_frontend/src/lib.rs
+++ b/crates/sifr_frontend/src/lib.rs
@@ -29,6 +29,7 @@ mod slot_table_tests;
 mod specialization_runner;
 mod specialization_support;
 pub use cache_keys::*;
+mod adapter_program_identity;
 mod analysis_views;
 pub use analysis_views::*;
 mod editor_semantics;

--- a/crates/sifr_frontend/src/specialization_runner.rs
+++ b/crates/sifr_frontend/src/specialization_runner.rs
@@ -166,6 +166,8 @@ pub(crate) fn run_specializations(
                     };
                     let canonical_value = crate::const_canonical::canonical_value(value);
                     let structural_contract_version = sifr_structural_identity::ALGORITHM_VERSION;
+                    let adapter_identity =
+                        crate::adapter_program_identity::post_adapter_hex(result, &request.owner);
                     let program_identity = sifr_structural_identity::static_program_identity(
                         structural_contract_version,
                         [
@@ -174,6 +176,7 @@ pub(crate) fn run_specializations(
                             ("package", request.package_module.as_bytes()),
                             ("function", request.function.as_bytes()),
                             ("shape", canonical_shape.as_bytes()),
+                            ("adapter", adapter_identity.as_bytes()),
                             ("value", canonical_value.as_bytes()),
                         ],
                     );

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -556,10 +556,13 @@ fn canonical_node(node: &ShapeNode) -> String {
             let variants = variants
                 .iter()
                 .map(|variant| {
+                    let value = variant
+                        .value
+                        .map_or_else(|| "none".to_string(), |value| format!("i64:{value}"));
                     format!(
-                        "{}={:?}:{}",
+                        "{}={}:{}",
                         variant.name,
-                        variant.value,
+                        value,
                         canonical_metadata(&variant.metadata)
                     )
                 })

--- a/crates/sifr_frontend/src/typed_descriptors.rs
+++ b/crates/sifr_frontend/src/typed_descriptors.rs
@@ -9,7 +9,7 @@ use sifr_lowering::{
     HirFunction, HirModule, LoweringResult, StaticProgramValue, TypedDeclarationDescriptor,
 };
 use sifr_python_ast::visitor::{self, Visitor};
-use sifr_python_ast::{Expr, ExprCall, Number, Stmt, StmtClassDef};
+use sifr_python_ast::{Expr, ExprCall, Number, Operator, Stmt, StmtClassDef};
 use sifr_type_system::{FunctionType, Type};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -231,6 +231,13 @@ impl DescriptorCollector<'_> {
     }
 
     fn collect_annotation(&mut self, expression: &Expr, owner: &str, target: String) {
+        if let Expr::BinOp(union) = expression {
+            if matches!(union.op, Operator::BitOr) {
+                self.collect_annotation(&union.left, owner, target.clone());
+                self.collect_annotation(&union.right, owner, target);
+            }
+            return;
+        }
         let Expr::Subscript(subscript) = expression else {
             return;
         };
@@ -238,6 +245,12 @@ impl DescriptorCollector<'_> {
             let Expr::Tuple(tuple) = subscript.slice.as_ref() else {
                 return;
             };
+            // Flatten from the declared type outward. This preserves the
+            // source order of nested Annotated layers, after which RHS
+            // descriptors are collected by the surrounding declaration pass.
+            if let Some(inner) = tuple.elts.first() {
+                self.collect_annotation(inner, owner, target.clone());
+            }
             for descriptor in tuple.elts.iter().skip(1) {
                 self.collect_use(
                     descriptor,
@@ -245,9 +258,6 @@ impl DescriptorCollector<'_> {
                     owner,
                     target.clone(),
                 );
-            }
-            if let Some(inner) = tuple.elts.first() {
-                self.collect_annotation(inner, owner, target);
             }
             return;
         }
@@ -443,7 +453,7 @@ impl DescriptorCollector<'_> {
 
     fn argument_value(&self, expression: &Expr, expected: &Type) -> DescriptorResult<ConstValue> {
         if let Some(value) = literal_const_value(expression) {
-            if const_value_assignable(&value, expected) {
+            if const_value_assignable(&value, expected) || static_value_expected(expected) {
                 return Ok(value);
             }
         }
@@ -649,6 +659,11 @@ pub(crate) fn const_value_assignable(value: &ConstValue, expected: &Type) -> boo
         {
             matches!(value, ConstValue::CallableIdentity(_))
         }
+        Type::Class { identity, name, .. }
+            if name == "StaticValue" && identity.as_deref() == Some("sifr.meta.StaticValue") =>
+        {
+            !matches!(value, ConstValue::SourceOrigin(_))
+        }
         Type::Class { fields, .. } => matches!(value, ConstValue::Record(values)
             if values.len() == fields.len()
                 && fields.iter().all(|(name, field)| values
@@ -674,6 +689,16 @@ fn callable_expected(expected: &Type) -> bool {
             name == "CallableIdentity" && identity.as_deref() == Some("sifr.meta.CallableIdentity")
         }
         Type::Union(members) => members.iter().any(callable_expected),
+        _ => false,
+    }
+}
+
+fn static_value_expected(expected: &Type) -> bool {
+    match expected.resolve_alias() {
+        Type::Class { identity, name, .. } => {
+            name == "StaticValue" && identity.as_deref() == Some("sifr.meta.StaticValue")
+        }
+        Type::Union(members) => members.iter().any(static_value_expected),
         _ => false,
     }
 }

--- a/crates/sifr_ir/src/specialization_metadata.rs
+++ b/crates/sifr_ir/src/specialization_metadata.rs
@@ -147,7 +147,26 @@ pub struct ClassAdapterSelection {
     pub descriptor_type: Type,
     pub marker_identities: Vec<String>,
     pub data_parent: Option<String>,
+    pub field_plans: Vec<AdapterFieldPlan>,
+    pub adapter_invocation_identity: [u8; 32],
+    pub post_adapter_identity: [u8; 32],
     pub range: TextRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdapterFieldPlan {
+    pub identity: String,
+    pub name: String,
+    pub declared_type: Type,
+    pub default: AdapterFieldDefault,
+    pub validation_policy: Option<StaticProgramValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdapterFieldDefault {
+    Required,
+    Const(StaticProgramValue),
+    Factory(CallableIdentity),
 }
 
 /// Canonical declaration exported by a package descriptor function.

--- a/crates/sifr_lowering/src/lib.rs
+++ b/crates/sifr_lowering/src/lib.rs
@@ -32,11 +32,11 @@ pub use lower::{
 };
 pub use scope::{NarrowingSnapshot, Scope};
 pub use sifr_ir::{
-    rust_opaque_close_method, AppliedAdapterMetadata, CallableIdentity,
-    ClassAdapterMarkerDeclaration, ClassAdapterProviderDeclaration, ClassAdapterSelection,
-    ConstSpecializationRequest, DeclarationDescriptorFunction, DeclarationDescriptorKind,
-    DeclarationMetadataTargetKind, HirDiagnostic, LoweringOutcome, LoweringResult,
-    LoweringWarningDiagnostic, RevealTypeDiagnostic, RustInteropDecoratorKind, StaticMethodParam,
-    StaticMethodSlot, StaticMethodSlotContext, StaticProgramValue, StaticSpecializationOutput,
-    TypedDeclarationDescriptor, TypedDeclarationMetadata,
+    rust_opaque_close_method, AdapterFieldDefault, AdapterFieldPlan, AppliedAdapterMetadata,
+    CallableIdentity, ClassAdapterMarkerDeclaration, ClassAdapterProviderDeclaration,
+    ClassAdapterSelection, ConstSpecializationRequest, DeclarationDescriptorFunction,
+    DeclarationDescriptorKind, DeclarationMetadataTargetKind, HirDiagnostic, LoweringOutcome,
+    LoweringResult, LoweringWarningDiagnostic, RevealTypeDiagnostic, RustInteropDecoratorKind,
+    StaticMethodParam, StaticMethodSlot, StaticMethodSlotContext, StaticProgramValue,
+    StaticSpecializationOutput, TypedDeclarationDescriptor, TypedDeclarationMetadata,
 };

--- a/crates/sifr_lowering/src/lower/adapter_field_plans.rs
+++ b/crates/sifr_lowering/src/lower/adapter_field_plans.rs
@@ -1,0 +1,203 @@
+use super::{HirExpr, LowerCtx, Type};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_ir::{AdapterFieldDefault, CallableIdentity, StaticProgramValue};
+
+pub(in crate::lower) fn defaults_for_class(
+    class_name: &str,
+    fields: &[(String, Type)],
+    source_defaults: Vec<(usize, HirExpr)>,
+    ctx: &mut LowerCtx,
+) -> Vec<(usize, HirExpr)> {
+    let Some(plans) = ctx.adapter_field_plans.get(class_name).cloned() else {
+        return source_defaults;
+    };
+    if plans.len() != fields.len() {
+        invalid_plan(
+            ctx,
+            class_name,
+            &format!(
+                "normalized field count changed before finalization (planned {}, finalized {}: {})",
+                plans.len(),
+                fields.len(),
+                fields
+                    .iter()
+                    .map(|(name, _)| name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        );
+        return Vec::new();
+    }
+    let mut defaults = Vec::new();
+    for (index, (plan, (name, ty))) in plans.iter().zip(fields).enumerate() {
+        if plan.name != *name || plan.declared_type != *ty {
+            invalid_plan(
+                ctx,
+                class_name,
+                &format!(
+                    "normalized field contract changed before finalization at index {index} (planned '{}: {}', finalized '{}: {}')",
+                    plan.name,
+                    plan.declared_type.display_name(),
+                    name,
+                    ty.display_name()
+                ),
+            );
+            return Vec::new();
+        }
+        let value = match &plan.default {
+            AdapterFieldDefault::Required => continue,
+            AdapterFieldDefault::Const(value) => static_value_expr(value, ty),
+            AdapterFieldDefault::Factory(factory) => factory_expr(factory, ty, ctx),
+        };
+        let Some(value) = value else {
+            invalid_plan(
+                ctx,
+                class_name,
+                &format!("default for field '{name}' cannot be lowered"),
+            );
+            return Vec::new();
+        };
+        defaults.push((index, value));
+    }
+    defaults
+}
+
+fn static_value_expr(value: &StaticProgramValue, expected: &Type) -> Option<HirExpr> {
+    match value {
+        StaticProgramValue::None => Some(HirExpr::NoneLiteral),
+        StaticProgramValue::Bool(value) => Some(HirExpr::BoolLiteral(*value)),
+        StaticProgramValue::Integer(value) => value
+            .parse::<i64>()
+            .map(HirExpr::IntLiteral)
+            .ok()
+            .or_else(|| Some(HirExpr::LargeIntLiteral(value.clone()))),
+        StaticProgramValue::FloatBits(value) => Some(HirExpr::FloatLiteral(f64::from_bits(*value))),
+        StaticProgramValue::String(value) => Some(HirExpr::StringLiteral(value.clone())),
+        StaticProgramValue::Bytes(values) => Some(HirExpr::ListLiteral {
+            elements: values
+                .iter()
+                .map(|value| HirExpr::IntLiteral(i64::from(*value)))
+                .collect(),
+            ty: Type::Bytes,
+        }),
+        StaticProgramValue::Tuple(values) => {
+            let Type::Tuple(types) = expected.resolve_alias() else {
+                return None;
+            };
+            if values.len() != types.len() {
+                return None;
+            }
+            Some(HirExpr::TupleLiteral {
+                elements: values
+                    .iter()
+                    .zip(types)
+                    .map(|(value, ty)| static_value_expr(value, ty))
+                    .collect::<Option<Vec<_>>>()?,
+                ty: expected.clone(),
+            })
+        }
+        StaticProgramValue::List(values) => {
+            let Type::List(item) = expected.resolve_alias() else {
+                return None;
+            };
+            Some(HirExpr::ListLiteral {
+                elements: values
+                    .iter()
+                    .map(|value| static_value_expr(value, item))
+                    .collect::<Option<Vec<_>>>()?,
+                ty: expected.clone(),
+            })
+        }
+        StaticProgramValue::Record(values) => record_expr(values, expected),
+        StaticProgramValue::CallableIdentity(_) => None,
+    }
+}
+
+fn record_expr(values: &[(String, StaticProgramValue)], expected: &Type) -> Option<HirExpr> {
+    match expected.resolve_alias() {
+        Type::Dict(key, item) if matches!(key.resolve_alias(), Type::Str) => {
+            Some(HirExpr::DictLiteral {
+                keys: values
+                    .iter()
+                    .map(|(name, _)| HirExpr::StringLiteral(name.clone()))
+                    .collect(),
+                values: values
+                    .iter()
+                    .map(|(_, value)| static_value_expr(value, item))
+                    .collect::<Option<Vec<_>>>()?,
+                ty: expected.clone(),
+            })
+        }
+        Type::Class { name, fields, .. } if fields.len() == values.len() => {
+            let args = fields
+                .iter()
+                .map(|(field_name, field_type)| {
+                    values
+                        .iter()
+                        .find(|(name, _)| name == field_name)
+                        .and_then(|(_, value)| static_value_expr(value, field_type))
+                })
+                .collect::<Option<Vec<_>>>()?;
+            Some(HirExpr::Call {
+                func: name.clone(),
+                args,
+                mutable_arg_places: Vec::new(),
+                ty: expected.clone(),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn factory_expr(factory: &CallableIdentity, expected: &Type, ctx: &LowerCtx) -> Option<HirExpr> {
+    if factory.module == "sifr.builtins" {
+        return Some(HirExpr::Call {
+            func: factory.symbol.clone(),
+            args: Vec::new(),
+            mutable_arg_places: Vec::new(),
+            ty: expected.clone(),
+        });
+    }
+    if let Some(owner) = &factory.owner {
+        let owner_name = owner
+            .rsplit_once('.')
+            .map_or(owner.as_str(), |(_, name)| name);
+        let local_owner = ctx
+            .imported_symbol_bindings
+            .get(&(factory.module.clone(), owner_name.to_string()))
+            .map_or(owner_name, String::as_str);
+        if factory.symbol == "__init__" {
+            return Some(HirExpr::ConstructorCall {
+                class_name: local_owner.to_string(),
+                args: Vec::new(),
+                ty: expected.clone(),
+            });
+        }
+        ctx.class_types.get(local_owner)?;
+        return Some(HirExpr::Call {
+            func: format!("{local_owner}::{}", factory.symbol),
+            args: Vec::new(),
+            mutable_arg_places: Vec::new(),
+            ty: expected.clone(),
+        });
+    }
+    let callable = ctx
+        .imported_symbol_bindings
+        .get(&(factory.module.clone(), factory.symbol.clone()))
+        .cloned()
+        .unwrap_or_else(|| factory.symbol.clone());
+    Some(HirExpr::Call {
+        func: callable,
+        args: Vec::new(),
+        mutable_arg_places: Vec::new(),
+        ty: expected.clone(),
+    })
+}
+
+fn invalid_plan(ctx: &mut LowerCtx, class_name: &str, detail: &str) {
+    ctx.error_with_code_at(
+        DiagnosticCode::META_MALFORMED_DECLARATION,
+        format!("adapted class '{class_name}' has an invalid finalized field plan: {detail}"),
+        ruff_text_size::TextRange::default(),
+    );
+}

--- a/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
@@ -387,22 +387,22 @@ pub(in crate::lower) fn lower_class(
 
     let parent_class_name =
         crate::lower::descriptor_declarations::data_parent_name(&class_name, ctx);
-    let parent_type = parent_class_name
-        .as_ref()
-        .and_then(|parent_name| ctx.class_types.get(parent_name))
-        .cloned();
+    let parent_type = crate::lower::descriptor_declarations::data_parent_type(class_def, ctx)
+        .or_else(|| {
+            parent_class_name
+                .as_ref()
+                .and_then(|parent_name| ctx.class_types.get(parent_name))
+                .cloned()
+        });
 
     // Separate own fields from inherited fields
     // For struct codegen, we only want the child's own fields (parent is embedded)
-    let parent_field_names: Vec<String> = if let Some(Type::Class { fields: pf, .. }) =
-        parent_class_name
-            .as_ref()
-            .and_then(|parent_name| ctx.class_types.get(parent_name))
-    {
-        pf.iter().map(|(n, _)| n.clone()).collect()
-    } else {
-        vec![]
-    };
+    let parent_field_names: Vec<String> =
+        if let Some(Type::Class { fields: pf, .. }) = parent_type.as_ref() {
+            pf.iter().map(|(n, _)| n.clone()).collect()
+        } else {
+            vec![]
+        };
 
     let own_fields: Vec<(String, Type)> = all_fields
         .iter()

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -316,7 +316,10 @@ pub(in crate::lower) fn collect_class_type(
         crate::lower::descriptor_declarations::data_parent_name(&class_name, ctx);
     let mut parent_class_chain: Option<String> = None;
     if let Some(ref parent_name) = parent_class_name {
-        if let Some(parent_ty) = ctx.class_types.get(parent_name).cloned() {
+        if let Some(parent_ty) =
+            crate::lower::descriptor_declarations::data_parent_type(class_def, ctx)
+                .or_else(|| ctx.class_types.get(parent_name).cloned())
+        {
             if let Type::Class {
                 identity: parent_identity,
                 name: parent_type_name,
@@ -356,6 +359,7 @@ pub(in crate::lower) fn collect_class_type(
             );
         }
     }
+    let inherited_field_count = fields.len();
 
     // Register a preliminary class type so self-referential annotations work
     // (e.g., `def distance(self, other: Point)` inside class Point)
@@ -388,9 +392,33 @@ pub(in crate::lower) fn collect_class_type(
             Stmt::AnnAssign(ann) => {
                 if let Expr::Name(name) = ann.target.as_ref() {
                     let ty = resolve_annotation_expr(&ann.annotation, ctx);
-                    let field_idx = fields.len();
+                    let inherited_override = fields
+                        .iter()
+                        .take(inherited_field_count)
+                        .position(|(field, _)| field == name.id.as_str());
+                    if let Some(index) = inherited_override {
+                        if !fields[index].1.is_assignable_to(&ty)
+                            || !ty.is_assignable_to(&fields[index].1)
+                        {
+                            ctx.error_with_code_at(
+                                DiagnosticCode::TYPE_MISMATCH,
+                                format!(
+                                    "inherited field '{}' cannot be re-annotated from '{}' to '{}'",
+                                    name.id,
+                                    fields[index].1.display_name(),
+                                    ty.display_name()
+                                ),
+                                ann.annotation.range(),
+                            );
+                            continue;
+                        }
+                        fields[index].1 = ty.clone();
+                    }
+                    let field_idx = inherited_override.unwrap_or(fields.len());
                     let own_field_idx = own_fields.len();
-                    fields.push((name.id.to_string(), ty));
+                    if inherited_override.is_none() {
+                        fields.push((name.id.to_string(), ty));
+                    }
                     own_fields.push((name.id.to_string(), name.range()));
                     // Collect default value if present (for auto-init default params)
                     if let Some(ref default_expr) = ann.value {
@@ -407,6 +435,23 @@ pub(in crate::lower) fn collect_class_type(
                                         .to_string(),
                                     default_expr.range(),
                                 );
+                            } else if ctx
+                                .class_adapter_selections
+                                .iter()
+                                .any(|selection| selection.owner == class_name)
+                            {
+                                // The provisional pass must permit calls that omit a
+                                // descriptor-owned default. The adapter replaces this
+                                // typed sentinel before any finalized HIR is retained.
+                                field_defaults.push((
+                                    field_idx,
+                                    HirExpr::Name {
+                                        name: "__sifr_adapter_provisional_default".to_string(),
+                                        binding_id: None,
+                                        ty: fields[field_idx].1.clone(),
+                                    },
+                                ));
+                                own_field_default_indices.insert(own_field_idx);
                             }
                             continue;
                         }
@@ -691,6 +736,19 @@ pub(in crate::lower) fn collect_class_type(
         );
     }
 
+    if ctx.adapter_field_plans.contains_key(&class_name) {
+        field_defaults = crate::lower::adapter_field_plans::defaults_for_class(
+            &class_name,
+            &fields,
+            field_defaults,
+            ctx,
+        );
+        own_field_default_indices = field_defaults
+            .iter()
+            .filter_map(|(index, _)| index.checked_sub(inherited_field_count))
+            .collect();
+    }
+
     let is_python_opaque = ctx.python_opaque_classes.contains_key(&class_name);
     let generic_type_args = ctx
         .class_declared_type_params
@@ -739,9 +797,14 @@ pub(in crate::lower) fn collect_class_type(
         }
 
         // Inheritance diagnostic: warn when child has own fields but no __init__ and extends a parent
-        if parent_class_name
-            .as_deref()
-            .is_some_and(|parent| parent != "NonSend")
+        if !ctx
+            .class_adapter_selections
+            .iter()
+            .any(|selection| selection.owner == class_name)
+            && !ctx.adapter_field_plans.contains_key(&class_name)
+            && parent_class_name
+                .as_deref()
+                .is_some_and(|parent| parent != "NonSend")
         {
             let parent_field_count = if let Some(ref pname) = parent_class_name {
                 ctx.class_types.get(pname).map_or(0, |ty| {

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -384,6 +384,7 @@ pub(in crate::lower) fn collect_class_type(
 
     let mut field_defaults: Vec<(usize, HirExpr)> = Vec::new();
     let mut own_fields: Vec<(String, ruff_text_size::TextRange)> = Vec::new();
+    let mut own_field_index_by_field_index = std::collections::HashMap::new();
     let mut own_field_default_indices = std::collections::HashSet::new();
 
     for stmt in &class_def.body {
@@ -420,6 +421,7 @@ pub(in crate::lower) fn collect_class_type(
                         fields.push((name.id.to_string(), ty));
                     }
                     own_fields.push((name.id.to_string(), name.range()));
+                    own_field_index_by_field_index.insert(field_idx, own_field_idx);
                     // Collect default value if present (for auto-init default params)
                     if let Some(ref default_expr) = ann.value {
                         if let Some(kind) =
@@ -745,7 +747,7 @@ pub(in crate::lower) fn collect_class_type(
         );
         own_field_default_indices = field_defaults
             .iter()
-            .filter_map(|(index, _)| index.checked_sub(inherited_field_count))
+            .filter_map(|(index, _)| own_field_index_by_field_index.get(index).copied())
             .collect();
     }
 

--- a/crates/sifr_lowering/src/lower/descriptor_declarations.rs
+++ b/crates/sifr_lowering/src/lower/descriptor_declarations.rs
@@ -25,6 +25,18 @@ pub(in crate::lower) fn data_parent_name(class_name: &str, ctx: &LowerCtx) -> Op
     ctx.class_data_parents.get(class_name).cloned().flatten()
 }
 
+pub(in crate::lower) fn data_parent_type(class: &StmtClassDef, ctx: &mut LowerCtx) -> Option<Type> {
+    let parent_name = data_parent_name(class.name.as_str(), ctx)?;
+    let base = class
+        .bases()
+        .iter()
+        .find(|base| base_symbol(base).is_some_and(|(name, _, _)| name == parent_name))?
+        .clone();
+    Some(crate::lower::typing_and_functions::resolve_annotation_expr(
+        &base, ctx,
+    ))
+}
+
 pub(in crate::lower) fn erase_markers(module: &mut HirModule, ctx: &LowerCtx) {
     let erased = ctx
         .class_adapter_markers
@@ -194,6 +206,8 @@ fn import_bindings(stmts: &[Stmt], ctx: &mut LowerCtx) {
                 .asname
                 .as_ref()
                 .map_or_else(|| original.clone(), ToString::to_string);
+            ctx.imported_symbol_bindings
+                .insert((module.clone(), original.clone()), local.clone());
             if let Some(declaration) = ctx
                 .externals
                 .descriptor_functions
@@ -273,17 +287,19 @@ fn collect_class_bases(stmts: &[Stmt], ctx: &mut LowerCtx) {
         let mut markers = Vec::new();
         let mut data_parents = Vec::new();
         for base in class.bases() {
-            let Expr::Name(name) = base else {
+            let Some((name, range, is_parameterized)) = base_symbol(base) else {
                 continue;
             };
-            if let Some(marker) = ctx.adapter_marker_bindings.get(name.id.as_str()) {
-                markers.push((name.range(), marker.clone()));
+            if !is_parameterized {
+                if let Some(marker) = ctx.adapter_marker_bindings.get(name) {
+                    markers.push((range, marker.clone()));
+                    continue;
+                }
+            }
+            if special_base(name) {
                 continue;
             }
-            if special_base(name.id.as_str()) {
-                continue;
-            }
-            data_parents.push((name.range(), name.id.to_string()));
+            data_parents.push((range, name.to_string()));
         }
         // Preserve the language's existing first-parent behavior for ordinary
         // classes. The one-data-parent restriction belongs to adapted classes.
@@ -369,6 +385,9 @@ fn collect_class_bases(stmts: &[Stmt], ctx: &mut LowerCtx) {
                 )
                 .collect(),
             data_parent,
+            field_plans: Vec::new(),
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
             range: markers
                 .first()
                 .map_or_else(|| class.range(), |(range, _)| *range),
@@ -377,6 +396,17 @@ fn collect_class_bases(stmts: &[Stmt], ctx: &mut LowerCtx) {
             ctx.adapted_class_bindings
                 .insert(class.name.to_string(), selection);
         }
+    }
+}
+
+fn base_symbol(base: &Expr) -> Option<(&str, ruff_text_size::TextRange, bool)> {
+    match base {
+        Expr::Name(name) => Some((name.id.as_str(), name.range(), false)),
+        Expr::Subscript(subscript) => match subscript.value.as_ref() {
+            Expr::Name(name) => Some((name.id.as_str(), subscript.range(), true)),
+            _ => None,
+        },
+        _ => None,
     }
 }
 
@@ -537,7 +567,9 @@ fn local_provider<'a>(
     descriptor: &DeclarationDescriptorFunction,
 ) -> Option<&'a ClassAdapterProviderDeclaration> {
     ctx.class_adapter_providers.iter().find(|provider| {
-        module == descriptor.provider_module && provider.function == descriptor.provider_function
+        module == descriptor.provider_module
+            && provider.module == descriptor.provider_module
+            && provider.function == descriptor.provider_function
     })
 }
 
@@ -577,9 +609,10 @@ fn finalize_markers_and_selections(ctx: &mut LowerCtx, module: &str) {
     for index in 0..ctx.class_adapter_markers.len() {
         let marker = ctx.class_adapter_markers[index].clone();
         let provider = if marker.provider_module == module {
-            ctx.class_adapter_providers
-                .iter()
-                .find(|provider| provider.function == marker.provider_function)
+            ctx.class_adapter_providers.iter().find(|provider| {
+                provider.module == marker.provider_module
+                    && provider.function == marker.provider_function
+            })
         } else {
             ctx.externals
                 .class_adapter_providers
@@ -605,9 +638,10 @@ fn finalize_markers_and_selections(ctx: &mut LowerCtx, module: &str) {
     for index in 0..ctx.class_adapter_selections.len() {
         let selection = ctx.class_adapter_selections[index].clone();
         let provider = if selection.provider_module == module {
-            ctx.class_adapter_providers
-                .iter()
-                .find(|provider| provider.function == selection.provider_function)
+            ctx.class_adapter_providers.iter().find(|provider| {
+                provider.module == selection.provider_module
+                    && provider.function == selection.provider_function
+            })
         } else {
             ctx.externals
                 .class_adapter_providers
@@ -669,6 +703,19 @@ fn closed_structural_type(ty: &Type, visiting: &mut HashSet<String>) -> bool {
         }
         Type::LiteralInt(_) | Type::LiteralStr(_) | Type::LiteralBool(_) => true,
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::special_base;
+
+    #[test]
+    fn adapter_parent_collection_preserves_language_special_bases() {
+        for name in ["Error", "Protocol", "int", "float", "str", "bool", "Enum"] {
+            assert!(special_base(name));
+        }
+        assert!(!special_base("DataParent"));
     }
 }
 

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -2,6 +2,7 @@ use crate::hir_nodes::{HirExpr, HirImport, HirModule};
 
 mod mod_context;
 pub use mod_context::*;
+mod adapter_field_plans;
 mod append_growth_shapes;
 mod arithmetic_warnings;
 mod assignment_widening;

--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -42,9 +42,12 @@ pub(in crate::lower) struct LowerCtx {
         HashMap<String, sifr_ir::ClassAdapterMarkerDeclaration>,
     pub(in crate::lower) adapted_class_bindings: HashMap<String, sifr_ir::ClassAdapterSelection>,
     pub(in crate::lower) class_data_parents: HashMap<String, Option<String>>,
+    pub(in crate::lower) adapter_field_plans:
+        std::collections::BTreeMap<String, Vec<sifr_ir::AdapterFieldPlan>>,
     pub(in crate::lower) descriptor_functions: Vec<sifr_ir::DeclarationDescriptorFunction>,
     pub(in crate::lower) descriptor_bindings:
         HashMap<String, sifr_ir::DeclarationDescriptorFunction>,
+    pub(in crate::lower) imported_symbol_bindings: HashMap<(String, String), String>,
     /// Whether each imported class can preserve all defaults and metadata in a
     /// compiler-owned structural identity.
     pub(in crate::lower) imported_structural_identity_inputs: HashMap<String, bool>,
@@ -233,8 +236,10 @@ impl LowerCtx {
             adapter_marker_bindings: HashMap::new(),
             adapted_class_bindings: HashMap::new(),
             class_data_parents: HashMap::new(),
+            adapter_field_plans: std::collections::BTreeMap::new(),
             descriptor_functions: Vec::new(),
             descriptor_bindings: HashMap::new(),
+            imported_symbol_bindings: HashMap::new(),
             imported_structural_identity_inputs: HashMap::new(),
             specialization_requests: Vec::new(),
             json_integer_boundary_requests: Vec::new(),
@@ -395,6 +400,7 @@ impl LowerCtx {
     pub(in crate::lower) fn with_options(mut self, options: LoweringOptions) -> Self {
         self.python_trust_policy = options.python_trust_policy;
         self.python_bridge_authorities = options.python_bridge_authorities;
+        self.adapter_field_plans = options.adapter_field_plans;
         self
     }
 
@@ -605,6 +611,7 @@ pub struct PythonTrustPolicy {
 pub struct LoweringOptions {
     pub python_trust_policy: Option<PythonTrustPolicy>,
     pub python_bridge_authorities: std::collections::BTreeMap<String, PythonBridgeTargetAuthority>,
+    pub adapter_field_plans: std::collections::BTreeMap<String, Vec<sifr_ir::AdapterFieldPlan>>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/crates/sifr_lowering/src/lower/typing_and_functions/annotation_resolution.rs
+++ b/crates/sifr_lowering/src/lower/typing_and_functions/annotation_resolution.rs
@@ -10,6 +10,14 @@ use super::{
 pub(in crate::lower) fn resolve_annotation_expr(expr: &Expr, ctx: &mut LowerCtx) -> Type {
     match expr {
         Expr::Name(name) => {
+            if ctx.adapter_marker_bindings.contains_key(name.id.as_str()) {
+                ctx.error_with_code_at(
+                    DiagnosticCode::META_MALFORMED_DECLARATION,
+                    "class-adapter markers are erased base-only declarations and cannot be used as annotations".to_string(),
+                    name.range(),
+                );
+                return Type::Any;
+            }
             // Check type variables first (e.g., T from TypeVar)
             if ctx.type_vars.contains(name.id.as_str()) {
                 return Type::TypeVar(name.id.to_string());

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -861,6 +861,17 @@ consumed class assignments are therefore metadata inputs, not runtime defaults o
 and external-definition boundary carry these records across modules without selecting a package or
 adapter implementation.
 
+Class adapters run across an explicit provisional-to-final lowering boundary. The provisional
+declaration input flattens inherited fields and methods before local declarations, preserves their
+canonical declaring identities, substitutes concrete generic parent arguments, and orders nested
+`Annotated` descriptors from inner to outer before right-hand-side descriptors. A validated plan
+normalizes every field to required, constant-default, or checked zero-argument factory-default
+state; final lowering alone materializes constructor defaults, and factory expressions execute at
+each call so mutable values are not shared. Adapter invocation identity hashes the source-location-
+free declaration input and provider HIR before evaluation. Post-adapter identity separately binds
+the invocation to the validated output and is an input to static-program identity, avoiding a
+cycle with later handler and attached-API outputs.
+
 The Native Pydantic-Sifr consumer architecture is documented in
 [`native_pydantic_sifr_architecture.md`](native_pydantic_sifr_architecture.md).
 The architecture includes the package-neutral static class-adapter contract.

--- a/stdlib/sifr/meta.sifr
+++ b/stdlib/sifr/meta.sifr
@@ -35,6 +35,10 @@ class CallableIdentity:
     pass
 
 
+class StaticValue:
+    pass
+
+
 class CallArgumentDeclaration:
     name: str | None
     origin: SourceOrigin
@@ -57,11 +61,14 @@ class ClassDeclarationItem:
     order: int
     kind: str
     name: str
+    identity: str
     origin: SourceOrigin
     annotation_origin: SourceOrigin | None
     value_origin: SourceOrigin | None
     return_origin: SourceOrigin | None
     declared_type: str | None
+    default_kind: str
+    default_value: StaticValue | None
     signature: str | None
     value_argument_origins: list[SourceOrigin]
     value_arguments: list[CallArgumentDeclaration]
@@ -95,6 +102,10 @@ class DeclarationInput[D]:
 class PlannedField:
     identity: str
     declared_type: str
+    default_kind: str = "required"
+    default_value: StaticValue | None = None
+    default_factory: CallableIdentity | None = None
+    validation_policy: str | None = None
 
 
 class PlannedMetadata[D]:

--- a/verification/areas/core_language/fixtures/static_class_adapter/app.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/app.sifr
@@ -1,11 +1,41 @@
-from fixture.facade import Contract, contract_config
+from fixture.facade import Contract, contract_config, contract_field
+from fixture.factories import Token as ExternalToken, make_names as external_names
+
+
+def make_names() -> list[str]:
+    return []
+
+
+class Factory:
+    @staticmethod
+    def make_names() -> list[str]:
+        return []
+
+
+class Token:
+    pass
 
 
 class Model(Contract):
     _config = contract_config(True)
     value: int
+    enabled: bool = contract_field(default=True)
+    tags: list[str] = contract_field(default_factory=list)
+    free_names: list[str] = contract_field(default_factory=make_names)
+    static_names: list[str] = contract_field(default_factory=Factory.make_names)
+    token: Token = contract_field(default_factory=Token)
+    external_free: list[str] = contract_field(default_factory=external_names)
+    external_token: ExternalToken = contract_field(default_factory=ExternalToken)
 
 
 def main():
-    model: Model = Model(7)
-    assert model.value == 7
+    first: Model = Model(7)
+    second: Model = Model(8)
+    first.tags.append("one")
+    assert first.value == 7
+    assert first.enabled
+    assert first.tags == ["one"]
+    assert second.tags == []
+    assert first.free_names == []
+    assert first.static_names == []
+    assert first.external_free == []

--- a/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr
@@ -1,8 +1,15 @@
-from sifr.meta import ConstSpecializationOutcome, DeclarationInput, DeclarationPlan, PlannedField, PlannedIssue, PlannedMetadata, ShapeInput
-from fixture.contract_types import ContractDescriptor
+from sifr.meta import CallableIdentity, ConstSpecializationOutcome, DeclarationInput, DeclarationPlan, PlannedField, PlannedIssue, PlannedMetadata, ShapeInput, StaticValue
 
 
-@class_adapter_provider("fixture.contract_types", "ContractDescriptor")
+class ContractDescriptor:
+    kind: str
+    enabled: bool
+    default_kind: str
+    default_value: StaticValue | None
+    default_factory: CallableIdentity | None
+
+
+@class_adapter_provider("fixture.contract", "ContractDescriptor")
 @const_eval
 def adapt_contract(
     declaration: DeclarationInput[ContractDescriptor],
@@ -14,8 +21,16 @@ def adapt_contract(
         if item.kind == "field":
             declared_type: str | None = item.declared_type
             if declared_type is not None:
-                identity: str = declaration.declaration.identity + "." + item.name
-                fields.append(PlannedField(identity, declared_type))
+                identity: str = item.identity
+                default_kind: str = item.default_kind
+                default_value: StaticValue | None = item.default_value
+                default_factory: CallableIdentity | None = None
+                for descriptor in declaration.descriptors:
+                    if descriptor.target_kind == "field" and descriptor.target_identity == identity:
+                        default_kind = descriptor.value.default_kind
+                        default_value = descriptor.value.default_value
+                        default_factory = descriptor.value.default_factory
+                fields.append(PlannedField(identity, declared_type, default_kind, default_value, default_factory, None))
     for descriptor in declaration.descriptors:
         if descriptor.target_kind == "class":
             metadata.append(
@@ -42,7 +57,19 @@ class Contract:
 
 @class_descriptor("fixture.contract", "adapt_contract")
 def contract_config(enabled: bool) -> ContractDescriptor:
-    return ContractDescriptor("class", enabled)
+    return ContractDescriptor("class", enabled, "required", None, None)
+
+
+@field_descriptor("fixture.contract", "adapt_contract")
+def contract_field(
+    default: StaticValue | None = None,
+    default_factory: CallableIdentity | None = None,
+) -> ContractDescriptor:
+    if default_factory is not None:
+        return ContractDescriptor("field", False, "factory", None, default_factory)
+    if default is not None:
+        return ContractDescriptor("field", False, "const", default, None)
+    return ContractDescriptor("field", False, "required", None, None)
 
 
 @const_eval

--- a/verification/areas/core_language/fixtures/static_class_adapter/fixture/facade.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/fixture/facade.sifr
@@ -1,1 +1,1 @@
-from fixture.contract import Contract, contract_config
+from fixture.contract import Contract, contract_config, contract_field

--- a/verification/areas/core_language/fixtures/static_class_adapter/fixture/factories.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/fixture/factories.sifr
@@ -1,0 +1,12 @@
+def make_names() -> list[str]:
+    return []
+
+
+class Factory:
+    @staticmethod
+    def make_names() -> list[str]:
+        return []
+
+
+class Token:
+    pass


### PR DESCRIPTION
## Summary
- normalize required, constant, and checked factory defaults across the provisional/final adapter boundary
- flatten nested Annotated descriptors, preserve inherited declaration identities, and substitute concrete generic parents
- separate adapter invocation/post-adapter cache identities and bind specialization identity to the finalized adapter output
- expand non-Pydantic native fixture coverage, including independent mutable factories

## Validation
- focused adapter/default, early-adapter, typed-descriptor, and special-base tests
- cargo test -p sifr_driver --lib (499 passed, 76 ignored)
- cargo test -p sifr -- --skip test_e2e_pass (only pre_v1-owned protocol_bound_unknown_forwarded_typevar failure)
- native static_class_adapter fixture run
- cargo clippy --workspace -- -D warnings
- cargo fmt --check
- HIR maintainability and 900-line file-size guardrails

Exact candidate: fc06fb578f3cdc67c45143652d05d807cdb502e8