### PR TITLE
Record M12 generic representation hardening

### DIFF
--- a/plans/issues/active/ad-hoc-static-class-adapters-and-pydantic-ergonomics.md
+++ b/plans/issues/active/ad-hoc-static-class-adapters-and-pydantic-ergonomics.md
@@ -2210,6 +2210,35 @@ can explain the two scope meanings beside the codegen binding.
 Next action: preserve consumer type-argument identity through substituted
 fields and close the nested union representation boundary.
 
+Compiler hardening item 8 state: complete
+PR: [`sifr-lang/sifr#3346`](https://github.com/sifr-lang/sifr/pull/3346)
+Base SHA: `3495369e2b2350d598e8fe0bfe859c73cb431d6a`
+Candidate SHA: `0f18a1f3ad2615d84e7b7475f69b12c0dc6f5825`
+Merge SHA: `f3831ebba061b4791ca47b4761f21b638285241d`
+Changed paths: the shared union-topology predicate, generic-parent source
+diagnostics, structural support parity, source-to-Rust positive coverage, a
+pre-codegen negative, and the durable compiler contract.
+Validation: all 136 type-system tests passed. The lowering suite passed 1,004
+tests and ignored one test. All 1,056 codegen tests and 107 frontend tests
+passed. The driver suite passed 539 tests and ignored 76 tests. Workspace
+Clippy passed with warnings denied. Rust formatting, both maintainability
+guards, the 900-line guard, and diff hygiene passed. The create-PR and merge
+gates each ran once on the exact candidate. Both gates passed generated demo
+freshness and every preceding guard. Both then stopped at the same two
+separately owned Rust-interop matrix inputs. Neither gate was rerun
+([create-PR evidence](https://github.com/sifr-lang/sifr/pull/3346#issuecomment-5345973128),
+[merge evidence](https://github.com/sifr-lang/sifr/pull/3346#issuecomment-5345998155)).
+Review evidence: the exact-SHA Opus review returned `SATISFIED` with no
+blocking findings
+([evidence](https://github.com/sifr-lang/sifr/pull/3346#issuecomment-5345972908)).
+Deferred follow-up: item 9 must select generic parent templates by canonical
+identity, not only by a local name. It must detect transitive general-storage
+hazards when a nested generic class introduces the changed union topology.
+It can also preserve the prior recursive fast path when ambiguity does not
+affect the fail-closed topology check.
+Next action: harden canonical parent-template lookup and transitive nested
+generic storage topology.
+
 Acceptance criteria:
 
 - The canonical demo contains no raw metadata or specialization decorators.
@@ -2297,12 +2326,12 @@ Next action:
 ## Current Handoff
 
 Current state: M0-M11 are merged and recorded. M12 compiler hardening items 1
-through 7 merged in Sifr PRs #3332, #3334, #3336, #3338, #3340, #3342, and
-#3344. The seven M11 compiler prerequisites merged in Sifr PRs #3317, #3319,
-#3321, #3323, #3325, #3327, and #3329. The M11 package surface merged in
-Pydantic-Sifr PR #47. M12 is in progress. The current compiler merge is
-`b9b8256de7d9c6c057014a0ec9f0eb4ee0b4f2bb`, and the current package merge is
-`a44116e188cc6b45cffb297d57b9084467a39e8f`.
+through 8 merged in Sifr PRs #3332, #3334, #3336, #3338, #3340, #3342,
+#3344, and #3346. The seven M11 compiler prerequisites merged in Sifr PRs
+#3317, #3319, #3321, #3323, #3325, #3327, and #3329. The M11 package surface
+merged in Pydantic-Sifr PR #47. M12 is in progress. The current compiler merge
+is `f3831ebba061b4791ca47b4761f21b638285241d`, and the current package merge
+is `a44116e188cc6b45cffb297d57b9084467a39e8f`.
 
 External gate record (2026-08-19): the one-time gates for the M11 compiler
 prerequisites stopped at the Rust-interop matrix. The matrix reported one
@@ -2310,6 +2339,6 @@ missing negative evidence source and one existing empty placeholder class.
 The items did not own or alter those inputs. The gates passed all earlier
 guards, and no gate was rerun.
 
-Next action: preserve consumer type-argument identity through substituted
-fields and close the nested union representation boundary. Then continue
-compiler-owned hardening before package certification and final review.
+Next action: harden canonical parent-template lookup and transitive nested
+generic storage topology. Then continue compiler-owned hardening before
+package certification and final review.


### PR DESCRIPTION
## Summary
- record M12 compiler hardening item 8 and PR #3346
- preserve exact review and one-time gate evidence
- carry canonical lookup and transitive storage work into item 9

Record-only update. Compiler files do not change, so no Sifr gates apply.