### PR TITLE
M5: add handler-bearing method descriptors

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests/receiver_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/receiver_codegen_tests.rs
@@ -106,7 +106,7 @@ class Consumable:
 
     assert!(rust_code.contains("fn read(&self) -> i64"));
     assert!(rust_code.contains("fn bump(&mut self)"));
-    assert!(rust_code.contains("fn close(&self)"));
+    assert!(rust_code.contains("fn close(self)"));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/static_program_codegen.rs
+++ b/crates/sifr_codegen/src/static_program_codegen.rs
@@ -339,6 +339,12 @@ mod tests {
             output_type: Type::Str,
             context_type: None,
             context_mutable: false,
+            descriptor_type: None,
+            descriptor_value: None,
+            descriptor_origin: None,
+            descriptor_range: None,
+            declaration_order: None,
+            is_fallible: true,
         });
         output.method_slot_context = Some(StaticMethodSlotContext::None);
 

--- a/crates/sifr_codegen/src/static_program_slots_codegen.rs
+++ b/crates/sifr_codegen/src/static_program_slots_codegen.rs
@@ -108,8 +108,17 @@ fn slot_arm(index: usize, slot: &StaticMethodSlot, context: &StaticMethodSlotCon
                 .is_some_and(|param| param.convention.is_mut_borrow()));
     let binding = if mutable_input { "mut " } else { "" };
     let call = slot_call_expression(slot, context);
+    let dispatch = if slot.is_fallible {
+        format!(
+            "match {call} {{\n                    Ok(output) => {STRUCTURAL}::StructuralProject::structural_project(&output, &mut {STRUCTURAL}::SlotSinkVisitor::new(sink)).map_err({STRUCTURAL}::SlotError::Contract),\n                    Err(error) => Err({STRUCTURAL}::SlotError::Slot(error.to_string())),\n                }}"
+        )
+    } else {
+        format!(
+            "let output = {call};\n                {STRUCTURAL}::StructuralProject::structural_project(&output, &mut {STRUCTURAL}::SlotSinkVisitor::new(sink)).map_err({STRUCTURAL}::SlotError::Contract)"
+        )
+    };
     format!(
-        "            {index}usize => {{\n                let {binding}value = {STRUCTURAL}::structural_construct::<{input}, _>(input).map_err({STRUCTURAL}::SlotError::Contract)?;\n                match {call} {{\n                    Ok(output) => {STRUCTURAL}::StructuralProject::structural_project(&output, &mut {STRUCTURAL}::SlotSinkVisitor::new(sink)).map_err({STRUCTURAL}::SlotError::Contract),\n                    Err(error) => Err({STRUCTURAL}::SlotError::Slot(error.to_string())),\n                }}\n            }}"
+        "            {index}usize => {{\n                let {binding}value = {STRUCTURAL}::structural_construct::<{input}, _>(input).map_err({STRUCTURAL}::SlotError::Contract)?;\n                {dispatch}\n            }}"
     )
 }
 

--- a/crates/sifr_driver/src/tests/handler_descriptors.rs
+++ b/crates/sifr_driver/src/tests/handler_descriptors.rs
@@ -1,0 +1,476 @@
+use super::support::parse_suite;
+use crate::{collect_project_hir_modules, compile_stdlib};
+use sifr_ir::{MethodKind, StaticMethodSlotContext, StaticProgramValue};
+use sifr_type_system::ReceiverConvention;
+use std::collections::HashMap;
+
+const TYPES: &str = r#"
+class HandlerDescriptor:
+    tag: str
+"#;
+
+const CONTRACT: &str = r#"
+from sifr.meta import CallableIdentity, ConstSpecializationOutcome, DeclarationInput, DeclarationPlan, PlannedField, PlannedHandler, ShapeInput
+from fixture.handler_types import HandlerDescriptor
+
+@class_adapter_provider("fixture.handler_types", "HandlerDescriptor")
+@const_eval
+def adapt_handlers(declaration: DeclarationInput[HandlerDescriptor]) -> DeclarationPlan[HandlerDescriptor]:
+    fields: list[PlannedField] = []
+    handlers: list[PlannedHandler[HandlerDescriptor]] = []
+    for item in declaration.declaration.items:
+        declared_type = item.declared_type
+        if item.kind == "field" and declared_type is not None:
+            fields.append(PlannedField(item.identity, declared_type))
+    for descriptor in declaration.descriptors:
+        target = descriptor.target_callable
+        if descriptor.target_kind == "method" and target is not None:
+            handlers.append(PlannedHandler(target, descriptor.value, descriptor.origin))
+    return DeclarationPlan(fields, [], "fixture.handlers", "specialize", [], handlers)
+
+@class_adapter_marker("fixture.handlers", "adapt_handlers")
+class HandlerContract:
+    pass
+
+@method_descriptor("fixture.handlers", "adapt_handlers")
+def handler(tag: str) -> HandlerDescriptor:
+    return HandlerDescriptor(tag)
+
+class HandlerProgram:
+    sifr_method_slots: list[CallableIdentity]
+
+@const_eval
+def specialize(shape: ShapeInput[HandlerDescriptor]) -> ConstSpecializationOutcome[HandlerProgram, HandlerDescriptor]:
+    slots: list[CallableIdentity] = []
+    for method in shape.root.methods:
+        target = method.target
+        descriptor = method.descriptor
+        if target is not None and descriptor is not None:
+            slots.append(target)
+    return ConstSpecializationOutcome("produced", HandlerProgram(slots), [])
+"#;
+
+fn project(main: &str) -> HashMap<String, Vec<sifr_python_ast::Stmt>> {
+    HashMap::from([
+        ("fixture.handler_types".to_string(), parse_suite(TYPES)),
+        ("fixture.handlers".to_string(), parse_suite(CONTRACT)),
+        ("main".to_string(), parse_suite(main)),
+    ])
+}
+
+fn compile_errors(main: &str) -> Vec<sifr_diagnostics::RenderedDiagnostic> {
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    match collect_project_hir_modules(&project(main), stdlib_defs) {
+        Ok(_) => panic!("handler fixture must fail"),
+        Err(errors) => errors,
+    }
+}
+
+#[test]
+fn handler_descriptors_select_checked_receivers_in_declaration_order() {
+    let modules = project(
+        r#"
+from fixture.handlers import HandlerContract, handler
+
+class Model(HandlerContract):
+    value: str
+
+    @staticmethod
+    @handler("static")
+    def parse_static(own value: str) -> str:
+        return value
+
+    @handler("class")
+    @classmethod
+    def parse_class(cls, own value: str) -> Result[str, ValueError]:
+        return value
+
+    @handler("shared")
+    def inspect(self) -> str:
+        return self.value
+
+    @handler("mutable")
+    def normalize(mut self) -> str:
+        return self.value
+
+    @handler("owned")
+    def finish(own self) -> Self:
+        return self
+"#,
+    );
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let compiled = collect_project_hir_modules(&modules, stdlib_defs)
+        .expect("non-Pydantic handler pipeline should compile");
+    let selection = compiled
+        .external_defs
+        .class_adapter_selections
+        .get("main")
+        .and_then(|classes| classes.get("Model"))
+        .expect("handler adapter selection exists");
+    assert_eq!(
+        selection
+            .handler_plans
+            .iter()
+            .map(|handler| handler.callable.symbol.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "parse_static",
+            "parse_class",
+            "inspect",
+            "normalize",
+            "finish"
+        ]
+    );
+    assert_eq!(
+        selection
+            .handler_plans
+            .iter()
+            .map(|handler| handler.declaration_order)
+            .collect::<Vec<_>>(),
+        [0, 1, 2, 3, 4]
+    );
+
+    let output = compiled
+        .external_defs
+        .specialization_outputs
+        .get("main")
+        .and_then(|outputs| outputs.first())
+        .expect("handler specialization output exists");
+    assert_eq!(
+        output
+            .method_slots
+            .iter()
+            .map(|slot| slot.name.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "parse_static",
+            "parse_class",
+            "inspect",
+            "normalize",
+            "finish"
+        ]
+    );
+    assert_eq!(output.method_slots[0].method_kind, MethodKind::StaticMethod);
+    assert!(!output.method_slots[0].is_fallible);
+    assert_eq!(output.method_slots[1].method_kind, MethodKind::ClassMethod);
+    assert!(output.method_slots[1].is_fallible);
+    assert_eq!(
+        output.method_slots[2].receiver,
+        Some(ReceiverConvention::SharedBorrow)
+    );
+    assert_eq!(
+        output.method_slots[3].receiver,
+        Some(ReceiverConvention::MutableBorrow)
+    );
+    assert_eq!(
+        output.method_slots[4].receiver,
+        Some(ReceiverConvention::Owned)
+    );
+    assert_eq!(
+        output.method_slot_context,
+        Some(StaticMethodSlotContext::None)
+    );
+    assert!(output.method_slots.iter().all(|slot| {
+        slot.descriptor_value
+            .as_ref()
+            .is_some_and(|value| matches!(value, StaticProgramValue::Record(_)))
+            && slot.descriptor_origin.is_some()
+            && slot.descriptor_range.is_some()
+    }));
+}
+
+#[test]
+fn classmethod_descriptor_must_be_the_outer_adjacent_decorator() {
+    let errors = compile_errors(
+        r#"
+from fixture.handlers import HandlerContract, handler
+
+class Invalid(HandlerContract):
+    value: str
+
+    @classmethod
+    @handler("wrong-order")
+    def parse(cls, own value: str) -> str:
+        return value
+"#,
+    );
+    assert!(errors.iter().any(|error| {
+        error.code == sifr_diagnostics::DiagnosticCode::META_MALFORMED_DECLARATION.code()
+            && error
+                .message
+                .contains("outer decorator with @classmethod directly above")
+    }));
+}
+
+#[test]
+fn owned_handler_requires_exact_self_output_at_the_descriptor() {
+    let errors = compile_errors(
+        r#"
+from fixture.handlers import HandlerContract, handler
+
+class Invalid(HandlerContract):
+    value: str
+
+    @handler("owned")
+    def finish(own self) -> str:
+        return self.value
+"#,
+    );
+    assert!(errors.iter().any(|error| {
+        error.code == sifr_diagnostics::DiagnosticCode::RUST_SLOT_SIGNATURE.code()
+            && error.message.contains("must return exactly Self")
+    }));
+}
+
+#[test]
+fn constructors_cannot_be_selected_as_handlers() {
+    let errors = compile_errors(
+        r#"
+from fixture.handlers import HandlerContract, handler
+
+class Invalid(HandlerContract):
+    value: str
+
+    @handler("constructor")
+    def __init__(self, own value: str):
+        self.value = value
+"#,
+    );
+    assert!(errors.iter().any(|error| {
+        error.code == sifr_diagnostics::DiagnosticCode::RUST_SLOT_METHOD.code()
+            && error.message.contains("cannot name a constructor")
+    }));
+}
+
+#[test]
+fn inherited_handlers_precede_local_handlers_deterministically() {
+    let modules = project(
+        r#"
+from fixture.handlers import HandlerContract, handler
+
+class Parent(HandlerContract):
+    parent_value: str
+
+    @staticmethod
+    @handler("parent")
+    def parent_handler(own value: str) -> str:
+        return value
+
+class Child(Parent):
+    child_value: str
+
+    @staticmethod
+    @handler("child")
+    def child_handler(own value: str) -> str:
+        return value
+"#,
+    );
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let compiled = collect_project_hir_modules(&modules, stdlib_defs)
+        .expect("inherited handlers should compile");
+    let child = compiled
+        .external_defs
+        .class_adapter_selections
+        .get("main")
+        .and_then(|classes| classes.get("Child"))
+        .expect("child selection exists");
+    assert_eq!(
+        child
+            .handler_plans
+            .iter()
+            .map(|handler| handler.callable.symbol.as_str())
+            .collect::<Vec<_>>(),
+        ["parent_handler", "child_handler"]
+    );
+    assert_eq!(
+        child
+            .handler_plans
+            .iter()
+            .map(|handler| handler.declaration_order)
+            .collect::<Vec<_>>(),
+        [0, 1]
+    );
+    let output = compiled
+        .external_defs
+        .specialization_outputs
+        .get("main")
+        .and_then(|outputs| outputs.iter().find(|output| output.owner == "Child"))
+        .expect("child specialization output exists");
+    assert_eq!(
+        output
+            .method_slots
+            .iter()
+            .map(|slot| slot.name.as_str())
+            .collect::<Vec<_>>(),
+        ["parent_handler", "child_handler"]
+    );
+}
+
+#[test]
+fn imported_inherited_handler_keeps_its_checked_owner() {
+    let mut modules = project(
+        r#"
+from base import Parent
+from fixture.handlers import handler
+
+class Child(Parent):
+    child_value: str
+
+    @staticmethod
+    @handler("child")
+    def child_handler(own value: str) -> str:
+        return value
+"#,
+    );
+    modules.insert(
+        "base".to_string(),
+        parse_suite(
+            r#"
+from fixture.handlers import HandlerContract, handler
+
+class Parent(HandlerContract):
+    parent_value: str
+
+    @staticmethod
+    @handler("parent")
+    def parent_handler(own value: str) -> str:
+        return value
+"#,
+        ),
+    );
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let compiled = collect_project_hir_modules(&modules, stdlib_defs)
+        .expect("imported inherited handler should compile");
+    let output = compiled
+        .external_defs
+        .specialization_outputs
+        .get("main")
+        .and_then(|outputs| outputs.iter().find(|output| output.owner == "Child"))
+        .expect("child specialization output exists");
+    assert_eq!(
+        output
+            .method_slots
+            .iter()
+            .map(|slot| (slot.owner_identity.as_str(), slot.name.as_str()))
+            .collect::<Vec<_>>(),
+        [
+            ("base.Parent", "parent_handler"),
+            ("main.Child", "child_handler")
+        ]
+    );
+}
+
+#[test]
+fn handler_context_must_be_borrowed() {
+    let errors = compile_errors(
+        r#"
+from fixture.handlers import HandlerContract, handler
+
+class AppContext:
+    calls: int
+
+class Invalid(HandlerContract):
+    value: str
+
+    @staticmethod
+    @handler("context")
+    def parse(own value: str, own context: AppContext) -> str:
+        return value
+"#,
+    );
+    assert!(errors.iter().any(|error| {
+        error.code == sifr_diagnostics::DiagnosticCode::RUST_SLOT_CONTEXT.code()
+            && error
+                .message
+                .contains("context must be an immutable or mutable borrow")
+    }));
+}
+
+#[test]
+fn handler_target_changes_static_program_identity() {
+    fn identity(method_name: &str) -> [u8; 32] {
+        let main = format!(
+            r#"
+from fixture.handlers import HandlerContract, handler
+
+class Model(HandlerContract):
+    value: str
+
+    @staticmethod
+    @handler("selected")
+    def {method_name}(own value: str) -> str:
+        return value
+"#
+        );
+        let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+        let compiled = collect_project_hir_modules(&project(&main), stdlib_defs)
+            .expect("handler identity fixture compiles");
+        compiled
+            .external_defs
+            .specialization_outputs
+            .get("main")
+            .and_then(|outputs| outputs.first())
+            .expect("specialization output exists")
+            .program_identity
+    }
+
+    assert_ne!(identity("first"), identity("second"));
+}
+
+#[test]
+fn owned_handler_receiver_moves_exactly_once() {
+    let errors = compile_errors(
+        r#"
+from fixture.handlers import HandlerContract, handler
+
+class Model(HandlerContract):
+    value: str
+
+    @handler("owned")
+    def finish(own self) -> Self:
+        return self
+
+def invalid_reuse() -> str:
+    model: Model = Model("value")
+    moved: Model = model.finish()
+    return model.value + moved.value
+"#,
+    );
+    assert!(errors.iter().any(|error| {
+        error.code == sifr_diagnostics::DiagnosticCode::OWN_USE_AFTER_MOVE.code()
+    }));
+}
+
+#[test]
+fn self_annotation_keeps_the_current_generic_specialization() {
+    let modules = project(
+        r#"
+class Box[T]:
+    value: T
+
+    def keep(own self) -> Self:
+        return self
+"#,
+    );
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let compiled = collect_project_hir_modules(&modules, stdlib_defs)
+        .expect("generic Self annotation should compile");
+    let method = compiled
+        .hir_modules
+        .get("main")
+        .and_then(|module| module.classes.iter().find(|class| class.name == "Box"))
+        .and_then(|class| class.methods.iter().find(|method| method.name == "keep"))
+        .expect("generic method exists");
+    let sifr_type_system::Type::Class {
+        name, type_args, ..
+    } = method.return_type.resolve_alias()
+    else {
+        panic!("Self should resolve to the current class specialization");
+    };
+    assert_eq!(name, "Box");
+    assert_eq!(
+        type_args,
+        &[sifr_type_system::Type::TypeVar("T".to_string())]
+    );
+    assert_eq!(method.receiver, Some(ReceiverConvention::Owned));
+}

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod adapter_defaults;
 mod diagnostics;
 mod discovery_and_workspace;
 mod early_adapters;
