### PR TITLE
fix: close M8-M10 compiler prerequisite audit

### DIFF
--- a/crates/sifr_codegen/src/static_program_codegen.rs
+++ b/crates/sifr_codegen/src/static_program_codegen.rs
@@ -233,6 +233,7 @@ mod tests {
     use super::*;
     use sifr_ir::{
         CallableIdentity, MethodKind, StaticMethodParam, StaticMethodSlot, StaticMethodSlotContext,
+        StaticMethodSlotInputRole,
     };
     use sifr_type_system::{ParamConvention, Type};
 
@@ -313,23 +314,8 @@ mod tests {
         assert!(method_slot_cache_fragment(&[output(7)]).is_empty());
     }
 
-    #[test]
-    fn emitted_symbols_cannot_collide_after_readable_name_normalization() {
-        let mut dotted = output(7);
-        dotted.package_module = "schema.package".to_string();
-        let mut underscored = output(8);
-        underscored.package_module = "schema_package".to_string();
-
-        assert_ne!(
-            rust_static_suffix(&dotted),
-            rust_static_suffix(&underscored)
-        );
-    }
-
-    #[test]
-    fn emits_monomorphic_method_slot_dispatch_and_header_identity() {
-        let mut output = output(9);
-        output.method_slots.push(StaticMethodSlot {
+    fn test_method_slot() -> StaticMethodSlot {
+        StaticMethodSlot {
             owner_identity: "fixture.Record".to_string(),
             owner_type: Type::Class {
                 identity: Some("fixture.Record".to_string()),
@@ -351,6 +337,7 @@ mod tests {
             }],
             return_type: Type::Result(Box::new(Type::Str), Box::new(Type::Str)),
             is_async: false,
+            input_role: StaticMethodSlotInputRole::Value,
             input_type: Type::Str,
             output_type: Type::Str,
             context_type: None,
@@ -361,7 +348,26 @@ mod tests {
             descriptor_range: None,
             declaration_order: None,
             is_fallible: true,
-        });
+        }
+    }
+
+    #[test]
+    fn emitted_symbols_cannot_collide_after_readable_name_normalization() {
+        let mut dotted = output(7);
+        dotted.package_module = "schema.package".to_string();
+        let mut underscored = output(8);
+        underscored.package_module = "schema_package".to_string();
+
+        assert_ne!(
+            rust_static_suffix(&dotted),
+            rust_static_suffix(&underscored)
+        );
+    }
+
+    #[test]
+    fn emits_monomorphic_method_slot_dispatch_and_header_identity() {
+        let mut output = output(9);
+        output.method_slots.push(test_method_slot());
         output.method_slot_context = Some(StaticMethodSlotContext::None);
 
         let cache_fragment = method_slot_cache_fragment(&[output.clone()]);
@@ -374,5 +380,27 @@ mod tests {
         assert!(emitted.contains("match index"));
         assert!(emitted.contains("Record::normalize(value)"));
         assert!(emitted.contains("Some(*__SIFR_METHOD_SLOT_IDENTITY_"));
+    }
+
+    #[test]
+    fn emits_receiver_and_value_dispatch_from_the_recorded_input_role() {
+        let mut output = output(10);
+        let mut slot = test_method_slot();
+        slot.name = "serialize".to_string();
+        slot.hir_name = "serialize".to_string();
+        slot.method_kind = MethodKind::Regular;
+        slot.receiver = Some(sifr_type_system::ReceiverConvention::SharedBorrow);
+        slot.input_role = StaticMethodSlotInputRole::ReceiverAndValue;
+        slot.input_type = Type::Tuple(vec![slot.owner_type.clone(), Type::Str]);
+        slot.return_type = Type::Str;
+        slot.is_fallible = false;
+        output.method_slots.push(slot);
+        output.method_slot_context = Some(StaticMethodSlotContext::None);
+
+        let emitted =
+            emit_static_specialization_programs(&[output], &BTreeSet::from(["Record".to_string()]));
+
+        assert!(emitted.contains("let (receiver, value) ="), "{emitted}");
+        assert!(emitted.contains("receiver.serialize(value)"), "{emitted}");
     }
 }

--- a/crates/sifr_codegen/src/static_program_slots_codegen.rs
+++ b/crates/sifr_codegen/src/static_program_slots_codegen.rs
@@ -1,4 +1,7 @@
-use sifr_ir::{MethodKind, StaticMethodSlot, StaticMethodSlotContext, StaticSpecializationOutput};
+use sifr_ir::{
+    MethodKind, StaticMethodSlot, StaticMethodSlotContext, StaticMethodSlotInputRole,
+    StaticSpecializationOutput,
+};
 use sifr_type_system::{ParamConvention, ReceiverConvention, Type};
 use std::fmt::Write as _;
 
@@ -100,7 +103,6 @@ fn slot_identity_expression(slot: &StaticMethodSlot) -> String {
 
 fn slot_arm(index: usize, slot: &StaticMethodSlot, context: &StaticMethodSlotContext) -> String {
     let input = render_slot_type(&slot.input_type);
-    let receiver_value_input = has_receiver_value_input(slot);
     let receiver_binding = if slot.receiver == Some(ReceiverConvention::MutableBorrow) {
         "mut "
     } else {
@@ -115,12 +117,12 @@ fn slot_arm(index: usize, slot: &StaticMethodSlot, context: &StaticMethodSlotCon
     } else {
         ""
     };
-    let binding = if receiver_value_input {
-        format!("({receiver_binding}receiver, {value_binding}value)")
-    } else {
-        let mutable_input = slot.receiver == Some(ReceiverConvention::MutableBorrow)
-            || (slot.receiver.is_none() && value_binding == "mut ");
-        format!("{}value", if mutable_input { "mut " } else { "" })
+    let binding = match slot.input_role {
+        StaticMethodSlotInputRole::ReceiverAndValue => {
+            format!("({receiver_binding}receiver, {value_binding}value)")
+        }
+        StaticMethodSlotInputRole::Receiver => format!("{receiver_binding}value"),
+        StaticMethodSlotInputRole::Value => format!("{value_binding}value"),
     };
     let call = slot_call_expression(slot, context);
     let dispatch = if slot.is_fallible {
@@ -147,7 +149,7 @@ fn slot_call_expression(slot: &StaticMethodSlot, context: &StaticMethodSlotConte
     });
     if slot.receiver.is_some() {
         let mut args = Vec::new();
-        let receiver = if has_receiver_value_input(slot) {
+        let receiver = if slot.input_role == StaticMethodSlotInputRole::ReceiverAndValue {
             let value = slot.params.first().map_or_else(
                 || "value".to_string(),
                 |param| argument_for_convention("value", param.convention),
@@ -174,11 +176,6 @@ fn slot_call_expression(slot: &StaticMethodSlot, context: &StaticMethodSlotConte
             format!("{owner}::{method}({})", args.join(", "))
         }
     }
-}
-
-fn has_receiver_value_input(slot: &StaticMethodSlot) -> bool {
-    slot.receiver.is_some()
-        && matches!(slot.input_type.resolve_alias(), Type::Tuple(values) if values.len() == 2)
 }
 
 fn argument_for_convention(name: &str, convention: ParamConvention) -> String {

--- a/crates/sifr_driver/src/tests/attached_api_audit.rs
+++ b/crates/sifr_driver/src/tests/attached_api_audit.rs
@@ -95,3 +95,42 @@ def invalid():
         "expected a StaticProgram eligibility diagnostic: {errors:#?}"
     );
 }
+
+#[test]
+fn attached_api_rejects_method_slots_bound_on_the_wrong_type_parameter() {
+    let contract = attached_contract()
+        .replace(
+            "from sifr.meta import StaticProgram, StringStructural, Structural, ",
+            "from sifr.meta import MethodSlots, StaticProgram, StringStructural, Structural, ",
+        )
+        .replace(
+            "@class_adapter_provider",
+            r#"@attached_api("fixture.contract", "ContractApi", public_name="misbound", receiver="type", owner="T")
+def misbound[T: Structural, Slots: MethodSlots]() -> int:
+    return 1
+
+@class_adapter_provider"#,
+        );
+    let modules = project(
+        r#"
+from fixture.contract import Contract
+
+class Model(Contract):
+    value: int
+"#,
+        &contract,
+    );
+
+    let errors = compile_errors(
+        &modules,
+        "a MethodSlots bound on a non-owner parameter must not authorize the owner",
+    );
+    assert!(
+        errors.iter().any(|error| {
+            error
+                .message
+                .contains("owner type parameter must be bounded by StaticProgram or MethodSlots")
+        }),
+        "expected the owner-bound diagnostic: {errors:#?}"
+    );
+}

--- a/crates/sifr_frontend/src/slot_table.rs
+++ b/crates/sifr_frontend/src/slot_table.rs
@@ -1,7 +1,7 @@
 use crate::{describe_type_with_externals, ShapeNode, StructuralShape};
 use sifr_lowering::{
     AdapterHandlerPlan, CallableIdentity, ExternalDefs, LoweringResult, StaticMethodParam,
-    StaticMethodSlot, StaticMethodSlotContext,
+    StaticMethodSlot, StaticMethodSlotContext, StaticMethodSlotInputRole,
 };
 use sifr_type_system::{ReceiverConvention, Type};
 use std::collections::{BTreeSet, HashMap};
@@ -476,6 +476,11 @@ fn resolve_method_slot(
             params: method.params.iter().map(static_method_param).collect(),
             return_type: method.return_type.clone(),
             is_async: method.is_async,
+            input_role: if method.receiver.is_some() {
+                StaticMethodSlotInputRole::Receiver
+            } else {
+                StaticMethodSlotInputRole::Value
+            },
             input_type: Type::Unknown,
             output_type: Type::Unknown,
             context_type: None,
@@ -511,6 +516,11 @@ fn resolve_method_slot(
         params: method.params.iter().map(static_method_param).collect(),
         return_type: method.return_type.clone(),
         is_async: method.is_async,
+        input_role: if method.receiver.is_some() {
+            StaticMethodSlotInputRole::Receiver
+        } else {
+            StaticMethodSlotInputRole::Value
+        },
         input_type: Type::Unknown,
         output_type: Type::Unknown,
         context_type: None,
@@ -642,10 +652,22 @@ fn finish_method_slot(
                 Some(parameter)
             }
             [value] => {
+                debug_assert!(value.convention.is_owned());
+                slot.input_role = StaticMethodSlotInputRole::ReceiverAndValue;
                 slot.input_type = Type::Tuple(vec![slot.owner_type.clone(), value.ty.clone()]);
                 None
             }
             [value, context] => {
+                if !value.convention.is_owned() {
+                    return Err(MethodSlotError::new(
+                        MethodSlotErrorKind::Signature,
+                        format!(
+                            "method slot `{}::{}` receiver value input must be owned",
+                            slot.owner_identity, slot.name
+                        ),
+                    ));
+                }
+                slot.input_role = StaticMethodSlotInputRole::ReceiverAndValue;
                 slot.input_type = Type::Tuple(vec![slot.owner_type.clone(), value.ty.clone()]);
                 Some(context)
             }

--- a/crates/sifr_frontend/src/slot_table_tests.rs
+++ b/crates/sifr_frontend/src/slot_table_tests.rs
@@ -1,5 +1,7 @@
 use crate::{collect_module_exports, compile_module_hir, FrontendDiagnosticStyle};
-use sifr_lowering::{ExternalDefs, LoweringResult, StaticMethodSlotContext};
+use sifr_lowering::{
+    ExternalDefs, LoweringResult, StaticMethodSlotContext, StaticMethodSlotInputRole,
+};
 use sifr_syntax::parse_module_suite;
 
 fn compile(
@@ -72,6 +74,16 @@ fn diagnostic_codes(
             .into_iter()
             .map(|diagnostic| diagnostic.code)
             .collect(),
+    }
+}
+
+fn diagnostics(
+    result: Result<LoweringResult, Vec<sifr_diagnostics::RenderedDiagnostic>>,
+    failure: &str,
+) -> Vec<sifr_diagnostics::RenderedDiagnostic> {
+    match result {
+        Ok(_) => panic!("{failure}"),
+        Err(diagnostics) => diagnostics,
     }
 }
 
@@ -163,8 +175,35 @@ class Record:
     )
     .expect("infallible checked method slot specializes");
     let slot = &result.specialization_outputs[0].method_slots[0];
+    assert_eq!(slot.input_role, StaticMethodSlotInputRole::Value);
     assert_eq!(slot.output_type, sifr_type_system::Type::Str);
     assert!(!slot.is_fallible);
+}
+
+#[test]
+fn receiver_only_slot_records_receiver_input_role() {
+    let mut external_defs = ExternalDefs::default();
+    install_specializer(&mut external_defs, &["target.Record::label"]);
+    let result = compile(
+        "target",
+        r#"
+from fixture.slots import describe
+
+@const_specialize("fixture.slots", "describe")
+class Record:
+    value: str
+
+    @metadata("fixture.slot", "label")
+    def label(self) -> str:
+        return self.value
+"#,
+        &external_defs,
+    )
+    .expect("receiver-only method slot specializes");
+    let slot = &result.specialization_outputs[0].method_slots[0];
+
+    assert_eq!(slot.input_role, StaticMethodSlotInputRole::Receiver);
+    assert_eq!(slot.input_type, slot.owner_type);
 }
 
 #[test]
@@ -192,10 +231,45 @@ class Record:
         slot.input_type,
         sifr_type_system::Type::Tuple(vec![slot.owner_type.clone(), sifr_type_system::Type::Str,])
     );
+    assert_eq!(slot.input_role, StaticMethodSlotInputRole::ReceiverAndValue);
     assert_eq!(
         result.specialization_outputs[0].method_slot_context,
         Some(StaticMethodSlotContext::None)
     );
+}
+
+#[test]
+fn receiver_slot_requires_an_owned_composite_value_input() {
+    let mut external_defs = ExternalDefs::default();
+    install_specializer(&mut external_defs, &["target.Record::serialize"]);
+    let diagnostics = diagnostics(
+        compile(
+            "target",
+            r#"
+from fixture.slots import describe
+
+class AppContext:
+    calls: int
+
+@const_specialize("fixture.slots", "describe")
+class Record:
+    value: str
+
+    @metadata("fixture.slot", "serialize")
+    def serialize(self, value: str, context: AppContext) -> str:
+        return self.value + value
+"#,
+            &external_defs,
+        ),
+        "a borrowed composite value input must fail",
+    );
+
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "SIFR-RUST-SLOT-0003"
+            && diagnostic
+                .message
+                .contains("receiver value input must be owned")
+    }));
 }
 
 #[test]
@@ -231,4 +305,68 @@ class Record:
         &external_defs,
     ));
     assert!(codes.iter().any(|code| code == "SIFR-RUST-SLOT-0005"));
+}
+
+#[test]
+fn static_method_slot_requires_one_value_input() {
+    let mut external_defs = ExternalDefs::default();
+    install_specializer(&mut external_defs, &["target.Record::missing"]);
+    let diagnostics = diagnostics(
+        compile(
+            "target",
+            r#"
+from fixture.slots import describe
+
+@const_specialize("fixture.slots", "describe")
+class Record:
+    value: str
+
+    @staticmethod
+    @metadata("fixture.slot", "missing")
+    def missing() -> str:
+        return "missing"
+"#,
+            &external_defs,
+        ),
+        "a static method slot without a value input must fail",
+    );
+
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "SIFR-RUST-SLOT-0003"
+            && diagnostic
+                .message
+                .contains("exactly one value input and at most one context parameter")
+    }));
+}
+
+#[test]
+fn method_slot_rejects_more_than_value_and_context_inputs() {
+    let mut external_defs = ExternalDefs::default();
+    install_specializer(&mut external_defs, &["target.Record::excess"]);
+    let diagnostics = diagnostics(
+        compile(
+            "target",
+            r#"
+from fixture.slots import describe
+
+@const_specialize("fixture.slots", "describe")
+class Record:
+    value: str
+
+    @staticmethod
+    @metadata("fixture.slot", "excess")
+    def excess(own value: str, context: str, extra: str) -> str:
+        return value
+"#,
+            &external_defs,
+        ),
+        "a method slot with three inputs must fail",
+    );
+
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "SIFR-RUST-SLOT-0003"
+            && diagnostic
+                .message
+                .contains("exactly one value input and at most one context parameter")
+    }));
 }

