### PR TITLE
Make static programs structurally executable

### DIFF
--- a/crates/sifr_runtime/src/interop/structural/static_program.rs
+++ b/crates/sifr_runtime/src/interop/structural/static_program.rs
@@ -107,8 +107,10 @@ pub struct StaticProgram<T> {
     _type: PhantomData<fn() -> T>,
 }
 
-/// Implemented only by compiler-emitted concrete types with retained static data.
-pub trait StaticProgramType: super::StructuralType + Sized + 'static {
+/// Implemented only by compiler-emitted concrete structural types with retained static data.
+pub trait StaticProgramType:
+    super::StructuralType + super::StructuralConstruct + super::StructuralProject + Sized + 'static
+{
     fn static_program() -> &'static StaticProgram<Self>;
 }
 
@@ -211,7 +213,18 @@ mod tests {
     use crate::interop::__generated_glue;
     use crate::interop::structural::{
         primitive, slot_table_identity, static_program_identity, SlotContextModeIdentity,
+        StructuralConstruct, StructuralProject,
     };
+
+    #[test]
+    fn static_program_types_are_structurally_constructible_and_projectable() {
+        #[allow(dead_code)]
+        fn require_structural<T: StructuralConstruct + StructuralProject>() {}
+        #[allow(dead_code)]
+        fn require_static<T: StaticProgramType>() {
+            require_structural::<T>();
+        }
+    }
 
     #[test]
     fn sealed_program_verifies_complete_envelope() {


### PR DESCRIPTION
M10 compiler prerequisite: strengthen StaticProgramType to guarantee StructuralConstruct and StructuralProject, matching every compiler-emitted static-program owner and allowing ordinary typed facades to call structural bridges.\n\nCandidate: 90f9086b11b7d3d2163a1a238aabbf6af048befb