### PR TITLE
Remove hidden compatibility name recognition

### DIFF
--- a/crates/sifr_lowering/src/lower/blocking_executor_calls.rs
+++ b/crates/sifr_lowering/src/lower/blocking_executor_calls.rs
@@ -126,12 +126,7 @@ pub(in crate::lower) fn lower_thread_pool_submit_call(
 }
 
 fn is_thread_pool_executor_type(ty: &Type) -> bool {
-    matches!(ty.resolve_alias(), Type::Class { name, .. } if public_type_name(name) == "ThreadPoolExecutor")
-}
-
-fn public_type_name(name: &str) -> &str {
-    name.strip_prefix("__compat_sifr_concurrent_")
-        .unwrap_or(name)
+    matches!(ty.resolve_alias(), Type::Class { name, .. } if name == "ThreadPoolExecutor")
 }
 
 fn first_call_keyword_range(call: &ExprCall) -> TextRange {

--- a/crates/sifr_lowering/src/lower/ipc_payload_calls.rs
+++ b/crates/sifr_lowering/src/lower/ipc_payload_calls.rs
@@ -95,10 +95,7 @@ fn non_ipc_serializable_reason_inner(ty: &Type, visiting: &mut HashSet<String>) 
             ..
         } => {
             if let Some(label) = ipc_local_resource_type_label(name) {
-                return Some(format!(
-                    "`{}` is a process-local {label}",
-                    task_scope_calls::public_type_name(name)
-                ));
+                return Some(format!("`{name}` is a process-local {label}"));
             }
             if let Some(reason) = task_scope_calls::non_send_reason(ty) {
                 return Some(reason);
@@ -168,7 +165,7 @@ fn class_has_non_send_marker(name: &str, parent_chain: Option<&str>) -> bool {
 }
 
 fn ipc_local_resource_type_label(name: &str) -> Option<&'static str> {
-    match task_scope_calls::public_type_name(name) {
+    match name {
         "Child" | "AsyncChild" | "ProcessHandle" => Some("process handle"),
         "PipeReader" | "PipeWriter" | "AsyncPipeReader" | "AsyncPipeWriter" => {
             Some("process pipe handle")

--- a/crates/sifr_lowering/src/lower/task_scope_calls.rs
+++ b/crates/sifr_lowering/src/lower/task_scope_calls.rs
@@ -245,7 +245,7 @@ pub(in crate::lower) fn validate_shared_constructor(
     call: &ExprCall,
     ctx: &mut LowerCtx,
 ) {
-    if public_type_name(func_name) != "Shared" {
+    if func_name != "Shared" {
         return;
     }
     let Some(arg) = args.first() else {
@@ -286,7 +286,7 @@ fn channel_send_arg_label(expr: &HirExpr) -> String {
 fn is_channel_sender_type(ty: &Type) -> bool {
     matches!(
         ty.resolve_alias(),
-        Type::Class { name, .. } if public_type_name(name) == "ChannelSender"
+        Type::Class { name, .. } if name == "ChannelSender"
     )
 }
 
@@ -324,7 +324,7 @@ fn non_share_safe_reason_inner(
             ..
         } => {
             if let Some(label) = process_handle_type_label_by_name(name) {
-                return Some(format!("`{}` is a {label}", public_type_name(name)));
+                return Some(format!("`{name}` is a {label}"));
             }
             if is_share_safe_sync_wrapper(name) {
                 return None;
@@ -345,8 +345,7 @@ fn non_share_safe_reason_inner(
             visiting.remove(&key);
             field_reason.or_else(|| {
                 Some(format!(
-                    "`{}` is a mutable class without an explicit synchronization wrapper",
-                    public_type_name(name)
+                    "`{name}` is a mutable class without an explicit synchronization wrapper"
                 ))
             })
         }
@@ -389,10 +388,10 @@ fn non_send_reason_inner(ty: &Type, visiting: &mut HashSet<(String, Vec<Type>)>)
             ..
         } => {
             if let Some(label) = process_handle_type_label_by_name(name) {
-                return Some(format!("`{}` is a {label}", public_type_name(name)));
+                return Some(format!("`{name}` is a {label}"));
             }
             if let Some(label) = sync_guard_type_label_by_name(name) {
-                return Some(format!("`{}` is a {label}", public_type_name(name)));
+                return Some(format!("`{name}` is a {label}"));
             }
             if class_has_non_send_marker(name, parent_class.as_deref()) {
                 return Some(format!("`{name}` inherits the `NonSend` marker"));
@@ -453,16 +452,13 @@ pub(in crate::lower) fn sync_guard_type_label(ty: &Type) -> Option<&'static str>
 }
 
 fn sync_guard_type_label_by_name(name: &str) -> Option<&'static str> {
-    matches!(
-        public_type_name(name),
-        "LockGuard" | "RwLockReadGuard" | "RwLockWriteGuard"
-    )
-    .then_some("lock guard")
-    .or_else(|| (public_type_name(name) == "SemaphorePermit").then_some("semaphore permit"))
+    matches!(name, "LockGuard" | "RwLockReadGuard" | "RwLockWriteGuard")
+        .then_some("lock guard")
+        .or_else(|| (name == "SemaphorePermit").then_some("semaphore permit"))
 }
 
 fn process_handle_type_label_by_name(name: &str) -> Option<&'static str> {
-    match public_type_name(name) {
+    match name {
         "Child" => Some("process child handle for sync subprocesses"),
         "AsyncChild" => Some("process child handle for async subprocesses"),
         "PipeReader" => Some("process pipe reader handle"),
@@ -476,13 +472,9 @@ fn process_handle_type_label_by_name(name: &str) -> Option<&'static str> {
 
 fn is_share_safe_sync_wrapper(name: &str) -> bool {
     matches!(
-        public_type_name(name),
+        name,
         "Shared" | "Lock" | "RwLock" | "Semaphore" | "Notify" | "ChannelSender" | "ChannelReceiver"
     )
-}
-
-pub(in crate::lower) fn public_type_name(name: &str) -> &str {
-    name.strip_prefix("__compat_sifr_sync_").unwrap_or(name)
 }
 
 pub(in crate::lower) fn task_group_spawn_owner(expr: &HirExpr) -> Option<String> {

--- a/verification/areas/developer_tooling/check_hidden_compatibility_prefixes.py
+++ b/verification/areas/developer_tooling/check_hidden_compatibility_prefixes.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Reject removed hidden compatibility names in production and fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCAN_ROOTS = (Path("crates"), Path("verification"))
+EXCLUDED_FILES = {
+    Path("verification/compatibility/pre_v1_compatibility_inventory.json"),
+    Path("verification/areas/developer_tooling/check_hidden_compatibility_prefixes.py"),
+}
+REMOVED_PREFIXES = (
+    "__compat_" + "sifr_sync_",
+    "__compat_" + "sifr_concurrent_",
+)
+
+
+def scan(root: Path) -> list[str]:
+    failures: list[str] = []
+    for scan_root in SCAN_ROOTS:
+        directory = root / scan_root
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.rglob("*")):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(root)
+            if relative in EXCLUDED_FILES or "target" in relative.parts:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                continue
+            for line_number, line in enumerate(text.splitlines(), start=1):
+                for prefix in REMOVED_PREFIXES:
+                    if prefix in line:
+                        failures.append(f"{relative}:{line_number}: removed hidden prefix {prefix}")
+    return failures
+
+
+def run_self_test() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        production = root / "crates/example/src/lib.rs"
+        fixture = root / "verification/areas/example/fixtures/main.sifr"
+        inventory = root / "verification/compatibility/pre_v1_compatibility_inventory.json"
+        archive = root / "plans/issues/archive/example.md"
+        for path in (production, fixture, inventory, archive):
+            path.parent.mkdir(parents=True, exist_ok=True)
+        production.write_text(f'const NAME: &str = "{REMOVED_PREFIXES[0]}Lock";\n', encoding="utf-8")
+        fixture.write_text(f"class {REMOVED_PREFIXES[1]}Pool:\n    pass\n", encoding="utf-8")
+        inventory.write_text("\n".join(REMOVED_PREFIXES), encoding="utf-8")
+        archive.write_text("\n".join(REMOVED_PREFIXES), encoding="utf-8")
+        failures = scan(root)
+    if len(failures) != 2:
+        raise SystemExit(f"hidden-prefix guard self-test expected 2 failures, got {failures}")
+    if not all(prefix in "\n".join(failures) for prefix in REMOVED_PREFIXES):
+        raise SystemExit("hidden-prefix guard self-test did not detect both removed prefixes")
+    print("hidden compatibility prefix guard self-test: PASS")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        run_self_test()
+        return 0
+
+    failures = scan(REPO_ROOT)
+    if failures:
+        for failure in failures:
+            print(f"hidden compatibility prefix guard: {failure}")
+        return 1
+    print("hidden compatibility prefix guard: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/developer_tooling/runner.py
+++ b/verification/areas/developer_tooling/runner.py
@@ -62,6 +62,14 @@ SUITE_COMMANDS: dict[str, list[tuple[str, list[str]]]] = {
         ),
         ("completion-quality", [sys.executable, str(AREA_ROOT / "check_completion_quality.py")]),
         ("completion-quality-self-test", [sys.executable, str(AREA_ROOT / "check_completion_quality.py"), "--self-test"]),
+        (
+            "hidden-compatibility-prefixes",
+            [sys.executable, str(AREA_ROOT / "check_hidden_compatibility_prefixes.py")],
+        ),
+        (
+            "hidden-compatibility-prefixes-self-test",
+            [sys.executable, str(AREA_ROOT / "check_hidden_compatibility_prefixes.py"), "--self-test"],
+        ),
     ],
     "formatter": [
         ("formatter-rules", [sys.executable, str(AREA_ROOT / "check_formatter_rules.py")]),


### PR DESCRIPTION
## Summary
- remove lowering support for hidden sync and concurrent compatibility-name prefixes
- use canonical task, synchronization, IPC, and blocking executor type names directly
- add a governed production/fixture residue guard with mutation self-test

## Validation
- `cargo test -p sifr_lowering` — 992 passed, 1 ignored; one unrelated existing class-diagnostic assertion failed and reproduces in its untouched test
- focused task/blocking/IPC lowering filters — 25 passed
- create-PR e2e selection — 140 passed
- runtime-platform golden — 11 passed, 1 capability-gated skip
- developer-tooling static suite — 14 passed
- fmt, Clippy, HIR/file-size guardrails, compatibility inventory, guard and self-test — passed
- one create-PR gate on `a3f75bbf4a9a5a1705da392dcbeda9f84a0b9524` stopped at the inherited verification-taxonomy conflict assigned to Item 16; it was not rerun

Phase item: `pre_v1_compat_12_hidden_names`.