### PR TITLE
Close M5 handler descriptor contract gaps

### DIFF
--- a/crates/sifr_driver/src/tests/handler_descriptors.rs
+++ b/crates/sifr_driver/src/tests/handler_descriptors.rs
@@ -203,6 +203,29 @@ class Invalid(HandlerContract):
 }
 
 #[test]
+fn staticmethod_descriptor_must_be_the_inner_adjacent_decorator() {
+    let errors = compile_errors(
+        r#"
+from fixture.handlers import HandlerContract, handler
+
+class Invalid(HandlerContract):
+    value: str
+
+    @handler("wrong-order")
+    @staticmethod
+    def parse(own value: str) -> str:
+        return value
+"#,
+    );
+    assert!(errors.iter().any(|error| {
+        error.code == sifr_diagnostics::DiagnosticCode::META_MALFORMED_DECLARATION.code()
+            && error
+                .message
+                .contains("directly above the method with @staticmethod as the outer decorator")
+    }));
+}
+
+#[test]
 fn owned_handler_requires_exact_self_output_at_the_descriptor() {
     let errors = compile_errors(
         r#"
@@ -473,4 +496,30 @@ class Box[T]:
         &[sifr_type_system::Type::TypeVar("T".to_string())]
     );
     assert_eq!(method.receiver, Some(ReceiverConvention::Owned));
+}
+
+#[test]
+fn self_annotation_is_rejected_in_static_and_class_methods() {
+    let errors = compile_errors(
+        r#"
+class Invalid:
+    @staticmethod
+    def static_value(value: Self) -> Self:
+        return value
+
+    @classmethod
+    def class_value(cls, value: Self) -> Self:
+        return value
+"#,
+    );
+    let invalid_self_count = errors
+        .iter()
+        .filter(|error| {
+            error.code == sifr_diagnostics::DiagnosticCode::TYPE_INVALID_ANNOTATION.code()
+                && error
+                    .message
+                    .contains("Self is valid only in an ordinary class method annotation")
+        })
+        .count();
+    assert!(invalid_self_count >= 4, "errors: {errors:#?}");
 }

--- a/crates/sifr_frontend/src/early_adapters/adapter_input.rs
+++ b/crates/sifr_frontend/src/early_adapters/adapter_input.rs
@@ -59,7 +59,7 @@ fn inherited_values(
     external_defs: &ExternalDefs,
     selection: &ClassAdapterSelection,
 ) -> Result<Vec<ConstValue>, &'static str> {
