### PR TITLE
fix structural mapping contracts

### DIFF
--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -160,7 +160,9 @@ pub use rust_interop_plan::{
 };
 mod rust_ir;
 pub use rust_ir::*;
+mod stdlib_codegen_metadata;
 mod stdlib_filter;
+pub use stdlib_codegen_metadata::StdlibCode;
 mod stdlib_import_signatures;
 mod stdlib_rust_source;
 pub use stdlib_rust_source::StdlibRustSource;

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -83,6 +83,8 @@ mod string_concat_codegen_tests;
 #[cfg(test)]
 mod structural_impl_demand_codegen_tests;
 #[cfg(test)]
+mod structural_stdlib_impl_codegen_tests;
+#[cfg(test)]
 mod structured_condition_codegen_tests;
 #[cfg(test)]
 mod structured_intrinsic_codegen_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_stdlib_impl_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_stdlib_impl_codegen_tests.rs
@@ -1,0 +1,148 @@
+use sifr_ir::{
+    HirClass, HirClassKind, HirFunction, HirImport, HirModule, MethodKind,
+    RustInteropAbiRequirements, RustInteropDeclaration, RustInteropDecoratorKind,
+    RustInteropEffect,
+};
+use sifr_type_system::Type;
+use std::collections::{HashMap, HashSet};
+
+const STRUCTURAL_IMPL_TARGET: &str = "impl ::sifr_runtime::interop::structural::StructuralType";
+
+#[test]
+fn multi_module_stdlib_structural_impl_is_emitted_for_each_imported_nominal() {
+    let mut alpha = module(Vec::new(), Vec::new());
+    alpha.imports.push(json_import());
+    let mut zeta = module(Vec::new(), Vec::new());
+    zeta.imports.push(json_import());
+    let main = module(vec![structural_function()], Vec::new());
+
+    let generated = crate::generate_rust_multi_with_metadata(
+        &[("zeta", &zeta), ("main", &main), ("alpha", &alpha)],
+        &json_stdlib(),
+    );
+    let count = generated
+        .rust_files
+        .values()
+        .map(|source| source.matches(STRUCTURAL_IMPL_TARGET).count())
+        .sum::<usize>();
+
+    assert_eq!(count, 2, "{:?}", generated.rust_files);
+    assert!(generated.rust_files["alpha"].contains(STRUCTURAL_IMPL_TARGET));
+    assert!(generated.rust_files["zeta"].contains(STRUCTURAL_IMPL_TARGET));
+}
+
+#[test]
+fn project_identity_with_stdlib_prefix_gets_no_origin_bypass() {
+    let mut payload = payload_class();
+    payload.identity = Some("sifr.fake.Payload".to_string());
+    let module = module(vec![structural_function()], vec![payload]);
+    let supported = HashSet::new();
+
+    let generated = crate::generate_rust_with_stdlib_for_module_with_project_policy(
+        &module,
+        &crate::StdlibCode::default(),
+        Some("main"),
+        Some("main"),
+        true,
+        None,
+        None,
+        None,
+        Some(&supported),
+        None,
+    )
+    .rust_source;
+
+    assert!(
+        !generated.contains("StructuralType for Payload"),
+        "{generated}"
+    );
+}
+
+fn json_import() -> HirImport {
+    HirImport {
+        module: "sifr.json".to_string(),
+        names: vec!["JsonValue".to_string()],
+        aliases: Vec::new(),
+    }
+}
+
+fn json_stdlib() -> crate::StdlibCode {
+    let mut template = payload_class();
+    template.name = "JsonValue".to_string();
+    template.identity = Some("sifr.json.JsonValue".to_string());
+    let mut stdlib = crate::StdlibCode::default();
+    stdlib.module_class_templates.insert(
+        "sifr.json".to_string(),
+        HashMap::from([("JsonValue".to_string(), template)]),
+    );
+    stdlib.module_rust_code.insert(
+        "sifr.json".to_string(),
+        crate::StdlibRustSource {
+            module: "sifr.json".to_string(),
+            source_path: "stdlib/sifr/json.sifr".to_string(),
+            source_sha256: "fixture".to_string(),
+            nominal_types: HashSet::from(["JsonValue".to_string()]),
+            rust: "struct JsonValue { value: i64 }".to_string(),
+        },
+    );
+    stdlib
+}
+
+fn module(functions: Vec<HirFunction>, classes: Vec<HirClass>) -> HirModule {
+    HirModule {
+        functions,
+        classes,
+        imports: Vec::new(),
+        constants: Vec::new(),
+        generic_functions: HashMap::new(),
+        type_param_bounds: HashMap::new(),
+    }
+}
+
+fn payload_class() -> HirClass {
+    HirClass {
+        name: "Payload".to_string(),
+        identity: None,
+        fields: vec![("value".to_string(), Type::Int)],
+        field_defaults: Vec::new(),
+        field_default_identities: Vec::new(),
+        declaration_metadata: Vec::new(),
+        methods: Vec::new(),
+        is_hashable: false,
+        is_error_type: false,
+        kind: HirClassKind::Regular,
+        operator_impls: Vec::new(),
+        newtype_inner: None,
+        implements_protocols: Vec::new(),
+        parent_class: None,
+        parent_type: None,
+        type_params: Vec::new(),
+        enum_variants: Vec::new(),
+        rust_interop: Vec::new(),
+    }
+}
+
+fn structural_function() -> HirFunction {
+    HirFunction {
+        name: "construct".to_string(),
+        params: Vec::new(),
+        return_type: Type::None,
+        body: Vec::new(),
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        receiver: None,
+        decorators: Vec::new(),
+        rust_interop: vec![RustInteropDeclaration {
+            kind: RustInteropDecoratorKind::Structural,
+            target: None,
+            arguments: Vec::new(),
+            span: Default::default(),
+            effect: RustInteropEffect::Sync,
+            abi_requirements: RustInteropAbiRequirements::default(),
+            consumes_receiver: false,
+        }],
+        python_interop: Vec::new(),
+        compiler_intrinsic: None,
+        type_params: Vec::new(),
+    }
+}

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -26,7 +26,7 @@ use crate::stdlib_filter::{
     filter_canonical_stdlib_ir_to_needed, seal_canonical_stdlib_names,
 };
 use crate::stdlib_import_signatures::register_imported_stdlib_signature;
