### PR TITLE
Consolidate structural type substitution

### DIFF
--- a/crates/sifr_codegen/src/structural_identity_codegen.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen.rs
@@ -1,11 +1,13 @@
 use sifr_ir::{canonical_structural_identity_value, HirClass, HirModule};
 use sifr_structural_identity::{self as identity, NominalField, ShapeIdentity, ALGORITHM_VERSION};
-use sifr_type_system::Type;
+use sifr_type_system::{substitute_type_vars_with_class_scopes, Type};
 use std::collections::{HashMap, HashSet};
 
 mod mapped_opaque;
 mod render;
-use crate::structural_record_fields::{concrete_record_fields, substitute_structural_type};
+#[cfg(test)]
+mod substitution_tests;
+use crate::structural_record_fields::concrete_record_fields;
 use mapped_opaque::{
     mapped_opaque_identity_expression, mapped_opaque_identity_expression_for_imported_type,
 };
@@ -70,6 +72,19 @@ impl<'a> IdentityContext<'a> {
         let candidate = candidates.next()?;
         candidates.next().is_none().then_some(candidate)
     }
+}
+
+fn substitute_structural_type(
+    ty: &Type,
+    bindings: &HashMap<String, Type>,
+    scope_module_name: &str,
+    context: &IdentityContext<'_>,
+) -> Type {
+    substitute_type_vars_with_class_scopes(ty, bindings, &|identity, name| {
+        context
+            .class_candidate(identity, name, scope_module_name)
+            .map(|(_, _, class)| class.type_params.clone())
+    })
 }
 
 impl CompiledIdentity {
@@ -359,7 +374,17 @@ fn compile_type(
                     class
                         .fields
                         .iter()
-                        .map(|(name, ty)| (name.clone(), substitute_structural_type(ty, &bindings)))
+                        .map(|(name, ty)| {
+                            (
+                                name.clone(),
+                                substitute_structural_type(
+                                    ty,
+                                    &bindings,
+                                    scope_module_name,
+                                    context,
+                                ),
+                            )
+                        })
                         .collect()
                 },
             );
@@ -603,88 +628,6 @@ mod tests {
             methods: Vec::new(),
             parent_class: None,
         }
-    }
-
-    #[test]
-    fn structural_substitution_preserves_generic_union_grouping() {
-        let template =
-            sifr_type_system::make_union(vec![Type::Int, Type::TypeVar("T".to_string())]);
-        let bindings = HashMap::from([("T".to_string(), Type::Bool)]);
-        let actual = substitute_structural_type(&template, &bindings);
-
-        assert_eq!(actual, Type::Union(vec![Type::Int, Type::Bool]));
-    }
-
-    #[test]
-    fn generic_union_identity_matches_reordered_collapsed_and_nested_substitutions() {
-        let modules = Vec::new();
-        let context = IdentityContext { modules: &modules };
-        let template =
-            sifr_type_system::make_union(vec![Type::Str, Type::TypeVar("T".to_string())]);
-        assert_eq!(
-            compile_type(&template, "main", &context, &mut Vec::new()).expression(),
-            format!(
-                "{STRUCTURAL}::union(&[{STRUCTURAL}::ShapeIdentity::from_bytes({:?}), <T as {STRUCTURAL}::StructuralType>::shape_identity()])",
-                identity::primitive("str").as_bytes()
-            )
-        );
-
-        let reordered =
-            substitute_structural_type(&template, &HashMap::from([("T".to_string(), Type::Int)]));
-        let reordered_identity =
-            compile_type(&reordered, "main", &context, &mut Vec::new()).static_value();
-        assert_eq!(
-            reordered_identity,
-            Some(identity::union(&[
-                identity::primitive("str"),
-                identity::primitive("int"),
-            ]))
-        );
-
-        let collapsed =
-            substitute_structural_type(&template, &HashMap::from([("T".to_string(), Type::Str)]));
-        let collapsed_identity =
-            compile_type(&collapsed, "main", &context, &mut Vec::new()).static_value();
-        assert_eq!(collapsed, Type::Union(vec![Type::Str, Type::Str]));
-        assert_eq!(collapsed_identity, Some(identity::primitive("str")));
-
-        let nested_argument = sifr_type_system::make_union(vec![Type::Int, Type::Bool]);
-        let nested = substitute_structural_type(
-            &template,
-            &HashMap::from([("T".to_string(), nested_argument)]),
-        );
-        let nested_identity =
-            compile_type(&nested, "main", &context, &mut Vec::new()).static_value();
-        assert_eq!(
-            nested_identity,
-            Some(identity::union(&[
-                identity::primitive("str"),
-                identity::union(&[identity::primitive("bool"), identity::primitive("int"),]),
-            ]))
-        );
-
-        let optional_template =
-            sifr_type_system::make_union(vec![Type::None, Type::TypeVar("T".to_string())]);
-        assert_eq!(
-            compile_type(&optional_template, "main", &context, &mut Vec::new()).expression(),
-            format!(
-                "{STRUCTURAL}::unary_container(\"optional\", <T as {STRUCTURAL}::StructuralType>::shape_identity())"
-            )
-        );
-        let optional_argument = sifr_type_system::make_union(vec![Type::None, Type::Str]);
-        let nested_optional = substitute_structural_type(
-            &optional_template,
-            &HashMap::from([("T".to_string(), optional_argument)]),
-        );
-        let nested_optional_identity =
-            compile_type(&nested_optional, "main", &context, &mut Vec::new()).static_value();
-        assert_eq!(
-            nested_optional_identity,
-            Some(identity::unary_container(
-                "optional",
-                identity::unary_container("optional", identity::primitive("str")),
-            ))
-        );
     }
 
     #[test]

