### PR TITLE
Reject unstable generic union representations

### DIFF
--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -3,6 +3,9 @@ use sifr_ir::{HirClass, HirModule, RustInteropDecoratorKind};
 use sifr_type_system::{class_rust_name, Type};
 use std::collections::{BTreeSet, HashSet};
 
+#[cfg(test)]
+mod generic_representation_tests;
+
 use crate::structural_record_fields::structural_record_fields;
 
 const STRUCTURAL: &str = "::sifr_runtime::interop::structural";
@@ -222,6 +225,7 @@ fn structural_parent_supported(
     };
     let Type::Class {
         identity,
+        type_args,
         name,
         fields,
         ..
@@ -232,7 +236,8 @@ fn structural_parent_supported(
     let Some(parent) = structural_class_candidate(identity.as_deref(), name, modules) else {
         return false;
     };
-    parent.parent_class.is_none()
+    generic_arguments_preserve_union_structure(parent, type_args)
+        && parent.parent_class.is_none()
         && !parent.methods.iter().any(|method| method.name == "new")
         && !parent.is_error_type
         && parent.newtype_inner.is_none()
@@ -298,15 +303,23 @@ fn structural_type_supported(
         Type::Union(values) => values
             .iter()
             .all(|value| structural_type_supported(value, modules, visiting)),
-        Type::Class { identity, name, .. } => {
+        Type::Class {
+            identity,
+            type_args,
+            name,
+            ..
+        } => {
             let key = identity.as_deref().unwrap_or(name);
-            if visiting.contains(key) {
-                return true;
-            }
             let Some(candidate) = structural_class_candidate(identity.as_deref(), name, modules)
             else {
                 return false;
             };
+            if !generic_arguments_preserve_union_structure(candidate, type_args) {
+                return false;
+            }
+            if visiting.contains(key) {
+                return true;
+            }
             if structural_mapped_opaque_supported(candidate) {
                 return true;
             }
@@ -321,6 +334,27 @@ fn structural_type_supported(
         Type::Newtype { .. } => false,
         _ => false,
     }
+}
+
+fn generic_arguments_preserve_union_structure(class: &HirClass, type_args: &[Type]) -> bool {
+    let bindings = class
+        .type_params
+        .iter()
+        .cloned()
+        .zip(type_args.iter().cloned())
+        .collect::<std::collections::HashMap<_, _>>();
+    class
+        .fields
+        .iter()
+        .all(|(_, ty)| sifr_type_system::substitution_preserves_union_structure(ty, &bindings))
+        && class.methods.iter().all(|method| {
+            method.params.iter().all(|param| {
+                sifr_type_system::substitution_preserves_union_structure(&param.ty, &bindings)
+            }) && sifr_type_system::substitution_preserves_union_structure(
+                &method.return_type,
+                &bindings,
+            )
+        })
 }
 
 fn structural_class_candidate<'a>(

--- a/crates/sifr_codegen/src/structural_impl_codegen/generic_representation_tests.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen/generic_representation_tests.rs
@@ -1,0 +1,69 @@
+use super::structural_record_identities_for_project;
+use sifr_ir::{HirClass, HirClassKind, HirModule};
+use sifr_type_system::Type;
+use std::collections::HashMap;
+
+fn class(name: &str, fields: Vec<(String, Type)>) -> HirClass {
+    HirClass {
+        name: name.to_string(),
+        identity: Some(format!("main.{name}")),
+        fields,
+        field_defaults: Vec::new(),
+        field_default_identities: Vec::new(),
+        declaration_metadata: Vec::new(),
+        methods: Vec::new(),
+        is_hashable: false,
+        is_error_type: false,
+        kind: HirClassKind::Regular,
+        operator_impls: Vec::new(),
+        newtype_inner: None,
+        implements_protocols: Vec::new(),
+        parent_class: None,
+        parent_type: None,
+        type_params: Vec::new(),
+        enum_variants: Vec::new(),
+        rust_interop: Vec::new(),
+    }
+}
+
+#[test]
+fn nested_generic_union_topology_change_is_not_structurally_supported() {
+    let mut generic = class(
+        "Generic",
+        vec![(
+            "value".to_string(),
+            Type::Union(vec![Type::None, Type::TypeVar("T".to_string())]),
+        )],
+    );
+    generic.type_params = vec!["T".to_string()];
+    let concrete = Type::Class {
+        identity: Some("main.Generic".to_string()),
+        type_args: vec![sifr_type_system::make_union(vec![Type::None, Type::Str])],
+        name: "Generic".to_string(),
+        fields: vec![(
+            "value".to_string(),
+            sifr_type_system::make_union(vec![Type::None, Type::Str]),
+        )],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let owner = class("Owner", vec![("payload".to_string(), concrete.clone())]);
+    let mut child = class("Child", vec![("label".to_string(), Type::Str)]);
+    child.parent_class = Some("Generic".to_string());
+    child.parent_type = Some(concrete);
+    let module = HirModule {
+        functions: Vec::new(),
+        classes: vec![generic, owner, child],
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: HashMap::new(),
+        type_param_bounds: HashMap::new(),
+    };
+    let modules = [("main", &module)];
+
+    let supported = structural_record_identities_for_project(&modules);
+
+    assert!(supported.contains("main.Generic"));
+    assert!(!supported.contains("main.Owner"));
+    assert!(!supported.contains("main.Child"));
+}

--- a/crates/sifr_driver/src/tests/generic_adapter_representation.rs
+++ b/crates/sifr_driver/src/tests/generic_adapter_representation.rs
@@ -1,0 +1,119 @@
+use super::project_build_check::mktemp_dir;
+use crate::{build_project, check_project};
+use sifr_diagnostics::DiagnosticCode;
+
+#[test]
+fn nested_optional_generic_parent_is_rejected_before_rust_codegen() {
+    let dir = mktemp_dir("nested_optional_generic_parent");
+    let main_file = dir.join("main.sifr");
+    std::fs::write(
+        &main_file,
+        r#"
+class Parent[T]:
+    value: T | None
+
+class Concrete(Parent[str | None]):
+    label: int
+
+    def __init__(self, value: str | None, label: int):
+        super().__init__(value)
+        self.label = label
+
+def main():
+    value: Concrete = Concrete(None, 1)
+    assert value.value is None
+"#,
+    )
+    .expect("main module should be written");
+
+    let errors = check_project(&main_file, &mut sifr_frontend::DiskSourceProvider::new());
+    assert!(errors.iter().any(|error| {
+        error.code == DiagnosticCode::CLASS_INVALID_BASE.code()
+            && error.message.contains("union's member topology")
+    }));
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn union_bearing_generic_parent_accepts_a_topology_preserving_argument() {
+    let dir = mktemp_dir("stable_union_generic_parent");
+    let main_file = dir.join("main.sifr");
+    let build_out = dir.join("build_out");
+    std::fs::write(
+        &main_file,
+        r#"
+class Parent[T]:
+    value: T | None
+
+class Concrete(Parent[str]):
+    def __init__(self, value: str | None):
+        super().__init__(value)
+
+def main():
+    value: Concrete = Concrete("ready")
+    assert value.value == "ready"
+"#,
+    )
+    .expect("main module should be written");
+
+    let result = build_project(
+        &main_file,
+        &build_out,
+        &mut sifr_frontend::DiskSourceProvider::new(),
+    );
+    assert!(
+        result.is_ok(),
+        "stable generic union topology must build: {result:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn consumer_class_identity_survives_imported_generic_parent_substitution() {
+    let dir = mktemp_dir("consumer_generic_parent_identity");
+    let main_file = dir.join("main.sifr");
+    let build_out = dir.join("build_out");
+    std::fs::write(
+        dir.join("models.sifr"),
+        r#"
+class Payload:
+    label: str
+
+class Parent[T]:
+    value: T
+"#,
+    )
+    .expect("models module should be written");
+    std::fs::write(
+        &main_file,
+        r#"
+from models import Parent
+
+class Payload:
+    value: int
+
+class Concrete(Parent[Payload]):
+    def __init__(self, value: Payload):
+        super().__init__(value)
+
+def main():
+    value: Concrete = Concrete(Payload(1))
+    assert value.value.value == 1
+"#,
+    )
+    .expect("main module should be written");
+
+    let result = build_project(
+        &main_file,
+        &build_out,
+        &mut sifr_frontend::DiskSourceProvider::new(),
+    );
+    assert!(
+        result.is_ok(),
+        "consumer class identity must survive substitution: {result:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod attached_api_aliases;
 mod diagnostics;
 mod discovery_and_workspace;
 mod early_adapters;
+mod generic_adapter_representation;
 mod handler_descriptors;
 mod imported_attached_apis;
 mod package_project_build_check;

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -317,6 +317,18 @@ pub(in crate::lower) fn collect_class_type(
             crate::lower::descriptor_declarations::data_parent_type(class_def, ctx)
                 .or_else(|| ctx.class_types.get(parent_name).cloned())
         {
+            if ctx.class_types.get(parent_name).is_some_and(|template| {
+                !super::super::generic_parent_representation::preserves_union_structure(
+                    template, &parent_ty,
+                )
+            }) {
+                invalid_class_base(
+                    ctx,
+                    &class_name,
+                    "generic parent arguments change a declared union's member topology",
+                    parent_class_range(class_def, parent_name),
+                );
+            }
             if let Type::Class {
                 identity: parent_identity,
                 name: parent_type_name,

--- a/crates/sifr_lowering/src/lower/generic_parent_representation.rs
+++ b/crates/sifr_lowering/src/lower/generic_parent_representation.rs
@@ -1,0 +1,69 @@
+use sifr_type_system::{substitution_preserves_union_structure, Type};
+use std::collections::HashMap;
+
+pub(super) fn preserves_union_structure(template: &Type, concrete: &Type) -> bool {
+    let (
+        Type::Class {
+            type_args: template_args,
+            fields,
+            methods,
+            ..
+        },
+        Type::Class {
+            type_args: concrete_args,
+            ..
+        },
+    ) = (template.resolve_alias(), concrete.resolve_alias())
+    else {
+        return true;
+    };
+    let bindings = template_args
+        .iter()
+        .zip(concrete_args)
+        .filter_map(|(template, concrete)| match template.resolve_alias() {
+            Type::TypeVar(name) => Some((name.clone(), concrete.clone())),
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
+    fields
+        .iter()
+        .all(|(_, ty)| substitution_preserves_union_structure(ty, &bindings))
+        && methods.iter().all(|(_, method)| {
+            method
+                .params
+                .iter()
+                .all(|(_, ty, _)| substitution_preserves_union_structure(ty, &bindings))
+                && substitution_preserves_union_structure(&method.return_type, &bindings)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::preserves_union_structure;
+    use sifr_type_system::Type;
+
+    fn parent(type_arg: Type, field: Type) -> Type {
+        Type::Class {
+            identity: Some("models.Parent".to_string()),
+            type_args: vec![type_arg],
+            name: "Parent".to_string(),
+            fields: vec![("value".to_string(), field)],
+            methods: Vec::new(),
+            parent_class: None,
+        }
+    }
+
+    #[test]
+    fn generic_parent_rejects_only_union_topology_changes() {
+        let template = parent(
+            Type::TypeVar("T".to_string()),
+            Type::Union(vec![Type::None, Type::TypeVar("T".to_string())]),
+        );
+        let safe = parent(Type::Str, Type::Union(vec![Type::None, Type::Str]));
+        let unsafe_arg = sifr_type_system::make_union(vec![Type::None, Type::Str]);
+        let unsafe_parent = parent(unsafe_arg, Type::Union(vec![Type::None, Type::Str]));
+
+        assert!(preserves_union_structure(&template, &safe));
+        assert!(!preserves_union_structure(&template, &unsafe_parent));
+    }
+}

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -67,6 +67,7 @@ mod function_scopes;
 mod generic_constructor_specialization;
 mod generic_inference;
 mod generic_method_requirements;
+mod generic_parent_representation;
 mod generic_receiver_specialization;
 mod guarded_index;
 mod if_branch_bindings;

--- a/crates/sifr_type_system/src/lib.rs
+++ b/crates/sifr_type_system/src/lib.rs
@@ -34,7 +34,10 @@ pub mod narrow;
 pub use literal::{widen as widen_literal, LiteralValue};
 pub use narrow::{narrow_type, NarrowingCondition};
 pub use safe_optional::safe_optional_result;
-pub use substitution::{substitute_type_vars, substitute_type_vars_with_class_scopes};
+pub use substitution::{
+    substitute_type_vars, substitute_type_vars_with_class_scopes,
+    substitution_preserves_union_structure,
+};
 
 /// Returns whether a declaration belongs to a public stdlib module's compiled
 /// export surface. Underscore-prefixed declarations are private except for the

--- a/crates/sifr_type_system/src/substitution.rs
+++ b/crates/sifr_type_system/src/substitution.rs
@@ -140,9 +140,63 @@ where
     }
 }
 
+/// Return whether substitution keeps every union's immediate member topology.
+///
+/// Rust generic storage retains the declaration's union nesting. A substituted
+/// union member cannot expand into another union or collapse into a sibling.
+pub fn substitution_preserves_union_structure(ty: &Type, bindings: &HashMap<String, Type>) -> bool {
+    let recurse = |ty: &Type| substitution_preserves_union_structure(ty, bindings);
+    let function_preserves = |function: &FunctionType| {
+        function.params.iter().all(|(_, ty, _)| recurse(ty)) && recurse(&function.return_type)
+    };
+
+    match ty {
+        Type::List(value)
+        | Type::Set(value)
+        | Type::Iterable(value)
+        | Type::Iterator(value)
+        | Type::PythonBuffer(value)
+        | Type::PythonDlpackTensor(value)
+        | Type::Failure(value)
+        | Type::Awaitable(value) => recurse(value),
+        Type::Dict(key, value)
+        | Type::Result(key, value)
+        | Type::Coroutine(key, value)
+        | Type::Task(key, value)
+        | Type::TaskResult(key, value)
+        | Type::Select2(key, value)
+        | Type::BlockingTask(key, value)
+        | Type::AsyncIterator(key, value)
+        | Type::AsyncGenerator(key, value)
+        | Type::JoinSet(key, value) => recurse(key) && recurse(value),
+        Type::TimeoutResult(value) => recurse(value),
+        Type::Tuple(values) => values.iter().all(recurse),
+        Type::Union(values) => {
+            let substituted = values
+                .iter()
+                .map(|value| substitute_type_vars(value, bindings))
+                .collect::<Vec<_>>();
+            !substituted
+                .iter()
+                .any(|value| matches!(value.resolve_alias(), Type::Union(_)))
+                && matches!(make_union(substituted), Type::Union(canonical) if canonical.len() == values.len())
+                && values.iter().all(recurse)
+        }
+        Type::Callable(params, _, result) | Type::AsyncCallable(params, _, result) => {
+            params.iter().all(recurse) && recurse(result)
+        }
+        Type::Alias {
+            type_args, body, ..
+        } => type_args.iter().all(recurse) && recurse(body),
+        Type::Function(function) | Type::AsyncFunction(function) => function_preserves(function),
+        Type::Class { type_args, .. } => type_args.iter().all(recurse),
+        _ => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::substitute_type_vars_with_class_scopes;
+    use super::{substitute_type_vars_with_class_scopes, substitution_preserves_union_structure};
     use crate::Type;
     use std::collections::HashMap;
 
@@ -187,5 +241,47 @@ mod tests {
             panic!("nested type must stay nominal");
         };
         assert_eq!(fields[0].1, Type::TypeVar("T".to_string()));
+    }
+
+    #[test]
+    fn union_structure_rejects_expansion_and_collapse_after_substitution() {
+        let template = Type::Union(vec![Type::None, Type::TypeVar("T".to_string())]);
+
+        assert!(substitution_preserves_union_structure(
+            &template,
+            &HashMap::from([("T".to_string(), Type::Str)]),
+        ));
+        assert!(!substitution_preserves_union_structure(
+            &template,
+            &HashMap::from([(
+                "T".to_string(),
+                crate::make_union(vec![Type::None, Type::Str]),
+            )]),
+        ));
+        assert!(!substitution_preserves_union_structure(
+            &template,
+            &HashMap::from([("T".to_string(), Type::None)]),
+        ));
+    }
+
+    #[test]
+    fn union_structure_does_not_capture_nested_class_fields() {
+        let nested = Type::Class {
+            identity: Some("models.Inner".to_string()),
+            type_args: vec![Type::Str],
+            name: "Inner".to_string(),
+            fields: vec![(
+                "value".to_string(),
+                Type::Union(vec![Type::None, Type::TypeVar("T".to_string())]),
+            )],
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let outer_optional = crate::make_union(vec![Type::None, Type::Int]);
+
+        assert!(substitution_preserves_union_structure(
+            &nested,
+            &HashMap::from([("T".to_string(), outer_optional)]),
+        ));
     }
 }

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -905,6 +905,13 @@ their declaration resolvers to the same visitor. Substitution also rebuilds unio
 canonical union constructor. Therefore, structural identity uses normalized concrete types after
 generic substitution. Code generation resolves nested scopes from the selected outer declaration's
 module. A consumer module cannot redirect an identityless nested field to a same-named class.
+Lowering gives user class arguments canonical module identities before substitution. This keeps a
+consumer-owned argument distinct from same-named classes in a generic declaration's module.
+
+Rust generic storage keeps the union nesting from its declaration. Therefore, a concrete generic
+parent cannot expand one union member into another union or collapse it into a sibling. Lowering
+rejects that parent specialization before code generation. Structural support applies the same
+rule when a concrete generic class is nested in another record.
 
 Checked adapted-handler exports retain the callable target with a signature specialized relative
 to the selected owner's type parameters. Generic substitution follows the full local ancestor

--- a/internal_docs/const_specialization.md
+++ b/internal_docs/const_specialization.md
@@ -159,6 +159,14 @@ that visitor their declaration resolvers. The visitor canonicalizes unions after
 Reordered, duplicate, and nested union members therefore produce one concrete structural identity.
 Project code generation uses the selected outer declaration's module for nested scope resolution.
 It does not use the consumer module for identityless nested fields.
+User class arguments already carry canonical module identities from lowering. Substitution keeps
+that identity when an argument moves into a declaration-owned field.
+
+A generic parent specialization must preserve each declared union's immediate member structure.
+Rust generic storage cannot flatten a union-valued argument inserted into another union. It also
+cannot remove a member that becomes equal to its sibling. Lowering rejects these specializations
+before Rust generation. Structural support rejects the same topology change in nested generic
+record fields.
 
 An unbound generic adapted declaration does not request a schema program.
 A concrete owner must supply all type arguments before static program generation.


### PR DESCRIPTION
## Summary
- detect generic substitutions that expand or collapse declared union topology
- reject unsafe generic parents before Rust codegen
- exclude the same unsafe concrete generic classes from structural support
- prove safe union parents and consumer-owned class identities through source-to-Rust builds

## Validation
- 136 type-system tests
- full lowering, 1,056 codegen, 107 frontend, and 539 driver tests with 76 ignored
- workspace clippy with warnings denied
- formatting, maintainability, file-size, and diff guardrails
- one create-PR gate reached only the known external Rust-interop inputs

Exact candidate: 0f18a1f3ad2615d84e7b7475f69b12c0dc6f5825