### PR TITLE
docs: record deterministic method slot bounds

### DIFF
--- a/plans/issues/active/ad-hoc-static-class-adapters-and-pydantic-ergonomics.md
+++ b/plans/issues/active/ad-hoc-static-class-adapters-and-pydantic-ergonomics.md
@@ -2477,7 +2477,7 @@ work.
 | M7c-M7d representation sequencing | Complete in item 21. Nested option-represented union payloads, per-member conversions, warning-clean `None` branches, owned registry-call widening, and shared assignment sequencing use the consuming-value conversion authority. Behavioral presence and absence runs remain certification work. Item 29 owns a separate pre-existing option-to-non-optional argument safety path. |
 | M7e structural construction defaults | Complete in item 22. Structural construction reserves generated locals, rejects required omissions before evaluating defaults, and has two-sided factory freshness evidence. Item 30 owns a distinct user-field and callable-name collision. Class-body lowering remained below the guard and did not need a split. |
 | M7f static-program integration | Complete in item 23. Speculative union branches restore string-cache state, imported mapped-opaque identities use canonical project paths, const evaluation and code generation accept the same `isinstance` targets, and generic bounds compose. Borrowed structural returns now require `Clone`; owned returns do not. Item 31 owns a separate pre-existing non-union `if` cache-state leak found by the final review. |
-| M8-M10 compiler prerequisites | Item 24 is complete. Method-slot input roles are explicit, dispatch and arity diagnostics have direct coverage, ordered mapping projection is pinned, provisional `MethodSlots` matches `StaticProgram`, and a bound on the wrong owner parameter is rejected. Item 25 owns deterministic multi-context selection and exact positive and negative generic-bound assertions. Body deduplication and clone-inference ideas are terminal without a failing case. |
+| M8-M10 compiler prerequisites | Complete in items 24 and 25. Method-slot input roles are explicit, dispatch and arity diagnostics have direct coverage, ordered mapping projection is pinned, provisional `MethodSlots` matches `StaticProgram`, and a bound on the wrong owner parameter is rejected. Multi-context selection follows deterministic HIR type-parameter order. Exact tests pin the positive `MethodSlots` composite bound and the `StaticProgram`-only negative. Body deduplication and clone-inference ideas are terminal without a failing case. |
 | M11 compiler prerequisites | Item 26. Close independent package-compilable negatives, direct attached codegen, stale installed-helper paths, duplicate decorator scans, concrete-owner assertions, nonliteral attached-default provider localization, generic hash predicate ownership, flattened parent defaults, recursive boxed parents, direct plain-parent structural coverage, structural-bound prescans, and retained `StdlibFeature` inventory. Negative metadata alignment is conditional on a future manifest-driven core harness. The 900-line guard owns the structural-test split. Broad probe-bound and clone-inference ideas are terminal unless a focused failure proves a mechanism gap. |
 | M12 items 1-16 | Complete. Item 1 closes the compiler part of nested direct generic specialization. Items 12 and 13-15 close impossible local handler ancestry and imported-boundary name collisions. Item 18 makes the handler ordering dependency local. Other remaining notes are assertions, comments, performance ideas, or certification work. Repeated ancestry walks and identity indexes are terminal without measured cost. |
 
@@ -2515,7 +2515,7 @@ string-cache state transactional in the ordinary `if` lowering path. A local
 declared in one branch must not suppress a later cache declaration outside
 that branch. Item 31 runs after item 30. No third item 23 review applies.
 
-Item 24 is complete. Next action: implement item 25, the second M8-M10 compiler
+Item 25 is complete. Next action: implement item 26, the M11 compiler
 prerequisite audit.
 
 Compiler hardening item 17 state: complete
@@ -2737,6 +2737,30 @@ mutable receiver-only binding coverage remain terminal suggestions. The
 external gate inputs and all `pre_v1` work remain out of scope.
 Next action: implement item 25, the second M8-M10 compiler prerequisite audit.
 
