### PR TITLE
Close M7/M7b attached API audit gaps

### DIFF
--- a/crates/sifr_codegen/src/function_emitter/sifr_int_analysis.rs
+++ b/crates/sifr_codegen/src/function_emitter/sifr_int_analysis.rs
@@ -244,7 +244,8 @@ pub(super) fn hir_expr_returns_sifr_int_result(
         HirExpr::BinOp { op, ty, .. } => {
             matches!(op.as_str(), "//" | "%") && is_result_int_type(ty)
         }
-        HirExpr::Call { func, .. } => result_function_returns.contains(func),
+        HirExpr::Call { func, .. } | HirExpr::GenericCall { func, .. } => result_function_returns
+            .contains(crate::stmt_support_emitter::canonical_plain_call_name_for_ir(func)),
         HirExpr::MethodCall { object, method, .. } => {
             hir_expr_class_name(object).is_some_and(|class_name| {
                 result_method_returns.contains(&result_method_key(&class_name, method))
@@ -444,10 +445,12 @@ pub(super) fn collect_sifr_int_call_arg_function_params(
     let mut discovered: HashMap<String, HashSet<usize>> = HashMap::new();
     let mut on_stmt = |_stmt: &HirStmt| {};
     let mut on_expr = |expr: &HirExpr| {
-        let HirExpr::Call { func, args, .. } = expr else {
+        let (HirExpr::Call { func, args, .. } | HirExpr::GenericCall { func, args, .. }) = expr
+        else {
             return;
         };
-        let Some(params) = module_function_params.get(func) else {
+        let canonical = crate::stmt_support_emitter::canonical_plain_call_name_for_ir(func);
+        let Some(params) = module_function_params.get(canonical) else {
             return;
         };
         for (idx, arg) in args.iter().enumerate() {
@@ -464,7 +467,10 @@ pub(super) fn collect_sifr_int_call_arg_function_params(
                 module_sifr_int_bindings,
                 function_sifr_int_returns,
             ) {
-                discovered.entry(func.clone()).or_default().insert(idx);
+                discovered
+                    .entry(canonical.to_string())
+                    .or_default()
+                    .insert(idx);
             }
         }
     };
@@ -511,10 +517,12 @@ pub(super) fn collect_sifr_int_result_call_arg_function_params_with_initial(
     let mut discovered: HashMap<String, HashSet<usize>> = HashMap::new();
     let mut on_stmt = |_stmt: &HirStmt| {};
     let mut on_expr = |expr: &HirExpr| {
-        let HirExpr::Call { func, args, .. } = expr else {
+        let (HirExpr::Call { func, args, .. } | HirExpr::GenericCall { func, args, .. }) = expr
+        else {
             return;
         };
-        let Some(params) = module_function_params.get(func) else {
+        let canonical = crate::stmt_support_emitter::canonical_plain_call_name_for_ir(func);
+        let Some(params) = module_function_params.get(canonical) else {
             return;
         };
         for (idx, arg) in args.iter().enumerate() {
@@ -529,7 +537,10 @@ pub(super) fn collect_sifr_int_result_call_arg_function_params_with_initial(
                     &local_result_bindings,
                 )
             {
-                discovered.entry(func.clone()).or_default().insert(idx);
+                discovered
+                    .entry(canonical.to_string())
+                    .or_default()
+                    .insert(idx);
             }
         }
     };
@@ -831,7 +842,8 @@ pub(super) fn hir_expr_needs_sifr_int_storage(
                 || (module_sifr_int_bindings.contains(name)
                     && !shadowed_module_bindings.contains(name))
         }
-        HirExpr::Call { func, .. } => function_sifr_int_returns.contains(func),
+        HirExpr::Call { func, .. } | HirExpr::GenericCall { func, .. } => function_sifr_int_returns
+            .contains(crate::stmt_support_emitter::canonical_plain_call_name_for_ir(func)),
         HirExpr::BinOp { op, ty, .. }
             if op == "**" && matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int) =>
         {

--- a/crates/sifr_codegen/src/function_emitter/tests.rs
+++ b/crates/sifr_codegen/src/function_emitter/tests.rs
@@ -232,3 +232,80 @@ fn unshadowed_module_const_still_promotes_return_to_sifr_int() {
         &HashSet::new(),
     ));
 }
+
+#[test]
+fn generic_call_uses_canonical_sifr_int_parameter_metadata() {
+    let body = vec![HirStmt::Expr {
+        expr: HirExpr::GenericCall {
+            func: "consume::<i64>".to_string(),
+            type_args: vec![Type::Int],
+            args: vec![HirExpr::LargeIntLiteral(
+                "100000000000000000000".to_string(),
+            )],
+            mutable_arg_places: vec![None],
+            ty: Type::None,
+        },
+    }];
+    let params = HashMap::from([("consume".to_string(), vec![Type::Int])]);
+
+    let discovered = collect_sifr_int_call_arg_function_params(
+        &body,
+        &params,
+        &HashSet::new(),
+        &HashSet::new(),
+        &HashSet::new(),
+        &HashSet::new(),
+    );
+
+    assert_eq!(discovered.get("consume"), Some(&HashSet::from([0])));
+}
+
+#[test]
+fn generic_call_uses_canonical_sifr_int_return_metadata() {
+    let expression = HirExpr::GenericCall {
+        func: "produce::<i64>".to_string(),
+        type_args: vec![Type::Int],
+        args: Vec::new(),
+        mutable_arg_places: Vec::new(),
+        ty: Type::Int,
+    };
+
+    assert!(hir_expr_needs_sifr_int_storage(
+        &expression,
+        &HashSet::new(),
+        &HashSet::new(),
+        &HashSet::new(),
+        &HashSet::from(["produce".to_string()]),
+    ));
+}
+
+#[test]
+fn generic_result_call_uses_canonical_sifr_int_metadata() {
+    let result_ty = Type::Result(Box::new(Type::Int), Box::new(Type::Str));
+    let body = vec![HirStmt::Expr {
+        expr: HirExpr::GenericCall {
+            func: "consume_result::<i64>".to_string(),
+            type_args: vec![Type::Int],
+            args: vec![HirExpr::GenericCall {
+                func: "produce_result::<i64>".to_string(),
+                type_args: vec![Type::Int],
+                args: Vec::new(),
+                mutable_arg_places: Vec::new(),
+                ty: result_ty.clone(),
+            }],
+            mutable_arg_places: vec![None],
+            ty: Type::None,
+        },
+    }];
+    let params = HashMap::from([("consume_result".to_string(), vec![result_ty])]);
+
+    let discovered = collect_sifr_int_result_call_arg_function_params_with_initial(
+        &body,
+        &params,
+        &HashSet::from(["produce_result".to_string()]),
+        &HashSet::new(),
+        HashSet::new(),
+    );
+
+    assert_eq!(discovered.get("consume_result"), Some(&HashSet::from([0])));
+}

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/builtin_numeric.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/builtin_numeric.rs
@@ -657,10 +657,12 @@ impl RustEmitter {
                     });
                 }
                 let lowered = self.try_lower_registry_expr_strict(&args[0])?;
-                let call_return_ty = if let HirExpr::Call { func, .. } = &args[0] {
-                    self.func_signatures.get(func).map(|(_, ret)| ret.clone())
-                } else {
-                    None
+                let call_return_ty = match &args[0] {
+                    HirExpr::Call { func, .. } | HirExpr::GenericCall { func, .. } => self
+                        .func_signatures
+                        .get(crate::stmt_support_emitter::canonical_plain_call_name_for_ir(func))
+                        .map(|(_, ret)| ret.clone()),
+                    _ => None,
                 };
                 let str_arg_ty = call_return_ty.as_ref().unwrap_or_else(|| args[0].ty());
                 if let Some(inner) = registry_option_inner_type(str_arg_ty) {

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
@@ -333,7 +333,8 @@ impl RustEmitter {
             lowered_args.push(lowered_arg);
         }
 
-        if let Some(captures) = self.nested_fn_captures.get(func).cloned() {
+        let canonical = crate::stmt_support_emitter::canonical_plain_call_name_for_ir(func);
+        if let Some(captures) = self.nested_fn_captures.get(canonical).cloned() {
             for capture in captures {
                 lowered_args.push(self.lower_recursive_capture_arg_for_ir(&capture));
             }

--- a/crates/sifr_codegen/src/stmt_support_emitter/expr_call_and_literal_helpers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/expr_call_and_literal_helpers.rs
@@ -782,7 +782,7 @@ macro_rules! stmt_expr_literals_and_calls {
                     }
                 }
             }
-            if let Some(captures) = $emitter.nested_fn_captures.get(func).cloned() {
+            if let Some(captures) = $emitter.nested_fn_captures.get(canonical_func).cloned() {
                 for capture in captures {
                     lowered_args.push($emitter.lower_recursive_capture_arg_for_ir(&capture));
                 }

--- a/crates/sifr_codegen/src/stmt_support_emitter/print_calls.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/print_calls.rs
@@ -96,7 +96,7 @@ impl RustEmitter {
                 args,
                 lowered_args,
             );
-            if let Some(captures) = self.nested_fn_captures.get(func).cloned() {
+            if let Some(captures) = self.nested_fn_captures.get(canonical_func).cloned() {
                 for capture in captures {
                     lowered_args.push(self.lower_recursive_capture_arg_for_ir(&capture));
                 }

--- a/crates/sifr_driver/src/tests/attached_api_audit.rs
+++ b/crates/sifr_driver/src/tests/attached_api_audit.rs
@@ -1,0 +1,97 @@
+use super::early_adapters::{attached_contract, compile_errors, project};
+
+#[test]
+fn attached_api_public_name_cannot_collide_with_a_field() {
+    let modules = project(
+        r#"
+from fixture.contract import Contract, contract_config
+
+class Invalid(Contract):
+    _config = contract_config(True)
+    describe: int
+"#,
+        &attached_contract(),
+    );
+
+    let errors = compile_errors(&modules, "an attached API and field collision must fail");
+    assert_eq!(
+        errors
+            .iter()
+            .filter(
+                |error| error.message.contains("attached API") && error.message.contains("collid")
+            )
+            .count(),
+        2,
+        "expected both collision diagnostics: {errors:#?}"
+    );
+}
+
+#[test]
+fn imported_private_attached_function_is_not_exposed() {
+    let contract = attached_contract().replace(
+        "@class_adapter_provider",
+        r#"@attached_api("fixture.contract", "ContractApi", public_name="hidden", receiver="type", owner="T")
+def _hidden[T: StaticProgram]() -> int:
+    return 1
+
+@class_adapter_provider"#,
+    );
+    let modules = project(
+        r#"
+from fixture.contract import Contract, contract_config
+
+class Model(Contract):
+    _config = contract_config(True)
+    value: int
+
+def invalid():
+    Model.hidden()
+"#,
+        &contract,
+    );
+
+    let errors = compile_errors(
+        &modules,
+        "an imported private attached API must stay hidden",
+    );
+    assert!(
+        errors.iter().any(|error| {
+            error.message.contains("hidden")
+                && (error.message.contains("unknown") || error.message.contains("has no"))
+        }),
+        "expected a missing-member diagnostic: {errors:#?}"
+    );
+}
+
+#[test]
+fn adapted_owner_requires_a_structurally_eligible_real_data_parent() {
+    let modules = project(
+        r#"
+from fixture.contract import Contract, contract_config
+
+class Grandparent:
+    value: int
+
+class Parent(Grandparent):
+    pass
+
+class Model(Parent, Contract):
+    _config = contract_config(True)
+
+def invalid():
+    Model.describe()
+"#,
+        &attached_contract(),
+    );
+
+    let errors = compile_errors(
+        &modules,
+        "an adapted owner with an ineligible real data parent must fail StaticProgram",
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.message.contains("StaticProgram")),
+        "expected a StaticProgram eligibility diagnostic: {errors:#?}"
+    );
+}

--- a/crates/sifr_driver/src/tests/mod.rs
+++ b/crates/sifr_driver/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod adapter_defaults;
 mod attached_api_aliases;
+mod attached_api_audit;
 mod diagnostics;
 mod discovery_and_workspace;
 mod early_adapters;

--- a/crates/sifr_frontend/src/early_adapters.rs
+++ b/crates/sifr_frontend/src/early_adapters.rs
@@ -443,10 +443,7 @@ fn attached_api_set_exists(
             .iter()
             .any(|set| set.identity == *identity)
     } else {
-        external_defs
-            .attached_api_sets
-            .get(&identity.module)
-            .is_some_and(|sets| sets.contains_key(&identity.symbol))
+        external_defs.contains_attached_api_set(identity)
     }
 }
 

--- a/crates/sifr_lowering/src/lower/attached_api_declarations.rs
+++ b/crates/sifr_lowering/src/lower/attached_api_declarations.rs
@@ -153,10 +153,7 @@ pub(super) fn finalize(ctx: &mut LowerCtx, module: &str) {
                 .iter()
                 .any(|set| set.identity == declaration.set)
         } else {
-            ctx.externals
-                .attached_api_sets
-                .get(&declaration.set.module)
-                .is_some_and(|sets| sets.contains_key(&declaration.set.symbol))
+            ctx.externals.contains_attached_api_set(&declaration.set)
         };
         if !set_exists {
             malformed(

--- a/crates/sifr_lowering/src/lower/attached_api_surfaces.rs
+++ b/crates/sifr_lowering/src/lower/attached_api_surfaces.rs
@@ -55,11 +55,7 @@ pub(super) fn apply(ctx: &mut LowerCtx) {
         };
         for declaration in declarations {
             let qualified = format!("{owner}.{}", declaration.public_name);
-            let has_collision = class_methods(&owner_type).is_some_and(|methods| {
-                methods
-                    .iter()
-                    .any(|(name, _)| name == &declaration.public_name)
-            });
+            let has_collision = class_has_member(&owner_type, &declaration.public_name);
             if has_collision {
                 if provisional {
                     continue;
@@ -89,9 +85,9 @@ pub(super) fn apply(ctx: &mut LowerCtx) {
             if let Some(Type::Class { methods, .. }) = ctx.class_types.get_mut(&owner) {
                 methods.push((declaration.public_name.clone(), surface));
             }
-            let canonical_qualified = class_name(&owner_type)
-                .filter(|name| *name != owner)
-                .map(|name| format!("{name}.{}", declaration.public_name));
+            let canonical_qualified = canonical_owner_binding_key(&selection.owner, &owner_type)
+                .filter(|identity| *identity != owner)
+                .map(|identity| format!("{identity}.{}", declaration.public_name));
             if declaration.receiver != AttachedApiReceiver::Type {
                 ctx.class_instance_methods.insert(qualified.clone());
                 if let Some(canonical) = canonical_qualified.as_ref() {
@@ -142,6 +138,7 @@ fn provisional_declarations(ctx: &LowerCtx, provider_module: &str) -> Vec<Attach
                 .attached_apis
                 .values()
                 .flat_map(HashMap::values)
+                .filter(|declaration| !declaration.function.starts_with('_'))
                 .cloned(),
         )
         .collect::<Vec<_>>();
@@ -174,7 +171,7 @@ fn declarations_for_set(
             .get(&set.module)
             .into_iter()
             .flat_map(HashMap::values)
-            .filter(|declaration| declaration.set == *set)
+            .filter(|declaration| declaration.set == *set && !declaration.function.starts_with('_'))
             .cloned()
             .collect::<Vec<_>>()
     };
@@ -244,18 +241,45 @@ fn substitute_function_type(
     }
 }
 
-fn class_methods(owner_type: &Type) -> Option<&[(String, FunctionType)]> {
+fn class_has_member(owner_type: &Type, member: &str) -> bool {
     match owner_type.resolve_alias() {
-        Type::Class { methods, .. } => Some(methods),
+        Type::Class {
+            methods, fields, ..
+        } => {
+            methods.iter().any(|(name, _)| name == member)
+                || fields.iter().any(|(name, _)| name == member)
+        }
+        _ => false,
+    }
+}
+
+fn canonical_owner_binding_key<'a>(selected_owner: &str, owner_type: &'a Type) -> Option<&'a str> {
+    match owner_type.resolve_alias() {
+        Type::Class {
+            identity: Some(identity),
+            ..
+        } if identity.rsplit('.').next() == Some(selected_owner) => Some(identity),
         _ => None,
     }
 }
 
-fn class_name(owner_type: &Type) -> Option<&str> {
-    match owner_type.resolve_alias() {
-        Type::Class { name, .. } => Some(name),
-        _ => None,
-    }
+pub(super) fn binding_for_owner<'a>(
+    ctx: &'a LowerCtx,
+    surface_name: &str,
+    owner_type: &Type,
+    member: &str,
+) -> Option<&'a AttachedMethodBinding> {
+    let (canonical_identity, emitted_name) = match owner_type.resolve_alias() {
+        Type::Class { identity, name, .. } => (identity.as_deref(), Some(name.as_str())),
+        _ => (None, None),
+    };
+    [Some(surface_name), canonical_identity, emitted_name]
+        .into_iter()
+        .flatten()
+        .find_map(|owner| {
+            ctx.attached_method_bindings
+                .get(&format!("{owner}.{member}"))
+        })
 }
 
 fn hidden_alias(module: &str, function: &str) -> String {
@@ -272,4 +296,37 @@ fn hidden_alias(module: &str, function: &str) -> String {
         })
         .collect::<String>();
     format!("__sifr_attached_api_{sanitized}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn class(identity: Option<&str>) -> Type {
+        Type::Class {
+            identity: identity.map(str::to_string),
+            type_args: Vec::new(),
+            name: "Selected".to_string(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            parent_class: None,
+        }
+    }
+
+    #[test]
+    fn canonical_binding_key_requires_the_selected_owner_symbol() {
+        let selected = class(Some("fixture.Selected"));
+        let mismatched = class(Some("fixture.Other"));
+
+        assert_eq!(
+            canonical_owner_binding_key("Selected", &selected),
+            Some("fixture.Selected")
+        );
+        assert_eq!(canonical_owner_binding_key("Selected", &mismatched), None);
+    }
+
+    #[test]
+    fn module_less_owner_does_not_gain_a_synthetic_binding_key() {
+        assert_eq!(canonical_owner_binding_key("Selected", &class(None)), None);
+    }
 }

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -317,6 +317,8 @@ pub(in crate::lower) fn collect_class_type(
             crate::lower::descriptor_declarations::data_parent_type(class_def, ctx)
                 .or_else(|| ctx.class_types.get(parent_name).cloned())
         {
+            ctx.class_data_parent_types
+                .insert(class_name.clone(), parent_ty.clone());
             if !super::super::generic_parent_representation::preserves_union_structure(
                 &ctx.class_types,
                 &ctx.class_declared_type_params,

--- a/crates/sifr_lowering/src/lower/expressions/attached_api_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/attached_api_calls.rs
@@ -35,25 +35,17 @@ pub(super) fn try_lower_type_call(
             if matches!(owner_type, Type::Any | Type::Unknown) {
                 return Some(None);
             }
-            let surface_name = if ctx
-                .attached_method_bindings
-                .contains_key(&format!("{}.{}", name.id, attr.attr))
-            {
-                name.id.to_string()
-            } else {
-                match owner_type.resolve_alias() {
-                    Type::Class { name, .. } => name.clone(),
-                    _ => return None,
-                }
-            };
-            (surface_name, owner_type)
+            (name.id.to_string(), owner_type)
         }
         _ => return None,
     };
-    let binding = ctx
-        .attached_method_bindings
-        .get(&format!("{surface_name}.{}", attr.attr))?
-        .clone();
+    let binding = super::super::attached_api_surfaces::binding_for_owner(
+        ctx,
+        &surface_name,
+        &owner_type,
+        attr.attr.as_str(),
+    )?
+    .clone();
     if binding.declaration.receiver != AttachedApiReceiver::Type {
         return None;
     }
@@ -76,10 +68,13 @@ pub(super) fn try_lower_instance_call(
     let Type::Class { name, .. } = object.ty().resolve_alias() else {
         return None;
     };
-    let binding = ctx
-        .attached_method_bindings
-        .get(&format!("{name}.{}", attr.attr))?
-        .clone();
+    let binding = super::super::attached_api_surfaces::binding_for_owner(
+        ctx,
+        name,
+        object.ty(),
+        attr.attr.as_str(),
+    )?
+    .clone();
     if binding.declaration.receiver == AttachedApiReceiver::Type {
         return None;
     }

--- a/crates/sifr_lowering/src/lower/external_defs.rs
+++ b/crates/sifr_lowering/src/lower/external_defs.rs
@@ -15,6 +15,36 @@ pub struct StructuralMethodExport {
     pub receiver: Option<ReceiverConvention>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attached_api_set_membership_checks_the_stored_canonical_identity() {
+        let mut defs = ExternalDefs::default();
+        defs.attached_api_sets
+            .entry("declared".to_string())
+            .or_default()
+            .insert(
+                "Api".to_string(),
+                sifr_ir::AttachedApiSetDeclaration {
+                    identity: sifr_ir::AttachedApiSetIdentity {
+                        module: "actual".to_string(),
+                        symbol: "Api".to_string(),
+                    },
+                    range: ruff_text_size::TextRange::default(),
+                },
+            );
+
+        assert!(
+            !defs.contains_attached_api_set(&sifr_ir::AttachedApiSetIdentity {
+                module: "declared".to_string(),
+                symbol: "Api".to_string(),
+            })
+        );
+    }
+}
+
 pub type StructuralMethodExports = std::collections::HashMap<String, Vec<StructuralMethodExport>>;
 type StructuralMethodModules = std::collections::HashMap<String, StructuralMethodExports>;
 
@@ -163,6 +193,14 @@ pub struct ExternalDefs {
 }
 
 impl ExternalDefs {
+    #[must_use]
+    pub fn contains_attached_api_set(&self, identity: &sifr_ir::AttachedApiSetIdentity) -> bool {
+        self.attached_api_sets
+            .get(&identity.module)
+            .and_then(|sets| sets.get(&identity.symbol))
+            .is_some_and(|declaration| declaration.identity == *identity)
+    }
+
     pub fn replace_structural_methods(
         &mut self,
         module_name: &str,

--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -53,6 +53,7 @@ pub(in crate::lower) struct LowerCtx {
     pub(in crate::lower) attached_api_set_bindings: HashSet<String>,
     pub(in crate::lower) adapted_class_bindings: HashMap<String, sifr_ir::ClassAdapterSelection>,
     pub(in crate::lower) class_data_parents: HashMap<String, Option<String>>,
+    pub(in crate::lower) class_data_parent_types: HashMap<String, Type>,
     pub(in crate::lower) adapter_field_plans:
         std::collections::BTreeMap<String, Vec<sifr_ir::AdapterFieldPlan>>,
     pub(in crate::lower) descriptor_functions: Vec<sifr_ir::DeclarationDescriptorFunction>,
@@ -262,6 +263,7 @@ impl LowerCtx {
             attached_api_set_bindings: HashSet::new(),
             adapted_class_bindings: HashMap::new(),
             class_data_parents: HashMap::new(),
+            class_data_parent_types: HashMap::new(),
             adapter_field_plans: std::collections::BTreeMap::new(),
             descriptor_functions: Vec::new(),
             descriptor_bindings: HashMap::new(),

--- a/crates/sifr_lowering/src/lower/type_bounds.rs
+++ b/crates/sifr_lowering/src/lower/type_bounds.rs
@@ -267,8 +267,7 @@ fn supports_structural_bridge_type_inner(
                         .get(name)
                         .is_none_or(Vec::is_empty);
             }
-            if (parent_class.is_some() && !ctx.adapted_class_bindings.contains_key(name))
-                || ctx.error_types.contains(name)
+            if ctx.error_types.contains(name)
                 || ctx.python_opaque_classes.contains_key(name)
                 || !structural_identity_inputs_supported(name, ctx)
             {
@@ -281,9 +280,22 @@ fn supports_structural_bridge_type_inner(
             if !visiting.insert(key.clone()) {
                 return true;
             }
-            let supported = type_args
-                .iter()
-                .all(|value| supports_structural_bridge_type_inner(value, ctx, visiting, false))
+            let data_parent_supported = match parent_class {
+                None => true,
+                Some(_) => {
+                    ctx.adapted_class_bindings.contains_key(name)
+                        && ctx.class_data_parent_types.get(name).map_or_else(
+                            || ctx.imported_structural_identity_inputs.contains_key(name),
+                            |parent| {
+                                supports_structural_bridge_type_inner(parent, ctx, visiting, false)
+                            },
+                        )
+                }
+            };
+            let supported = data_parent_supported
+                && type_args.iter().all(|value| {
+                    supports_structural_bridge_type_inner(value, ctx, visiting, false)
+                })
                 && fields.iter().all(|(_, field)| {
                     supports_structural_bridge_type_inner(field, ctx, visiting, true)
                 });

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -958,7 +958,10 @@ consumer lowering never applies provisional candidates to an imported owner, inc
 final plan selected no set. Attached signatures are added to the adapted
 `Type::Class` surface without adding HIR methods, structural members, handler slots, or synthesized
 method bodies. Calls lower directly to the declared package function through deterministic hidden
-imports. The lowering substitutes the concrete owner and `Self`, infers residual type parameters,
+imports. Local and imported declarations use the same public-function filter. Binding keys use the
+selected class's canonical identity when its final symbol matches the selected owner. Classes
+without a module identity use their local emitted name and do not gain a synthetic module key. The
+lowering substitutes the concrete owner and `Self`, infers residual type parameters,
 records their concrete arguments in the emitted call identity, and applies the checked package
 function defaults to omitted public arguments. Instance bindings remove the hidden owner parameter
 before they map default indexes. A generic type alias can forward an attached type call when its
@@ -968,6 +971,9 @@ mutable-borrow, and owned receivers use the normal call and ownership checks; ty
 do not construct or pass a dummy owner value. For a structural Rust bridge, a type receiver's
 declared owner is a valid use of its exact `StaticProgram` type parameter. The generated call keeps
 that concrete Rust type argument even when no runtime parameter or result contains the owner.
+Sifr lowering enforces declared protocol bounds before code generation. Generated Rust generics
+therefore emit only the weaker bounds required by generated operations. Rust bounds are not a
+second copy of the Sifr protocol contract.
 
 The Native Pydantic-Sifr consumer architecture is documented in
 [`native_pydantic_sifr_architecture.md`](native_pydantic_sifr_architecture.md).


### PR DESCRIPTION
Closes #3370.

Closes item 20 of the active static class-adapter phase.

- require exact canonical identity for imported attached-API sets
- reject attached API collisions with fields and methods
- make canonical/module-less owner binding keys explicit
- filter private declarations symmetrically
- validate concrete real data-parent eligibility
- canonicalize generic-call metadata lookups
- document emitted Rust generic-bound authority

Validation on `78d510dacfcf0abae4b792de1859f5c32b905eb4`:
- `cargo test -p sifr_runtime`: 80 passed
- `cargo test -p sifr_codegen --lib`: 1,062 passed
- `cargo test -p sifr_frontend`: 117 passed
- `cargo test -p sifr_lowering`: 1,014 passed, 1 ignored
- `cargo test -p sifr_driver`: 546 passed, 76 ignored
- workspace clippy, fmt, HIR maintainability, file-size, and diff checks passed