### PR TITLE
Bind no-context method-slot wrappers

### DIFF
--- a/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
+++ b/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
@@ -59,7 +59,9 @@ impl RustEmitter {
                         Some(context) => format!(
                             "{base} + sifr_runtime::interop::structural::MethodSlotTable<{context}>"
                         ),
-                        None => base,
+                        None => format!(
+                            "{base} + sifr_runtime::interop::structural::MethodSlotTable<sifr_runtime::interop::structural::NoContext>"
+                        ),
                     }
                 } else {
                     base

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -483,6 +483,32 @@ fn plain_static_program_generic_emits_the_sealed_runtime_bound() {
 }
 
 #[test]
+fn no_context_method_slots_generic_emits_the_slot_table_bound() {
+    let mut retain = ordinary_function("retain", Type::TypeVar("T".to_string()));
+    retain.return_type = Type::TypeVar("T".to_string());
+    retain.type_params = vec!["T".to_string()];
+    retain.body = vec![sifr_ir::HirStmt::Return {
+        value: Some(HirExpr::Name {
+            name: "value".to_string(),
+            binding_id: None,
+            ty: Type::TypeVar("T".to_string()),
+        }),
+    }];
+    let mut module = module(vec![retain], Vec::new());
+    module.type_param_bounds.insert(
+        "retain".to_string(),
+        std::collections::HashMap::from([("T".to_string(), vec!["MethodSlots".to_string()])]),
+    );
+
+    let rust_code = generate_rust(&module);
+
+    assert!(
+        rust_code.contains("MethodSlotTable<::sifr_runtime::interop::structural::NoContext>"),
+        "{rust_code}"
+    );
+}
+
+#[test]
 fn project_static_program_owners_include_supported_imported_fields() {
     let imported = HirClass {
         name: "ImportedPayload".to_string(),


### PR DESCRIPTION
M10 compiler prerequisite for serializer-aware attached dump methods.

A generic function bounded by `MethodSlots` and no explicit `Context` now emits the canonical `MethodSlotTable<NoContext>` Rust bound. Includes focused code-generation coverage.

Exact candidate: `7861d4db6f508f55ea342a22a4096bc399b32ea5`.