### PR TITLE
Record text and data compatibility removal

### DIFF
--- a/plans/issues/active/ad-hoc-pre-v1-compatibility-removal.md
+++ b/plans/issues/active/ad-hoc-pre-v1-compatibility-removal.md
@@ -1,6 +1,6 @@
 # Ad Hoc Phase: Pre-v1 Compatibility Removal
 
-Status: in progress; Item 3 merged and ready for Item 4 on 2026-08-18
+Status: in progress; Item 4 merged and ready for Item 5 on 2026-08-18
 
 ## Objective
 
@@ -396,11 +396,11 @@ Scope:
 
 Acceptance criteria:
 
-- [ ] Each operation has one public name and one documented signature.
-- [ ] Canonical JSON serialization preserves every approved input type.
-- [ ] Regex keyword conflicts have one documented Sifr spelling.
-- [ ] No old name remains through a private import re-export.
-- [ ] Public docs and examples use canonical names only.
+- [x] Each operation has one public name and one documented signature.
+- [x] Canonical JSON serialization preserves every approved input type.
+- [x] Regex keyword conflicts have one documented Sifr spelling.
+- [x] No old name remains through a private import re-export.
+- [x] Public docs and examples use canonical names only.
 
 Focused validation:
 
@@ -993,7 +993,7 @@ migrates its repository consumers before the old path disappears.
 | 1. Public `bigint` transition | merged | [#3242](https://github.com/sifr-lang/sifr/pull/3242) | `54a1af60896ec216a5ce1838b50bf1cdd3ebb607` | Candidate `87b9e0ea7ee7ccb49a6a064c07491c1a425e94da`: type-system, lowering, codegen, runtime-int, driver, exact-int, heapq, fixed-width, diagnostics, generated-code panic, formatting, file-size, HIR, and residue checks passed. The one create-PR and one merge gate both stopped on the same verification-taxonomy failure reproduced at base `5285d7cb6d8df3338d2964f5af4308c94b9a3f48`; Item 1 changed none of the reported files. | [Exact-SHA Opus review](https://github.com/sifr-lang/sifr/pull/3242#issuecomment-5326605073): SATISFIED, no blocking findings. | Removed the public transition type and diagnostics while preserving arbitrary-precision `int`; recorded inherited integer-model and verification follow-ups below. |
 | 2. Numeric and random names | merged | [#3246](https://github.com/sifr-lang/sifr/pull/3246) | `b5c90b9c56a3fc5e0dfd067d1b4d356fbc4db8a0` | Initial candidate `3008253603e2d68fbbe806b990d8daeebb51749f`: driver stdlib (71 passed, 2 ignored), lowering (986 passed, 1 ignored), codegen (1021 passed), stdlib, canonical export, stateful random, math/random e2e, parity, demo, inventory, formatting, file-size, HIR, and residue checks passed. The pass suite completed 684 of 685 fixtures; its host-timing cleanup failure passed in immediate isolation. A separate pre-existing protocol diagnostic/CFG fail fixture remained out of scope. The one create-PR gate stopped at inherited verification-taxonomy failures. After demo-only remediation, four emitted artifacts byte-matched live emission, all affected Sifr and idiomatic demos ran, and the one merge gate on final candidate `bbeee29689ddf4f5ed2c3c0f84955992c1e8f46e` stopped at the same inherited taxonomy failure; neither gate was repeated. | [Initial exact-SHA review](https://github.com/sifr-lang/sifr/pull/3246#issuecomment-5327168534): NOT SATISFIED for stale demo companions; [one remediation review](https://github.com/sifr-lang/sifr/pull/3246#issuecomment-5327211679): SATISFIED, no blocking findings. | Removed duplicate numeric/random public names, preserved stateful canonical random behavior, taught bootstrap/lowering/codegen to honor private function aliases, migrated consumers, and deleted the alias demo. |
 | 3. Runtime-information names | merged | [#3250](https://github.com/sifr-lang/sifr/pull/3250) | `c96d0b5048cd4f9916a2bc6995f6fd356ddbdbf0` | Candidate `b15f3b443ae3252a8ed7c505eff789672d57e372`: focused compiled-export coverage, 11 affected e2e fixtures, sys/process runtime checks, six regenerated Sifr demos, eight idiomatic companions, full stdlib parity and self-test, driver stdlib (72 passed, 2 ignored), `sifr_stdlib` (56 passed), `sifr_sysroot` (11 passed), stdlib manifest (39 passed), installed/source sysroot equivalence, broad CLI tests, formatting, file-size, HIR, inventory, and residue checks passed. The one create-PR and one merge gate stopped at the inherited verification-taxonomy failure assigned to Item 16; neither gate was repeated. | [Exact-SHA Opus review](https://github.com/sifr-lang/sifr/pull/3250#issuecomment-5327677808): SATISFIED, no blocking findings. | Removed intrinsic-shaped runtime-information exports, kept private aliases behind canonical wrappers, preserved typed environment defaults, migrated consumers, and removed the duplicate UTC constructor. |
-| 4. Text and structured-data names | pending | — | — | — | — | — |
+| 4. Text and structured-data names | merged | [#3254](https://github.com/sifr-lang/sifr/pull/3254) | `4bdb89b741a4d6cfbf8a4bcc3b8bb6d676d75501` | Candidate `b98864c82c61f42909b3395aae7714cc53215937`: 27 focused e2e fixtures, affected Sifr and idiomatic demos, fresh generated baselines, codegen filter shadowing, driver stdlib (73 passed, 2 ignored), codegen (1023 passed), `sifr_stdlib` (56 passed), `sifr_sysroot` (11 passed), stdlib manifest (39 passed), broad CLI tests, installed/source sysroot equivalence, formatting, file-size, HIR, compatibility inventory, full module parity, and complexity checks passed. The aggregate parity runner's two failures were inherited bare-namespace and Python import-path issues. The one create-PR and one merge gate stopped at the inherited verification-taxonomy failure assigned to Item 16; neither gate was repeated. | [Exact-SHA Opus review](https://github.com/sifr-lang/sifr/pull/3254#issuecomment-5328750688): SATISFIED, no blocking findings. | Removed the duplicate text/data names, preserved the broad canonical JSON input contract, kept regex keyword handling under `Pattern.is_match`, privatized implementation imports, migrated consumers, and fixed imported/user-defined `filter` shadowing. |
 | 5. Binary and hashing helpers | pending | — | — | — | — | — |
 | 6. Collection helpers | pending | — | — | — | — | — |
 | 7. Remaining stdlib residue | pending | — | — | — | — | — |
@@ -1028,6 +1028,12 @@ migrates its repository consumers before the old path disappears.
 | Item 3 | Public underscore privacy relies on export retention; `sifr.heapq` exceptions and the duplicate frontend policy need explicit reconciliation. | `pre_v1_compat_7_stdlib_residue` | Consolidate and directly test the approved private-export policy in the final stdlib sweep. |
 | Item 3 | Current stdlib architecture and parity records still name the obsolete `lib/sifr/*.sifr` source path. | `pre_v1_compat_7_stdlib_residue` | Correct current documentation paths while making public docs match the final compiled export inventory. |
 | Item 3 | Regenerated demo companions contained substantial pre-existing emission drift beyond the public-name edits. | `pre_v1_compat_7_stdlib_residue` | Reconcile remaining stdlib demo artifacts during the final stdlib sweep without reopening Item 3. |
+| Item 4 | Two migrated CPython fixture header comments are mechanically worded, and several fixtures duplicate a local `has_match` adapter instead of covering `Pattern.is_match` directly. | `pre_v1_compat_7_stdlib_residue` | Clean the fixture prose and consolidate canonical regex consumer coverage during the final stdlib sweep. |
+| Item 4 | JSON keeps a private `_loads_impl` to avoid current flat generated-name collisions while TOML internal callers can use public `loads` directly. | `pre_v1_compat_7_stdlib_residue` | Reconcile the redundant internal shape after the final public-export and collision policy is explicit. |
+| Item 4 | User-defined `map` still has the same pre-existing name-based plain-call lowering risk that Item 4 removed for `filter`. | `pre_v1_compat_7_stdlib_residue` | Route builtin `map` exclusively through typed iterator HIR and add shadowing coverage during the final stdlib sweep. |
+| Item 4 | `sifr.base64` still imports first-class byte transition helpers without private aliases. | `pre_v1_compat_5_binary_hashing` | Resolve the binary helper ownership while removing the bytes transition surface. |
+| Item 4 | `sifr.json` and `sifr.tomllib` retain unaliased cross-module imports that can appear in compiled public metadata. | `pre_v1_compat_7_stdlib_residue` | Apply the final compiled-export policy to non-intrinsic cross-module imports. |
+| Item 4 | The full stdlib parity runner reports inherited bare `math` namespace references and an `audit_fixtures.py` import-path failure. | `pre_v1_compat_7_stdlib_residue` and `pre_v1_compat_13_verification` | Correct the demo namespace residue in Item 7 and the runner environment in Item 13; do not reopen Item 4. |
 
 ## Phase Completion Record
 


### PR DESCRIPTION
## Summary
- record Item 4 implementation, validation, review, and merge evidence
- close Item 4 acceptance criteria and hand off to Item 5
- assign nonblocking reviewer and inherited infrastructure findings to later phase items

## Validation
- `git diff --check`
- compatibility inventory checker
- documentation structure checker

Record-only update: no external review or compiler gates required.
