### PR TITLE
Resolve structural fields in declaring modules

### DIFF
--- a/crates/sifr_codegen/src/structural_identity_codegen.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen.rs
@@ -362,6 +362,8 @@ fn compile_type(
                 .iter()
                 .map(|argument| compile_type(argument, scope_module_name, context, stack))
                 .collect::<Vec<_>>();
+            let declaration_module_name =
+                candidate.map_or(scope_module_name, |(module_name, _, _)| module_name);
             let concrete_fields = candidate.map_or_else(
                 || fields.clone(),
                 |(_, _, class)| {
@@ -380,7 +382,7 @@ fn compile_type(
                                 substitute_structural_type(
                                     ty,
                                     &bindings,
-                                    scope_module_name,
+                                    declaration_module_name,
                                     context,
                                 ),
                             )
@@ -393,7 +395,7 @@ fn compile_type(
                 &arguments,
                 &concrete_fields,
                 candidate.map(|(_, _, class)| class),
-                candidate.map_or(scope_module_name, |(module_name, _, _)| module_name),
+                declaration_module_name,
                 context,
                 stack,
             );

--- a/crates/sifr_codegen/src/structural_identity_codegen/substitution_tests.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen/substitution_tests.rs
@@ -91,6 +91,89 @@ fn structural_substitution_uses_project_nominal_scope_authority() {
 }
 
 #[test]
+fn imported_outer_fields_resolve_nested_scopes_in_the_declaring_module() {
+    let mut model_inner = class(
+        "Inner",
+        vec![("value".to_string(), Type::TypeVar("T".to_string()))],
+    );
+    model_inner.type_params = vec!["T".to_string()];
+    let mut model_outer = class(
+        "Outer",
+        vec![(
+            "inner".to_string(),
+            Type::Class {
+                identity: None,
+                type_args: vec![Type::Str],
+                name: "Inner".to_string(),
+                fields: vec![("value".to_string(), Type::TypeVar("T".to_string()))],
+                methods: Vec::new(),
+                parent_class: None,
+            },
+        )],
+    );
+    model_outer.identity = Some("models.Outer".to_string());
+    model_outer.type_params = vec!["T".to_string()];
+    let models = HirModule {
+        functions: Vec::new(),
+        classes: vec![model_inner, model_outer],
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: HashMap::new(),
+        type_param_bounds: HashMap::new(),
+    };
+
+    let mut consumer_inner = class(
+        "Inner",
+        vec![("value".to_string(), Type::TypeVar("U".to_string()))],
+    );
+    consumer_inner.type_params = vec!["U".to_string()];
+    let main = HirModule {
+        functions: Vec::new(),
+        classes: vec![consumer_inner],
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: HashMap::new(),
+        type_param_bounds: HashMap::new(),
+    };
+    let modules = [("models", &models), ("main", &main)];
+    let context = IdentityContext { modules: &modules };
+    let concrete_outer = Type::Class {
+        identity: Some("models.Outer".to_string()),
+        type_args: vec![Type::Int],
+        name: "Outer".to_string(),
+        fields: Vec::new(),
+        methods: Vec::new(),
+        parent_class: None,
+    };
+
+    let actual = compile_type(&concrete_outer, "main", &context, &mut Vec::new()).static_value();
+    let inner = identity::nominal_record(
+        "models.Inner",
+        &[identity::primitive("str")],
+        &[NominalField {
+            name: "value",
+            identity: identity::primitive("str"),
+            required: true,
+            default_identity: None,
+        }],
+        identity::metadata(&[]),
+    );
+    let expected = identity::nominal_record(
+        "models.Outer",
+        &[identity::primitive("int")],
+        &[NominalField {
+            name: "inner",
+            identity: inner,
+            required: true,
+            default_identity: None,
+        }],
+        identity::metadata(&[]),
+    );
+
+    assert_eq!(actual, Some(expected));
+}
+
+#[test]
 fn generic_union_identity_matches_reordered_collapsed_and_nested_substitutions() {
     let modules = Vec::new();
     let context = IdentityContext { modules: &modules };

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -903,7 +903,8 @@ unresolved nested scope stays symbolic and does not use a consumer-local class w
 The type system owns this substitution visitor. Lowering and structural code generation supply
 their declaration resolvers to the same visitor. Substitution also rebuilds unions through the
 canonical union constructor. Therefore, structural identity uses normalized concrete types after
-generic substitution.
+generic substitution. Code generation resolves nested scopes from the selected outer declaration's
+module. A consumer module cannot redirect an identityless nested field to a same-named class.
 
 Checked adapted-handler exports retain the callable target with a signature specialized relative
 to the selected owner's type parameters. Generic substitution follows the full local ancestor

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -157,6 +157,8 @@ that authority is unavailable, nested parameters stay unresolved and cannot capt
 The type system owns the shared substitution visitor. Lowering and project code generation give
 that visitor their declaration resolvers. The visitor canonicalizes unions after substitution.
 Reordered, duplicate, and nested union members therefore produce one concrete structural identity.
+Project code generation uses the selected outer declaration's module for nested scope resolution.
+It does not use the consumer module for identityless nested fields.
 
 An unbound generic adapted declaration does not request a schema program.
 A concrete owner must supply all type arguments before static program generation.


### PR DESCRIPTION
## Summary
- resolve nested field scopes from the selected outer declaration's module
- prevent consumer-local same-named classes from redirecting imported structural identity
- add a project collision regression and document the authority

## Validation
- 1,055 sifr_codegen tests
- workspace clippy with warnings denied
- formatting, maintainability, file-size, and diff guardrails
- one create-PR gate reached only the known external Rust-interop fixture inputs

Exact candidate: d24ce74361792cb23da6f2254b8a9132d49b2cc9