### PR TITLE
Fail closed on unresolved handler ancestry

### DIFF
--- a/crates/sifr_frontend/src/handler_ancestry.rs
+++ b/crates/sifr_frontend/src/handler_ancestry.rs
@@ -115,7 +115,8 @@ fn bind_exact(
 #[cfg(test)]
 mod tests {
     use super::{resolve, HandlerAncestry};
-    use sifr_lowering::{lower_module, ExternalDefs};
+    use crate::{collect_module_exports, compile_module_hir, FrontendDiagnosticStyle};
+    use sifr_lowering::{lower_module, ExternalDefs, LoweringResult};
     use sifr_syntax::parse_module_suite;
     use sifr_type_system::Type;
 
@@ -126,6 +127,17 @@ mod tests {
         )
         .expect("fixture parses");
         lower_module(&parsed).expect("fixture lowers")
+    }
+
+    fn compile(module: &str, source: &str, external_defs: &ExternalDefs) -> LoweringResult {
+        let parsed = parse_module_suite(source, None).expect("fixture parses");
+        compile_module_hir(
+            module,
+            &parsed,
+            external_defs,
+            FrontendDiagnosticStyle::Bare,
+        )
+        .expect("fixture compiles")
     }
 
     #[test]
@@ -159,6 +171,35 @@ mod tests {
             "fixture.Base",
             &lowered,
             &ExternalDefs::default(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn imported_generic_ancestor_rejects_parameter_arity_mismatch() {
+        let mut external_defs = ExternalDefs::default();
+        let models = compile("models", "class Base[T]:\n    value: T\n", &external_defs);
+        collect_module_exports("models", &models, &mut external_defs);
+        let consumer = compile(
+            "consumer",
+            "from models import Base\n\nclass Child[U](Base[U]):\n    pass\n",
+            &external_defs,
+        );
+        external_defs
+            .class_type_params
+            .get_mut("models")
+            .and_then(|classes| classes.get_mut("Base"))
+            .expect("imported parameter metadata exists")
+            .push("V".to_string());
+        let child = &consumer.module.classes[0];
+
+        assert!(resolve(
+            "consumer",
+            child,
+            &[Type::TypeVar("U".to_string())],
+            "models.Base",
+            &consumer,
+            &external_defs,
         )
         .is_none());
     }

--- a/crates/sifr_frontend/src/structural_shape.rs
+++ b/crates/sifr_frontend/src/structural_shape.rs
@@ -19,6 +19,8 @@ use crate::const_canonical::canonical_value;
 use canonical_helpers::canonical_sequence;
 mod defaults;
 use defaults::shape_field_default;
+#[cfg(test)]
+mod ancestry_tests;
 mod generic_fields;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/sifr_frontend/src/structural_shape/ancestry_tests.rs
+++ b/crates/sifr_frontend/src/structural_shape/ancestry_tests.rs
@@ -1,0 +1,107 @@
+use super::*;
+use sifr_lowering::{
+    lower_module, AdapterHandlerPlan, CallableIdentity, ClassAdapterSelection, SourceOriginId,
+    StaticProgramValue,
+};
+use sifr_syntax::parse_module_suite;
+use sifr_type_system::FunctionType;
+
+fn class_type(class: &sifr_lowering::HirClass) -> Type {
+    Type::Class {
+        identity: None,
+        type_args: Vec::new(),
+        name: class.name.clone(),
+        fields: class.fields.clone(),
+        methods: class
+            .methods
+            .iter()
+            .chain(class.operator_impls.iter().map(|(_, method)| method))
+            .map(|method| {
+                (
+                    method.name.clone(),
+                    FunctionType {
+                        receiver: method.receiver,
+                        params: method
+                            .params
+                            .iter()
+                            .map(|param| (param.name.clone(), param.ty.clone(), param.convention))
+                            .collect(),
+                        return_type: Box::new(method.return_type.clone()),
+                    },
+                )
+            })
+            .collect(),
+        parent_class: None,
+    }
+}
+
+#[test]
+fn unresolved_handler_ancestry_uses_an_opaque_checked_contract() {
+    let source = r#"
+class Parent[T]:
+    @classmethod
+    def normalize(cls, own value: T) -> T:
+        return value
+
+class Child(Parent[int]):
+    pass
+"#;
+    let parsed = parse_module_suite(source, None).expect("fixture parses");
+    let mut lowered = lower_module(&parsed).expect("fixture lowers");
+    let Type::Class { type_args, .. } = lowered.module.classes[1]
+        .parent_type
+        .as_mut()
+        .expect("child parent type exists")
+    else {
+        panic!("child parent must be a class")
+    };
+    type_args.clear();
+    let callable = CallableIdentity {
+        module: "fixture.unresolved".to_string(),
+        owner: Some("fixture.unresolved.Parent".to_string()),
+        symbol: "normalize".to_string(),
+        generic_arguments: Vec::new(),
+        signature: "checked".to_string(),
+    };
+    lowered
+        .class_adapter_selections
+        .push(ClassAdapterSelection {
+            owner: "Child".to_string(),
+            provider_module: "fixture.adapter".to_string(),
+            provider_function: "adapt".to_string(),
+            descriptor_type: Type::Str,
+            marker_identities: Vec::new(),
+            data_parent: Some("Parent".to_string()),
+            field_plans: Vec::new(),
+            handler_plans: vec![AdapterHandlerPlan {
+                callable: callable.clone(),
+                descriptor_type: Type::Str,
+                descriptor_value: StaticProgramValue::String("after".to_string()),
+                descriptor_origin: SourceOriginId::new([9; 32], 1),
+                descriptor_range: ruff_text_size::TextRange::default(),
+                declaration_order: 0,
+            }],
+            attached_api_set: None,
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
+            range: ruff_text_size::TextRange::default(),
+        });
+    let child = &lowered.module.classes[1];
+    let shape = describe_type_with_externals(
+        "fixture.unresolved",
+        &class_type(child),
+        &lowered,
+        &ExternalDefs::default(),
+    );
+    let ShapeNode::Nominal { methods, .. } = shape.root else {
+        panic!("child must have a nominal shape")
+    };
+
+    assert_eq!(methods.len(), 1);
+    assert_eq!(methods[0].target.as_ref(), Some(&callable));
+    assert!(methods[0].params.is_empty());
+    assert_eq!(
+        *methods[0].output,
+        ShapeNode::Other("checked_handler".to_string())
+    );
+}

--- a/crates/sifr_frontend/src/structural_shape/methods.rs
+++ b/crates/sifr_frontend/src/structural_shape/methods.rs
@@ -271,24 +271,28 @@ fn described_handler(
                             .iter()
                             .chain(owner_class.operator_impls.iter().map(|(_, method)| method))
                             .find(|method| method.name == hir_name)
-                            .map(|method| (source_name, owner_class, method))
+                            .map(|method| (source_name, method))
                     })
             })
             .flatten()
