### PR TITLE
Require exact generic ancestor bindings

### DIFF
--- a/crates/sifr_frontend/src/handler_ancestry.rs
+++ b/crates/sifr_frontend/src/handler_ancestry.rs
@@ -21,12 +21,7 @@ pub(crate) fn resolve(
     lowering: &LoweringResult,
     external_defs: &ExternalDefs,
 ) -> Option<HandlerAncestry> {
-    let bindings = root
-        .type_params
-        .iter()
-        .cloned()
-        .zip(root_type_args.iter().cloned())
-        .collect();
+    let bindings = bind_exact(&root.type_params, root_type_args.iter().cloned())?;
     walk_local(
         module_name,
         root,
@@ -80,12 +75,7 @@ fn walk_local(
                 && parent_identity == format!("{module_name}.{}", candidate.name))
     });
     if let Some(parent) = local_parent {
-        let parent_bindings = parent
-            .type_params
-            .iter()
-            .cloned()
-            .zip(parent_args)
-            .collect();
+        let parent_bindings = bind_exact(&parent.type_params, parent_args)?;
         return walk_local(
             module_name,
             parent,
@@ -101,7 +91,7 @@ fn walk_local(
         .class_type_params
         .get(source_module)
         .and_then(|classes| classes.get(source_name))?;
-    let parent_bindings = type_params.iter().cloned().zip(parent_args).collect();
+    let parent_bindings = bind_exact(type_params, parent_args)?;
     if parent_identity == owner_identity {
         Some(HandlerAncestry::Owner(parent_bindings))
     } else {
@@ -110,5 +100,66 @@ fn walk_local(
             name: source_name.to_string(),
             bindings: parent_bindings,
         })
+    }
+}
+
+fn bind_exact(
+    type_params: &[String],
+    type_args: impl IntoIterator<Item = Type>,
+) -> Option<HashMap<String, Type>> {
+    let type_args = type_args.into_iter().collect::<Vec<_>>();
+    (type_params.len() == type_args.len())
+        .then(|| type_params.iter().cloned().zip(type_args).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve, HandlerAncestry};
+    use sifr_lowering::{lower_module, ExternalDefs};
+    use sifr_syntax::parse_module_suite;
+    use sifr_type_system::Type;
+
+    fn generic_chain() -> sifr_lowering::LoweringResult {
+        let parsed = parse_module_suite(
+            "class Base[T]:\n    value: T\n\nclass Child[U](Base[U]):\n    pass\n",
+            None,
+        )
+        .expect("fixture parses");
+        lower_module(&parsed).expect("fixture lowers")
+    }
+
+    #[test]
+    fn unspecialized_generic_ancestor_keeps_its_symbolic_argument() {
+        let lowered = generic_chain();
+        let child = &lowered.module.classes[1];
+        let ancestry = resolve(
+            "fixture",
+            child,
+            &[Type::TypeVar("U".to_string())],
+            "fixture.Base",
+            &lowered,
+            &ExternalDefs::default(),
+        );
+
+        let Some(HandlerAncestry::Owner(bindings)) = ancestry else {
+            panic!("local base must resolve")
+        };
+        assert_eq!(bindings.get("T"), Some(&Type::TypeVar("U".to_string())));
+    }
+
+    #[test]
+    fn unspecialized_generic_ancestor_rejects_missing_root_arguments() {
+        let lowered = generic_chain();
+        let child = &lowered.module.classes[1];
+
+        assert!(resolve(
+            "fixture",
+            child,
+            &[],
+            "fixture.Base",
+            &lowered,
+            &ExternalDefs::default(),
+        )
+        .is_none());
     }
 }

--- a/crates/sifr_type_system/src/substitution.rs
+++ b/crates/sifr_type_system/src/substitution.rs
@@ -418,4 +418,27 @@ mod tests {
 
         assert!(!preserved);
     }
+
+    #[test]
+    fn generic_alias_arguments_and_body_use_the_same_outer_binding() {
+        let alias = Type::Alias {
+            name: "Boxed".to_string(),
+            type_args: vec![Type::TypeVar("T".to_string())],
+            body: Box::new(Type::List(Box::new(Type::TypeVar("T".to_string())))),
+        };
+        let substituted = substitute_type_vars_with_class_scopes(
+            &alias,
+            &HashMap::from([("T".to_string(), Type::Int)]),
+            &|_, _| None,
+        );
+
+        assert_eq!(
+            substituted,
+            Type::Alias {
+                name: "Boxed".to_string(),
+                type_args: vec![Type::Int],
+                body: Box::new(Type::List(Box::new(Type::Int))),
+            }
+        );
+    }
 }

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -893,6 +893,10 @@ normalizes diagnostic ranges while retaining checked interop declarations. Post-
 separately binds the invocation to the validated output and is an input to static-program identity,
 avoiding a cycle with later handler and attached-API outputs.
 
+Generic alias instances specialize their arguments and bodies before structural substitution.
+Generic ancestor walks require exact parameter and argument arity. Unspecialized exports pass
+their declaration parameters as explicit symbolic arguments instead of leaving bindings absent.
+
 Structural shape derivation specializes finalized adapter field-plan types with the concrete
 owner arguments before package specialization. Local and imported adapted generic classes use the
 same substitution rule, so nested concrete uses do not expose unbound declaration parameters to a


### PR DESCRIPTION
## Summary
- require exact parameter and argument arity while walking generic handler ancestry
- preserve explicit symbolic arguments for valid unspecialized exports
- pin generic alias argument and body specialization agreement

## Validation
- 139 type-system tests
- 109 frontend tests
- 540 driver tests with 76 ignored
- workspace Clippy with warnings denied
- formatting, maintainability, file-size, and diff checks
- create-PR gate ran once on e4e458766e26b03a6fcb99f29c82c4b535ebe206 and stopped only at the separately owned Rust-interop inputs after all preceding guards passed
