### PR TITLE
fix: resolve adapter parents by canonical identity

### DIFF
--- a/crates/sifr_frontend/src/early_adapters.rs
+++ b/crates/sifr_frontend/src/early_adapters.rs
@@ -673,12 +673,12 @@ fn normalized_field_types(
             _ => None,
         })
         .or_else(|| parent_name.map(|name| format!("{module_name}.{name}")));
-    let parent = parent_name.and_then(|name| {
+    let parent = parent_name.and_then(|_| {
         inheritance::parent_selection(
+            module_name,
             result,
             external_defs,
             parent_identity.as_deref().unwrap_or(""),
-            name,
         )
     });
     let type_args = match class.parent_type.as_ref() {

--- a/crates/sifr_frontend/src/early_adapters/handler_plans.rs
+++ b/crates/sifr_frontend/src/early_adapters/handler_plans.rs
@@ -132,7 +132,7 @@ pub(super) fn inherited_handler_plans(
             _ => None,
         })
         .unwrap_or_else(|| format!("{module_name}.{parent_name}"));
-    inheritance::parent_selection(result, external_defs, &parent_identity, parent_name)
+    inheritance::parent_selection(module_name, result, external_defs, &parent_identity)
         .map(|parent| parent.handler_plans.clone())
         .unwrap_or_default()
 }

--- a/crates/sifr_frontend/src/early_adapters/inheritance.rs
+++ b/crates/sifr_frontend/src/early_adapters/inheritance.rs
@@ -56,7 +56,7 @@ pub(super) fn declaration_value(
     } else {
         return Err("adapted data parent shape is unavailable");
     };
-    let parent_selection = parent_selection(result, external_defs, &parent_identity, parent_name);
+    let parent_selection = parent_selection(module_name, result, external_defs, &parent_identity);
     if let Some(parent) = parent_selection.filter(|parent| !parent.field_plans.is_empty()) {
         let type_args = match class.parent_type.as_ref() {
             Some(Type::Class { type_args, .. }) => type_args.as_slice(),
@@ -317,17 +317,22 @@ fn inherited_method_item(
 }
 
 pub(super) fn parent_selection<'a>(
+    module_name: &str,
     result: &'a LoweringResult,
     external_defs: &'a ExternalDefs,
     parent_identity: &str,
-    parent_name: &str,
 ) -> Option<&'a ClassAdapterSelection> {
-    if let Some(parent) = result
-        .class_adapter_selections
-        .iter()
-        .find(|selection| selection.owner == parent_name)
-    {
-        return Some(parent);
+    if let Some(local_name) = result.module.classes.iter().find_map(|class| {
+        let identity = class
+            .identity
+            .clone()
+            .unwrap_or_else(|| format!("{module_name}.{}", class.name));
+        (identity == parent_identity).then_some(class.name.as_str())
+    }) {
+        return result
+            .class_adapter_selections
+            .iter()
+            .find(|selection| selection.owner == local_name);
     }
     let (module, owner) = parent_identity.rsplit_once('.')?;
     external_defs
@@ -384,4 +389,61 @@ fn inherited_field_item(
         ("decorators".to_string(), ConstValue::List(Vec::new())),
         ("parameters".to_string(), ConstValue::List(Vec::new())),
     ])))
+}
+
+#[cfg(test)]
+mod parent_selection_tests {
+    use super::parent_selection;
+    use sifr_lowering::{lower_module, ClassAdapterSelection, ExternalDefs, LoweringResult};
+    use sifr_syntax::parse_module_suite;
+
+    fn selection(owner: &str, provider_module: &str) -> ClassAdapterSelection {
+        ClassAdapterSelection {
+            owner: owner.to_string(),
+            provider_module: provider_module.to_string(),
+            provider_function: "adapt".to_string(),
+            descriptor_type: sifr_type_system::Type::None,
+            marker_identities: Vec::new(),
+            data_parent: None,
+            field_plans: Vec::new(),
+            handler_plans: Vec::new(),
+            attached_api_set: None,
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
+            range: ruff_text_size::TextRange::default(),
+        }
+    }
+
+    fn local_result() -> LoweringResult {
+        let parsed = parse_module_suite("class Parent:\n    pass\n", None).expect("fixture parses");
+        let mut result = lower_module(&parsed).expect("fixture lowers");
+        result
+            .class_adapter_selections
+            .push(selection("Parent", "local.provider"));
+        result
+    }
+
+    #[test]
+    fn canonical_imported_parent_wins_over_a_colliding_local_selection() {
+        let result = local_result();
+        let mut external_defs = ExternalDefs::default();
+        external_defs
+            .class_adapter_selections
+            .entry("models".to_string())
+            .or_default()
+            .insert("Parent".to_string(), selection("Parent", "models.provider"));
+
+        let selected = parent_selection("consumer", &result, &external_defs, "models.Parent")
+            .expect("imported selection exists");
+        assert_eq!(selected.provider_module, "models.provider");
+    }
+
+    #[test]
+    fn canonical_local_parent_keeps_the_local_selection() {
+        let result = local_result();
+        let external_defs = ExternalDefs::default();
+        let selected = parent_selection("consumer", &result, &external_defs, "consumer.Parent")
+            .expect("local selection exists");
+        assert_eq!(selected.provider_module, "local.provider");
+    }
 }

