### PR TITLE
fix(codegen): sequence optional union call coercions

### DIFF
--- a/crates/sifr_codegen/src/helpers/helpers_impl.rs
+++ b/crates/sifr_codegen/src/helpers/helpers_impl.rs
@@ -284,13 +284,6 @@ pub(crate) fn widen_option_value_for_union_target(
         return None;
     }
     let source_payload = source.optional_member_type()?;
-    if matches!(
-        crate::resolve_alias_type_for_plain_call(&source_payload),
-        Type::Union(_)
-    ) {
-        return None;
-    }
-    let payload_member = find_union_member(target_members, &source_payload)?;
     if !target_members
         .iter()
         .any(|member| matches!(member.resolve_alias(), Type::None))
@@ -298,12 +291,41 @@ pub(crate) fn widen_option_value_for_union_target(
         return None;
     }
     let target_name = target.union_enum_name();
-    let present = RustExpr::FnCall {
-        func: Box::new(RustExpr::Path(vec![
-            target_name.clone(),
-            payload_member.union_variant_name(),
-        ])),
-        args: vec![RustExpr::Ident("__sifr_union_value".to_string())],
+    let payload_value = RustExpr::Ident("__sifr_union_value".to_string());
+    let present = if let Type::Union(source_members) =
+        crate::resolve_alias_type_for_plain_call(&source_payload)
+    {
+        let mut arms = Vec::with_capacity(source_members.len());
+        for source_member in source_members {
+            let wrapped = wrap_union_member_expr(
+                target,
+                source_member,
+                RustExpr::Ident("__sifr_union_member".to_string()),
+            )?;
+            arms.push(crate::RustMatchArm {
+                pattern: format!(
+                    "{}::{}(__sifr_union_member)",
+                    source_payload.union_enum_name(),
+                    source_member.union_variant_name()
+                ),
+                bindings: Vec::new(),
+                guard: None,
+                body: vec![crate::RustStmt::TailExpr(wrapped)],
+            });
+        }
+        RustExpr::Match {
+            expr: Box::new(payload_value),
+            arms,
+        }
+    } else {
+        let payload_member = find_union_member(target_members, &source_payload)?;
+        RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec![
+                target_name.clone(),
+                payload_member.union_variant_name(),
+            ])),
+            args: vec![payload_value],
+        }
     };
     let mapped = RustExpr::MethodCall {
         receiver: Box::new(value),

--- a/crates/sifr_codegen/src/helpers/tests.rs
+++ b/crates/sifr_codegen/src/helpers/tests.rs
@@ -705,3 +705,20 @@ fn optional_member_widens_into_larger_union_without_source_enum() {
     assert!(rendered.contains(&target.union_enum_name()), "{rendered}");
     assert!(!rendered.contains(&source.union_enum_name()), "{rendered}");
 }
+
+#[test]
+fn option_represented_union_payload_widens_through_its_inner_enum() {
+    let payload = sifr_type_system::make_union(vec![Type::Int, Type::Str]);
+    let source = sifr_type_system::safe_optional_result(payload.clone());
+    let target = sifr_type_system::make_union(vec![Type::Bool, Type::Int, Type::Str, Type::None]);
+    let widened =
+        widen_option_value_for_union_target(&target, &source, RustExpr::Ident("value".to_string()))
+            .expect("option-represented union should widen into the target union");
+    let rendered = crate::render_expr(&widened);
+
+    assert!(rendered.contains(".map("), "{rendered}");
+    assert!(rendered.contains(".unwrap_or("), "{rendered}");
+    assert!(rendered.contains(&payload.union_enum_name()), "{rendered}");
+    assert!(rendered.contains(&target.union_enum_name()), "{rendered}");
+    assert!(!rendered.contains(&source.union_enum_name()), "{rendered}");
+}

--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -14,3 +14,4 @@ mod narrowing_helpers;
 mod plain_call_args;
 mod recursive_exprs;
 mod recursive_method_calls;
+mod registry_method_arg_conventions;

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
@@ -110,9 +110,17 @@ impl RustEmitter {
                     &effective_arg_ty,
                     coercion_probe.clone(),
                 ) != coercion_probe;
+            let unadapted_option_arg = lowered_arg.clone();
+            let mut consuming_value_adapted = false;
             if convention.is_owned() {
-                lowered_arg =
-                    self.consuming_value_upcast_for_ir(param_ty, &effective_arg_ty, lowered_arg);
+                (lowered_arg, consuming_value_adapted) = self.adapt_consuming_call_argument_for_ir(
+                    arg,
+                    param_ty,
+                    &effective_arg_ty,
+                    *convention,
+                    lowered_arg,
+                    borrowed_name_arg,
+                );
             } else if needs_borrowed_structural_coercion {
                 if !crate::helpers::is_copy_type_for_codegen(&effective_arg_ty) {
                     lowered_arg = crate::RustExpr::MethodCall {
@@ -123,6 +131,7 @@ impl RustEmitter {
                 }
                 lowered_arg =
                     self.consuming_value_upcast_for_ir(param_ty, &effective_arg_ty, lowered_arg);
+                consuming_value_adapted = true;
             } else if let Type::Union(_) = resolved_param {
                 if !crate::helpers::is_option_type(resolved_param)
                     && !matches!(
@@ -145,14 +154,15 @@ impl RustEmitter {
                 }
             }
 
-            let unadapted_option_arg = lowered_arg.clone();
-            lowered_arg = Self::flatten_option_argument_for_ir(
-                arg,
-                param_ty,
-                &effective_arg_ty,
-                *convention,
-                lowered_arg,
-            );
+            if !consuming_value_adapted {
+                lowered_arg = Self::flatten_option_argument_for_ir(
+                    arg,
+                    param_ty,
+                    &effective_arg_ty,
+                    *convention,
+                    lowered_arg,
+                );
+            }
             let option_value_adapted = lowered_arg != unadapted_option_arg;
 
             let mut recursive_option_adapted = false;
@@ -262,7 +272,11 @@ impl RustEmitter {
                 }
             }
 
-            if convention.is_owned() && borrowed_name_arg && !recursive_option_adapted {
+            if convention.is_owned()
+                && borrowed_name_arg
+                && !recursive_option_adapted
+                && !consuming_value_adapted
+            {
                 lowered_arg = crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),
                     method: "clone".to_string(),
@@ -471,85 +485,6 @@ impl RustEmitter {
                             .collect::<Vec<_>>()
                     })
             })
-    }
-
-    pub(crate) fn apply_registry_method_arg_convention(
-        &self,
-        arg: &HirExpr,
-        param_ty: &Type,
-        convention: ParamConvention,
-        mut lowered_arg: crate::RustExpr,
-    ) -> crate::RustExpr {
-        let resolved_param = crate::resolve_alias_type_for_plain_call(param_ty);
-        if let Type::AsyncCallable(params, _, _) = resolved_param {
-            lowered_arg = Self::send_async_callable_adapter(lowered_arg, params.len());
-        }
-        let effective_arg_ty = self.effective_registry_expr_ty(arg);
-        let arg_is_option = crate::helpers::is_option_type(&effective_arg_ty);
-        let unadapted_option_arg = lowered_arg.clone();
-        lowered_arg = Self::flatten_option_argument_for_ir(
-            arg,
-            param_ty,
-            &effective_arg_ty,
-            convention,
-            lowered_arg,
-        );
-        let option_value_adapted = lowered_arg != unadapted_option_arg;
-        if crate::helpers::is_option_type(param_ty)
-            && !arg_is_option
-            && !matches!(arg, HirExpr::NoneLiteral)
-        {
-            if !crate::helpers::is_copy_type_for_codegen(&effective_arg_ty) {
-                lowered_arg = crate::RustExpr::MethodCall {
-                    receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),
-                    method: "clone".to_string(),
-                    args: vec![],
-                };
-            }
-            lowered_arg = crate::RustExpr::FnCall {
-                func: Box::new(crate::RustExpr::Path(vec!["Some".to_string()])),
-                args: vec![lowered_arg],
-            };
-        } else if arg_is_option
-            && !crate::helpers::is_option_type(param_ty)
-            && !option_value_adapted
-        {
-            if !crate::helpers::is_copy_type_for_codegen(&effective_arg_ty) {
-                lowered_arg = crate::RustExpr::MethodCall {
-                    receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),
-                    method: "clone".to_string(),
-                    args: vec![],
-                };
-            }
-            lowered_arg = Self::force_unwrap_option_expr_for_ir(
-                lowered_arg,
-                "compiler-verified option argument should be Some",
-            );
-        }
-
-        let requires_shared_borrow = convention.is_shared_borrow()
-            && (param_ty.ownership() != sifr_type_system::OwnershipKind::Copy
-                || matches!(resolved_param, Type::TypeVar(_)));
-        let requires_mut_borrow = convention.is_mut_borrow()
-            && (param_ty.ownership() != sifr_type_system::OwnershipKind::Copy
-                || matches!(resolved_param, Type::TypeVar(_)));
-
-        if requires_shared_borrow
-            && !self.arg_is_already_borrowed_for_registry_call(arg, &lowered_arg)
-        {
-            lowered_arg = crate::RustExpr::Ref {
-                mutable: false,
-                expr: Box::new(lowered_arg),
-            };
-        } else if requires_mut_borrow
-            && !self.arg_is_already_mut_borrowed_for_registry_call(arg, &lowered_arg)
-        {
-            lowered_arg = crate::RustExpr::Ref {
-                mutable: true,
-                expr: Box::new(lowered_arg),
-            };
-        }
-        lowered_arg
     }
 
     pub(crate) fn try_lower_registry_compare_expr(

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/registry_method_arg_conventions.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/registry_method_arg_conventions.rs
@@ -1,0 +1,97 @@
+use super::{HirExpr, ParamConvention, RustEmitter, Type};
+
+impl RustEmitter {
+    pub(crate) fn apply_registry_method_arg_convention(
+        &self,
+        arg: &HirExpr,
+        param_ty: &Type,
+        convention: ParamConvention,
+        mut lowered_arg: crate::RustExpr,
+    ) -> crate::RustExpr {
+        let resolved_param = crate::resolve_alias_type_for_plain_call(param_ty);
+        if let Type::AsyncCallable(params, _, _) = resolved_param {
+            lowered_arg = Self::send_async_callable_adapter(lowered_arg, params.len());
+        }
+        let effective_arg_ty = self.effective_registry_expr_ty(arg);
+        let arg_is_option = crate::helpers::is_option_type(&effective_arg_ty);
+        let borrowed_name_arg = matches!(arg, HirExpr::Name { name, ty, .. }
+            if self.borrowed_params.contains(name)
+                || self.mut_borrowed_params.contains(name)
+                || ty.rust_type().starts_with('&'));
+        let unadapted_option_arg = lowered_arg.clone();
+        if convention.is_owned() {
+            (lowered_arg, _) = self.adapt_consuming_call_argument_for_ir(
+                arg,
+                param_ty,
+                &effective_arg_ty,
+                convention,
+                lowered_arg,
+                borrowed_name_arg,
+            );
+        } else {
+            lowered_arg = Self::flatten_option_argument_for_ir(
+                arg,
+                param_ty,
+                &effective_arg_ty,
+                convention,
+                lowered_arg,
+            );
+        }
+        let option_value_adapted = lowered_arg != unadapted_option_arg;
+        if crate::helpers::is_option_type(param_ty)
+            && !arg_is_option
+            && !matches!(arg, HirExpr::NoneLiteral)
+        {
+            if !crate::helpers::is_copy_type_for_codegen(&effective_arg_ty) {
+                lowered_arg = crate::RustExpr::MethodCall {
+                    receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),
+                    method: "clone".to_string(),
+                    args: vec![],
+                };
+            }
+            lowered_arg = crate::RustExpr::FnCall {
+                func: Box::new(crate::RustExpr::Path(vec!["Some".to_string()])),
+                args: vec![lowered_arg],
+            };
+        } else if arg_is_option
+            && !crate::helpers::is_option_type(param_ty)
+            && !option_value_adapted
+        {
+            if !crate::helpers::is_copy_type_for_codegen(&effective_arg_ty) {
+                lowered_arg = crate::RustExpr::MethodCall {
+                    receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),
+                    method: "clone".to_string(),
+                    args: vec![],
+                };
+            }
+            lowered_arg = Self::force_unwrap_option_expr_for_ir(
+                lowered_arg,
+                "compiler-verified option argument should be Some",
+            );
+        }
+
+        let requires_shared_borrow = convention.is_shared_borrow()
+            && (param_ty.ownership() != sifr_type_system::OwnershipKind::Copy
+                || matches!(resolved_param, Type::TypeVar(_)));
+        let requires_mut_borrow = convention.is_mut_borrow()
+            && (param_ty.ownership() != sifr_type_system::OwnershipKind::Copy
+                || matches!(resolved_param, Type::TypeVar(_)));
+
+        if requires_shared_borrow
+            && !self.arg_is_already_borrowed_for_registry_call(arg, &lowered_arg)
+        {
+            lowered_arg = crate::RustExpr::Ref {
+                mutable: false,
+                expr: Box::new(lowered_arg),
+            };
+        } else if requires_mut_borrow
+            && !self.arg_is_already_mut_borrowed_for_registry_call(arg, &lowered_arg)
+        {
+            lowered_arg = crate::RustExpr::Ref {
+                mutable: true,
+                expr: Box::new(lowered_arg),
+            };
+        }
+        lowered_arg
+    }
+}

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -90,3 +90,5 @@ mod structured_intrinsic_codegen_tests;
 mod structured_lowering_codegen_tests;
 #[cfg(test)]
 mod structured_path_codegen_tests;
