### PR TITLE
Support type-directed structural bridges

### DIFF
--- a/crates/sifr_lowering/src/lower/attached_api_declarations.rs
+++ b/crates/sifr_lowering/src/lower/attached_api_declarations.rs
@@ -17,6 +17,20 @@ pub(super) fn owner_type_param(function: &StmtFunctionDef) -> Option<String> {
     })
 }
 
+pub(super) fn type_receiver_owner_type_param(function: &StmtFunctionDef) -> Option<String> {
+    function.decorator_list.iter().find_map(|decorator| {
+        let Expr::Call(call) = &decorator.expression else {
+            return None;
+        };
+        if !matches!(call.func.as_ref(), Expr::Name(name) if name.id.as_str() == "attached_api")
+            || keyword_string(call, "receiver").as_deref() != Some("type")
+        {
+            return None;
+        }
+        keyword_string(call, "owner")
+    })
+}
+
 pub(super) fn collect_set(class: &StmtClassDef, ctx: &mut LowerCtx) {
     let Some(range) = class.decorator_list.iter().find_map(|decorator| {
         matches!(&decorator.expression, Expr::Name(name) if name.id.as_str() == "attached_api_set")

--- a/crates/sifr_lowering/src/lower/rust_interop_structural.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural.rs
@@ -12,6 +12,7 @@ pub(in crate::lower) struct StructuralFunctionContract<'a> {
     pub(in crate::lower) return_type: &'a Type,
     pub(in crate::lower) type_params: &'a [String],
     pub(in crate::lower) declarations: &'a [RustInteropDeclaration],
+    pub(in crate::lower) type_receiver_owner: Option<&'a str>,
     pub(in crate::lower) is_async: bool,
     pub(in crate::lower) span: TextRange,
 }
@@ -26,6 +27,7 @@ pub(in crate::lower) fn validate_structural_function_contract(
         return_type,
         type_params,
         declarations,
+        type_receiver_owner,
         is_async,
         span,
     } = contract;
@@ -202,7 +204,9 @@ pub(in crate::lower) fn validate_structural_function_contract(
             }
             _ => {}
         }
-        if !used {
+        let used_by_type_receiver = exact_bound.as_deref() == Some("StaticProgram")
+            && type_receiver_owner == Some(type_param.as_str());
+        if !used && !used_by_type_receiver {
             structural_type_error(
                 ctx,
                 format!(

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -114,6 +114,55 @@ def decode[T: StaticProgram]() -> Result[T, CodecError | RustPanicError]: ...
 }
 
 #[test]
+fn type_receiver_bridge_uses_its_static_program_owner_without_a_value() {
+    let source = r#"
+from sifr.meta import StaticProgram
+
+class SchemaError(Error):
+    message: str
+
+@attached_api_set
+class SchemaApi:
+    pass
+
+@attached_api("", "SchemaApi", public_name="schema", receiver="type", owner="T")
+@rust.structural
+@rust(bridge.schema.generate)
+def schema[T: StaticProgram]() -> Result[bytes, SchemaError | RustPanicError]: ...
+"#;
+    let parsed = parse_module(source).expect("source should parse");
+    let module = lower_module_with_externals(parsed.suite(), &structural_externals())
+        .map(|result| result.module)
+        .expect("type receiver should supply the static-program owner");
+    assert_eq!(module.type_param_bounds["schema"]["T"], ["StaticProgram"]);
+}
+
+#[test]
+fn ordinary_bridge_still_rejects_an_unused_static_program_owner() {
+    let source = r"
+from sifr.meta import StaticProgram
+
+class SchemaError(Error):
+    message: str
+
+@rust.structural
+@rust(bridge.schema.generate)
+def schema[T: StaticProgram]() -> Result[bytes, SchemaError | RustPanicError]: ...
+";
+    let parsed = parse_module(source).expect("source should parse");
+    let errors = match lower_module_with_externals(parsed.suite(), &structural_externals()) {
+        Ok(_) => panic!("ordinary unused static-program parameters must fail"),
+        Err(errors) => errors,
+    };
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::RUST_TYPE_PROBE_FAILURE)
+            && error
+                .message
+                .contains("is not used by the bridge signature")
+    }));
+}
+
+#[test]
 fn rust_interop_accepts_distinct_structural_input_and_static_output() {
     let source = r"
 from sifr.meta import StaticProgram, Structural

--- a/crates/sifr_lowering/src/lower/typing_and_functions/annotations_and_function_lowering.rs
+++ b/crates/sifr_lowering/src/lower/typing_and_functions/annotations_and_function_lowering.rs
@@ -390,6 +390,8 @@ pub(in crate::lower) fn lower_function(
         .get::<str>(func.name.as_ref())
         .cloned()
         .unwrap_or_default();
+    let type_receiver_owner =
+        super::super::attached_api_declarations::type_receiver_owner_type_param(func);
     validate_structural_function_contract(
         StructuralFunctionContract {
             function_name: func.name.as_str(),
@@ -397,6 +399,7 @@ pub(in crate::lower) fn lower_function(
             return_type: &inferred_return_type,
             type_params: &type_params,
             declarations: &rust_interop,
+            type_receiver_owner: type_receiver_owner.as_deref(),
             is_async: effective_is_async,
             span: func.name.range(),
         },

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -909,7 +909,9 @@ method bodies. Calls lower directly to the declared package function through det
 imports. The lowering substitutes the concrete owner and `Self`, infers residual type parameters,
 and records their concrete arguments in the emitted call identity. Type, shared-borrow,
 mutable-borrow, and owned receivers use the normal call and ownership checks; type-directed calls
-do not construct or pass a dummy owner value.
+do not construct or pass a dummy owner value. For a structural Rust bridge, a type receiver's
+declared owner is a valid use of its exact `StaticProgram` type parameter. The generated call keeps
+that concrete Rust type argument even when no runtime parameter or result contains the owner.
 
 The Native Pydantic-Sifr consumer architecture is documented in
 [`native_pydantic_sifr_architecture.md`](native_pydantic_sifr_architecture.md).

--- a/verification/areas/core_language/fixtures/static_class_adapter/src/api.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/src/api.sifr
@@ -38,6 +38,20 @@ def construct_contract[T: StaticProgram]() -> Result[
 @attached_api(
     "fixture.api",
     "ContractApi",
+    public_name="program_identity_is_bound",
+    receiver="type",
+    owner="T",
+)
+@rust.structural
+@rust(bridge.defaults.program_identity_is_bound)
+def program_identity_is_bound_contract[T: StaticProgram]() -> Result[
+    bool, ContractError | RustPanicError
+]: ...
+
+
+@attached_api(
+    "fixture.api",
+    "ContractApi",
     public_name="echo",
     receiver="type",
     owner="T",

--- a/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
@@ -77,6 +77,8 @@ def main() -> Result[None, ContractError | RustPanicError]:
     assert imported.touch() == 42
     assert plain.value == 12
     try:
+        identity_is_bound: bool = AttachedModel.program_identity_is_bound()
+        assert identity_is_bound
         defaulted: StructuralDefaults = StructuralDefaults.construct()
         expected_value: int64 = 17
         assert defaulted.value == expected_value

--- a/verification/areas/core_language/fixtures/static_class_adapter/src/bridges/defaults.rs
+++ b/verification/areas/core_language/fixtures/static_class_adapter/src/bridges/defaults.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use sifr_runtime::interop::structural::{
     structural_construct, ArenaNode, NodeId, StructuralArena, StructuralConstruct,
     StructuralContractError, StructuralEdgeKind, StructuralKind, StructuralNodeEdge,
-    StructuralScalar, StructuralType,
+    StructuralScalar, StructuralType, StaticProgramType,
 };
 
 #[derive(Debug)]
@@ -26,6 +26,13 @@ impl fmt::Display for ContractError {
 }
 
 impl std::error::Error for ContractError {}
+
+pub fn program_identity_is_bound<T>() -> Result<bool, ContractError>
+where
+    T: StaticProgramType,
+{
+    Ok(T::static_program().header().identity().as_bytes().len() == 32)
+}
 
 pub fn construct_partial<T>() -> Result<T, ContractError>
 where


### PR DESCRIPTION
M11 compiler prerequisite: allow an attached type-receiver structural Rust bridge to use its exact StaticProgram owner without a dummy runtime value. Includes lowering regressions and package-neutral native fixture evidence.