### PR TITLE
Stabilize adapter provider identity

### DIFF
--- a/crates/sifr_driver/src/tests/adapter_defaults.rs
+++ b/crates/sifr_driver/src/tests/adapter_defaults.rs
@@ -267,6 +267,39 @@ class Model(Contract):
 }
 
 #[test]
+fn unrelated_declaration_order_does_not_change_adapter_identity() {
+    let source = r#"
+from fixture.defaults import Contract
+class Model(Contract):
+    value: int
+"#;
+    let identities = |contract: &str| {
+        let compiled = compile_with_contract(source, contract);
+        let selection = compiled
+            .external_defs
+            .class_adapter_selections
+            .get("main")
+            .and_then(|classes| classes.get("Model"))
+            .expect("adapter identity is exported");
+        (
+            selection.adapter_invocation_identity,
+            selection.post_adapter_identity,
+        )
+    };
+    let unrelated = r#"
+def unrelated(value: int) -> int:
+    shifted: int = value + 1
+    return shifted
+
+"#;
+
+    assert_eq!(
+        identities(CONTRACT),
+        identities(&format!("{unrelated}{CONTRACT}"))
+    );
+}
+
+#[test]
 fn relevant_adapter_edits_invalidate_invocation_and_post_adapter_identity() {
     let source = r#"
 from fixture.defaults import Contract

--- a/crates/sifr_frontend/src/adapter_program_identity.rs
+++ b/crates/sifr_frontend/src/adapter_program_identity.rs
@@ -2,15 +2,18 @@
 
 use sifr_lowering::{
     HirAsyncWithKind, HirExpr, HirFunction, HirModule, HirPattern, HirStmt, LoweringResult,
+    PythonArrowSchemaMode, PythonDlpackStreamMode, PythonInteropDeclaration,
+    RustInteropDeclaration, RustInteropValue,
 };
 use std::fmt::Write;
 
 pub(crate) fn canonical_const_functions(module: &HirModule) -> String {
-    let mut canonical = module.clone();
-    for function in &mut canonical.functions {
+    let mut functions = module.functions.clone();
+    functions.sort_by(|left, right| left.name.cmp(&right.name));
+    for function in &mut functions {
         strip_function_locations(function);
     }
-    format!("{canonical:#?}")
+    format!("{functions:#?}")
 }
 
 fn strip_function_locations(function: &mut HirFunction) {
@@ -20,10 +23,62 @@ fn strip_function_locations(function: &mut HirFunction) {
         }
     }
     strip_stmt_locations(&mut function.body);
-    // Interop declarations do not participate in deterministic const evaluation,
-    // and their diagnostic spans are intentionally source-relative.
-    function.rust_interop.clear();
-    function.python_interop.clear();
+    for declaration in &mut function.rust_interop {
+        strip_rust_interop_locations(declaration);
+    }
+    for declaration in &mut function.python_interop {
+        strip_python_interop_locations(declaration);
+    }
+}
+
+fn strip_rust_interop_locations(declaration: &mut RustInteropDeclaration) {
+    declaration.span = ruff_text_size::TextRange::default();
+    if let Some(target) = &mut declaration.target {
+        target.span = ruff_text_size::TextRange::default();
+    }
+    for argument in &mut declaration.arguments {
+        argument.span = ruff_text_size::TextRange::default();
+        strip_rust_interop_value_locations(&mut argument.value);
+    }
+}
+
+fn strip_rust_interop_value_locations(value: &mut RustInteropValue) {
+    match value {
+        RustInteropValue::PolicyCall { argument, span, .. } => {
+            *span = ruff_text_size::TextRange::default();
+            strip_rust_interop_value_locations(argument);
+        }
+        RustInteropValue::TargetPath(target) => {
+            target.span = ruff_text_size::TextRange::default();
+        }
+        RustInteropValue::Boolean(_)
+        | RustInteropValue::Symbol(_)
+        | RustInteropValue::Integer(_)
+        | RustInteropValue::IntegerList(_) => {}
+    }
+}
+
+fn strip_python_interop_locations(declaration: &mut PythonInteropDeclaration) {
+    declaration.span = ruff_text_size::TextRange::default();
+    if let Some(target) = &mut declaration.target {
+        target.span = ruff_text_size::TextRange::default();
+    }
+    for parameter in &mut declaration.parameters {
+        parameter.span = ruff_text_size::TextRange::default();
+    }
+    for callback in &mut declaration.callbacks {
+        callback.span = ruff_text_size::TextRange::default();
+    }
+    if let Some(arrow) = &mut declaration.arrow {
+        if let PythonArrowSchemaMode::Parameter { span, .. } = &mut arrow.schema {
+            *span = ruff_text_size::TextRange::default();
+        }
+    }
+    if let Some(dlpack) = &mut declaration.dlpack {
+        if let PythonDlpackStreamMode::Parameter { span, .. } = &mut dlpack.stream {
+            *span = ruff_text_size::TextRange::default();
+        }
+    }
 }
 
 fn strip_stmt_locations(statements: &mut [HirStmt]) {
@@ -167,8 +222,8 @@ fn strip_expr_locations(expression: &mut HirExpr) {
         | HirExpr::StringLiteral(_)
         | HirExpr::BoolLiteral(_)
         | HirExpr::NoneLiteral
-        | HirExpr::Name { .. }
         | HirExpr::EnumVariant { .. } => {}
+        HirExpr::Name { binding_id, .. } => *binding_id = None,
         HirExpr::BinOp { left, right, .. } => {
             strip_expr_locations(left);
             strip_expr_locations(right);
@@ -194,11 +249,27 @@ fn strip_expr_locations(expression: &mut HirExpr) {
         | HirExpr::TupleLiteral {
             elements: values, ..
         } => strip_expr_list_locations(values),
-        HirExpr::Call { args, .. }
-        | HirExpr::GenericCall { args, .. }
-        | HirExpr::IteratorCall { args, .. }
-        | HirExpr::ConstructorCall { args, .. }
-        | HirExpr::SuperCall { args, .. } => strip_expr_list_locations(args),
+        HirExpr::Call {
+            args,
+            mutable_arg_places,
+            ..
+        }
+        | HirExpr::GenericCall {
+            args,
+            mutable_arg_places,
+            ..
+        }
+        | HirExpr::IteratorCall {
+            args,
+            mutable_arg_places,
+            ..
+        } => {
+            strip_expr_list_locations(args);
+            mutable_arg_places.clear();
+        }
+        HirExpr::ConstructorCall { args, .. } | HirExpr::SuperCall { args, .. } => {
+            strip_expr_list_locations(args);
+        }
         HirExpr::PythonCall {
             args,
             record_expansions,
@@ -254,11 +325,15 @@ fn strip_expr_locations(expression: &mut HirExpr) {
         HirExpr::MethodCall {
             object,
             args,
+            receiver_target,
+            mutable_arg_places,
             source,
             ..
         } => {
             strip_expr_locations(object);
             strip_expr_list_locations(args);
+            *receiver_target = None;
+            mutable_arg_places.clear();
             *source = None;
         }
         HirExpr::FString { parts, .. } => {
@@ -390,4 +465,94 @@ pub(crate) fn post_adapter_hex(result: &LoweringResult, owner: &str) -> String {
                 },
             )
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canonical_const_functions;
+    use ruff_text_size::{TextRange, TextSize};
+    use sifr_lowering::{
+        BindingId, HirExpr, HirFunction, HirModule, HirStmt, MethodKind,
+        RustInteropAbiRequirements, RustInteropDeclaration, RustInteropDecoratorKind,
+        RustInteropEffect, RustTargetPath,
+    };
+    use sifr_type_system::Type;
+    use std::collections::HashMap;
+
+    fn function(body: Vec<HirStmt>) -> HirFunction {
+        HirFunction {
+            name: "adapt".to_string(),
+            params: Vec::new(),
+            return_type: Type::Int,
+            body,
+            is_async: false,
+            method_kind: MethodKind::Regular,
+            receiver: None,
+            decorators: vec!["const_eval".to_string()],
+            rust_interop: Vec::new(),
+            python_interop: Vec::new(),
+            compiler_intrinsic: None,
+            type_params: Vec::new(),
+        }
+    }
+
+    fn module(function: HirFunction) -> HirModule {
+        HirModule {
+            functions: vec![function],
+            classes: Vec::new(),
+            imports: Vec::new(),
+            constants: Vec::new(),
+            generic_functions: HashMap::new(),
+            type_param_bounds: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn provider_identity_ignores_lowering_binding_ids() {
+        let with_id = |id| {
+            module(function(vec![HirStmt::Return {
+                value: Some(HirExpr::Name {
+                    name: "value".to_string(),
+                    binding_id: Some(BindingId(id)),
+                    ty: Type::Int,
+                }),
+            }]))
+        };
+
+        assert_eq!(
+            canonical_const_functions(&with_id(4)),
+            canonical_const_functions(&with_id(91))
+        );
+    }
+
+    #[test]
+    fn provider_identity_keeps_interop_semantics_but_ignores_interop_spans() {
+        let range = |start, end| TextRange::new(TextSize::new(start), TextSize::new(end));
+        let with_target = |segments: &[&str], span| {
+            let mut provider = function(Vec::new());
+            provider.rust_interop.push(RustInteropDeclaration {
+                kind: RustInteropDecoratorKind::Function,
+                target: Some(RustTargetPath {
+                    segments: segments
+                        .iter()
+                        .map(|segment| (*segment).to_string())
+                        .collect(),
+                    span,
+                }),
+                arguments: Vec::new(),
+                span,
+                effect: RustInteropEffect::Sync,
+                abi_requirements: RustInteropAbiRequirements::default(),
+                consumes_receiver: false,
+            });
+            module(provider)
+        };
+
+        let base = canonical_const_functions(&with_target(&["bridge", "adapt"], range(1, 8)));
+        let moved = canonical_const_functions(&with_target(&["bridge", "adapt"], range(41, 48)));
+        let changed = canonical_const_functions(&with_target(&["bridge", "other"], range(41, 48)));
+
+        assert_eq!(base, moved);
+        assert_ne!(base, changed);
+    }
 }

--- a/crates/sifr_lowering/src/lib.rs
+++ b/crates/sifr_lowering/src/lib.rs
@@ -39,7 +39,9 @@ pub use sifr_ir::{
     ClassAdapterProviderDeclaration, ClassAdapterSelection, ConstSpecializationRequest,
     DeclarationDescriptorFunction, DeclarationDescriptorKind, DeclarationMetadataTargetKind,
     HirDiagnostic, LoweringOutcome, LoweringResult, LoweringWarningDiagnostic,
-    RevealTypeDiagnostic, RustInteropDecoratorKind, SourceOriginId, StaticMethodParam,
+    PythonArrowSchemaMode, PythonDlpackStreamMode, PythonInteropDeclaration, RevealTypeDiagnostic,
+    RustInteropAbiRequirements, RustInteropDeclaration, RustInteropDecoratorKind,
+    RustInteropEffect, RustInteropValue, RustTargetPath, SourceOriginId, StaticMethodParam,
     StaticMethodSlot, StaticMethodSlotContext, StaticProgramValue, StaticSpecializationOutput,
     TypedDeclarationDescriptor, TypedDeclarationMetadata,
 };

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -887,9 +887,11 @@ canonical declaring identities, substitutes concrete generic parent arguments, a
 normalizes every field to required, constant-default, or checked zero-argument factory-default
 state; final lowering alone materializes constructor defaults, and factory expressions execute at
 each call so mutable values are not shared. Adapter invocation identity hashes the source-location-
-free declaration input and provider HIR before evaluation. Post-adapter identity separately binds
-the invocation to the validated output and is an input to static-program identity, avoiding a
-cycle with later handler and attached-API outputs.
+free declaration input and semantic provider HIR before evaluation. Provider canonicalization
+sorts the const function set, removes lowering-assigned binding and ownership-place IDs, and
+normalizes diagnostic ranges while retaining checked interop declarations. Post-adapter identity
+separately binds the invocation to the validated output and is an input to static-program identity,
+avoiding a cycle with later handler and attached-API outputs.
 
 Structural shape derivation specializes finalized adapter field-plan types with the concrete
 owner arguments before package specialization. Local and imported adapted generic classes use the

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -77,6 +77,12 @@ An imported or re-exported function keeps its canonical body and package identit
 Lists evaluate each item against the declared item type.
 Nested calls use the same deterministic limits as adapter and specialization evaluation.
 
+Adapter provider identity uses the semantic, name-sorted `@const_eval` function set. It excludes
+lowering-assigned binding and ownership-place IDs and all diagnostic byte ranges. It retains
+checked types, function bodies, decorators, intrinsic selection, and Rust and Python interop
+declarations. Moving or reordering unrelated declarations cannot change the identity. Changing a
+semantic provider declaration must change it.
+
 ## Evaluation and outcomes
 
 Const evaluation is deterministic and fails closed. Default limits are 100,000 evaluation steps,


### PR DESCRIPTION
## Summary
- exclude lowering-assigned binding and ownership-place IDs from adapter provider identity
- retain semantic Rust/Python interop declarations while normalizing their diagnostic spans
- sort the provider function set and document/test declaration-order stability

## Validation
- `cargo test -p sifr_frontend --lib --no-fail-fast`
- `cargo test -p sifr_driver tests::adapter_defaults --no-fail-fast`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- create-PR gate (single run): stopped at externally owned Rust interop matrix inputs: missing `negative/package_generated_type_import_rejected.sifr`; placeholder `examples/method_slot_runtime/src/schema_program.sifr`