--- a/crates/sifr_ir/src/specialization_metadata.rs
+++ b/crates/sifr_ir/src/specialization_metadata.rs
@@ -357,6 +357,16 @@ pub enum StaticMethodSlotContext {
     Mutable(Type),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaticMethodSlotInputRole {
+    /// The structural input is the checked method's value parameter.
+    Value,
+    /// The structural input is the checked method's receiver.
+    Receiver,
+    /// The structural input is `(receiver, value)`.
+    ReceiverAndValue,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StaticMethodSlot {
     /// Exact module-qualified nominal owner identity.
@@ -372,6 +382,7 @@ pub struct StaticMethodSlot {
     pub params: Vec<StaticMethodParam>,
     pub return_type: Type,
     pub is_async: bool,
+    pub input_role: StaticMethodSlotInputRole,
     pub input_type: Type,
     pub output_type: Type,
     pub context_type: Option<Type>,

--- a/crates/sifr_lowering/src/lib.rs
+++ b/crates/sifr_lowering/src/lib.rs
@@ -42,6 +42,6 @@ pub use sifr_ir::{
     PythonArrowSchemaMode, PythonDlpackStreamMode, PythonInteropDeclaration, RevealTypeDiagnostic,
     RustInteropAbiRequirements, RustInteropDeclaration, RustInteropDecoratorKind,
     RustInteropEffect, RustInteropValue, RustTargetPath, SourceOriginId, StaticMethodParam,
-    StaticMethodSlot, StaticMethodSlotContext, StaticProgramValue, StaticSpecializationOutput,
-    TypedDeclarationDescriptor, TypedDeclarationMetadata,
+    StaticMethodSlot, StaticMethodSlotContext, StaticMethodSlotInputRole, StaticProgramValue,
+    StaticSpecializationOutput, TypedDeclarationDescriptor, TypedDeclarationMetadata,
 };

--- a/crates/sifr_lowering/src/lower/expressions/attached_api_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/attached_api_calls.rs
@@ -221,10 +221,12 @@ fn validate_bindings(
         };
         let mut constraints = Vec::new();
         for bound in bounds {
-            if binding.provisional
-                && type_param == &binding.declaration.owner_type_param
-                && bound == "StaticProgram"
-            {
+            if provisional_owner_bound_is_deferred(
+                binding.provisional,
+                type_param,
+                &binding.declaration.owner_type_param,
+                bound,
+            ) {
                 continue;
             }
             if let Some(constraint) = decode_typevar_constraint(bound) {
@@ -256,6 +258,17 @@ fn validate_bindings(
             );
         }
     }
+}
+
+fn provisional_owner_bound_is_deferred(
+    provisional: bool,
+    type_param: &str,
+    owner_type_param: &str,
+    bound: &str,
+) -> bool {
+    provisional
+        && type_param == owner_type_param
+        && matches!(bound, "StaticProgram" | "MethodSlots")
 }
 
 fn validate_arguments(
@@ -328,5 +341,44 @@ fn substitute_function_type(
             })
             .collect(),
         return_type: Box::new(substitute_type_vars(&function_type.return_type, bindings)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::provisional_owner_bound_is_deferred;
+
+    #[test]
+    fn provisional_static_owner_bounds_have_exact_parity() {
+        assert!(provisional_owner_bound_is_deferred(
+            true,
+            "T",
+            "T",
+            "StaticProgram"
+        ));
+        assert!(provisional_owner_bound_is_deferred(
+            true,
+            "T",
+            "T",
+            "MethodSlots"
+        ));
+        assert!(!provisional_owner_bound_is_deferred(
+            true,
+            "T",
+            "T",
+            "Structural"
+        ));
+        assert!(!provisional_owner_bound_is_deferred(
+            true,
+            "Context",
+            "T",
+            "MethodSlots"
+        ));
+        assert!(!provisional_owner_bound_is_deferred(
+            false,
+            "T",
+            "T",
+            "MethodSlots"
+        ));
     }
 }

--- a/crates/sifr_runtime/src/interop/structural/implementations.rs
+++ b/crates/sifr_runtime/src/interop/structural/implementations.rs
@@ -298,9 +298,46 @@ mod tests {
     use super::*;
     use crate::interop::structural::{
         primitive, structural_construct, ArenaNode, StructuralArena, StructuralNodeEdge,
-        StructuralScalar,
+        StructuralScalar, StructuralScalarRef,
     };
     use crate::SifrInt;
+
+    #[derive(Default)]
+    struct MappingProjectionVisitor {
+        events: Vec<String>,
+    }
+
+    impl<'value> StructuralVisitor<'value> for MappingProjectionVisitor {
+        type Error = std::convert::Infallible;
+
+        fn enter(&mut self, _event: StructuralEnter<'value>) -> Result<VisitControl, Self::Error> {
+            Ok(VisitControl::Continue)
+        }
+
+        fn edge(&mut self, edge: StructuralEdge<'value>) -> Result<(), Self::Error> {
+            match edge.kind() {
+                StructuralEdgeKind::MappingKey(index) => {
+                    self.events.push(format!("key:{index}"));
+                }
+                StructuralEdgeKind::MappingValue(index) => {
+                    self.events.push(format!("value:{index}"));
+                }
+                _ => {}
+            }
+            Ok(())
+        }
+
+        fn scalar(&mut self, value: StructuralScalarRef<'value>) -> Result<(), Self::Error> {
+            if let StructuralScalarRef::String(value) = value {
+                self.events.push(value.to_string());
+            }
+            Ok(())
+        }
+
+        fn exit(&mut self, _kind: StructuralKind) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn index_map_construction_preserves_mapping_order() {
@@ -330,6 +367,24 @@ mod tests {
         assert_eq!(
             output.keys().map(String::as_str).collect::<Vec<_>>(),
             vec!["first", "second"]
+        );
+    }
+
+    #[test]
+    fn index_map_projection_preserves_mapping_order() {
+        let input = IndexMap::from([
+            ("first".to_string(), SifrInt::from(1_i64)),
+            ("second".to_string(), SifrInt::from(2_i64)),
+        ]);
+        let mut visitor = MappingProjectionVisitor::default();
+
+        input
+            .structural_project(&mut visitor)
+            .expect("mapping projection is infallible");
+
+        assert_eq!(
+            visitor.events,
+            vec!["key:0", "first", "value:0", "key:1", "second", "value:1"]
         );
     }
 


### PR DESCRIPTION
Closes #3382.

Implements phase item 24:
- records method-slot input roles explicitly in IR metadata;
- dispatches receiver/value glue from that role instead of tuple-shape inference;
- enforces owned receiver-plus-value inputs and adds direct arity diagnostics;
- gives provisional `MethodSlots` owner bounds parity with `StaticProgram`;
- rejects a `MethodSlots` bound placed on the wrong type parameter;
- adds direct ordered `IndexMap` projection coverage.

The parallel `pre_v1` task and its worktree, processes, artifacts, failures, fixes, and fixture inputs are out of scope.