### PR TITLE
feat: add string-only structural bound

### DIFF
--- a/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
+++ b/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
@@ -21,7 +21,10 @@ impl RustEmitter {
             .map(|type_param| {
                 let structural = func.rust_interop.iter().any(|declaration| {
                     declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural
-                });
+                }) || self
+                    .structural_type_params
+                    .get(&func.name)
+                    .is_some_and(|params| params.contains(type_param));
                 let static_program = self
                     .static_program_type_params
                     .get(&func.name)

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -483,6 +483,38 @@ fn plain_static_program_generic_emits_the_sealed_runtime_bound() {
 }
 
 #[test]
+fn plain_string_structural_generic_emits_projection_bounds() {
+    let mut retain = ordinary_function("retain", Type::TypeVar("T".to_string()));
+    retain.return_type = Type::TypeVar("T".to_string());
+    retain.type_params = vec!["T".to_string()];
+    retain.body = vec![sifr_ir::HirStmt::Return {
+        value: Some(HirExpr::Name {
+            name: "value".to_string(),
+            binding_id: None,
+            ty: Type::TypeVar("T".to_string()),
+        }),
+    }];
+    let mut module = module(vec![retain], Vec::new());
+    module.type_param_bounds.insert(
+        "retain".to_string(),
+        std::collections::HashMap::from([("T".to_string(), vec!["StringStructural".to_string()])]),
+    );
+
+    let rust_code = generate_rust(&module);
+
+    assert!(
+        rust_code.contains(
+            "T: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject"
+        ),
+        "{rust_code}"
+    );
+    assert!(
+        !rust_code.contains("T: Clone + std::fmt::Display"),
+        "{rust_code}"
+    );
+}
+
+#[test]
 fn no_context_method_slots_generic_emits_the_slot_table_bound() {
     let mut retain = ordinary_function("retain", Type::TypeVar("T".to_string()));
     retain.return_type = Type::TypeVar("T".to_string());

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -515,6 +515,34 @@ fn plain_string_structural_generic_emits_projection_bounds() {
 }
 
 #[test]
+fn attached_structural_generic_preserves_attached_api_bounds() {
+    let mut retain = ordinary_function("retain", Type::TypeVar("T".to_string()));
+    retain.return_type = Type::TypeVar("T".to_string());
+    retain.type_params = vec!["T".to_string()];
+    retain.decorators = vec!["attached_api".to_string()];
+    retain.body = vec![sifr_ir::HirStmt::Return {
+        value: Some(HirExpr::Name {
+            name: "value".to_string(),
+            binding_id: None,
+            ty: Type::TypeVar("T".to_string()),
+        }),
+    }];
+    let mut module = module(vec![retain], Vec::new());
+    module.type_param_bounds.insert(
+        "retain".to_string(),
+        std::collections::HashMap::from([("T".to_string(), vec!["Structural".to_string()])]),
+    );
+
+    let rust_code = generate_rust(&module);
+
+    assert!(rust_code.contains("T: Clone + 'static"), "{rust_code}");
+    assert!(
+        !rust_code.contains("T: ::sifr_runtime::interop::structural::StructuralConstruct"),
+        "{rust_code}"
+    );
+}
+
+#[test]
 fn no_context_method_slots_generic_emits_the_slot_table_bound() {
     let mut retain = ordinary_function("retain", Type::TypeVar("T".to_string()));
     retain.return_type = Type::TypeVar("T".to_string());

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -63,6 +63,8 @@ pub struct RustEmitter {
     pub(crate) structural_identity_module_name: Option<String>,
     /// Static-program type parameters for each structural bridge function.
     pub(crate) static_program_type_params: HashMap<String, HashSet<String>>,
+    /// Structurally projected type parameters, including compile-time string-leaf subsets.
+    pub(crate) structural_type_params: HashMap<String, HashSet<String>>,
     /// Method-slot owners for each structural bridge function.
     pub(crate) method_slot_type_params: HashMap<String, HashSet<String>>,
     /// Caller-context type parameters for each structural bridge function.
@@ -244,6 +246,7 @@ impl RustEmitter {
             project_structural_identity_expressions: None,
             structural_identity_module_name: None,
             static_program_type_params: HashMap::new(),
+            structural_type_params: HashMap::new(),
             method_slot_type_params: HashMap::new(),
             context_type_params: HashMap::new(),
             used_stdlib_modules: HashSet::new(),

--- a/crates/sifr_codegen/src/module_prescan.rs
+++ b/crates/sifr_codegen/src/module_prescan.rs
@@ -8,6 +8,20 @@ impl RustEmitter {
         self.collect_display_class_metadata(module);
         self.collect_parent_field_metadata(module);
         self.collect_function_signature_metadata(module);
+        self.structural_type_params = module
+            .type_param_bounds
+            .iter()
+            .filter_map(|(owner, bounds)| {
+                let params = bounds
+                    .iter()
+                    .filter(|(_, values)| {
+                        matches!(values.as_slice(), [bound] if bound == "Structural" || bound == "StringStructural")
+                    })
+                    .map(|(name, _)| name.clone())
+                    .collect::<HashSet<_>>();
+                (!params.is_empty()).then(|| (owner.clone(), params))
+            })
+            .collect();
         self.static_program_type_params = module
             .type_param_bounds
             .iter()

--- a/crates/sifr_codegen/src/module_prescan.rs
+++ b/crates/sifr_codegen/src/module_prescan.rs
@@ -14,9 +14,7 @@ impl RustEmitter {
             .filter_map(|(owner, bounds)| {
                 let params = bounds
                     .iter()
-                    .filter(|(_, values)| {
-                        matches!(values.as_slice(), [bound] if bound == "Structural" || bound == "StringStructural")
-                    })
+                    .filter(|(_, values)| values.as_slice() == ["StringStructural"])
                     .map(|(name, _)| name.clone())
                     .collect::<HashSet<_>>();
                 (!params.is_empty()).then(|| (owner.clone(), params))

--- a/crates/sifr_codegen/src/rust_interop_bridge_contract.rs
+++ b/crates/sifr_codegen/src/rust_interop_bridge_contract.rs
@@ -358,7 +358,11 @@ impl ModuleCatalog {
                                     [bound]
                                         if matches!(
                                             bound.as_str(),
-                                            "Structural" | "StaticProgram" | "MethodSlots" | "Context"
+                                            "Structural"
+                                                | "StringStructural"
+                                                | "StaticProgram"
+                                                | "MethodSlots"
+                                                | "Context"
                                         )
                                 )
                             })

--- a/crates/sifr_driver/src/tests/early_adapters.rs
+++ b/crates/sifr_driver/src/tests/early_adapters.rs
@@ -79,7 +79,7 @@ pub(super) fn attached_contract() -> String {
     CONTRACT
         .replace(
             "from sifr.meta import ",
-            "from sifr.meta import StaticProgram, Structural, ",
+            "from sifr.meta import StaticProgram, StringStructural, Structural, ",
         )
         .replace(
             "@class_adapter_provider",
@@ -93,6 +93,10 @@ def describe[T: StaticProgram]() -> str:
 
 @attached_api("fixture.contract", "ContractApi", public_name="echo", receiver="type", owner="T")
 def echo[T: StaticProgram, Input: Structural](input: Input) -> Input:
+    return input
+
+@attached_api("fixture.contract", "ContractApi", public_name="echo_strings", receiver="type", owner="T")
+def echo_strings[T: StaticProgram, Input: StringStructural](input: Input) -> Input:
     return input
 
 @attached_api("fixture.contract", "ContractApi", public_name="touch", receiver="mutable", owner="T")
@@ -115,8 +119,8 @@ def finish[T: StaticProgram](own target: Self) -> int:
 fn attached_api_owner_accepts_method_slots_bound() {
     let contract = attached_contract()
         .replace(
-            "from sifr.meta import StaticProgram, Structural, ",
-            "from sifr.meta import MethodSlots, StaticProgram, Structural, ",
+            "from sifr.meta import StaticProgram, StringStructural, Structural, ",
+            "from sifr.meta import MethodSlots, StaticProgram, StringStructural, Structural, ",
         )
         .replace(
             "@class_adapter_provider",
@@ -247,6 +251,7 @@ class Model(Contract):
 def main():
     assert Model.describe() == "attached"
     assert Model.echo("residual") == "residual"
+    assert Model.echo_strings({"nested": ["left", "right"]}) == {"nested": ["left", "right"]}
 "#,
         &contract,
     );
@@ -289,6 +294,31 @@ def main():
             method.name.as_str(),
             "describe" | "echo" | "touch" | "finish"
         )
+    }));
+}
+
+#[test]
+fn attached_string_structural_api_rejects_a_non_string_leaf() {
+    let contract = attached_contract();
+    let modules = project(
+        r#"
+from fixture.contract import Contract, contract_config
+
+class Model(Contract):
+    _config = contract_config(True)
+    value: int
+
+def main():
+    Model.echo_strings({"invalid": [1]})
+"#,
+        &contract,
+    );
+    let errors = compile_errors(&modules, "non-string attached input must fail checking");
+    assert!(errors.iter().any(|error| {
+        error.code == sifr_diagnostics::DiagnosticCode::PROTO_BOUND_NOT_SATISFIED.code()
+            && error
+                .message
+                .contains("does not implement protocol 'StringStructural'")
     }));
 }
 

--- a/crates/sifr_lowering/src/lower/imports.rs
+++ b/crates/sifr_lowering/src/lower/imports.rs
@@ -162,6 +162,9 @@ pub(in crate::lower) fn resolve_imports_early(
     ctx.local_structural_marker_declared = stmts
         .iter()
         .any(|stmt| matches!(stmt, Stmt::ClassDef(class) if class.name.as_str() == "Structural"));
+    ctx.local_string_structural_marker_declared = stmts.iter().any(
+        |stmt| matches!(stmt, Stmt::ClassDef(class) if class.name.as_str() == "StringStructural"),
+    );
     ctx.local_static_program_marker_declared = stmts.iter().any(
         |stmt| matches!(stmt, Stmt::ClassDef(class) if class.name.as_str() == "StaticProgram"),
     );
@@ -208,6 +211,13 @@ pub(in crate::lower) fn resolve_imports_early(
                     .any(|alias| alias.name.as_str() == "Structural" && alias.asname.is_none())
             {
                 ctx.canonical_structural_marker_imported = true;
+            }
+            if module_name == "sifr.meta"
+                && import_from.names.iter().any(|alias| {
+                    alias.name.as_str() == "StringStructural" && alias.asname.is_none()
+                })
+            {
+                ctx.canonical_string_structural_marker_imported = true;
             }
             if module_name == "sifr.meta"
                 && import_from

--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -67,6 +67,9 @@ pub(in crate::lower) struct LowerCtx {
     /// Whether the exact compiler-owned `sifr.meta.Structural` spelling was imported.
     pub(in crate::lower) canonical_structural_marker_imported: bool,
     pub(in crate::lower) local_structural_marker_declared: bool,
+    /// Whether the exact compiler-owned `sifr.meta.StringStructural` spelling was imported.
+    pub(in crate::lower) canonical_string_structural_marker_imported: bool,
+    pub(in crate::lower) local_string_structural_marker_declared: bool,
     /// Whether the exact compiler-owned `sifr.meta.StaticProgram` spelling was imported.
     pub(in crate::lower) canonical_static_program_marker_imported: bool,
     pub(in crate::lower) local_static_program_marker_declared: bool,
@@ -266,6 +269,8 @@ impl LowerCtx {
             json_integer_boundary_requests: Vec::new(),
             canonical_structural_marker_imported: false,
             local_structural_marker_declared: false,
+            canonical_string_structural_marker_imported: false,
+            local_string_structural_marker_declared: false,
             canonical_static_program_marker_imported: false,
             local_static_program_marker_declared: false,
             canonical_method_slots_marker_imported: false,

--- a/crates/sifr_lowering/src/lower/rust_interop_structural.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural.rs
@@ -87,7 +87,11 @@ pub(in crate::lower) fn validate_structural_function_contract(
                 [bound]
                     if matches!(
                         bound.as_str(),
-                        "Structural" | "StaticProgram" | "MethodSlots" | "Context"
+                        "Structural"
+                            | "StringStructural"
+                            | "StaticProgram"
+                            | "MethodSlots"
+                            | "Context"
                     ) =>
                 {
                     Some(bound.clone())
@@ -98,7 +102,7 @@ pub(in crate::lower) fn validate_structural_function_contract(
             structural_type_error(
                 ctx,
                 format!(
-                    "type parameter `{type_param}` must have the exact `Structural`, `StaticProgram`, `MethodSlots`, or `Context` bound"
+                    "type parameter `{type_param}` must have the exact `Structural`, `StringStructural`, `StaticProgram`, `MethodSlots`, or `Context` bound"
                 ),
                 span,
             );
@@ -110,6 +114,14 @@ pub(in crate::lower) fn validate_structural_function_contract(
                 "sifr.meta.Structural",
                 ctx.canonical_structural_marker_imported,
                 ctx.local_structural_marker_declared,
+                span,
+            ),
+            Some("StringStructural") => validate_marker(
+                ctx,
+                "StringStructural",
+                "sifr.meta.StringStructural",
+                ctx.canonical_string_structural_marker_imported,
+                ctx.local_string_structural_marker_declared,
                 span,
             ),
             Some("StaticProgram") => validate_marker(

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -404,6 +404,36 @@ def use(value: Token) -> None:
 }
 
 #[test]
+fn string_structural_bound_rejects_mapped_rust_values_without_visible_leaf_types() {
+    let errors = lower_errors(
+        r"
+from sifr.meta import StringStructural
+
+@rust.opaque(
+    type=bridge.token.Token,
+    structural=bridge.token.TokenMapping,
+    close=none,
+)
+class Token:
+    pass
+
+def accept[T: StringStructural](value: T) -> None:
+    pass
+
+def use(value: Token) -> None:
+    accept(value)
+",
+    );
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
+            && error
+                .message
+                .contains("does not implement protocol 'StringStructural'")
+    }));
+}
+
+#[test]
 fn structurally_mapped_rust_values_reject_fields_parents_and_generics() {
     for declaration in [
         "class Token:\n    value: str",

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -24,6 +24,17 @@ fn structural_externals() -> ExternalDefs {
                 },
             ),
             (
+                "StringStructural".to_string(),
+                Type::Class {
+                    identity: Some("sifr.meta.StringStructural".to_string()),
+                    type_args: Vec::new(),
+                    name: "StringStructural".to_string(),
+                    fields: Vec::new(),
+                    methods: Vec::new(),
+                    parent_class: None,
+                },
+            ),
+            (
                 "StaticProgram".to_string(),
                 Type::Class {
                     identity: Some("sifr.meta.StaticProgram".to_string()),
@@ -126,6 +137,98 @@ def convert[Output: StaticProgram, Input: Structural](
         ["StaticProgram"]
     );
     assert_eq!(module.type_param_bounds["convert"]["Input"], ["Structural"]);
+}
+
+#[test]
+fn string_structural_bound_accepts_only_recursive_string_leaves() {
+    let source = r#"
+from sifr.meta import StringStructural
+
+class Leaf:
+    value: str
+
+class Payload:
+    label: str
+    leaves: list[Leaf]
+    metadata: dict[str, str]
+
+def accept[T: StringStructural](value: T) -> None:
+    pass
+
+def use(payload: Payload) -> None:
+    accept("root")
+    accept(payload)
+    accept({"nested": ["left", "right"]})
+"#;
+    let parsed = parse_module(source).expect("source should parse");
+    lower_module_with_externals(parsed.suite(), &structural_externals())
+        .expect("bare and recursively nested string inputs should lower");
+
+    for invalid_type in ["int", "list[bool]", "dict[int, str]", "str | None"] {
+        let source = format!(
+            r#"
+from sifr.meta import StringStructural
+
+def accept[T: StringStructural](value: T) -> None:
+    pass
+
+def use(value: {invalid_type}) -> None:
+    accept(value)
+"#
+        );
+        let parsed = parse_module(&source).expect("source should parse");
+        let errors = match lower_module_with_externals(parsed.suite(), &structural_externals()) {
+            Ok(_) => panic!("non-string leaf type {invalid_type} must fail"),
+            Err(errors) => errors,
+        };
+        assert!(errors.iter().any(|error| {
+            error.code == Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
+                && error
+                    .message
+                    .contains("does not implement protocol 'StringStructural'")
+        }));
+    }
+}
+
+#[test]
+fn rust_interop_accepts_the_canonical_string_structural_marker() {
+    let source = r"
+from sifr.meta import StringStructural
+
+class CodecError(Error):
+    message: str
+
+@rust.structural
+@rust(bridge.codec.observe)
+def observe[T: StringStructural](value: T) -> Result[str, CodecError | RustPanicError]: ...
+";
+    let parsed = parse_module(source).expect("source should parse");
+    let module = lower_module_with_externals(parsed.suite(), &structural_externals())
+        .map(|result| result.module)
+        .expect("canonical string-structural bridge should lower");
+    assert_eq!(
+        module.type_param_bounds["observe"]["T"],
+        ["StringStructural"]
+    );
+}
+
+#[test]
+fn rust_interop_rejects_aliased_string_structural_marker() {
+    let source = r"
+from sifr.meta import StringStructural as Strings
+
+class CodecError(Error):
+    message: str
+
+@rust.structural
+@rust(bridge.codec.observe)
+def observe[T: StringStructural](value: T) -> Result[str, CodecError | RustPanicError]: ...
+";
+    let errors = lower_errors_without_marker_import(source);
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::RUST_TYPE_PROBE_FAILURE)
+            && error.message.contains("compiler-owned")
+    }));
 }
 
 #[test]

--- a/crates/sifr_lowering/src/lower/type_bounds.rs
+++ b/crates/sifr_lowering/src/lower/type_bounds.rs
@@ -30,6 +30,7 @@ fn is_builtin_bound(name: &str) -> bool {
             | "Addable"
             | "Hashable"
             | "Structural"
+            | "StringStructural"
             | "StaticProgram"
             | "MethodSlots"
             | "Context"
@@ -79,6 +80,9 @@ fn typevar_satisfies_spec(tv_name: &str, target_spec: &str, ctx: &LowerCtx) -> b
         if spec == target_spec {
             return true;
         }
+        if target_spec == "Structural" && spec == "StringStructural" {
+            return true;
+        }
 
         // Built-in bounds only imply themselves, which is handled by exact match above.
         if is_builtin_bound(spec) {
@@ -114,6 +118,60 @@ fn type_satisfies_comparable_bound(ty: &Type, ctx: &LowerCtx) -> bool {
 
 fn supports_structural_bridge_type(ty: &Type, ctx: &LowerCtx) -> bool {
     supports_structural_bridge_type_inner(ty, ctx, &mut std::collections::HashSet::new(), false)
+}
+
+fn supports_string_structural_type(ty: &Type, ctx: &LowerCtx) -> bool {
+    if !supports_structural_bridge_type(ty, ctx) {
+        return false;
+    }
+    supports_string_structural_type_inner(ty, ctx, &mut std::collections::HashSet::new())
+}
+
+fn supports_string_structural_type_inner(
+    ty: &Type,
+    ctx: &LowerCtx,
+    visiting: &mut std::collections::HashSet<(String, Vec<Type>)>,
+) -> bool {
+    match ty.resolve_alias() {
+        Type::Str => true,
+        Type::TypeVar(name) => typevar_satisfies_spec(name, "StringStructural", ctx),
+        Type::List(value) => supports_string_structural_type_inner(value, ctx, visiting),
+        Type::Set(value) => {
+            supports_hash_key_in_context(value, ctx)
+                && supports_string_structural_type_inner(value, ctx, visiting)
+        }
+        Type::Dict(key, value) => {
+            matches!(key.resolve_alias(), Type::Str)
+                && supports_string_structural_type_inner(value, ctx, visiting)
+        }
+        Type::Tuple(values) => values
+            .iter()
+            .all(|value| supports_string_structural_type_inner(value, ctx, visiting)),
+        Type::Union(values) => values
+            .iter()
+            .all(|value| supports_string_structural_type_inner(value, ctx, visiting)),
+        Type::Class {
+            identity,
+            type_args,
+            name,
+            fields,
+            ..
+        } => {
+            let key = (
+                identity.clone().unwrap_or_else(|| name.clone()),
+                type_args.clone(),
+            );
+            if !visiting.insert(key.clone()) {
+                return true;
+            }
+            let supported = fields
+                .iter()
+                .all(|(_, field)| supports_string_structural_type_inner(field, ctx, visiting));
+            visiting.remove(&key);
+            supported
+        }
+        _ => false,
+    }
 }
 
 fn structural_identity_inputs_supported(class_name: &str, ctx: &LowerCtx) -> bool {
@@ -491,6 +549,7 @@ pub(in crate::lower) fn type_satisfies_bound(ty: &Type, bound: &str, ctx: &Lower
         "Addable" => matches!(ty, Type::Int | Type::Float | Type::Str),
         "Hashable" => supports_hash_key_in_context(ty, ctx),
         "Structural" => supports_structural_bridge_type(ty, ctx),
+        "StringStructural" => supports_string_structural_type(ty, ctx),
         "StaticProgram" => supports_static_program_type(ty, ctx),
         "MethodSlots" => supports_static_program_type(ty, ctx),
         "Context" => supports_structural_bridge_type(ty, ctx),

--- a/crates/sifr_lowering/src/lower/type_bounds.rs
+++ b/crates/sifr_lowering/src/lower/type_bounds.rs
@@ -157,6 +157,9 @@ fn supports_string_structural_type_inner(
             fields,
             ..
         } => {
+            if ctx.rust_opaque_classes.contains(name) {
+                return false;
+            }
             let key = (
                 identity.clone().unwrap_or_else(|| name.clone()),
                 type_args.clone(),

--- a/crates/sifr_lowering/src/lower/typevar_annotations.rs
+++ b/crates/sifr_lowering/src/lower/typevar_annotations.rs
@@ -14,6 +14,7 @@ fn is_known_typevar_spec(name: &str, ctx: &LowerCtx) -> bool {
             | "Addable"
             | "Hashable"
             | "Structural"
+            | "StringStructural"
             | "StaticProgram"
             | "MethodSlots"
             | "Context"

--- a/docs/stdlib/public-api.mdx
+++ b/docs/stdlib/public-api.mdx
@@ -170,7 +170,7 @@ Constants: `e`, `inf`, `nan`, `pi`, `tau`.
 
 ## `sifr.meta`
 
-Classes: `CallArgumentDeclaration`, `CallableIdentity`, `ClassDeclaration`, `ClassDeclarationItem`, `ClassDecoratorDeclaration`, `ClassParameterDeclaration`, `ConstIssueLabel`, `ConstIssueTemplate`, `ConstPackageIssue`, `ConstSpecializationOutcome`, `Context`, `DeclarationInput`, `DeclarationPlan`, `DescriptorUse`, `JsonIntegerBoundaryDescriptor`, `MethodSlots`, `NoContext`, `PlannedField`, `PlannedHandler`, `PlannedIssue`, `PlannedIssueLabel`, `PlannedMetadata`, `ShapeInput`, `ShapeMetadata`, `ShapeMethod`, `ShapeRoot`, `SourceOrigin`, `StaticProgram`, `StaticValue`, `Structural`.
+Classes: `CallArgumentDeclaration`, `CallableIdentity`, `ClassDeclaration`, `ClassDeclarationItem`, `ClassDecoratorDeclaration`, `ClassParameterDeclaration`, `ConstIssueLabel`, `ConstIssueTemplate`, `ConstPackageIssue`, `ConstSpecializationOutcome`, `Context`, `DeclarationInput`, `DeclarationPlan`, `DescriptorUse`, `JsonIntegerBoundaryDescriptor`, `MethodSlots`, `NoContext`, `PlannedField`, `PlannedHandler`, `PlannedIssue`, `PlannedIssueLabel`, `PlannedMetadata`, `ShapeInput`, `ShapeMetadata`, `ShapeMethod`, `ShapeRoot`, `SourceOrigin`, `StaticProgram`, `StaticValue`, `StringStructural`, `Structural`.
 
 ## `sifr.net`
 

--- a/internal_docs/native_pydantic_sifr_architecture.md
+++ b/internal_docs/native_pydantic_sifr_architecture.md
@@ -1356,7 +1356,10 @@ Validation selects one of three input profiles over that abstraction:
 The strings-profile public entry point is generic over an input `S`.
 Compile-time shape verification accepts `S` when it is `str`, or when every
 terminal scalar in its structural projection, including mapping keys, is
-`str`; nested records, mappings, and sequences are allowed. A bare `str` uses
+`str`; nested records, mappings, and sequences are allowed. The package uses
+the compiler-owned `sifr.meta.StringStructural` bound for this check. The bound
+is a compile-time subset of `Structural`. It emits the same structural Rust
+projection contract and adds no runtime trait or value tree. A bare `str` uses
 the normal scalar projection. The compiler-generated projection for `S` is
 therefore the input type—there is no `Any` or package-owned recursive value
 tree. The profile reuses the native structural adapter with a leaf-kind

--- a/internal_docs/native_pydantic_sifr_architecture.md
+++ b/internal_docs/native_pydantic_sifr_architecture.md
@@ -1362,7 +1362,8 @@ is a compile-time subset of `Structural`. It emits the same structural Rust
 projection contract and adds no runtime trait or value tree. A bare `str` uses
 the normal scalar projection. The compiler-generated projection for `S` is
 therefore the input type—there is no `Any` or package-owned recursive value
-tree. The profile reuses the native structural adapter with a leaf-kind
+tree. Rust-opaque package values do not satisfy this bound because the compiler
+cannot inspect their mapped leaf types. The profile reuses the native structural adapter with a leaf-kind
 restriction and different conversion rules; it is not a third schema compiler,
 value representation, or validation engine.
 

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -457,6 +457,8 @@ accepts `str` and structural values whose terminal scalar leaves and mapping
 keys are all `str`. Records, mappings, sequences, and tuples can be nested. The
 bound emits the same `StructuralConstruct` and `StructuralProject` Rust traits.
 It adds no runtime trait, reflection path, or second structural representation.
+Rust-opaque values with package mappings do not satisfy this bound because the
+compiler cannot inspect the mapping's leaf types.
 
 Package-defined native values satisfy `Structural` only through the opt-in
 `@rust.opaque(..., structural=Mapping)` contract. The runtime carrier delegates

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -452,6 +452,12 @@ functions, affine resources, and values containing unsupported borrowed or
 opaque members do not satisfy it. The compiler reports the unsupported member
 path at the declaration or specialization site.
 
+`sifr.meta.StringStructural` is a compile-time subset of `Structural`. It
+accepts `str` and structural values whose terminal scalar leaves and mapping
+keys are all `str`. Records, mappings, sequences, and tuples can be nested. The
+bound emits the same `StructuralConstruct` and `StructuralProject` Rust traits.
+It adds no runtime trait, reflection path, or second structural representation.
+
 Package-defined native values satisfy `Structural` only through the opt-in
 `@rust.opaque(..., structural=Mapping)` contract. The runtime carrier delegates
 `StructuralType`, `StructuralConstruct`, and `StructuralProject` to the checked

--- a/stdlib/sifr/meta.sifr
+++ b/stdlib/sifr/meta.sifr
@@ -5,6 +5,10 @@ class Structural:
     pass
 
 
+class StringStructural:
+    pass
+
+
 class StaticProgram:
     pass
 

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/main.sifr
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/examples/structural_bridge_runtime/src/main.sifr
@@ -4,7 +4,7 @@
 # expected-result: structural-roundtrip-clean
 # contract: mapped native values and structural JSON output retain nominal identity
 
-from sifr.meta import Structural
+from sifr.meta import StringStructural, Structural
 from sifr.json import JsonValue
 from enum import Enum
 from typing import Callable
@@ -45,6 +45,12 @@ class Status(Enum):
 class SumPayload:
     choice: int | str
     status: Status
+
+
+class StringEnvelope:
+    label: str
+    tags: list[str]
+    metadata: dict[str, str]
 
 
 @rust.opaque(
@@ -102,6 +108,13 @@ def observe_structural[T: Structural](value: T) -> Result[str, StructuralBridgeE
 
 
 @rust.structural
+@rust(bridge.structural.observe)
+def observe_string_structural[T: StringStructural](
+    value: T,
+) -> Result[str, StructuralBridgeError | RustPanicError]: ...
+
+
+@rust.structural
 @rust(bridge.structural.construct_mapped)
 def construct_mapped[T: Structural](value: str) -> Result[T, StructuralBridgeError | RustPanicError]: ...
 
@@ -152,6 +165,13 @@ def verify_structural_bridge_runtime() -> Result[str, StructuralBridgeError | Ru
     try:
         projection: str = observe_structural(original)
         assert projection == "records=3;sequences=1;optionals=1;strings=input,x,input-box"
+        strings_projection: str = observe_string_structural(
+            StringEnvelope("packet", ["left", "right"], {"source": "checked"})
+        )
+        assert (
+            strings_projection
+            == "records=1;sequences=1;optionals=0;strings=packet,left,right,source,checked"
+        )
         nested_optional: OptionalBox[str | None] = OptionalBox(None)
         nested_optional_projection: str = observe_structural(nested_optional)
         assert nested_optional_projection == "records=1;sequences=0;optionals=1;strings="

--- a/verification/areas/rust_interop/fixtures/structural_bridge_calls/positive/specialized_structural_value_and_output.sifr
+++ b/verification/areas/rust_interop/fixtures/structural_bridge_calls/positive/specialized_structural_value_and_output.sifr
@@ -4,12 +4,17 @@
 # execution-kind: runtime-observed
 # expected-result: pass
 
-from sifr.meta import Structural
+from sifr.meta import StringStructural, Structural
 from sifr.json import JsonValue
 
 
 class StructuralBridgeError(Error):
     message: str
+
+
+class StringEnvelope:
+    label: str
+    tags: list[str]
 
 
 @rust.opaque(
@@ -28,6 +33,13 @@ class MappedToken:
 @rust.structural
 @rust(bridge.structural.observe)
 def observe_structural[T: Structural](value: T) -> Result[str, StructuralBridgeError | RustPanicError]: ...
+
+
+@rust.structural
+@rust(bridge.structural.observe)
+def observe_string_structural[T: StringStructural](
+    value: T,
+) -> Result[str, StructuralBridgeError | RustPanicError]: ...
 
 
 @rust.structural
@@ -60,6 +72,10 @@ def mapped_panic_is_contained() -> bool:
 
 def verify_specialized_structural_value_and_output() -> Result[str, StructuralBridgeError | RustPanicError]:
     try:
+        strings_projection: str = observe_string_structural(
+            StringEnvelope("installed", ["one", "two"])
+        )
+        assert strings_projection == "records=1;sequences=1;optionals=0;strings=installed,one,two"
         mapped: MappedToken = construct_mapped("installed-token")
         mapped_value: str = mapped.value()
         assert mapped_value == "installed-token"


### PR DESCRIPTION
## Summary
- add the compiler-owned `sifr.meta.StringStructural` bound
- reject non-string leaves and opaque mappings during type checking
- reuse the existing structural Rust projection contract for ordinary, Rust-interop, and attached APIs
- add package-neutral unit, adapter, documentation, and native runtime evidence

## Scope
This is the bounded compiler prerequisite for M11 in `ad-hoc-static-class-adapters-and-pydantic-ergonomics`. Type-directed schema attachment and the remaining Pydantic API surface are later M11 work.

## Validation
- `cargo test -p sifr_lowering` (1000 passed, 1 ignored)
- `cargo test -p sifr_codegen` (1051 passed)
- all 22 `early_adapters` tests
- stdlib public API equality test
- affected-crate Clippy with warnings denied
- formatting, diff, HIR maintainability, file-size, and docs-link guards
- native structural runtime fixture on the initial source; remediation did not change the fixture or its ordinary-record path

## Review
Exact candidate `039e531c105bb2badc363868f4433fb17b2c00ab` received a final Opus verdict of SATISFIED after one remediation round.