### PR TITLE
Reject transitive generic union topology changes

### DIFF
--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -236,7 +236,7 @@ fn structural_parent_supported(
     let Some(parent) = structural_class_candidate(identity.as_deref(), name, modules) else {
         return false;
     };
-    generic_arguments_preserve_union_structure(parent, type_args)
+    generic_arguments_preserve_union_structure(parent, type_args, modules)
         && parent.parent_class.is_none()
         && !parent.methods.iter().any(|method| method.name == "new")
         && !parent.is_error_type
@@ -310,15 +310,15 @@ fn structural_type_supported(
             ..
         } => {
             let key = identity.as_deref().unwrap_or(name);
+            if visiting.contains(key) {
+                return true;
+            }
             let Some(candidate) = structural_class_candidate(identity.as_deref(), name, modules)
             else {
                 return false;
             };
-            if !generic_arguments_preserve_union_structure(candidate, type_args) {
+            if !generic_arguments_preserve_union_structure(candidate, type_args, modules) {
                 return false;
-            }
-            if visiting.contains(key) {
-                return true;
             }
             if structural_mapped_opaque_supported(candidate) {
                 return true;
@@ -336,25 +336,55 @@ fn structural_type_supported(
     }
 }
 
-fn generic_arguments_preserve_union_structure(class: &HirClass, type_args: &[Type]) -> bool {
+fn generic_arguments_preserve_union_structure(
+    class: &HirClass,
+    type_args: &[Type],
+    modules: &[(&str, &HirModule)],
+) -> bool {
     let bindings = class
         .type_params
         .iter()
         .cloned()
         .zip(type_args.iter().cloned())
         .collect::<std::collections::HashMap<_, _>>();
-    class
+    let class_scope = |identity: Option<&str>, name: &str| {
+        structural_class_candidate(identity, name, modules).map(generic_union_scope)
+    };
+    class.fields.iter().all(|(_, ty)| {
+        sifr_type_system::substitution_preserves_union_structure_with_class_scopes(
+            ty,
+            &bindings,
+            &class_scope,
+        )
+    }) && class.methods.iter().all(|method| {
+        method.params.iter().all(|param| {
+            sifr_type_system::substitution_preserves_union_structure_with_class_scopes(
+                &param.ty,
+                &bindings,
+                &class_scope,
+            )
+        }) && sifr_type_system::substitution_preserves_union_structure_with_class_scopes(
+            &method.return_type,
+            &bindings,
+            &class_scope,
+        )
+    })
+}
+
+fn generic_union_scope(class: &HirClass) -> sifr_type_system::UnionStructureClassScope {
+    let mut member_types = class
         .fields
         .iter()
-        .all(|(_, ty)| sifr_type_system::substitution_preserves_union_structure(ty, &bindings))
-        && class.methods.iter().all(|method| {
-            method.params.iter().all(|param| {
-                sifr_type_system::substitution_preserves_union_structure(&param.ty, &bindings)
-            }) && sifr_type_system::substitution_preserves_union_structure(
-                &method.return_type,
-                &bindings,
-            )
-        })
+        .map(|(_, ty)| ty.clone())
+        .collect::<Vec<_>>();
+    for method in &class.methods {
+        member_types.extend(method.params.iter().map(|param| param.ty.clone()));
+        member_types.push(method.return_type.clone());
+    }
+    sifr_type_system::UnionStructureClassScope {
+        type_params: class.type_params.clone(),
+        member_types,
+    }
 }
 
 fn structural_class_candidate<'a>(

--- a/crates/sifr_codegen/src/structural_impl_codegen/generic_representation_tests.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen/generic_representation_tests.rs
@@ -67,3 +67,54 @@ fn nested_generic_union_topology_change_is_not_structurally_supported() {
     assert!(!supported.contains("main.Owner"));
     assert!(!supported.contains("main.Child"));
 }
+
+#[test]
+fn transitive_nested_generic_union_change_is_not_structurally_supported() {
+    let mut inner = class(
+        "Inner",
+        vec![(
+            "value".to_string(),
+            Type::Union(vec![Type::None, Type::TypeVar("U".to_string())]),
+        )],
+    );
+    inner.type_params = vec!["U".to_string()];
+    let mut outer = class(
+        "Outer",
+        vec![(
+            "inner".to_string(),
+            Type::Class {
+                identity: Some("main.Inner".to_string()),
+                type_args: vec![Type::TypeVar("T".to_string())],
+                name: "Inner".to_string(),
+                fields: Vec::new(),
+                methods: Vec::new(),
+                parent_class: None,
+            },
+        )],
+    );
+    outer.type_params = vec!["T".to_string()];
+    let concrete = Type::Class {
+        identity: Some("main.Outer".to_string()),
+        type_args: vec![sifr_type_system::make_union(vec![Type::None, Type::Str])],
+        name: "Outer".to_string(),
+        fields: Vec::new(),
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let owner = class("Owner", vec![("payload".to_string(), concrete)]);
+    let module = HirModule {
+        functions: Vec::new(),
+        classes: vec![inner, outer, owner],
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: HashMap::new(),
+        type_param_bounds: HashMap::new(),
+    };
+    let modules = [("main", &module)];
+
+    let supported = structural_record_identities_for_project(&modules);
+
+    assert!(supported.contains("main.Inner"));
+    assert!(supported.contains("main.Outer"));
+    assert!(!supported.contains("main.Owner"));
+}

--- a/crates/sifr_driver/src/tests/generic_adapter_representation.rs
+++ b/crates/sifr_driver/src/tests/generic_adapter_representation.rs
@@ -36,6 +36,38 @@ def main():
 }
 
 #[test]
+fn transitive_nested_generic_union_parent_is_rejected_before_rust_codegen() {
+    let dir = mktemp_dir("transitive_nested_union_generic_parent");
+    let main_file = dir.join("main.sifr");
+    std::fs::write(
+        &main_file,
+        r#"
+class Inner[U]:
+    value: U | None
+
+class Parent[T]:
+    inner: Inner[T]
+
+class Concrete(Parent[str | None]):
+    def __init__(self, inner: Inner[str | None]):
+        super().__init__(inner)
+
+def main():
+    pass
+"#,
+    )
+    .expect("main module should be written");
+
+    let errors = check_project(&main_file, &mut sifr_frontend::DiskSourceProvider::new());
+    assert!(errors.iter().any(|error| {
+        error.code == DiagnosticCode::CLASS_INVALID_BASE.code()
+            && error.message.contains("union's member topology")
+    }));
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 fn union_bearing_generic_parent_accepts_a_topology_preserving_argument() {
     let dir = mktemp_dir("stable_union_generic_parent");
     let main_file = dir.join("main.sifr");

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -317,11 +317,11 @@ pub(in crate::lower) fn collect_class_type(
             crate::lower::descriptor_declarations::data_parent_type(class_def, ctx)
                 .or_else(|| ctx.class_types.get(parent_name).cloned())
         {
-            if ctx.class_types.get(parent_name).is_some_and(|template| {
-                !super::super::generic_parent_representation::preserves_union_structure(
-                    template, &parent_ty,
-                )
-            }) {
+            if !super::super::generic_parent_representation::preserves_union_structure(
+                &ctx.class_types,
+                parent_name,
+                &parent_ty,
+            ) {
                 invalid_class_base(
                     ctx,
                     &class_name,

--- a/crates/sifr_lowering/src/lower/generic_parent_representation.rs
+++ b/crates/sifr_lowering/src/lower/generic_parent_representation.rs
@@ -1,7 +1,16 @@
-use sifr_type_system::{substitution_preserves_union_structure, Type};
+use sifr_type_system::{
+    substitution_preserves_union_structure_with_class_scopes, Type, UnionStructureClassScope,
+};
 use std::collections::HashMap;
 
-pub(super) fn preserves_union_structure(template: &Type, concrete: &Type) -> bool {
+pub(super) fn preserves_union_structure(
+    class_types: &HashMap<String, Type>,
+    parent_name: &str,
+    concrete: &Type,
+) -> bool {
+    let Some(template) = class_template(class_types, concrete, parent_name) else {
+        return true;
+    };
     let (
         Type::Class {
             type_args: template_args,
@@ -25,22 +34,79 @@ pub(super) fn preserves_union_structure(template: &Type, concrete: &Type) -> boo
             _ => None,
         })
         .collect::<HashMap<_, _>>();
-    fields
+    let class_scope = |identity: Option<&str>, name: &str| {
+        class_candidate(class_types, identity, name).and_then(class_union_scope)
+    };
+    fields.iter().all(|(_, ty)| {
+        substitution_preserves_union_structure_with_class_scopes(ty, &bindings, &class_scope)
+    }) && methods.iter().all(|(_, method)| {
+        method.params.iter().all(|(_, ty, _)| {
+            substitution_preserves_union_structure_with_class_scopes(ty, &bindings, &class_scope)
+        }) && substitution_preserves_union_structure_with_class_scopes(
+            &method.return_type,
+            &bindings,
+            &class_scope,
+        )
+    })
+}
+
+fn class_template<'a>(
+    class_types: &'a HashMap<String, Type>,
+    concrete: &Type,
+    fallback_name: &str,
+) -> Option<&'a Type> {
+    let Type::Class { identity, .. } = concrete.resolve_alias() else {
+        return None;
+    };
+    class_candidate(class_types, identity.as_deref(), fallback_name)
+}
+
+fn class_candidate<'a>(
+    class_types: &'a HashMap<String, Type>,
+    identity: Option<&str>,
+    name: &str,
+) -> Option<&'a Type> {
+    if let Some(identity) = identity {
+        return class_types.values().find(|candidate| {
+            matches!(candidate.resolve_alias(), Type::Class { identity: Some(candidate), .. } if candidate == identity)
+        });
+    }
+    class_types.get(name)
+}
+
+fn class_union_scope(ty: &Type) -> Option<UnionStructureClassScope> {
+    let Type::Class {
+        type_args,
+        fields,
+        methods,
+        ..
+    } = ty.resolve_alias()
+    else {
+        return None;
+    };
+    let type_params = type_args
         .iter()
-        .all(|(_, ty)| substitution_preserves_union_structure(ty, &bindings))
-        && methods.iter().all(|(_, method)| {
-            method
-                .params
-                .iter()
-                .all(|(_, ty, _)| substitution_preserves_union_structure(ty, &bindings))
-                && substitution_preserves_union_structure(&method.return_type, &bindings)
+        .filter_map(|argument| match argument.resolve_alias() {
+            Type::TypeVar(name) => Some(name.clone()),
+            _ => None,
         })
+        .collect();
+    let mut member_types = fields.iter().map(|(_, ty)| ty.clone()).collect::<Vec<_>>();
+    for (_, method) in methods {
+        member_types.extend(method.params.iter().map(|(_, ty, _)| ty.clone()));
+        member_types.push(method.return_type.as_ref().clone());
+    }
+    Some(UnionStructureClassScope {
+        type_params,
+        member_types,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::preserves_union_structure;
     use sifr_type_system::Type;
+    use std::collections::HashMap;
 
     fn parent(type_arg: Type, field: Type) -> Type {
         Type::Class {
@@ -62,8 +128,56 @@ mod tests {
         let safe = parent(Type::Str, Type::Union(vec![Type::None, Type::Str]));
         let unsafe_arg = sifr_type_system::make_union(vec![Type::None, Type::Str]);
         let unsafe_parent = parent(unsafe_arg, Type::Union(vec![Type::None, Type::Str]));
+        let classes = HashMap::from([("Parent".to_string(), template)]);
 
-        assert!(preserves_union_structure(&template, &safe));
-        assert!(!preserves_union_structure(&template, &unsafe_parent));
+        assert!(preserves_union_structure(&classes, "Parent", &safe));
+        assert!(!preserves_union_structure(
+            &classes,
+            "Parent",
+            &unsafe_parent
+        ));
+    }
+
+    #[test]
+    fn canonical_identity_selects_the_parent_and_finds_transitive_hazards() {
+        let inner = Type::Class {
+            identity: Some("models.Inner".to_string()),
+            type_args: vec![Type::TypeVar("U".to_string())],
+            name: "Inner".to_string(),
+            fields: vec![(
+                "value".to_string(),
+                Type::Union(vec![Type::None, Type::TypeVar("U".to_string())]),
+            )],
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let imported_parent = parent(
+            Type::TypeVar("T".to_string()),
+            Type::Class {
+                identity: Some("models.Inner".to_string()),
+                type_args: vec![Type::TypeVar("T".to_string())],
+                name: "Inner".to_string(),
+                fields: Vec::new(),
+                methods: Vec::new(),
+                parent_class: None,
+            },
+        );
+        let mut wrong_local = parent(
+            Type::TypeVar("V".to_string()),
+            Type::TypeVar("V".to_string()),
+        );
+        let Type::Class { identity, .. } = &mut wrong_local else {
+            unreachable!("the parent test helper always returns a class")
+        };
+        *identity = Some("main.Parent".to_string());
+        let unsafe_arg = sifr_type_system::make_union(vec![Type::None, Type::Str]);
+        let concrete = parent(unsafe_arg, Type::Unknown);
+        let classes = HashMap::from([
+            ("Parent".to_string(), wrong_local),
+            ("ImportedParent".to_string(), imported_parent),
+            ("Inner".to_string(), inner),
+        ]);
+
+        assert!(!preserves_union_structure(&classes, "Parent", &concrete));
     }
 }

--- a/crates/sifr_type_system/src/lib.rs
+++ b/crates/sifr_type_system/src/lib.rs
@@ -37,6 +37,7 @@ pub use safe_optional::safe_optional_result;
 pub use substitution::{
     substitute_type_vars, substitute_type_vars_with_class_scopes,
     substitution_preserves_union_structure,
+    substitution_preserves_union_structure_with_class_scopes, UnionStructureClassScope,
 };
 
 /// Returns whether a declaration belongs to a public stdlib module's compiled

--- a/crates/sifr_type_system/src/substitution.rs
+++ b/crates/sifr_type_system/src/substitution.rs
@@ -1,7 +1,7 @@
 //! Type-variable substitution across nested nominal declaration scopes.
 
 use crate::{make_union, FunctionType, Type};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Substitute type variables without declaration-scope metadata.
 pub fn substitute_type_vars(ty: &Type, bindings: &HashMap<String, Type>) -> Type {
@@ -145,10 +145,53 @@ where
 /// Rust generic storage retains the declaration's union nesting. A substituted
 /// union member cannot expand into another union or collapse into a sibling.
 pub fn substitution_preserves_union_structure(ty: &Type, bindings: &HashMap<String, Type>) -> bool {
-    let recurse = |ty: &Type| substitution_preserves_union_structure(ty, bindings);
-    let function_preserves = |function: &FunctionType| {
-        function.params.iter().all(|(_, ty, _)| recurse(ty)) && recurse(&function.return_type)
-    };
+    substitution_preserves_union_structure_with_class_scopes(ty, bindings, &|_, _| None)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnionStructureClassScope {
+    pub type_params: Vec<String>,
+    pub member_types: Vec<Type>,
+}
+
+/// Check union topology and rebind nested class declarations through one resolver.
+pub fn substitution_preserves_union_structure_with_class_scopes<F>(
+    ty: &Type,
+    bindings: &HashMap<String, Type>,
+    class_scope: &F,
+) -> bool
+where
+    F: Fn(Option<&str>, &str) -> Option<UnionStructureClassScope>,
+{
+    preserves_union_structure(ty, bindings, class_scope, &mut HashSet::new())
+}
+
+fn function_preserves_union_structure<F>(
+    function: &FunctionType,
+    bindings: &HashMap<String, Type>,
+    class_scope: &F,
+    visiting: &mut HashSet<String>,
+) -> bool
+where
+    F: Fn(Option<&str>, &str) -> Option<UnionStructureClassScope>,
+{
+    function
+        .params
+        .iter()
+        .all(|(_, ty, _)| preserves_union_structure(ty, bindings, class_scope, visiting))
+        && preserves_union_structure(&function.return_type, bindings, class_scope, visiting)
+}
+
+fn preserves_union_structure<F>(
+    ty: &Type,
+    bindings: &HashMap<String, Type>,
+    class_scope: &F,
+    visiting: &mut HashSet<String>,
+) -> bool
+where
+    F: Fn(Option<&str>, &str) -> Option<UnionStructureClassScope>,
+{
+    let mut recurse = |ty: &Type| preserves_union_structure(ty, bindings, class_scope, visiting);
 
     match ty {
         Type::List(value)
@@ -170,7 +213,7 @@ pub fn substitution_preserves_union_structure(ty: &Type, bindings: &HashMap<Stri
         | Type::AsyncGenerator(key, value)
         | Type::JoinSet(key, value) => recurse(key) && recurse(value),
         Type::TimeoutResult(value) => recurse(value),
-        Type::Tuple(values) => values.iter().all(recurse),
+        Type::Tuple(values) => values.iter().all(&mut recurse),
         Type::Union(values) => {
             let substituted = values
                 .iter()
@@ -180,23 +223,58 @@ pub fn substitution_preserves_union_structure(ty: &Type, bindings: &HashMap<Stri
                 .iter()
                 .any(|value| matches!(value.resolve_alias(), Type::Union(_)))
                 && matches!(make_union(substituted), Type::Union(canonical) if canonical.len() == values.len())
-                && values.iter().all(recurse)
+                && values.iter().all(&mut recurse)
         }
         Type::Callable(params, _, result) | Type::AsyncCallable(params, _, result) => {
-            params.iter().all(recurse) && recurse(result)
+            params.iter().all(&mut recurse) && recurse(result)
         }
         Type::Alias {
             type_args, body, ..
-        } => type_args.iter().all(recurse) && recurse(body),
-        Type::Function(function) | Type::AsyncFunction(function) => function_preserves(function),
-        Type::Class { type_args, .. } => type_args.iter().all(recurse),
+        } => type_args.iter().all(&mut recurse) && recurse(body),
+        Type::Function(function) | Type::AsyncFunction(function) => {
+            function_preserves_union_structure(function, bindings, class_scope, visiting)
+        }
+        Type::Class {
+            identity,
+            type_args,
+            name,
+            ..
+        } => {
+            if !type_args.iter().all(&mut recurse) {
+                return false;
+            }
+            let Some(scope) = class_scope(identity.as_deref(), name) else {
+                return true;
+            };
+            let key = identity.as_deref().unwrap_or(name).to_string();
+            if !visiting.insert(key.clone()) {
+                return true;
+            }
+            let concrete_args = type_args
+                .iter()
+                .map(|argument| substitute_type_vars(argument, bindings))
+                .collect::<Vec<_>>();
+            let nested_bindings = scope
+                .type_params
+                .into_iter()
+                .zip(concrete_args)
+                .collect::<HashMap<_, _>>();
+            let preserved = scope.member_types.iter().all(|member| {
+                preserves_union_structure(member, &nested_bindings, class_scope, visiting)
+            });
+            visiting.remove(&key);
+            preserved
+        }
         _ => true,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{substitute_type_vars_with_class_scopes, substitution_preserves_union_structure};
+    use super::{
+        substitute_type_vars_with_class_scopes, substitution_preserves_union_structure,
+        substitution_preserves_union_structure_with_class_scopes, UnionStructureClassScope,
+    };
     use crate::Type;
     use std::collections::HashMap;
 
@@ -283,5 +361,33 @@ mod tests {
             &nested,
             &HashMap::from([("T".to_string(), outer_optional)]),
         ));
+    }
+
+    #[test]
+    fn scoped_union_structure_detects_a_transitive_nested_expansion() {
+        let nested = Type::Class {
+            identity: Some("models.Inner".to_string()),
+            type_args: vec![Type::TypeVar("T".to_string())],
+            name: "Inner".to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        };
+        let outer_optional = crate::make_union(vec![Type::None, Type::Str]);
+        let preserved = substitution_preserves_union_structure_with_class_scopes(
+            &nested,
+            &HashMap::from([("T".to_string(), outer_optional)]),
+            &|identity, _| {
+                (identity == Some("models.Inner")).then(|| UnionStructureClassScope {
+                    type_params: vec!["U".to_string()],
+                    member_types: vec![Type::Union(vec![
+                        Type::None,
+                        Type::TypeVar("U".to_string()),
+                    ])],
+                })
+            },
+        );
+
+        assert!(!preserved);
     }
 }

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -911,7 +911,9 @@ consumer-owned argument distinct from same-named classes in a generic declaratio
 Rust generic storage keeps the union nesting from its declaration. Therefore, a concrete generic
 parent cannot expand one union member into another union or collapse it into a sibling. Lowering
 rejects that parent specialization before code generation. Structural support applies the same
-rule when a concrete generic class is nested in another record.
+rule when a concrete generic class is nested in another record. Lowering selects an imported
+parent template by canonical identity. The shared type-system check follows nested generic class
+declarations, binds their local parameters, and rejects transitive union-topology changes.
 
 Checked adapted-handler exports retain the callable target with a signature specialized relative
 to the selected owner's type parameters. Generic substitution follows the full local ancestor


### PR DESCRIPTION
## Summary
- select generic parent templates by canonical identity
- follow nested generic declarations in the shared union-topology check
- reject transitive representation changes before Rust code generation

## Validation
- cargo test -p sifr_type_system --no-fail-fast
- cargo test -p sifr_lowering --no-fail-fast
- cargo test -p sifr_codegen --no-fail-fast
- cargo test -p sifr_frontend --no-fail-fast
- cargo test -p sifr_driver --no-fail-fast
- cargo clippy --workspace -- -D warnings
- cargo fmt --all -- --check
- maintainability, file-size, and diff guards
- create-PR gate ran once on e2ff698497de3b902f81d1ad451fc2b97fda2a82; all preceding checks passed before the separately owned Rust-interop matrix stop
