### PR TITLE
fix(codegen): support typed adapter descriptor unions

### DIFF
--- a/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
@@ -108,7 +108,8 @@ impl RustEmitter {
                 if self.borrowed_params.contains(name) || self.mut_borrowed_params.contains(name)
         );
 
-        let needs_clone = (is_self_access || is_borrowed_parameter) && needs_clone_for_type(ty);
+        let needs_clone = needs_clone_for_type(ty)
+            && (is_self_access || is_borrowed_parameter || ty.supports_derived_clone());
 
         let lowered_field = self.lower_field_storage_access_for_class(
             class_name_for_parent.as_deref(),

--- a/crates/sifr_codegen/src/expr_render_helpers/tests.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/tests.rs
@@ -30,6 +30,33 @@ fn field_read_from_borrowed_parameter_clones_move_value() {
 }
 
 #[test]
+fn field_read_from_owned_local_clones_reusable_value() {
+    let class = Type::Class {
+        identity: Some("records.Item".to_string()),
+        type_args: Vec::new(),
+        name: "Item".to_string(),
+        fields: vec![("identity".to_string(), Type::Str)],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let object = HirExpr::Name {
+        name: "item".to_string(),
+        binding_id: None,
+        ty: class,
+    };
+    let mut emitter = RustEmitter::new();
+
+    let lowered = emitter.lower_field_access_expr_with_lowered_object(
+        &object,
+        "identity",
+        &Type::Str,
+        RustExpr::Ident("item".to_string()),
+    );
+
+    assert_eq!(crate::render_expr(&lowered), "item.identity.clone()");
+}
+
+#[test]
 fn inherited_field_value_read_uses_shared_storage_rerooting() {
     let child = Type::Class {
         identity: None,

--- a/crates/sifr_codegen/src/helpers/helpers_impl.rs
+++ b/crates/sifr_codegen/src/helpers/helpers_impl.rs
@@ -268,6 +268,68 @@ pub(crate) fn flatten_option_value_for_target(
     value
 }
 
+/// Widen an ordinary `T | None` (`Option<T>`) into a larger enum-backed union.
+/// The source wrapper must be mapped member-by-member; treating it as the
+/// target representation either drops the present value or references an
+/// enum that does not represent the source option.
+pub(crate) fn widen_option_value_for_union_target(
+    target: &Type,
+    source: &Type,
+    value: RustExpr,
+) -> Option<RustExpr> {
+    let Type::Union(target_members) = crate::resolve_alias_type_for_plain_call(target) else {
+        return None;
+    };
+    if is_option_type(target) {
+        return None;
+    }
+    let source_payload = source.optional_member_type()?;
+    if matches!(
+        crate::resolve_alias_type_for_plain_call(&source_payload),
+        Type::Union(_)
+    ) {
+        return None;
+    }
+    let payload_member = find_union_member(target_members, &source_payload)?;
+    if !target_members
+        .iter()
+        .any(|member| matches!(member.resolve_alias(), Type::None))
+    {
+        return None;
+    }
+    let target_name = target.union_enum_name();
+    let present = RustExpr::FnCall {
+        func: Box::new(RustExpr::Path(vec![
+            target_name.clone(),
+            payload_member.union_variant_name(),
+        ])),
+        args: vec![RustExpr::Ident("__sifr_union_value".to_string())],
+    };
+    let mapped = RustExpr::MethodCall {
+        receiver: Box::new(value),
+        method: "map".to_string(),
+        args: vec![RustExpr::Closure {
+            params: vec![crate::RustParam::Named {
+                name: "__sifr_union_value".to_string(),
+                ty: crate::RustType::Named("_".to_string()),
+            }],
+            body: Box::new(present),
+            is_move: false,
+        }],
+    };
+    Some(RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::Paren(Box::new(mapped))),
+        method: "unwrap_or".to_string(),
+        args: vec![RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec![
+                target_name,
+                Type::None.union_variant_name(),
+            ])),
+            args: vec![RustExpr::Literal(crate::RustLiteral::Unit)],
+        }],
+    })
+}
+
 /// Normalize nested absence produced by a safe collection operation.
 pub(crate) fn normalize_safe_option_result(payload: &Type, value: RustExpr) -> RustExpr {
     let canonical_payload = match crate::resolve_alias_type_for_plain_call(payload) {
@@ -464,9 +526,17 @@ pub(crate) fn wrap_union_member_expr(
         return None;
     }
     let variant = find_union_variant(members, member_ty)?;
+    let payload = if matches!(
+        crate::resolve_alias_type_for_plain_call(member_ty),
+        Type::None
+    ) {
+        RustExpr::Literal(crate::RustLiteral::Unit)
+    } else {
+        lowered
+    };
     Some(RustExpr::FnCall {
         func: Box::new(RustExpr::Path(vec![union_ty.union_enum_name(), variant])),
-        args: vec![lowered],
+        args: vec![payload],
     })
 }
 

--- a/crates/sifr_codegen/src/helpers/tests.rs
+++ b/crates/sifr_codegen/src/helpers/tests.rs
@@ -666,3 +666,42 @@ fn safe_option_result_flattens_simple_option_and_preserves_nullable_union() {
         value
     );
 }
