### PR TITLE
fix: preserve generic inherited handler plans

### DIFF
--- a/crates/sifr_frontend/src/class_method_exports.rs
+++ b/crates/sifr_frontend/src/class_method_exports.rs
@@ -102,24 +102,31 @@ fn adapted_handler_method(
         .cloned()
         .map(Type::TypeVar)
         .collect::<Vec<_>>();
-    let bindings = crate::handler_ancestry::bindings_for_owner(
+    let ancestry = crate::handler_ancestry::resolve(
         module_name,
         owner,
         &root_args,
         callable_owner,
         lowering,
         external_defs,
-    );
-    if bindings.is_none() {
-        return adapted_imported_parent_method(
-            owner,
-            &root_args,
-            handler,
-            local_classes,
-            external_defs,
-        );
-    }
-    let bindings = bindings.unwrap_or_default();
+    )?;
+    let bindings = match ancestry {
+        crate::handler_ancestry::HandlerAncestry::Owner(bindings) => bindings,
+        crate::handler_ancestry::HandlerAncestry::ImportedBoundary {
+            module,
+            name,
+            bindings,
+        } => {
+            return adapted_imported_boundary_method(
+                &module,
+                &name,
+                &bindings,
+                handler,
+                local_classes,
+                external_defs,
+            );
+        }
+    };
     let (source_module, source_name) = callable_owner.rsplit_once('.')?;
     let hir_name = if handler.callable.symbol == "__init__" {
         "new"
@@ -183,57 +190,28 @@ fn adapted_handler_method(
     Some(method)
 }
 
-fn adapted_imported_parent_method(
-    owner: &HirClass,
-    root_args: &[Type],
+fn adapted_imported_boundary_method(
+    boundary_module: &str,
+    boundary_name: &str,
+    boundary_bindings: &HashMap<String, Type>,
     handler: &AdapterHandlerPlan,
     local_classes: &HashMap<String, String>,
     external_defs: &ExternalDefs,
 ) -> Option<StructuralMethodExport> {
-    let root_bindings = owner
-        .type_params
-        .iter()
-        .cloned()
-        .zip(root_args.iter().cloned())
-        .collect::<HashMap<_, _>>();
-    let Type::Class {
-        identity,
-        name,
-        type_args,
-        ..
-    } = owner.parent_type.as_ref()?.resolve_alias()
-    else {
-        return None;
-    };
-    let parent_identity = identity.as_deref().unwrap_or(name);
-    let (parent_module, parent_name) = parent_identity.rsplit_once('.')?;
-    let parent_params = external_defs
-        .class_type_params
-        .get(parent_module)
-        .and_then(|classes| classes.get(parent_name))?;
-    let parent_bindings = parent_params
-        .iter()
-        .cloned()
-        .zip(
-            type_args
-                .iter()
-                .map(|argument| substitute_type_vars(argument, &root_bindings)),
-        )
-        .collect::<HashMap<_, _>>();
     let mut method = external_defs
-        .structural_methods_for(parent_module)?
-        .get(parent_name)?
+        .structural_methods_for(boundary_module)?
+        .get(boundary_name)?
         .iter()
         .find(|method| method.handler_target.as_ref() == Some(&handler.callable))?
         .clone();
     for parameter in &mut method.params {
         parameter.ty = canonicalize_user_export_type(
-            &substitute_type_vars(&parameter.ty, &parent_bindings),
+            &substitute_type_vars(&parameter.ty, boundary_bindings),
             local_classes,
         );
     }
     method.return_type = canonicalize_user_export_type(
-        &substitute_type_vars(&method.return_type, &parent_bindings),
+        &substitute_type_vars(&method.return_type, boundary_bindings),
         local_classes,
     );
     Some(method)

--- a/crates/sifr_frontend/src/class_method_exports.rs
+++ b/crates/sifr_frontend/src/class_method_exports.rs
@@ -1,7 +1,8 @@
 use sifr_lowering::{
-    canonicalize_user_export_type, DeclarationMetadataTargetKind, ExternalDefs, HirClass,
-    MethodKind, StructuralMethodExport,
+    canonicalize_user_export_type, substitute_type_vars, AdapterHandlerPlan,
+    DeclarationMetadataTargetKind, ExternalDefs, HirClass, MethodKind, StructuralMethodExport,
 };
+use sifr_type_system::Type;
 use std::collections::{HashMap, HashSet};
 
 #[derive(Default)]
@@ -65,6 +66,7 @@ fn exported_structural_methods(
                 .chain(class.operator_impls.iter().map(|(_, method)| method))
                 .find(|method| method.name == hir_name)?;
             Some(StructuralMethodExport {
+                handler_target: None,
                 name: declared_name.to_string(),
                 params: method
                     .params
@@ -85,10 +87,164 @@ fn exported_structural_methods(
     (!methods.is_empty()).then_some(methods)
 }
 
+fn adapted_handler_method(
+    module_name: &str,
+    owner: &HirClass,
+    handler: &AdapterHandlerPlan,
+    local_classes: &HashMap<String, String>,
+    lowering: &sifr_lowering::LoweringResult,
+    external_defs: &ExternalDefs,
+) -> Option<StructuralMethodExport> {
+    let callable_owner = handler.callable.owner.as_deref()?;
+    let root_args = owner
+        .type_params
+        .iter()
+        .cloned()
+        .map(Type::TypeVar)
+        .collect::<Vec<_>>();
+    let bindings = crate::handler_ancestry::bindings_for_owner(
+        module_name,
+        owner,
+        &root_args,
+        callable_owner,
+        lowering,
+        external_defs,
+    );
+    if bindings.is_none() {
+        return adapted_imported_parent_method(
+            owner,
+            &root_args,
+            handler,
+            local_classes,
+            external_defs,
+        );
+    }
+    let bindings = bindings.unwrap_or_default();
+    let (source_module, source_name) = callable_owner.rsplit_once('.')?;
+    let hir_name = if handler.callable.symbol == "__init__" {
+        "new"
+    } else {
+        handler.callable.symbol.as_str()
+    };
+    if source_module == module_name {
+        let source = lowering.module.classes.iter().find(|class| {
+            class.identity.as_deref() == Some(callable_owner)
+                || (class.identity.is_none() && class.name == source_name)
+        })?;
+        let method = source
+            .methods
+            .iter()
+            .chain(source.operator_impls.iter().map(|(_, method)| method))
+            .find(|method| method.name == hir_name)?;
+        return Some(StructuralMethodExport {
+            handler_target: Some(handler.callable.clone()),
+            name: handler.callable.symbol.clone(),
+            params: method
+                .params
+                .iter()
+                .cloned()
+                .map(|mut param| {
+                    param.ty = canonicalize_user_export_type(
+                        &substitute_type_vars(&param.ty, &bindings),
+                        local_classes,
+                    );
+                    param
+                })
+                .collect(),
+            return_type: canonicalize_user_export_type(
+                &substitute_type_vars(&method.return_type, &bindings),
+                local_classes,
+            ),
+            is_async: method.is_async,
+            method_kind: method.method_kind,
+            receiver: method.receiver,
+        });
+    }
+    let method = external_defs
+        .structural_methods_for(source_module)?
+        .get(source_name)?
+        .iter()
+        .find(|method| {
+            method.handler_target.as_ref() == Some(&handler.callable)
+                || (method.handler_target.is_none() && method.name == handler.callable.symbol)
+        })?;
+    let mut method = method.clone();
+    method.handler_target = Some(handler.callable.clone());
+    for parameter in &mut method.params {
+        parameter.ty = canonicalize_user_export_type(
+            &substitute_type_vars(&parameter.ty, &bindings),
+            local_classes,
+        );
+    }
+    method.return_type = canonicalize_user_export_type(
+        &substitute_type_vars(&method.return_type, &bindings),
+        local_classes,
+    );
+    Some(method)
+}
+
+fn adapted_imported_parent_method(
+    owner: &HirClass,
+    root_args: &[Type],
+    handler: &AdapterHandlerPlan,
+    local_classes: &HashMap<String, String>,
+    external_defs: &ExternalDefs,
+) -> Option<StructuralMethodExport> {
+    let root_bindings = owner
+        .type_params
+        .iter()
+        .cloned()
+        .zip(root_args.iter().cloned())
+        .collect::<HashMap<_, _>>();
+    let Type::Class {
+        identity,
+        name,
+        type_args,
+        ..
+    } = owner.parent_type.as_ref()?.resolve_alias()
+    else {
+        return None;
+    };
+    let parent_identity = identity.as_deref().unwrap_or(name);
+    let (parent_module, parent_name) = parent_identity.rsplit_once('.')?;
+    let parent_params = external_defs
+        .class_type_params
+        .get(parent_module)
+        .and_then(|classes| classes.get(parent_name))?;
+    let parent_bindings = parent_params
+        .iter()
+        .cloned()
+        .zip(
+            type_args
+                .iter()
+                .map(|argument| substitute_type_vars(argument, &root_bindings)),
+        )
+        .collect::<HashMap<_, _>>();
+    let mut method = external_defs
+        .structural_methods_for(parent_module)?
+        .get(parent_name)?
+        .iter()
+        .find(|method| method.handler_target.as_ref() == Some(&handler.callable))?
+        .clone();
+    for parameter in &mut method.params {
+        parameter.ty = canonicalize_user_export_type(
+            &substitute_type_vars(&parameter.ty, &parent_bindings),
+            local_classes,
+        );
+    }
+    method.return_type = canonicalize_user_export_type(
+        &substitute_type_vars(&method.return_type, &parent_bindings),
+        local_classes,
+    );
+    Some(method)
+}
+
 pub(crate) fn structural_method_map(
+    module_name: &str,
     module: &sifr_lowering::HirModule,
     local_classes: &HashMap<String, String>,
     lowering: &sifr_lowering::LoweringResult,
+    external_defs: &ExternalDefs,
 ) -> HashMap<String, Vec<StructuralMethodExport>> {
     if module.classes.is_empty() {
         return HashMap::new();
@@ -129,10 +285,7 @@ pub(crate) fn structural_method_map(
             }
         }
     }
-    if names_by_class.is_empty() {
-        return HashMap::new();
-    }
-    module
+    let mut methods = module
         .classes
         .iter()
         .filter_map(|class| {
@@ -140,7 +293,37 @@ pub(crate) fn structural_method_map(
             exported_structural_methods(class, local_classes, declared_names)
                 .map(|methods| (class.name.clone(), methods))
         })
-        .collect()
+        .collect::<HashMap<_, _>>();
+    for selection in &lowering.class_adapter_selections {
+        let Some(owner) = module
+            .classes
+            .iter()
+            .find(|class| class.name == selection.owner)
+        else {
+            continue;
+        };
+        let exports = selection
+            .handler_plans
+            .iter()
+            .filter_map(|handler| {
+                adapted_handler_method(
+                    module_name,
+                    owner,
+                    handler,
+                    local_classes,
+                    lowering,
+                    external_defs,
+                )
+            })
+            .collect::<Vec<_>>();
+        if !exports.is_empty() {
+            methods
+                .entry(selection.owner.clone())
+                .or_default()
+                .extend(exports);
+        }
+    }
+    methods
 }
 
 impl ClassMethodExports {

--- a/crates/sifr_frontend/src/handler_ancestry.rs
+++ b/crates/sifr_frontend/src/handler_ancestry.rs
@@ -4,14 +4,23 @@ use sifr_lowering::{substitute_type_vars, ExternalDefs, HirClass, LoweringResult
 use sifr_type_system::Type;
 use std::collections::{BTreeSet, HashMap};
 
-pub(crate) fn bindings_for_owner(
+pub(crate) enum HandlerAncestry {
+    Owner(HashMap<String, Type>),
+    ImportedBoundary {
+        module: String,
+        name: String,
+        bindings: HashMap<String, Type>,
+    },
+}
+
+pub(crate) fn resolve(
     module_name: &str,
     root: &HirClass,
     root_type_args: &[Type],
     owner_identity: &str,
     lowering: &LoweringResult,
     external_defs: &ExternalDefs,
-) -> Option<HashMap<String, Type>> {
+) -> Option<HandlerAncestry> {
     let bindings = root
         .type_params
         .iter()
@@ -38,13 +47,13 @@ fn walk_local(
     lowering: &LoweringResult,
     external_defs: &ExternalDefs,
     visiting: &mut BTreeSet<String>,
-) -> Option<HashMap<String, Type>> {
+) -> Option<HandlerAncestry> {
     let current_identity = current
         .identity
         .clone()
         .unwrap_or_else(|| format!("{module_name}.{}", current.name));
     if current_identity == owner_identity {
-        return Some(bindings);
+        return Some(HandlerAncestry::Owner(bindings));
     }
     if !visiting.insert(current_identity) {
         return None;
@@ -87,13 +96,19 @@ fn walk_local(
             visiting,
         );
     }
-    if parent_identity != owner_identity {
-        return None;
-    }
     let (source_module, source_name) = parent_identity.rsplit_once('.')?;
     let type_params = external_defs
         .class_type_params
         .get(source_module)
         .and_then(|classes| classes.get(source_name))?;
-    Some(type_params.iter().cloned().zip(parent_args).collect())
+    let parent_bindings = type_params.iter().cloned().zip(parent_args).collect();
+    if parent_identity == owner_identity {
+        Some(HandlerAncestry::Owner(parent_bindings))
+    } else {
+        Some(HandlerAncestry::ImportedBoundary {
+            module: source_module.to_string(),
+            name: source_name.to_string(),
+            bindings: parent_bindings,
+        })
+    }
 }

--- a/crates/sifr_frontend/src/handler_ancestry.rs
+++ b/crates/sifr_frontend/src/handler_ancestry.rs
@@ -1,0 +1,99 @@
+//! Concrete generic bindings from an adapted class to a checked handler owner.
+
+use sifr_lowering::{substitute_type_vars, ExternalDefs, HirClass, LoweringResult};
+use sifr_type_system::Type;
+use std::collections::{BTreeSet, HashMap};
+
+pub(crate) fn bindings_for_owner(
+    module_name: &str,
+    root: &HirClass,
+    root_type_args: &[Type],
+    owner_identity: &str,
+    lowering: &LoweringResult,
+    external_defs: &ExternalDefs,
+) -> Option<HashMap<String, Type>> {
+    let bindings = root
+        .type_params
+        .iter()
+        .cloned()
+        .zip(root_type_args.iter().cloned())
+        .collect();
+    walk_local(
+        module_name,
+        root,
+        bindings,
+        owner_identity,
+        lowering,
+        external_defs,
+        &mut BTreeSet::new(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_local(
+    module_name: &str,
+    current: &HirClass,
+    bindings: HashMap<String, Type>,
+    owner_identity: &str,
+    lowering: &LoweringResult,
+    external_defs: &ExternalDefs,
+    visiting: &mut BTreeSet<String>,
+) -> Option<HashMap<String, Type>> {
+    let current_identity = current
+        .identity
+        .clone()
+        .unwrap_or_else(|| format!("{module_name}.{}", current.name));
+    if current_identity == owner_identity {
+        return Some(bindings);
+    }
+    if !visiting.insert(current_identity) {
+        return None;
+    }
+    let Type::Class {
+        identity,
+        name,
+        type_args,
+        ..
+    } = current.parent_type.as_ref()?.resolve_alias()
+    else {
+        return None;
+    };
+    let parent_identity = identity
+        .clone()
+        .unwrap_or_else(|| format!("{module_name}.{name}"));
+    let parent_args = type_args
+        .iter()
+        .map(|argument| substitute_type_vars(argument, &bindings))
+        .collect::<Vec<_>>();
+    let local_parent = lowering.module.classes.iter().find(|candidate| {
+        candidate.identity.as_deref() == Some(parent_identity.as_str())
+            || (candidate.name == *name
+                && parent_identity == format!("{module_name}.{}", candidate.name))
+    });
+    if let Some(parent) = local_parent {
+        let parent_bindings = parent
+            .type_params
+            .iter()
+            .cloned()
+            .zip(parent_args)
+            .collect();
+        return walk_local(
+            module_name,
+            parent,
+            parent_bindings,
+            owner_identity,
+            lowering,
+            external_defs,
+            visiting,
+        );
+    }
+    if parent_identity != owner_identity {
+        return None;
+    }
+    let (source_module, source_name) = parent_identity.rsplit_once('.')?;
+    let type_params = external_defs
+        .class_type_params
+        .get(source_module)
+        .and_then(|classes| classes.get(source_name))?;
+    Some(type_params.iter().cloned().zip(parent_args).collect())
+}

--- a/crates/sifr_frontend/src/lib.rs
+++ b/crates/sifr_frontend/src/lib.rs
@@ -23,6 +23,7 @@ pub use const_evaluator::*;
 mod structural_shape;
 pub use structural_shape::*;
 mod class_method_exports;
+mod handler_ancestry;
 mod slot_table;
 #[cfg(test)]
 mod slot_table_tests;

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -193,7 +193,13 @@ pub fn collect_module_exports(
     let mut rust_callback_exports = RustCallbackExports::default();
     let (mut generic_exports, mut type_param_bound_exports, local_classes) =
         declared_generic_metadata(module_name, module);
-    let structural_method_exports = structural_method_map(module, &local_classes, lowering_result);
+    let structural_method_exports = structural_method_map(
+        module_name,
+        module,
+        &local_classes,
+        lowering_result,
+        external_defs,
+    );
     let imported_ancestry = imported_class_ancestry(module, external_defs);
 
     for (name, (type_params, alias)) in &lowering_result.generic_type_aliases {

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -410,10 +410,18 @@ fn describe_class(
             .and_then(|classes| classes.get(source_name))
             .map(Vec::as_slice)
             .unwrap_or_default();
+        let handlers = external_defs
+            .class_adapter_selections
+            .get(source_module)
+            .and_then(|classes| classes.get(source_name))
+            .map(|selection| selection.handler_plans.as_slice())
+            .unwrap_or_default();
         described_exported_methods(
             module_name,
+            &identity,
             source_name,
             methods,
+            handlers,
             type_params,
             type_args,
             declaration_metadata,

--- a/crates/sifr_frontend/src/structural_shape/methods.rs
+++ b/crates/sifr_frontend/src/structural_shape/methods.rs
@@ -243,6 +243,16 @@ fn described_handler(
         .clone()
         .unwrap_or_else(|| format!("{module_name}.{}", class.name));
     let callable_owner = handler.callable.owner.as_deref();
+    let root_args = class
+        .type_params
+        .iter()
+        .map(|name| {
+            bindings
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| Type::TypeVar(name.clone()))
+        })
+        .collect::<Vec<_>>();
     let local_detail = callable_owner.and_then(|owner| {
         let (source_module, source_name) = owner.rsplit_once('.')?;
         (source_module == module_name)
@@ -266,9 +276,17 @@ fn described_handler(
             })
             .flatten()
     });
-    let mut method = if let Some((source_name, owner_class, method)) = local_detail {
+    let mut method = if let Some((source_name, _owner_class, method)) = local_detail {
         let owner = format!("{source_name}.{declared_name}");
-        let inherited_bindings = inherited_handler_bindings(class, owner_class, bindings);
+        let inherited_bindings = crate::handler_ancestry::bindings_for_owner(
+            module_name,
+            class,
+            &root_args,
+            callable_owner.unwrap_or(&local_owner),
+            lowering,
+            external_defs,
+        )
+        .unwrap_or_default();
         described_method(
             module_name,
             &owner,
@@ -290,14 +308,20 @@ fn described_handler(
             external_defs,
             visiting,
         )
-    } else if let Some(method) = imported_handler_method(handler, external_defs) {
+    } else if let Some((method, inherited_bindings)) = imported_handler_detail(
+        module_name,
+        class,
+        &root_args,
+        handler,
+        lowering,
+        external_defs,
+    ) {
         let owner_name = handler
             .callable
             .owner
             .as_deref()
             .and_then(|owner| owner.rsplit_once('.').map(|(_, name)| name))
             .unwrap_or(class_name);
-        let inherited_bindings = imported_handler_bindings(class, handler, bindings, external_defs);
         described_method(
             &handler.callable.module,
             &format!("{owner_name}.{declared_name}"),
@@ -339,83 +363,6 @@ fn described_handler(
     method
 }
 
-fn imported_handler_bindings(
-    child: &HirClass,
-    handler: &AdapterHandlerPlan,
-    child_bindings: &HashMap<String, Type>,
-    external_defs: &sifr_lowering::ExternalDefs,
-) -> HashMap<String, Type> {
-    let Some(owner) = handler.callable.owner.as_deref() else {
-        return HashMap::new();
-    };
-    let Some((source_module, source_name)) = owner.rsplit_once('.') else {
-        return HashMap::new();
-    };
-    let Some(Type::Class {
-        identity,
-        name,
-        type_args,
-        ..
-    }) = child.parent_type.as_ref().map(Type::resolve_alias)
-    else {
-        return HashMap::new();
-    };
-    if identity
-        .as_deref()
-        .map_or(name != source_name, |value| value != owner)
-    {
-        return HashMap::new();
-    }
-    let type_params = external_defs
-        .class_type_params
-        .get(source_module)
-        .and_then(|classes| classes.get(source_name))
-        .map(Vec::as_slice)
-        .unwrap_or_default();
-    type_params
-        .iter()
-        .cloned()
-        .zip(
-            type_args
-                .iter()
-                .map(|argument| substitute_type_vars(argument, child_bindings)),
-        )
-        .collect()
-}
-
-fn inherited_handler_bindings(
-    child: &HirClass,
-    owner: &HirClass,
-    child_bindings: &HashMap<String, Type>,
-) -> HashMap<String, Type> {
-    if child.name == owner.name {
-        return child_bindings.clone();
-    }
-    let Some(Type::Class {
-        identity,
-        name,
-        type_args,
-        ..
-    }) = child.parent_type.as_ref().map(Type::resolve_alias)
-    else {
-        return HashMap::new();
-    };
-    let owner_identity = owner.identity.as_deref().unwrap_or(&owner.name);
-    if identity.as_deref().unwrap_or(name) != owner_identity && name != &owner.name {
-        return HashMap::new();
-    }
-    owner
-        .type_params
-        .iter()
-        .cloned()
-        .zip(
-            type_args
-                .iter()
-                .map(|argument| substitute_type_vars(argument, child_bindings)),
-        )
-        .collect()
-}
-
 fn imported_handler_method<'a>(
     handler: &AdapterHandlerPlan,
     external_defs: &'a sifr_lowering::ExternalDefs,
@@ -429,14 +376,76 @@ fn imported_handler_method<'a>(
         .structural_methods_for(source_module)?
         .get(source_name)?
         .iter()
-        .find(|method| method.name == handler.callable.symbol)
+        .find(|method| {
+            method.handler_target.as_ref() == Some(&handler.callable)
+                || (method.handler_target.is_none() && method.name == handler.callable.symbol)
+        })
+}
+
+fn imported_handler_detail<'a>(
+    module_name: &str,
+    class: &HirClass,
+    root_args: &[Type],
+    handler: &AdapterHandlerPlan,
+    lowering: &LoweringResult,
+    external_defs: &'a sifr_lowering::ExternalDefs,
+) -> Option<(&'a StructuralMethodExport, HashMap<String, Type>)> {
+    let owner = handler.callable.owner.as_deref()?;
+    if let Some(bindings) = crate::handler_ancestry::bindings_for_owner(
+        module_name,
+        class,
+        root_args,
+        owner,
+        lowering,
+        external_defs,
+    ) {
+        return Some((imported_handler_method(handler, external_defs)?, bindings));
+    }
+    let root_bindings = class
+        .type_params
+        .iter()
+        .cloned()
+        .zip(root_args.iter().cloned())
+        .collect::<HashMap<_, _>>();
+    let Type::Class {
+        identity,
+        name,
+        type_args,
+        ..
+    } = class.parent_type.as_ref()?.resolve_alias()
+    else {
+        return None;
+    };
+    let parent_identity = identity.as_deref().unwrap_or(name);
+    let (parent_module, parent_name) = parent_identity.rsplit_once('.')?;
+    let parent_params = external_defs
+        .class_type_params
+        .get(parent_module)
+        .and_then(|classes| classes.get(parent_name))?;
+    let parent_bindings = parent_params
+        .iter()
+        .cloned()
+        .zip(
+            type_args
+                .iter()
+                .map(|argument| substitute_type_vars(argument, &root_bindings)),
+        )
+        .collect::<HashMap<_, _>>();
+    let method = external_defs
+        .structural_methods_for(parent_module)?
+        .get(parent_name)?
+        .iter()
+        .find(|method| method.handler_target.as_ref() == Some(&handler.callable))?;
+    Some((method, parent_bindings))
 }
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn described_exported_methods(
     module_name: &str,
+    source_identity: &str,
     class_name: &str,
     methods: &[StructuralMethodExport],
+    handlers: &[AdapterHandlerPlan],
     type_params: &[String],
     type_args: &[Type],
     declaration_metadata: &[TypedDeclarationMetadata],
@@ -449,8 +458,16 @@ pub(super) fn described_exported_methods(
         .cloned()
         .zip(type_args.iter().cloned())
         .collect::<HashMap<_, _>>();
-    methods
+    let own_handler_names = handlers
         .iter()
+        .filter(|handler| handler.callable.owner.as_deref() == Some(source_identity))
+        .map(|handler| handler.callable.symbol.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut described = methods
+        .iter()
+        .filter(|method| {
+            method.handler_target.is_none() && !own_handler_names.contains(method.name.as_str())
+        })
         .map(|method| {
             let owner = format!("{class_name}.{}", method.name);
             described_method(
@@ -475,7 +492,56 @@ pub(super) fn described_exported_methods(
                 visiting,
             )
         })
-        .collect()
+        .collect::<Vec<_>>();
+    let mut ordered_handlers = handlers.iter().collect::<Vec<_>>();
+    ordered_handlers.sort_by_key(|handler| handler.declaration_order);
+    for handler in ordered_handlers {
+        let Some(method) = methods
+            .iter()
+            .find(|method| method.handler_target.as_ref() == Some(&handler.callable))
+        else {
+            continue;
+        };
+        let owner_name = handler
+            .callable
+            .owner
+            .as_deref()
+            .and_then(|owner| owner.rsplit_once('.').map(|(_, name)| name))
+            .unwrap_or(class_name);
+        let owner = format!("{owner_name}.{}", handler.callable.symbol);
+        let handler_metadata = external_defs
+            .declaration_metadata
+            .get(&handler.callable.module)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let mut described_handler = described_method(
+            &handler.callable.module,
+            &owner,
+            &handler.callable.symbol,
+            &method.params,
+            &method.return_type,
+            method.method_kind,
+            method.receiver,
+            method.is_async,
+            &bindings,
+            metadata_for(
+                handler_metadata,
+                &owner,
+                DeclarationMetadataTargetKind::Method,
+                None,
+            ),
+            handler_metadata,
+            lowering,
+            external_defs,
+            visiting,
+        );
+        described_handler.target = Some(handler.callable.clone());
+        described_handler.descriptor = Some(validated_adapter_value(&handler.descriptor_value));
+        described_handler.origin = None;
+        described_handler.declaration_order = Some(handler.declaration_order);
+        described.push(described_handler);
+    }
+    described
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/sifr_frontend/src/structural_shape/methods.rs
+++ b/crates/sifr_frontend/src/structural_shape/methods.rs
@@ -278,15 +278,17 @@ fn described_handler(
     });
     let mut method = if let Some((source_name, _owner_class, method)) = local_detail {
         let owner = format!("{source_name}.{declared_name}");
-        let inherited_bindings = crate::handler_ancestry::bindings_for_owner(
+        let inherited_bindings = match crate::handler_ancestry::resolve(
             module_name,
             class,
             &root_args,
             callable_owner.unwrap_or(&local_owner),
             lowering,
             external_defs,
-        )
-        .unwrap_or_default();
+        ) {
+            Some(crate::handler_ancestry::HandlerAncestry::Owner(bindings)) => bindings,
+            _ => HashMap::new(),
+        };
         described_method(
             module_name,
             &owner,
@@ -322,9 +324,15 @@ fn described_handler(
             .as_deref()
             .and_then(|owner| owner.rsplit_once('.').map(|(_, name)| name))
             .unwrap_or(class_name);
+        let handler_metadata = external_defs
+            .declaration_metadata
+            .get(&handler.callable.module)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let owner = format!("{owner_name}.{declared_name}");
         described_method(
             &handler.callable.module,
-            &format!("{owner_name}.{declared_name}"),
+            &owner,
             declared_name,
             &method.params,
             &method.return_type,
@@ -332,8 +340,13 @@ fn described_handler(
             method.receiver,
             method.is_async,
             &inherited_bindings,
-            Vec::new(),
-            &[],
+            metadata_for(
+                handler_metadata,
+                &owner,
+                DeclarationMetadataTargetKind::Method,
+                None,
+            ),
+            handler_metadata,
             lowering,
             external_defs,
             visiting,
@@ -391,52 +404,30 @@ fn imported_handler_detail<'a>(
     external_defs: &'a sifr_lowering::ExternalDefs,
 ) -> Option<(&'a StructuralMethodExport, HashMap<String, Type>)> {
     let owner = handler.callable.owner.as_deref()?;
-    if let Some(bindings) = crate::handler_ancestry::bindings_for_owner(
+    match crate::handler_ancestry::resolve(
         module_name,
         class,
         root_args,
         owner,
         lowering,
         external_defs,
-    ) {
-        return Some((imported_handler_method(handler, external_defs)?, bindings));
-    }
-    let root_bindings = class
-        .type_params
-        .iter()
-        .cloned()
-        .zip(root_args.iter().cloned())
-        .collect::<HashMap<_, _>>();
-    let Type::Class {
-        identity,
-        name,
-        type_args,
-        ..
-    } = class.parent_type.as_ref()?.resolve_alias()
-    else {
-        return None;
-    };
-    let parent_identity = identity.as_deref().unwrap_or(name);
-    let (parent_module, parent_name) = parent_identity.rsplit_once('.')?;
-    let parent_params = external_defs
-        .class_type_params
-        .get(parent_module)
-        .and_then(|classes| classes.get(parent_name))?;
-    let parent_bindings = parent_params
-        .iter()
-        .cloned()
-        .zip(
-            type_args
+    )? {
+        crate::handler_ancestry::HandlerAncestry::Owner(bindings) => {
+            Some((imported_handler_method(handler, external_defs)?, bindings))
+        }
+        crate::handler_ancestry::HandlerAncestry::ImportedBoundary {
+            module,
+            name,
+            bindings,
+        } => {
+            let method = external_defs
+                .structural_methods_for(&module)?
+                .get(&name)?
                 .iter()
-                .map(|argument| substitute_type_vars(argument, &root_bindings)),
-        )
-        .collect::<HashMap<_, _>>();
-    let method = external_defs
-        .structural_methods_for(parent_module)?
-        .get(parent_name)?
-        .iter()
-        .find(|method| method.handler_target.as_ref() == Some(&handler.callable))?;
-    Some((method, parent_bindings))
+                .find(|method| method.handler_target.as_ref() == Some(&handler.callable))?;
+            Some((method, bindings))
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/sifr_frontend/src/structural_shape/tests.rs
+++ b/crates/sifr_frontend/src/structural_shape/tests.rs
@@ -513,6 +513,90 @@ class Child(Parent[int]):
 }
 
 #[test]
+fn transitive_generic_ancestor_handler_uses_concrete_child_arguments() {
+    use sifr_lowering::{
+        AdapterFieldDefault, AdapterFieldPlan, AdapterHandlerPlan, CallableIdentity,
+        ClassAdapterSelection, SourceOriginId, StaticProgramValue,
+    };
+
+    let source = r#"
+class Grand[T]:
+    value: T
+
+    @classmethod
+    @metadata("fixture.callback", "after")
+    def normalize(cls, own value: T) -> T:
+        return value
+
+class Parent[U](Grand[list[U]]):
+    pass
+
+class Child(Parent[int]):
+    pass
+"#;
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let mut lowered = lower_module(&parsed).expect("fixture lowers");
+    let callable = CallableIdentity {
+        module: "fixture.transitive".to_string(),
+        owner: Some("fixture.transitive.Grand".to_string()),
+        symbol: "normalize".to_string(),
+        generic_arguments: Vec::new(),
+        signature: "checked".to_string(),
+    };
+    lowered
+        .class_adapter_selections
+        .push(ClassAdapterSelection {
+            owner: "Child".to_string(),
+            provider_module: "fixture.adapter".to_string(),
+            provider_function: "adapt".to_string(),
+            descriptor_type: Type::Str,
+            marker_identities: Vec::new(),
+            data_parent: Some("Parent".to_string()),
+            field_plans: vec![AdapterFieldPlan {
+                identity: "fixture.transitive.Grand.value".to_string(),
+                name: "value".to_string(),
+                declared_type: Type::List(Box::new(Type::Int)),
+                default: AdapterFieldDefault::Required,
+                validation_policy: None,
+            }],
+            handler_plans: vec![AdapterHandlerPlan {
+                callable: callable.clone(),
+                descriptor_type: Type::Str,
+                descriptor_value: StaticProgramValue::String("after".to_string()),
+                descriptor_origin: SourceOriginId::new([8; 32], 1),
+                descriptor_range: ruff_text_size::TextRange::default(),
+                declaration_order: 0,
+            }],
+            attached_api_set: None,
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
+            range: ruff_text_size::TextRange::default(),
+        });
+    let child = &lowered.module.classes[2];
+    let shape = describe_type(
+        "fixture.transitive",
+        &class_type(child, Vec::new()),
+        &lowered,
+    );
+    let ShapeNode::Nominal { methods, .. } = shape.root else {
+        panic!("child must have a nominal shape");
+    };
+    assert_eq!(methods.len(), 1);
+    assert_eq!(methods[0].target.as_ref(), Some(&callable));
+    assert_eq!(
+        methods[0].params[0].declared_type,
+        ShapeNode::List(Box::new(ShapeNode::Primitive("int".to_string())))
+    );
+    assert_eq!(
+        *methods[0].result,
+        ShapeNode::List(Box::new(ShapeNode::Primitive("int".to_string())))
+    );
+    assert_eq!(methods[0].origin, None);
+    assert!(!shape.canonical_identity.contains("param:T"));
+    assert!(!shape.canonical_identity.contains("param:U"));
+}
+
+#[test]
 fn async_method_contract_is_identical_at_root_and_nested_positions() {
     let source = r#"
 class Inner:

--- a/crates/sifr_frontend/src/structural_shape_import_tests.rs
+++ b/crates/sifr_frontend/src/structural_shape_import_tests.rs
@@ -42,6 +42,7 @@ class Parent[T]:
 
     @classmethod
     @metadata("fixture.callback", "after")
+    @metadata("parameter", "value", "fixture.role", "input")
     def normalize(cls, own value: T) -> T:
         return value
 "#,
@@ -54,7 +55,10 @@ class Parent[T]:
         r#"
 from models import Parent
 
-class Child(Parent[int]):
+class Mid[V](Parent[V]):
+    pass
+
+class Child(Mid[int]):
     pass
 
 class Use:
@@ -248,13 +252,13 @@ class Model[T]:
     );
     assert_eq!(methods[0].declaration_order, Some(0));
     assert_eq!(methods[0].origin, None);
+    assert_eq!(methods[0].metadata[0].key, "fixture.callback");
+    assert_eq!(methods[0].params[0].metadata[0].key, "fixture.role");
     assert_eq!(
         methods[0].params[0].declared_type,
         ShapeNode::Primitive("int".to_string())
     );
     assert_eq!(*methods[0].result, ShapeNode::Primitive("int".to_string()));
-    assert_eq!(methods[0].metadata[0].key, "fixture.callback");
-    assert_eq!(methods[0].params[0].metadata[0].key, "fixture.role");
     assert!(!shape.canonical_identity.contains("param:T"));
 }
 
@@ -269,6 +273,7 @@ class Grand[T]:
 
     @classmethod
     @metadata("fixture.callback", "after")
+    @metadata("parameter", "value", "fixture.role", "input")
     def normalize(cls, own value: T) -> T:
         return value
 
@@ -336,7 +341,10 @@ class Parent[U](Grand[list[U]]):
         r#"
 from models import Parent
 
-class Child(Parent[int]):
+class Mid[V](Parent[V]):
+    pass
+
+class Child(Mid[int]):
     pass
 
 class Use:
@@ -352,7 +360,7 @@ class Use:
             provider_function: "adapt".to_string(),
             descriptor_type: Type::Str,
             marker_identities: Vec::new(),
-            data_parent: Some("models.Parent".to_string()),
+            data_parent: Some("Mid".to_string()),
             field_plans: vec![AdapterFieldPlan {
                 identity: "models.Grand.value".to_string(),
                 name: "value".to_string(),
@@ -393,6 +401,8 @@ class Use:
         ShapeNode::List(Box::new(ShapeNode::Primitive("int".to_string())))
     );
     assert_eq!(methods[0].origin, None);
+    assert_eq!(methods[0].metadata[0].key, "fixture.callback");
+    assert_eq!(methods[0].params[0].metadata[0].key, "fixture.role");
     assert!(!shape.canonical_identity.contains("param:T"));
     assert!(!shape.canonical_identity.contains("param:U"));
 }

--- a/crates/sifr_frontend/src/structural_shape_import_tests.rs
+++ b/crates/sifr_frontend/src/structural_shape_import_tests.rs
@@ -174,6 +174,230 @@ class Box[T]:
 }
 
 #[test]
+fn fully_imported_adapted_handler_preserves_metadata_and_concrete_types() {
+    let mut external_defs = ExternalDefs::default();
+    let mut models = compile(
+        "models",
+        r#"
+class Model[T]:
+    value: T
+
+    @classmethod
+    @metadata("fixture.callback", "after")
+    @metadata("parameter", "value", "fixture.role", "input")
+    def normalize(cls, own value: T) -> T:
+        return value
+"#,
+        &external_defs,
+    );
+    let callable = CallableIdentity {
+        module: "models".to_string(),
+        owner: Some("models.Model".to_string()),
+        symbol: "normalize".to_string(),
+        generic_arguments: Vec::new(),
+        signature: "checked".to_string(),
+    };
+    models.class_adapter_selections.push(ClassAdapterSelection {
+        owner: "Model".to_string(),
+        provider_module: "fixture.adapter".to_string(),
+        provider_function: "adapt".to_string(),
+        descriptor_type: Type::Str,
+        marker_identities: Vec::new(),
+        data_parent: None,
+        field_plans: vec![AdapterFieldPlan {
+            identity: "models.Model.value".to_string(),
+            name: "value".to_string(),
+            declared_type: Type::TypeVar("T".to_string()),
+            default: AdapterFieldDefault::Required,
+            validation_policy: None,
+        }],
+        handler_plans: vec![AdapterHandlerPlan {
+            callable: callable.clone(),
+            descriptor_type: Type::Str,
+            descriptor_value: StaticProgramValue::String("after".to_string()),
+            descriptor_origin: SourceOriginId::new([10; 32], 2),
+            descriptor_range: ruff_text_size::TextRange::default(),
+            declaration_order: 0,
+        }],
+        attached_api_set: None,
+        adapter_invocation_identity: [0; 32],
+        post_adapter_identity: [0; 32],
+        range: ruff_text_size::TextRange::default(),
+    });
+    collect_module_exports("models", &models, &mut external_defs);
+
+    let consumer = compile(
+        "consumer",
+        "from models import Model\n\nclass Container:\n    item: Model[int]\n",
+        &external_defs,
+    );
+    let shape = describe_type_with_externals(
+        "consumer",
+        field_type(&consumer, "Container", "item"),
+        &consumer,
+        &external_defs,
+    );
+    let ShapeNode::Nominal { methods, .. } = shape.root else {
+        panic!("model must have a nominal shape");
+    };
+    assert_eq!(methods.len(), 1);
+    assert_eq!(methods[0].target.as_ref(), Some(&callable));
+    assert_eq!(
+        methods[0].descriptor,
+        Some(crate::ConstValue::String("after".to_string()))
+    );
+    assert_eq!(methods[0].declaration_order, Some(0));
+    assert_eq!(methods[0].origin, None);
+    assert_eq!(
+        methods[0].params[0].declared_type,
+        ShapeNode::Primitive("int".to_string())
+    );
+    assert_eq!(*methods[0].result, ShapeNode::Primitive("int".to_string()));
+    assert_eq!(methods[0].metadata[0].key, "fixture.callback");
+    assert_eq!(methods[0].params[0].metadata[0].key, "fixture.role");
+    assert!(!shape.canonical_identity.contains("param:T"));
+}
+
+#[test]
+fn imported_transitive_generic_handler_uses_the_concrete_child_argument() {
+    let mut external_defs = ExternalDefs::default();
+    let mut models = compile(
+        "models",
+        r#"
+class Grand[T]:
+    value: T
+
+    @classmethod
+    @metadata("fixture.callback", "after")
+    def normalize(cls, own value: T) -> T:
+        return value
+
+class Parent[U](Grand[list[U]]):
+    pass
+"#,
+        &external_defs,
+    );
+    let callable = CallableIdentity {
+        module: "models".to_string(),
+        owner: Some("models.Grand".to_string()),
+        symbol: "normalize".to_string(),
+        generic_arguments: Vec::new(),
+        signature: "checked".to_string(),
+    };
+    for (owner, declared_type, data_parent) in [
+        ("Grand", Type::TypeVar("T".to_string()), None),
+        (
+            "Parent",
+            Type::List(Box::new(Type::TypeVar("U".to_string()))),
+            Some("Grand".to_string()),
+        ),
+    ] {
+        models.class_adapter_selections.push(ClassAdapterSelection {
+            owner: owner.to_string(),
+            provider_module: "fixture.adapter".to_string(),
+            provider_function: "adapt".to_string(),
+            descriptor_type: Type::Str,
+            marker_identities: Vec::new(),
+            data_parent,
+            field_plans: vec![AdapterFieldPlan {
+                identity: "models.Grand.value".to_string(),
+                name: "value".to_string(),
+                declared_type,
+                default: AdapterFieldDefault::Required,
+                validation_policy: None,
+            }],
+            handler_plans: vec![AdapterHandlerPlan {
+                callable: callable.clone(),
+                descriptor_type: Type::Str,
+                descriptor_value: StaticProgramValue::String("after".to_string()),
+                descriptor_origin: SourceOriginId::new([11; 32], 1),
+                descriptor_range: ruff_text_size::TextRange::default(),
+                declaration_order: 0,
+            }],
+            attached_api_set: None,
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
+            range: ruff_text_size::TextRange::default(),
+        });
+    }
+    collect_module_exports("models", &models, &mut external_defs);
+    assert!(external_defs
+        .structural_methods_for("models")
+        .and_then(|classes| classes.get("Parent"))
+        .is_some_and(|methods| {
+            methods
+                .iter()
+                .any(|method| method.handler_target.as_ref() == Some(&callable))
+        }));
+    external_defs.class_adapter_selections.remove("models");
+
+    let mut consumer = compile(
+        "consumer",
+        r#"
+from models import Parent
+
+class Child(Parent[int]):
+    pass
+
+class Use:
+    value: Child
+"#,
+        &external_defs,
+    );
+    consumer
+        .class_adapter_selections
+        .push(ClassAdapterSelection {
+            owner: "Child".to_string(),
+            provider_module: "fixture.adapter".to_string(),
+            provider_function: "adapt".to_string(),
+            descriptor_type: Type::Str,
+            marker_identities: Vec::new(),
+            data_parent: Some("models.Parent".to_string()),
+            field_plans: vec![AdapterFieldPlan {
+                identity: "models.Grand.value".to_string(),
+                name: "value".to_string(),
+                declared_type: Type::List(Box::new(Type::Int)),
+                default: AdapterFieldDefault::Required,
+                validation_policy: None,
+            }],
+            handler_plans: vec![AdapterHandlerPlan {
+                callable: callable.clone(),
+                descriptor_type: Type::Str,
+                descriptor_value: StaticProgramValue::String("after".to_string()),
+                descriptor_origin: SourceOriginId::new([12; 32], 1),
+                descriptor_range: ruff_text_size::TextRange::default(),
+                declaration_order: 0,
+            }],
+            attached_api_set: None,
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
+            range: ruff_text_size::TextRange::default(),
+        });
+    let shape = describe_type_with_externals(
+        "consumer",
+        field_type(&consumer, "Use", "value"),
+        &consumer,
+        &external_defs,
+    );
+    let ShapeNode::Nominal { methods, .. } = shape.root else {
+        panic!("child must have a nominal shape");
+    };
+    assert_eq!(methods.len(), 1);
+    assert_eq!(methods[0].target.as_ref(), Some(&callable));
+    assert_eq!(
+        methods[0].params[0].declared_type,
+        ShapeNode::List(Box::new(ShapeNode::Primitive("int".to_string())))
+    );
+    assert_eq!(
+        *methods[0].result,
+        ShapeNode::List(Box::new(ShapeNode::Primitive("int".to_string())))
+    );
+    assert_eq!(methods[0].origin, None);
+    assert!(!shape.canonical_identity.contains("param:T"));
+    assert!(!shape.canonical_identity.contains("param:U"));
+}
+
+#[test]
 fn recollection_removes_stale_structural_shape_exports() {
     let mut external_defs = ExternalDefs::default();
     let annotated = compile(

--- a/crates/sifr_lowering/src/lower/external_defs.rs
+++ b/crates/sifr_lowering/src/lower/external_defs.rs
@@ -5,6 +5,8 @@ use sifr_type_system::{FunctionType, ReceiverConvention, Type};
 /// Package-neutral method contract retained for imported structural shape descriptions.
 #[derive(Debug, Clone)]
 pub struct StructuralMethodExport {
+    /// Checked handler target when this method was exported for an adapted owner.
+    pub handler_target: Option<sifr_ir::CallableIdentity>,
     pub name: String,
     pub params: Vec<HirParam>,
     pub return_type: Type,

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -896,6 +896,13 @@ owner arguments before package specialization. Local and imported adapted generi
 same substitution rule, so nested concrete uses do not expose unbound declaration parameters to a
 package specializer.
 
+Checked adapted-handler exports retain the callable target with a signature specialized relative
+to the selected owner's type parameters. Generic substitution follows the full local ancestor
+chain before export. Imported structural shapes bind those owner parameters to the concrete use
+and restore the handler descriptor, order, and declaration metadata. Source origins remain scoped
+to the declaration that created them; inherited and imported handler shapes do not expose a
+foreign origin to another declaration's package-issue registry.
+
 The same final field state governs structural construction. Structural records match incoming
 edges by field name, reject unknown and duplicate names, and fill omitted defaulted fields from
 their checked HIR defaults. Factory defaults retain a canonical callable-identity side channel in

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -176,6 +176,14 @@ flag. For `Result[T, E]`, `output` describes `T` and `fallible` is true. For oth
 `output` equals `result` and `fallible` is false. Packages use these typed facts to reject invalid
 handler signatures during specialization. They do not parse a displayed type name.
 
+An inherited handler signature is specialized through every generic ancestor from the concrete
+adapted owner to the checked callable owner. Module exports retain a handler's checked callable
+target and its signature relative to the exported adapted owner's type parameters. An importing
+module therefore reconstructs the same concrete handler shape, descriptor, declaration order, and
+method or parameter metadata. A descriptor source origin is exposed only while its declaring class
+is the current declaration. Inherited and imported shapes omit that unrelated origin instead of
+making it available to a different declaration's issue registry.
+
 The compiler accepts synchronous static, class, shared-instance, mutable-instance, and owned
 receiver handlers. A checked handler can return an infallible structural value or a typed `Result`.
 An instance handler can also declare one owned structural value before its optional borrowed


### PR DESCRIPTION
## Summary
- specialize checked handler signatures across transitive generic ancestors
- export adapted handler contracts relative to the selected owner
- reconstruct fully imported handler targets, descriptors, order, and metadata
- keep descriptor origins scoped to their declaring source registry
- cover local, fully imported, and imported-transitive cases

## Validation
- `cargo test -p sifr_frontend` (103 passed)
- `cargo test -p sifr_driver --lib adapter_defaults` (14 passed)
- `cargo clippy -p sifr_frontend -p sifr_lowering --lib -- -D warnings`
- formatting, HIR maintainability, file-size, and diff guards passed
- create-PR gate ran once on `8e5f21e487a028bf6b4b5941269ffce4cfde66bf`; all preceding guards passed, then the known separately owned Rust-interop matrix inputs stopped it. It was not rerun.