### PR TITLE
Allow method-slot owners for attached APIs

### DIFF
--- a/crates/sifr_driver/src/tests/early_adapters.rs
+++ b/crates/sifr_driver/src/tests/early_adapters.rs
@@ -112,6 +112,40 @@ def finish[T: StaticProgram](own target: Self) -> int:
 }
 
 #[test]
+fn attached_api_owner_accepts_method_slots_bound() {
+    let contract = attached_contract()
+        .replace(
+            "from sifr.meta import StaticProgram, Structural, ",
+            "from sifr.meta import MethodSlots, StaticProgram, Structural, ",
+        )
+        .replace(
+            "@class_adapter_provider",
+            r#"@attached_api("fixture.contract", "ContractApi", public_name="serialize", receiver="immutable", owner="T")
+def serialize[T: MethodSlots](target: Self) -> int:
+    return 3
+
+@class_adapter_provider"#,
+        );
+    let modules = project(
+        r#"
+from fixture.contract import Contract, contract_config
+
+class Model(Contract):
+    _config = contract_config(True)
+    value: int
+
+def main():
+    model: Model = Model(1)
+    assert model.serialize() == 3
+"#,
+        &contract,
+    );
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    collect_project_hir_modules(&modules, stdlib_defs)
+        .expect("a MethodSlots-bound attached API owner should lower");
+}
+
+#[test]
 fn erased_marker_runs_adapter_and_specializes_without_layout_or_constructor_cost() {
     let modules = project(
         r#"

--- a/crates/sifr_lowering/src/lower/attached_api_declarations.rs
+++ b/crates/sifr_lowering/src/lower/attached_api_declarations.rs
@@ -191,12 +191,16 @@ pub(super) fn finalize(ctx: &mut LowerCtx, module: &str) {
             .unwrap_or_default();
         if !bounds
             .get(&declaration.owner_type_param)
-            .is_some_and(|items| items.iter().any(|item| item == "StaticProgram"))
+            .is_some_and(|items| {
+                items
+                    .iter()
+                    .any(|item| item == "StaticProgram" || item == "MethodSlots")
+            })
         {
             malformed(
                 ctx,
                 "attached_api_owner_bound",
-                "attached API owner type parameter must be bounded by StaticProgram",
+                "attached API owner type parameter must be bounded by StaticProgram or MethodSlots",
                 declaration.range,
             );
             continue;


### PR DESCRIPTION
M10 compiler prerequisite for serializer-aware attached dump methods.

Allows an attached API owner to use the package-neutral `MethodSlots` bound, which already implies the static-program contract, and adds focused lowering coverage.

Exact candidate: `ae39a8826c3d23c7253b8cea0b927006c26045bc`.