+mod handler_descriptors;
 mod package_project_build_check;
 mod panic_boundary;
 mod project_build_check;

--- a/crates/sifr_frontend/src/callable_identities.rs
+++ b/crates/sifr_frontend/src/callable_identities.rs
@@ -59,6 +59,43 @@ pub(crate) fn contract_for_identity(
     .contract(identity)
 }
 
+pub(crate) fn method_declaration(
+    module_name: &str,
+    result: &LoweringResult,
+    owner: &str,
+    method_name: &str,
+) -> Option<CallableIdentity> {
+    let class = result
+        .module
+        .classes
+        .iter()
+        .find(|class| class.name == owner)?;
+    let hir_name = if method_name == "__init__" {
+        "new"
+    } else {
+        method_name
+    };
+    let method = class
+        .methods
+        .iter()
+        .chain(class.operator_impls.iter().map(|(_, method)| method))
+        .find(|method| method.name == hir_name)?;
+    let local_classes = result
+        .module
+        .classes
+        .iter()
+        .map(|class| (class.name.clone(), format!("{module_name}.{}", class.name)))
+        .collect();
+    let function = canonicalize_user_export_function_type(&function_type(method), &local_classes);
+    Some(CallableIdentity {
+        module: module_name.to_string(),
+        owner: Some(format!("{module_name}.{owner}")),
+        symbol: method_name.to_string(),
+        generic_arguments: Vec::new(),
+        signature: signature(&function),
+    })
+}
+
 struct Resolver<'a> {
     module_name: &'a str,
     result: &'a LoweringResult,

--- a/crates/sifr_frontend/src/class_declarations.rs
+++ b/crates/sifr_frontend/src/class_declarations.rs
@@ -2,15 +2,9 @@
 
 use crate::ConstValue;
 use ruff_text_size::{Ranged, TextRange};
