### PR TITLE
Respect nested generic scopes in adapter fields

### DIFF
--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -370,6 +370,7 @@ fn describe_class(
         type_args,
         fields,
         field_plans,
+        lowering,
         external_defs,
     );
     let described_fields = effective_fields

--- a/crates/sifr_frontend/src/structural_shape/generic_fields.rs
+++ b/crates/sifr_frontend/src/structural_shape/generic_fields.rs
@@ -1,6 +1,9 @@
 //! Concrete field types selected by finalized adapted generic declarations.
 
-use sifr_lowering::{substitute_type_vars, AdapterFieldPlan, ExternalDefs, HirClass};
+use sifr_lowering::{
+    substitute_type_vars_with_class_scopes, AdapterFieldPlan, ExternalDefs, HirClass,
+    LoweringResult,
+};
 use sifr_type_system::Type;
 use std::collections::HashMap;
 
@@ -12,6 +15,7 @@ pub(super) fn effective_fields(
     type_args: &[Type],
     declared_fields: &[(String, Type)],
     field_plans: Option<&[AdapterFieldPlan]>,
+    lowering: &LoweringResult,
     external_defs: &ExternalDefs,
 ) -> Vec<(String, Type)> {
     let Some(field_plans) = field_plans else {
@@ -37,8 +41,53 @@ pub(super) fn effective_fields(
         .map(|field| {
             (
                 field.name.clone(),
-                substitute_type_vars(&field.declared_type, &bindings),
+                substitute_type_vars_with_class_scopes(
+                    &field.declared_type,
+                    &bindings,
+                    &|identity, name| {
+                        class_type_params(identity, name, source_module, lowering, external_defs)
+                    },
+                ),
             )
         })
         .collect()
+}
+
+fn class_type_params(
+    identity: Option<&str>,
+    name: &str,
+    module_name: &str,
+    lowering: &LoweringResult,
+    external_defs: &ExternalDefs,
+) -> Vec<String> {
+    let (source_module, source_name) = identity
+        .and_then(|identity| identity.rsplit_once('.'))
+        .unwrap_or((module_name, name));
+    let canonical_identity = format!("{source_module}.{source_name}");
+    if let Some(class) = lowering
+        .module
+        .classes
+        .iter()
+        .find(|class| class.identity.as_deref() == Some(&canonical_identity))
+    {
+        return class.type_params.clone();
+    }
+    if let Some(type_params) = external_defs
+        .class_type_params
+        .get(source_module)
+        .and_then(|classes| classes.get(source_name))
+        .cloned()
+    {
+        return type_params;
+    }
+    if source_module == module_name {
+        return lowering
+            .module
+            .classes
+            .iter()
+            .find(|class| class.name == source_name)
+            .map(|class| class.type_params.clone())
+            .unwrap_or_default();
+    }
+    Vec::new()
 }

--- a/crates/sifr_frontend/src/structural_shape/tests.rs
+++ b/crates/sifr_frontend/src/structural_shape/tests.rs
@@ -402,6 +402,95 @@ class Container:
 }
 
 #[test]
+fn adapted_field_substitution_respects_nested_generic_scope() {
+    use sifr_lowering::{AdapterFieldDefault, AdapterFieldPlan, ClassAdapterSelection};
+
+    let source = r#"
+class Inner[T]:
+    value: T
+
+class Outer[T]:
+    nested: Inner[str]
+    direct: T
+
+class Container:
+    item: Outer[int]
+"#;
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let mut lowered = lower_module(&parsed).expect("fixture lowers");
+    let nested = Type::Class {
+        identity: Some("fixture.scoped_generics.Inner".to_string()),
+        type_args: vec![Type::Str],
+        name: "Inner".to_string(),
+        fields: vec![("value".to_string(), Type::TypeVar("T".to_string()))],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    lowered
+        .class_adapter_selections
+        .push(ClassAdapterSelection {
+            owner: "Outer".to_string(),
+            provider_module: "fixture.adapter".to_string(),
+            provider_function: "adapt".to_string(),
+            descriptor_type: Type::None,
+            marker_identities: Vec::new(),
+            data_parent: None,
+            field_plans: vec![
+                AdapterFieldPlan {
+                    identity: "fixture.scoped_generics.Outer.nested".to_string(),
+                    name: "nested".to_string(),
+                    declared_type: nested,
+                    default: AdapterFieldDefault::Required,
+                    validation_policy: None,
+                },
+                AdapterFieldPlan {
+                    identity: "fixture.scoped_generics.Outer.direct".to_string(),
+                    name: "direct".to_string(),
+                    declared_type: Type::TypeVar("T".to_string()),
+                    default: AdapterFieldDefault::Required,
+                    validation_policy: None,
+                },
+            ],
+            handler_plans: Vec::new(),
+            attached_api_set: None,
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
+            range: ruff_text_size::TextRange::default(),
+        });
+    let container = &lowered.module.classes[2];
+    let shape = describe_type(
+        "fixture.scoped_generics",
+        &class_type(container, Vec::new()),
+        &lowered,
+    );
+    let ShapeNode::Nominal { fields, .. } = shape.root else {
+        panic!("container must have a nominal shape");
+    };
+    let ShapeNode::Nominal {
+        fields: outer_fields,
+        ..
+    } = &fields[0].declared_type
+    else {
+        panic!("container item must preserve its concrete outer shape");
+    };
+    let ShapeNode::Nominal {
+        fields: inner_fields,
+        ..
+    } = &outer_fields[0].declared_type
+    else {
+        panic!("outer field must preserve its concrete inner shape");
+    };
+    assert_eq!(
+        inner_fields[0].declared_type,
+        ShapeNode::Primitive("str".to_string())
+    );
+    assert_eq!(
+        outer_fields[1].declared_type,
+        ShapeNode::Primitive("int".to_string())
+    );
+}
+
+#[test]
 fn inherited_handler_preserves_checked_signature_and_uses_child_diagnostic_origin() {
     use sifr_lowering::{
         AdapterFieldDefault, AdapterFieldPlan, AdapterHandlerPlan, CallableIdentity,

--- a/crates/sifr_frontend/src/structural_shape_import_tests.rs
+++ b/crates/sifr_frontend/src/structural_shape_import_tests.rs
@@ -178,6 +178,91 @@ class Box[T]:
 }
 
 #[test]
+fn imported_adapted_field_substitution_respects_nested_generic_scope() {
+    let mut external_defs = ExternalDefs::default();
+    let mut models = compile(
+        "models",
+        r#"
+class Inner[T]:
+    value: T
+
+class Outer[T]:
+    nested: Inner[str]
+    direct: T
+"#,
+        &external_defs,
+    );
+    let nested = Type::Class {
+        identity: Some("models.Inner".to_string()),
+        type_args: vec![Type::Str],
+        name: "Inner".to_string(),
+        fields: vec![("value".to_string(), Type::TypeVar("T".to_string()))],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    models.class_adapter_selections.push(ClassAdapterSelection {
+        owner: "Outer".to_string(),
+        provider_module: "fixture.adapter".to_string(),
+        provider_function: "adapt".to_string(),
+        descriptor_type: Type::None,
+        marker_identities: Vec::new(),
+        data_parent: None,
+        field_plans: vec![
+            AdapterFieldPlan {
+                identity: "models.Outer.nested".to_string(),
+                name: "nested".to_string(),
+                declared_type: nested,
+                default: AdapterFieldDefault::Required,
+                validation_policy: None,
+            },
+            AdapterFieldPlan {
+                identity: "models.Outer.direct".to_string(),
+                name: "direct".to_string(),
+                declared_type: Type::TypeVar("T".to_string()),
+                default: AdapterFieldDefault::Required,
+                validation_policy: None,
+            },
+        ],
+        handler_plans: Vec::new(),
+        attached_api_set: None,
+        adapter_invocation_identity: [0; 32],
+        post_adapter_identity: [0; 32],
+        range: ruff_text_size::TextRange::default(),
+    });
+    collect_module_exports("models", &models, &mut external_defs);
+
+    let consumer = compile(
+        "consumer",
+        "from models import Outer\n\nclass Container:\n    item: Outer[int]\n",
+        &external_defs,
+    );
+    let shape = describe_type_with_externals(
+        "consumer",
+        field_type(&consumer, "Container", "item"),
+        &consumer,
+        &external_defs,
+    );
+    let ShapeNode::Nominal { fields, .. } = shape.root else {
+        panic!("outer must have a nominal shape");
+    };
+    let ShapeNode::Nominal {
+        fields: inner_fields,
+        ..
+    } = &fields[0].declared_type
+    else {
+        panic!("outer field must preserve its concrete inner shape");
+    };
+    assert_eq!(
+        inner_fields[0].declared_type,
+        ShapeNode::Primitive("str".to_string())
+    );
+    assert_eq!(
+        fields[1].declared_type,
+        ShapeNode::Primitive("int".to_string())
+    );
+}
+
+#[test]
 fn fully_imported_adapted_handler_preserves_metadata_and_concrete_types() {
     let mut external_defs = ExternalDefs::default();
     let mut models = compile(

--- a/crates/sifr_lowering/src/lib.rs
+++ b/crates/sifr_lowering/src/lib.rs
@@ -26,8 +26,8 @@ pub use lower::{
     lower_module_sysroot_private_declaration_with_externals, lower_module_sysroot_public_stdlib,
     lower_module_sysroot_public_stdlib_with_externals, lower_module_with_externals,
     lower_module_with_externals_and_name, lower_module_with_externals_name_and_options,
-    substitute_type_vars, ExternalDefs, LoweringOptions, LoweringSourceOrigin,
-    PythonBridgeTargetAuthority, PythonTrustPolicy, StructuralMethodExport,
+    substitute_type_vars, substitute_type_vars_with_class_scopes, ExternalDefs, LoweringOptions,
+    LoweringSourceOrigin, PythonBridgeTargetAuthority, PythonTrustPolicy, StructuralMethodExport,
     StructuralMethodExports,
 };
 pub use scope::{NarrowingSnapshot, Scope};

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -169,6 +169,8 @@ mod rust_interop_tests;
 #[cfg(test)]
 mod rust_opaque_constructor_tests;
 mod scope_helpers;
+mod scoped_type_substitution;
+pub use scoped_type_substitution::substitute_type_vars_with_class_scopes;
 mod sequence_guard_detection;
 mod sequence_guard_updates;
 mod sequence_guards;

--- a/crates/sifr_lowering/src/lower/scoped_type_substitution.rs
+++ b/crates/sifr_lowering/src/lower/scoped_type_substitution.rs
@@ -1,0 +1,164 @@
+//! Type-variable substitution across nested nominal declaration scopes.
+
+use sifr_type_system::{make_union, FunctionType, Type};
+use std::collections::HashMap;
+
+/// Substitute free type variables while rebinding each nested class's declared parameters.
+pub fn substitute_type_vars_with_class_scopes<F>(
+    ty: &Type,
+    bindings: &HashMap<String, Type>,
+    class_type_params: &F,
+) -> Type
+where
+    F: Fn(Option<&str>, &str) -> Vec<String>,
+{
+    let recurse =
+        |ty: &Type| substitute_type_vars_with_class_scopes(ty, bindings, class_type_params);
+    let substitute_function = |function: &FunctionType| FunctionType {
+        receiver: function.receiver,
+        params: function
+            .params
+            .iter()
+            .map(|(name, ty, convention)| (name.clone(), recurse(ty), *convention))
+            .collect(),
+        return_type: Box::new(recurse(&function.return_type)),
+    };
+
+    match ty {
+        Type::TypeVar(name) => bindings.get(name).cloned().unwrap_or_else(|| ty.clone()),
+        Type::List(value) => Type::List(Box::new(recurse(value))),
+        Type::Set(value) => Type::Set(Box::new(recurse(value))),
+        Type::Iterable(value) => Type::Iterable(Box::new(recurse(value))),
+        Type::Iterator(value) => Type::Iterator(Box::new(recurse(value))),
+        Type::PythonBuffer(value) => Type::PythonBuffer(Box::new(recurse(value))),
+        Type::PythonDlpackTensor(value) => Type::PythonDlpackTensor(Box::new(recurse(value))),
+        Type::Dict(key, value) => Type::Dict(Box::new(recurse(key)), Box::new(recurse(value))),
+        Type::Tuple(values) => Type::Tuple(values.iter().map(recurse).collect()),
+        Type::Union(values) => make_union(values.iter().map(recurse).collect()),
+        Type::Callable(params, conventions, result) => Type::Callable(
+            params.iter().map(recurse).collect(),
+            conventions.clone(),
+            Box::new(recurse(result)),
+        ),
+        Type::AsyncCallable(params, conventions, result) => Type::AsyncCallable(
+            params.iter().map(recurse).collect(),
+            conventions.clone(),
+            Box::new(recurse(result)),
+        ),
+        Type::Result(ok, error) => Type::Result(Box::new(recurse(ok)), Box::new(recurse(error))),
+        Type::Coroutine(ok, error) => {
+            Type::Coroutine(Box::new(recurse(ok)), Box::new(recurse(error)))
+        }
+        Type::Task(ok, error) => Type::Task(Box::new(recurse(ok)), Box::new(recurse(error))),
+        Type::TaskResult(ok, error) => {
+            Type::TaskResult(Box::new(recurse(ok)), Box::new(recurse(error)))
+        }
+        Type::Failure(error) => Type::Failure(Box::new(recurse(error))),
+        Type::Select2(first, second) => {
+            Type::Select2(Box::new(recurse(first)), Box::new(recurse(second)))
+        }
+        Type::TimeoutResult(error) => Type::TimeoutResult(Box::new(recurse(error))),
+        Type::BlockingTask(ok, error) => {
+            Type::BlockingTask(Box::new(recurse(ok)), Box::new(recurse(error)))
+        }
+        Type::Awaitable(result) => Type::Awaitable(Box::new(recurse(result))),
+        Type::AsyncIterator(item, error) => {
+            Type::AsyncIterator(Box::new(recurse(item)), Box::new(recurse(error)))
+        }
+        Type::AsyncGenerator(item, error) => {
+            Type::AsyncGenerator(Box::new(recurse(item)), Box::new(recurse(error)))
+        }
+        Type::JoinSet(ok, error) => Type::JoinSet(Box::new(recurse(ok)), Box::new(recurse(error))),
+        Type::Alias {
+            name,
+            type_args,
+            body,
+        } => Type::Alias {
+            name: name.clone(),
+            type_args: type_args.iter().map(recurse).collect(),
+            body: Box::new(recurse(body)),
+        },
+        Type::Function(function) => Type::Function(substitute_function(function)),
+        Type::AsyncFunction(function) => Type::AsyncFunction(substitute_function(function)),
+        Type::Class {
+            identity,
+            type_args,
+            name,
+            fields,
+            methods,
+            parent_class,
+        } => {
+            let type_args = type_args.iter().map(recurse).collect::<Vec<_>>();
+            let mut nested_bindings = bindings.clone();
+            let declared_params = class_type_params(identity.as_deref(), name);
+            for parameter in &declared_params {
+                nested_bindings.remove(parameter);
+            }
+            nested_bindings.extend(declared_params.into_iter().zip(type_args.iter().cloned()));
+            let nested = |ty: &Type| {
+                substitute_type_vars_with_class_scopes(ty, &nested_bindings, class_type_params)
+            };
+            Type::Class {
+                identity: identity.clone(),
+                type_args,
+                name: name.clone(),
+                fields: fields
+                    .iter()
+                    .map(|(field, ty)| (field.clone(), nested(ty)))
+                    .collect(),
+                methods: methods
+                    .iter()
+                    .map(|(method, function)| {
+                        (
+                            method.clone(),
+                            FunctionType {
+                                receiver: function.receiver,
+                                params: function
+                                    .params
+                                    .iter()
+                                    .map(|(name, ty, convention)| {
+                                        (name.clone(), nested(ty), *convention)
+                                    })
+                                    .collect(),
+                                return_type: Box::new(nested(&function.return_type)),
+                            },
+                        )
+                    })
+                    .collect(),
+                parent_class: parent_class.clone(),
+            }
+        }
+        _ => ty.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::substitute_type_vars_with_class_scopes;
+    use sifr_type_system::Type;
+    use std::collections::HashMap;
+
+    #[test]
+    fn nested_class_parameters_shadow_same_named_outer_bindings() {
+        let nested = Type::Class {
+            identity: Some("fixture.Inner".to_string()),
+            type_args: vec![Type::Str],
+            name: "Inner".to_string(),
+            fields: vec![("value".to_string(), Type::TypeVar("T".to_string()))],
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let bindings = HashMap::from([("T".to_string(), Type::Int)]);
+
+        let substituted =
+            substitute_type_vars_with_class_scopes(&nested, &bindings, &|identity, name| {
+                assert_eq!(identity, Some("fixture.Inner"));
+                assert_eq!(name, "Inner");
+                vec!["T".to_string()]
+            });
+        let Type::Class { fields, .. } = substituted else {
+            panic!("nested type must stay nominal");
+        };
+        assert_eq!(fields[0].1, Type::Str);
+    }
+}

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -896,7 +896,8 @@ avoiding a cycle with later handler and attached-API outputs.
 Structural shape derivation specializes finalized adapter field-plan types with the concrete
 owner arguments before package specialization. Local and imported adapted generic classes use the
 same substitution rule, so nested concrete uses do not expose unbound declaration parameters to a
-package specializer.
+package specializer. Nested nominal declarations rebind their own type parameters before field and
+method substitution. An outer parameter with the same name cannot capture the nested parameter.
 
 Checked adapted-handler exports retain the callable target with a signature specialized relative
 to the selected owner's type parameters. Generic substitution follows the full local ancestor

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -150,6 +150,8 @@ The finalized adapter field plan supplies the required and default states for th
 When a concrete generic adapted type is described, the compiler substitutes its concrete type
 arguments into every finalized field-plan type. The same rule applies to local and imported
 adapted classes. A concrete static-program shape cannot retain the declaration's type parameters.
+Substitution respects nested nominal scopes. A nested class binds its own type parameters before
+the compiler substitutes its fields and methods, even when an outer class uses the same names.
 
 An unbound generic adapted declaration does not request a schema program.
 A concrete owner must supply all type arguments before static program generation.


### PR DESCRIPTION
## Summary
- add declaration-aware type substitution for nested nominal scopes
- use local and exported class parameter ownership for adapted field plans
- add local and imported same-name generic scope regressions
- document the nested scope contract

## Validation
- `cargo test -p sifr_lowering --lib --no-fail-fast`: 1004 passed, 1 ignored
- `cargo test -p sifr_frontend --lib --no-fail-fast`: 107 passed
- `cargo test -p sifr_driver tests::adapter_defaults --no-fail-fast`: 15 passed
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --check`
- HIR maintainability and file-size guardrails
- create-PR gate (single run): stopped only at the externally owned missing Rust-interop negative fixture and empty schema-program placeholder