+
+#[test]
+fn union_member_wrapper_uses_unit_for_none_payload() {
+    let target = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
+    let wrapped = wrap_union_member_expr(
+        &target,
+        &Type::None,
+        RustExpr::Literal(crate::RustLiteral::None),
+    )
+    .expect("none should be wrapped as an ordinary union member");
+    let rendered = crate::render_expr(&wrapped);
+    assert!(rendered.contains(&target.union_enum_name()), "{rendered}");
+    assert!(rendered.ends_with("(())"), "{rendered}");
+}
+
+#[test]
+fn optional_member_widens_into_larger_union_without_source_enum() {
+    let target = sifr_type_system::make_union(vec![
+        Type::Str,
+        Type::None,
+        Type::Class {
+            identity: Some("fixture.Path".to_string()),
+            type_args: Vec::new(),
+            name: "Path".to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        },
+    ]);
+    let source = sifr_type_system::make_union(vec![Type::Str, Type::None]);
+    let widened =
+        widen_option_value_for_union_target(&target, &source, RustExpr::Ident("value".to_string()))
+            .expect("optional subset should widen into the target union");
+    let rendered = crate::render_expr(&widened);
+    assert!(rendered.contains(".map("), "{rendered}");
+    assert!(rendered.contains(".unwrap_or("), "{rendered}");
+    assert!(rendered.contains(&target.union_enum_name()), "{rendered}");
+    assert!(!rendered.contains(&source.union_enum_name()), "{rendered}");
+}

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
@@ -123,23 +123,24 @@ impl RustEmitter {
                 }
                 lowered_arg =
                     self.consuming_value_upcast_for_ir(param_ty, &effective_arg_ty, lowered_arg);
