### PR TITLE
Finalize imported attached API owners

### DIFF
--- a/crates/sifr_driver/src/tests/early_adapters.rs
+++ b/crates/sifr_driver/src/tests/early_adapters.rs
@@ -3,13 +3,13 @@ use crate::{collect_project_hir_modules, compile_stdlib};
 use sifr_ir::{DeclarationMetadataTargetKind, StaticProgramValue};
 use std::collections::HashMap;
 
-const TYPES: &str = r#"
+pub(super) const TYPES: &str = r#"
 class ContractDescriptor:
     kind: str
     enabled: bool
 "#;
 
-const CONTRACT: &str = r#"
+pub(super) const CONTRACT: &str = r#"
 from sifr.meta import ConstSpecializationOutcome, DeclarationInput, DeclarationPlan, PlannedField, PlannedIssue, PlannedIssueLabel, PlannedMetadata, ShapeInput
 from fixture.contract_types import ContractDescriptor
 
@@ -56,7 +56,7 @@ def specialize(shape: ShapeInput[ContractDescriptor]) -> ConstSpecializationOutc
     raise ValueError("adapter metadata was not applied")
 "#;
 
-fn project(main: &str, contract: &str) -> HashMap<String, Vec<sifr_python_ast::Stmt>> {
+pub(super) fn project(main: &str, contract: &str) -> HashMap<String, Vec<sifr_python_ast::Stmt>> {
     HashMap::from([
         ("fixture.contract_types".to_string(), parse_suite(TYPES)),
         ("fixture.contract".to_string(), parse_suite(contract)),
@@ -64,7 +64,7 @@ fn project(main: &str, contract: &str) -> HashMap<String, Vec<sifr_python_ast::S
     ])
 }
 
-fn compile_errors(
+pub(super) fn compile_errors(
     modules: &HashMap<String, Vec<sifr_python_ast::Stmt>>,
     message: &str,
 ) -> Vec<sifr_diagnostics::RenderedDiagnostic> {
@@ -75,7 +75,7 @@ fn compile_errors(
     }
 }
 
-fn attached_contract() -> String {
+pub(super) fn attached_contract() -> String {
     CONTRACT
         .replace(
             "from sifr.meta import ",

--- a/crates/sifr_driver/src/tests/imported_attached_apis.rs
+++ b/crates/sifr_driver/src/tests/imported_attached_apis.rs
@@ -1,0 +1,142 @@
+use super::early_adapters::{attached_contract, compile_errors, project};
+use super::support::parse_suite;
+use crate::{collect_project_hir_modules, compile_stdlib};
+
+const MODELS: &str = r#"
+from fixture.contract import Contract, contract_config
+
+class Selected(Contract):
+    _config = contract_config(True)
+    value: int
+
+class Plain(Contract):
+    _config = contract_config(True)
+    value: int
+"#;
+
+fn selective_contract() -> String {
+    attached_contract().replace(
+        "return DeclarationPlan(fields, metadata, \"fixture.contract\", \"specialize\", issues, [], \"fixture.contract\", \"ContractApi\")",
+        r#"attached_module: str | None = "fixture.contract"
+    attached_symbol: str | None = "ContractApi"
+    if declaration.declaration.name == "Plain":
+        attached_module = None
+        attached_symbol = None
+    return DeclarationPlan(fields, metadata, "fixture.contract", "specialize", issues, [], attached_module, attached_symbol)"#,
+    )
+}
+
+#[test]
+fn imported_selected_owner_uses_finalized_set_through_type_and_instance_aliases() {
+    let contract = selective_contract();
+    let mut modules = project(
+        r#"
+from fixture.models import Plain as PlainAlias, Selected as SelectedAlias
+
+def main():
+    selected: SelectedAlias = SelectedAlias(1)
+    plain: PlainAlias = PlainAlias(2)
+    assert SelectedAlias.describe() == "attached"
+    assert SelectedAlias.echo("residual") == "residual"
+    assert selected.touch() == 1
+    assert plain.value == 2
+"#,
+        &contract,
+    );
+    modules.insert("fixture.models".to_string(), parse_suite(MODELS));
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let compiled = collect_project_hir_modules(&modules, stdlib_defs)
+        .expect("imported selected attached APIs should lower through aliases");
+    let main = compiled
+        .hir_modules
+        .get("main")
+        .expect("main module exists");
+    let debug_hir = format!("{main:?}");
+    assert!(
+        debug_hir.contains("describe::<SelectedAlias>"),
+        "{debug_hir}"
+    );
+    assert!(
+        debug_hir.contains("echo::<String, SelectedAlias>"),
+        "{debug_hir}"
+    );
+    assert!(debug_hir.contains("touch::<SelectedAlias>"), "{debug_hir}");
+}
+
+#[test]
+fn imported_unselected_owner_exposes_no_provisional_attached_api() {
+    let contract = selective_contract();
+    let mut modules = project(
+        r#"
+from fixture.models import Plain as PlainAlias, Selected as SelectedAlias
+
+def invalid():
+    plain: PlainAlias = PlainAlias(1)
+    assert SelectedAlias.describe() == "attached"
+    PlainAlias.describe()
+    plain.touch()
+"#,
+        &contract,
+    );
+    modules.insert("fixture.models".to_string(), parse_suite(MODELS));
+    let errors = compile_errors(
+        &modules,
+        "an imported finalized owner without a selected set must expose no attached API",
+    );
+    let missing_members = errors
+        .iter()
+        .filter(|error| {
+            error.code == sifr_diagnostics::DiagnosticCode::CLASS_MISSING_MEMBER.code()
+                && error.message.contains("PlainAlias")
+                && (error.message.contains("describe") || error.message.contains("touch"))
+        })
+        .count();
+    assert_eq!(
+        missing_members, 2,
+        "expected imported type and instance missing-member diagnostics: {errors:#?}"
+    );
+}
+
+#[test]
+fn imported_unbound_generic_owner_still_fails_static_program_bound() {
+    let contract = attached_contract().replace(
+        "return DeclarationPlan(fields, metadata, \"fixture.contract\", \"specialize\", issues, [], \"fixture.contract\", \"ContractApi\")",
+        r#"specialization_module: str | None = "fixture.contract"
+    specialization_function: str | None = "specialize"
+    if declaration.declaration.name == "Generic":
+        specialization_module = None
+        specialization_function = None
+    return DeclarationPlan(fields, metadata, specialization_module, specialization_function, issues, [], "fixture.contract", "ContractApi")"#,
+    );
+    let mut modules = project(
+        r#"
+from fixture.models import Generic as GenericAlias
+
+def invalid():
+    GenericAlias.describe()
+"#,
+        &contract,
+    );
+    modules.insert(
+        "fixture.models".to_string(),
+        parse_suite(
+            r#"
+from fixture.contract import Contract, contract_config
+
+class Generic[T](Contract):
+    _config = contract_config(True)
+    value: T
+"#,
+        ),
+    );
+    let errors = compile_errors(
+        &modules,
+        "an imported unbound generic owner must not satisfy StaticProgram",
+    );
+    assert!(
+        errors.iter().any(|error| {
+            error.message.contains("StaticProgram") || error.message.contains("concrete")
+        }),
+        "expected imported StaticProgram diagnostic: {errors:#?}"
+    );
+}

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod diagnostics;
 mod discovery_and_workspace;
 mod early_adapters;
 mod handler_descriptors;
+mod imported_attached_apis;
 mod package_project_build_check;
 mod panic_boundary;
 mod project_build_check;

--- a/crates/sifr_lowering/src/lower/attached_api_surfaces.rs
+++ b/crates/sifr_lowering/src/lower/attached_api_surfaces.rs
@@ -20,9 +20,14 @@ pub(super) fn apply(ctx: &mut LowerCtx) {
     let mut imports: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
 
     for (owner, selection) in selections {
+        let owner_is_local = ctx
+            .class_adapter_selections
+            .iter()
+            .any(|candidate| candidate.owner == owner);
+        let selection_is_finalized = ctx.attached_api_selections_finalized || !owner_is_local;
         let (declarations, provisional) = match selection.attached_api_set.as_ref() {
             Some(set) => (declarations_for_set(ctx, set, &module), false),
-            None if ctx.attached_api_selections_finalized => continue,
+            None if selection_is_finalized => continue,
             None => (
                 provisional_declarations(ctx, &selection.provider_module),
                 true,
@@ -84,8 +89,14 @@ pub(super) fn apply(ctx: &mut LowerCtx) {
             if let Some(Type::Class { methods, .. }) = ctx.class_types.get_mut(&owner) {
                 methods.push((declaration.public_name.clone(), surface));
             }
+            let canonical_qualified = class_name(&owner_type)
+                .filter(|name| *name != owner)
+                .map(|name| format!("{name}.{}", declaration.public_name));
             if declaration.receiver != AttachedApiReceiver::Type {
                 ctx.class_instance_methods.insert(qualified.clone());
+                if let Some(canonical) = canonical_qualified.as_ref() {
+                    ctx.class_instance_methods.insert(canonical.clone());
+                }
             }
             let emitted_function = if declaration.module == module {
                 declaration.function.clone()
@@ -97,14 +108,16 @@ pub(super) fn apply(ctx: &mut LowerCtx) {
                     .insert(declaration.function.clone(), alias.clone());
                 alias
             };
-            ctx.attached_method_bindings.insert(
-                qualified,
-                AttachedMethodBinding {
-                    declaration,
-                    emitted_function,
-                    provisional,
-                },
-            );
+            let binding = AttachedMethodBinding {
+                declaration,
+                emitted_function,
+                provisional,
+            };
+            ctx.attached_method_bindings
+                .insert(qualified, binding.clone());
+            if let Some(canonical) = canonical_qualified {
+                ctx.attached_method_bindings.insert(canonical, binding);
+            }
         }
     }
 
@@ -234,6 +247,13 @@ fn substitute_function_type(
 fn class_methods(owner_type: &Type) -> Option<&[(String, FunctionType)]> {
     match owner_type.resolve_alias() {
         Type::Class { methods, .. } => Some(methods),
+        _ => None,
+    }
+}
+
+fn class_name(owner_type: &Type) -> Option<&str> {
+    match owner_type.resolve_alias() {
+        Type::Class { name, .. } => Some(name),
         _ => None,
     }
 }

--- a/crates/sifr_lowering/src/lower/type_bounds.rs
+++ b/crates/sifr_lowering/src/lower/type_bounds.rs
@@ -218,13 +218,29 @@ fn supports_structural_bridge_type_inner(
 }
 
 fn supports_static_program_type(ty: &Type, ctx: &LowerCtx) -> bool {
-    let Type::Class { name, .. } = ty.resolve_alias() else {
+    let Type::Class { identity, name, .. } = ty.resolve_alias() else {
         return false;
     };
-    ctx.specialization_requests
+    let local_request = ctx
+        .specialization_requests
         .iter()
-        .any(|request| request.owner == *name)
-        && supports_structural_bridge_type(ty, ctx)
+        .any(|request| request.owner == *name);
+    let imported_identity = identity
+        .as_deref()
+        .and_then(|canonical| canonical.rsplit_once('.'));
+    let imported_request = imported_identity
+        .and_then(|(module, canonical_owner)| {
+            ctx.externals
+                .specialization_requests
+                .get(module)
+                .map(|requests| (requests, canonical_owner))
+        })
+        .is_some_and(|(requests, canonical_owner)| {
+            requests
+                .iter()
+                .any(|request| request.owner == canonical_owner)
+        });
+    (local_request || imported_request) && supports_structural_bridge_type(ty, ctx)
 }
 
 fn contains_declared_generic_class(

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -875,7 +875,9 @@ cycle with later handler and attached-API outputs.
 Attached package APIs are erased compile-time declarations grouped into canonical module-and-set
 identities. Adapter output selects exactly one set. Provisional lowering may expose visible
 package candidates so class bodies can type-check before adapter execution, while final lowering
-uses only the selected set as authority. Attached signatures are added to the adapted
+uses only the selected set as authority. Imported adapter selections are finalized external facts;
+consumer lowering never applies provisional candidates to an imported owner, including when its
+final plan selected no set. Attached signatures are added to the adapted
 `Type::Class` surface without adding HIR methods, structural members, handler slots, or synthesized
 method bodies. Calls lower directly to the declared package function through deterministic hidden
 imports. The lowering substitutes the concrete owner and `Self`, infers residual type parameters,

--- a/verification/areas/core_language/fixtures/static_class_adapter/app.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/app.sifr
@@ -1,5 +1,6 @@
 from fixture.facade import Contract, ContractError, contract_config, contract_field
 from fixture.factories import Token as ExternalToken, make_names as external_names
+from fixture.models import ImportedAttached as ImportedAlias, ImportedPlain as PlainAlias
 
 
 def make_names() -> list[str]:
@@ -51,6 +52,13 @@ def main():
     assert attached.inspect() == 41
     assert attached.touch() == 42
     assert consumed.finish() == 43
+    imported: ImportedAlias = ImportedAlias(11)
+    plain: PlainAlias = PlainAlias(12)
+    assert ImportedAlias.describe() == "attached-contract"
+    assert ImportedAlias.echo("imported") == "imported"
+    assert imported.inspect() == 41
+    assert imported.touch() == 42
+    assert plain.value == 12
 
 
 def compile_result_construction() -> Result[AttachedModel, ContractError]:

--- a/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr
@@ -42,6 +42,11 @@ def adapt_contract(
                     descriptor.value,
                 )
             )
+    attached_api_module: str | None = "fixture.api"
+    attached_api_symbol: str | None = "ContractApi"
+    if declaration.declaration.name == "ImportedPlain":
+        attached_api_module = None
+        attached_api_symbol = None
     return DeclarationPlan(
         fields,
         metadata,
@@ -49,8 +54,8 @@ def adapt_contract(
         "specialize",
         issues,
         [],
-        "fixture.api",
-        "ContractApi",
+        attached_api_module,
+        attached_api_symbol,
     )
 
 

--- a/verification/areas/core_language/fixtures/static_class_adapter/fixture/models.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/fixture/models.sifr
@@ -1,0 +1,11 @@
+from fixture.facade import Contract, contract_config
+
+
+class ImportedAttached(Contract):
+    _config = contract_config(True)
+    value: int
+
+
+class ImportedPlain(Contract):
+    _config = contract_config(True)
+    value: int


### PR DESCRIPTION
Implements M7b from the active static-class-adapter ergonomics phase.\n\n- treats imported adapter selections as finalized external facts\n- preserves selected APIs and explicit no-set absence in consumer modules\n- resolves type and instance attached calls through import aliases\n- uses canonical external specialization requests for imported StaticProgram owners\n- adds cross-module driver and generated-Rust fixture coverage\n\nExact candidate: 071aaa51a53dce22df0156158eecb7e6b483d095