### PR TITLE
Remove flat installation layout compatibility

### DIFF
--- a/crates/sifr/src/self_update_receipt.rs
+++ b/crates/sifr/src/self_update_receipt.rs
@@ -105,10 +105,6 @@ fn discover_receipt_path(env: &ReceiptDiscoveryEnv) -> Result<PathBuf, Box<Rende
                 }
             }
         }
-        let receipt_path = bin_dir.join("install.json");
-        if receipt_path.is_file() {
-            return Ok(receipt_path);
-        }
     }
 
     if let Some(home_dir) = &env.home_dir {
@@ -172,9 +168,7 @@ fn validate_receipt_eligibility(
     }
     let sysroot_path = canonicalize_for_receipt(Path::new(&receipt.sysroot_path), "sysroot_path")?;
     let expected_binary_parent = sysroot_path.join("bin");
-    if !paths_same_after_canonicalization(&expected_binary_parent, binary_parent)
-        && !paths_same_after_canonicalization(&sysroot_path, binary_parent)
-    {
+    if !paths_same_after_canonicalization(&expected_binary_parent, binary_parent) {
         return Err(unmanaged_receipt_diagnostic(format!(
             "standalone install receipt binary_path {} is not paired with sysroot_path {}",
             receipt.binary_path, receipt.sysroot_path
@@ -608,8 +602,8 @@ mod tests {
     }
 
     #[test]
-    fn discovers_manifest_dir_before_adjacent_manifest() {
-        let tmp = TestDir::new("discovery-order");
+    fn discovers_explicit_manifest_dir() {
+        let tmp = TestDir::new("explicit-manifest");
         let binary = tmp.path().join("bin/sifr");
         touch(&binary);
         write_receipt(
@@ -618,13 +612,6 @@ mod tests {
             "beta",
             &binary,
         );
-        write_receipt(
-            &tmp.path().join("bin/install.json"),
-            "0.1.0-alpha.1",
-            "alpha",
-            &binary,
-        );
-
         let discovered = discover_install_receipt(&ReceiptDiscoveryEnv {
             current_executable: binary,
             manifest_dir: Some(tmp.path().join("manifest")),
@@ -708,13 +695,13 @@ mod tests {
     }
 
     #[test]
-    fn accepts_flat_custom_install_layout() {
-        let tmp = TestDir::new("flat-custom");
+    fn rejects_binary_at_sysroot_root() {
+        let tmp = TestDir::new("binary-at-sysroot-root");
         let install_dir = tmp.path().join("toolchain");
         let binary = install_dir.join("sifr");
         let receipt_path = install_dir.join("install.json");
         touch(&binary);
-        fs::write(install_dir.join("sysroot.toml"), "").expect("write flat sysroot manifest");
+        fs::write(install_dir.join("sysroot.toml"), "").expect("write sysroot manifest");
         fs::write(
             &receipt_path,
             serde_json::json!({
@@ -735,19 +722,20 @@ mod tests {
             })
             .to_string(),
         )
-        .expect("write flat receipt");
+        .expect("write receipt");
 
-        let discovered = discover_install_receipt(&ReceiptDiscoveryEnv {
+        let error = discover_install_receipt(&ReceiptDiscoveryEnv {
             current_executable: binary,
             manifest_dir: Some(install_dir),
             home_dir: None,
         })
-        .expect("flat install receipt discovers");
+        .expect_err("binary at the sysroot root is unmanaged");
 
         assert_eq!(
-            discovered.receipt.sysroot_path,
-            discovered.receipt.install_dir
+            error.code,
+            DiagnosticCode::SELF_UPDATE_UNMANAGED_RECEIPT.code()
         );
+        assert!(error.message.contains("not paired with sysroot_path"));
     }
 
     #[test]

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -76,9 +76,8 @@ Withdrawn or unknown versions fail before installer execution.
 
 Set `SIFR_INSTALL_DIR` to place the managed binary directory somewhere other
 than `~/.sifr/bin`. The installer writes the binary to
-`SIFR_INSTALL_DIR/sifr` and, when the directory ends in `/bin`, installs the
-sysroot next to that `bin` directory. For legacy flat custom directories that
-do not end in `/bin`, the same directory is used as the sysroot root.
+`SIFR_INSTALL_DIR/sifr`. The directory must end in `/bin`. Its parent is the
+toolchain root.
 
 ```bash
 curl -fsSL https://sifr.sh/install | SIFR_INSTALL_DIR="$HOME/.local/sifr/bin" sh

--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -346,10 +346,9 @@ The generated installer embeds:
 
 The generated installer honors `SIFR_ARTIFACT_BASE_URL`, `SIFR_TARGET`,
 `SIFR_INSTALL_DIR`, `SIFR_SYSROOT_INSTALL_DIR`, and `SIFR_NO_MODIFY_PATH` for
-local validation. `SIFR_INSTALL_DIR` remains the binary directory; when it ends
-in `/bin`, the default sysroot root is its parent. Otherwise the binary
-directory itself is the flat sysroot root for compatibility with older custom
-install examples.
+local validation. `SIFR_INSTALL_DIR` is the toolchain `bin` directory and must
+end in `/bin`. `SIFR_SYSROOT_INSTALL_DIR` is its parent. The installer rejects
+any other relationship.
 
 ## Self-Update Receipt Rules
 
@@ -382,9 +381,8 @@ The authoritative field enumeration lives at `verification/areas/distribution_re
 `modify_path` records the actual installer request, including
 `SIFR_NO_MODIFY_PATH=1` and `--no-modify-path`. `binary_path` and
 `sysroot_path` record canonical installed paths when the platform can resolve
-them. `sifr self update` validates that `binary_path` is paired with either
-`sysroot_path/bin/sifr` for toolchain-root installs or `sysroot_path/sifr` for
-legacy flat custom installs, and delegates to the immutable installer with both
+them. `sifr self update` requires `binary_path` to equal
+`sysroot_path/bin/sifr`. It delegates to the immutable installer with both
 paths under the same install lock.
 
 ## Self-Update TLS And Delegation Policy

--- a/scripts/distribution/generate_version_installer.sh
+++ b/scripts/distribution/generate_version_installer.sh
@@ -154,10 +154,9 @@ Options:
 Environment:
   SIFR_INSTALL_DIR        Install directory (default: \$HOME/.sifr/bin)
   SIFR_SYSROOT_INSTALL_DIR
-                          Sysroot/toolchain root (default: parent of SIFR_INSTALL_DIR when it ends in /bin)
+                          Sysroot/toolchain root (default: parent of SIFR_INSTALL_DIR)
   SIFR_INSTALL_MANIFEST_DIR
-                          Install manifest directory (default: \$HOME/.sifr for the default install dir,
-                          otherwise SIFR_INSTALL_DIR)
+                          Install manifest directory (default: the sysroot/toolchain root)
   SIFR_NO_MODIFY_PATH=1   Do not update shell profiles
   SIFR_INSTALL_LOCK_HELD=1
                           Internal self-update handoff; caller already holds the install lock
@@ -570,25 +569,20 @@ if [ -z "\${install_dir}" ]; then
   [ -n "\${HOME:-}" ] || fail "HOME or SIFR_INSTALL_DIR is required"
   install_dir="\${HOME}/.sifr/bin"
 fi
+if [ "\$(basename "\${install_dir}")" != "bin" ]; then
+  fail "SIFR_INSTALL_DIR must name the toolchain bin directory"
+fi
 
-manifest_dir="\${SIFR_INSTALL_MANIFEST_DIR:-}"
-default_sysroot_dir=""
-if [ "\$(basename "\${install_dir}")" = "bin" ]; then
-  default_sysroot_dir="\$(dirname "\${install_dir}")"
-else
-  default_sysroot_dir="\${install_dir}"
-fi
-if [ -z "\${manifest_dir}" ]; then
-  if [ -n "\${HOME:-}" ] && [ "\${install_dir}" = "\${HOME}/.sifr/bin" ]; then
-    manifest_dir="\${HOME}/.sifr"
-  elif [ "\$(basename "\${install_dir}")" = "bin" ]; then
-    manifest_dir="\$(dirname "\${install_dir}")"
-  else
-    manifest_dir="\${install_dir}"
-  fi
-fi
-manifest_path="\${manifest_dir}/install.json"
+default_sysroot_dir="\$(dirname "\${install_dir}")"
 sysroot_dir="\${SIFR_SYSROOT_INSTALL_DIR:-\${default_sysroot_dir}}"
+mkdir -p "\${install_dir}" "\${sysroot_dir}"
+canonical_install_dir="\$(cd "\${install_dir}" && pwd -P)"
+canonical_sysroot_dir="\$(cd "\${sysroot_dir}" && pwd -P)"
+if [ "\${canonical_install_dir}" != "\${canonical_sysroot_dir}/bin" ]; then
+  fail "SIFR_INSTALL_DIR must equal SIFR_SYSROOT_INSTALL_DIR/bin"
+fi
+manifest_dir="\${SIFR_INSTALL_MANIFEST_DIR:-\${sysroot_dir}}"
+manifest_path="\${manifest_dir}/install.json"
 installed_binary="\${install_dir}/sifr"
 install_lock_path=""
 manifest_tmp=""

--- a/verification/areas/distribution_release/cases/artifact_self_update_receipt_rules.sh
+++ b/verification/areas/distribution_release/cases/artifact_self_update_receipt_rules.sh
@@ -102,31 +102,29 @@ if [[ -e "${install_dir}/.sifr-update.lock" ]]; then
   exit 1
 fi
 
-flat_install_dir="${tmp_dir}/flat-managed"
-SIFR_TARGET="${target}" \
-  SIFR_ARTIFACT_BASE_URL="file://${artifact_dir}" \
-  SIFR_INSTALL_DIR="${flat_install_dir}" \
-  SIFR_NO_MODIFY_PATH=1 \
-  sh "${installer}" --no-modify-path >/dev/null
+non_bin_install_dir="${tmp_dir}/non-bin-managed"
+require_failure_contains \
+  "SIFR_INSTALL_DIR must name the toolchain bin directory" \
+  env SIFR_TARGET="${target}" \
+    SIFR_ARTIFACT_BASE_URL="file://${artifact_dir}" \
+    SIFR_INSTALL_DIR="${non_bin_install_dir}" \
+    SIFR_NO_MODIFY_PATH=1 \
+    sh "${installer}" --no-modify-path
 
-python3 - "${flat_install_dir}/install.json" "${flat_install_dir}" <<'PY'
-import json
-import pathlib
-import sys
+if [[ -e "${non_bin_install_dir}/install.json" ]]; then
+  echo "installer wrote a receipt for a non-canonical binary directory" >&2
+  exit 1
+fi
 
-receipt = json.loads(pathlib.Path(sys.argv[1]).read_text())
-install_dir_text = sys.argv[2]
-install_dir = pathlib.Path(install_dir_text)
-install_dir_resolved = install_dir.resolve()
-if receipt["install_dir"] != install_dir_text:
-    raise SystemExit("flat install_dir drifted")
-if receipt["binary_path"] != str((install_dir / "sifr").resolve()):
-    raise SystemExit("flat binary_path drifted")
-if receipt["sysroot_path"] != str(install_dir_resolved):
-    raise SystemExit("flat sysroot_path must equal install_dir")
-if not (install_dir / "sysroot.toml").is_file():
-    raise SystemExit("flat install did not install sysroot.toml")
-PY
+mismatched_install_dir="${tmp_dir}/mismatched/bin"
+require_failure_contains \
+  "SIFR_INSTALL_DIR must equal SIFR_SYSROOT_INSTALL_DIR/bin" \
+  env SIFR_TARGET="${target}" \
+    SIFR_ARTIFACT_BASE_URL="file://${artifact_dir}" \
+    SIFR_INSTALL_DIR="${mismatched_install_dir}" \
+    SIFR_SYSROOT_INSTALL_DIR="${tmp_dir}/another-sysroot" \
+    SIFR_NO_MODIFY_PATH=1 \
+    sh "${installer}" --no-modify-path
 
 external_lock_install_dir="${tmp_dir}/external-lock/bin"
 mkdir -p "${external_lock_install_dir}"


### PR DESCRIPTION
## Summary

- require the canonical `<sysroot>/bin/sifr` installation layout
- remove flat receipt discovery and validation
- reject installer configurations that do not place the binary under the selected sysroot `bin` directory
- update distribution verification and installation documentation

## Impact

Legacy flat installations at `<sysroot>/sifr` are now unmanaged. Current installers, self-update, and uninstall use one canonical binary/sysroot relationship. No migration or receipt conversion path is added.

## Validation

- `cargo test -p sifr self_update_receipt`
- `cargo test -p sifr self_update`
- `verification/areas/distribution_release/cases/artifact_self_update_receipt_rules.sh`
- distribution-release representative suite: 56 variants passed
- sysroot boundary: canonical installed-stdlib boundary passed; inherited external static-adapter fixture dependency path failed
- `cargo test -p sifr -- --skip test_e2e_pass`: inherited diagnostic-code mismatch only
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- HIR maintainability guardrail
- first-party file-size guardrail
- docs structure and compatibility inventory checks
- create-PR gate (one shot): stopped at inherited verification-taxonomy conflict