-            } else if let Type::Union(members) = resolved_param {
+            } else if let Type::Union(_) = resolved_param {
                 if !crate::helpers::is_option_type(resolved_param)
                     && !matches!(
                         crate::resolve_alias_type_for_plain_call(&effective_arg_ty),
                         Type::Union(_)
                     )
                 {
-                    if let Some(variant) =
-                        crate::helpers::find_union_variant(members, &effective_arg_ty)
-                    {
-                        lowered_arg = crate::RustExpr::FnCall {
-                            func: Box::new(crate::RustExpr::Path(vec![
-                                resolved_param.union_enum_name(),
-                                variant,
-                            ])),
-                            args: vec![lowered_arg],
-                        };
+                    let member_ty = if matches!(arg, HirExpr::NoneLiteral) {
+                        &Type::None
+                    } else {
+                        &effective_arg_ty
+                    };
+                    if let Some(wrapped) = crate::helpers::wrap_union_member_expr(
+                        resolved_param,
+                        member_ty,
+                        lowered_arg.clone(),
+                    ) {
+                        lowered_arg = wrapped;
                     }
                 }
             }

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -658,6 +658,7 @@ impl RustEmitter {
                         self.coerce_local_value_for_target_type_for_ir(&target_ty, value, lowered)?;
                     if !crate::helpers::is_option_type(&target_ty)
                         && crate::helpers::is_option_type(value.ty())
+                        && !value.ty().is_assignable_to(&target_ty)
                     {
                         let fallback = if crate::helpers::is_copy_type_for_codegen(&target_ty) {
                             RustExpr::Ident(name.clone())
@@ -680,6 +681,7 @@ impl RustEmitter {
                         self.coerce_local_value_for_target_type_for_ir(&target_ty, value, lowered)?;
                     if !crate::helpers::is_option_type(&target_ty)
                         && crate::helpers::is_option_type(value.ty())
+                        && !value.ty().is_assignable_to(&target_ty)
                     {
                         let fallback = if crate::helpers::is_copy_type_for_codegen(&target_ty) {
                             RustExpr::Ident(name.clone())

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -333,8 +333,12 @@ pub fn generate_rust_multi_with_metadata(
     } else {
         HashSet::new()
     };
-    let stdlib_nominal_plan =
-        project_stdlib_nominal_plan(&union_usage.unions, stdlib_code, modules);
+    let stdlib_nominal_plan = project_stdlib_nominal_plan(
+        &union_usage.unions,
+        stdlib_code,
+        modules,
+        structural_interop_enabled,
+    );
     let crate_root_modules = HashSet::from(["main"]);
     let structural_identity_expressions = if structural_interop_enabled {
         crate::structural_identity_codegen::class_identity_expressions_for_project(

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -49,8 +49,12 @@ pub fn generate_rust_test_project_with_metadata(
     } else {
         HashSet::new()
     };
-    let stdlib_nominal_plan =
-        project_stdlib_nominal_plan(&union_usage.unions, stdlib_code, &all_modules);
+    let stdlib_nominal_plan = project_stdlib_nominal_plan(
+        &union_usage.unions,
+        stdlib_code,
+        &all_modules,
+        structural_interop_enabled,
+    );
     let crate_root_modules = test_modules
         .iter()
         .map(|(module_name, _)| *module_name)

--- a/crates/sifr_codegen/src/lower_stmt/return_and_assignment_values.rs
+++ b/crates/sifr_codegen/src/lower_stmt/return_and_assignment_values.rs
@@ -157,11 +157,23 @@ pub(super) fn try_lower_simple_let_value(ty: &Type, value: &HirExpr) -> Option<R
     }
     if let Type::Union(members) = resolve_alias_type(ty) {
         let lowered = try_lower_leaf_or_name_expr(value)?;
-        let variant = crate::helpers::find_union_variant(members, value.ty())?;
-        return Some(RustExpr::FnCall {
-            func: Box::new(RustExpr::Path(vec![ty.union_enum_name(), variant])),
-            args: vec![lowered],
-        });
+        let member_ty = if matches!(value, HirExpr::NoneLiteral) {
+            &Type::None
+        } else {
+            value.ty()
+        };
+        if let Some(wrapped) =
+            crate::helpers::wrap_union_member_expr(ty, member_ty, lowered.clone())
+        {
+            return Some(wrapped);
+        }
+        return (|| {
+            let variant = crate::helpers::find_union_variant(members, member_ty)?;
+            Some(RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec![ty.union_enum_name(), variant])),
+                args: vec![lowered],
+            })
+        })();
     }
     if matches!(
         crate::resolve_alias_type_for_plain_call(ty),

--- a/crates/sifr_codegen/src/lower_stmt/return_and_assignment_values.rs
+++ b/crates/sifr_codegen/src/lower_stmt/return_and_assignment_values.rs
@@ -97,11 +97,24 @@ pub(super) fn try_lower_simple_return_stmt(
 
     if let Some(return_ty) = ctx.return_type {
         if let Type::Union(members) = resolve_alias_type(return_ty) {
-            if is_option_like_type(value.ty()) && !matches!(value.ty(), Type::None) {
+            if is_option_like_type(value.ty())
+                && !matches!(value, HirExpr::NoneLiteral)
+                && !is_none_type(value.ty())
+            {
                 return None;
             }
             let lowered = try_lower_leaf_or_name_expr(value)?;
-            let variant = crate::helpers::find_union_variant(members, value.ty())?;
+            let member_ty = if matches!(value, HirExpr::NoneLiteral) || is_none_type(value.ty()) {
+                &Type::None
+            } else {
+                value.ty()
+            };
+            if let Some(wrapped) =
+                crate::helpers::wrap_union_member_expr(return_ty, member_ty, lowered.clone())
+            {
+                return Some(vec![RustStmt::Return(Some(wrapped))]);
+            }
+            let variant = crate::helpers::find_union_variant(members, member_ty)?;
             let enum_name = return_ty.union_enum_name();
             return Some(vec![RustStmt::Return(Some(RustExpr::FnCall {
                 func: Box::new(RustExpr::Path(vec![enum_name, variant])),

--- a/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
+++ b/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
@@ -396,6 +396,23 @@ pub(super) fn coerce_simple_assign_value_for_target_type(
     if adapted_value != lowered_value {
         return adapted_value;
     }
+    if let Some(widened) = crate::helpers::widen_option_value_for_union_target(
+        target_ty,
+        value.ty(),
+        lowered_value.clone(),
+    ) {
+        return widened;
+    }
+    let wrapped_member = if matches!(value, HirExpr::NoneLiteral) {
+        &Type::None
+    } else {
+        value.ty()
+    };
+    if let Some(wrapped) =
+        crate::helpers::wrap_union_member_expr(target_ty, wrapped_member, lowered_value.clone())
+    {
+        return wrapped;
+    }
     if !crate::helpers::is_option_type(target_ty) {
         return lowered_value;
     }

--- a/crates/sifr_codegen/src/project_stdlib_nominals.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals.rs
@@ -77,6 +77,7 @@ pub(crate) fn project_stdlib_nominal_plan(
     unions: &HashMap<String, Vec<Type>>,
     stdlib_code: &StdlibCode,
     modules: &[(&str, &HirModule)],
+    structural_interop_enabled: bool,
 ) -> ProjectStdlibNominalPlan {
     let mut declarations = BTreeMap::<String, HashSet<String>>::new();
     let mut builtin_types = BTreeMap::<String, Type>::new();
@@ -84,6 +85,9 @@ pub(crate) fn project_stdlib_nominal_plan(
         for member in members {
             collect_shared_nominals(member, &mut declarations, &mut builtin_types);
         }
+    }
+    for (_, module) in modules {
+        collect_module_nominals(module, &mut declarations, &mut builtin_types);
     }
     let mut python_error_rust_names = HashSet::new();
     if builtin_types.contains_key("Error") {
@@ -169,7 +173,7 @@ pub(crate) fn project_stdlib_nominal_plan(
         &synthetic_module,
         stdlib_code,
         Some("main"),
-        false,
+        structural_interop_enabled,
     );
     let probe_name_refs = probe_names.iter().map(String::as_str).collect();
     let shared_source = strip_rust_items_by_name(&generated.rust_source, &probe_name_refs);
@@ -256,6 +260,47 @@ fn collect_function_nominals(
     collect_shared_nominals(&function.return_type, declarations, builtin_types);
 }
 
+fn collect_hir_function_nominals(
+    function: &HirFunction,
+    declarations: &mut BTreeMap<String, HashSet<String>>,
+    builtin_types: &mut BTreeMap<String, Type>,
+) {
+    for parameter in &function.params {
+        collect_shared_nominals(&parameter.ty, declarations, builtin_types);
+    }
+    collect_shared_nominals(&function.return_type, declarations, builtin_types);
+    for ty in crate::hir_analysis::queries::collect_let_declared_types(&function.body) {
+        collect_shared_nominals(&ty, declarations, builtin_types);
+    }
+}
+
+fn collect_module_nominals(
+    module: &HirModule,
+    declarations: &mut BTreeMap<String, HashSet<String>>,
+    builtin_types: &mut BTreeMap<String, Type>,
+) {
+    for function in &module.functions {
+        collect_hir_function_nominals(function, declarations, builtin_types);
+    }
+    for class in &module.classes {
+        for (_, field) in &class.fields {
+            collect_shared_nominals(field, declarations, builtin_types);
+        }
+        if let Some(parent) = &class.parent_type {
+            collect_shared_nominals(parent, declarations, builtin_types);
+        }
+        for method in &class.methods {
+            collect_hir_function_nominals(method, declarations, builtin_types);
+        }
+        for (_, operator) in &class.operator_impls {
+            collect_hir_function_nominals(operator, declarations, builtin_types);
+        }
+    }
+    for (_, ty, _) in &module.constants {
+        collect_shared_nominals(ty, declarations, builtin_types);
+    }
+}
+
 fn collect_shared_nominals(
     ty: &Type,
     declarations: &mut BTreeMap<String, HashSet<String>>,
@@ -266,6 +311,8 @@ fn collect_shared_nominals(
             identity,
             type_args,
             name,
+            fields,
+            methods,
             ..
         } => {
             if crate::BUILTIN_ERROR_CLASSES.contains(&name.as_str()) {
@@ -278,6 +325,16 @@ fn collect_shared_nominals(
             }
             for type_arg in type_args {
                 collect_shared_nominals(type_arg, declarations, builtin_types);
+            }
+            if identity.as_deref().is_some_and(|identity| {
+                identity.starts_with("sifr.") || identity.starts_with("_sifr.")
+            }) {
+                for (_, field) in fields {
+                    collect_shared_nominals(field, declarations, builtin_types);
+                }
+                for (_, method) in methods {
+                    collect_function_nominals(method, declarations, builtin_types);
+                }
             }
         }
         Type::Protocol {
@@ -390,7 +447,7 @@ mod tests {
             ],
         )]);
 
-        let plan = project_stdlib_nominal_plan(&unions, &StdlibCode::default(), &[]);
+        let plan = project_stdlib_nominal_plan(&unions, &StdlibCode::default(), &[], false);
 
         assert!(plan.prelude.contains("pub struct TimeoutError"));
         assert!(plan

--- a/crates/sifr_codegen/src/stmt_support_emitter/await_and_async_comprehension.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/await_and_async_comprehension.rs
@@ -163,18 +163,24 @@ impl RustEmitter {
                 args: vec![lowered_value],
             });
         }
-        let lowered_value = self.consuming_value_upcast_for_ir(target_ty, value_ty, lowered_value);
+        let upcasted_value =
+            self.consuming_value_upcast_for_ir(target_ty, value_ty, lowered_value.clone());
+        let value_was_upcasted = upcasted_value != lowered_value;
         let lowered_value =
-            crate::helpers::flatten_option_value_for_target(target_ty, value_ty, lowered_value);
+            crate::helpers::flatten_option_value_for_target(target_ty, value_ty, upcasted_value);
         let wrapped_member = if matches!(value, HirExpr::NoneLiteral) {
             &Type::None
         } else {
             value_ty
         };
-        if let Some(wrapped) =
-            crate::helpers::wrap_union_member_expr(target_ty, wrapped_member, lowered_value.clone())
-        {
-            return Ok(wrapped);
+        if !value_was_upcasted {
+            if let Some(wrapped) = crate::helpers::wrap_union_member_expr(
+                target_ty,
+                wrapped_member,
+                lowered_value.clone(),
+            ) {
+                return Ok(wrapped);
+            }
         }
         let lowered_value =
             crate::helpers::adapt_collection_storage_for_target(target_ty, value_ty, lowered_value);

--- a/crates/sifr_codegen/src/stmt_support_emitter/await_and_async_comprehension.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/await_and_async_comprehension.rs
@@ -166,6 +166,16 @@ impl RustEmitter {
         let lowered_value = self.consuming_value_upcast_for_ir(target_ty, value_ty, lowered_value);
         let lowered_value =
             crate::helpers::flatten_option_value_for_target(target_ty, value_ty, lowered_value);
+        let wrapped_member = if matches!(value, HirExpr::NoneLiteral) {
+            &Type::None
+        } else {
+            value_ty
+        };
+        if let Some(wrapped) =
+            crate::helpers::wrap_union_member_expr(target_ty, wrapped_member, lowered_value.clone())
+        {
+            return Ok(wrapped);
+        }
         let lowered_value =
             crate::helpers::adapt_collection_storage_for_target(target_ty, value_ty, lowered_value);
         let lowered_value =

--- a/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
@@ -84,7 +84,17 @@ impl RustEmitter {
 
             if convention.is_owned() {
                 lowered_arg =
-                    self.consuming_class_upcast_for_ir(param_ty, &effective_arg_ty, lowered_arg);
+                    self.consuming_value_upcast_for_ir(param_ty, &effective_arg_ty, lowered_arg);
+            } else if let Some(wrapped) = crate::helpers::wrap_union_member_expr(
+                param_ty,
+                if matches!(hir_arg, HirExpr::NoneLiteral) {
+                    &Type::None
+                } else {
+                    &effective_arg_ty
+                },
+                lowered_arg.clone(),
+            ) {
+                lowered_arg = wrapped;
             }
 
             let mut recursive_option_adapted = false;

--- a/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
@@ -13,6 +13,14 @@ impl RustEmitter {
             return lowered;
         }
 
+        if let Some(widened) = crate::helpers::widen_option_value_for_union_target(
+            target_ty,
+            source_ty,
+            lowered.clone(),
+        ) {
+            return widened;
+        }
+
         if let Some(target_inner) = Self::option_inner_type_for_ir(target_ty) {
             if let Some(source_inner) = Self::option_inner_type_for_ir(source_ty) {
                 let value = crate::RustExpr::Ident("__sifr_option_value".to_string());
@@ -92,6 +100,11 @@ impl RustEmitter {
             {
                 let converted =
                     self.consuming_value_upcast_for_ir(target_member, source_ty, lowered);
+                let converted = if matches!(target_member.resolve_alias(), Type::None) {
+                    crate::RustExpr::Literal(crate::RustLiteral::Unit)
+                } else {
+                    converted
+                };
                 return crate::RustExpr::FnCall {
                     func: Box::new(crate::RustExpr::Path(vec![
                         target.union_enum_name(),

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
@@ -137,6 +137,7 @@ impl RustEmitter {
                         )?;
                         if !crate::helpers::is_option_type(&target_ty)
                             && crate::helpers::is_option_type(value.ty())
+                            && !value.ty().is_assignable_to(&target_ty)
                         {
                             let fallback = if crate::helpers::is_copy_type_for_codegen(&target_ty) {
                                 crate::RustExpr::Ident(name.clone())

--- a/crates/sifr_driver/src/tests/adapter_defaults.rs
+++ b/crates/sifr_driver/src/tests/adapter_defaults.rs
@@ -322,6 +322,12 @@ class Child(Parent):
 fn reexported_default_descriptors_finalize_constructor_parameters() {
     let modules = HashMap::from([
         (
+            "fixture.api".to_string(),
+            parse_suite(include_str!(
+                "../../../../verification/areas/core_language/fixtures/static_class_adapter/fixture/api.sifr"
+            )),
+        ),
+        (
             "fixture.contract_types".to_string(),
             parse_suite(include_str!(
                 "../../../../verification/areas/core_language/fixtures/static_class_adapter/fixture/contract_types.sifr"

--- a/plans/issues/active/ad-hoc-static-class-adapters-and-pydantic-ergonomics.md
+++ b/plans/issues/active/ad-hoc-static-class-adapters-and-pydantic-ergonomics.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Status: active on 2026-08-18. M0-M7b are complete; M8 is next.
+Status: active on 2026-08-18. M0-M7b are complete; M7c is active.
 
 This phase starts after the completed Native Pydantic-Sifr engine phase. It
 does not reopen the validated schema engine, structural bridge, or native core.
@@ -983,6 +983,45 @@ The pre-v1 worktree, task, processes, artifacts, and failures remain entirely
 outside this phase.
 Next action: implement M8 Pydantic model, field, and configuration declarations.
 
+### M7c: Typed Adapter Union and Shared-Nominal Code Generation
+
+Owner: `sifr-lang/sifr`.
+
+Scope:
+
+- Emit unit payloads for `None` members of enum-backed unions.
+- Widen ordinary optional values into larger union representations without
+  requiring a source enum that does not exist in Rust.
+- Preserve optional-to-union assignment semantics when the target itself
+  accepts `None`.
+- Share compiler-owned stdlib nominal types once across generated project
+  modules, including their structural implementations.
+- Preserve reusable owned records after clone-capable field reads while
+  retaining move behavior for affine fields and checked storage places.
+- Extend the synthetic static-class-adapter fixture with cross-module typed
+  descriptors and non-domain optional/union fields.
+
+Acceptance criteria:
+
+- A package descriptor declared in one module can carry compiler-owned
+  `sifr.meta` values and be consumed by an adapter in another module.
+- `None`, `T | None`, and `T | U | None` descriptor values lower to valid Rust
+  in locals, assignments, returns, and constructor arguments.
+- Assigning `T | None` into a wider union that accepts `None` preserves the
+  source absence instead of retaining the previous target value.
+- Repeated clone-capable field reads do not partially move their owning
+  record; affine field reads remain move-only.
+- The package-neutral static-class-adapter fixture builds and runs.
+- The paused M8 fields-and-configuration demo builds and runs without a
+  Pydantic-specific compiler path.
+
+Exit gate: typed cross-module adapter descriptors with optional and wider-union
+fields generate valid Rust and unblock M8.
+
+State: active
+Issue: [`sifr-lang/sifr#3271`](https://github.com/sifr-lang/sifr/issues/3271)
+Next action: complete M7c, then resume M8 without changing its preserved work.
+
 ### M8: Pydantic Model, Field, and Configuration Declarations
 
 Owner: `sifr-lang/pydantic-sifr`.
@@ -1257,8 +1296,7 @@ Next action:
 
 ## Current Handoff
 
-Current state: M0-M7b are merged and recorded.
+Current state: M0-M7b are merged and recorded; M7c is active.
 
-Next action: complete M8 in `sifr-lang/pydantic-sifr`. Declare the familiar
-model, field, configuration, constraint, and specialized public-value facade
-on the installed M1-M7b compiler substrate without raw metadata.
+Next action: complete M7c in `sifr-lang/sifr`, then resume the preserved M8
+work in `sifr-lang/pydantic-sifr` on the merged compiler substrate.

--- a/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr
@@ -13,6 +13,8 @@ def adapt_contract(
     issues: list[PlannedIssue[ContractDescriptor]] = []
     validation_alias: str | ContractAlias | None = None
     threshold: int | float | None = None
+    direct_alias: str | ContractAlias | None = ContractAlias(["direct"])
+    direct_alias = "literal"
     for item in declaration.declaration.items:
         if item.kind == "field":
             declared_type: str | None = item.declared_type
@@ -73,7 +75,9 @@ class Contract:
 
 @class_descriptor("fixture.contract", "adapt_contract")
 def contract_config(enabled: bool) -> ContractDescriptor:
-    return ContractDescriptor("class", enabled, "required", None, None)
+    return ContractDescriptor(
+        "class", enabled, "required", None, None, None, None, 1
+    )
 
 
 @field_descriptor("fixture.contract", "adapt_contract")
@@ -86,6 +90,11 @@ def contract_field(
     if default is not None:
         return ContractDescriptor("field", False, "const", default, None)
     return ContractDescriptor("field", False, "required", None, None)
+
+
+@const_eval
+def no_contract_alias() -> str | ContractAlias | None:
+    return None
 
 
 @const_eval

--- a/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr
@@ -1,13 +1,6 @@
 from sifr.meta import CallableIdentity, ConstSpecializationOutcome, DeclarationInput, DeclarationPlan, PlannedField, PlannedIssue, PlannedMetadata, ShapeInput, StaticValue
 from fixture.api import ContractApi
-
-
-class ContractDescriptor:
-    kind: str
-    enabled: bool
-    default_kind: str
-    default_value: StaticValue | None
-    default_factory: CallableIdentity | None
+from fixture.contract_types import ContractAlias, ContractDescriptor
 
 
 @class_adapter_provider("fixture.contract", "ContractDescriptor")
@@ -18,6 +11,8 @@ def adapt_contract(
     fields: list[PlannedField] = []
     metadata: list[PlannedMetadata[ContractDescriptor]] = []
     issues: list[PlannedIssue[ContractDescriptor]] = []
+    validation_alias: str | ContractAlias | None = None
+    threshold: int | float | None = None
     for item in declaration.declaration.items:
         if item.kind == "field":
             declared_type: str | None = item.declared_type
@@ -31,6 +26,18 @@ def adapt_contract(
                         default_kind = descriptor.value.default_kind
                         default_value = descriptor.value.default_value
                         default_factory = descriptor.value.default_factory
+                        validation_alias = descriptor.value.validation_alias
+                        if validation_alias is None:
+                            validation_alias = descriptor.value.alias
+                        threshold = descriptor.value.threshold
+                        metadata.append(
+                            PlannedMetadata(
+                                "field",
+                                item.identity,
+                                "fixture.field",
+                                descriptor.value,
+                            )
+                        )
                 fields.append(PlannedField(identity, declared_type, default_kind, default_value, default_factory, None))
     for descriptor in declaration.descriptors:
         if descriptor.target_kind == "class":

--- a/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract_types.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract_types.sifr
@@ -1,3 +1,16 @@
+from sifr.meta import CallableIdentity, StaticValue
+
+
+class ContractAlias:
+    path: list[str]
+
+
 class ContractDescriptor:
     kind: str
     enabled: bool
+    default_kind: str
+    default_value: StaticValue | None
+    default_factory: CallableIdentity | None
+    alias: str | None = None
+    validation_alias: str | ContractAlias | None = None
+    threshold: int | float | None = None

--- a/verification/areas/core_language/fixtures/static_class_adapter/sifr.toml
+++ b/verification/areas/core_language/fixtures/static_class_adapter/sifr.toml
@@ -8,4 +8,4 @@ sifr-version = ">=0.3,<0.4"
 roots = ["."]
 
 [exports]
-modules = ["fixture.contract"]
+modules = ["fixture.contract", "fixture.contract_types"]


### PR DESCRIPTION
## Summary
- lower `None`, optional subsets, and wider closed unions with their actual Rust representations
- relocate compiler-owned stdlib nominal records and structural implementations once per project
- preserve reusable clone-capable record fields and extend the package-neutral static adapter fixture
- record M7c as the bounded compiler prerequisite for the paused M8 package work

Closes #3271.

## Validation
- `cargo test -p sifr_codegen` (1,028 passed)
- `cargo test -p sifr_driver adapter_defaults -- --nocapture` (10 passed)
- `cargo test -p sifr_driver early_adapters -- --nocapture` (19 passed)
- package-neutral static-class-adapter fixture: fresh debug build/run, `attached-contract`
- paused M8 fields/configuration demo: fresh debug build/run
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `git diff --check`; touched source files remain below 900 lines

Exact candidate: `6613690e954512476e95c7dfc0d3ddad3eea5c6a`
