### PR TITLE
Close M7f static-program integration audit

### DIFF
--- a/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
+++ b/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
@@ -1,4 +1,5 @@
 use super::{HirFunction, HirStmt, RustEmitter, RustTypeParam, Type};
+use std::collections::HashSet;
 
 impl RustEmitter {
     pub(crate) fn lower_function_type_params(&self, func: &HirFunction) -> Vec<RustTypeParam> {
@@ -35,6 +36,7 @@ impl RustEmitter {
                     .get(&func.name)
                     .is_some_and(|params| params.contains(type_param));
                 let attached_api = func.decorators.iter().any(|item| item == "attached_api");
+                let attached_storage = attached_api || Self::is_nullcontext_value_forwarder(func);
                 let method_slots = self
                     .method_slot_type_params
                     .get(&func.name)
@@ -43,7 +45,7 @@ impl RustEmitter {
                     .context_type_params
                     .get(&func.name)
                     .is_some_and(|params| params.contains(type_param));
-                let base = if context {
+                let mut base = if context {
                     "sifr_runtime::interop::structural::StructuralType".to_string()
                 } else if structural && static_program {
                     "sifr_runtime::interop::structural::StructuralConstruct + sifr_runtime::interop::structural::StructuralProject + sifr_runtime::interop::structural::StaticProgramType"
@@ -54,13 +56,20 @@ impl RustEmitter {
                     "sifr_runtime::interop::structural::StructuralConstruct + sifr_runtime::interop::structural::StructuralProject + Clone + 'static".to_string()
                 } else if structural {
                     "sifr_runtime::interop::structural::StructuralConstruct + sifr_runtime::interop::structural::StructuralProject".to_string()
-                } else if attached_api || Self::is_nullcontext_value_forwarder(func) {
+                } else if attached_storage {
                     "Clone + 'static".to_string()
                 } else if needs_hash_eq {
                     "Clone + std::fmt::Display + PartialOrd + std::hash::Hash + Eq + 'static".to_string()
                 } else {
                     "Clone + std::fmt::Display + PartialOrd + 'static".to_string()
                 };
+                if Self::returns_borrowed_type_param(func, type_param) {
+                    Self::append_bound(&mut base, "Clone");
+                }
+                if attached_storage {
+                    Self::append_bound(&mut base, "Clone");
+                    Self::append_bound(&mut base, "'static");
+                }
                 let base = if method_slots {
                     match context_type_param {
                         Some(context) if context_is_shared => format!(
@@ -112,5 +121,45 @@ impl RustEmitter {
             && args.iter().all(|arg| {
                 matches!(arg, crate::HirExpr::Name { name, .. } if func.params.iter().any(|param| param.name == *name))
             })
+    }
+
+    fn returns_borrowed_type_param(func: &HirFunction, type_param: &str) -> bool {
+        let borrowed = func
+            .params
+            .iter()
+            .filter(|param| {
+                param.convention.is_borrowed()
+                    && Self::type_mentions_type_param(&param.ty, type_param)
+            })
+            .map(|param| param.name.as_str())
+            .collect::<HashSet<_>>();
+        if borrowed.is_empty() {
+            return false;
+        }
+        let mut returned = false;
+        let mut on_stmt = |stmt: &HirStmt| {
+            if let HirStmt::Return {
+                value: Some(crate::HirExpr::Name { name, .. }),
+            } = stmt
+            {
+                returned |= borrowed.contains(name.as_str());
+            }
+        };
+        let mut on_expr = |_expr: &crate::HirExpr| {};
+        crate::hir_analysis::traversal::walk_stmts(
+            &func.body,
+            crate::hir_analysis::traversal::TraversalConfig::LOCAL_SCOPE_ONLY,
+            &mut on_stmt,
+            &mut on_expr,
+        );
+        returned
+    }
+
+    fn append_bound(bounds: &mut String, bound: &str) {
+        if bounds.split(" + ").any(|existing| existing == bound) {
+            return;
+        }
+        bounds.push_str(" + ");
+        bounds.push_str(bound);
     }
 }

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -83,6 +83,8 @@ mod string_concat_codegen_tests;
 #[cfg(test)]
 mod structural_impl_demand_codegen_tests;
 #[cfg(test)]
+mod structural_inheritance_codegen_tests;
+#[cfg(test)]
 mod structural_stdlib_impl_codegen_tests;
 #[cfg(test)]
 mod structured_condition_codegen_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -574,11 +574,14 @@ fn plain_structural_generic_emits_projection_bounds() {
 
     assert!(
         rust_code.contains(
-            "T: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject"
+            "T: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject + Clone"
         ),
         "{rust_code}"
     );
-    assert!(!rust_code.contains("T: Clone + 'static"), "{rust_code}");
+    assert!(
+        !rust_code.contains("StructuralProject + Clone + 'static"),
+        "{rust_code}"
+    );
 }
 
 #[test]
@@ -604,11 +607,72 @@ fn attached_structural_generic_emits_projection_bounds() {
 
     assert!(
         rust_code.contains(
+            "T: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject + Clone + 'static"
+        ),
+        "{rust_code}"
+    );
+}
+
+#[test]
+fn owned_structural_generic_does_not_require_clone() {
+    let mut retain = ordinary_function("retain", Type::TypeVar("T".to_string()));
+    retain.params[0].convention = ParamConvention::own();
+    retain.return_type = Type::TypeVar("T".to_string());
+    retain.type_params = vec!["T".to_string()];
+    retain.body = vec![sifr_ir::HirStmt::Return {
+        value: Some(HirExpr::Name {
+            name: "value".to_string(),
+            binding_id: None,
+            ty: Type::TypeVar("T".to_string()),
+        }),
+    }];
+    let mut module = module(vec![retain], Vec::new());
+    module.type_param_bounds.insert(
+        "retain".to_string(),
+        std::collections::HashMap::from([("T".to_string(), vec!["Structural".to_string()])]),
+    );
+
+    let rust_code = generate_rust(&module);
+
+    assert!(
+        rust_code.contains(
             "T: ::sifr_runtime::interop::structural::StructuralConstruct + ::sifr_runtime::interop::structural::StructuralProject"
         ),
         "{rust_code}"
     );
-    assert!(!rust_code.contains("T: Clone + 'static"), "{rust_code}");
+    assert!(
+        !rust_code.contains("StructuralProject + Clone"),
+        "{rust_code}"
+    );
+}
+
+#[test]
+fn attached_static_program_generic_keeps_clone_and_static_bounds() {
+    let mut retain = ordinary_function("retain", Type::TypeVar("T".to_string()));
+    retain.return_type = Type::TypeVar("T".to_string());
+    retain.type_params = vec!["T".to_string()];
+    retain.decorators = vec!["attached_api".to_string()];
+    retain.body = vec![sifr_ir::HirStmt::Return {
+        value: Some(HirExpr::Name {
+            name: "value".to_string(),
+            binding_id: None,
+            ty: Type::TypeVar("T".to_string()),
+        }),
+    }];
+    let mut module = module(vec![retain], Vec::new());
+    module.type_param_bounds.insert(
+        "retain".to_string(),
+        std::collections::HashMap::from([("T".to_string(), vec!["StaticProgram".to_string()])]),
+    );
+
+    let rust_code = generate_rust(&module);
+
+    assert!(
+        rust_code.contains(
+            "T: ::sifr_runtime::interop::structural::StaticProgramType + Clone + 'static"
+        ),
+        "{rust_code}"
+    );
 }
 
 #[test]
@@ -670,113 +734,7 @@ fn project_static_program_owners_include_supported_imported_fields() {
     assert!(project.contains("Owner"));
 }
 
-#[test]
-fn concrete_generic_child_flattens_parent_fields_for_structural_bridge() {
-    let parent = HirClass {
-        name: "GenericParent".to_string(),
-        identity: Some("models.GenericParent".to_string()),
-        fields: vec![("value".to_string(), Type::TypeVar("T".to_string()))],
-        type_params: vec!["T".to_string()],
-        is_hashable: true,
-        ..payload_class()
-    };
-    let parent_type = Type::Class {
-        identity: Some("models.GenericParent".to_string()),
-        type_args: vec![Type::Int],
-        name: "GenericParent".to_string(),
-        fields: vec![("value".to_string(), Type::Int)],
-        methods: Vec::new(),
-        parent_class: None,
-    };
-    let child = HirClass {
-        name: "Concrete".to_string(),
-        identity: Some("main.Concrete".to_string()),
-        fields: vec![("label".to_string(), Type::Str)],
-        parent_class: Some("GenericParent".to_string()),
-        parent_type: Some(parent_type),
-        is_hashable: true,
-        ..payload_class()
-    };
-    let nested = HirClass {
-        name: "Nested".to_string(),
-        identity: Some("main.Nested".to_string()),
-        fields: vec![(
-            "payload".to_string(),
-            Type::Class {
-                identity: Some("main.Concrete".to_string()),
-                type_args: Vec::new(),
-                name: "Concrete".to_string(),
-                fields: vec![
-                    ("value".to_string(), Type::Int),
-                    ("label".to_string(), Type::Str),
-                ],
-                methods: Vec::new(),
-                parent_class: Some("models.GenericParent".to_string()),
-            },
-        )],
-        is_hashable: true,
-        ..payload_class()
-    };
-    let models = module(Vec::new(), vec![parent]);
-    let main = module(vec![structural_function()], vec![child, nested]);
-    let modules = [("models", &models), ("main", &main)];
-
-    let project = crate::generate_rust_multi_with_metadata(&modules, &crate::StdlibCode::default());
-    let main_rust = project
-        .rust_files
-        .get("main")
-        .expect("main module is generated");
-    assert!(
-        main_rust.contains("StructuralType for Concrete"),
-        "{main_rust}"
-    );
-    assert!(
-        main_rust.contains("StructuralConstruct for Concrete"),
-        "{main_rust}"
-    );
-    assert!(
-        main_rust.contains("StructuralProject for Concrete"),
-        "{main_rust}"
-    );
-    assert!(
-        main_rust.contains("StructuralType for Nested"),
-        "{main_rust}"
-    );
-    assert!(main_rust.contains("RecordField(\"value\")"), "{main_rust}");
-    assert!(main_rust.contains("RecordField(\"label\")"), "{main_rust}");
-    assert!(
-        main_rust.contains("genericparent: <GenericParent<i64>>::new(value)"),
-        "{main_rust}"
-    );
-
-    let supported =
-        crate::structural_impl_codegen::structural_record_identities_for_project(&modules);
-    let identities = crate::structural_identity_codegen::static_class_identities_for_project(
-        &modules, &supported,
-    );
-    let expected = nominal_record(
-        "main.Concrete",
-        &[],
-        &[
-            NominalField {
-                name: "value",
-                identity: primitive("int"),
-                required: true,
-                default_identity: None,
-            },
-            NominalField {
-                name: "label",
-                identity: primitive("str"),
-                required: true,
-                default_identity: None,
-            },
-        ],
-        metadata(&[]),
-    );
-    assert_eq!(identities.get("main.Concrete"), Some(&expected));
-}
-
-fn module(functions: Vec<HirFunction>, classes: Vec<HirClass>) -> HirModule {
+pub(super) fn module(functions: Vec<HirFunction>, classes: Vec<HirClass>) -> HirModule {
     HirModule {
         functions,
         classes,
@@ -787,7 +745,7 @@ fn module(functions: Vec<HirFunction>, classes: Vec<HirClass>) -> HirModule {
     }
 }
 
-fn payload_class() -> HirClass {
+pub(super) fn payload_class() -> HirClass {
     HirClass {
         name: "Payload".to_string(),
         identity: None,
@@ -810,7 +768,7 @@ fn payload_class() -> HirClass {
     }
 }
 
-fn structural_function() -> HirFunction {
+pub(super) fn structural_function() -> HirFunction {
     HirFunction {
         name: "construct".to_string(),
         params: Vec::new(),

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_inheritance_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_inheritance_codegen_tests.rs
@@ -1,0 +1,110 @@
+use super::structural_impl_demand_codegen_tests::{module, payload_class, structural_function};
+use sifr_ir::HirClass;
+use sifr_structural_identity::{metadata, nominal_record, primitive, NominalField};
+use sifr_type_system::Type;
+
+#[test]
+fn concrete_generic_child_flattens_parent_fields_for_structural_bridge() {
+    let parent = HirClass {
+        name: "GenericParent".to_string(),
+        identity: Some("models.GenericParent".to_string()),
+        fields: vec![("value".to_string(), Type::TypeVar("T".to_string()))],
+        type_params: vec!["T".to_string()],
+        is_hashable: true,
+        ..payload_class()
+    };
+    let parent_type = Type::Class {
+        identity: Some("models.GenericParent".to_string()),
+        type_args: vec![Type::Int],
+        name: "GenericParent".to_string(),
+        fields: vec![("value".to_string(), Type::Int)],
+        methods: Vec::new(),
+        parent_class: None,
+    };
+    let child = HirClass {
+        name: "Concrete".to_string(),
+        identity: Some("main.Concrete".to_string()),
+        fields: vec![("label".to_string(), Type::Str)],
+        parent_class: Some("GenericParent".to_string()),
+        parent_type: Some(parent_type),
+        is_hashable: true,
+        ..payload_class()
+    };
+    let nested = HirClass {
+        name: "Nested".to_string(),
+        identity: Some("main.Nested".to_string()),
+        fields: vec![(
+            "payload".to_string(),
+            Type::Class {
+                identity: Some("main.Concrete".to_string()),
+                type_args: Vec::new(),
+                name: "Concrete".to_string(),
+                fields: vec![
+                    ("value".to_string(), Type::Int),
+                    ("label".to_string(), Type::Str),
+                ],
+                methods: Vec::new(),
+                parent_class: Some("models.GenericParent".to_string()),
+            },
+        )],
+        is_hashable: true,
+        ..payload_class()
+    };
+    let models = module(Vec::new(), vec![parent]);
+    let main = module(vec![structural_function()], vec![child, nested]);
+    let modules = [("models", &models), ("main", &main)];
+
+    let project = crate::generate_rust_multi_with_metadata(&modules, &crate::StdlibCode::default());
+    let main_rust = project
+        .rust_files
+        .get("main")
+        .expect("main module is generated");
+    assert!(
+        main_rust.contains("StructuralType for Concrete"),
+        "{main_rust}"
+    );
+    assert!(
+        main_rust.contains("StructuralConstruct for Concrete"),
+        "{main_rust}"
+    );
+    assert!(
+        main_rust.contains("StructuralProject for Concrete"),
+        "{main_rust}"
+    );
+    assert!(
+        main_rust.contains("StructuralType for Nested"),
+        "{main_rust}"
+    );
+    assert!(main_rust.contains("RecordField(\"value\")"), "{main_rust}");
+    assert!(main_rust.contains("RecordField(\"label\")"), "{main_rust}");
+    assert!(
+        main_rust.contains("genericparent: <GenericParent<i64>>::new(value)"),
+        "{main_rust}"
+    );
+
+    let supported =
+        crate::structural_impl_codegen::structural_record_identities_for_project(&modules);
+    let identities = crate::structural_identity_codegen::static_class_identities_for_project(
+        &modules, &supported,
+    );
+    let expected = nominal_record(
+        "main.Concrete",
+        &[],
+        &[
+            NominalField {
+                name: "value",
+                identity: primitive("int"),
+                required: true,
+                default_identity: None,
+            },
+            NominalField {
+                name: "label",
+                identity: primitive("str"),
+                required: true,
+                default_identity: None,
+            },
+        ],
+        metadata(&[]),
+    );
+    assert_eq!(identities.get("main.Concrete"), Some(&expected));
+}

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -340,15 +340,16 @@ pub fn generate_rust_multi_with_metadata(
         structural_interop_enabled,
     );
     let crate_root_modules = HashSet::from(["main"]);
+    let mut nominal_type_paths = project_nominal_type_paths(modules, &crate_root_modules);
     let structural_identity_expressions = if structural_interop_enabled {
         crate::structural_identity_codegen::class_identity_expressions_for_project(
             modules,
             &structural_record_identities,
+            &nominal_type_paths,
         )
     } else {
         HashMap::new()
     };
-    let mut nominal_type_paths = project_nominal_type_paths(modules, &crate_root_modules);
     nominal_type_paths.extend(stdlib_nominal_plan.nominal_paths.clone());
     let union_prelude = render_project_union_prelude(&union_usage, &nominal_type_paths);
     let project_union_prelude = [stdlib_nominal_plan.prelude.as_str(), union_prelude.as_str()]

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -59,15 +59,16 @@ pub fn generate_rust_test_project_with_metadata(
         .iter()
         .map(|(module_name, _)| *module_name)
         .collect::<HashSet<_>>();
+    let mut nominal_type_paths = project_nominal_type_paths(&all_modules, &crate_root_modules);
     let structural_identity_expressions = if structural_interop_enabled {
         crate::structural_identity_codegen::class_identity_expressions_for_project(
             &all_modules,
             &structural_record_identities,
+            &nominal_type_paths,
         )
     } else {
         HashMap::new()
     };
-    let mut nominal_type_paths = project_nominal_type_paths(&all_modules, &crate_root_modules);
     nominal_type_paths.extend(stdlib_nominal_plan.nominal_paths.clone());
     let union_prelude = render_project_union_prelude(&union_usage, &nominal_type_paths);
     let project_union_prelude = [stdlib_nominal_plan.prelude.as_str(), union_prelude.as_str()]

--- a/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
@@ -355,7 +355,8 @@ impl RustEmitter {
                                 .collect::<Vec<_>>()
                         })
                         .unwrap_or_default();
-                    let Some(lowered_else_body) = self.try_lower_stmt_block_for_ir(else_body)?
+                    let Some(lowered_else_body) =
+                        self.try_lower_speculative_branch_for_ir(else_body)?
                     else {
                         return Ok(None);
                     };
@@ -395,7 +396,7 @@ impl RustEmitter {
                     } else {
                         var_name.clone()
                     };
-                    let Some(lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
+                    let Some(lowered_body) = self.try_lower_speculative_branch_for_ir(body)? else {
                         return Ok(None);
                     };
                     nested_else = Some(vec![RustStmt::IfLet {
@@ -575,6 +576,24 @@ impl RustEmitter {
         }))
     }
 
+    fn try_lower_speculative_branch_for_ir(
+        &mut self,
+        body: &[HirStmt],
+    ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
+        let string_char_cache_vars = self.string_char_cache_vars.clone();
+        match self.try_lower_stmt_block_for_ir(body) {
+            Ok(Some(lowered)) => Ok(Some(lowered)),
+            Ok(None) => {
+                self.string_char_cache_vars = string_char_cache_vars;
+                Ok(None)
+            }
+            Err(error) => {
+                self.string_char_cache_vars = string_char_cache_vars;
+                Err(error)
+            }
+        }
+    }
+
     pub(crate) fn detect_or_is_none_vars_with_bindings_for_ir(
         &self,
         expr: &HirExpr,
@@ -620,5 +639,43 @@ impl RustEmitter {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declined_speculative_branch_restores_string_cache_state() {
+        let mut emitter = RustEmitter::new();
+        emitter
+            .string_char_cache_required_names
+            .insert("text".to_string());
+        emitter
+            .string_char_cache_vars
+            .insert("existing".to_string(), "__sifr_existing_chars".to_string());
+        let before = emitter.string_char_cache_vars.clone();
+        let body = vec![
+            HirStmt::Let {
+                name: "text".to_string(),
+                ty: Type::Str,
+                value: HirExpr::StringLiteral("value".to_string()),
+                is_mutable: false,
+            },
+            HirStmt::AttributeAugAssign {
+                object: "self".to_string(),
+                field: "label".to_string(),
+                op: "+=".to_string(),
+                value: HirExpr::StringLiteral("suffix".to_string()),
+            },
+        ];
+
+        let lowered = emitter
+            .try_lower_speculative_branch_for_ir(&body)
+            .expect("speculative lowering must not error");
+
+        assert!(lowered.is_none());
+        assert_eq!(emitter.string_char_cache_vars, before);
     }
 }

--- a/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
@@ -342,72 +342,80 @@ impl RustEmitter {
                 branch_specs.push((elif_variant, elif_body.as_slice()));
             }
             if all_isinstance {
-                let enum_name = self.resolve_union_enum_name(&first_enum_name, &needed_variants);
-                let mut nested_else = if let Some(else_body) = else_body {
-                    let remaining_variants = self
-                        .union_enums
-                        .get(&enum_name)
-                        .map(|members| {
-                            members
-                                .iter()
-                                .map(Type::union_variant_name)
-                                .filter(|variant| !needed_variants.contains(variant))
-                                .collect::<Vec<_>>()
-                        })
-                        .unwrap_or_default();
-                    let Some(lowered_else_body) =
-                        self.try_lower_speculative_branch_for_ir(else_body)?
-                    else {
-                        return Ok(None);
+                let speculative_string_char_cache_vars = self.string_char_cache_vars.clone();
+                let lowered_union = (|| -> Result<Option<RustStmt>, crate::CodegenError> {
+                    let enum_name =
+                        self.resolve_union_enum_name(&first_enum_name, &needed_variants);
+                    let mut nested_else = if let Some(else_body) = else_body {
+                        let remaining_variants = self
+                            .union_enums
+                            .get(&enum_name)
+                            .map(|members| {
+                                members
+                                    .iter()
+                                    .map(Type::union_variant_name)
+                                    .filter(|variant| !needed_variants.contains(variant))
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default();
+                        let Some(lowered_else_body) =
+                            self.try_lower_speculative_branch_for_ir(else_body)?
+                        else {
+                            return Ok(None);
+                        };
+                        if remaining_variants.len() == 1 {
+                            let else_mutated = queries::collect_mutated_vars(else_body, None);
+                            let else_binding = if else_mutated.contains(&var_name) {
+                                format!("mut {var_name}")
+                            } else {
+                                var_name.clone()
+                            };
+                            Some(vec![RustStmt::IfLet {
+                                pattern: format!(
+                                    "{enum_name}::{}({else_binding})",
+                                    remaining_variants[0]
+                                ),
+                                expr: crate::RustExpr::Ident(var_name.clone()),
+                                then_body: lowered_else_body,
+                                else_body: Some(vec![RustStmt::Expr(
+                                    crate::RustExpr::FormatMacro {
+                                        name: "unreachable".to_string(),
+                                        format_str: "sifr union narrowing fell through exhaustive branch chain"
+                                            .to_string(),
+                                        args: vec![],
+                                    },
+                                )]),
+                            }])
+                        } else {
+                            Some(lowered_else_body)
+                        }
+                    } else {
+                        None
                     };
-                    if remaining_variants.len() == 1 {
-                        let else_mutated = queries::collect_mutated_vars(else_body, None);
-                        let else_binding = if else_mutated.contains(&var_name) {
+
+                    for (variant_name, body) in branch_specs.iter().rev() {
+                        let mutated = queries::collect_mutated_vars(body, None);
+                        let binding = if mutated.contains(&var_name) {
                             format!("mut {var_name}")
                         } else {
                             var_name.clone()
                         };
-                        Some(vec![RustStmt::IfLet {
-                            pattern: format!(
-                                "{enum_name}::{}({else_binding})",
-                                remaining_variants[0]
-                            ),
+                        let Some(lowered_body) = self.try_lower_speculative_branch_for_ir(body)?
+                        else {
+                            return Ok(None);
+                        };
+                        nested_else = Some(vec![RustStmt::IfLet {
+                            pattern: format!("{enum_name}::{variant_name}({binding})"),
                             expr: crate::RustExpr::Ident(var_name.clone()),
-                            then_body: lowered_else_body,
-                            else_body: Some(vec![RustStmt::Expr(crate::RustExpr::FormatMacro {
-                                name: "unreachable".to_string(),
-                                format_str:
-                                    "sifr union narrowing fell through exhaustive branch chain"
-                                        .to_string(),
-                                args: vec![],
-                            })]),
-                        }])
-                    } else {
-                        Some(lowered_else_body)
+                            then_body: lowered_body,
+                            else_body: nested_else,
+                        }]);
                     }
-                } else {
-                    None
-                };
 
-                for (variant_name, body) in branch_specs.iter().rev() {
-                    let mutated = queries::collect_mutated_vars(body, None);
-                    let binding = if mutated.contains(&var_name) {
-                        format!("mut {var_name}")
-                    } else {
-                        var_name.clone()
-                    };
-                    let Some(lowered_body) = self.try_lower_speculative_branch_for_ir(body)? else {
-                        return Ok(None);
-                    };
-                    nested_else = Some(vec![RustStmt::IfLet {
-                        pattern: format!("{enum_name}::{variant_name}({binding})"),
-                        expr: crate::RustExpr::Ident(var_name.clone()),
-                        then_body: lowered_body,
-                        else_body: nested_else,
-                    }]);
-                }
-
-                return Ok(nested_else.and_then(|stmts| stmts.into_iter().next()));
+                    Ok(nested_else.and_then(|stmts| stmts.into_iter().next()))
+                })();
+                self.string_char_cache_vars = speculative_string_char_cache_vars;
+                return lowered_union;
             }
         }
 
@@ -582,7 +590,10 @@ impl RustEmitter {
     ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
         let string_char_cache_vars = self.string_char_cache_vars.clone();
         match self.try_lower_stmt_block_for_ir(body) {
-            Ok(Some(lowered)) => Ok(Some(lowered)),
+            Ok(Some(lowered)) => {
+                self.string_char_cache_vars = string_char_cache_vars;
+                Ok(Some(lowered))
+            }
             Ok(None) => {
                 self.string_char_cache_vars = string_char_cache_vars;
                 Ok(None)
@@ -646,6 +657,22 @@ impl RustEmitter {
 mod tests {
     use super::*;
 
+    fn isinstance_union_condition(target: &str) -> HirExpr {
+        HirExpr::Call {
+            func: "isinstance".to_string(),
+            args: vec![
+                HirExpr::Name {
+                    name: "value".to_string(),
+                    binding_id: None,
+                    ty: Type::Union(vec![Type::Int, Type::Str]),
+                },
+                HirExpr::StringLiteral(target.to_string()),
+            ],
+            mutable_arg_places: vec![None, None],
+            ty: Type::Bool,
+        }
+    }
+
     #[test]
     fn declined_speculative_branch_restores_string_cache_state() {
         let mut emitter = RustEmitter::new();
@@ -674,6 +701,64 @@ mod tests {
         let lowered = emitter
             .try_lower_speculative_branch_for_ir(&body)
             .expect("speculative lowering must not error");
+
+        assert!(lowered.is_none());
+        assert_eq!(emitter.string_char_cache_vars, before);
+    }
+
+    #[test]
+    fn successful_speculative_branch_restores_string_cache_state() {
+        let mut emitter = RustEmitter::new();
+        emitter
+            .string_char_cache_required_names
+            .insert("text".to_string());
+        let before = emitter.string_char_cache_vars.clone();
+        let body = vec![HirStmt::Let {
+            name: "text".to_string(),
+            ty: Type::Str,
+            value: HirExpr::StringLiteral("value".to_string()),
+            is_mutable: false,
+        }];
+
+        let lowered = emitter
+            .try_lower_speculative_branch_for_ir(&body)
+            .expect("speculative lowering must not error");
+
+        assert!(lowered.is_some());
+        assert_eq!(emitter.string_char_cache_vars, before);
+    }
+
+    #[test]
+    fn declined_isinstance_union_restores_successful_sibling_cache_state() {
+        let mut emitter = RustEmitter::new();
+        emitter
+            .string_char_cache_required_names
+            .insert("text".to_string());
+        emitter
+            .string_char_cache_vars
+            .insert("existing".to_string(), "__sifr_existing_chars".to_string());
+        let before = emitter.string_char_cache_vars.clone();
+        let declined_then_body = vec![HirStmt::AttributeAugAssign {
+            object: "self".to_string(),
+            field: "label".to_string(),
+            op: "+=".to_string(),
+            value: HirExpr::StringLiteral("suffix".to_string()),
+        }];
+        let successful_elif_body = vec![HirStmt::Let {
+            name: "text".to_string(),
+            ty: Type::Str,
+            value: HirExpr::StringLiteral("value".to_string()),
+            is_mutable: false,
+        }];
+
+        let lowered = emitter
+            .try_lower_if_stmt_for_ir(
+                &isinstance_union_condition("int"),
+                &declined_then_body,
+                &[(isinstance_union_condition("str"), successful_elif_body)],
+                None,
+            )
+            .expect("union lowering must not error");
 
         assert!(lowered.is_none());
         assert_eq!(emitter.string_char_cache_vars, before);

--- a/crates/sifr_codegen/src/structural_identity_codegen.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen.rs
@@ -23,6 +23,7 @@ enum CompiledIdentity {
 
 struct IdentityContext<'a> {
     modules: &'a [(&'a str, &'a HirModule)],
+    nominal_type_paths: Option<&'a HashMap<String, String>>,
 }
 
 impl<'a> IdentityContext<'a> {
@@ -110,7 +111,10 @@ pub(crate) fn class_identity_expression(
 ) -> String {
     let module_key = module_name.unwrap_or("");
     let modules = [(module_key, module)];
-    let context = IdentityContext { modules: &modules };
+    let context = IdentityContext {
+        modules: &modules,
+        nominal_type_paths: None,
+    };
     if class.is_enum() {
         compile_enum(class, module_name).expression()
     } else {
@@ -121,8 +125,12 @@ pub(crate) fn class_identity_expression(
 pub(crate) fn class_identity_expressions_for_project(
     modules: &[(&str, &HirModule)],
     structural_record_identities: &HashSet<String>,
+    nominal_type_paths: &HashMap<String, String>,
 ) -> HashMap<String, String> {
-    let context = IdentityContext { modules };
+    let context = IdentityContext {
+        modules,
+        nominal_type_paths: Some(nominal_type_paths),
+    };
     modules
         .iter()
         .flat_map(|(module_name, module)| {
@@ -151,7 +159,12 @@ pub(crate) fn static_class_identities_for_project(
     modules: &[(&str, &HirModule)],
     structural_record_identities: &HashSet<String>,
 ) -> HashMap<String, ShapeIdentity> {
-    let context = IdentityContext { modules };
+    let nominal_type_paths =
+        crate::lib_project_codegen::project_nominal_type_paths(modules, &HashSet::new());
+    let context = IdentityContext {
+        modules,
+        nominal_type_paths: Some(&nominal_type_paths),
+    };
     modules
         .iter()
         .flat_map(|(module_name, module)| {
@@ -183,7 +196,10 @@ pub(crate) fn static_class_identity(
 ) -> Option<ShapeIdentity> {
     let module_key = module_name.unwrap_or("");
     let modules = [(module_key, module)];
-    let context = IdentityContext { modules: &modules };
+    let context = IdentityContext {
+        modules: &modules,
+        nominal_type_paths: None,
+    };
     if class.is_enum() {
         compile_enum(class, module_name).static_value()
     } else {
@@ -340,7 +356,13 @@ fn compile_type(
                 let mapped_expression = if module_name == scope_module_name {
                     mapped_opaque_identity_expression(class)
                 } else {
-                    mapped_opaque_identity_expression_for_imported_type(class, module_name)
+                    context.nominal_type_paths.and_then(|paths| {
+                        mapped_opaque_identity_expression_for_imported_type(
+                            class,
+                            module_name,
+                            paths,
+                        )
+                    })
                 };
                 if let Some(expression) = mapped_expression {
                     return CompiledIdentity::Dynamic(expression);
@@ -635,7 +657,10 @@ mod tests {
     #[test]
     fn exact_and_fixed_width_integer_identities_are_distinct() {
         let modules = Vec::new();
-        let context = IdentityContext { modules: &modules };
+        let context = IdentityContext {
+            modules: &modules,
+            nominal_type_paths: None,
+        };
         let exact = compile_type(&Type::Int, "main", &context, &mut Vec::new()).static_value();
         let fixed = compile_type(
             &Type::FixedInt(sifr_type_system::FixedIntType::I64),
@@ -653,7 +678,10 @@ mod tests {
     #[test]
     fn structural_identity_recanonicalizes_raw_union_members() {
         let modules = Vec::new();
-        let context = IdentityContext { modules: &modules };
+        let context = IdentityContext {
+            modules: &modules,
+            nominal_type_paths: None,
+        };
         let raw = Type::Union(vec![Type::Int, Type::Bool]);
         let canonical = sifr_type_system::make_union(vec![Type::Int, Type::Bool]);
         let actual = compile_type(&raw, "main", &context, &mut Vec::new()).static_value();
@@ -763,6 +791,7 @@ mod tests {
         let expressions = class_identity_expressions_for_project(
             &modules,
             &HashSet::from(["models.Payload".to_string(), "main.Envelope".to_string()]),
+            &HashMap::new(),
         );
         let payload_identity =
             static_class_identity(&payload, &models, Some("models")).expect("static payload");

--- a/crates/sifr_codegen/src/structural_identity_codegen/mapped_opaque.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen/mapped_opaque.rs
@@ -1,4 +1,5 @@
 use sifr_ir::HirClass;
+use std::collections::HashMap;
 
 const STRUCTURAL: &str = "::sifr_runtime::interop::structural";
 
@@ -18,14 +19,18 @@ pub(super) fn mapped_opaque_identity_expression(class: &HirClass) -> Option<Stri
 pub(super) fn mapped_opaque_identity_expression_for_imported_type(
     class: &HirClass,
     module_name: &str,
+    nominal_type_paths: &HashMap<String, String>,
 ) -> Option<String> {
     if !crate::structural_impl_codegen::structural_mapped_opaque_supported(class) {
         return None;
     }
-    let module_path = module_name.replace('.', "::");
+    let canonical = class
+        .identity
+        .clone()
+        .unwrap_or_else(|| format!("{module_name}.{}", class.name));
+    let generated_path = nominal_type_paths.get(&canonical)?;
     Some(format!(
-        "<crate::{module_path}::{} as {STRUCTURAL}::StructuralType>::shape_identity()",
-        class.name
+        "<{generated_path} as {STRUCTURAL}::StructuralType>::shape_identity()"
     ))
 }
 
@@ -141,6 +146,10 @@ mod tests {
         let expressions = super::super::class_identity_expressions_for_project(
             &[("values", &values), ("main", &main)],
             &HashSet::from(["main.Envelope".to_string()]),
+            &HashMap::from([(
+                "values.Token".to_string(),
+                "crate::values::Token".to_string(),
+            )]),
         );
         let expression = expressions
             .get("main.Envelope")
@@ -152,5 +161,65 @@ mod tests {
             "{expression}"
         );
         assert!(!expression.contains("::bridge::"), "{expression}");
+        let static_identities = super::super::static_class_identities_for_project(
+            &[("values", &values), ("main", &main)],
+            &HashSet::from(["main.Envelope".to_string()]),
+        );
+        assert!(
+            !static_identities.contains_key("main.Envelope"),
+            "mapped identities must remain dynamic: {static_identities:?}"
+        );
+    }
+
+    #[test]
+    fn imported_identity_uses_crate_root_and_escaped_project_paths() {
+        let mut token = class("std", Vec::new());
+        token.identity = Some("main.std".to_string());
+        token.rust_interop = vec![RustInteropDeclaration {
+            kind: RustInteropDecoratorKind::Opaque,
+            target: None,
+            arguments: vec![
+                RustInteropArgument {
+                    name: Some("type".to_string()),
+                    value: RustInteropValue::TargetPath(RustTargetPath {
+                        segments: ["bridge", "token", "Token"].map(str::to_string).to_vec(),
+                        span: Default::default(),
+                    }),
+                    span: Default::default(),
+                },
+                RustInteropArgument {
+                    name: Some("structural".to_string()),
+                    value: RustInteropValue::TargetPath(RustTargetPath {
+                        segments: ["bridge", "token", "TokenMapping"]
+                            .map(str::to_string)
+                            .to_vec(),
+                        span: Default::default(),
+                    }),
+                    span: Default::default(),
+                },
+            ],
+            span: Default::default(),
+            effect: RustInteropEffect::Sync,
+            abi_requirements: RustInteropAbiRequirements {
+                opaque_handle: true,
+                ..RustInteropAbiRequirements::default()
+            },
+            consumes_receiver: false,
+        }];
+        let expression = mapped_opaque_identity_expression_for_imported_type(
+            &token,
+            "main",
+            &HashMap::from([(
+                "main.std".to_string(),
+                "crate::__SifrSource_std".to_string(),
+            )]),
+        )
+        .expect("mapped opaque identity must be available");
+
+        assert!(
+            expression.contains("<crate::__SifrSource_std as"),
+            "{expression}"
+        );
+        assert!(!expression.contains("crate::main::std"), "{expression}");
     }
 }

--- a/crates/sifr_codegen/src/structural_identity_codegen/substitution_tests.rs
+++ b/crates/sifr_codegen/src/structural_identity_codegen/substitution_tests.rs
@@ -27,7 +27,10 @@ fn class(name: &str, fields: Vec<(String, Type)>) -> HirClass {
 #[test]
 fn structural_substitution_canonicalizes_generic_union_members() {
     let modules = Vec::new();
-    let context = IdentityContext { modules: &modules };
+    let context = IdentityContext {
+        modules: &modules,
+        nominal_type_paths: None,
+    };
     let template = sifr_type_system::make_union(vec![Type::Int, Type::TypeVar("T".to_string())]);
     let bindings = HashMap::from([("T".to_string(), Type::Bool)]);
     let actual = substitute_structural_type(&template, &bindings, "main", &context);
@@ -51,7 +54,10 @@ fn structural_substitution_uses_project_nominal_scope_authority() {
         type_param_bounds: HashMap::new(),
     };
     let modules = [("models", &module)];
-    let context = IdentityContext { modules: &modules };
+    let context = IdentityContext {
+        modules: &modules,
+        nominal_type_paths: None,
+    };
     let template = Type::Class {
         identity: Some("models.Inner".to_string()),
         type_args: vec![Type::Str],
@@ -136,7 +142,10 @@ fn imported_outer_fields_resolve_nested_scopes_in_the_declaring_module() {
         type_param_bounds: HashMap::new(),
     };
     let modules = [("models", &models), ("main", &main)];
-    let context = IdentityContext { modules: &modules };
+    let context = IdentityContext {
+        modules: &modules,
+        nominal_type_paths: None,
+    };
     let concrete_outer = Type::Class {
         identity: Some("models.Outer".to_string()),
         type_args: vec![Type::Int],
@@ -176,7 +185,10 @@ fn imported_outer_fields_resolve_nested_scopes_in_the_declaring_module() {
 #[test]
 fn generic_union_identity_matches_reordered_collapsed_and_nested_substitutions() {
     let modules = Vec::new();
-    let context = IdentityContext { modules: &modules };
+    let context = IdentityContext {
+        modules: &modules,
+        nominal_type_paths: None,
+    };
     let template = sifr_type_system::make_union(vec![Type::Str, Type::TypeVar("T".to_string())]);
     assert_eq!(
         compile_type(&template, "main", &context, &mut Vec::new()).expression(),

--- a/crates/sifr_frontend/src/const_evaluator.rs
+++ b/crates/sifr_frontend/src/const_evaluator.rs
@@ -501,11 +501,14 @@ impl<'a> DeterministicConstEvaluator<'a> {
             );
         }
         let value = self.eval_expr(&arguments[0], environment, depth)?;
-        let HirExpr::StringLiteral(name) = &arguments[1] else {
-            return error(
-                ConstEvalErrorKind::TypeMismatch,
-                "const isinstance requires one primitive type name",
-            );
+        let name = match &arguments[1] {
+            HirExpr::StringLiteral(name) | HirExpr::Name { name, .. } => name,
+            _ => {
+                return error(
+                    ConstEvalErrorKind::TypeMismatch,
+                    "const isinstance requires one primitive type name",
+                );
+            }
         };
         let matches = match (name.as_str(), &value) {
             ("bool", ConstValue::Bool(_))
@@ -762,6 +765,10 @@ fn error<T>(kind: ConstEvalErrorKind, detail: impl Into<String>) -> Result<T, Co
         detail: detail.into(),
     })
 }
+
+#[cfg(test)]
+#[path = "const_evaluator_target_tests.rs"]
+mod target_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/sifr_frontend/src/const_evaluator_target_tests.rs
+++ b/crates/sifr_frontend/src/const_evaluator_target_tests.rs
@@ -1,0 +1,24 @@
+use super::*;
+
+#[test]
+fn accepts_the_codegen_name_form_for_const_isinstance_targets() {
+    let parsed = sifr_syntax::parse_module_suite("", None).expect("fixture parses");
+    let lowered = sifr_lowering::lower_module(&parsed).expect("fixture lowers");
+    let mut evaluator = DeterministicConstEvaluator::new(&lowered.module);
+    let value = evaluator
+        .eval_isinstance(
+            &[
+                HirExpr::StringLiteral("value".to_string()),
+                HirExpr::Name {
+                    name: "str".to_string(),
+                    binding_id: None,
+                    ty: Type::Str,
+                },
+            ],
+            &mut Environment::new(),
+            0,
+        )
+        .expect("the codegen HIR target form must be accepted");
+
+    assert_eq!(value, ConstValue::Bool(true));
+}


### PR DESCRIPTION
Closes #3379.

Closes the remaining M7f mechanisms: speculative branch rollback, canonical imported mapped-opaque Rust paths, const/codegen `isinstance` target parity, and compositional generic bounds. The reproduced borrowed `Structural` return now declares `Clone`, while owned structural values remain unconstrained and attached static-program bounds retain `'static`.

Exact candidate: `456c061ff7014fe17bc81e662e0b60ebee7717c5`

Validation:
- package-neutral static-class-adapter fixture built and ran natively, printing `attached-contract`
- `cargo test -q -p sifr_frontend` (118 passed)
- `cargo test -q -p sifr_codegen --lib` (1069 passed)
- `cargo test -q -p sifr_driver` (546 passed, 76 ignored)
- workspace format, clippy, HIR maintainability, file-size, and diff checks passed
- focused state-restoration, mapped-path, const-target, and generic-bound tests passed