### PR TITLE
fix: require class identity for adapter parents

### DIFF
--- a/crates/sifr_frontend/src/early_adapters.rs
+++ b/crates/sifr_frontend/src/early_adapters.rs
@@ -662,19 +662,14 @@ fn normalized_field_types(
     expected: &[(String, String)],
 ) -> Result<Vec<(String, Type)>, String> {
     let local_prefix = format!("{module_name}.{}.", selection.owner);
-    let parent_name = selection.data_parent.as_deref();
-    let parent_identity = class
-        .parent_type
-        .as_ref()
-        .and_then(|parent| match parent {
-            Type::Class { identity, name, .. } => Some(inheritance::canonical_parent_identity(
-                module_name,
-                identity.as_deref(),
-                name,
-            )),
-            _ => None,
-        })
-        .or_else(|| parent_name.map(|name| format!("{module_name}.{name}")));
+    let parent_identity = class.parent_type.as_ref().and_then(|parent| match parent {
+        Type::Class { identity, name, .. } => Some(inheritance::canonical_parent_identity(
+            module_name,
+            identity.as_deref(),
+            name,
+        )),
+        _ => None,
+    });
     let parent = parent_identity.as_deref().and_then(|identity| {
         inheritance::parent_selection(module_name, result, external_defs, identity)
     });

--- a/crates/sifr_frontend/src/early_adapters/handler_plans.rs
+++ b/crates/sifr_frontend/src/early_adapters/handler_plans.rs
@@ -116,10 +116,10 @@ pub(super) fn inherited_handler_plans(
     external_defs: &ExternalDefs,
     selection: &ClassAdapterSelection,
 ) -> Vec<AdapterHandlerPlan> {
-    let Some(parent_name) = selection.data_parent.as_deref() else {
+    if selection.data_parent.is_none() {
         return Vec::new();
-    };
-    let parent_identity = result
+    }
+    let Some(parent_identity) = result
         .module
         .classes
         .iter()
@@ -133,7 +133,9 @@ pub(super) fn inherited_handler_plans(
             )),
             _ => None,
         })
-        .unwrap_or_else(|| format!("{module_name}.{parent_name}"));
+    else {
+        return Vec::new();
+    };
     inheritance::parent_selection(module_name, result, external_defs, &parent_identity)
         .map(|parent| parent.handler_plans.clone())
         .unwrap_or_default()

--- a/crates/sifr_lowering/src/lower/type_alias_tests.rs
+++ b/crates/sifr_lowering/src/lower/type_alias_tests.rs
@@ -33,6 +33,17 @@ fn test_forward_type_alias_resolves_independent_of_declaration_order() {
 }
 
 #[test]
+fn test_class_alias_cannot_supply_parent_identity() {
+    let source = "class Parent:\n    value: int\n\ntype ParentAlias = Parent\n\nclass Child(ParentAlias):\n    pass\n";
+    let errors = lower_source(source).expect_err("class alias base must fail before inheritance");
+    assert!(errors.iter().any(|error| {
+        error.message == "invalid base class for 'Child': parent type 'ParentAlias' is not a class"
+            && error.code == Some(DiagnosticCode::CLASS_INVALID_BASE)
+            && error.primary_range == Some(range_for_after(source, "class Child(", "ParentAlias"))
+    }));
+}
+
+#[test]
 fn test_recursive_type_alias_name_resolves_without_unknown_type_error() {
     let result = lower_source(
         "type Json = None | bool | int | float | str | list[Json] | dict[str, Json]\n\ndef main():\n    print(\"ok\")\n",

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -896,7 +896,8 @@ avoiding a cycle with later handler and attached-API outputs.
 Adapter inheritance selects parent plans and type-parameter bindings by canonical class identity. A
 colliding local bare name cannot redirect an imported parent. Duplicate local aliases prefer a
 requested matching key, then use deterministic key order. Declaration reconstruction stops when a
-data parent has no canonical class type.
+data parent has no canonical class type. Class-base lowering rejects a type alias as data-parent
+identity authority.
 
 Generic alias instances specialize their arguments and bodies before structural substitution.
 Generic ancestor walks require exact parameter and argument arity. Unspecialized exports pass


### PR DESCRIPTION
## Summary

- remove unreachable parent identity synthesis outside real class parent types
- fail closed in inherited handler lookup when no class identity exists
- pin that a type alias cannot supply class-parent identity

## Validation

- cargo test -p sifr_lowering --no-fail-fast
- cargo test -p sifr_frontend --no-fail-fast
- cargo test -p sifr_driver --no-fail-fast
- cargo clippy --workspace -- -D warnings
- formatting and repository guardrails
- create-PR gate ran once on bc4a92c5eba3e9150a7cd9a4f506929d456f41f7; all preceding checks passed, then the two separately owned Rust-interop inputs stopped the lane
