### PR TITLE
Preserve inherited handler contracts in structural shapes

### DIFF
--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -362,7 +362,14 @@ fn describe_class(
                     .map(|selection| selection.field_plans.as_slice()),
             )
         };
-    let described_fields = fields
+    let planned_fields = field_plans.map(|plans| {
+        plans
+            .iter()
+            .map(|field| (field.name.clone(), field.declared_type.clone()))
+            .collect::<Vec<_>>()
+    });
+    let effective_fields = planned_fields.as_deref().unwrap_or(fields);
+    let described_fields = effective_fields
         .iter()
         .enumerate()
         .map(|(index, (name, ty))| ShapeField {
@@ -641,13 +648,15 @@ fn canonical_method(method: &ShapeMethod) -> String {
         .as_ref()
         .map_or_else(|| "none".to_string(), canonical_value);
     format!(
-        "{}:{}:{}:{}:{}:target[{target}]:descriptor[{descriptor}]:params[{params}]:result[{}]:meta[{}]",
+        "{}:{}:{}:{}:{}:target[{target}]:descriptor[{descriptor}]:params[{params}]:result[{}]:output[{}]:fallible[{}]:meta[{}]",
         method.name.len(),
         method.name,
         method.kind,
         method.receiver.as_deref().unwrap_or("none"),
         method.is_async,
         canonical_node(&method.result),
+        canonical_node(&method.output),
+        method.fallible,
         canonical_metadata(&method.metadata)
     )
 }

--- a/crates/sifr_frontend/src/structural_shape/methods.rs
+++ b/crates/sifr_frontend/src/structural_shape/methods.rs
@@ -30,6 +30,9 @@ pub struct ShapeMethod {
     pub is_async: bool,
     pub params: Vec<ShapeParameter>,
     pub result: Box<ShapeNode>,
+    /// Successful checked output, with a `Result` carrier removed.
+    pub output: Box<ShapeNode>,
+    pub fallible: bool,
     pub metadata: Vec<ShapeMetadata>,
 }
 
@@ -110,6 +113,8 @@ pub(super) fn const_value(method: &ShapeMethod) -> ConstValue {
             ),
         ),
         ("result".to_string(), node_const_value(&method.result)),
+        ("output".to_string(), node_const_value(&method.output)),
+        ("fallible".to_string(), ConstValue::Bool(method.fallible)),
         (
             "metadata".to_string(),
             metadata_const_value(&method.metadata),
@@ -237,17 +242,33 @@ fn described_handler(
         .identity
         .clone()
         .unwrap_or_else(|| format!("{module_name}.{}", class.name));
-    let detailed = (handler.callable.owner.as_deref() == Some(local_owner.as_str()))
-        .then(|| {
-            class
-                .methods
-                .iter()
-                .chain(class.operator_impls.iter().map(|(_, method)| method))
-                .find(|method| method.name == hir_name)
-        })
-        .flatten();
-    let mut method = if let Some(method) = detailed {
-        let owner = format!("{class_name}.{declared_name}");
+    let callable_owner = handler.callable.owner.as_deref();
+    let local_detail = callable_owner.and_then(|owner| {
+        let (source_module, source_name) = owner.rsplit_once('.')?;
+        (source_module == module_name)
+            .then(|| {
+                lowering
+                    .module
+                    .classes
+                    .iter()
+                    .find(|candidate| {
+                        candidate.identity.as_deref() == Some(owner)
+                            || (candidate.identity.is_none() && candidate.name == source_name)
+                    })
+                    .and_then(|owner_class| {
+                        owner_class
+                            .methods
+                            .iter()
+                            .chain(owner_class.operator_impls.iter().map(|(_, method)| method))
+                            .find(|method| method.name == hir_name)
+                            .map(|method| (source_name, owner_class, method))
+                    })
+            })
+            .flatten()
+    });
+    let mut method = if let Some((source_name, owner_class, method)) = local_detail {
+        let owner = format!("{source_name}.{declared_name}");
+        let inherited_bindings = inherited_handler_bindings(class, owner_class, bindings);
         described_method(
             module_name,
             &owner,
@@ -257,7 +278,7 @@ fn described_handler(
             method.method_kind,
             method.receiver,
             method.is_async,
-            bindings,
+            &inherited_bindings,
             metadata_for(
                 &lowering.declaration_metadata,
                 &owner,
@@ -265,6 +286,30 @@ fn described_handler(
                 None,
             ),
             &lowering.declaration_metadata,
+            lowering,
+            external_defs,
+            visiting,
+        )
+    } else if let Some(method) = imported_handler_method(handler, external_defs) {
+        let owner_name = handler
+            .callable
+            .owner
+            .as_deref()
+            .and_then(|owner| owner.rsplit_once('.').map(|(_, name)| name))
+            .unwrap_or(class_name);
+        let inherited_bindings = imported_handler_bindings(class, handler, bindings, external_defs);
+        described_method(
+            &handler.callable.module,
+            &format!("{owner_name}.{declared_name}"),
+            declared_name,
+            &method.params,
+            &method.return_type,
+            method.method_kind,
+            method.receiver,
+            method.is_async,
+            &inherited_bindings,
+            Vec::new(),
+            &[],
             lowering,
             external_defs,
             visiting,
@@ -281,14 +326,110 @@ fn described_handler(
             is_async: false,
             params: Vec::new(),
             result: Box::new(ShapeNode::Other("checked_handler".to_string())),
+            output: Box::new(ShapeNode::Other("checked_handler".to_string())),
+            fallible: false,
             metadata: Vec::new(),
         }
     };
     method.target = Some(handler.callable.clone());
     method.descriptor = Some(validated_adapter_value(&handler.descriptor_value));
-    method.origin = Some(handler.descriptor_origin);
+    method.origin =
+        (callable_owner == Some(local_owner.as_str())).then_some(handler.descriptor_origin);
     method.declaration_order = Some(handler.declaration_order);
     method
+}
+
+fn imported_handler_bindings(
+    child: &HirClass,
+    handler: &AdapterHandlerPlan,
+    child_bindings: &HashMap<String, Type>,
+    external_defs: &sifr_lowering::ExternalDefs,
+) -> HashMap<String, Type> {
+    let Some(owner) = handler.callable.owner.as_deref() else {
+        return HashMap::new();
+    };
+    let Some((source_module, source_name)) = owner.rsplit_once('.') else {
+        return HashMap::new();
+    };
+    let Some(Type::Class {
+        identity,
+        name,
+        type_args,
+        ..
+    }) = child.parent_type.as_ref().map(Type::resolve_alias)
+    else {
+        return HashMap::new();
+    };
+    if identity
+        .as_deref()
+        .map_or(name != source_name, |value| value != owner)
+    {
+        return HashMap::new();
+    }
+    let type_params = external_defs
+        .class_type_params
+        .get(source_module)
+        .and_then(|classes| classes.get(source_name))
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    type_params
+        .iter()
+        .cloned()
+        .zip(
+            type_args
+                .iter()
+                .map(|argument| substitute_type_vars(argument, child_bindings)),
+        )
+        .collect()
+}
+
+fn inherited_handler_bindings(
+    child: &HirClass,
+    owner: &HirClass,
+    child_bindings: &HashMap<String, Type>,
+) -> HashMap<String, Type> {
+    if child.name == owner.name {
+        return child_bindings.clone();
+    }
+    let Some(Type::Class {
+        identity,
+        name,
+        type_args,
+        ..
+    }) = child.parent_type.as_ref().map(Type::resolve_alias)
+    else {
+        return HashMap::new();
+    };
+    let owner_identity = owner.identity.as_deref().unwrap_or(&owner.name);
+    if identity.as_deref().unwrap_or(name) != owner_identity && name != &owner.name {
+        return HashMap::new();
+    }
+    owner
+        .type_params
+        .iter()
+        .cloned()
+        .zip(
+            type_args
+                .iter()
+                .map(|argument| substitute_type_vars(argument, child_bindings)),
+        )
+        .collect()
+}
+
+fn imported_handler_method<'a>(
+    handler: &AdapterHandlerPlan,
+    external_defs: &'a sifr_lowering::ExternalDefs,
+) -> Option<&'a StructuralMethodExport> {
+    let owner = handler.callable.owner.as_deref()?;
+    let (source_module, source_name) = owner.rsplit_once('.')?;
+    if source_module != handler.callable.module {
+        return None;
+    }
+    external_defs
+        .structural_methods_for(source_module)?
+        .get(source_name)?
+        .iter()
+        .find(|method| method.name == handler.callable.symbol)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -354,6 +495,11 @@ fn described_method(
     external_defs: &sifr_lowering::ExternalDefs,
     visiting: &mut BTreeSet<String>,
 ) -> ShapeMethod {
+    let substituted_result = substitute_type_vars(return_type, bindings);
+    let (output_type, fallible) = match substituted_result.resolve_alias() {
+        Type::Result(output, _) => (output.as_ref(), true),
+        output => (output, false),
+    };
     ShapeMethod {
         target: None,
         descriptor: None,
@@ -386,11 +532,19 @@ fn described_method(
             .collect(),
         result: Box::new(describe_node(
             module_name,
-            &substitute_type_vars(return_type, bindings),
+            &substituted_result,
             lowering,
             external_defs,
             visiting,
         )),
+        output: Box::new(describe_node(
+            module_name,
+            output_type,
+            lowering,
+            external_defs,
+            visiting,
+        )),
+        fallible,
         metadata,
     }
 }

--- a/crates/sifr_frontend/src/structural_shape/tests.rs
+++ b/crates/sifr_frontend/src/structural_shape/tests.rs
@@ -277,6 +277,38 @@ class Model:
 }
 
 #[test]
+fn described_method_exposes_successful_result_output() {
+    let source = r#"
+class HandlerFailure(Error):
+    message: str
+
+class Model:
+    @staticmethod
+    @metadata("fixture.callback", "checked")
+    def checked(own value: str) -> Result[int, HandlerFailure]:
+        return 1
+"#;
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let lowered = lower_module(&parsed).expect("fixture lowers");
+    let model = &lowered.module.classes[1];
+    let shape = describe_type(
+        "fixture.successful_output",
+        &class_type(model, Vec::new()),
+        &lowered,
+    );
+    let ShapeNode::Nominal { methods, .. } = shape.root else {
+        panic!("model must have a nominal shape");
+    };
+    assert_eq!(methods.len(), 1);
+    assert!(matches!(*methods[0].result, ShapeNode::Other(_)));
+    assert_eq!(
+        methods[0].output.as_ref(),
+        &ShapeNode::Primitive("int".to_string())
+    );
+    assert!(methods[0].fallible);
+}
+
+#[test]
 fn generic_method_contract_uses_concrete_class_arguments() {
     let source = r#"
 class Box[T]:
@@ -310,6 +342,117 @@ class Container:
     );
     assert_eq!(*methods[0].result, ShapeNode::Primitive("int".to_string()));
     assert!(!shape.canonical_identity.contains("param:T"));
+}
+
+#[test]
+fn inherited_handler_preserves_checked_signature_and_uses_child_diagnostic_origin() {
+    use sifr_lowering::{
+        AdapterFieldDefault, AdapterFieldPlan, AdapterHandlerPlan, CallableIdentity,
+        ClassAdapterSelection, SourceOriginId, StaticProgramValue,
+    };
+
+    let source = r#"
+class Parent[T]:
+    value: T
+
+    @classmethod
+    def normalize(cls, own value: T) -> T:
+        return value
+
+class Child(Parent[int]):
+    @classmethod
+    def finish(cls, own value: int) -> int:
+        return value
+"#;
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let mut lowered = lower_module(&parsed).expect("fixture lowers");
+    let callable = CallableIdentity {
+        module: "fixture.inherited".to_string(),
+        owner: Some("fixture.inherited.Parent".to_string()),
+        symbol: "normalize".to_string(),
+        generic_arguments: Vec::new(),
+        signature: "checked".to_string(),
+    };
+    let child_callable = CallableIdentity {
+        module: "fixture.inherited".to_string(),
+        owner: Some("fixture.inherited.Child".to_string()),
+        symbol: "finish".to_string(),
+        generic_arguments: Vec::new(),
+        signature: "checked-child".to_string(),
+    };
+    lowered
+        .class_adapter_selections
+        .push(ClassAdapterSelection {
+            owner: "Child".to_string(),
+            provider_module: "fixture.adapter".to_string(),
+            provider_function: "adapt".to_string(),
+            descriptor_type: Type::Str,
+            marker_identities: Vec::new(),
+            data_parent: Some("Parent".to_string()),
+            field_plans: vec![AdapterFieldPlan {
+                identity: "fixture.inherited.Child.value".to_string(),
+                name: "value".to_string(),
+                declared_type: Type::Int,
+                default: AdapterFieldDefault::Required,
+                validation_policy: None,
+            }],
+            handler_plans: vec![
+                AdapterHandlerPlan {
+                    callable: callable.clone(),
+                    descriptor_type: Type::Str,
+                    descriptor_value: StaticProgramValue::String("after".to_string()),
+                    descriptor_origin: SourceOriginId::new([7; 32], 3),
+                    descriptor_range: ruff_text_size::TextRange::default(),
+                    declaration_order: 0,
+                },
+                AdapterHandlerPlan {
+                    callable: child_callable.clone(),
+                    descriptor_type: Type::Str,
+                    descriptor_value: StaticProgramValue::String("after".to_string()),
+                    descriptor_origin: SourceOriginId::new([7; 32], 4),
+                    descriptor_range: ruff_text_size::TextRange::default(),
+                    declaration_order: 1,
+                },
+            ],
+            attached_api_set: None,
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
+            range: ruff_text_size::TextRange::default(),
+        });
+    let child = &lowered.module.classes[1];
+    let shape = describe_type(
+        "fixture.inherited",
+        &class_type(child, Vec::new()),
+        &lowered,
+    );
+    let ShapeNode::Nominal {
+        fields, methods, ..
+    } = shape.root
+    else {
+        panic!("child must have a nominal shape");
+    };
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name, "value");
+    assert_eq!(
+        fields[0].declared_type,
+        ShapeNode::Primitive("int".to_string())
+    );
+    assert_eq!(methods.len(), 2);
+    assert_eq!(methods[0].name, "normalize");
+    assert_eq!(methods[1].name, "finish");
+    assert_eq!(methods[0].target.as_ref(), Some(&callable));
+    assert_eq!(methods[0].kind, "class");
+    assert_eq!(methods[0].receiver, None);
+    assert_eq!(
+        methods[0].params[0].declared_type,
+        ShapeNode::Primitive("int".to_string())
+    );
+    assert_eq!(*methods[0].result, ShapeNode::Primitive("int".to_string()));
+    assert_eq!(*methods[0].output, ShapeNode::Primitive("int".to_string()));
+    assert!(!methods[0].fallible);
+    assert_eq!(methods[0].origin, None);
+    assert_eq!(methods[1].target.as_ref(), Some(&child_callable));
+    assert_eq!(methods[1].origin, Some(SourceOriginId::new([7; 32], 4)));
 }
 
 #[test]

--- a/crates/sifr_frontend/src/structural_shape_import_tests.rs
+++ b/crates/sifr_frontend/src/structural_shape_import_tests.rs
@@ -1,8 +1,11 @@
 use crate::{
     collect_module_exports, compile_module_hir, describe_type_with_externals,
-    FrontendDiagnosticStyle,
+    FrontendDiagnosticStyle, ShapeNode,
 };
-use sifr_lowering::{ExternalDefs, LoweringResult};
+use sifr_lowering::{
+    AdapterFieldDefault, AdapterFieldPlan, AdapterHandlerPlan, CallableIdentity,
+    ClassAdapterSelection, ExternalDefs, LoweringResult, SourceOriginId, StaticProgramValue,
+};
 use sifr_syntax::parse_module_suite;
 use sifr_type_system::Type;
 
@@ -26,6 +29,94 @@ fn field_type<'a>(result: &'a LoweringResult, class_name: &str, field: &str) -> 
         .and_then(|class| class.fields.iter().find(|(name, _)| name == field))
         .map(|(_, ty)| ty)
         .expect("field exists")
+}
+
+#[test]
+fn imported_generic_parent_handler_uses_the_concrete_child_argument() {
+    let mut external_defs = ExternalDefs::default();
+    let models = compile(
+        "models",
+        r#"
+class Parent[T]:
+    value: T
+
+    @classmethod
+    @metadata("fixture.callback", "after")
+    def normalize(cls, own value: T) -> T:
+        return value
+"#,
+        &external_defs,
+    );
+    collect_module_exports("models", &models, &mut external_defs);
+
+    let mut consumer = compile(
+        "consumer",
+        r#"
+from models import Parent
+
+class Child(Parent[int]):
+    pass
+
+class Use:
+    value: Child
+"#,
+        &external_defs,
+    );
+    let callable = CallableIdentity {
+        module: "models".to_string(),
+        owner: Some("models.Parent".to_string()),
+        symbol: "normalize".to_string(),
+        generic_arguments: Vec::new(),
+        signature: "checked".to_string(),
+    };
+    consumer
+        .class_adapter_selections
+        .push(ClassAdapterSelection {
+            owner: "Child".to_string(),
+            provider_module: "fixture.adapter".to_string(),
+            provider_function: "adapt".to_string(),
+            descriptor_type: Type::Str,
+            marker_identities: Vec::new(),
+            data_parent: Some("models.Parent".to_string()),
+            field_plans: vec![AdapterFieldPlan {
+                identity: "consumer.Child.value".to_string(),
+                name: "value".to_string(),
+                declared_type: Type::Int,
+                default: AdapterFieldDefault::Required,
+                validation_policy: None,
+            }],
+            handler_plans: vec![AdapterHandlerPlan {
+                callable: callable.clone(),
+                descriptor_type: Type::Str,
+                descriptor_value: StaticProgramValue::String("after".to_string()),
+                descriptor_origin: SourceOriginId::new([9; 32], 1),
+                descriptor_range: ruff_text_size::TextRange::default(),
+                declaration_order: 0,
+            }],
+            attached_api_set: None,
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
+            range: ruff_text_size::TextRange::default(),
+        });
+
+    let shape = describe_type_with_externals(
+        "consumer",
+        field_type(&consumer, "Use", "value"),
+        &consumer,
+        &external_defs,
+    );
+    let ShapeNode::Nominal { methods, .. } = shape.root else {
+        panic!("child must have a nominal shape");
+    };
+    assert_eq!(methods.len(), 1);
+    assert_eq!(methods[0].target.as_ref(), Some(&callable));
+    assert_eq!(
+        methods[0].params[0].declared_type,
+        ShapeNode::Primitive("int".to_string())
+    );
+    assert_eq!(*methods[0].result, ShapeNode::Primitive("int".to_string()));
+    assert_eq!(*methods[0].output, ShapeNode::Primitive("int".to_string()));
+    assert!(!shape.canonical_identity.contains("param:T"));
 }
 
 #[test]

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -156,6 +156,11 @@ payload cover types with and without handlers. Package method descriptors expose
 source origin, and the specializer selects those identities through `sifr_method_slots`. Legacy
 annotated slots can still use exact `module.Type::method` strings.
 
+Each described method contains its declared `result`, its successful `output`, and a `fallible`
+flag. For `Result[T, E]`, `output` describes `T` and `fallible` is true. For other results,
+`output` equals `result` and `fallible` is false. Packages use these typed facts to reject invalid
+handler signatures during specialization. They do not parse a displayed type name.
+
 The compiler accepts synchronous static, class, shared-instance, mutable-instance, and owned
 receiver handlers. A checked handler can return an infallible structural value or a typed `Result`.
 An owned receiver must return the exact current `Self` specialization, directly or as the successful


### PR DESCRIPTION
M9 compiler prerequisite for pydantic-sifr validators.\n\nPreserves checked inherited handler signatures, exposes successful Result output separately from the declared result, and uses finalized adapter fields in structural shapes.\n\nTargeted evidence: 13 structural-shape tests; sifr_frontend clippy; formatting; HIR maintainability; 900-line guardrail; release compiler successfully built and used by the M9 package demo.