### PR TITLE
fix: specialize adapted generic field plans

### DIFF
--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -19,6 +19,7 @@ use crate::const_canonical::canonical_value;
 use canonical_helpers::canonical_sequence;
 mod defaults;
 use defaults::shape_field_default;
+mod generic_fields;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructuralShape {
@@ -362,13 +363,15 @@ fn describe_class(
                     .map(|selection| selection.field_plans.as_slice()),
             )
         };
-    let planned_fields = field_plans.map(|plans| {
-        plans
-            .iter()
-            .map(|field| (field.name.clone(), field.declared_type.clone()))
-            .collect::<Vec<_>>()
-    });
-    let effective_fields = planned_fields.as_deref().unwrap_or(fields);
+    let effective_fields = generic_fields::effective_fields(
+        local_class,
+        source_module,
+        source_name,
+        type_args,
+        fields,
+        field_plans,
+        external_defs,
+    );
     let described_fields = effective_fields
         .iter()
         .enumerate()

--- a/crates/sifr_frontend/src/structural_shape/generic_fields.rs
+++ b/crates/sifr_frontend/src/structural_shape/generic_fields.rs
@@ -1,0 +1,44 @@
+//! Concrete field types selected by finalized adapted generic declarations.
+
+use sifr_lowering::{substitute_type_vars, AdapterFieldPlan, ExternalDefs, HirClass};
+use sifr_type_system::Type;
+use std::collections::HashMap;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn effective_fields(
+    local_class: Option<&HirClass>,
+    source_module: &str,
+    source_name: &str,
+    type_args: &[Type],
+    declared_fields: &[(String, Type)],
+    field_plans: Option<&[AdapterFieldPlan]>,
+    external_defs: &ExternalDefs,
+) -> Vec<(String, Type)> {
+    let Some(field_plans) = field_plans else {
+        return declared_fields.to_vec();
+    };
+    let type_params = local_class
+        .map(|class| class.type_params.as_slice())
+        .or_else(|| {
+            external_defs
+                .class_type_params
+                .get(source_module)
+                .and_then(|classes| classes.get(source_name))
+                .map(Vec::as_slice)
+        })
+        .unwrap_or_default();
+    let bindings = type_params
+        .iter()
+        .cloned()
+        .zip(type_args.iter().cloned())
+        .collect::<HashMap<_, _>>();
+    field_plans
+        .iter()
+        .map(|field| {
+            (
+                field.name.clone(),
+                substitute_type_vars(&field.declared_type, &bindings),
+            )
+        })
+        .collect()
+}

--- a/crates/sifr_frontend/src/structural_shape/tests.rs
+++ b/crates/sifr_frontend/src/structural_shape/tests.rs
@@ -345,6 +345,63 @@ class Container:
 }
 
 #[test]
