### PR TITLE
fix: retain string structural body bounds

### DIFF
--- a/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
+++ b/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
@@ -19,12 +19,14 @@ impl RustEmitter {
         func.type_params
             .iter()
             .map(|type_param| {
-                let structural = func.rust_interop.iter().any(|declaration| {
-                    declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural
-                }) || self
+                let string_structural = self
                     .structural_type_params
                     .get(&func.name)
                     .is_some_and(|params| params.contains(type_param));
+                let structural = string_structural
+                    || func.rust_interop.iter().any(|declaration| {
+                        declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural
+                    });
                 let static_program = self
                     .static_program_type_params
                     .get(&func.name)
@@ -45,6 +47,8 @@ impl RustEmitter {
                         .to_string()
                 } else if static_program {
                     "sifr_runtime::interop::structural::StaticProgramType + Clone".to_string()
+                } else if string_structural {
+                    "sifr_runtime::interop::structural::StructuralConstruct + sifr_runtime::interop::structural::StructuralProject + Clone + 'static".to_string()
                 } else if structural {
                     "sifr_runtime::interop::structural::StructuralConstruct + sifr_runtime::interop::structural::StructuralProject".to_string()
                 } else if attached_api || Self::is_nullcontext_value_forwarder(func) {

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -504,7 +504,7 @@ fn plain_string_structural_generic_emits_projection_bounds() {
 
     assert!(
         rust_code.contains(
-            "T: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject"
+            "T: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject + Clone + 'static"
         ),
         "{rust_code}"
     );

--- a/crates/sifr_driver/src/tests/early_adapters.rs
+++ b/crates/sifr_driver/src/tests/early_adapters.rs
@@ -9,6 +9,10 @@ class ContractDescriptor:
     enabled: bool
 "#;
 
+const STRING_STRUCTURAL_NEGATIVE: &str = include_str!(
+    "../../../../verification/areas/core_language/fixtures/static_class_adapter/negative/non_string_leaf_rejected.sifr"
+);
+
 pub(super) const CONTRACT: &str = r#"
 from sifr.meta import ConstSpecializationOutcome, DeclarationInput, DeclarationPlan, PlannedField, PlannedIssue, PlannedIssueLabel, PlannedMetadata, ShapeInput
 from fixture.contract_types import ContractDescriptor
@@ -300,19 +304,7 @@ def main():
 #[test]
 fn attached_string_structural_api_rejects_a_non_string_leaf() {
     let contract = attached_contract();
-    let modules = project(
-        r#"
-from fixture.contract import Contract, contract_config
-
-class Model(Contract):
-    _config = contract_config(True)
-    value: int
-
-def main():
-    Model.echo_strings({"invalid": [1]})
-"#,
-        &contract,
-    );
+    let modules = project(STRING_STRUCTURAL_NEGATIVE, &contract);
     let errors = compile_errors(&modules, "non-string attached input must fail checking");
     assert!(errors.iter().any(|error| {
         error.code == sifr_diagnostics::DiagnosticCode::PROTO_BOUND_NOT_SATISFIED.code()

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -191,6 +191,33 @@ def use(value: {invalid_type}) -> None:
 }
 
 #[test]
+fn string_structural_bound_checks_generic_type_arguments() {
+    let source = r#"
+from sifr.meta import StringStructural
+
+class Phantom[T]:
+    pass
+
+def accept[T: StringStructural](value: T) -> None:
+    pass
+
+def use(value: Phantom[int]) -> None:
+    accept(value)
+"#;
+    let parsed = parse_module(source).expect("source should parse");
+    let errors = match lower_module_with_externals(parsed.suite(), &structural_externals()) {
+        Ok(_) => panic!("non-string generic type arguments must fail"),
+        Err(errors) => errors,
+    };
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
+            && error
+                .message
+                .contains("does not implement protocol 'StringStructural'")
+    }));
+}
+
+#[test]
 fn rust_interop_accepts_the_canonical_string_structural_marker() {
     let source = r"
 from sifr.meta import StringStructural

--- a/crates/sifr_lowering/src/lower/type_bounds.rs
+++ b/crates/sifr_lowering/src/lower/type_bounds.rs
@@ -167,9 +167,12 @@ fn supports_string_structural_type_inner(
             if !visiting.insert(key.clone()) {
                 return true;
             }
-            let supported = fields
+            let supported = type_args
                 .iter()
-                .all(|(_, field)| supports_string_structural_type_inner(field, ctx, visiting));
+                .all(|value| supports_string_structural_type_inner(value, ctx, visiting))
+                && fields
+                    .iter()
+                    .all(|(_, field)| supports_string_structural_type_inner(field, ctx, visiting));
             visiting.remove(&key);
             supported
         }

--- a/internal_docs/native_pydantic_sifr_architecture.md
+++ b/internal_docs/native_pydantic_sifr_architecture.md
@@ -1359,8 +1359,9 @@ terminal scalar in its structural projection, including mapping keys, is
 `str`; nested records, mappings, and sequences are allowed. The package uses
 the compiler-owned `sifr.meta.StringStructural` bound for this check. The bound
 is a compile-time subset of `Structural`. It emits the same structural Rust
-projection contract and adds no runtime trait or value tree. A bare `str` uses
-the normal scalar projection. The compiler-generated projection for `S` is
+projection contract and retains the owned-value bounds needed by generated
+function bodies. It adds no runtime trait or value tree. A bare `str` uses the
+normal scalar projection. The compiler-generated projection for `S` is
 therefore the input type—there is no `Any` or package-owned recursive value
 tree. Rust-opaque package values do not satisfy this bound because the compiler
 cannot inspect their mapped leaf types. The profile reuses the native structural adapter with a leaf-kind

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -457,6 +457,8 @@ accepts `str` and structural values whose terminal scalar leaves and mapping
 keys are all `str`. Records, mappings, sequences, and tuples can be nested. The
 bound emits the same `StructuralConstruct` and `StructuralProject` Rust traits.
 It adds no runtime trait, reflection path, or second structural representation.
+Ordinary and attached function emission also keeps the owned-value `Clone` and
+`'static` bounds required by generated bodies.
 Rust-opaque values with package mappings do not satisfy this bound because the
 compiler cannot inspect the mapping's leaf types.
 

--- a/verification/areas/core_language/fixtures/static_class_adapter/negative/non_string_leaf_rejected.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/negative/non_string_leaf_rejected.sifr
@@ -1,0 +1,12 @@
+# expected-diagnostic: SIFR-PROTO-0001
+
+from fixture.contract import Contract, contract_config
+
+
+class Model(Contract):
+    _config = contract_config(True)
+    value: int
+
+
+def main():
+    Model.echo_strings({"invalid": [1]})

--- a/verification/areas/core_language/fixtures/static_class_adapter/src/api.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/src/api.sifr
@@ -1,4 +1,4 @@
-from sifr.meta import StaticProgram, Structural
+from sifr.meta import StaticProgram, StringStructural, Structural
 
 
 @attached_api_set
@@ -30,7 +30,9 @@ def describe_contract[T: StaticProgram]() -> str:
 )
 @rust.structural
 @rust(bridge.defaults.construct_partial)
-def construct_contract[T: StaticProgram]() -> Result[T, ContractError | RustPanicError]: ...
+def construct_contract[T: StaticProgram]() -> Result[
+    T, ContractError | RustPanicError
+]: ...
 
 
 @attached_api(
@@ -41,6 +43,19 @@ def construct_contract[T: StaticProgram]() -> Result[T, ContractError | RustPani
     owner="T",
 )
 def echo_contract[T: StaticProgram, Input: Structural](input: Input) -> Input:
+    return input
+
+
+@attached_api(
+    "fixture.api",
+    "ContractApi",
+    public_name="echo_strings",
+    receiver="type",
+    owner="T",
+)
+def echo_strings_contract[T: StaticProgram, Input: StringStructural](
+    input: Input,
+) -> Input:
     return input
 
 

--- a/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
@@ -1,7 +1,10 @@
 from fixture.contract import retain_static_program
 from fixture.facade import Contract, ContractError, contract_config, contract_field
 from fixture.factories import Token as ExternalToken, make_names as external_names
-from fixture.models import ImportedAttached as ImportedAlias, ImportedPlain as PlainAlias
+from fixture.models import (
+    ImportedAttached as ImportedAlias,
+    ImportedPlain as PlainAlias,
+)
 
 
 def make_names() -> list[str]:
@@ -59,6 +62,9 @@ def main() -> Result[None, ContractError | RustPanicError]:
     consumed: AttachedModel = AttachedModel(10)
     print(AttachedModel.describe())
     assert AttachedModel.echo("residual") == "residual"
+    assert AttachedModel.echo_strings({"nested": ["left", "right"]}) == {
+        "nested": ["left", "right"]
+    }
     assert attached.inspect() == 41
     assert attached.touch() == 42
     assert consumed.finish() == 43
@@ -66,6 +72,7 @@ def main() -> Result[None, ContractError | RustPanicError]:
     plain: PlainAlias = PlainAlias(12)
     assert ImportedAlias.describe() == "attached-contract"
     assert ImportedAlias.echo("imported") == "imported"
+    assert ImportedAlias.echo_strings("imported-strings") == "imported-strings"
     assert imported.inspect() == 41
     assert imported.touch() == 42
     assert plain.value == 12
@@ -86,5 +93,7 @@ def main() -> Result[None, ContractError | RustPanicError]:
     return None
 
 
-def compile_result_construction() -> Result[AttachedModel, ContractError | RustPanicError]:
+def compile_result_construction() -> Result[
+    AttachedModel, ContractError | RustPanicError
+]:
     return AttachedModel.construct()


### PR DESCRIPTION
## Summary
- retain `Clone + 'static` for ordinary and attached `StringStructural` bodies
- check generic type arguments in the string-only structural proof
- compile and execute nested and imported attached calls in the package-neutral adapter fixture
- add durable negative attached-call evidence

## Validation
- full `sifr_lowering`: 1001 passed, 1 ignored
- full `sifr_codegen`: 1051 passed
- full `sifr_driver`: 532 passed, 76 ignored
- focused StringStructural, codegen, and early-adapter tests
- package-neutral attached fixture compiled with rustc and executed
- structural Rust-bridge native runtime test passed
- affected-crate Clippy with warnings denied
- Rust and Sifr formatting plus repository guardrails

This is the bounded follow-up recorded from the final review of Sifr PR #3317.