-use crate::StdlibRustSource;
+use crate::StdlibCode;
 use sifr_ir::HirModule;
 use sifr_stdlib_manifest::StdlibFeature;
 use sifr_type_system::{ParamConvention, Type};
@@ -35,7 +35,6 @@ use std::fmt::Write as _;
 
 pub(crate) type FuncSignature = (Vec<(Type, ParamConvention)>, Type);
 pub(crate) type ModuleFuncSignatures = HashMap<String, FuncSignature>;
-type StdlibFuncSignatures = HashMap<String, ModuleFuncSignatures>;
 pub(crate) type UnionVariantTypes = Vec<(String, Type)>;
 pub(crate) type IsinstanceUnionMatch = (String, String, String, UnionVariantTypes);
 
@@ -100,38 +99,6 @@ pub struct LoweringStats {
     pub stmt_candidate_structured: u64,
     pub expr_candidate_total: u64,
     pub expr_candidate_structured: u64,
-}
-
-/// Compiled stdlib information for codegen.
-/// Contains per-module checked Rust code and callable metadata.
-#[derive(Clone, Default)]
-pub struct StdlibCode {
-    /// Map of `module_name` -> compiled Rust source with checked-source provenance.
-    pub module_rust_code: HashMap<String, StdlibRustSource>,
-    /// Map of `module_name` -> (`constant_name` -> (type, `rust_name`)) for stdlib constants
-    /// This allows user code to reference stdlib constants with the correct Rust names.
-    pub module_constants: HashMap<String, HashMap<String, (Type, String)>>,
-    /// Map of `module_name` -> (`func_name` -> (`param_types_with_conventions`, `return_type`))
-    /// for pure Sifr stdlib functions. Used to emit correct borrow prefixes at call sites.
-    pub func_signatures: StdlibFuncSignatures,
-    /// Map of `module_name` -> set of transitive intrinsic module dependencies.
-    /// E.g., sifr.secrets depends on _sifr.crypto, so when user imports sifr.secrets,
-    /// the Cargo dependencies for _sifr.crypto (rand) must be included.
-    pub transitive_deps: HashMap<String, HashSet<String>>,
-    /// Map of `module_name` -> set of function names that are generators (contain yield).
-    /// Used to emit .`collect()` when assigning generator results to list[T] in user code.
-    pub generator_functions: HashMap<String, HashSet<String>>,
-    /// Set of class names that have generic type parameters across all stdlib modules.
-    pub generic_classes: HashSet<String>,
-    /// Map of stdlib generic class name -> declared type parameter names.
-    pub generic_class_params: HashMap<String, Vec<String>>,
-    /// Map of stdlib generic class name -> template HIR class for concrete type-argument inference.
-    pub generic_class_templates: HashMap<String, sifr_ir::HirClass>,
-    /// Map of `module_name` -> (`class_name` -> ordered class fields).
-    /// Multi-module project codegen also uses this for local helper modules.
-    pub module_class_fields: HashMap<String, HashMap<String, Vec<(String, Type)>>>,
-    /// Checked stdlib classes retained for late project-policy implementations.
-    pub module_class_templates: HashMap<String, HashMap<String, sifr_ir::HirClass>>,
 }
 
 pub(super) fn module_func_signatures(module: &HirModule) -> ModuleFuncSignatures {

--- a/crates/sifr_codegen/src/stdlib_codegen_metadata.rs
+++ b/crates/sifr_codegen/src/stdlib_codegen_metadata.rs
@@ -1,0 +1,28 @@
+use crate::{ModuleFuncSignatures, StdlibRustSource};
+use sifr_type_system::Type;
+use std::collections::{HashMap, HashSet};
+
+/// Compiled stdlib information for code generation.
+#[derive(Clone, Default)]
+pub struct StdlibCode {
+    /// Checked Rust source for each stdlib module.
+    pub module_rust_code: HashMap<String, StdlibRustSource>,
+    /// Exported constants and their generated Rust names by module.
+    pub module_constants: HashMap<String, HashMap<String, (Type, String)>>,
+    /// Checked function and method signatures by module.
+    pub func_signatures: HashMap<String, ModuleFuncSignatures>,
+    /// Transitive intrinsic dependencies by module.
+    pub transitive_deps: HashMap<String, HashSet<String>>,
+    /// Generator functions by module.
+    pub generator_functions: HashMap<String, HashSet<String>>,
+    /// Generic stdlib class names.
+    pub generic_classes: HashSet<String>,
+    /// Declared type parameters for each generic stdlib class.
+    pub generic_class_params: HashMap<String, Vec<String>>,
+    /// Generic stdlib class templates used for concrete inference.
+    pub generic_class_templates: HashMap<String, sifr_ir::HirClass>,
+    /// Ordered fields for each stdlib class by module.
+    pub module_class_fields: HashMap<String, HashMap<String, Vec<(String, Type)>>>,
+    /// Checked stdlib classes retained for late project-policy implementations.
+    pub module_class_templates: HashMap<String, HashMap<String, sifr_ir::HirClass>>,
+}

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -1,12 +1,14 @@
 use crate::{RustEmitter, RustItem, RustParam, RustStmt, RustType, RustTypeParam, Visibility};
 use sifr_ir::{HirClass, HirModule, RustInteropDecoratorKind};
-use sifr_type_system::{class_rust_name, Type};
+use sifr_type_system::Type;
 use std::collections::{BTreeSet, HashSet};
 
 #[cfg(test)]
 mod generic_representation_tests;
 
 use crate::structural_record_fields::structural_record_fields;
+
+mod stdlib_implementations;
 
 const STRUCTURAL: &str = "::sifr_runtime::interop::structural";
 
@@ -36,11 +38,16 @@ impl RustEmitter {
                 let Some(class) = templates.get(name) else {
                     continue;
                 };
-                let target = imported_stdlib_impl_target(class);
+                let target = stdlib_implementations::target(class);
                 if !emitted_targets.insert(target.clone()) {
                     continue;
                 }
-                self.emit_structural_record_impls_for_target(class, &support_module, &target);
+                self.emit_structural_record_impls_for_target(
+                    class,
+                    &support_module,
+                    &target,
+                    StructuralRecordOrigin::Stdlib,
+                );
                 self.emit_structural_enum_impls_for_target(class, &target);
             }
         }