--- a/crates/sifr_codegen/src/structural_identity_codegen/substitution_tests.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen/substitution_tests.rs
@@ -1,0 +1,174 @@
+use super::*;
+use sifr_ir::HirClassKind;
+
+fn class(name: &str, fields: Vec<(String, Type)>) -> HirClass {
+    HirClass {
+        name: name.to_string(),
+        identity: None,
+        fields,
+        field_defaults: Vec::new(),
+        field_default_identities: Vec::new(),
+        declaration_metadata: Vec::new(),
+        methods: Vec::new(),
+        is_hashable: false,
+        is_error_type: false,
+        kind: HirClassKind::Regular,
+        operator_impls: Vec::new(),
+        newtype_inner: None,
+        implements_protocols: Vec::new(),
+        parent_class: None,
+        parent_type: None,
+        type_params: Vec::new(),
+        enum_variants: Vec::new(),
+        rust_interop: Vec::new(),
+    }
+}
+
+#[test]
+fn structural_substitution_canonicalizes_generic_union_members() {
+    let modules = Vec::new();
+    let context = IdentityContext { modules: &modules };
+    let template = sifr_type_system::make_union(vec![Type::Int, Type::TypeVar("T".to_string())]);
+    let bindings = HashMap::from([("T".to_string(), Type::Bool)]);
+    let actual = substitute_structural_type(&template, &bindings, "main", &context);
+
+    assert_eq!(actual, Type::Union(vec![Type::Bool, Type::Int]));
+}
+
+#[test]
+fn structural_substitution_uses_project_nominal_scope_authority() {
+    let mut inner = class(
+        "Inner",
+        vec![("value".to_string(), Type::TypeVar("T".to_string()))],
+    );
+    inner.type_params = vec!["T".to_string()];
+    let module = HirModule {
+        functions: Vec::new(),
+        classes: vec![inner],
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: HashMap::new(),
+        type_param_bounds: HashMap::new(),
+    };
+    let modules = [("models", &module)];
+    let context = IdentityContext { modules: &modules };
+    let template = Type::Class {
+        identity: Some("models.Inner".to_string()),
+        type_args: vec![Type::Str],
+        name: "Inner".to_string(),
+        fields: vec![("value".to_string(), Type::TypeVar("T".to_string()))],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let bindings = HashMap::from([("T".to_string(), Type::Int)]);
+    let resolved = substitute_structural_type(&template, &bindings, "models", &context);
+    let Type::Class {
+        type_args, fields, ..
+    } = resolved
+    else {
+        panic!("resolved nested type must stay nominal");
+    };
+    assert_eq!(type_args, vec![Type::Str]);
+    assert_eq!(fields[0].1, Type::Str);
+
+    let missing = Type::Class {
+        identity: Some("missing.Inner".to_string()),
+        type_args: vec![Type::TypeVar("T".to_string())],
+        name: "Inner".to_string(),
+        fields: vec![("value".to_string(), Type::TypeVar("T".to_string()))],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let unresolved = substitute_structural_type(&missing, &bindings, "models", &context);
+    let Type::Class {
+        type_args, fields, ..
+    } = unresolved
+    else {
+        panic!("unresolved nested type must stay nominal");
+    };
+    assert_eq!(type_args, vec![Type::Int]);
+    assert_eq!(fields[0].1, Type::TypeVar("T".to_string()));
+}
+
+#[test]
+fn generic_union_identity_matches_reordered_collapsed_and_nested_substitutions() {
+    let modules = Vec::new();
+    let context = IdentityContext { modules: &modules };
+    let template = sifr_type_system::make_union(vec![Type::Str, Type::TypeVar("T".to_string())]);
+    assert_eq!(
+        compile_type(&template, "main", &context, &mut Vec::new()).expression(),
+        format!(
+            "{STRUCTURAL}::union(&[{STRUCTURAL}::ShapeIdentity::from_bytes({:?}), <T as {STRUCTURAL}::StructuralType>::shape_identity()])",
+            identity::primitive("str").as_bytes()
+        )
+    );
+
+    let reordered = substitute_structural_type(
+        &template,
+        &HashMap::from([("T".to_string(), Type::Int)]),
+        "main",
+        &context,
+    );
+    let reordered_identity =
+        compile_type(&reordered, "main", &context, &mut Vec::new()).static_value();
+    assert_eq!(
+        reordered_identity,
+        Some(identity::union(&[
+            identity::primitive("str"),
+            identity::primitive("int"),
+        ]))
+    );
+
+    let collapsed = substitute_structural_type(
+        &template,
+        &HashMap::from([("T".to_string(), Type::Str)]),
+        "main",
+        &context,
+    );
+    let collapsed_identity =
+        compile_type(&collapsed, "main", &context, &mut Vec::new()).static_value();
+    assert_eq!(collapsed, Type::Str);
+    assert_eq!(collapsed_identity, Some(identity::primitive("str")));
+
+    let nested_argument = sifr_type_system::make_union(vec![Type::Int, Type::Bool]);
+    let nested = substitute_structural_type(
+        &template,
+        &HashMap::from([("T".to_string(), nested_argument)]),
+        "main",
+        &context,
+    );
+    let nested_identity = compile_type(&nested, "main", &context, &mut Vec::new()).static_value();
+    assert_eq!(
+        nested_identity,
+        Some(identity::union(&[
+            identity::primitive("str"),
+            identity::primitive("bool"),
+            identity::primitive("int"),
+        ]))
+    );
+
+    let optional_template =
+        sifr_type_system::make_union(vec![Type::None, Type::TypeVar("T".to_string())]);
+    assert_eq!(
+        compile_type(&optional_template, "main", &context, &mut Vec::new()).expression(),
+        format!(
+            "{STRUCTURAL}::unary_container(\"optional\", <T as {STRUCTURAL}::StructuralType>::shape_identity())"
+        )
+    );
+    let optional_argument = sifr_type_system::make_union(vec![Type::None, Type::Str]);
+    let nested_optional = substitute_structural_type(
+        &optional_template,
+        &HashMap::from([("T".to_string(), optional_argument)]),
+        "main",
+        &context,
+    );
+    let nested_optional_identity =
+        compile_type(&nested_optional, "main", &context, &mut Vec::new()).static_value();
+    assert_eq!(
+        nested_optional_identity,
+        Some(identity::unary_container(
+            "optional",
+            identity::primitive("str")
+        ))
+    );
+}

--- a/crates/sifr_codegen/src/structural_record_fields.rs
+++ b/crates/sifr_codegen/src/structural_record_fields.rs
@@ -1,6 +1,5 @@
 use sifr_ir::HirClass;
 use sifr_type_system::Type;
-use std::collections::HashMap;
 
 pub(crate) struct StructuralRecordField<'a> {
     pub(crate) name: &'a str,
@@ -37,62 +36,4 @@ pub(crate) fn concrete_record_fields(class: &HirClass) -> Vec<(String, Type)> {
         .into_iter()
         .map(|field| (field.name.to_string(), field.ty.clone()))
         .collect()
-}
-
-pub(crate) fn substitute_structural_type(ty: &Type, bindings: &HashMap<String, Type>) -> Type {
-    match ty {
-        Type::TypeVar(name) => bindings.get(name).cloned().unwrap_or_else(|| ty.clone()),
-        Type::List(value) => Type::List(Box::new(substitute_structural_type(value, bindings))),
-        Type::Set(value) => Type::Set(Box::new(substitute_structural_type(value, bindings))),
-        Type::Dict(key, value) => Type::Dict(
-            Box::new(substitute_structural_type(key, bindings)),
-            Box::new(substitute_structural_type(value, bindings)),
-        ),
-        Type::Tuple(values) => Type::Tuple(
-            values
-                .iter()
-                .map(|value| substitute_structural_type(value, bindings))
-                .collect(),
-        ),
-        Type::Union(values) => Type::Union(
-            values
-                .iter()
-                .map(|value| substitute_structural_type(value, bindings))
-                .collect(),
-        ),
-        Type::Class {
-            identity,
-            type_args,
-            name,
-            fields,
-            methods,
-            parent_class,
-        } => Type::Class {
-            identity: identity.clone(),
-            type_args: type_args
-                .iter()
-                .map(|value| substitute_structural_type(value, bindings))
-                .collect(),
-            name: name.clone(),
-            fields: fields
-                .iter()
-                .map(|(name, value)| (name.clone(), substitute_structural_type(value, bindings)))
-                .collect(),
-            methods: methods.clone(),
-            parent_class: parent_class.clone(),
-        },
-        Type::Alias {
-            name,
-            type_args,
-            body,
-        } => Type::Alias {
-            name: name.clone(),
-            type_args: type_args
-                .iter()
-                .map(|value| substitute_structural_type(value, bindings))
-                .collect(),
-            body: Box::new(substitute_structural_type(body, bindings)),
-        },
-        other => other.clone(),
-    }
 }

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -169,8 +169,6 @@ mod rust_interop_tests;
 #[cfg(test)]
 mod rust_opaque_constructor_tests;
 mod scope_helpers;
-mod scoped_type_substitution;
-pub use scoped_type_substitution::{substitute_type_vars, substitute_type_vars_with_class_scopes};
 mod sequence_guard_detection;
 mod sequence_guard_updates;
 mod sequence_guards;
@@ -250,6 +248,7 @@ use imports::resolve_imports_early;
 use ruff_text_size::{Ranged, TextRange};
 use sifr_diagnostics::DiagnosticCode;
 use sifr_python_ast::{Expr, Stmt};
+pub use sifr_type_system::{substitute_type_vars, substitute_type_vars_with_class_scopes};
 use sifr_type_system::{FunctionType, Type};
 use std::collections::HashMap;
 use type_aliases::{collect_type_alias_decls, predeclare_type_aliases, resolve_type_aliases};

--- a/crates/sifr_type_system/src/lib.rs
+++ b/crates/sifr_type_system/src/lib.rs
@@ -11,6 +11,7 @@ mod collection_capabilities;
 pub mod infer;
 pub mod literal;
 mod safe_optional;
+mod substitution;
 #[cfg(test)]
 mod type_capability_identity_tests;
 mod types;
@@ -33,6 +34,7 @@ pub mod narrow;
 pub use literal::{widen as widen_literal, LiteralValue};
 pub use narrow::{narrow_type, NarrowingCondition};
 pub use safe_optional::safe_optional_result;
+pub use substitution::{substitute_type_vars, substitute_type_vars_with_class_scopes};
 
 /// Returns whether a declaration belongs to a public stdlib module's compiled
 /// export surface. Underscore-prefixed declarations are private except for the

--- a/crates/sifr_type_system/src/substitution.rs
+++ b/crates/sifr_type_system/src/substitution.rs
@@ -1,6 +1,6 @@
 //! Type-variable substitution across nested nominal declaration scopes.
 
-use sifr_type_system::{make_union, FunctionType, Type};
+use crate::{make_union, FunctionType, Type};
 use std::collections::HashMap;
 
 /// Substitute type variables without declaration-scope metadata.
@@ -143,7 +143,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::substitute_type_vars_with_class_scopes;
-    use sifr_type_system::Type;
+    use crate::Type;
     use std::collections::HashMap;
 
     #[test]

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -900,6 +900,10 @@ package specializer. Nested nominal declarations rebind their own type parameter
 method substitution. An outer parameter with the same name cannot capture the nested parameter.
 Local declaration identity and exported parameter metadata are the only binding authorities. An
 unresolved nested scope stays symbolic and does not use a consumer-local class with the same name.
+The type system owns this substitution visitor. Lowering and structural code generation supply
+their declaration resolvers to the same visitor. Substitution also rebuilds unions through the
+canonical union constructor. Therefore, structural identity uses normalized concrete types after
+generic substitution.
 
 Checked adapted-handler exports retain the callable target with a signature specialized relative
 to the selected owner's type parameters. Generic substitution follows the full local ancestor

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -154,6 +154,9 @@ Substitution respects nested nominal scopes. A nested class binds its own type p
 the compiler substitutes its fields and methods, even when an outer class uses the same names.
 The compiler uses local declaration identity or exported parameter metadata for this binding. If
 that authority is unavailable, nested parameters stay unresolved and cannot capture outer values.
+The type system owns the shared substitution visitor. Lowering and project code generation give
+that visitor their declaration resolvers. The visitor canonicalizes unions after substitution.
+Reordered, duplicate, and nested union members therefore produce one concrete structural identity.
 
 An unbound generic adapted declaration does not request a schema program.
 A concrete owner must supply all type arguments before static program generation.


### PR DESCRIPTION
## Summary
- move generic type substitution into the shared type-system crate
- route structural identity codegen through project-aware nominal scope resolution
- canonicalize substituted unions and document the shared authority

## Validation
- cargo test -p sifr_type_system --lib --no-fail-fast
- cargo test -p sifr_lowering --lib --no-fail-fast
- cargo test -p sifr_codegen --lib --no-fail-fast
- cargo test -p sifr_frontend --lib --no-fail-fast
- cargo test -p sifr_driver --lib --no-fail-fast
- cargo clippy --workspace -- -D warnings
- cargo fmt --all --check
- maintainability and file-size guardrails
- create-PR gate reached only the known external Rust-interop fixture inputs after all preceding checks passed

Exact candidate: 3d4eb41f33344ddab749a63874e87dd4a9ce5fe0