+Compiler hardening item 25 state: complete
+Issue: [`sifr-lang/sifr#3385`](https://github.com/sifr-lang/sifr/issues/3385)
+PR: [`sifr-lang/sifr#3386`](https://github.com/sifr-lang/sifr/pull/3386)
+Base SHA: `b89daa9c1f33b29007c969396c80240570b0be7c`
+Candidate SHA: `d97428e6f5cf16789efbac52a0cd11227c8b9410`
+Merge SHA: `efd13da807fc1e3d444cffd5a253c1c6d441455c`
+Changed paths: deterministic method-slot context selection and exact positive
+and negative generic-bound tests.
+Validation: all 1,073 codegen tests passed. Workspace Clippy, formatting, HIR
+maintainability, the 900-line guard, and diff hygiene passed. The create-PR and
+merge gates each ran once on the exact candidate. Both passed every earlier
+guard. Both stopped at the same two separately owned Rust-interop matrix
+inputs. Neither gate ran again
+([evidence](https://github.com/sifr-lang/sifr/pull/3386#issuecomment-5357320317)).
+Review evidence: the exact-SHA Opus review returned `SATISFIED` with no blocking
+finding
+([evidence](https://github.com/sifr-lang/sifr/pull/3386#issuecomment-5357243340)).
+Deferred follow-up: lowering currently sorts generic type parameters, so the
+deterministic authority is HIR order and is lexical for source-lowered
+functions. Rejecting multiple `Context` parameters would be a separate policy.
+A repeated context-map lookup remains a terminal cleanup. The external gate
+inputs and all `pre_v1` work remain out of scope.
+Next action: implement item 26, the M11 compiler prerequisite audit.
+
 Acceptance criteria:
 
 - The canonical demo contains no raw metadata or specialization decorators.
@@ -2824,7 +2848,7 @@ Next action:
 ## Current Handoff
 
 Current state: M0-M11 are merged and recorded. M12 compiler hardening items 1
-through 24 are merged and recorded. Items 1-16 close the first compiler
+through 25 are merged and recorded. Items 1-16 close the first compiler
 mechanism sequence. Item 17 classifies every remaining compiler deferral and
 orders items 18-26. Item 18 closes the M5 audit. Item 19 closes the M6 audit
 and adds item 27 for second-review coverage. Item 20 closes the M7/M7b audit
@@ -2832,11 +2856,11 @@ and adds item 28 for lookup consistency. Item 21 closes the M7c/M7d
 representation audit. It adds item 29 for option-argument safety. Item 22
 closes the M7e audit and adds item 30 for structural-default naming. Item 23
 closes the M7f audit and adds item 31 for non-union conditional state. Item 24
-closes the first M8-M10 prerequisite audit. The seven
+and item 25 close the M8-M10 prerequisite audit. The seven
 M11 compiler prerequisites merged in Sifr PRs #3317, #3319, #3321, #3323,
 #3325, #3327, and #3329. The M11 package surface merged in Pydantic-Sifr PR
 #47. M12 is in progress. The current compiler merge is
-`435991bfdfd8b80d62d0788f6a1640786a9d5342`, and the current package merge is
+`efd13da807fc1e3d444cffd5a253c1c6d441455c`, and the current package merge is
 `a44116e188cc6b45cffb297d57b9084467a39e8f`.
 
 External gate record (2026-08-19): the one-time gates for the M11 compiler
@@ -2845,5 +2869,5 @@ missing negative evidence source and one existing empty placeholder class.
 The items did not own or alter those inputs. The gates passed all earlier
 guards, and no gate was rerun.
 
-Next action: implement item 25, then continue items 26-31 before package
+Next action: implement item 26, then continue items 27-31 before package
 certification and final review.


### PR DESCRIPTION
Records merged compiler hardening item 25, its exact-SHA Opus review, and its one-shot gate evidence. Advances the phase to item 26.

Documentation only. Compiler tests, compiler gates, and an additional Opus review do not apply to this record update.