### PR TITLE
Preserve structural bounds on ordinary generics

### DIFF
--- a/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
+++ b/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
@@ -20,10 +20,13 @@ impl RustEmitter {
             .iter()
             .map(|type_param| {
                 let string_structural = self
-                    .structural_type_params
+                    .string_structural_type_params
                     .get(&func.name)
                     .is_some_and(|params| params.contains(type_param));
-                let structural = string_structural
+                let structural = self
+                    .structural_type_params
+                    .get(&func.name)
+                    .is_some_and(|params| params.contains(type_param))
                     || func.rust_interop.iter().any(|declaration| {
                         declaration.kind == sifr_ir::RustInteropDecoratorKind::Structural
                     });

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -515,7 +515,36 @@ fn plain_string_structural_generic_emits_projection_bounds() {
 }
 
 #[test]
-fn attached_structural_generic_preserves_attached_api_bounds() {
+fn plain_structural_generic_emits_projection_bounds() {
+    let mut retain = ordinary_function("retain", Type::TypeVar("T".to_string()));
+    retain.return_type = Type::TypeVar("T".to_string());
+    retain.type_params = vec!["T".to_string()];
+    retain.body = vec![sifr_ir::HirStmt::Return {
+        value: Some(HirExpr::Name {
+            name: "value".to_string(),
+            binding_id: None,
+            ty: Type::TypeVar("T".to_string()),
+        }),
+    }];
+    let mut module = module(vec![retain], Vec::new());
+    module.type_param_bounds.insert(
+        "retain".to_string(),
+        std::collections::HashMap::from([("T".to_string(), vec!["Structural".to_string()])]),
+    );
+
+    let rust_code = generate_rust(&module);
+
+    assert!(
+        rust_code.contains(
+            "T: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject"
+        ),
+        "{rust_code}"
+    );
+    assert!(!rust_code.contains("T: Clone + 'static"), "{rust_code}");
+}
+
+#[test]
+fn attached_structural_generic_emits_projection_bounds() {
     let mut retain = ordinary_function("retain", Type::TypeVar("T".to_string()));
     retain.return_type = Type::TypeVar("T".to_string());
     retain.type_params = vec!["T".to_string()];
@@ -535,11 +564,13 @@ fn attached_structural_generic_preserves_attached_api_bounds() {
 
     let rust_code = generate_rust(&module);
 
-    assert!(rust_code.contains("T: Clone + 'static"), "{rust_code}");
     assert!(
-        !rust_code.contains("T: ::sifr_runtime::interop::structural::StructuralConstruct"),
+        rust_code.contains(
+            "T: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject"
+        ),
         "{rust_code}"
     );
+    assert!(!rust_code.contains("T: Clone + 'static"), "{rust_code}");
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -63,8 +63,10 @@ pub struct RustEmitter {
     pub(crate) structural_identity_module_name: Option<String>,
     /// Static-program type parameters for each structural bridge function.
     pub(crate) static_program_type_params: HashMap<String, HashSet<String>>,
-    /// Structurally projected type parameters, including compile-time string-leaf subsets.
+    /// Type parameters with a source-level `Structural` or `StringStructural` bound.
     pub(crate) structural_type_params: HashMap<String, HashSet<String>>,
+    /// Type parameters whose structural shape is restricted to string leaves.
+    pub(crate) string_structural_type_params: HashMap<String, HashSet<String>>,
     /// Method-slot owners for each structural bridge function.
     pub(crate) method_slot_type_params: HashMap<String, HashSet<String>>,
     /// Caller-context type parameters for each structural bridge function.
@@ -247,6 +249,7 @@ impl RustEmitter {
             structural_identity_module_name: None,
             static_program_type_params: HashMap::new(),
             structural_type_params: HashMap::new(),
+            string_structural_type_params: HashMap::new(),
             method_slot_type_params: HashMap::new(),
             context_type_params: HashMap::new(),
             used_stdlib_modules: HashSet::new(),

--- a/crates/sifr_codegen/src/module_prescan.rs
+++ b/crates/sifr_codegen/src/module_prescan.rs
@@ -14,6 +14,20 @@ impl RustEmitter {
             .filter_map(|(owner, bounds)| {
                 let params = bounds
                     .iter()
+                    .filter(|(_, values)| {
+                        matches!(values.as_slice(), [bound] if bound == "Structural" || bound == "StringStructural")
+                    })
+                    .map(|(name, _)| name.clone())
+                    .collect::<HashSet<_>>();
+                (!params.is_empty()).then(|| (owner.clone(), params))
+            })
+            .collect();
+        self.string_structural_type_params = module
+            .type_param_bounds
+            .iter()
+            .filter_map(|(owner, bounds)| {
+                let params = bounds
+                    .iter()
                     .filter(|(_, values)| values.as_slice() == ["StringStructural"])
                     .map(|(name, _)| name.clone())
                     .collect::<HashSet<_>>();


### PR DESCRIPTION
## Summary
- classify ordinary `Structural` type parameters separately from `StringStructural`
- emit `StructuralConstruct + StructuralProject` for plain and attached generic Sifr functions
- retain the additional clone/static contract only for `StringStructural`

## Phase item
M11 compiler prerequisite 6 for `ad-hoc-static-class-adapters-and-pydantic-ergonomics`.

## Validation
- `cargo test -p sifr_codegen` (1053 passed)
- `cargo clippy -p sifr_codegen -- -D warnings`
- `cargo fmt --check`
- HIR maintainability guardrails, touched-file 900-line guardrail, and `git diff --check`
- release compiler regenerated the package M11 attached wrappers with the required construction/projection bounds; the build advanced to the package's separate registry-dependency policy failure