@@ -48,7 +55,12 @@ impl RustEmitter {
 
     pub(crate) fn emit_structural_record_impls(&mut self, class: &HirClass, module: &HirModule) {
         let target = Self::class_impl_target(class);
-        self.emit_structural_record_impls_for_target(class, module, &target);
+        self.emit_structural_record_impls_for_target(
+            class,
+            module,
+            &target,
+            StructuralRecordOrigin::Project,
+        );
     }
 
     fn emit_structural_record_impls_for_target(
@@ -56,6 +68,7 @@ impl RustEmitter {
         class: &HirClass,
         module: &HirModule,
         target: &str,
+        origin: StructuralRecordOrigin,
     ) {
         let supported = self
             .project_structural_record_identities
@@ -66,7 +79,7 @@ impl RustEmitter {
                     let identity =
                         structural_record_identity(class, self.current_module_name.as_deref());
                     identities.contains(&identity)
-                        || (identity.starts_with("sifr.")
+                        || (origin == StructuralRecordOrigin::Stdlib
                             && structural_record_supported(class, module))
                 },
             );
@@ -141,13 +154,10 @@ impl RustEmitter {
     }
 }
 
-fn imported_stdlib_impl_target(class: &HirClass) -> String {
-    let rust_name = class_rust_name(class.identity.as_deref(), &class.name);
-    if class.type_params.is_empty() {
-        rust_name
-    } else {
-        format!("{rust_name}<{}>", class.type_params.join(", "))
-    }
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StructuralRecordOrigin {
+    Project,
+    Stdlib,
 }
 
 pub(crate) fn structural_record_supported(class: &HirClass, module: &HirModule) -> bool {

--- a/crates/sifr_codegen/src/structural_impl_codegen/stdlib_implementations.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen/stdlib_implementations.rs
@@ -1,0 +1,11 @@
+use sifr_ir::HirClass;
+use sifr_type_system::class_rust_name;
+
+pub(super) fn target(class: &HirClass) -> String {
+    let rust_name = class_rust_name(class.identity.as_deref(), &class.name);
+    if class.type_params.is_empty() {
+        rust_name
+    } else {
+        format!("{rust_name}<{}>", class.type_params.join(", "))
+    }
+}

--- a/crates/sifr_driver/src/build/rust_interop_probe.rs
+++ b/crates/sifr_driver/src/build/rust_interop_probe.rs
@@ -232,35 +232,49 @@ fn prefixed_probe_source(prefix: &str, body: &str) -> String {
 }
 
 fn opaque_probe_source(probe: &PendingRustBridgeProbe, rust_path: &str) -> String {
+    opaque_type_probe_source(
+        rust_path,
+        opaque_target_argument(probe, "structural").as_deref(),
+        opaque_bool_argument(probe, "send"),
+        opaque_bool_argument(probe, "sync"),
+        opaque_symbol_argument(probe, "clone") == Some("copy"),
+    )
+}
+
+pub(super) fn opaque_type_probe_source(
+    rust_path: &str,
+    structural_mapping: Option<&str>,
+    requires_send: bool,
+    requires_sync: bool,
+    requires_copy: bool,
+) -> String {
     let mut out = format!("#![allow(dead_code)]\ntype __SifrProbe = {rust_path};\n");
-    let structural_mapping =
-        opaque_target_argument(probe, "structural").filter(|mapping| mapping != rust_path);
-    if let Some(mapping) = &structural_mapping {
+    if let Some(mapping) = structural_mapping {
         let _ = writeln!(out, "type __SifrMapping = {mapping};");
         out.push_str(
             "fn __sifr_assert_structural_mapping<M: sifr_runtime::interop::structural::StructuralMapping<__SifrProbe>>() {}\n",
         );
     }
-    if opaque_bool_argument(probe, "send") {
+    if requires_send {
         out.push_str("fn __sifr_assert_send<T: Send>() {}\n");
     }
-    if opaque_bool_argument(probe, "sync") {
+    if requires_sync {
         out.push_str("fn __sifr_assert_sync<T: Sync>() {}\n");
     }
-    if opaque_symbol_argument(probe, "clone") == Some("copy") {
+    if requires_copy {
         out.push_str("fn __sifr_assert_copy<T: Copy>() {}\n");
     }
     out.push_str("fn __sifr_probe() {\n");
     if structural_mapping.is_some() {
         out.push_str("    __sifr_assert_structural_mapping::<__SifrMapping>();\n");
     }
-    if opaque_bool_argument(probe, "send") {
+    if requires_send {
         out.push_str("    __sifr_assert_send::<__SifrProbe>();\n");
     }
-    if opaque_bool_argument(probe, "sync") {
+    if requires_sync {
         out.push_str("    __sifr_assert_sync::<__SifrProbe>();\n");
     }
-    if opaque_symbol_argument(probe, "clone") == Some("copy") {
+    if requires_copy {
         out.push_str("    __sifr_assert_copy::<__SifrProbe>();\n");
     }
     out.push_str("}\n");

--- a/crates/sifr_driver/src/build/rust_interop_probe_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_probe_tests.rs
@@ -3,8 +3,9 @@ use super::super::rust_interop_probe_paths::{
 };
 use super::super::workspace::artifact_cache_root;
 use super::{
-    dependency_features, generated_bridge_type_stubs, prefixed_probe_source, probe_cargo_toml,
-    probe_cargo_vendor_args, python_raw_callback_probe_source, signature_return_probe_type,
+    dependency_features, generated_bridge_type_stubs, opaque_type_probe_source,
+    prefixed_probe_source, probe_cargo_toml, probe_cargo_vendor_args,
+    python_raw_callback_probe_source, signature_return_probe_type,
     structural_signature_probe_source, zero_copy_type_probe_source,
 };
 use ruff_text_size::TextRange;
@@ -29,6 +30,17 @@ fn zero_copy_type_probe_emits_each_declared_thread_obligation() {
         assert_eq!(source.contains("__sifr_assert_send::<__SifrView>();"), send);
         assert_eq!(source.contains("__sifr_assert_sync::<__SifrView>();"), sync);
     }
+}
+
+#[test]
+fn same_path_structural_mapping_keeps_the_mapping_obligation() {
+    let source =
+        opaque_type_probe_source("bridge::Token", Some("bridge::Token"), false, false, false);
+
+    assert!(source.contains("type __SifrProbe = bridge::Token;"));
+    assert!(source.contains("type __SifrMapping = bridge::Token;"));
+    assert!(source.contains("StructuralMapping<__SifrProbe>"));
+    assert!(source.contains("__sifr_assert_structural_mapping::<__SifrMapping>();"));
 }
 
 #[test]

--- a/crates/sifr_lowering/src/lower/rust_interop.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop.rs
@@ -33,12 +33,7 @@ pub(in crate::lower) fn collect_rust_opaque_close_methods(stmts: &[Stmt], ctx: &
             continue;
         };
         ctx.rust_opaque_classes.insert(class_def.name.to_string());
-        if opaque.arguments.keywords.iter().any(|keyword| {
-            keyword
-                .arg
-                .as_ref()
-                .is_some_and(|name| name.as_str() == "structural")
-        }) {
+        if has_valid_rust_opaque_structural_mapping_syntax(opaque) {
             ctx.rust_structural_classes
                 .insert(class_def.name.to_string());
         }
@@ -61,6 +56,16 @@ pub(in crate::lower) fn collect_rust_opaque_close_methods(stmts: &[Stmt], ctx: &
                 .insert(format!("{}.{}", class_def.name, close_method));
         }
     }
+}
+
+fn has_valid_rust_opaque_structural_mapping_syntax(opaque: &ExprCall) -> bool {
+    opaque.arguments.keywords.iter().any(|keyword| {
+        keyword
+            .arg
+            .as_ref()
+            .is_some_and(|name| name.as_str() == "structural")
+            && matches!(keyword.value, Expr::Attribute(_))
+    })
 }
 
 pub(in crate::lower) fn has_rust_opaque_structural_mapping_syntax(

--- a/crates/sifr_lowering/src/lower/rust_interop.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop.rs
@@ -64,7 +64,7 @@ fn has_valid_rust_opaque_structural_mapping_syntax(opaque: &ExprCall) -> bool {
             .arg
             .as_ref()
             .is_some_and(|name| name.as_str() == "structural")
-            && matches!(keyword.value, Expr::Attribute(_))
+            && target_path_segments(&keyword.value, RustInteropOwner::Class).is_ok()
     })
 }
 
@@ -568,45 +568,36 @@ fn parse_target_path(
     owner: RustInteropOwner,
     ctx: &mut LowerCtx,
 ) -> Option<RustTargetPath> {
-    let mut segments = Vec::new();
-    collect_path_segments(expr, &mut segments).or_else(|| {
-        malformed(
-            ctx,
-            "Rust target must be a dotted identifier path, not a dynamic expression".to_string(),
-            expr.range(),
-        );
-        None
-    })?;
-    if segments.len() < 2 {
-        malformed(
-            ctx,
-            "Rust target path must include a root and item name".to_string(),
-            expr.range(),
-        );
-        return None;
-    }
-    let root = &segments[0];
-    if root == "rust" {
-        malformed(
-            ctx,
-            "`rust` is the decorator namespace and cannot be a Rust target root".to_string(),
-            expr.range(),
-        );
-        return None;
-    }
-    if root == "Self" && owner != RustInteropOwner::Method {
-        malformed(
-            ctx,
-            "`Self` Rust target paths are valid only on methods inside Rust opaque classes"
-                .to_string(),
-            expr.range(),
-        );
-        return None;
-    }
+    let segments = match target_path_segments(expr, owner) {
+        Ok(segments) => segments,
+        Err(message) => {
+            malformed(ctx, message.to_string(), expr.range());
+            return None;
+        }
+    };
     Some(RustTargetPath {
         segments,
         span: expr.range(),
     })
+}
+
+fn target_path_segments(expr: &Expr, owner: RustInteropOwner) -> Result<Vec<String>, &'static str> {
+    let mut segments = Vec::new();
+    collect_path_segments(expr, &mut segments)
+        .ok_or("Rust target must be a dotted identifier path, not a dynamic expression")?;
+    if segments.len() < 2 {
+        return Err("Rust target path must include a root and item name");
+    }
+    let root = &segments[0];
+    if root == "rust" {
+        return Err("`rust` is the decorator namespace and cannot be a Rust target root");
+    }
+    if root == "Self" && owner != RustInteropOwner::Method {
+        return Err(
+            "`Self` Rust target paths are valid only on methods inside Rust opaque classes",
+        );
+    }
+    Ok(segments)
 }
 
 fn collect_path_segments(expr: &Expr, segments: &mut Vec<String>) -> Option<()> {

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -557,9 +557,10 @@ def use(value: Token) -> None:
 
 #[test]
 fn malformed_local_mapping_does_not_mark_the_opaque_class_structural() {
-    let errors = lower_errors(
-        r"
-@rust.opaque(type=bridge.token.Token, structural=invalid, close=none)
+    for mapping in ["invalid", "rust.Invalid", "make().Invalid"] {
+        let errors = lower_errors(&format!(
+            r"
+@rust.opaque(type=bridge.token.Token, structural={mapping}, close=none)
 class Token:
     pass
 
@@ -569,14 +570,15 @@ def accept[T: Structural](value: T) -> None:
 def use(value: Token) -> None:
     accept(value)
 ",
-    );
+        ));
 
-    assert!(errors.iter().any(|error| {
-        error.code == Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
-            && error
-                .message
-                .contains("does not implement protocol 'Structural'")
-    }));
+        assert!(errors.iter().any(|error| {
+            error.code == Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
+                && error
+                    .message
+                    .contains("does not implement protocol 'Structural'")
+        }));
+    }
 }
 
 #[test]

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -556,6 +556,30 @@ def use(value: Token) -> None:
 }
 
 #[test]
+fn malformed_local_mapping_does_not_mark_the_opaque_class_structural() {
+    let errors = lower_errors(
+        r"
+@rust.opaque(type=bridge.token.Token, structural=invalid, close=none)
+class Token:
+    pass
+
+def accept[T: Structural](value: T) -> None:
+    pass
+
+def use(value: Token) -> None:
+    accept(value)
+",
+    );
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
+            && error
+                .message
+                .contains("does not implement protocol 'Structural'")
+    }));
+}
+
+#[test]
 fn structural_bound_rejects_enum_discriminant_overflow() {
     let errors = lower_errors(
         r"

--- a/crates/sifr_runtime/src/interop/structural/mapped.rs
+++ b/crates/sifr_runtime/src/interop/structural/mapped.rs
@@ -14,6 +14,9 @@ use super::{
 /// The mapping type and native value type are both selected by a checked Sifr
 /// declaration. Implementations remain in the native package; generated code
 /// only names this trait and [`MappedValue`].
+///
+/// `MappedValue<T, M>` retains both type parameters. Rust therefore derives
+/// `Send` and `Sync` only when both the stored value and mapping marker do.
 pub trait StructuralMapping<T> {
     fn shape_identity() -> ShapeIdentity;
 
@@ -220,5 +223,12 @@ mod tests {
             structural_construct::<Value, _>(mismatch),
             Err(StructuralContractError::ShapeMismatch)
         );
+    }
+
+    #[test]
+    fn mapped_value_preserves_send_and_sync_backstops() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<MappedValue<String, StringMapping>>();
     }
 }

--- a/crates/sifr_runtime/src/interop/structural/mapped.rs
+++ b/crates/sifr_runtime/src/interop/structural/mapped.rs
@@ -14,9 +14,6 @@ use super::{
 /// The mapping type and native value type are both selected by a checked Sifr
 /// declaration. Implementations remain in the native package; generated code
 /// only names this trait and [`MappedValue`].
-///
-/// `MappedValue<T, M>` retains both type parameters. Rust therefore derives
-/// `Send` and `Sync` only when both the stored value and mapping marker do.
 pub trait StructuralMapping<T> {
     fn shape_identity() -> ShapeIdentity;
 
@@ -41,6 +38,10 @@ pub trait StructuralMapping<T> {
 /// Unlike an opaque resource handle, this value has no closed or poisoned
 /// state. The handle-shaped accessors let existing generated Rust method glue
 /// borrow or consume the native value without exposing its representation.
+///
+/// The mapping marker has no runtime state and uses `PhantomData<fn() -> M>`.
+/// Consequently, `Send` and `Sync` follow `T` alone. A package must encode any
+/// thread-safety restriction in the stored native value, not in `M`.
 pub struct MappedValue<T, M> {
     value: T,
     _mapping: PhantomData<fn() -> M>,
@@ -227,8 +228,13 @@ mod tests {
 
     #[test]
     fn mapped_value_preserves_send_and_sync_backstops() {
+        struct NonThreadSafeMarker {
+            _not_send_sync: *mut (),
+        }
+
         fn assert_send_sync<T: Send + Sync>() {}
 
         assert_send_sync::<MappedValue<String, StringMapping>>();
+        assert_send_sync::<MappedValue<String, NonThreadSafeMarker>>();
     }
 }


### PR DESCRIPTION
## Summary
- keep same-path structural mapping probes enforceable and align malformed local marking with exported metadata
- track stdlib structural implementation origin explicitly and cover late multi-module emission
- document and test mapped-value thread-safety backstops while restoring source-file headroom

## Validation
- cargo test -q -p sifr_runtime --features structural
- cargo test -q -p sifr_lowering -p sifr_codegen -p sifr_driver -- --skip test_e2e_pass
- cargo clippy --workspace -- -D warnings
- cargo fmt --check
- python3 scripts/check_hir_maintainability_guardrails.py
- python3 scripts/check_file_size_guardrails.py
- git diff --check

Exact candidate: c631ca82d97773e223b4176001de5df0f07384ed