### PR TITLE
Support concrete generic inherited structural programs

### DIFF
--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -171,6 +171,7 @@ mod string_char_cache;
 mod string_char_cache_scan;
 mod structural_identity_codegen;
 mod structural_impl_codegen;
+mod structural_record_fields;
 pub use static_program_codegen::{
     emit_static_specialization_programs, method_slot_cache_fragment, static_program_cache_fragment,
     structural_static_program_owners, structural_static_program_owners_for_project,

--- a/crates/sifr_codegen/src/lib_codegen_tests/class_trait_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/class_trait_codegen_tests.rs
@@ -6,6 +6,9 @@ fn generic_and_inherited_class_formatting_matches_emitted_traits() {
         r#"class Box[T]:
     value: T
 
+class Items[T]:
+    values: list[T]
+
 class Parent:
     value: int
 
@@ -25,7 +28,11 @@ def show_child(value: Child) -> str:
 
     assert!(rust_code.contains("struct Box<T>"), "{rust_code}");
     assert!(
-        rust_code.contains("#[derive(Debug, Clone, PartialEq)]\nstruct Box<T>"),
+        rust_code.contains("#[derive(Debug, Clone, PartialEq, Eq, Hash)]\nstruct Box<T>"),
+        "{rust_code}"
+    );
+    assert!(
+        rust_code.contains("#[derive(Debug, Clone, PartialEq)]\nstruct Items<T>"),
         "{rust_code}"
     );
     assert!(!rust_code.contains("__sifr_type_marker"));

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -601,6 +601,112 @@ fn project_static_program_owners_include_supported_imported_fields() {
     assert!(project.contains("Owner"));
 }
 
+#[test]
+fn concrete_generic_child_flattens_parent_fields_for_structural_bridge() {
+    let parent = HirClass {
+        name: "GenericParent".to_string(),
+        identity: Some("models.GenericParent".to_string()),
+        fields: vec![("value".to_string(), Type::TypeVar("T".to_string()))],
+        type_params: vec!["T".to_string()],
+        is_hashable: true,
+        ..payload_class()
+    };
+    let parent_type = Type::Class {
+        identity: Some("models.GenericParent".to_string()),
+        type_args: vec![Type::Int],
+        name: "GenericParent".to_string(),
+        fields: vec![("value".to_string(), Type::Int)],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let child = HirClass {
+        name: "Concrete".to_string(),
+        identity: Some("main.Concrete".to_string()),
+        fields: vec![("label".to_string(), Type::Str)],
+        parent_class: Some("GenericParent".to_string()),
+        parent_type: Some(parent_type),
+        is_hashable: true,
+        ..payload_class()
+    };
+    let nested = HirClass {
+        name: "Nested".to_string(),
+        identity: Some("main.Nested".to_string()),
+        fields: vec![(
+            "payload".to_string(),
+            Type::Class {
+                identity: Some("main.Concrete".to_string()),
+                type_args: Vec::new(),
+                name: "Concrete".to_string(),
+                fields: vec![
+                    ("value".to_string(), Type::Int),
+                    ("label".to_string(), Type::Str),
+                ],
+                methods: Vec::new(),
+                parent_class: Some("models.GenericParent".to_string()),
+            },
+        )],
+        is_hashable: true,
+        ..payload_class()
+    };
+    let models = module(Vec::new(), vec![parent]);
+    let main = module(vec![structural_function()], vec![child, nested]);
+    let modules = [("models", &models), ("main", &main)];
+
+    let project = crate::generate_rust_multi_with_metadata(&modules, &crate::StdlibCode::default());
+    let main_rust = project
+        .rust_files
+        .get("main")
+        .expect("main module is generated");
+    assert!(
+        main_rust.contains("StructuralType for Concrete"),
+        "{main_rust}"
+    );
+    assert!(
+        main_rust.contains("StructuralConstruct for Concrete"),
+        "{main_rust}"
+    );
+    assert!(
+        main_rust.contains("StructuralProject for Concrete"),
+        "{main_rust}"
+    );
+    assert!(
+        main_rust.contains("StructuralType for Nested"),
+        "{main_rust}"
+    );
+    assert!(main_rust.contains("RecordField(\"value\")"), "{main_rust}");
+    assert!(main_rust.contains("RecordField(\"label\")"), "{main_rust}");
+    assert!(
+        main_rust.contains("genericparent: <GenericParent<i64>>::new(value)"),
+        "{main_rust}"
+    );
+
+    let supported =
+        crate::structural_impl_codegen::structural_record_identities_for_project(&modules);
+    let identities = crate::structural_identity_codegen::static_class_identities_for_project(
+        &modules, &supported,
+    );
+    let expected = nominal_record(
+        "main.Concrete",
+        &[],
+        &[
+            NominalField {
+                name: "value",
+                identity: primitive("int"),
+                required: true,
+                default_identity: None,
+            },
+            NominalField {
+                name: "label",
+                identity: primitive("str"),
+                required: true,
+                default_identity: None,
+            },
+        ],
+        metadata(&[]),
+    );
+    assert_eq!(identities.get("main.Concrete"), Some(&expected));
+}
+
 fn module(functions: Vec<HirFunction>, classes: Vec<HirClass>) -> HirModule {
     HirModule {
         functions,

--- a/crates/sifr_codegen/src/structural_identity_codegen.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 
 mod mapped_opaque;
 mod render;
+use crate::structural_record_fields::{concrete_record_fields, substitute_structural_type};
 use mapped_opaque::{
     mapped_opaque_identity_expression, mapped_opaque_identity_expression_for_imported_type,
 };
@@ -215,10 +216,11 @@ fn compile_class(
             ))
         })
         .collect::<Vec<_>>();
+    let fields = concrete_record_fields(class);
     compile_record(
         &nominal,
         &type_arguments,
-        &class.fields,
+        &fields,
         Some(class),
         module_name,
         context,
@@ -376,64 +378,6 @@ fn compile_type(
         other => unreachable!(
             "unsupported structural type reached compiler-owned identity generation: {other:?}"
         ),
-    }
-}
-
-fn substitute_structural_type(ty: &Type, bindings: &HashMap<String, Type>) -> Type {
-    match ty {
-        Type::TypeVar(name) => bindings.get(name).cloned().unwrap_or_else(|| ty.clone()),
-        Type::List(value) => Type::List(Box::new(substitute_structural_type(value, bindings))),
-        Type::Set(value) => Type::Set(Box::new(substitute_structural_type(value, bindings))),
-        Type::Dict(key, value) => Type::Dict(
-            Box::new(substitute_structural_type(key, bindings)),
-            Box::new(substitute_structural_type(value, bindings)),
-        ),
-        Type::Tuple(values) => Type::Tuple(
-            values
-                .iter()
-                .map(|value| substitute_structural_type(value, bindings))
-                .collect(),
-        ),
-        Type::Union(values) => Type::Union(
-            values
-                .iter()
-                .map(|value| substitute_structural_type(value, bindings))
-                .collect(),
-        ),
-        Type::Class {
-            identity,
-            type_args,
-            name,
-            fields,
-            methods,
-            parent_class,
-        } => Type::Class {
-            identity: identity.clone(),
-            type_args: type_args
-                .iter()
-                .map(|value| substitute_structural_type(value, bindings))
-                .collect(),
-            name: name.clone(),
-            fields: fields
-                .iter()
-                .map(|(name, value)| (name.clone(), substitute_structural_type(value, bindings)))
-                .collect(),
-            methods: methods.clone(),
-            parent_class: parent_class.clone(),
-        },
-        Type::Alias {
-            name,
-            type_args,
-            body,
-        } => Type::Alias {
-            name: name.clone(),
-            type_args: type_args
-                .iter()
-                .map(|value| substitute_structural_type(value, bindings))
-                .collect(),
-            body: Box::new(substitute_structural_type(body, bindings)),
-        },
-        other => other.clone(),
     }
 }
 

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -3,6 +3,8 @@ use sifr_ir::{HirClass, HirModule, RustInteropDecoratorKind};
 use sifr_type_system::{class_rust_name, Type};
 use std::collections::{BTreeSet, HashSet};
 
+use crate::structural_record_fields::structural_record_fields;
+
 const STRUCTURAL: &str = "::sifr_runtime::interop::structural";
 
 impl RustEmitter {
@@ -184,8 +186,17 @@ fn structural_record_identity(class: &HirClass, module_name: Option<&str>) -> St
 }
 
 fn structural_record_supported_in(class: &HirClass, modules: &[(&str, &HirModule)]) -> bool {
-    let mut visiting = BTreeSet::from([class.name.clone()]);
-    class.parent_class.is_none()
+    let mut visiting =
+        BTreeSet::from([class.identity.clone().unwrap_or_else(|| class.name.clone())]);
+    structural_record_supported_with_visiting(class, modules, &mut visiting)
+}
+
+fn structural_record_supported_with_visiting(
+    class: &HirClass,
+    modules: &[(&str, &HirModule)],
+    visiting: &mut BTreeSet<String>,
+) -> bool {
+    structural_parent_supported(class, modules, visiting)
         && !class.is_error_type
         && class.newtype_inner.is_none()
         && crate::structural_identity_codegen::class_identity_inputs_supported(class)
@@ -198,7 +209,42 @@ fn structural_record_supported_in(class: &HirClass, modules: &[(&str, &HirModule
         && class
             .fields
             .iter()
-            .all(|(_, ty)| structural_record_field_supported(ty, modules, &mut visiting))
+            .all(|(_, ty)| structural_record_field_supported(ty, modules, visiting))
+}
+
+fn structural_parent_supported(
+    class: &HirClass,
+    modules: &[(&str, &HirModule)],
+    visiting: &mut BTreeSet<String>,
+) -> bool {
+    let Some(parent_type) = class.parent_type.as_ref() else {
+        return class.parent_class.is_none();
+    };
+    let Type::Class {
+        identity,
+        name,
+        fields,
+        ..
+    } = parent_type.resolve_alias()
+    else {
+        return false;
+    };
+    let Some(parent) = structural_class_candidate(identity.as_deref(), name, modules) else {
+        return false;
+    };
+    parent.parent_class.is_none()
+        && !parent.methods.iter().any(|method| method.name == "new")
+        && !parent.is_error_type
+        && parent.newtype_inner.is_none()
+        && crate::structural_identity_codegen::class_identity_inputs_supported(parent)
+        && parent.python_opaque_declaration().is_none()
+        && !parent
+            .rust_interop
+            .iter()
+            .any(|declaration| declaration.kind == RustInteropDecoratorKind::Opaque)
+        && fields
+            .iter()
+            .all(|(_, ty)| structural_record_field_supported(ty, modules, visiting))
 }
 
 pub(crate) fn structural_mapped_opaque_supported(class: &HirClass) -> bool {
@@ -267,23 +313,8 @@ fn structural_type_supported(
             if candidate.is_enum() {
                 return structural_enum_supported(candidate);
             }
-            if candidate.parent_class.is_some()
-                || candidate.is_error_type
-                || candidate.newtype_inner.is_some()
-                || !crate::structural_identity_codegen::class_identity_inputs_supported(candidate)
-                || candidate.python_opaque_declaration().is_some()
-                || candidate
-                    .rust_interop
-                    .iter()
-                    .any(|declaration| declaration.kind == RustInteropDecoratorKind::Opaque)
-            {
-                return false;
-            }
             visiting.insert(key.to_string());
-            let supported = candidate
-                .fields
-                .iter()
-                .all(|(_, field)| structural_record_field_supported(field, modules, visiting));
+            let supported = structural_record_supported_with_visiting(candidate, modules, visiting);
             visiting.remove(key);
             supported
         }
@@ -428,17 +459,20 @@ fn structural_construct_impl(
     nominal_identity: &str,
     emitter: &mut RustEmitter,
 ) -> RustItem {
-    let edge_cases = class
-        .fields
+    let fields = structural_record_fields(class);
+    let edge_cases = fields
         .iter()
         .enumerate()
-        .map(|(index, (name, _))| {
+        .map(|(index, field)| {
+            let name = field.name;
             format!("{STRUCTURAL}::StructuralEdgeKind::RecordField(\"{name}\") => {index},")
         })
         .collect::<Vec<_>>()
         .join("\n");
-    let mut field_values = Vec::with_capacity(class.fields.len());
-    for (index, (name, ty)) in class.fields.iter().enumerate() {
+    let mut field_values = Vec::with_capacity(fields.len());
+    for (index, field) in fields.iter().enumerate() {
+        let name = field.name;
+        let ty = field.ty;
         let rust_name = crate::Renderer::render_identifier(name);
         let present = if matches!(ty.resolve_alias(), Type::Bytes) {
             format!(
@@ -468,23 +502,39 @@ fn structural_construct_impl(
         ));
     }
     let field_values = field_values.join("\n");
-    let mut initializers = class
-        .fields
+    let inherited_names = fields
         .iter()
-        .map(|(name, _)| crate::Renderer::render_identifier(name))
+        .filter(|field| field.inherited)
+        .map(|field| crate::Renderer::render_identifier(field.name))
         .collect::<Vec<_>>();
+    let mut initializers = Vec::new();
+    if let (Some(parent_name), Some(parent_type)) = (&class.parent_class, &class.parent_type) {
+        let parent_rust_type =
+            crate::Renderer::render_type_string(&crate::sifr_type_to_rust_type(parent_type));
+        initializers.push(format!(
+            "{}: <{parent_rust_type}>::new({})",
+            parent_name.to_lowercase(),
+            inherited_names.join(", ")
+        ));
+    }
+    initializers.extend(
+        fields
+            .iter()
+            .filter(|field| !field.inherited)
+            .map(|field| crate::Renderer::render_identifier(field.name)),
+    );
     if RustEmitter::class_needs_phantom_marker(class) {
         initializers.push("__sifr_type_marker: std::marker::PhantomData".to_string());
     }
-    let collect_children = if class.fields.is_empty() {
+    let collect_children = if fields.is_empty() {
         format!(
             "if !description.edges().is_empty() {{ return Err({STRUCTURAL}::StructuralContractError::MemberMismatch); }}"
         )
     } else {
         format!(
             "let mut child_nodes: [Option<{STRUCTURAL}::NodeId>; {}] = [None; {}];\nfor edge in description.edges() {{\nlet field_index: usize = match edge.kind() {{\n{edge_cases}\n_ => return Err({STRUCTURAL}::StructuralContractError::MemberMismatch),\n}};\nif child_nodes[field_index].replace(edge.node()).is_some() {{ return Err({STRUCTURAL}::StructuralContractError::MemberMismatch); }}\n}}",
-            class.fields.len(),
-            class.fields.len()
+            fields.len(),
+            fields.len()
         )
     };
     let body = format!(
@@ -535,18 +585,32 @@ fn structural_project_impl(
     type_params: Vec<RustTypeParam>,
     nominal_identity: &str,
 ) -> RustItem {
-    let visits = class
-        .fields
+    let fields = structural_record_fields(class);
+    let visits = fields
         .iter()
-        .map(|(name, ty)| {
+        .map(|field| {
+            let name = field.name;
+            let ty = field.ty;
             let rust_name = crate::Renderer::render_identifier(name);
+            let access = if field.inherited {
+                format!(
+                    "self.{}.{rust_name}",
+                    class
+                        .parent_class
+                        .as_deref()
+                        .unwrap_or_default()
+                        .to_lowercase()
+                )
+            } else {
+                format!("self.{rust_name}")
+            };
             if matches!(ty.resolve_alias(), Type::Bytes) {
                 return format!(
-                    "visitor.edge({STRUCTURAL}::StructuralEdge::new({STRUCTURAL}::StructuralEdgeKind::RecordField(\"{name}\")))?;\n{STRUCTURAL}::project_bytes(&self.{rust_name}, visitor)?;"
+                    "visitor.edge({STRUCTURAL}::StructuralEdge::new({STRUCTURAL}::StructuralEdgeKind::RecordField(\"{name}\")))?;\n{STRUCTURAL}::project_bytes(&{access}, visitor)?;"
                 );
             }
             format!(
-                "visitor.edge({STRUCTURAL}::StructuralEdge::new({STRUCTURAL}::StructuralEdgeKind::RecordField(\"{name}\")))?;\n{STRUCTURAL}::StructuralProject::structural_project(&self.{rust_name}, visitor)?;"
+                "visitor.edge({STRUCTURAL}::StructuralEdge::new({STRUCTURAL}::StructuralEdgeKind::RecordField(\"{name}\")))?;\n{STRUCTURAL}::StructuralProject::structural_project(&{access}, visitor)?;"
             )
         })
         .collect::<Vec<_>>()
@@ -554,7 +618,7 @@ fn structural_project_impl(
     let body = format!(
         "let control = visitor.enter({STRUCTURAL}::StructuralEnter::new({STRUCTURAL}::StructuralKind::Record, Some({}), {}))?;\nif control == {STRUCTURAL}::VisitControl::Continue {{\n{visits}\n}}\nvisitor.exit({STRUCTURAL}::StructuralKind::Record)",
         nominal_identity,
-        class.fields.len()
+        fields.len()
     );
     RustItem::Impl {
         target: target.to_string(),

--- a/crates/sifr_codegen/src/structural_record_fields.rs
+++ b/crates/sifr_codegen/src/structural_record_fields.rs
@@ -1,0 +1,98 @@
+use sifr_ir::HirClass;
+use sifr_type_system::Type;
+use std::collections::HashMap;
+
+pub(crate) struct StructuralRecordField<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) ty: &'a Type,
+    pub(crate) inherited: bool,
+}
+
+pub(crate) fn structural_record_fields(class: &HirClass) -> Vec<StructuralRecordField<'_>> {
+    let mut fields = class
+        .parent_type
+        .as_ref()
+        .and_then(|parent| match parent.resolve_alias() {
+            Type::Class { fields, .. } => Some(fields.as_slice()),
+            _ => None,
+        })
+        .unwrap_or_default()
+        .iter()
+        .map(|(name, ty)| StructuralRecordField {
+            name,
+            ty,
+            inherited: true,
+        })
+        .collect::<Vec<_>>();
+    fields.extend(class.fields.iter().map(|(name, ty)| StructuralRecordField {
+        name,
+        ty,
+        inherited: false,
+    }));
+    fields
+}
+
+pub(crate) fn concrete_record_fields(class: &HirClass) -> Vec<(String, Type)> {
+    structural_record_fields(class)
+        .into_iter()
+        .map(|field| (field.name.to_string(), field.ty.clone()))
+        .collect()
+}
+
+pub(crate) fn substitute_structural_type(ty: &Type, bindings: &HashMap<String, Type>) -> Type {
+    match ty {
+        Type::TypeVar(name) => bindings.get(name).cloned().unwrap_or_else(|| ty.clone()),
+        Type::List(value) => Type::List(Box::new(substitute_structural_type(value, bindings))),
+        Type::Set(value) => Type::Set(Box::new(substitute_structural_type(value, bindings))),
+        Type::Dict(key, value) => Type::Dict(
+            Box::new(substitute_structural_type(key, bindings)),
+            Box::new(substitute_structural_type(value, bindings)),
+        ),
+        Type::Tuple(values) => Type::Tuple(
+            values
+                .iter()
+                .map(|value| substitute_structural_type(value, bindings))
+                .collect(),
+        ),
+        Type::Union(values) => Type::Union(
+            values
+                .iter()
+                .map(|value| substitute_structural_type(value, bindings))
+                .collect(),
+        ),
+        Type::Class {
+            identity,
+            type_args,
+            name,
+            fields,
+            methods,
+            parent_class,
+        } => Type::Class {
+            identity: identity.clone(),
+            type_args: type_args
+                .iter()
+                .map(|value| substitute_structural_type(value, bindings))
+                .collect(),
+            name: name.clone(),
+            fields: fields
+                .iter()
+                .map(|(name, value)| (name.clone(), substitute_structural_type(value, bindings)))
+                .collect(),
+            methods: methods.clone(),
+            parent_class: parent_class.clone(),
+        },
+        Type::Alias {
+            name,
+            type_args,
+            body,
+        } => Type::Alias {
+            name: name.clone(),
+            type_args: type_args
+                .iter()
+                .map(|value| substitute_structural_type(value, bindings))
+                .collect(),
+            body: Box::new(substitute_structural_type(body, bindings)),
+        },
+        other => other.clone(),
+    }
+}

--- a/crates/sifr_driver/src/tests/early_adapters.rs
+++ b/crates/sifr_driver/src/tests/early_adapters.rs
@@ -1,6 +1,7 @@
 use super::support::parse_suite;
 use crate::{collect_project_hir_modules, compile_stdlib};
 use sifr_ir::{DeclarationMetadataTargetKind, StaticProgramValue};
+use sifr_type_system::Type;
 use std::collections::HashMap;
 
 pub(super) const TYPES: &str = r#"
@@ -493,6 +494,29 @@ def main():
     let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
     let compiled = collect_project_hir_modules(&modules, stdlib_defs)
         .expect("concrete generic adapted child should receive attached APIs");
+    let output = compiled
+        .external_defs
+        .specialization_outputs
+        .get("main")
+        .and_then(|outputs| outputs.iter().find(|output| output.owner == "Concrete"))
+        .expect("concrete generic adapted child should own a static program");
+    assert_eq!(output.package_module, "fixture.contract");
+    let exported = compiled
+        .external_defs
+        .classes
+        .get("main")
+        .and_then(|classes| classes.get("Concrete"))
+        .expect("concrete generic child should be exported");
+    let Type::Class { fields, .. } = exported.resolve_alias() else {
+        panic!("concrete generic child should retain its class type");
+    };
+    assert_eq!(
+        fields,
+        &vec![
+            ("value".to_string(), Type::Int),
+            ("label".to_string(), Type::Str),
+        ]
+    );
     let main = compiled
         .hir_modules
         .get("main")

--- a/crates/sifr_frontend/src/export_type_localization.rs
+++ b/crates/sifr_frontend/src/export_type_localization.rs
@@ -1,4 +1,4 @@
-use sifr_lowering::{ExternalDefs, HirModule};
+use sifr_lowering::{ExternalDefs, HirClass, HirModule};
 use sifr_type_system::Type;
 use std::collections::HashMap;
 
@@ -9,6 +9,21 @@ pub(crate) fn should_export_callable(module_name: &str, callable_name: &str) -> 
 pub(crate) type GenericExports = HashMap<String, Vec<String>>;
 pub(crate) type BoundExports = HashMap<String, HashMap<String, Vec<String>>>;
 pub(crate) type ImportedClassAncestry = HashMap<String, (String, Option<String>)>;
+
+pub(crate) fn exported_class_fields(class: &HirClass) -> Vec<(String, Type)> {
+    class
+        .parent_type
+        .as_ref()
+        .and_then(|parent| match parent.resolve_alias() {
+            Type::Class { fields, .. } => Some(fields.as_slice()),
+            _ => None,
+        })
+        .into_iter()
+        .flatten()
+        .chain(class.fields.iter())
+        .cloned()
+        .collect()
+}
 
 pub(crate) fn imported_class_ancestry(
     module: &HirModule,

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -7,7 +7,7 @@ use crate::class_method_exports::{structural_method_map, ClassMethodExports};
 pub(crate) use crate::export_type_localization::should_export_callable;
 use crate::export_type_localization::{
     copy_class_generic_metadata, copy_function_generic_metadata, declared_generic_metadata,
-    exported_parent_chain, imported_class_ancestry, reexport_class_aliases,
+    exported_class_fields, exported_parent_chain, imported_class_ancestry, reexport_class_aliases,
 };
 use crate::module_export_storage::replace_module_entry;
 use crate::module_signatures::ModuleSignature;
@@ -313,7 +313,7 @@ pub fn collect_module_exports(
                             .map(Type::TypeVar)
                             .collect(),
                         name: class.name.clone(),
-                        fields: class.fields.clone(),
+                        fields: exported_class_fields(class),
                         methods,
                         parent_class: exported_parent_chain(
                             class.parent_class.as_deref(),

--- a/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
@@ -1,5 +1,4 @@
 use super::class_shape_metadata::{declaration_metadata, field_default_identities, field_defaults};
-use super::is_hashable_type;
 use super::parameter_conventions::{
     class_method_param_convention, class_method_param_default, declared_receiver_convention,
     prepare_method_param_ownership,
@@ -13,6 +12,7 @@ use super::{
     HirClassKind, HirFunction, HirParam, LowerCtx, MethodKind, ParamConvention, Ranged, Stmt,
     StmtClassDef, Type,
 };
+use super::{is_derivably_hashable_type, is_hashable_type};
 use crate::lower::ownership_diagnostics;
 use crate::lower::python_interop::{
     classify_python_interop_stub_body, collect_python_method_declarations,
@@ -409,7 +409,9 @@ pub(in crate::lower) fn lower_class(
         .collect();
 
     // Determine if all fields are hashable (primitives: int, float, bool, str)
-    let is_hashable = all_fields.iter().all(|(_, ty)| is_hashable_type(ty));
+    let is_hashable = all_fields
+        .iter()
+        .all(|(_, ty)| is_derivably_hashable_type(ty));
 
     let mut hir_methods = Vec::new();
     let mut operator_impls = Vec::new();

--- a/crates/sifr_lowering/src/lower/classes/class_semantics.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_semantics.rs
@@ -6,6 +6,35 @@ pub(in crate::lower) fn is_hashable_type(ty: &Type) -> bool {
     ty.supports_hash_key()
 }
 
+/// Check whether Rust can derive conditional `Eq` and `Hash` implementations.
+///
+/// A type variable is valid here because Rust adds the required bounds to the
+/// generated trait implementation. Containers that are never hashable remain
+/// excluded even when they contain a type variable.
+pub(in crate::lower) fn is_derivably_hashable_type(ty: &Type) -> bool {
+    match ty.resolve_alias() {
+        Type::TypeVar(_) => true,
+        Type::Tuple(values) | Type::Union(values) => values.iter().all(is_derivably_hashable_type),
+        Type::Result(left, right) => {
+            is_derivably_hashable_type(left) && is_derivably_hashable_type(right)
+        }
+        Type::Newtype { inner, .. } => is_derivably_hashable_type(inner),
+        Type::Class {
+            fields,
+            methods,
+            parent_class,
+            ..
+        } => {
+            parent_class.as_deref() != Some("NonSend")
+                && !methods.iter().any(|(name, _)| name == "__eq__")
+                && fields
+                    .iter()
+                    .all(|(_, field)| is_derivably_hashable_type(field))
+        }
+        _ => ty.supports_hash_key(),
+    }
+}
+
 /// Check if a method body directly mutates receiver-owned storage.
 pub(in crate::lower) fn body_contains_receiver_mutation(stmts: &[HirStmt]) -> bool {
     fn stmt_contains_receiver_mutation(stmt: &HirStmt) -> bool {

--- a/demos/generic_classes/emitted.rs
+++ b/demos/generic_classes/emitted.rs
@@ -1,5 +1,5 @@
 // src/main.rs
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct Pair<T> {
     first: T,
     second: T,
@@ -55,7 +55,7 @@ impl<T> Stack<T> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct Wrapper<T> {
     value: T,
 }

--- a/demos/generic_functions_and_iterators/emitted.rs
+++ b/demos/generic_functions_and_iterators/emitted.rs
@@ -187,7 +187,7 @@ fn pow(x: f64, y: f64) -> f64 {
 }
 // --- end stdlib ---
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct Container<T> {
     value: T,
 }

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -898,6 +898,13 @@ HIR because their executable call expression is not a constant literal; bound ch
 identity, and code generation all consume that same identity. Required omissions remain typed
 structural contract errors rather than generated panics.
 
+Structural support includes a class with one direct data parent when that parent uses the
+compiler-generated constructor. The parent cannot have another data parent. The wire record lists
+concrete inherited fields before local fields. Rust storage keeps the parent embedded. Structural
+construction builds that embedded parent, and projection reads inherited fields through it. A
+supported inherited record can also appear inside another structural record. Module exports keep
+the same flattened field list, so imported code retains inherited field access.
+
 Attached package APIs are erased compile-time declarations grouped into canonical module-and-set
 identities. Adapter output selects exactly one set. Provisional lowering may expose visible
 package candidates so class bodies can type-check before adapter execution, while final lowering
@@ -1116,7 +1123,10 @@ supports them. This is a language rule, not an implementation detail.
   fieldless declaration has a valid, inhabited Rust representation without
   inheriting the argument's Rust auto traits. Concrete Clone, Debug, equality,
   and hash capability checks still include every type argument because Rust's
-  generated derives impose those bounds.
+  generated derives impose those bounds. A generic field can therefore receive
+  conditional `Eq` and `Hash` derives. Rust applies the required bounds to each
+  concrete type argument. A container that is never hashable does not receive
+  those derives.
 - **Codegen:** the compiler emits only the derives supported by the complete
   generated struct, newtype, or union representation.
 - **Enum types (enum type-system work):** enum types unconditionally derive `Debug`, `Clone`, `PartialEq`, `Eq`, `Hash`. All enum values are usable as dict keys and set members.

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -150,6 +150,13 @@ lowering also uses the package function's checked defaults for omitted public
 arguments; instance receivers shift default indexes after the hidden owner is
 removed.
 
+A concrete adapted subclass can use one direct, structurally supported generic
+data parent. Static-program identity flattens the parent's substituted fields
+before local fields. Generated Rust keeps the parent as embedded storage.
+Structural construction calls the parent's compiler-generated constructor, and
+projection reads inherited fields through that storage. This support does not
+accept a parent with another data parent or an explicit constructor.
+
 Project code generation checks structural program owners against the complete module graph.
 An imported mapped opaque field uses the generated package type's structural identity.
 It does not refer to the dependency's private Rust bridge path from the consumer module.

--- a/internal_docs/native_pydantic_sifr_architecture.md
+++ b/internal_docs/native_pydantic_sifr_architecture.md
@@ -763,6 +763,10 @@ Pydantic-Sifr uses these rules:
   declaration.
 - The data parent can be a concretely instantiated generic class that uses the
   same adapter provider.
+- A concrete child gets one static program from its flattened inherited and
+  local fields. Generated Rust keeps the concrete generic parent embedded.
+- The structural bridge constructs that embedded parent and projects inherited
+  fields through it. The parent must use the compiler-generated constructor.
 - Schema generation requires concrete type arguments.
 
 ### Identity and bounded evaluation

--- a/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
@@ -3,6 +3,7 @@ from fixture.facade import Contract, ContractError, contract_config, contract_fi
 from fixture.factories import Token as ExternalToken, make_names as external_names
 from fixture.models import (
     ImportedAttached as ImportedAlias,
+    ImportedConcrete,
     ImportedPlain as PlainAlias,
 )
 
@@ -45,6 +46,18 @@ class StructuralDefaults(Contract):
     names: list[str] = contract_field(default_factory=make_names)
 
 
+class GenericAttached[T](Contract):
+    value: T
+
+
+class ConcreteAttached(GenericAttached[int]):
+    label: str
+
+    def __init__(self, value: int, label: str):
+        super().__init__(value)
+        self.label = label
+
+
 def main() -> Result[None, ContractError | RustPanicError]:
     first: Model = Model(7)
     second: Model = Model(8)
@@ -76,6 +89,14 @@ def main() -> Result[None, ContractError | RustPanicError]:
     assert imported.inspect() == 41
     assert imported.touch() == 42
     assert plain.value == 12
+    concrete: ConcreteAttached = ConcreteAttached(13, "local")
+    imported_concrete: ImportedConcrete = ImportedConcrete(14, "imported")
+    assert ConcreteAttached.describe() == "attached-contract"
+    assert ImportedConcrete.describe() == "attached-contract"
+    assert concrete.value == 13
+    assert concrete.label == "local"
+    assert imported_concrete.value == 14
+    assert imported_concrete.label == "imported"
     try:
         identity_is_bound: bool = AttachedModel.program_identity_is_bound()
         assert identity_is_bound

--- a/verification/areas/core_language/fixtures/static_class_adapter/src/models.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/src/models.sifr
@@ -9,3 +9,15 @@ class ImportedAttached(Contract):
 class ImportedPlain(Contract):
     _config = contract_config(True)
     value: int
+
+
+class ImportedGeneric[T](Contract):
+    value: T
+
+
+class ImportedConcrete(ImportedGeneric[int]):
+    label: str
+
+    def __init__(self, value: int, label: str):
+        super().__init__(value)
+        self.label = label


### PR DESCRIPTION
## Summary
- generate structural identity, construction, and projection for a class with one supported direct generic data parent
- preserve flattened inherited fields across module exports and nested structural records
- emit conditional Eq and Hash derives for generic field parameters
- add package-neutral local, imported, nested, and native fixture coverage

## Validation
- cargo test -p sifr_lowering
- cargo test -p sifr_frontend
- cargo test -p sifr_codegen
- cargo test -p sifr_driver --lib -- --skip test_e2e_pass
- affected-crate clippy with warnings denied
- formatting, maintainability, file-size, docs-link, and diff guards
- release compiler build
- package-neutral static class-adapter fixture built and ran through rustc
- M11 package source check passed; native build reaches only package-owned generic wrapper bound errors