+fn adapted_generic_field_plan_uses_concrete_class_arguments() {
+    use sifr_lowering::{AdapterFieldDefault, AdapterFieldPlan, ClassAdapterSelection};
+
+    let source = r#"
+class Box[T]:
+    value: T
+
+class Container:
+    item: Box[int]
+"#;
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let mut lowered = lower_module(&parsed).expect("fixture lowers");
+    lowered
+        .class_adapter_selections
+        .push(ClassAdapterSelection {
+            owner: "Box".to_string(),
+            provider_module: "fixture.adapter".to_string(),
+            provider_function: "adapt".to_string(),
+            descriptor_type: Type::None,
+            marker_identities: Vec::new(),
+            data_parent: None,
+            field_plans: vec![AdapterFieldPlan {
+                identity: "fixture.generic_fields.Box.value".to_string(),
+                name: "value".to_string(),
+                declared_type: Type::TypeVar("T".to_string()),
+                default: AdapterFieldDefault::Required,
+                validation_policy: None,
+            }],
+            handler_plans: Vec::new(),
+            attached_api_set: None,
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
+            range: ruff_text_size::TextRange::default(),
+        });
+    let container = &lowered.module.classes[1];
+    let shape = describe_type(
+        "fixture.generic_fields",
+        &class_type(container, Vec::new()),
+        &lowered,
+    );
+    let ShapeNode::Nominal { fields, .. } = shape.root else {
+        panic!("container must have a nominal shape");
+    };
+    let ShapeNode::Nominal {
+        fields: box_fields, ..
+    } = &fields[0].declared_type
+    else {
+        panic!("container item must preserve its concrete box shape");
+    };
+    assert_eq!(
+        box_fields[0].declared_type,
+        ShapeNode::Primitive("int".to_string())
+    );
+    assert!(!shape.canonical_identity.contains("param:T"));
+}
+
+#[test]
 fn inherited_handler_preserves_checked_signature_and_uses_child_diagnostic_origin() {
     use sifr_lowering::{
         AdapterFieldDefault, AdapterFieldPlan, AdapterHandlerPlan, CallableIdentity,

--- a/crates/sifr_frontend/src/structural_shape_import_tests.rs
+++ b/crates/sifr_frontend/src/structural_shape_import_tests.rs
@@ -120,6 +120,60 @@ class Use:
 }
 
 #[test]
+fn imported_adapted_generic_field_plan_uses_the_concrete_argument() {
+    let mut external_defs = ExternalDefs::default();
+    let mut models = compile(
+        "models",
+        r#"
+class Box[T]:
+    value: T
+"#,
+        &external_defs,
+    );
+    models.class_adapter_selections.push(ClassAdapterSelection {
+        owner: "Box".to_string(),
+        provider_module: "fixture.adapter".to_string(),
+        provider_function: "adapt".to_string(),
+        descriptor_type: Type::None,
+        marker_identities: Vec::new(),
+        data_parent: None,
+        field_plans: vec![AdapterFieldPlan {
+            identity: "models.Box.value".to_string(),
+            name: "value".to_string(),
+            declared_type: Type::TypeVar("T".to_string()),
+            default: AdapterFieldDefault::Required,
+            validation_policy: None,
+        }],
+        handler_plans: Vec::new(),
+        attached_api_set: None,
+        adapter_invocation_identity: [0; 32],
+        post_adapter_identity: [0; 32],
+        range: ruff_text_size::TextRange::default(),
+    });
+    collect_module_exports("models", &models, &mut external_defs);
+
+    let consumer = compile(
+        "consumer",
+        "from models import Box\n\nclass Container:\n    item: Box[int]\n",
+        &external_defs,
+    );
+    let shape = describe_type_with_externals(
+        "consumer",
+        field_type(&consumer, "Container", "item"),
+        &consumer,
+        &external_defs,
+    );
+    let ShapeNode::Nominal { fields, .. } = shape.root else {
+        panic!("box must have a nominal shape");
+    };
+    assert_eq!(
+        fields[0].declared_type,
+        ShapeNode::Primitive("int".to_string())
+    );
+    assert!(!shape.canonical_identity.contains("param:T"));
+}
+
+#[test]
 fn recollection_removes_stale_structural_shape_exports() {
     let mut external_defs = ExternalDefs::default();
     let annotated = compile(

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -891,6 +891,11 @@ free declaration input and provider HIR before evaluation. Post-adapter identity
 the invocation to the validated output and is an input to static-program identity, avoiding a
 cycle with later handler and attached-API outputs.
 
+Structural shape derivation specializes finalized adapter field-plan types with the concrete
+owner arguments before package specialization. Local and imported adapted generic classes use the
+same substitution rule, so nested concrete uses do not expose unbound declaration parameters to a
+package specializer.
+
 The same final field state governs structural construction. Structural records match incoming
 edges by field name, reject unknown and duplicate names, and fill omitted defaulted fields from
 their checked HIR defaults. Factory defaults retain a canonical callable-identity side channel in

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -141,6 +141,9 @@ The provisional adapter pass accepts `StaticProgram` bounds before attached API 
 The final pass still requires a produced program and complete structural support.
 Descriptor-shaped field defaults do not affect required-field ordering during the provisional pass.
 The finalized adapter field plan supplies the required and default states for the final check.
+When a concrete generic adapted type is described, the compiler substitutes its concrete type
+arguments into every finalized field-plan type. The same rule applies to local and imported
+adapted classes. A concrete static-program shape cannot retain the declaration's type parameters.
 
 An unbound generic adapted declaration does not request a schema program.
 A concrete owner must supply all type arguments before static program generation.


### PR DESCRIPTION
## Summary
- substitute concrete owner arguments into finalized adapted field-plan types
- apply the same structural-shape rule to local and imported generic classes
- split generic field specialization from the near-limit structural-shape module
- document the static-program contract

## Validation
- `cargo test -p sifr_frontend` (100 passed)
- `cargo clippy -p sifr_frontend --lib -- -D warnings`
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `python3 scripts/check_file_size_guardrails.py`
- `git diff --check`
- create-PR gate ran once on `1d15737a6bb89f759cd0967876495f9edd4cbadc`; all preceding guards passed, then the separately owned Rust-interop matrix stopped on the known missing generated-type-import negative source and empty method-slot schema placeholder. It was not rerun.

This is the first bounded M12 compiler hardening item.