-    inherited_handler_plans(module_name, result, external_defs, selection)
+    inherited_handler_plans(module_name, result, external_defs, selection)?
         .into_iter()
         .map(|handler| {
             Ok(ConstValue::Record(BTreeMap::from([

--- a/crates/sifr_frontend/src/early_adapters/handler_plans.rs
+++ b/crates/sifr_frontend/src/early_adapters/handler_plans.rs
@@ -18,7 +18,7 @@ pub(super) fn validate_handlers(
     selection: &ClassAdapterSelection,
     values: Vec<ConstValue>,
 ) -> Result<Vec<AdapterHandlerPlan>, String> {
-    let mut eligible = inherited_handler_plans(module_name, result, external_defs, selection);
+    let mut eligible = inherited_handler_plans(module_name, result, external_defs, selection)?;
     let inherited_count = eligible.len();
     eligible.extend(
         result
@@ -115,9 +115,9 @@ pub(super) fn inherited_handler_plans(
     result: &LoweringResult,
     external_defs: &ExternalDefs,
     selection: &ClassAdapterSelection,
-) -> Vec<AdapterHandlerPlan> {
+) -> Result<Vec<AdapterHandlerPlan>, &'static str> {
     if selection.data_parent.is_none() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     let Some(parent_identity) = result
         .module
@@ -134,9 +134,43 @@ pub(super) fn inherited_handler_plans(
             _ => None,
         })
     else {
-        return Vec::new();
+        return Err("adapted data parent shape is unavailable");
     };
-    inheritance::parent_selection(module_name, result, external_defs, &parent_identity)
-        .map(|parent| parent.handler_plans.clone())
-        .unwrap_or_default()
+    Ok(
+        inheritance::parent_selection(module_name, result, external_defs, &parent_identity)
+            .map(|parent| parent.handler_plans.clone())
+            .unwrap_or_default(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::inherited_handler_plans;
+    use sifr_lowering::{lower_module, ClassAdapterSelection, ExternalDefs};
+    use sifr_syntax::parse_module_suite;
+
+    #[test]
+    fn inherited_handlers_require_the_declared_data_parent_shape_locally() {
+        let parsed = parse_module_suite("class Child:\n    pass\n", None).expect("fixture parses");
+        let result = lower_module(&parsed).expect("fixture lowers");
+        let selection = ClassAdapterSelection {
+            owner: "Child".to_string(),
+            provider_module: "fixture.provider".to_string(),
+            provider_function: "adapt".to_string(),
+            descriptor_type: sifr_type_system::Type::None,
+            marker_identities: Vec::new(),
+            data_parent: Some("Parent".to_string()),
+            field_plans: Vec::new(),
+            handler_plans: Vec::new(),
+            attached_api_set: None,
+            adapter_invocation_identity: [0; 32],
+            post_adapter_identity: [0; 32],
+            range: ruff_text_size::TextRange::default(),
+        };
+
+        assert_eq!(
+            inherited_handler_plans("main", &result, &ExternalDefs::default(), &selection),
+            Err("adapted data parent shape is unavailable")
+        );
+    }
 }

--- a/crates/sifr_frontend/src/typed_descriptors.rs
+++ b/crates/sifr_frontend/src/typed_descriptors.rs
@@ -15,6 +15,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 type DescriptorResult<T> = Result<T, Box<HirDiagnostic>>;
 
+mod method_decorator_ordering;
 mod nested_const_calls;
 
 pub(crate) fn collect(
@@ -188,34 +189,7 @@ impl DescriptorCollector<'_> {
                             sifr_lowering::MethodKind::StaticMethod => "static",
                             sifr_lowering::MethodKind::ClassMethod => "class",
                         });
-                    let classmethod_index = function.decorator_list.iter().position(|decorator| {
-                        matches!(
-                            &decorator.expression,
-                            Expr::Name(name) if name.id.as_str() == "classmethod"
-                        )
-                    });
-                    if let Some(classmethod_index) = classmethod_index {
-                        for (index, decorator) in function.decorator_list.iter().enumerate() {
-                            let Some((declaration, call)) =
-                                self.resolver.call(&decorator.expression)
-                            else {
-                                continue;
-                            };
-                            if declaration.kind == DeclarationDescriptorKind::Method
-                                && (index + 1 != classmethod_index
-                                    || classmethod_index + 1 != function.decorator_list.len())
-                            {
-                                self.errors.push(diagnostic(
-                                    DiagnosticCode::META_MALFORMED_DECLARATION,
-                                    format!(
-                                        "method descriptor '{}' must be the outer decorator with @classmethod directly above the method",
-                                        declaration.function
-                                    ),
-                                    call.range(),
-                                ));
-                            }
-                        }
-                    }
+                    method_decorator_ordering::validate(function, self.resolver, &mut self.errors);
                     for decorator in &function.decorator_list {
                         self.collect_use(
                             &decorator.expression,

--- a/crates/sifr_frontend/src/typed_descriptors/method_decorator_ordering.rs
+++ b/crates/sifr_frontend/src/typed_descriptors/method_decorator_ordering.rs
@@ -1,0 +1,54 @@
+use super::{diagnostic, DescriptorResolver};
+use ruff_text_size::Ranged;
+use sifr_diagnostics::DiagnosticCode;
+use sifr_lowering::{DeclarationDescriptorKind, HirDiagnostic};
+use sifr_python_ast::{Expr, StmtFunctionDef};
+
+pub(super) fn validate(
+    function: &StmtFunctionDef,
+    resolver: &DescriptorResolver,
+    errors: &mut Vec<HirDiagnostic>,
+) {
+    let classmethod_index = decorator_index(function, "classmethod");
+    let staticmethod_index = decorator_index(function, "staticmethod");
+    for (index, decorator) in function.decorator_list.iter().enumerate() {
+        let Some((declaration, call)) = resolver.call(&decorator.expression) else {
+            continue;
+        };
+        if declaration.kind != DeclarationDescriptorKind::Method {
+            continue;
+        }
+        if classmethod_index.is_some_and(|classmethod_index| {
+            index + 1 != classmethod_index || classmethod_index + 1 != function.decorator_list.len()
+        }) {
+            errors.push(diagnostic(
+                DiagnosticCode::META_MALFORMED_DECLARATION,
+                format!(
+                    "method descriptor '{}' must be the outer decorator with @classmethod directly above the method",
+                    declaration.function
+                ),
+                call.range(),
+            ));
+        }
+        if staticmethod_index.is_some_and(|staticmethod_index| {
+            staticmethod_index != 0
+                || index != staticmethod_index + 1
+                || index + 1 != function.decorator_list.len()
+        }) {
+            errors.push(diagnostic(
+                DiagnosticCode::META_MALFORMED_DECLARATION,
+                format!(
+                    "method descriptor '{}' must be directly above the method with @staticmethod as the outer decorator",
+                    declaration.function
+                ),
+                call.range(),
+            ));
+        }
+    }
+}
+
+fn decorator_index(function: &StmtFunctionDef, name: &str) -> Option<usize> {
+    function.decorator_list.iter().position(
+        |decorator| matches!(&decorator.expression, Expr::Name(found) if found.id.as_str() == name),
+    )
+}

--- a/crates/sifr_lowering/src/lower/classes.rs
+++ b/crates/sifr_lowering/src/lower/classes.rs
@@ -29,4 +29,5 @@ mod class_body_lowering;
 pub(in crate::lower) use class_body_lowering::*;
 mod parameter_conventions;
 pub(in crate::lower) use parameter_conventions::fixed_trait_receiver_convention;
+mod python_cleanup_validation;
 mod rust_opaque_validation;

--- a/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_body_lowering.rs
@@ -16,8 +16,7 @@ use super::{is_derivably_hashable_type, is_hashable_type};
 use crate::lower::ownership_diagnostics;
 use crate::lower::python_interop::{
     classify_python_interop_stub_body, collect_python_method_declarations,
-    has_python_interop_decorator_syntax, receiver_is_owned, validate_context_class_methods,
-    validate_python_interop_signature,
+    has_python_interop_decorator_syntax, receiver_is_owned, validate_python_interop_signature,
 };
 use crate::lower::rust_interop::{
     classify_rust_interop_stub_body, collect_rust_interop_declarations,
@@ -103,6 +102,7 @@ pub(in crate::lower) fn lower_class(
         let variants = collect_enum_variants(class_def);
         let mut hir_methods = Vec::new();
         ctx.current_class = Some(class_name.clone());
+        ctx.self_annotation_available = true;
         for stmt in &class_def.body {
             if let Stmt::FunctionDef(func) = stmt {
                 let method_name = func.name.to_string();
@@ -203,6 +203,7 @@ pub(in crate::lower) fn lower_class(
                 });
             }
         }
+        ctx.self_annotation_available = false;
         ctx.current_class = None;
         return Some(HirClass {
             name: class_name.clone(),
@@ -247,6 +248,7 @@ pub(in crate::lower) fn lower_class(
                     continue;
                 } // Skip __init__ for newtypes
                 ctx.current_class = Some(class_name.clone());
+                ctx.self_annotation_available = true;
                 ctx.scope.push();
                 let receiver = declared_receiver_convention(&func.parameters);
                 let receiver_id =
@@ -329,6 +331,7 @@ pub(in crate::lower) fn lower_class(
                 ctx.current_method = previous_method;
                 ctx.current_owner = previous_owner;
                 ctx.scope.pop();
+                ctx.self_annotation_available = false;
                 ctx.current_class = None;
                 hir_methods.push(HirFunction {
                     name: method_name,
@@ -437,6 +440,7 @@ pub(in crate::lower) fn lower_class(
 
             // Set current class context for `self` resolution
             ctx.current_class = Some(class_name.clone());
+            ctx.self_annotation_available = method_kind == MethodKind::Regular;
             ctx.current_parent_class.clone_from(&parent_class_name);
             ctx.current_parent_type.clone_from(&parent_type);
 
@@ -657,6 +661,7 @@ pub(in crate::lower) fn lower_class(
             ctx.current_owner = previous_owner;
 
             ctx.scope.pop();
+            ctx.self_annotation_available = false;
             ctx.current_class = None;
             ctx.current_parent_class = None;
             ctx.current_parent_type = None;
@@ -719,102 +724,7 @@ pub(in crate::lower) fn lower_class(
     );
     opaque::validate_rust_opaque_close_method(class_def, &hir_methods, &rust_interop, ctx);
 
-    let semantic_close_methods = hir_methods
-        .iter()
-        .filter(|method| {
-            method.receiver == Some(ReceiverConvention::Owned)
-                && method.python_interop.first().is_some_and(|declaration| {
-                    declaration.consumes_receiver
-                        && declaration.kind == sifr_ir::PythonInteropDecoratorKind::Function
-                        && declaration
-                            .target
-                            .as_ref()
-                            .is_some_and(|target| target.segments.as_slice() == ["Self", "close"])
-                        && method.params.is_empty()
-                        && matches!(
-                            method.return_type.resolve_alias(),
-                            Type::Result(ok, _) if ok.resolve_alias() == &Type::None
-                        )
-                })
-        })
-        .count();
-    let cleanup = ctx
-        .python_opaque_classes
-        .get(&class_name)
-        .and_then(|declaration| declaration.cleanup);
-    validate_context_class_methods(&class_name, &hir_methods, cleanup, ctx, class_def.range);
-    if cleanup == Some(sifr_ir::PythonCleanupPolicy::Close) && semantic_close_methods != 1 {
-        ctx.error_with_code_at(
-            sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
-            "`cleanup=close` requires exactly one `@python(Self.close)` method declared as `def close(own self) -> Result[None, PythonError]`".to_string(),
-            class_def.range,
-        );
-    }
-    let semantic_async_close_methods = hir_methods
-        .iter()
-        .filter(|method| {
-            method.receiver == Some(ReceiverConvention::Owned)
-                && method.python_interop.first().is_some_and(|declaration| {
-                    declaration.consumes_receiver
-                        && declaration.kind == sifr_ir::PythonInteropDecoratorKind::Coroutine
-                        && declaration
-                            .target
-                            .as_ref()
-                            .is_some_and(|target| target.segments.as_slice() == ["Self", "aclose"])
-                        && method.params.is_empty()
-                        && matches!(
-                            method.return_type.resolve_alias(),
-                            Type::Result(ok, _) if ok.resolve_alias() == &Type::None
-                        )
-                })
-        })
-        .count();
-    if cleanup == Some(sifr_ir::PythonCleanupPolicy::AsyncClose)
-        && semantic_async_close_methods != 1
-    {
-        ctx.error_with_code_at(
-            sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
-            "`cleanup=async_close` requires exactly one `@python.coroutine(Self.aclose)` method declared as `async def aclose(own self) -> Result[None, PythonError]`".to_string(),
-            class_def.range,
-        );
-    }
-    let has_unmatched_consuming_method =
-        hir_methods.iter().any(|method| {
-            method.python_interop.first().is_some_and(|declaration| {
-                if !declaration.consumes_receiver {
-                    return false;
-                }
-                match cleanup {
-                    Some(sifr_ir::PythonCleanupPolicy::Close) => {
-                        declaration.kind != sifr_ir::PythonInteropDecoratorKind::Function
-                            || declaration.target.as_ref().is_none_or(|target| {
-                                target.segments.as_slice() != ["Self", "close"]
-                            })
-                    }
-                    Some(sifr_ir::PythonCleanupPolicy::AsyncClose) => {
-                        declaration.kind != sifr_ir::PythonInteropDecoratorKind::Coroutine
-                            || declaration.target.as_ref().is_none_or(|target| {
-                                target.segments.as_slice() != ["Self", "aclose"]
-                            })
-                    }
-                    Some(sifr_ir::PythonCleanupPolicy::Context) => {
-                        declaration.kind != sifr_ir::PythonInteropDecoratorKind::ContextExit
-                    }
-                    Some(sifr_ir::PythonCleanupPolicy::AsyncContext) => {
-                        declaration.kind != sifr_ir::PythonInteropDecoratorKind::ContextAsyncExit
-                    }
-                    _ => true,
-                }
-            })
-        });
-    if has_unmatched_consuming_method {
-        ctx.error_with_code_at(
-            sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
-            "a consuming Python method is reserved for the declared semantic cleanup operation"
-                .to_string(),
-            class_def.range,
-        );
-    }
+    super::python_cleanup_validation::validate(class_def, &hir_methods, ctx);
 
     let is_error = ctx.error_types.contains(&class_name);
     if is_error

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -517,7 +517,13 @@ pub(in crate::lower) fn collect_class_type(
             // Method definitions
             Stmt::FunctionDef(func) => {
                 let method_name = func.name.to_string();
+                let is_static = has_decorator(func, "staticmethod");
+                let is_class = has_decorator(func, "classmethod");
                 let previous_current_class = ctx.current_class.replace(class_name.clone());
+                let previous_self_annotation_available = std::mem::replace(
+                    &mut ctx.self_annotation_available,
+                    method_name == "__init__" || (!is_static && !is_class),
+                );
                 method_ranges.insert(method_name.clone(), func.name.range());
                 if method_name == "__init__" {
                     // Constructor: extract params (skip `self`)
@@ -582,8 +588,6 @@ pub(in crate::lower) fn collect_class_type(
                         ctx.function_defaults.insert(class_name.clone(), defaults);
                     }
                 } else {
-                    let is_static = has_decorator(func, "staticmethod");
-                    let is_class = has_decorator(func, "classmethod");
                     record_declared_class_method_metadata(
                         ctx,
                         &class_name,
@@ -725,6 +729,7 @@ pub(in crate::lower) fn collect_class_type(
                         ctx,
                     );
                 }
+                ctx.self_annotation_available = previous_self_annotation_available;
                 ctx.current_class = previous_current_class;
             }
             Stmt::Pass(_) => {} // Allow pass in class body

--- a/crates/sifr_lowering/src/lower/classes/python_cleanup_validation.rs
+++ b/crates/sifr_lowering/src/lower/classes/python_cleanup_validation.rs
@@ -1,0 +1,112 @@
+use super::{HirFunction, LowerCtx, StmtClassDef, Type};
+use crate::lower::python_interop::validate_context_class_methods;
+use sifr_type_system::ReceiverConvention;
+
+pub(super) fn validate(class: &StmtClassDef, methods: &[HirFunction], ctx: &mut LowerCtx) {
+    let class_name = class.name.as_str();
+    let cleanup = ctx
+        .python_opaque_classes
+        .get(class_name)
+        .and_then(|declaration| declaration.cleanup);
+    validate_context_class_methods(class_name, methods, cleanup, ctx, class.range);
+    let close_count = methods
+        .iter()
+        .filter(|method| {
+            is_semantic_cleanup(
+                method,
+                sifr_ir::PythonInteropDecoratorKind::Function,
+                "close",
+            )
+        })
+        .count();
+    if cleanup == Some(sifr_ir::PythonCleanupPolicy::Close) && close_count != 1 {
+        ctx.error_with_code_at(
+            sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
+            "`cleanup=close` requires exactly one `@python(Self.close)` method declared as `def close(own self) -> Result[None, PythonError]`".to_string(),
+            class.range,
+        );
+    }
+    let async_close_count = methods
+        .iter()
+        .filter(|method| {
+            is_semantic_cleanup(
+                method,
+                sifr_ir::PythonInteropDecoratorKind::Coroutine,
+                "aclose",
+            )
+        })
+        .count();
+    if cleanup == Some(sifr_ir::PythonCleanupPolicy::AsyncClose) && async_close_count != 1 {
+        ctx.error_with_code_at(
+            sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
+            "`cleanup=async_close` requires exactly one `@python.coroutine(Self.aclose)` method declared as `async def aclose(own self) -> Result[None, PythonError]`".to_string(),
+            class.range,
+        );
+    }
+    if methods
+        .iter()
+        .any(|method| has_unmatched_consuming_declaration(method, cleanup))
+    {
+        ctx.error_with_code_at(
+            sifr_diagnostics::DiagnosticCode::PYCALL_INVALID_SHAPE,
+            "a consuming Python method is reserved for the declared semantic cleanup operation"
+                .to_string(),
+            class.range,
+        );
+    }
+}
+
+fn is_semantic_cleanup(
+    method: &HirFunction,
+    kind: sifr_ir::PythonInteropDecoratorKind,
+    target_member: &str,
+) -> bool {
+    method.receiver == Some(ReceiverConvention::Owned)
+        && method.python_interop.first().is_some_and(|declaration| {
+            declaration.consumes_receiver
+                && declaration.kind == kind
+                && declaration
+                    .target
+                    .as_ref()
+                    .is_some_and(|target| target.segments.as_slice() == ["Self", target_member])
+                && method.params.is_empty()
+                && matches!(
+                    method.return_type.resolve_alias(),
+                    Type::Result(ok, _) if ok.resolve_alias() == &Type::None
+                )
+        })
+}
+
+fn has_unmatched_consuming_declaration(
+    method: &HirFunction,
+    cleanup: Option<sifr_ir::PythonCleanupPolicy>,
+) -> bool {
+    method.python_interop.first().is_some_and(|declaration| {
+        if !declaration.consumes_receiver {
+            return false;
+        }
+        match cleanup {
+            Some(sifr_ir::PythonCleanupPolicy::Close) => {
+                declaration.kind != sifr_ir::PythonInteropDecoratorKind::Function
+                    || declaration
+                        .target
+                        .as_ref()
+                        .is_none_or(|target| target.segments.as_slice() != ["Self", "close"])
+            }
+            Some(sifr_ir::PythonCleanupPolicy::AsyncClose) => {
+                declaration.kind != sifr_ir::PythonInteropDecoratorKind::Coroutine
+                    || declaration
+                        .target
+                        .as_ref()
+                        .is_none_or(|target| target.segments.as_slice() != ["Self", "aclose"])
+            }
+            Some(sifr_ir::PythonCleanupPolicy::Context) => {
+                declaration.kind != sifr_ir::PythonInteropDecoratorKind::ContextExit
+            }
+            Some(sifr_ir::PythonCleanupPolicy::AsyncContext) => {
+                declaration.kind != sifr_ir::PythonInteropDecoratorKind::ContextAsyncExit
+            }
+            _ => true,
+        }
+    })
+}

--- a/crates/sifr_lowering/src/lower/expressions/method_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_calls.rs
@@ -350,6 +350,11 @@ pub(in crate::lower) fn lower_method_call(
 
 fn consume_declared_owned_receiver(object: &HirExpr, range: TextRange, ctx: &mut LowerCtx) {
     let HirExpr::Name { name, .. } = object else {
+        ctx.error_with_code_at(
+            DiagnosticCode::OWN_BORROWED_PARAMETER_ESCAPES,
+            "declared owned receiver must consume an owned local binding; field and temporary receivers cannot prove exclusive ownership".to_string(),
+            range,
+        );
         return;
     };
     if ctx.borrowed_params.contains(name) {

--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -134,6 +134,8 @@ pub(in crate::lower) struct LowerCtx {
     pub(in crate::lower) warnings: Vec<LoweringWarningDiagnostic>,
     /// Whether we're currently inside a class method (tracks `self` type)
     pub(in crate::lower) current_class: Option<String>,
+    /// Whether `Self` annotations are valid in the current class method.
+    pub(in crate::lower) self_annotation_available: bool,
     /// Current function/method owner name while lowering a body.
     pub(in crate::lower) current_owner: Option<String>,
     /// Current class method name, used to retain generated Rust trait requirements per method.
@@ -304,6 +306,7 @@ impl LowerCtx {
             reveal_types: Vec::new(),
             warnings: Vec::new(),
             current_class: None,
+            self_annotation_available: false,
             current_owner: None,
             current_method: None,
             current_parent_class: None,

--- a/crates/sifr_lowering/src/lower/own_mut_semantics_tests.rs
+++ b/crates/sifr_lowering/src/lower/own_mut_semantics_tests.rs
@@ -77,6 +77,37 @@ fn test_own_parameter_cannot_be_mutated_without_mut() {
 }
 
 #[test]
+fn declared_owned_receiver_rejects_field_and_temporary_storage() {
+    let source = r#"
+class Resource:
+    value: str
+
+    def finish(own self) -> Self:
+        return self
+
+class Holder:
+    resource: Resource
+
+def consume_field(holder: Holder) -> Resource:
+    return holder.resource.finish()
+
+def consume_temporary() -> Resource:
+    return Resource("value").finish()
+"#;
+    let errors = lower_errors(source);
+    let storage_errors = errors
+        .iter()
+        .filter(|error| {
+            error.code == Some(DiagnosticCode::OWN_BORROWED_PARAMETER_ESCAPES)
+                && error.message.contains(
+                    "declared owned receiver must consume an owned local binding; field and temporary receivers cannot prove exclusive ownership",
+                )
+        })
+        .count();
+    assert_eq!(storage_errors, 2, "errors: {errors:#?}");
+}
+
+#[test]
 fn test_own_parameter_mutating_method_requires_mut() {
     let source = "def owned_immutable_append(own items: list[int] = [1]) -> list[int]:\n    items.append(5)\n    return items\n";
     let errors = lower_errors(source);

--- a/crates/sifr_lowering/src/lower/typing_and_functions/annotation_resolution.rs
+++ b/crates/sifr_lowering/src/lower/typing_and_functions/annotation_resolution.rs
@@ -14,7 +14,10 @@ pub(in crate::lower) fn resolve_annotation_expr(expr: &Expr, ctx: &mut LowerCtx)
                 if let Some(type_param) = ctx.attached_self_type_param.as_ref() {
                     return Type::TypeVar(type_param.clone());
                 }
-                if let Some(current_class) = ctx.current_class.as_deref() {
+                if ctx.self_annotation_available {
+                    let Some(current_class) = ctx.current_class.as_deref() else {
+                        unreachable!("Self annotation availability requires a current class");
+                    };
                     if let Some(class_ty) = ctx.class_types.get(current_class) {
                         return class_ty.clone();
                     }


### PR DESCRIPTION
## Summary
- reject declared-owned field and temporary receivers without an owned local binding
- restrict `Self` annotations to ordinary class methods and pin static-method descriptor stacking
- make inherited-handler shape validation local to handler planning
- split decorator-order and Python-cleanup validation along responsibility boundaries

## Validation
- affected lowering, frontend, and driver suites
- workspace Clippy with warnings denied
- formatting, maintainability, diff hygiene, and 900-line guard
- create-PR gate attempted once on exact candidate `5c44c248d9a0144fb0c95151349b06061c45167b`; all preceding guards passed, then the out-of-scope Rust-interop matrix stopped on its known missing negative fixture and empty placeholder class