+#[cfg(test)]
+mod union_representation_codegen_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/union_representation_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/union_representation_codegen_tests.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+#[test]
+fn owned_optional_argument_widening_is_not_force_unwrapped_after_conversion() {
+    let target = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
+    let rust_code = generate_rust_from_source(
+        r#"def consume(own value: int | str | None) -> bool:
+    return value is None
+
+def forward(value: str | None) -> bool:
+    return consume(value)
+"#,
+    );
+
+    assert!(rust_code.contains(&target.union_enum_name()), "{rust_code}");
+    assert!(rust_code.contains(".map("), "{rust_code}");
+    assert!(rust_code.contains(".unwrap_or("), "{rust_code}");
+    assert!(
+        !rust_code.contains("compiler-verified option argument should be Some"),
+        "{rust_code}"
+    );
+}
+
+#[test]
+fn option_represented_union_argument_matches_the_payload_enum() {
+    let payload = sifr_type_system::make_union(vec![Type::Int, Type::Str]);
+    let runtime_source = sifr_type_system::safe_optional_result(payload.clone());
+    let target = sifr_type_system::make_union(vec![Type::Bool, Type::Int, Type::Str, Type::None]);
+    let rust_code = generate_rust_from_source(
+        r#"def consume(own value: bool | int | str | None) -> bool:
+    return value is None
+
+def forward(values: dict[str, int | str]) -> bool:
+    return consume(values.get("value"))
+"#,
+    );
+
+    assert!(rust_code.contains(&target.union_enum_name()), "{rust_code}");
+    assert!(
+        rust_code.contains(&format!("{}::", payload.union_enum_name())),
+        "{rust_code}"
+    );
+    assert!(
+        !rust_code.contains(&format!("{}::", runtime_source.union_enum_name())),
+        "{rust_code}"
+    );
+}
+
+#[test]
+fn owned_method_optional_argument_uses_the_same_widening_sequence() {
+    let rust_code = generate_rust_from_source(
+        r#"class Consumer:
+    def accept(self, own value: int | str | None) -> bool:
+        return value is None
+
+def forward(consumer: Consumer, value: str | None) -> bool:
+    return consumer.accept(value)
+"#,
+    );
+
+    assert!(rust_code.contains(".map("), "{rust_code}");
+    assert!(rust_code.contains(".unwrap_or("), "{rust_code}");
+    assert!(
+        !rust_code.contains("compiler-verified option argument should be Some"),
+        "{rust_code}"
+    );
+}
+
+#[test]
+fn option_represented_exact_union_argument_flattens_only_once() {
+    let rust_code = generate_rust_from_source(
+        r#"def consume(own value: int | str | None) -> bool:
+    return value is None
+
+def forward(values: dict[str, int | str | None]) -> bool:
+    return consume(values.get("value"))
+"#,
+    );
+
+    assert!(rust_code.contains(".unwrap_or("), "{rust_code}");
+    assert!(
+        !rust_code.contains("__sifr_union_value| match __sifr_union_value"),
+        "{rust_code}"
+    );
+}