--- a/crates/sifr_lowering/src/lower/generic_parent_representation.rs
+++ b/crates/sifr_lowering/src/lower/generic_parent_representation.rs
@@ -77,10 +77,20 @@ fn class_candidate<'a>(
     name: &str,
 ) -> Option<(&'a str, &'a Type)> {
     if let Some(identity) = identity {
-        return class_types.iter().find_map(|(candidate_name, candidate)| {
+        if let Some((candidate_name, candidate)) =
+            class_types.get_key_value(name).filter(|(_, candidate)| {
+                matches!(candidate.resolve_alias(), Type::Class { identity: Some(candidate), .. } if candidate == identity)
+            })
+        {
+            return Some((candidate_name.as_str(), candidate));
+        }
+        return class_types
+            .iter()
+            .filter_map(|(candidate_name, candidate)| {
             matches!(candidate.resolve_alias(), Type::Class { identity: Some(candidate), .. } if candidate == identity)
                 .then_some((candidate_name.as_str(), candidate))
-        });
+            })
+            .min_by_key(|(candidate_name, _)| *candidate_name);
     }
     class_types
         .get_key_value(name)
@@ -107,7 +117,7 @@ fn class_union_scope(ty: &Type, declared_params: &[String]) -> Option<UnionStruc
 
 #[cfg(test)]
 mod tests {
-    use super::preserves_union_structure;
+    use super::{class_candidate, preserves_union_structure};
     use sifr_type_system::Type;
     use std::collections::HashMap;
 
@@ -218,5 +228,18 @@ mod tests {
             "Parent",
             &concrete
         ));
+    }
+
+    #[test]
+    fn duplicate_canonical_candidates_use_a_deterministic_key() {
+        let candidate = parent(Type::TypeVar("T".to_string()), Type::Str);
+        let classes = HashMap::from([
+            ("AliasZ".to_string(), candidate.clone()),
+            ("AliasA".to_string(), candidate),
+        ]);
+
+        let (selected, _) = class_candidate(&classes, Some("models.Parent"), "Missing")
+            .expect("canonical candidate exists");
+        assert_eq!(selected, "AliasA");
     }
 }

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -893,6 +893,9 @@ normalizes diagnostic ranges while retaining checked interop declarations. Post-
 separately binds the invocation to the validated output and is an input to static-program identity,
 avoiding a cycle with later handler and attached-API outputs.
 
+Adapter inheritance selects parent plans by canonical class identity. A colliding local bare name
+cannot redirect an imported parent plan. Duplicate local aliases use a deterministic key order.
+
 Generic alias instances specialize their arguments and bodies before structural substitution.
 Generic ancestor walks require exact parameter and argument arity. Unspecialized exports pass
 their declaration parameters as explicit symbolic arguments instead of leaving bindings absent.


### PR DESCRIPTION
## Summary

- select inherited adapter plans by canonical class identity
- prevent a colliding local bare name from redirecting imported inheritance
- make duplicate canonical generic-parent candidates deterministic

## Validation

- cargo test -p sifr_lowering --no-fail-fast
- cargo test -p sifr_frontend --no-fail-fast
- cargo test -p sifr_driver --no-fail-fast
- cargo clippy --workspace -- -D warnings
- formatting and repository guardrails
- create-PR gate ran once on a0ba94e5e2416de1cce716ca56758658218f39fc; all preceding checks passed, then the two separately owned Rust-interop inputs stopped the lane