+            .and_then(|(source_name, method)| {
+                match crate::handler_ancestry::resolve(
+                    module_name,
+                    class,
+                    &root_args,
+                    owner,
+                    lowering,
+                    external_defs,
+                ) {
+                    Some(crate::handler_ancestry::HandlerAncestry::Owner(bindings)) => {
+                        Some((source_name, method, bindings))
+                    }
+                    _ => None,
+                }
+            })
     });
-    let mut method = if let Some((source_name, _owner_class, method)) = local_detail {
+    let mut method = if let Some((source_name, method, inherited_bindings)) = local_detail {
         let owner = format!("{source_name}.{declared_name}");
-        let inherited_bindings = match crate::handler_ancestry::resolve(
-            module_name,
-            class,
-            &root_args,
-            callable_owner.unwrap_or(&local_owner),
-            lowering,
-            external_defs,
-        ) {
-            Some(crate::handler_ancestry::HandlerAncestry::Owner(bindings)) => bindings,
-            _ => HashMap::new(),
-        };
         described_method(
             module_name,
             &owner,

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -896,6 +896,8 @@ avoiding a cycle with later handler and attached-API outputs.
 Generic alias instances specialize their arguments and bodies before structural substitution.
 Generic ancestor walks require exact parameter and argument arity. Unspecialized exports pass
 their declaration parameters as explicit symbolic arguments instead of leaving bindings absent.
+An unresolved handler ancestry never substitutes a partial signature. Structural metadata keeps
+an opaque checked-handler contract until complete ancestry becomes available.
 
 Structural shape derivation specializes finalized adapter field-plan types with the concrete
 owner arguments before package specialization. Local and imported adapted generic classes use the


### PR DESCRIPTION
## Summary
- remove partial inherited-signature substitution when ancestry resolution fails
- retain an explicit opaque checked-handler contract for unresolved metadata
- add direct imported arity-mismatch coverage
- split ancestry regressions into their own test module

## Validation
- 111 frontend tests
- 540 driver tests with 76 ignored
- workspace Clippy with warnings denied
- formatting, maintainability, file-size, and diff checks
- create-PR gate ran once on 15d8bda3c50d664c37881864ff8535484c787052 and stopped only at the separately owned Rust-interop inputs after all preceding guards passed