--- a/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
@@ -67,35 +67,43 @@ impl RustEmitter {
                     || ty.rust_type().starts_with('&'));
 
             let unadapted_option_arg = lowered_arg.clone();
-            lowered_arg = Self::flatten_option_argument_for_ir(
-                hir_arg,
-                param_ty,
-                &effective_arg_ty,
-                *convention,
-                lowered_arg,
-            );
-            let option_value_adapted = lowered_arg != unadapted_option_arg;
-
             if matches!(hir_arg, HirExpr::NoneLiteral)
                 && matches!(resolved_param, Type::None | Type::TypeVar(_))
             {
                 lowered_arg = crate::RustExpr::Literal(crate::RustLiteral::Unit);
             }
 
+            let mut consuming_value_adapted = false;
             if convention.is_owned() {
-                lowered_arg =
-                    self.consuming_value_upcast_for_ir(param_ty, &effective_arg_ty, lowered_arg);
-            } else if let Some(wrapped) = crate::helpers::wrap_union_member_expr(
-                param_ty,
-                if matches!(hir_arg, HirExpr::NoneLiteral) {
-                    &Type::None
-                } else {
-                    &effective_arg_ty
-                },
-                lowered_arg.clone(),
-            ) {
-                lowered_arg = wrapped;
+                (lowered_arg, consuming_value_adapted) = self.adapt_consuming_call_argument_for_ir(
+                    hir_arg,
+                    param_ty,
+                    &effective_arg_ty,
+                    *convention,
+                    lowered_arg,
+                    borrowed_name_arg,
+                );
+            } else {
+                lowered_arg = Self::flatten_option_argument_for_ir(
+                    hir_arg,
+                    param_ty,
+                    &effective_arg_ty,
+                    *convention,
+                    lowered_arg,
+                );
+                if let Some(wrapped) = crate::helpers::wrap_union_member_expr(
+                    param_ty,
+                    if matches!(hir_arg, HirExpr::NoneLiteral) {
+                        &Type::None
+                    } else {
+                        &effective_arg_ty
+                    },
+                    lowered_arg.clone(),
+                ) {
+                    lowered_arg = wrapped;
+                }
             }
