### PR TITLE
Close M7e structural default audit

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -32,7 +32,7 @@ fn structural_construction_uses_checked_defaults_for_missing_fields() {
     let generated = generate_rust(&module);
 
     assert!(
-        generated.contains("let mut child_nodes: [Option<"),
+        generated.contains("let mut __sifr_child_nodes: [Option<"),
         "{generated}"
     );
     assert!(
@@ -42,6 +42,44 @@ fn structural_construction_uses_checked_defaults_for_missing_fields() {
     assert!(
         !generated.contains("description.edges().len() != 1"),
         "defaulted structural fields must be omittable: {generated}"
+    );
+}
+
+#[test]
+fn structural_construction_checks_required_fields_before_default_factories() {
+    let mut payload = payload_class();
+    payload.fields = vec![
+        ("names".to_string(), Type::List(Box::new(Type::Str))),
+        ("required".to_string(), Type::Int),
+    ];
+    payload.field_defaults = vec![(
+        0,
+        HirExpr::Call {
+            func: "description".to_string(),
+            args: Vec::new(),
+            mutable_arg_places: Vec::new(),
+            ty: Type::List(Box::new(Type::Str)),
+        },
+    )];
+    payload.field_default_identities = vec![(0, "callable[main.description]".to_string())];
+    let module = module(vec![structural_function()], vec![payload]);
+
+    let generated = generate_rust(&module);
+    let required_check = generated
+        .find("if __sifr_child_nodes[1].is_none()")
+        .unwrap_or_else(|| panic!("required-field precheck must be emitted: {generated}"));
+    let factory_call = generated
+        .find("None => description()")
+        .expect("checked default factory must remain callable");
+
+    assert!(required_check < factory_call, "{generated}");
+    assert!(
+        generated.contains("let __sifr_description = __sifr_source.node(__sifr_node)?;"),
+        "generated locals must not shadow default callables: {generated}"
+    );
+    assert!(
+        generated.contains("let __sifr_field_index: usize"),
+        "generated edge locals must use reserved names: {generated}"
     );
 }
 

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -550,13 +550,13 @@ fn structural_construct_impl(
         let rust_name = crate::Renderer::render_identifier(name);
         let present = if matches!(ty.resolve_alias(), Type::Bytes) {
             format!(
-                "{STRUCTURAL}::construct_bytes_at(__sifr_source, child, __sifr_construct_token)?"
+                "{STRUCTURAL}::construct_bytes_at(__sifr_source, __sifr_child, __sifr_construct_token)?"
             )
         } else {
             let rust_type = emitter.class_struct_field_rust_type(class, name, ty);
             let rust_type = crate::Renderer::render_type_string(&rust_type);
             format!(
-                "<{rust_type} as {STRUCTURAL}::StructuralConstruct>::structural_construct_at(__sifr_source, child, __sifr_construct_token)?"
+                "<{rust_type} as {STRUCTURAL}::StructuralConstruct>::structural_construct_at(__sifr_source, __sifr_child, __sifr_construct_token)?"
             )
         };
         let missing = class
@@ -572,10 +572,26 @@ fn structural_construct_impl(
                 },
             );
         field_values.push(format!(
-            "let {rust_name} = match child_nodes[{index}] {{ Some(child) => {present}, None => {missing}, }};"
+            "let {rust_name} = match __sifr_child_nodes[{index}] {{ Some(__sifr_child) => {present}, None => {missing}, }};"
         ));
     }
     let field_values = field_values.join("\n");
+    let required_prechecks = fields
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| {
+            !class
+                .field_defaults
+                .iter()
+                .any(|(field_index, _)| field_index == index)
+        })
+        .map(|(index, _)| {
+            format!(
+                "if __sifr_child_nodes[{index}].is_none() {{ return Err({STRUCTURAL}::StructuralContractError::ArityMismatch); }}"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
     let inherited_names = fields
         .iter()
         .filter(|field| field.inherited)
@@ -602,17 +618,17 @@ fn structural_construct_impl(
     }
     let collect_children = if fields.is_empty() {
         format!(
-            "if !description.edges().is_empty() {{ return Err({STRUCTURAL}::StructuralContractError::MemberMismatch); }}"
+            "if !__sifr_description.edges().is_empty() {{ return Err({STRUCTURAL}::StructuralContractError::MemberMismatch); }}"
         )
     } else {
         format!(
-            "let mut child_nodes: [Option<{STRUCTURAL}::NodeId>; {}] = [None; {}];\nfor edge in description.edges() {{\nlet field_index: usize = match edge.kind() {{\n{edge_cases}\n_ => return Err({STRUCTURAL}::StructuralContractError::MemberMismatch),\n}};\nif child_nodes[field_index].replace(edge.node()).is_some() {{ return Err({STRUCTURAL}::StructuralContractError::MemberMismatch); }}\n}}",
+            "let mut __sifr_child_nodes: [Option<{STRUCTURAL}::NodeId>; {}] = [None; {}];\nfor __sifr_edge in __sifr_description.edges() {{\nlet __sifr_field_index: usize = match __sifr_edge.kind() {{\n{edge_cases}\n_ => return Err({STRUCTURAL}::StructuralContractError::MemberMismatch),\n}};\nif __sifr_child_nodes[__sifr_field_index].replace(__sifr_edge.node()).is_some() {{ return Err({STRUCTURAL}::StructuralContractError::MemberMismatch); }}\n}}",
             fields.len(),
             fields.len()
         )
     };
     let body = format!(
-        "let description = __sifr_source.node(__sifr_node)?;\nif description.kind() != {STRUCTURAL}::StructuralKind::Record {{ return Err({STRUCTURAL}::StructuralContractError::KindMismatch); }}\nif description.nominal_identity() != Some({}) {{ return Err({STRUCTURAL}::StructuralContractError::MemberMismatch); }}\n{collect_children}\n{field_values}\nOk(Self {{ {} }})",
+        "let __sifr_description = __sifr_source.node(__sifr_node)?;\nif __sifr_description.kind() != {STRUCTURAL}::StructuralKind::Record {{ return Err({STRUCTURAL}::StructuralContractError::KindMismatch); }}\nif __sifr_description.nominal_identity() != Some({}) {{ return Err({STRUCTURAL}::StructuralContractError::MemberMismatch); }}\n{collect_children}\n{required_prechecks}\n{field_values}\nOk(Self {{ {} }})",
         nominal_identity,
         initializers.join(", ")
     );

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -941,7 +941,9 @@ edges by field name, reject unknown and duplicate names, and fill omitted defaul
 their checked HIR defaults. Factory defaults retain a canonical callable-identity side channel in
 HIR because their executable call expression is not a constant literal; bound checking, shape
 identity, and code generation all consume that same identity. Required omissions remain typed
-structural contract errors rather than generated panics.
+structural contract errors rather than generated panics. Construction checks all required fields
+before it evaluates any omitted-field default. A later required omission therefore cannot run an
+earlier constant or factory default.
 
 Structural support includes a class with one direct data parent when that parent uses the
 compiler-generated constructor. The parent cannot have another data parent. The wire record lists

--- a/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
@@ -12,6 +12,10 @@ def make_names() -> list[str]:
     return []
 
 
+def description() -> list[str]:
+    return []
+
+
 class Factory:
     @staticmethod
     def make_names() -> list[str]:
@@ -44,6 +48,7 @@ class StructuralDefaults(Contract):
     enabled: bool = contract_field(default=True)
     tags: list[str] = contract_field(default_factory=list)
     names: list[str] = contract_field(default_factory=make_names)
+    descriptions: list[str] = contract_field(default_factory=description)
 
 
 class GenericAttached[T](Contract):
@@ -106,8 +111,10 @@ def main() -> Result[None, ContractError | RustPanicError]:
         assert defaulted.enabled
         assert defaulted.tags == []
         assert defaulted.names == []
+        assert defaulted.descriptions == []
         another: StructuralDefaults = StructuralDefaults.construct()
         defaulted.tags.append("one")
+        assert defaulted.tags == ["one"]
         assert another.tags == []
     except ContractError as error:
         raise error


### PR DESCRIPTION
Closes #3376.

Hardens structural construction by reserving generated local names, checking every required omission before evaluating omitted-field defaults, documenting that ordering contract, and strengthening two-instance factory freshness evidence.

Exact candidate: `44971b4fd83db9163efa95bb025d4de3920564fe`

Validation:
- `cargo test -q -p sifr_codegen --lib` (1065 passed)
- `cargo test -q -p sifr_driver adapter_defaults` (15 passed)
- focused structural-construction tests passed
- workspace format, clippy, HIR maintainability, file-size, and diff checks passed
- package-neutral fixture reached generated Rust and proved the `description()` collision is absent; it then stopped at a separate existing M7f generic clone-bound defect, deferred to item 23