-use sifr_lowering::LoweringResult;
+use sifr_lowering::{LoweringResult, SourceOriginId};
 use sifr_python_ast::{Decorator, Expr, Stmt, StmtClassDef, StmtFunctionDef};
 use std::collections::BTreeMap;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct SourceOriginId {
-    namespace: [u8; 32],
-    index: u32,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceOriginKind {
@@ -41,7 +35,7 @@ pub(crate) struct SourceOriginTable {
 impl SourceOriginTable {
     #[must_use]
     pub(crate) fn resolve(&self, id: SourceOriginId) -> Option<&SourceOriginEntry> {
-        (id.namespace == self.namespace)
+        id.belongs_to(self.namespace)
             .then(|| self.entries.get(&id))
             .flatten()
     }
@@ -568,10 +562,7 @@ impl DeclarationCollector {
     }
 
     fn add_origin(&mut self, kind: SourceOriginKind, range: TextRange) -> SourceOriginId {
-        let id = SourceOriginId {
-            namespace: self.namespace,
-            index: self.next_origin,
-        };
+        let id = SourceOriginId::new(self.namespace, self.next_origin);
         self.next_origin = self.next_origin.saturating_add(1);
         self.entries
             .insert(id, SourceOriginEntry { id, kind, range });

--- a/crates/sifr_frontend/src/class_method_exports.rs
+++ b/crates/sifr_frontend/src/class_method_exports.rs
@@ -90,19 +90,14 @@ pub(crate) fn structural_method_map(
     local_classes: &HashMap<String, String>,
     lowering: &sifr_lowering::LoweringResult,
 ) -> HashMap<String, Vec<StructuralMethodExport>> {
-    if module.classes.is_empty()
-        || !lowering
-            .declaration_metadata
-            .iter()
-            .any(|entry| entry.target_kind == DeclarationMetadataTargetKind::Method)
-    {
+    if module.classes.is_empty() {
         return HashMap::new();
     }
     let mut names_by_class: HashMap<&str, Vec<&str>> = HashMap::new();
-    let mut seen = HashSet::new();
+    let mut seen: HashSet<String> = HashSet::new();
     for entry in &lowering.declaration_metadata {
         if entry.target_kind != DeclarationMetadataTargetKind::Method
-            || !seen.insert(entry.owner.as_str())
+            || !seen.insert(entry.owner.clone())
         {
             continue;
         }
@@ -113,6 +108,26 @@ pub(crate) fn structural_method_map(
             .entry(class_name)
             .or_default()
             .push(method_name);
+    }
+    for selection in &lowering.class_adapter_selections {
+        for handler in &selection.handler_plans {
+            let Some(owner) = handler.callable.owner.as_deref() else {
+                continue;
+            };
+            let Some(class_name) = owner.rsplit_once('.').map(|(_, name)| name) else {
+                continue;
+            };
+            if local_classes.get(class_name).map(String::as_str) != Some(owner) {
+                continue;
+            }
+            let key = format!("{class_name}.{}", handler.callable.symbol);
+            if seen.insert(key) {
+                names_by_class
+                    .entry(class_name)
+                    .or_default()
+                    .push(handler.callable.symbol.as_str());
+            }
+        }
     }
     if names_by_class.is_empty() {
         return HashMap::new();

--- a/crates/sifr_frontend/src/const_specialization.rs
+++ b/crates/sifr_frontend/src/const_specialization.rs
@@ -30,7 +30,7 @@ pub enum ConstValue {
     CallableIdentity(sifr_lowering::CallableIdentity),
     /// Compiler-issued diagnostic token. Package const code can carry this
     /// value but cannot construct it or retain it in a static program.
-    SourceOrigin(crate::class_declarations::SourceOriginId),
+    SourceOrigin(sifr_lowering::SourceOriginId),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/sifr_frontend/src/early_adapters.rs
+++ b/crates/sifr_frontend/src/early_adapters.rs
@@ -1,20 +1,25 @@
 //! Erased marker selection and bounded early class-adapter execution.
 
+mod adapter_input;
+mod handler_plans;
 mod inheritance;
+
+use adapter_input::adapter_input;
+use handler_plans::validate_handlers;
 
 use crate::package_issues::{
     evaluation_error, issue_templates, replace_unknown_package, SpecializationDiagnostic,
     SpecializationDiagnostics,
 };
-use crate::specialization_support::{const_value, malformed, static_program_value};
+use crate::specialization_support::{malformed, static_program_value};
 use crate::{
     decode_const_specialization_outcome, package_note, ConstIssueSeverity, ConstPackageIssue,
     ConstValue, DeterministicConstEvaluator,
 };
 use sifr_lowering::{
-    AdapterFieldDefault, AdapterFieldPlan, AppliedAdapterMetadata, ClassAdapterSelection,
-    ConstSpecializationRequest, DeclarationDescriptorKind, DeclarationMetadataTargetKind,
-    LoweringWarningDiagnostic, TypedDeclarationDescriptor,
+    AdapterFieldDefault, AdapterFieldPlan, AdapterHandlerPlan, AppliedAdapterMetadata,
+    ClassAdapterSelection, ConstSpecializationRequest, DeclarationMetadataTargetKind,
+    LoweringWarningDiagnostic,
 };
 use sifr_lowering::{ExternalDefs, HirModule, LoweringResult};
 use sifr_type_system::Type;
@@ -189,65 +194,6 @@ fn run_one(
     }
 }
 
-fn adapter_input(
-    module_name: &str,
-    result: &LoweringResult,
-    external_defs: &ExternalDefs,
-    declaration: &crate::class_declarations::ClassDeclaration,
-    selection: &ClassAdapterSelection,
-    descriptors: &[&TypedDeclarationDescriptor],
-) -> Result<ConstValue, &'static str> {
-    let descriptors = descriptors
-        .iter()
-        .map(|descriptor| {
-            let origin = declaration
-                .origin_for_range(descriptor.range)
-                .ok_or("descriptor source origin is unavailable")?;
-            Ok(ConstValue::Record(BTreeMap::from([
-                (
-                    "target_kind".to_string(),
-                    ConstValue::String(descriptor_kind(descriptor.target_kind).to_string()),
-                ),
-                (
-                    "target_identity".to_string(),
-                    ConstValue::String(canonical_target(module_name, &descriptor.target_identity)),
-                ),
-                ("value".to_string(), const_value(&descriptor.value)?),
-                ("origin".to_string(), ConstValue::SourceOrigin(origin)),
-            ])))
-        })
-        .collect::<Result<Vec<_>, &'static str>>()?;
-    let data_parent = selection
-        .data_parent
-        .as_ref()
-        .and_then(|_| {
-            result
-                .module
-                .classes
-                .iter()
-                .find(|class| class.name == selection.owner)
-                .and_then(|class| class.parent_type.as_ref())
-        })
-        .map_or(ConstValue::None, |parent| {
-            ConstValue::String(crate::canonical_types::type_identity(parent))
-        });
-    let declaration =
-        inheritance::declaration_value(module_name, result, external_defs, declaration, selection)?;
-    Ok(ConstValue::Record(BTreeMap::from([
-        ("declaration".to_string(), declaration),
-        ("descriptors".to_string(), ConstValue::List(descriptors)),
-        (
-            "provider_module".to_string(),
-            ConstValue::String(selection.provider_module.clone()),
-        ),
-        (
-            "provider_function".to_string(),
-            ConstValue::String(selection.provider_function.clone()),
-        ),
-        ("data_parent".to_string(), data_parent),
-    ])))
-}
-
 fn const_functions(
     result: &LoweringResult,
     external_defs: &ExternalDefs,
@@ -302,11 +248,11 @@ fn validate_issues(
         ));
         return None;
     };
-    if fields.len() != 5 {
+    if fields.len() != 6 {
         diagnostics.push(malformed(
             &selection.provider_module,
             "adapter_plan",
-            "adapter plan must contain exactly these fields: fields, metadata, specialization_module, specialization_function, and issues",
+            "adapter plan must contain exactly these fields: fields, metadata, specialization_module, specialization_function, issues, and handlers",
             selection.range,
         ));
         return None;
@@ -380,6 +326,7 @@ fn validate_issues(
 
 struct ValidatedPlan {
     fields: Vec<AdapterFieldPlan>,
+    handlers: Vec<AdapterHandlerPlan>,
     metadata: Vec<AppliedAdapterMetadata>,
     specialization: Option<(String, String)>,
 }
@@ -395,7 +342,7 @@ fn validate_plan(
     let ConstValue::Record(mut fields) = value else {
         return Err("adapter plan value must be a record".to_string());
     };
-    if fields.len() != 4 {
+    if fields.len() != 5 {
         return Err("adapter plan contains unknown output fields".to_string());
     }
     let planned_fields = take_list(&mut fields, "fields")?;
@@ -426,6 +373,14 @@ fn validate_plan(
             )
         })
         .collect::<Result<Vec<_>, _>>()?;
+    let handlers = validate_handlers(
+        module_name,
+        declaration,
+        result,
+        external_defs,
+        selection,
+        take_list(&mut fields, "handlers")?,
+    )?;
     let module = take_optional_string(&mut fields, "specialization_module")?;
     let function = take_optional_string(&mut fields, "specialization_function")?;
     if !fields.is_empty() {
@@ -451,6 +406,7 @@ fn validate_plan(
     }
     Ok(ValidatedPlan {
         fields: planned_fields,
+        handlers,
         metadata,
         specialization,
     })
@@ -805,6 +761,7 @@ fn apply_plan(
         .find(|candidate| candidate.owner == selection.owner)
     {
         applied.field_plans = plan.fields;
+        applied.handler_plans = plan.handlers;
         applied.adapter_invocation_identity = adapter_invocation_identity;
         applied.post_adapter_identity = post_adapter_identity;
     }
@@ -818,20 +775,6 @@ fn apply_plan(
                 function,
                 range: selection.range,
             });
-    }
-}
-
-fn canonical_target(module_name: &str, target: &str) -> String {
-    let target = target.split_once(':').map_or(target, |(target, _)| target);
-    format!("{module_name}.{target}")
-}
-
-fn descriptor_kind(kind: DeclarationDescriptorKind) -> &'static str {
-    match kind {
-        DeclarationDescriptorKind::Field => "field",
-        DeclarationDescriptorKind::Class => "class",
-        DeclarationDescriptorKind::Method => "method",
-        DeclarationDescriptorKind::Type => "type",
     }
 }
 

--- a/crates/sifr_frontend/src/early_adapters/adapter_input.rs
+++ b/crates/sifr_frontend/src/early_adapters/adapter_input.rs
@@ -1,0 +1,143 @@
+//! Closed declaration input passed to one package adapter invocation.
+
+use super::{handler_plans::inherited_handler_plans, inheritance};
+use crate::specialization_support::const_value;
+use crate::ConstValue;
+use sifr_lowering::{
+    ClassAdapterSelection, DeclarationDescriptorKind, ExternalDefs, LoweringResult,
+    TypedDeclarationDescriptor,
+};
+use std::collections::BTreeMap;
+
+pub(super) fn adapter_input(
+    module_name: &str,
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    declaration: &crate::class_declarations::ClassDeclaration,
+    selection: &ClassAdapterSelection,
+    descriptors: &[&TypedDeclarationDescriptor],
+) -> Result<ConstValue, &'static str> {
+    let mut descriptor_values = inherited_values(module_name, result, external_defs, selection)?;
+    descriptor_values.extend(local_values(module_name, declaration, descriptors)?);
+    let data_parent = selection
+        .data_parent
+        .as_ref()
+        .and_then(|_| {
+            result
+                .module
+                .classes
+                .iter()
+                .find(|class| class.name == selection.owner)
+                .and_then(|class| class.parent_type.as_ref())
+        })
+        .map_or(ConstValue::None, |parent| {
+            ConstValue::String(crate::canonical_types::type_identity(parent))
+        });
+    let declaration =
+        inheritance::declaration_value(module_name, result, external_defs, declaration, selection)?;
+    Ok(ConstValue::Record(BTreeMap::from([
+        ("declaration".to_string(), declaration),
+        (
+            "descriptors".to_string(),
+            ConstValue::List(descriptor_values),
+        ),
+        (
+            "provider_module".to_string(),
+            ConstValue::String(selection.provider_module.clone()),
+        ),
+        (
+            "provider_function".to_string(),
+            ConstValue::String(selection.provider_function.clone()),
+        ),
+        ("data_parent".to_string(), data_parent),
+    ])))
+}
+
+fn inherited_values(
+    module_name: &str,
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    selection: &ClassAdapterSelection,
+) -> Result<Vec<ConstValue>, &'static str> {
+    inherited_handler_plans(module_name, result, external_defs, selection)
+        .into_iter()
+        .map(|handler| {
+            Ok(ConstValue::Record(BTreeMap::from([
+                (
+                    "target_kind".to_string(),
+                    ConstValue::String("method".to_string()),
+                ),
+                (
+                    "target_identity".to_string(),
+                    ConstValue::String(format!(
+                        "{}::{}",
+                        handler
+                            .callable
+                            .owner
+                            .as_deref()
+                            .unwrap_or(&handler.callable.module),
+                        handler.callable.symbol
+                    )),
+                ),
+                (
+                    "target_callable".to_string(),
+                    ConstValue::CallableIdentity(handler.callable),
+                ),
+                ("value".to_string(), const_value(&handler.descriptor_value)?),
+                (
+                    "origin".to_string(),
+                    ConstValue::SourceOrigin(handler.descriptor_origin),
+                ),
+            ])))
+        })
+        .collect()
+}
+
+fn local_values(
+    module_name: &str,
+    declaration: &crate::class_declarations::ClassDeclaration,
+    descriptors: &[&TypedDeclarationDescriptor],
+) -> Result<Vec<ConstValue>, &'static str> {
+    descriptors
+        .iter()
+        .map(|descriptor| {
+            let origin = declaration
+                .origin_for_range(descriptor.range)
+                .ok_or("descriptor source origin is unavailable")?;
+            Ok(ConstValue::Record(BTreeMap::from([
+                (
+                    "target_kind".to_string(),
+                    ConstValue::String(descriptor_kind(descriptor.target_kind).to_string()),
+                ),
+                (
+                    "target_identity".to_string(),
+                    ConstValue::String(canonical_target(module_name, &descriptor.target_identity)),
+                ),
+                (
+                    "target_callable".to_string(),
+                    descriptor
+                        .target_callable
+                        .clone()
+                        .map(ConstValue::CallableIdentity)
+                        .unwrap_or(ConstValue::None),
+                ),
+                ("value".to_string(), const_value(&descriptor.value)?),
+                ("origin".to_string(), ConstValue::SourceOrigin(origin)),
+            ])))
+        })
+        .collect()
+}
+
+fn canonical_target(module_name: &str, target: &str) -> String {
+    let target = target.split_once(':').map_or(target, |(target, _)| target);
+    format!("{module_name}.{target}")
+}
+
+const fn descriptor_kind(kind: DeclarationDescriptorKind) -> &'static str {
+    match kind {
+        DeclarationDescriptorKind::Field => "field",
+        DeclarationDescriptorKind::Class => "class",
+        DeclarationDescriptorKind::Method => "method",
+        DeclarationDescriptorKind::Type => "type",
+    }
+}

--- a/crates/sifr_frontend/src/early_adapters/handler_plans.rs
+++ b/crates/sifr_frontend/src/early_adapters/handler_plans.rs
@@ -1,0 +1,138 @@
+//! Validation and inheritance of package-selected method handlers.
+
+use super::inheritance;
+use crate::specialization_support::static_program_value;
+use crate::ConstValue;
+use sifr_lowering::{
+    AdapterHandlerPlan, ClassAdapterSelection, DeclarationDescriptorKind, ExternalDefs,
+    LoweringResult,
+};
+use sifr_type_system::Type;
+use std::collections::BTreeSet;
+
+pub(super) fn validate_handlers(
+    module_name: &str,
+    declaration: &crate::class_declarations::ClassDeclaration,
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    selection: &ClassAdapterSelection,
+    values: Vec<ConstValue>,
+) -> Result<Vec<AdapterHandlerPlan>, String> {
+    let mut eligible = inherited_handler_plans(module_name, result, external_defs, selection);
+    let inherited_count = eligible.len();
+    eligible.extend(
+        result
+            .declaration_descriptors
+            .iter()
+            .filter(|descriptor| {
+                descriptor.owner == selection.owner
+                    && descriptor.target_kind == DeclarationDescriptorKind::Method
+            })
+            .enumerate()
+            .map(|(index, descriptor)| {
+                let callable = descriptor.target_callable.clone().ok_or_else(|| {
+                    "method descriptor target has no sealed callable identity".to_string()
+                })?;
+                let descriptor_origin = declaration
+                    .origin_for_range(descriptor.range)
+                    .ok_or_else(|| "method descriptor source origin is unavailable".to_string())?;
+                Ok(AdapterHandlerPlan {
+                    callable,
+                    descriptor_type: descriptor.value_type.clone(),
+                    descriptor_value: descriptor.value.clone(),
+                    descriptor_origin,
+                    descriptor_range: descriptor.range,
+                    declaration_order: inherited_count + index,
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?,
+    );
+
+    let mut seen = BTreeSet::new();
+    values
+        .into_iter()
+        .map(|value| validate_one(value, &eligible, &mut seen))
+        .collect()
+}
+
+fn validate_one(
+    value: ConstValue,
+    eligible: &[AdapterHandlerPlan],
+    seen: &mut BTreeSet<(String, Option<String>, String)>,
+) -> Result<AdapterHandlerPlan, String> {
+    let ConstValue::Record(mut fields) = value else {
+        return Err("planned handler must be a record".to_string());
+    };
+    if fields.len() != 3 {
+        return Err("planned handler must contain target, descriptor, and origin".to_string());
+    }
+    let callable = match fields.remove("target") {
+        Some(ConstValue::CallableIdentity(callable)) => callable,
+        _ => return Err("planned handler target must be a sealed callable identity".to_string()),
+    };
+    let descriptor = fields
+        .remove("descriptor")
+        .ok_or_else(|| "planned handler is missing descriptor".to_string())?;
+    let origin = match fields.remove("origin") {
+        Some(ConstValue::SourceOrigin(origin)) => origin,
+        _ => return Err("planned handler origin must be a compiler source origin".to_string()),
+    };
+    if !fields.is_empty() {
+        return Err("planned handler contains unknown fields".to_string());
+    }
+    let key = (
+        callable.module.clone(),
+        callable.owner.clone(),
+        callable.symbol.clone(),
+    );
+    if !seen.insert(key) {
+        return Err(format!(
+            "planned handler '{}::{}' is duplicated",
+            callable.owner.as_deref().unwrap_or(&callable.module),
+            callable.symbol
+        ));
+    }
+    let descriptor = static_program_value(&descriptor).map_err(str::to_string)?;
+    eligible
+        .iter()
+        .find(|candidate| {
+            candidate.callable == callable
+                && candidate.descriptor_value == descriptor
+                && candidate.descriptor_origin == origin
+        })
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "planned handler '{}::{}' does not match a method descriptor on the adapted declaration",
+                callable.owner.as_deref().unwrap_or(&callable.module),
+                callable.symbol
+            )
+        })
+}
+
+pub(super) fn inherited_handler_plans(
+    module_name: &str,
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    selection: &ClassAdapterSelection,
+) -> Vec<AdapterHandlerPlan> {
+    let Some(parent_name) = selection.data_parent.as_deref() else {
+        return Vec::new();
+    };
+    let parent_identity = result
+        .module
+        .classes
+        .iter()
+        .find(|class| class.name == selection.owner)
+        .and_then(|class| class.parent_type.as_ref())
+        .and_then(|parent| match parent {
+            Type::Class { identity, name, .. } => {
+                Some(identity.clone().unwrap_or_else(|| name.clone()))
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| format!("{module_name}.{parent_name}"));
+    inheritance::parent_selection(result, external_defs, &parent_identity, parent_name)
+        .map(|parent| parent.handler_plans.clone())
+        .unwrap_or_default()
+}

--- a/crates/sifr_frontend/src/lib.rs
+++ b/crates/sifr_frontend/src/lib.rs
@@ -9,7 +9,7 @@ mod cache_keys;
 mod callable_exports;
 mod canonical_types;
 mod class_declarations;
-pub use class_declarations::SourceOriginId;
+pub use sifr_lowering::SourceOriginId;
 mod callable_identities;
 mod const_specialization;
 mod descriptor_exports;

--- a/crates/sifr_frontend/src/slot_table.rs
+++ b/crates/sifr_frontend/src/slot_table.rs
@@ -1,8 +1,9 @@
 use crate::{describe_type_with_externals, ShapeNode, StructuralShape};
 use sifr_lowering::{
-    ExternalDefs, LoweringResult, StaticMethodParam, StaticMethodSlot, StaticMethodSlotContext,
+    AdapterHandlerPlan, CallableIdentity, ExternalDefs, LoweringResult, StaticMethodParam,
+    StaticMethodSlot, StaticMethodSlotContext,
 };
-use sifr_type_system::Type;
+use sifr_type_system::{ReceiverConvention, Type};
 use std::collections::{BTreeSet, HashMap};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -17,6 +18,7 @@ pub(crate) enum MethodSlotErrorKind {
 pub(crate) struct MethodSlotError {
     kind: MethodSlotErrorKind,
     reason: String,
+    range: Option<ruff_text_size::TextRange>,
 }
 
 impl MethodSlotError {
@@ -24,7 +26,13 @@ impl MethodSlotError {
         Self {
             kind,
             reason: reason.into(),
+            range: None,
         }
+    }
+
+    fn at(mut self, range: Option<ruff_text_size::TextRange>) -> Self {
+        self.range = range.or(self.range);
+        self
     }
 
     pub(crate) const fn kind(&self) -> MethodSlotErrorKind {
@@ -33,6 +41,10 @@ impl MethodSlotError {
 
     pub(crate) fn into_reason(self) -> String {
         self.reason
+    }
+
+    pub(crate) const fn range(&self) -> Option<ruff_text_size::TextRange> {
+        self.range
     }
 }
 
@@ -59,39 +71,90 @@ pub(crate) fn resolve_method_slots(
     );
     let available = shape_method_references(&described_shape.root);
     let mut slots = Vec::with_capacity(references.len());
+    let handler_plans = handler_plans_for_target(target_type, result);
     for reference in references {
-        if !available.contains(&reference) {
-            return Err(MethodSlotError::new(
-                MethodSlotErrorKind::Method,
-                format!(
-                    "method slot `{reference}` does not name an annotated method in the concrete structural shape"
-                ),
-            ));
-        }
-        let (owner_identity, method_name) = reference.rsplit_once("::").ok_or_else(|| {
-            MethodSlotError::new(
-                MethodSlotErrorKind::List,
-                format!(
-                    "method slot `{reference}` must use the exact `module.Type::method` identity"
-                ),
-            )
-        })?;
-        let owner_type = owner_types.get(owner_identity).cloned().ok_or_else(|| {
-            MethodSlotError::new(
-                MethodSlotErrorKind::Method,
-                format!(
-                    "method slot owner `{owner_identity}` is not reachable from the concrete type"
-                ),
-            )
-        })?;
-        slots.push(resolve_method_slot(
-            owner_identity,
-            method_name,
-            owner_type,
+        let (owner_identity, method_name, handler) = match reference {
+            MethodSlotReference::Legacy(reference) => {
+                if !available.contains(&reference) {
+                    return Err(MethodSlotError::new(
+                        MethodSlotErrorKind::Method,
+                        format!(
+                            "method slot `{reference}` does not name an annotated method in the concrete structural shape"
+                        ),
+                    ));
+                }
+                let (owner, method) = reference.rsplit_once("::").ok_or_else(|| {
+                    MethodSlotError::new(
+                        MethodSlotErrorKind::List,
+                        format!(
+                            "method slot `{reference}` must use the exact `module.Type::method` identity"
+                        ),
+                    )
+                })?;
+                (owner.to_string(), method.to_string(), None)
+            }
+            MethodSlotReference::Handler(callable) => {
+                let handler = handler_plans
+                    .iter()
+                    .find(|handler| handler.callable == callable)
+                    .ok_or_else(|| {
+                        MethodSlotError::new(
+                            MethodSlotErrorKind::Method,
+                            format!(
+                                "selected handler '{}::{}' was not produced by a method descriptor on the adapted class",
+                                callable.owner.as_deref().unwrap_or(&callable.module),
+                                callable.symbol
+                            ),
+                        )
+                    })?;
+                let owner = callable.owner.clone().ok_or_else(|| {
+                    MethodSlotError::new(
+                        MethodSlotErrorKind::Method,
+                        "selected handler must name a user-authored method",
+                    )
+                })?;
+                (owner, callable.symbol.clone(), Some(handler))
+            }
+        };
+        let owner_type = owner_types
+            .get(&owner_identity)
+            .cloned()
+            .or_else(|| {
+                owner_type_for_identity(
+                    &owner_identity,
+                    target_type,
+                    module_name,
+                    result,
+                    external_defs,
+                )
+            })
+            .ok_or_else(|| {
+                MethodSlotError::new(
+                    MethodSlotErrorKind::Method,
+                    format!(
+                        "method slot owner `{owner_identity}` is not reachable from the concrete type"
+                    ),
+                )
+            })?;
+        let expected = handler.map(|handler| &handler.callable);
+        let mut slot = resolve_method_slot(
+            &owner_identity,
+            &method_name,
+            &owner_type,
             module_name,
             result,
             external_defs,
-        )?);
+            expected,
+        )
+        .map_err(|problem| problem.at(handler.map(|handler| handler.descriptor_range)))?;
+        if let Some(handler) = handler {
+            slot.descriptor_type = Some(handler.descriptor_type.clone());
+            slot.descriptor_value = Some(handler.descriptor_value.clone());
+            slot.descriptor_origin = Some(handler.descriptor_origin);
+            slot.descriptor_range = Some(handler.descriptor_range);
+            slot.declaration_order = Some(handler.declaration_order);
+        }
+        slots.push(slot);
     }
     let mut context_contract: Option<(&Type, bool)> = None;
     for slot in &slots {
@@ -106,7 +169,8 @@ pub(crate) fn resolve_method_slots(
                 return Err(MethodSlotError::new(
                     MethodSlotErrorKind::Context,
                     "all method slots in one static program must use one context type and borrow mode",
-                ));
+                )
+                .at(slot.descriptor_range));
             }
         }
     }
@@ -129,9 +193,14 @@ pub(crate) fn resolve_method_slots(
     Ok((slots, Some(context)))
 }
 
+enum MethodSlotReference {
+    Legacy(String),
+    Handler(CallableIdentity),
+}
+
 fn method_slot_references(
     value: &crate::ConstValue,
-) -> Result<Option<Vec<String>>, MethodSlotError> {
+) -> Result<Option<Vec<MethodSlotReference>>, MethodSlotError> {
     let crate::ConstValue::Record(fields) = value else {
         return Ok(None);
     };
@@ -141,25 +210,40 @@ fn method_slot_references(
     let crate::ConstValue::List(values) = value else {
         return Err(MethodSlotError::new(
             MethodSlotErrorKind::List,
-            "reserved `sifr_method_slots` must be a list of strings",
+            "reserved `sifr_method_slots` must be a list of exact method identities",
         ));
     };
     let mut seen = BTreeSet::new();
     let mut references = Vec::with_capacity(values.len());
     for value in values {
-        let crate::ConstValue::String(reference) = value else {
-            return Err(MethodSlotError::new(
-                MethodSlotErrorKind::List,
-                "reserved `sifr_method_slots` must contain only strings",
-            ));
+        let reference = match value {
+            crate::ConstValue::String(reference) => MethodSlotReference::Legacy(reference.clone()),
+            crate::ConstValue::CallableIdentity(callable) => {
+                MethodSlotReference::Handler(callable.clone())
+            }
+            _ => {
+                return Err(MethodSlotError::new(
+                    MethodSlotErrorKind::List,
+                    "reserved `sifr_method_slots` must contain only exact method identities",
+                ));
+            }
         };
-        if !seen.insert(reference.clone()) {
+        let key = match &reference {
+            MethodSlotReference::Legacy(reference) => reference.clone(),
+            MethodSlotReference::Handler(callable) => format!(
+                "{}::{}:{}",
+                callable.owner.as_deref().unwrap_or(&callable.module),
+                callable.symbol,
+                callable.signature
+            ),
+        };
+        if !seen.insert(key.clone()) {
             return Err(MethodSlotError::new(
                 MethodSlotErrorKind::List,
-                format!("method slot `{reference}` is duplicated"),
+                format!("method slot `{key}` is duplicated"),
             ));
         }
-        references.push(reference.clone());
+        references.push(reference);
     }
     Ok(Some(references))
 }
@@ -269,13 +353,81 @@ fn collect_nominal_types(
     }
 }
 
-fn resolve_method_slot(
+fn handler_plans_for_target<'a>(
+    target_type: &Type,
+    result: &'a LoweringResult,
+) -> &'a [AdapterHandlerPlan] {
+    let Type::Class { name, .. } = target_type.resolve_alias() else {
+        return &[];
+    };
+    result
+        .class_adapter_selections
+        .iter()
+        .find(|selection| selection.owner == *name)
+        .map(|selection| selection.handler_plans.as_slice())
+        .unwrap_or_default()
+}
+
+fn owner_type_for_identity(
     owner_identity: &str,
-    method_name: &str,
-    owner_type: Type,
+    target_type: &Type,
     module_name: &str,
     result: &LoweringResult,
     external_defs: &ExternalDefs,
+) -> Option<Type> {
+    if matches!(
+        target_type.resolve_alias(),
+        Type::Class { identity, name, .. }
+            if identity.as_deref().unwrap_or(name) == owner_identity
+    ) {
+        return Some(target_type.clone());
+    }
+    for class in &result.module.classes {
+        if let Some(parent) = &class.parent_type {
+            if matches!(
+                parent.resolve_alias(),
+                Type::Class { identity, name, .. }
+                    if identity.as_deref().unwrap_or(name) == owner_identity
+            ) {
+                return Some(parent.clone());
+            }
+        }
+        let identity = class
+            .identity
+            .clone()
+            .unwrap_or_else(|| format!("{module_name}.{}", class.name));
+        if identity == owner_identity {
+            return Some(Type::Class {
+                identity: Some(identity),
+                type_args: class
+                    .type_params
+                    .iter()
+                    .cloned()
+                    .map(Type::TypeVar)
+                    .collect(),
+                name: class.name.clone(),
+                fields: class.fields.clone(),
+                methods: Vec::new(),
+                parent_class: class.parent_class.clone(),
+            });
+        }
+    }
+    let (source_module, class_name) = owner_identity.rsplit_once('.')?;
+    external_defs
+        .classes
+        .get(source_module)?
+        .get(class_name)
+        .cloned()
+}
+
+fn resolve_method_slot(
+    owner_identity: &str,
+    method_name: &str,
+    owner_type: &Type,
+    module_name: &str,
+    result: &LoweringResult,
+    external_defs: &ExternalDefs,
+    expected_identity: Option<&CallableIdentity>,
 ) -> Result<StaticMethodSlot, MethodSlotError> {
     let (source_module, class_name) = owner_identity.rsplit_once('.').ok_or_else(|| {
         MethodSlotError::new(
@@ -314,41 +466,9 @@ fn resolve_method_slot(
                     format!("method slot `{owner_identity}::{method_name}` is unavailable"),
                 )
             })?;
-        return finish_method_slot(
-            StaticMethodSlot {
-                owner_identity: owner_identity.to_string(),
-                owner_type,
-                name: method_name.to_string(),
-                hir_name: hir_name.to_string(),
-                method_kind: method.method_kind,
-                receiver: method.receiver,
-                params: method.params.iter().map(static_method_param).collect(),
-                return_type: method.return_type.clone(),
-                is_async: method.is_async,
-                input_type: Type::Unknown,
-                output_type: Type::Unknown,
-                context_type: None,
-                context_mutable: false,
-            },
-            module_name,
-            result,
-            external_defs,
-        );
-    }
-    let method = external_defs
-        .structural_methods_for(source_module)
-        .and_then(|classes| classes.get(class_name))
-        .and_then(|methods| methods.iter().find(|method| method.name == method_name))
-        .ok_or_else(|| {
-            MethodSlotError::new(
-                MethodSlotErrorKind::Method,
-                format!("imported method slot `{owner_identity}::{method_name}` is unavailable"),
-            )
-        })?;
-    finish_method_slot(
-        StaticMethodSlot {
+        let mut slot = StaticMethodSlot {
             owner_identity: owner_identity.to_string(),
-            owner_type,
+            owner_type: owner_type.clone(),
             name: method_name.to_string(),
             hir_name: hir_name.to_string(),
             method_kind: method.method_kind,
@@ -360,11 +480,109 @@ fn resolve_method_slot(
             output_type: Type::Unknown,
             context_type: None,
             context_mutable: false,
-        },
-        module_name,
-        result,
-        external_defs,
-    )
+            descriptor_type: None,
+            descriptor_value: None,
+            descriptor_origin: None,
+            descriptor_range: None,
+            declaration_order: None,
+            is_fallible: false,
+        };
+        validate_expected_identity(&slot, expected_identity)?;
+        specialize_slot_types(&mut slot, &class.type_params, owner_type);
+        return finish_method_slot(slot, module_name, result, external_defs);
+    }
+    let method = external_defs
+        .structural_methods_for(source_module)
+        .and_then(|classes| classes.get(class_name))
+        .and_then(|methods| methods.iter().find(|method| method.name == method_name))
+        .ok_or_else(|| {
+            MethodSlotError::new(
+                MethodSlotErrorKind::Method,
+                format!("imported method slot `{owner_identity}::{method_name}` is unavailable"),
+            )
+        })?;
+    let mut slot = StaticMethodSlot {
+        owner_identity: owner_identity.to_string(),
+        owner_type: owner_type.clone(),
+        name: method_name.to_string(),
+        hir_name: hir_name.to_string(),
+        method_kind: method.method_kind,
+        receiver: method.receiver,
+        params: method.params.iter().map(static_method_param).collect(),
+        return_type: method.return_type.clone(),
+        is_async: method.is_async,
+        input_type: Type::Unknown,
+        output_type: Type::Unknown,
+        context_type: None,
+        context_mutable: false,
+        descriptor_type: None,
+        descriptor_value: None,
+        descriptor_origin: None,
+        descriptor_range: None,
+        declaration_order: None,
+        is_fallible: false,
+    };
+    let type_params = external_defs
+        .class_type_params
+        .get(source_module)
+        .and_then(|classes| classes.get(class_name))
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    validate_expected_identity(&slot, expected_identity)?;
+    specialize_slot_types(&mut slot, type_params, owner_type);
+    finish_method_slot(slot, module_name, result, external_defs)
+}
+
+fn specialize_slot_types(slot: &mut StaticMethodSlot, type_params: &[String], owner_type: &Type) {
+    let Type::Class { type_args, .. } = owner_type.resolve_alias() else {
+        return;
+    };
+    let bindings = type_params
+        .iter()
+        .cloned()
+        .zip(type_args.iter().cloned())
+        .collect::<HashMap<_, _>>();
+    for parameter in &mut slot.params {
+        parameter.ty = sifr_lowering::substitute_type_vars(&parameter.ty, &bindings);
+    }
+    slot.return_type = sifr_lowering::substitute_type_vars(&slot.return_type, &bindings);
+}
+
+fn validate_expected_identity(
+    slot: &StaticMethodSlot,
+    expected: Option<&CallableIdentity>,
+) -> Result<(), MethodSlotError> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    let signature = crate::canonical_types::function_identity(&sifr_type_system::FunctionType {
+        receiver: slot.receiver,
+        params: slot
+            .params
+            .iter()
+            .map(|parameter| {
+                (
+                    parameter.name.clone(),
+                    parameter.ty.clone(),
+                    parameter.convention,
+                )
+            })
+            .collect(),
+        return_type: Box::new(slot.return_type.clone()),
+    });
+    if expected.owner.as_deref() != Some(slot.owner_identity.as_str())
+        || expected.symbol != slot.name
+        || expected.signature != signature
+    {
+        return Err(MethodSlotError::new(
+            MethodSlotErrorKind::Signature,
+            format!(
+                "selected handler `{}::{}` no longer matches its checked method signature",
+                slot.owner_identity, slot.name
+            ),
+        ));
+    }
+    Ok(())
 }
 
 fn finish_method_slot(
@@ -382,15 +600,6 @@ fn finish_method_slot(
             ),
         ));
     }
-    if slot.method_kind == sifr_lowering::MethodKind::ClassMethod {
-        return Err(MethodSlotError::new(
-            MethodSlotErrorKind::Method,
-            format!(
-                "method slot `{}::{}` cannot be a class method; use a static method or instance receiver",
-                slot.owner_identity, slot.name
-            ),
-        ));
-    }
     if slot.is_async {
         return Err(MethodSlotError::new(
             MethodSlotErrorKind::Method,
@@ -400,16 +609,16 @@ fn finish_method_slot(
             ),
         ));
     }
-    let Type::Result(output, _) = slot.return_type.resolve_alias() else {
-        return Err(MethodSlotError::new(
-            MethodSlotErrorKind::Signature,
-            format!(
-                "method slot `{}::{}` must return Result",
-                slot.owner_identity, slot.name
-            ),
-        ));
-    };
-    slot.output_type = output.as_ref().clone();
+    match slot.return_type.resolve_alias() {
+        Type::Result(output, _) => {
+            slot.output_type = output.as_ref().clone();
+            slot.is_fallible = true;
+        }
+        output => {
+            slot.output_type = output.clone();
+            slot.is_fallible = false;
+        }
+    }
     let receiver_input = slot.receiver.is_some();
     let maximum_params = if receiver_input { 1 } else { 2 };
     let minimum_params = usize::from(!receiver_input);
@@ -451,18 +660,55 @@ fn finish_method_slot(
         slot.context_type = Some(context.ty.clone());
         slot.context_mutable = context.convention.is_mutable();
     }
+    if slot.receiver == Some(ReceiverConvention::Owned)
+        && !same_nominal_specialization(&slot.output_type, &slot.owner_type)
+    {
+        return Err(MethodSlotError::new(
+            MethodSlotErrorKind::Signature,
+            format!(
+                "owned handler `{}::{}` must return exactly Self or Result[Self, E]",
+                slot.owner_identity, slot.name
+            ),
+        ));
+    }
     if !structural_slot_type_supported(&slot.input_type, module_name, result, external_defs)
         || !structural_slot_type_supported(&slot.output_type, module_name, result, external_defs)
     {
         return Err(MethodSlotError::new(
             MethodSlotErrorKind::Signature,
             format!(
-                "method slot `{}::{}` input and successful Result output must be structural types",
+                "method slot `{}::{}` input and output must be structural types",
                 slot.owner_identity, slot.name
             ),
         ));
     }
     Ok(slot)
+}
+
+fn same_nominal_specialization(left: &Type, right: &Type) -> bool {
+    let (
+        Type::Class {
+            identity: left_identity,
+            name: left_name,
+            type_args: left_args,
+            ..
+        },
+        Type::Class {
+            identity: right_identity,
+            name: right_name,
+            type_args: right_args,
+            ..
+        },
+    ) = (left.resolve_alias(), right.resolve_alias())
+    else {
+        return false;
+    };
+    left_name == right_name
+        && left_args == right_args
+        && match (left_identity, right_identity) {
+            (Some(left), Some(right)) => left == right,
+            _ => true,
+        }
 }
 
 fn structural_slot_type_supported(

--- a/crates/sifr_frontend/src/slot_table_tests.rs
+++ b/crates/sifr_frontend/src/slot_table_tests.rs
@@ -142,10 +142,10 @@ class Record:
 }
 
 #[test]
-fn non_result_slot_uses_signature_diagnostic() {
+fn infallible_slot_uses_checked_output_signature() {
     let mut external_defs = ExternalDefs::default();
     install_specializer(&mut external_defs, &["target.Record::normalize"]);
-    let codes = diagnostic_codes(compile(
+    let result = compile(
         "target",
         r#"
 from fixture.slots import describe
@@ -160,8 +160,11 @@ class Record:
         return value
 "#,
         &external_defs,
-    ));
-    assert!(codes.iter().any(|code| code == "SIFR-RUST-SLOT-0003"));
+    )
+    .expect("infallible checked method slot specializes");
+    let slot = &result.specialization_outputs[0].method_slots[0];
+    assert_eq!(slot.output_type, sifr_type_system::Type::Str);
+    assert!(!slot.is_fallible);
 }
 
 #[test]

--- a/crates/sifr_frontend/src/specialization_support.rs
+++ b/crates/sifr_frontend/src/specialization_support.rs
@@ -113,6 +113,7 @@ pub(crate) fn method_slot_diagnostic(
     error: crate::slot_table::MethodSlotError,
     range: TextRange,
 ) -> HirDiagnostic {
+    let primary_range = error.range().unwrap_or(range);
     let code = match error.kind() {
         crate::slot_table::MethodSlotErrorKind::List => DiagnosticCode::RUST_SLOT_LIST,
         crate::slot_table::MethodSlotErrorKind::Method => DiagnosticCode::RUST_SLOT_METHOD,
@@ -130,7 +131,7 @@ pub(crate) fn method_slot_diagnostic(
         },
         args: BTreeMap::from([("reason".to_string(), DiagnosticArg::String(reason))]),
         help: None,
-        primary_range: Some(range),
+        primary_range: Some(primary_range),
         line: None,
         col: None,
     }

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -607,8 +607,16 @@ fn canonical_method(method: &ShapeMethod) -> String {
         })
         .collect::<Vec<_>>()
         .join(",");
+    let target = method.target.as_ref().map_or_else(
+        || "none".to_string(),
+        |target| canonical_value(&ConstValue::CallableIdentity(target.clone())),
+    );
+    let descriptor = method
+        .descriptor
+        .as_ref()
+        .map_or_else(|| "none".to_string(), canonical_value);
     format!(
-        "{}:{}:{}:{}:{}:params[{params}]:result[{}]:meta[{}]",
+        "{}:{}:{}:{}:{}:target[{target}]:descriptor[{descriptor}]:params[{params}]:result[{}]:meta[{}]",
         method.name.len(),
         method.name,
         method.kind,
@@ -619,7 +627,7 @@ fn canonical_method(method: &ShapeMethod) -> String {
     )
 }
 
-fn node_const_value(node: &ShapeNode) -> ConstValue {
+pub(super) fn node_const_value(node: &ShapeNode) -> ConstValue {
     let mut record = BTreeMap::new();
     match node {
         ShapeNode::Primitive(name) => {
@@ -709,7 +717,7 @@ fn node_const_value(node: &ShapeNode) -> ConstValue {
             );
             record.insert(
                 "methods".to_string(),
-                ConstValue::List(methods.iter().map(method_const_value).collect()),
+                ConstValue::List(methods.iter().map(methods::const_value).collect()),
             );
             record.insert("metadata".to_string(), metadata_const_value(metadata));
         }
@@ -782,55 +790,7 @@ fn node_const_value(node: &ShapeNode) -> ConstValue {
     ConstValue::Record(record)
 }
 
-fn method_const_value(method: &ShapeMethod) -> ConstValue {
-    ConstValue::Record(BTreeMap::from([
-        ("name".to_string(), ConstValue::String(method.name.clone())),
-        ("kind".to_string(), ConstValue::String(method.kind.clone())),
-        (
-            "receiver".to_string(),
-            method
-                .receiver
-                .clone()
-                .map(ConstValue::String)
-                .unwrap_or(ConstValue::None),
-        ),
-        ("is_async".to_string(), ConstValue::Bool(method.is_async)),
-        (
-            "params".to_string(),
-            ConstValue::List(
-                method
-                    .params
-                    .iter()
-                    .map(|param| {
-                        ConstValue::Record(BTreeMap::from([
-                            ("name".to_string(), ConstValue::String(param.name.clone())),
-                            ("type".to_string(), node_const_value(&param.declared_type)),
-                            (
-                                "convention".to_string(),
-                                ConstValue::String(param.convention.clone()),
-                            ),
-                            (
-                                "keyword_only".to_string(),
-                                ConstValue::Bool(param.keyword_only),
-                            ),
-                            (
-                                "metadata".to_string(),
-                                metadata_const_value(&param.metadata),
-                            ),
-                        ]))
-                    })
-                    .collect(),
-            ),
-        ),
-        ("result".to_string(), node_const_value(&method.result)),
-        (
-            "metadata".to_string(),
-            metadata_const_value(&method.metadata),
-        ),
-    ]))
-}
-
-fn metadata_const_value(metadata: &[ShapeMetadata]) -> ConstValue {
+pub(super) fn metadata_const_value(metadata: &[ShapeMetadata]) -> ConstValue {
     ConstValue::List(
         metadata
             .iter()

--- a/crates/sifr_frontend/src/structural_shape/methods.rs
+++ b/crates/sifr_frontend/src/structural_shape/methods.rs
@@ -1,15 +1,29 @@
-use super::{describe_node, metadata_for, ShapeMetadata, ShapeNode};
+use super::{
+    describe_node, metadata_const_value, metadata_for, node_const_value, validated_adapter_value,
+    ShapeMetadata, ShapeNode,
+};
+use crate::ConstValue;
+use num_bigint::BigInt;
 use sifr_lowering::{
-    substitute_type_vars, DeclarationMetadataTargetKind, HirClass, HirParam, LoweringResult,
-    MethodKind, StructuralMethodExport, TypedDeclarationMetadata,
+    substitute_type_vars, AdapterHandlerPlan, CallableIdentity, DeclarationMetadataTargetKind,
+    HirClass, HirParam, LoweringResult, MethodKind, SourceOriginId, StructuralMethodExport,
+    TypedDeclarationMetadata,
 };
 use sifr_type_system::{
     ParamConvention, ParamMutability, ParamOwnership, ReceiverConvention, Type,
 };
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShapeMethod {
+    /// Compiler-sealed checked method target for package-selected handlers.
+    pub target: Option<CallableIdentity>,
+    /// Package-owned descriptor value paired with `target`.
+    pub descriptor: Option<ConstValue>,
+    /// Diagnostic-only source location token for the descriptor application.
+    pub origin: Option<SourceOriginId>,
+    /// Package declaration/inheritance order for deterministic selection.
+    pub declaration_order: Option<usize>,
     pub name: String,
     pub kind: String,
     pub receiver: Option<String>,
@@ -26,6 +40,81 @@ pub struct ShapeParameter {
     pub convention: String,
     pub keyword_only: bool,
     pub metadata: Vec<ShapeMetadata>,
+}
+
+pub(super) fn const_value(method: &ShapeMethod) -> ConstValue {
+    ConstValue::Record(BTreeMap::from([
+        (
+            "target".to_string(),
+            method
+                .target
+                .clone()
+                .map(ConstValue::CallableIdentity)
+                .unwrap_or(ConstValue::None),
+        ),
+        (
+            "descriptor".to_string(),
+            method.descriptor.clone().unwrap_or(ConstValue::None),
+        ),
+        (
+            "origin".to_string(),
+            method
+                .origin
+                .map(ConstValue::SourceOrigin)
+                .unwrap_or(ConstValue::None),
+        ),
+        (
+            "declaration_order".to_string(),
+            method
+                .declaration_order
+                .map(BigInt::from)
+                .map(ConstValue::Integer)
+                .unwrap_or(ConstValue::None),
+        ),
+        ("name".to_string(), ConstValue::String(method.name.clone())),
+        ("kind".to_string(), ConstValue::String(method.kind.clone())),
+        (
+            "receiver".to_string(),
+            method
+                .receiver
+                .clone()
+                .map(ConstValue::String)
+                .unwrap_or(ConstValue::None),
+        ),
+        ("is_async".to_string(), ConstValue::Bool(method.is_async)),
+        (
+            "params".to_string(),
+            ConstValue::List(
+                method
+                    .params
+                    .iter()
+                    .map(|param| {
+                        ConstValue::Record(BTreeMap::from([
+                            ("name".to_string(), ConstValue::String(param.name.clone())),
+                            ("type".to_string(), node_const_value(&param.declared_type)),
+                            (
+                                "convention".to_string(),
+                                ConstValue::String(param.convention.clone()),
+                            ),
+                            (
+                                "keyword_only".to_string(),
+                                ConstValue::Bool(param.keyword_only),
+                            ),
+                            (
+                                "metadata".to_string(),
+                                metadata_const_value(&param.metadata),
+                            ),
+                        ]))
+                    })
+                    .collect(),
+            ),
+        ),
+        ("result".to_string(), node_const_value(&method.result)),
+        (
+            "metadata".to_string(),
+            metadata_const_value(&method.metadata),
+        ),
+    ]))
 }
 
 pub(super) fn described_methods(
@@ -45,7 +134,22 @@ pub(super) fn described_methods(
         .cloned()
         .zip(type_args.iter().cloned())
         .collect::<HashMap<_, _>>();
-    lowering
+    let handlers = lowering
+        .class_adapter_selections
+        .iter()
+        .find(|selection| selection.owner == class.name)
+        .map(|selection| selection.handler_plans.as_slice())
+        .unwrap_or_default();
+    let handler_targets = handlers
+        .iter()
+        .filter_map(|handler| {
+            Some((
+                handler.callable.owner.clone()?,
+                handler.callable.symbol.clone(),
+            ))
+        })
+        .collect::<BTreeSet<_>>();
+    let mut methods = lowering
         .declaration_metadata
         .iter()
         .filter(|entry| {
@@ -65,6 +169,13 @@ pub(super) fn described_methods(
                 .iter()
                 .chain(class.operator_impls.iter().map(|(_, method)| method))
                 .find(|method| method.name == hir_name)?;
+            let local_owner = class
+                .identity
+                .clone()
+                .unwrap_or_else(|| format!("{module_name}.{}", class.name));
+            if handler_targets.contains(&(local_owner, declared_name.to_string())) {
+                return None;
+            }
             Some(described_method(
                 module_name,
                 &entry.owner,
@@ -87,7 +198,97 @@ pub(super) fn described_methods(
                 visiting,
             ))
         })
-        .collect()
+        .collect::<Vec<_>>();
+    let mut ordered_handlers = handlers.iter().collect::<Vec<_>>();
+    ordered_handlers.sort_by_key(|handler| handler.declaration_order);
+    for handler in ordered_handlers {
+        methods.push(described_handler(
+            module_name,
+            class_name,
+            class,
+            handler,
+            &bindings,
+            lowering,
+            external_defs,
+            visiting,
+        ));
+    }
+    methods
+}
+
+#[allow(clippy::too_many_arguments)]
+fn described_handler(
+    module_name: &str,
+    class_name: &str,
+    class: &HirClass,
+    handler: &AdapterHandlerPlan,
+    bindings: &HashMap<String, Type>,
+    lowering: &LoweringResult,
+    external_defs: &sifr_lowering::ExternalDefs,
+    visiting: &mut BTreeSet<String>,
+) -> ShapeMethod {
+    let declared_name = handler.callable.symbol.as_str();
+    let hir_name = if declared_name == "__init__" {
+        "new"
+    } else {
+        declared_name
+    };
+    let local_owner = class
+        .identity
+        .clone()
+        .unwrap_or_else(|| format!("{module_name}.{}", class.name));
+    let detailed = (handler.callable.owner.as_deref() == Some(local_owner.as_str()))
+        .then(|| {
+            class
+                .methods
+                .iter()
+                .chain(class.operator_impls.iter().map(|(_, method)| method))
+                .find(|method| method.name == hir_name)
+        })
+        .flatten();
+    let mut method = if let Some(method) = detailed {
+        let owner = format!("{class_name}.{declared_name}");
+        described_method(
+            module_name,
+            &owner,
+            declared_name,
+            &method.params,
+            &method.return_type,
+            method.method_kind,
+            method.receiver,
+            method.is_async,
+            bindings,
+            metadata_for(
+                &lowering.declaration_metadata,
+                &owner,
+                DeclarationMetadataTargetKind::Method,
+                None,
+            ),
+            &lowering.declaration_metadata,
+            lowering,
+            external_defs,
+            visiting,
+        )
+    } else {
+        ShapeMethod {
+            target: None,
+            descriptor: None,
+            origin: None,
+            declaration_order: None,
+            name: declared_name.to_string(),
+            kind: "inherited".to_string(),
+            receiver: None,
+            is_async: false,
+            params: Vec::new(),
+            result: Box::new(ShapeNode::Other("checked_handler".to_string())),
+            metadata: Vec::new(),
+        }
+    };
+    method.target = Some(handler.callable.clone());
+    method.descriptor = Some(validated_adapter_value(&handler.descriptor_value));
+    method.origin = Some(handler.descriptor_origin);
+    method.declaration_order = Some(handler.declaration_order);
+    method
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -154,6 +355,10 @@ fn described_method(
     visiting: &mut BTreeSet<String>,
 ) -> ShapeMethod {
     ShapeMethod {
+        target: None,
+        descriptor: None,
+        origin: None,
+        declaration_order: None,
         name: declared_name.to_string(),
         kind: method_kind_name(method_kind).to_string(),
         receiver: receiver.map(receiver_convention_name).map(str::to_string),

--- a/crates/sifr_frontend/src/typed_descriptors.rs
+++ b/crates/sifr_frontend/src/typed_descriptors.rs
@@ -186,6 +186,34 @@ impl DescriptorCollector<'_> {
                             sifr_lowering::MethodKind::StaticMethod => "static",
                             sifr_lowering::MethodKind::ClassMethod => "class",
                         });
+                    let classmethod_index = function.decorator_list.iter().position(|decorator| {
+                        matches!(
+                            &decorator.expression,
+                            Expr::Name(name) if name.id.as_str() == "classmethod"
+                        )
+                    });
+                    if let Some(classmethod_index) = classmethod_index {
+                        for (index, decorator) in function.decorator_list.iter().enumerate() {
+                            let Some((declaration, call)) =
+                                self.resolver.call(&decorator.expression)
+                            else {
+                                continue;
+                            };
+                            if declaration.kind == DeclarationDescriptorKind::Method
+                                && (index + 1 != classmethod_index
+                                    || classmethod_index + 1 != function.decorator_list.len())
+                            {
+                                self.errors.push(diagnostic(
+                                    DiagnosticCode::META_MALFORMED_DECLARATION,
+                                    format!(
+                                        "method descriptor '{}' must be the outer decorator with @classmethod directly above the method",
+                                        declaration.function
+                                    ),
+                                    call.range(),
+                                ));
+                            }
+                        }
+                    }
                     for decorator in &function.decorator_list {
                         self.collect_use(
                             &decorator.expression,
@@ -313,11 +341,39 @@ impl DescriptorCollector<'_> {
             return;
         }
         self.current_provider = Some(provider);
+        let target_callable = if expected_kind == DeclarationDescriptorKind::Method {
+            let prefix = format!("{owner}.");
+            let method = target_identity
+                .strip_prefix(&prefix)
+                .and_then(|identity| identity.split_once(':').map(|(method, _)| method))
+                .unwrap_or(target_identity.as_str());
+            if let Some(identity) = crate::callable_identities::method_declaration(
+                self.module_name,
+                self.result,
+                owner,
+                method,
+            ) {
+                Some(identity)
+            } else {
+                self.errors.push(diagnostic(
+                    DiagnosticCode::META_MALFORMED_DECLARATION,
+                    format!(
+                        "method descriptor '{}' target does not have a checked method identity",
+                        declaration.function
+                    ),
+                    call.range(),
+                ));
+                return;
+            }
+        } else {
+            None
+        };
         match self.evaluate_call(declaration, call) {
             Ok(value) => self.descriptors.push(TypedDeclarationDescriptor {
                 owner: owner.to_string(),
                 target_kind: expected_kind,
                 target_identity,
+                target_callable,
                 provider_module: declaration.provider_module.clone(),
                 provider_function: declaration.provider_function.clone(),
                 value_type: declaration.return_type.clone(),

--- a/crates/sifr_ir/src/specialization_metadata.rs
+++ b/crates/sifr_ir/src/specialization_metadata.rs
@@ -3,6 +3,25 @@
 use crate::{HirExpr, MethodKind};
 use ruff_text_size::TextRange;
 use sifr_type_system::{ParamConvention, ReceiverConvention, Type};
+
+/// Opaque compiler-issued source-origin identity used only for diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SourceOriginId {
+    namespace: [u8; 32],
+    index: u32,
+}
+
+impl SourceOriginId {
+    #[must_use]
+    pub const fn new(namespace: [u8; 32], index: u32) -> Self {
+        Self { namespace, index }
+    }
+
+    #[must_use]
+    pub fn belongs_to(self, namespace: [u8; 32]) -> bool {
+        self.namespace == namespace
+    }
+}
 use std::collections::HashSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -148,9 +167,21 @@ pub struct ClassAdapterSelection {
     pub marker_identities: Vec<String>,
     pub data_parent: Option<String>,
     pub field_plans: Vec<AdapterFieldPlan>,
+    pub handler_plans: Vec<AdapterHandlerPlan>,
     pub adapter_invocation_identity: [u8; 32],
     pub post_adapter_identity: [u8; 32],
     pub range: TextRange,
+}
+
+/// One package-selected user method carried from adaptation into specialization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdapterHandlerPlan {
+    pub callable: CallableIdentity,
+    pub descriptor_type: Type,
+    pub descriptor_value: StaticProgramValue,
+    pub descriptor_origin: SourceOriginId,
+    pub descriptor_range: TextRange,
+    pub declaration_order: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -198,6 +229,8 @@ pub struct TypedDeclarationDescriptor {
     pub owner: String,
     pub target_kind: DeclarationDescriptorKind,
     pub target_identity: String,
+    /// Sealed checked method identity for method descriptors only.
+    pub target_callable: Option<CallableIdentity>,
     pub provider_module: String,
     pub provider_function: String,
     pub value_type: Type,
@@ -281,6 +314,13 @@ pub struct StaticMethodSlot {
     pub output_type: Type,
     pub context_type: Option<Type>,
     pub context_mutable: bool,
+    /// Package method descriptor retained for handler-aware code generation.
+    pub descriptor_type: Option<Type>,
+    pub descriptor_value: Option<StaticProgramValue>,
+    pub descriptor_origin: Option<SourceOriginId>,
+    pub descriptor_range: Option<TextRange>,
+    pub declaration_order: Option<usize>,
+    pub is_fallible: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/sifr_lowering/src/lib.rs
+++ b/crates/sifr_lowering/src/lib.rs
@@ -32,11 +32,12 @@ pub use lower::{
 };
 pub use scope::{NarrowingSnapshot, Scope};
 pub use sifr_ir::{
-    rust_opaque_close_method, AdapterFieldDefault, AdapterFieldPlan, AppliedAdapterMetadata,
-    CallableIdentity, ClassAdapterMarkerDeclaration, ClassAdapterProviderDeclaration,
-    ClassAdapterSelection, ConstSpecializationRequest, DeclarationDescriptorFunction,
-    DeclarationDescriptorKind, DeclarationMetadataTargetKind, HirDiagnostic, LoweringOutcome,
-    LoweringResult, LoweringWarningDiagnostic, RevealTypeDiagnostic, RustInteropDecoratorKind,
-    StaticMethodParam, StaticMethodSlot, StaticMethodSlotContext, StaticProgramValue,
-    StaticSpecializationOutput, TypedDeclarationDescriptor, TypedDeclarationMetadata,
+    rust_opaque_close_method, AdapterFieldDefault, AdapterFieldPlan, AdapterHandlerPlan,
+    AppliedAdapterMetadata, CallableIdentity, ClassAdapterMarkerDeclaration,
+    ClassAdapterProviderDeclaration, ClassAdapterSelection, ConstSpecializationRequest,
+    DeclarationDescriptorFunction, DeclarationDescriptorKind, DeclarationMetadataTargetKind,
+    HirDiagnostic, LoweringOutcome, LoweringResult, LoweringWarningDiagnostic,
+    RevealTypeDiagnostic, RustInteropDecoratorKind, SourceOriginId, StaticMethodParam,
+    StaticMethodSlot, StaticMethodSlotContext, StaticProgramValue, StaticSpecializationOutput,
+    TypedDeclarationDescriptor, TypedDeclarationMetadata,
 };

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -507,6 +507,7 @@ pub(in crate::lower) fn collect_class_type(
             // Method definitions
             Stmt::FunctionDef(func) => {
                 let method_name = func.name.to_string();
+                let previous_current_class = ctx.current_class.replace(class_name.clone());
                 method_ranges.insert(method_name.clone(), func.name.range());
                 if method_name == "__init__" {
                     // Constructor: extract params (skip `self`)
@@ -715,6 +716,7 @@ pub(in crate::lower) fn collect_class_type(
                         ctx,
                     );
                 }
+                ctx.current_class = previous_current_class;
             }
             Stmt::Pass(_) => {} // Allow pass in class body
             _ => {

--- a/crates/sifr_lowering/src/lower/classes/parameter_conventions.rs
+++ b/crates/sifr_lowering/src/lower/classes/parameter_conventions.rs
@@ -14,7 +14,9 @@ pub(in crate::lower) fn declared_receiver_convention(
         .map_or_else(AstParamConvention::borrow, |parameter| {
             parameter.parameter.convention
         });
-    if convention.is_mutable() {
+    if convention.is_owned() {
+        ReceiverConvention::Owned
+    } else if convention.is_mutable() {
         ReceiverConvention::MutableBorrow
     } else {
         ReceiverConvention::SharedBorrow

--- a/crates/sifr_lowering/src/lower/descriptor_declarations.rs
+++ b/crates/sifr_lowering/src/lower/descriptor_declarations.rs
@@ -386,6 +386,7 @@ fn collect_class_bases(stmts: &[Stmt], ctx: &mut LowerCtx) {
                 .collect(),
             data_parent,
             field_plans: Vec::new(),
+            handler_plans: Vec::new(),
             adapter_invocation_identity: [0; 32],
             post_adapter_identity: [0; 32],
             range: markers

--- a/crates/sifr_lowering/src/lower/expressions/method_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_calls.rs
@@ -308,6 +308,21 @@ pub(in crate::lower) fn lower_method_call(
     } else {
         receiver_convention
     };
+    let interop_receiver_already_consumed = match object_ty.resolve_alias() {
+        Type::Class { name, .. } => {
+            let qualified = format!("{name}.{method_name}");
+            ctx.python_consuming_methods.contains(&qualified)
+                || ctx.rust_consuming_methods.contains(&qualified)
+        }
+        _ => false,
+    };
+    let declared_class_owned = matches!(object_ty.resolve_alias(), Type::Class { .. })
+        && method_type
+            .as_ref()
+            .is_some_and(|signature| signature.receiver == Some(ReceiverConvention::Owned));
+    if declared_class_owned && !interop_receiver_already_consumed {
+        consume_declared_owned_receiver(&object, attr.value.range(), ctx);
+    }
     Some(HirExpr::MethodCall {
         object: Box::new(object),
         method: method_name,
@@ -322,6 +337,25 @@ pub(in crate::lower) fn lower_method_call(
         }),
         ty: return_ty,
     })
+}
+
+fn consume_declared_owned_receiver(object: &HirExpr, range: TextRange, ctx: &mut LowerCtx) {
+    let HirExpr::Name { name, .. } = object else {
+        return;
+    };
+    if ctx.borrowed_params.contains(name) {
+        ctx.error_with_code_at(
+            DiagnosticCode::OWN_BORROWED_PARAMETER_ESCAPES,
+            format!(
+                "cannot consume borrowed parameter '{name}' through an owned receiver; accept it with `own`"
+            ),
+            range,
+        );
+    } else if ctx.scope.is_moved(name) {
+        super::ownership_diagnostics::use_after_move(ctx, name, range);
+    } else {
+        ctx.mark_moved_with_flow(name);
+    }
 }
 
 /// Resolve the return type of a method call on a given type.

--- a/crates/sifr_lowering/src/lower/typing_and_functions/annotation_resolution.rs
+++ b/crates/sifr_lowering/src/lower/typing_and_functions/annotation_resolution.rs
@@ -10,6 +10,19 @@ use super::{
 pub(in crate::lower) fn resolve_annotation_expr(expr: &Expr, ctx: &mut LowerCtx) -> Type {
     match expr {
         Expr::Name(name) => {
+            if name.id.as_str() == "Self" {
+                if let Some(current_class) = ctx.current_class.as_deref() {
+                    if let Some(class_ty) = ctx.class_types.get(current_class) {
+                        return class_ty.clone();
+                    }
+                }
+                invalid_type_annotation(
+                    ctx,
+                    "Self is valid only in an ordinary class method annotation",
+                    name.range(),
+                );
+                return Type::Any;
+            }
             if ctx.adapter_marker_bindings.contains_key(name.id.as_str()) {
                 ctx.error_with_code_at(
                     DiagnosticCode::META_MALFORMED_DECLARATION,

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -118,16 +118,22 @@ All five components participate in the canonical result and therefore the static
 identity. Packages can carry this value through records and collections but cannot construct it
 from strings. A new variant requires a contract and cache-identity review.
 
-A produced value can request a method-slot table through exactly one reserved entry:
-`sifr_method_slots: list[str]`. The field is ordered. An empty list emits no slot table, which
-lets one typed specialization payload cover types with and without callbacks. Each value is an exact
-`module.Type::method` identity, including for imported or re-exported owners. Duplicate,
-unqualified, missing, unannotated, asynchronous, constructor, class-method, non-`Result`, or
-nonstructural method contracts fail with `SIFR-RUST-SLOT-####`. The compiler derives one context
-type and borrow mode from the selected methods and emits the table only when a Rust declaration
-uses the package-neutral `MethodSlots` and `Context` bounds. Programs without caller-owned
-context use `NoContext`. A nonempty table identity includes slot order, structural signatures, receiver
-mode, context shape and borrow mode, handler shapes, and the static-program identity.
+A produced value can request a method-slot table through the reserved `sifr_method_slots` field.
+The field is ordered. An empty list emits no slot table, which lets one typed specialization
+payload cover types with and without handlers. Package method descriptors expose compiler-sealed
+`CallableIdentity` values in the structural shape. The adapter validates the descriptor value and
+source origin, and the specializer selects those identities through `sifr_method_slots`. Legacy
+annotated slots can still use exact `module.Type::method` strings.
+
+The compiler accepts synchronous static, class, shared-instance, mutable-instance, and owned
+receiver handlers. A checked handler can return an infallible structural value or a typed `Result`.
+An owned receiver must return the exact current `Self` specialization, directly or as the successful
+`Result` value. Duplicate, unqualified, missing, constructor, asynchronous, invalid-context, and
+nonstructural contracts fail with `SIFR-RUST-SLOT-####` at the method descriptor when one exists.
+The compiler derives one context type and borrow mode from the selected methods. Programs without
+caller-owned context use `NoContext`. A nonempty table identity includes slot order, structural
+signatures, receiver mode, context shape and borrow mode, descriptor-backed handler identities,
+and the static-program identity.
 
 ## Integer boundary verification
 

--- a/stdlib/sifr/meta.sifr
+++ b/stdlib/sifr/meta.sifr
@@ -87,6 +87,7 @@ class ClassDeclaration:
 class DescriptorUse[D]:
     target_kind: str
     target_identity: str
+    target_callable: CallableIdentity | None
     value: D
     origin: SourceOrigin
 
@@ -115,6 +116,12 @@ class PlannedMetadata[D]:
     value: D
 
 
+class PlannedHandler[D]:
+    target: CallableIdentity
+    descriptor: D
+    origin: SourceOrigin
+
+
 class PlannedIssueLabel:
     origin: SourceOrigin
     message: str
@@ -136,6 +143,7 @@ class DeclarationPlan[D]:
     specialization_module: str | None
     specialization_function: str | None
     issues: list[PlannedIssue[D]]
+    handlers: list[PlannedHandler[D]] = []
 
 
 class ShapeMetadata[D]:
@@ -143,8 +151,16 @@ class ShapeMetadata[D]:
     value: D
 
 
+class ShapeMethod[D]:
+    target: CallableIdentity | None
+    descriptor: D | None
+    origin: SourceOrigin | None
+    declaration_order: int | None
+
+
 class ShapeRoot[D]:
     metadata: list[ShapeMetadata[D]]
+    methods: list[ShapeMethod[D]]
 
 
 class ShapeInput[D]:

--- a/verification/areas/rust_interop/fixtures/method_slot_table/README.md
+++ b/verification/areas/rust_interop/fixtures/method_slot_table/README.md
@@ -1,6 +1,6 @@
 # Method slot table
 
 This package-neutral fixture proves compiler-emitted, static-program-indexed
-method dispatch with a caller-owned mutable context. The Rust core sees only
-the generic context parameter and checked structural input/output channels.
-
+method dispatch selected by package-owned method descriptors, with a
+caller-owned mutable context. The Rust core sees only the generic context
+parameter and checked structural input/output channels.

--- a/verification/areas/rust_interop/fixtures/method_slot_table/examples/method_slot_runtime/src/main.sifr
+++ b/verification/areas/rust_interop/fixtures/method_slot_table/examples/method_slot_runtime/src/main.sifr
@@ -1,7 +1,7 @@
 # execution-kind: runtime-observed
 # expected-result: method-slot-dispatch-ok
 
-from method_slot_runtime.schema_program import derive, derive_no_context, derive_shared
+from method_slot_runtime.schema_program import SlotContract, slot
 from sifr.meta import Context, MethodSlots, NoContext
 
 
@@ -14,18 +14,20 @@ class AppContext:
 
 
 @const_specialize("method_slot_runtime.schema_program", "derive")
-class Record:
+class Record(SlotContract):
     value: str
 
     @staticmethod
-    @metadata("fixture.slot", "normalize")
+    @slot("normalize")
     def normalize(
         own value: str, mut context: AppContext
     ) -> Result[str, SlotFailure]:
+        if value == "error":
+            raise SlotFailure("typed-handler-error")
         context.calls += 1
         return value + "-normalized"
 
-    @metadata("fixture.slot", "finalize")
+    @slot("finalize")
     def finalize(
         mut self, mut context: AppContext
     ) -> Result[str, SlotFailure]:
@@ -34,25 +36,25 @@ class Record:
         return self.value + ""
 
 
-@const_specialize("method_slot_runtime.schema_program", "derive_no_context")
-class NoContextRecord:
+@const_specialize("method_slot_runtime.schema_program", "derive")
+class NoContextRecord(SlotContract):
     value: str
 
-    @staticmethod
-    @metadata("fixture.slot", "normalize")
-    def normalize(own value: str) -> Result[str, SlotFailure]:
+    @slot("normalize")
+    @classmethod
+    def normalize(cls, own value: str) -> Result[str, SlotFailure]:
         return value + "-no-context"
 
 
-@const_specialize("method_slot_runtime.schema_program", "derive_shared")
-class SharedRecord:
+@const_specialize("method_slot_runtime.schema_program", "derive")
+class SharedRecord(SlotContract):
     value: str
 
     @staticmethod
-    @metadata("fixture.slot", "normalize")
+    @slot("normalize")
     def normalize(
         own value: str, context: AppContext
-    ) -> Result[str, SlotFailure]:
+    ) -> str:
         return value + "-shared-" + str(context.calls)
 
 
@@ -83,6 +85,15 @@ def verify_method_slot_runtime() -> Result[str, SlotFailure | RustPanicError]:
         assert output == "value-normalized"
         assert context.calls == 1
         print(output)
+        try:
+            unexpected: str = invoke_slot(model, "error", context)
+            assert unexpected == "unreachable"
+            assert False
+        except SlotFailure as error:
+            assert str(error).find("typed-handler-error") is not None
+        except RustPanicError as error:
+            raise error
+        assert context.calls == 1
         receiver_output: str = invoke_receiver_slot(model, context)
         assert receiver_output == "input-receiver"
         assert context.calls == 2

--- a/verification/areas/rust_interop/fixtures/method_slot_table/examples/method_slot_runtime/src/schema_program.sifr
+++ b/verification/areas/rust_interop/fixtures/method_slot_table/examples/method_slot_runtime/src/schema_program.sifr
@@ -1,36 +1,50 @@
+from sifr.meta import CallableIdentity, ConstSpecializationOutcome, DeclarationInput, DeclarationPlan, PlannedField, PlannedHandler, ShapeInput
+
+
+class SlotDescriptor:
+    tag: str
+
+
+@class_adapter_provider("method_slot_runtime.schema_program", "SlotDescriptor")
+@const_eval
+def adapt_slots(declaration: DeclarationInput[SlotDescriptor]) -> DeclarationPlan[SlotDescriptor]:
+    fields: list[PlannedField] = []
+    handlers: list[PlannedHandler[SlotDescriptor]] = []
+    for item in declaration.declaration.items:
+        if item.kind == "field":
+            declared_type = item.declared_type
+            if declared_type is None:
+                continue
+            fields.append(PlannedField(item.identity, declared_type))
+    for descriptor in declaration.descriptors:
+        if descriptor.target_kind == "method":
+            target = descriptor.target_callable
+            if target is None:
+                continue
+            handlers.append(PlannedHandler(target, descriptor.value, descriptor.origin))
+    return DeclarationPlan(fields, [], None, None, [], handlers)
+
+
+@class_adapter_marker("method_slot_runtime.schema_program", "adapt_slots")
+class SlotContract:
+    pass
+
+
+@method_descriptor("method_slot_runtime.schema_program", "adapt_slots")
+def slot(tag: str) -> SlotDescriptor:
+    return SlotDescriptor(tag)
+
+
 class SlotProgram:
-    sifr_method_slots: list[str]
-
-
-class ProgramOutcome:
-    status: str
-    value: SlotProgram | None
-    issues: list[str]
+    sifr_method_slots: list[CallableIdentity]
 
 
 @const_eval
-def derive(shape: dict[str, str]) -> ProgramOutcome:
-    return ProgramOutcome(
-        "produced",
-        SlotProgram(
-            [
-                "main.Record::normalize",
-                "main.Record::finalize",
-            ]
-        ),
-        [],
-    )
-
-
-@const_eval
-def derive_no_context(shape: dict[str, str]) -> ProgramOutcome:
-    return ProgramOutcome(
-        "produced", SlotProgram(["main.NoContextRecord::normalize"]), []
-    )
-
-
-@const_eval
-def derive_shared(shape: dict[str, str]) -> ProgramOutcome:
-    return ProgramOutcome(
-        "produced", SlotProgram(["main.SharedRecord::normalize"]), []
-    )
+def derive(shape: ShapeInput[SlotDescriptor]) -> ConstSpecializationOutcome[SlotProgram, SlotDescriptor]:
+    slots: list[CallableIdentity] = []
+    for method in shape.root.methods:
+        target = method.target
+        descriptor = method.descriptor
+        if target is not None and descriptor is not None:
+            slots.append(target)
+    return ConstSpecializationOutcome("produced", SlotProgram(slots), [])


### PR DESCRIPTION
## Scope
- resolve descriptor-planned user methods into typed static method slots
- support static, class, shared, mutable, and owned receivers, including infallible and `Result` handlers
- preserve descriptor identity, source origin, and deterministic inherited/local order
- enforce `Self` and owned-receiver move semantics
- update runtime coverage and specialization documentation

## Validation
- `cargo test -p sifr_driver handler_descriptors`
- `cargo test -p sifr_lowering -p sifr_frontend -p sifr_codegen -p sifr_driver --lib -- --skip test_e2e_pass --skip test_unknown_parent_class_has_class_code`
- `cargo test -p sifr_driver test_method_slot_runtime -- --ignored --nocapture`
- `cargo test -p sifr_driver test_method_slot_lifetime_thread_and_shared_context_rejections -- --ignored --nocapture`
- `cargo test -p sifr_codegen receiver`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_docs_error_code_links.py`
- `git diff --check`

## Deferred existing phase work
The M4-owned unknown-parent diagnostic mismatch remains excluded from M5 validation and is recorded for the later phase closure item. The separate `pre_v1` session/worktree is wholly out of scope.

Candidate: `2cdc8380ccc710f7a1dc86e9b5bbeedfa07d9d66`
Base: `4f3a475428b6c9ca789acd76212d6619f2e32d6b`