+            let option_value_adapted = lowered_arg != unadapted_option_arg;
 
             let mut recursive_option_adapted = false;
             if crate::helpers::is_option_type(resolved_param) {
@@ -169,7 +177,11 @@ impl RustEmitter {
                 };
             }
 
-            if convention.is_owned() && borrowed_name_arg && !recursive_option_adapted {
+            if convention.is_owned()
+                && borrowed_name_arg
+                && !recursive_option_adapted
+                && !consuming_value_adapted
+            {
                 lowered_arg = crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),
                     method: "clone".to_string(),

--- a/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
@@ -1,6 +1,45 @@
-use super::{RustEmitter, Type};
+use super::{HirExpr, RustEmitter, Type};
+use crate::ParamConvention;
 
 impl RustEmitter {
+    pub(crate) fn adapt_consuming_call_argument_for_ir(
+        &self,
+        arg: &HirExpr,
+        target_ty: &Type,
+        source_ty: &Type,
+        convention: ParamConvention,
+        lowered: crate::RustExpr,
+        borrowed_source: bool,
+    ) -> (crate::RustExpr, bool) {
+        let flattened = Self::flatten_option_argument_for_ir(
+            arg,
+            target_ty,
+            source_ty,
+            convention,
+            lowered.clone(),
+        );
+        if flattened != lowered {
+            return (flattened, true);
+        }
+        let probe = crate::RustExpr::Ident("__sifr_consuming_upcast_probe".to_string());
+        if self.consuming_value_upcast_for_ir(target_ty, source_ty, probe.clone()) == probe {
+            return (lowered, false);
+        }
+        let lowered = if borrowed_source && !crate::helpers::is_copy_type_for_codegen(source_ty) {
+            crate::RustExpr::MethodCall {
+                receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered))),
+                method: "clone".to_string(),
+                args: Vec::new(),
+            }
+        } else {
+            lowered
+        };
+        (
+            self.consuming_value_upcast_for_ir(target_ty, source_ty, lowered),
+            true,
+        )
+    }
+
     pub(crate) fn consuming_value_upcast_for_ir(
         &self,
         target_ty: &Type,

--- a/plans/issues/active/ad-hoc-static-class-adapters-and-pydantic-ergonomics.md
+++ b/plans/issues/active/ad-hoc-static-class-adapters-and-pydantic-ergonomics.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Status: active on 2026-08-18. M0-M7c are complete; M7d is next.
+Status: active on 2026-08-18. M0-M7c are complete; M7d is active.
 
 This phase starts after the completed Native Pydantic-Sifr engine phase. It
 does not reopen the validated schema engine, structural bridge, or native core.
@@ -1080,9 +1080,9 @@ Acceptance criteria:
 Exit gate: optional values use one correct representation transition when they
 enter wider-union call, assignment, and consuming-value paths.
 
-State: pending
+State: active
 Issue: [`sifr-lang/sifr#3274`](https://github.com/sifr-lang/sifr/issues/3274)
-Next action: implement M7d, then resume M8 without changing its preserved work.
+Next action: complete M7d, then resume M8 without changing its preserved work.
 
 ### M8: Pydantic Model, Field, and Configuration Declarations
 
@@ -1358,7 +1358,7 @@ Next action:
 
 ## Current Handoff
 
-Current state: M0-M7c are merged and recorded; M7d is next.
+Current state: M0-M7c are merged and recorded; M7d is active.
 
 Next action: complete M7d in `sifr-lang/sifr`, then resume the preserved M8 work
 in `sifr-lang/pydantic-sifr` on the merged compiler substrate.

--- a/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/fixture/contract.sifr
@@ -97,6 +97,29 @@ def no_contract_alias() -> str | ContractAlias | None:
     return None
 
 
+def consume_contract_union(
+    own value: bool | str | ContractAlias | None,
+) -> bool:
+    return value is None
+
+
+def widen_contract_optional(value: str | None) -> bool:
+    return consume_contract_union(value)
+
+
+def widen_contract_optional_union(
+    values: dict[str, str | ContractAlias],
+) -> bool:
+    widened: bool | str | ContractAlias | None = values.get("contract")
+    return consume_contract_union(widened)
+
+
+def flatten_contract_optional_union(
+    values: dict[str, bool | str | ContractAlias | None],
+) -> bool:
+    return consume_contract_union(values.get("contract"))
+
+
 @const_eval
 def specialize(
     shape: ShapeInput[ContractDescriptor],


### PR DESCRIPTION
## Summary
- make consuming call adaptation choose exactly one option-flattening or union-widening transition
- map option-represented union payload enums into wider target unions
- cover owned free-function and method calls, exact and wider union payloads, assignment, and package fixtures
- split registry method argument conventions into a focused module for the 900-line guardrail

Closes #3274.

## Validation
- `cargo test -p sifr_codegen` (1,035 passed)
- `cargo test -p sifr_driver adapter_defaults -- --nocapture` (10 passed)
- `cargo test -p sifr_driver early_adapters -- --nocapture` (19 passed)
- fresh debug compiler builds the package-neutral static adapter fixture
- preserved downstream M8 fields/configuration demo runs successfully
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `python3 scripts/check_file_size_guardrails.py`
- `git diff --check`

Exact candidate: `f15e3c34177e409af1719080ec284329fffc48f8`
