### PR TITLE
Gate opaque pre-scan capabilities on parsed declarations

### DIFF
--- a/crates/sifr_driver/src/build/rust_interop_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_contract_tests.rs
@@ -258,6 +258,83 @@ fn package_rust_interop_direct_probe_accepts_mutable_borrow_signature() {
 }
 
 #[test]
+#[doc = "sifr-evidence: executes-cargo-probe"]
+fn package_rust_interop_opaque_probe_accepts_declared_send_sync_copy() {
+    let backend_root = temp_package_root("rust_interop_opaque_send_sync_copy");
+    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
+    std::fs::write(
+        backend_root.join("Cargo.toml"),
+        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .expect("write backend cargo toml");
+    std::fs::write(
+        backend_root.join("src/lib.rs"),
+        "#[derive(Clone, Copy)]\npub struct Tokenizer(pub u64);\n",
+    )
+    .expect("write backend lib");
+
+    let generated = base_project_with_contracts(
+        vec![opaque_class_declaration_entry(vec![
+            target_argument("type", "native.Tokenizer"),
+            bool_argument("send", true),
+            bool_argument("sync", true),
+            symbol_argument("clone", "copy"),
+        ])],
+        Vec::new(),
+    );
+    let context = package_context(
+        TrustPolicy::default(),
+        vec![backend_with_manifest(
+            "native",
+            backend_root.join("Cargo.toml"),
+        )],
+    );
+
+    let generated = apply_package_rust_interop_metadata(generated, Some(context))
+        .expect("opaque Send + Sync + Copy type should pass probe");
+    let probe = &generated.interop.rust.probe_plan.probes[0];
+    assert_eq!(probe.kind, sifr_codegen::RustBridgeProbeKind::OpaqueHandle);
+    assert!(probe.requires_send);
+    assert!(probe.requires_sync);
+}
+
+#[test]
+fn package_rust_interop_opaque_probe_rejects_unsatisfied_send_obligation() {
+    let backend_root = temp_package_root("rust_interop_opaque_not_send");
+    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
+    std::fs::write(
+        backend_root.join("Cargo.toml"),
+        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .expect("write backend cargo toml");
+    std::fs::write(
+        backend_root.join("src/lib.rs"),
+        "pub struct Tokenizer(pub std::rc::Rc<()>);\n",
+    )
+    .expect("write backend lib");
+
+    let generated = base_project_with_contracts(
+        vec![opaque_class_declaration_entry(vec![
+            target_argument("type", "native.Tokenizer"),
+            bool_argument("send", true),
+        ])],
+        Vec::new(),
+    );
+    let context = package_context(
+        TrustPolicy::default(),
+        vec![backend_with_manifest(
+            "native",
+            backend_root.join("Cargo.toml"),
+        )],
+    );
+
+    let diagnostics = interop_errors(generated, Some(context), "Send probe must fail");
+
+    assert_eq!(diagnostics[0].code, "SIFR-RUST-TYPE-0001");
+    assert!(diagnostics[0].message.contains("Rust bridge probe failed"));
+}
+
+#[test]
 fn package_rust_interop_opaque_rejects_unknown_contract_key() {
     let generated = base_project_with_contracts(
         vec![opaque_class_declaration_entry(vec![
@@ -616,7 +693,7 @@ pub(super) fn target_argument(name: &str, target: &str) -> RustInteropArgument {
     }
 }
 
-pub(super) fn bool_argument(name: &str, value: bool) -> RustInteropArgument {
+fn bool_argument(name: &str, value: bool) -> RustInteropArgument {
     RustInteropArgument {
         name: Some(name.to_string()),
         value: RustInteropValue::Boolean(value),

--- a/crates/sifr_driver/src/build/rust_interop_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_contract_tests.rs
@@ -258,119 +258,6 @@ fn package_rust_interop_direct_probe_accepts_mutable_borrow_signature() {
 }
 
 #[test]
-#[doc = "sifr-evidence: executes-cargo-probe"]
-fn package_rust_interop_opaque_probe_accepts_declared_send_sync_copy() {
-    let backend_root = temp_package_root("rust_interop_opaque_send_sync_copy");
-    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
-    std::fs::write(
-        backend_root.join("Cargo.toml"),
-        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
-    )
-    .expect("write backend cargo toml");
-    std::fs::write(
-        backend_root.join("src/lib.rs"),
-        "#[derive(Clone, Copy)]\npub struct Tokenizer(pub u64);\n",
-    )
-    .expect("write backend lib");
-
-    let generated = base_project_with_contracts(
-        vec![opaque_class_declaration_entry(vec![
-            target_argument("type", "native.Tokenizer"),
-            bool_argument("send", true),
-            bool_argument("sync", true),
-            symbol_argument("clone", "copy"),
-        ])],
-        Vec::new(),
-    );
-    let context = package_context(
-        TrustPolicy::default(),
-        vec![backend_with_manifest(
-            "native",
-            backend_root.join("Cargo.toml"),
-        )],
-    );
-
-    let generated = apply_package_rust_interop_metadata(generated, Some(context))
-        .expect("opaque Send + Sync + Copy type should pass probe");
-    let probe = &generated.interop.rust.probe_plan.probes[0];
-    assert_eq!(probe.kind, sifr_codegen::RustBridgeProbeKind::OpaqueHandle);
-    assert!(probe.requires_send);
-    assert!(probe.requires_sync);
-}
-
-#[test]
-fn package_rust_interop_opaque_probe_rejects_unsatisfied_send_obligation() {
-    let backend_root = temp_package_root("rust_interop_opaque_not_send");
-    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
-    std::fs::write(
-        backend_root.join("Cargo.toml"),
-        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
-    )
-    .expect("write backend cargo toml");
-    std::fs::write(
-        backend_root.join("src/lib.rs"),
-        "pub struct Tokenizer(pub std::rc::Rc<()>);\n",
-    )
-    .expect("write backend lib");
-
-    let generated = base_project_with_contracts(
-        vec![opaque_class_declaration_entry(vec![
-            target_argument("type", "native.Tokenizer"),
-            bool_argument("send", true),
-        ])],
-        Vec::new(),
-    );
-    let context = package_context(
-        TrustPolicy::default(),
-        vec![backend_with_manifest(
-            "native",
-            backend_root.join("Cargo.toml"),
-        )],
-    );
-
-    let diagnostics = interop_errors(generated, Some(context), "Send probe must fail");
-
-    assert_eq!(diagnostics[0].code, "SIFR-RUST-TYPE-0001");
-    assert!(diagnostics[0].message.contains("Rust bridge probe failed"));
-}
-
-#[test]
-fn package_rust_interop_opaque_probe_rejects_unsatisfied_copy_clone_policy() {
-    let backend_root = temp_package_root("rust_interop_opaque_not_copy");
-    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
-    std::fs::write(
-        backend_root.join("Cargo.toml"),
-        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
-    )
-    .expect("write backend cargo toml");
-    std::fs::write(
-        backend_root.join("src/lib.rs"),
-        "#[derive(Clone)]\npub struct Tokenizer(pub String);\n",
-    )
-    .expect("write backend lib");
-
-    let generated = base_project_with_contracts(
-        vec![opaque_class_declaration_entry(vec![
-            target_argument("type", "native.Tokenizer"),
-            symbol_argument("clone", "copy"),
-        ])],
-        Vec::new(),
-    );
-    let context = package_context(
-        TrustPolicy::default(),
-        vec![backend_with_manifest(
-            "native",
-            backend_root.join("Cargo.toml"),
-        )],
-    );
-
-    let diagnostics = interop_errors(generated, Some(context), "Copy probe must fail");
-
-    assert_eq!(diagnostics[0].code, "SIFR-RUST-TYPE-0001");
-    assert!(diagnostics[0].message.contains("Rust bridge probe failed"));
-}
-
-#[test]
 fn package_rust_interop_opaque_rejects_unknown_contract_key() {
     let generated = base_project_with_contracts(
         vec![opaque_class_declaration_entry(vec![
@@ -729,7 +616,7 @@ pub(super) fn target_argument(name: &str, target: &str) -> RustInteropArgument {
     }
 }
 
-fn bool_argument(name: &str, value: bool) -> RustInteropArgument {
+pub(super) fn bool_argument(name: &str, value: bool) -> RustInteropArgument {
     RustInteropArgument {
         name: Some(name.to_string()),
         value: RustInteropValue::Boolean(value),

--- a/crates/sifr_driver/src/build/rust_interop_opaque_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_opaque_contract_tests.rs
@@ -1,11 +1,166 @@
 use super::rust_interop::apply_package_rust_interop_metadata;
 use super::rust_interop_contract_tests::{
-    base_project_with_contracts, interop_errors, opaque_class_declaration_entry, package_context,
-    set_bridge_roots, symbol_argument, target_argument, tokenizer_method_declaration_entry,
+    backend_with_manifest, base_project_with_contracts, bool_argument, interop_errors,
+    opaque_class_declaration_entry, package_context, set_bridge_roots, symbol_argument,
+    target_argument, temp_package_root, tokenizer_method_declaration_entry,
 };
 use sifr_ir::RustInteropDecoratorKind;
 use sifr_package::TrustPolicy;
 use std::path::PathBuf;
+
+#[test]
+#[doc = "sifr-evidence: executes-cargo-probe"]
+fn package_rust_interop_opaque_probe_accepts_declared_send_sync_copy() {
+    let backend_root = temp_package_root("rust_interop_opaque_send_sync_copy");
+    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
+    std::fs::write(
+        backend_root.join("Cargo.toml"),
+        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .expect("write backend cargo toml");
+    std::fs::write(
+        backend_root.join("src/lib.rs"),
+        "#[derive(Clone, Copy)]\npub struct Tokenizer(pub u64);\n",
+    )
+    .expect("write backend lib");
+
+    let generated = base_project_with_contracts(
+        vec![opaque_class_declaration_entry(vec![
+            target_argument("type", "native.Tokenizer"),
+            bool_argument("send", true),
+            bool_argument("sync", true),
+            symbol_argument("clone", "copy"),
+        ])],
+        Vec::new(),
+    );
+    let context = package_context(
+        TrustPolicy::default(),
+        vec![backend_with_manifest(
+            "native",
+            backend_root.join("Cargo.toml"),
+        )],
+    );
+
+    let generated = apply_package_rust_interop_metadata(generated, Some(context))
+        .expect("opaque Send + Sync + Copy type should pass probe");
+    let probe = &generated.interop.rust.probe_plan.probes[0];
+    assert_eq!(probe.kind, sifr_codegen::RustBridgeProbeKind::OpaqueHandle);
+    assert!(probe.requires_send);
+    assert!(probe.requires_sync);
+}
+
+#[test]
+fn package_rust_interop_opaque_probe_rejects_unsatisfied_send_obligation() {
+    let backend_root = temp_package_root("rust_interop_opaque_not_send");
+    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
+    std::fs::write(
+        backend_root.join("Cargo.toml"),
+        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .expect("write backend cargo toml");
+    std::fs::write(
+        backend_root.join("src/lib.rs"),
+        "pub struct Tokenizer(pub std::rc::Rc<()>);\n",
+    )
+    .expect("write backend lib");
+
+    let generated = base_project_with_contracts(
+        vec![opaque_class_declaration_entry(vec![
+            target_argument("type", "native.Tokenizer"),
+            bool_argument("send", true),
+        ])],
+        Vec::new(),
+    );
+    let context = package_context(
+        TrustPolicy::default(),
+        vec![backend_with_manifest(
+            "native",
+            backend_root.join("Cargo.toml"),
+        )],
+    );
+
+    let diagnostics = interop_errors(generated, Some(context), "Send probe must fail");
+
+    assert_eq!(diagnostics[0].code, "SIFR-RUST-TYPE-0001");
+    assert!(diagnostics[0].message.contains("Rust bridge probe failed"));
+}
+
+#[test]
+fn package_rust_interop_opaque_probe_rejects_unsatisfied_copy_clone_policy() {
+    let backend_root = temp_package_root("rust_interop_opaque_not_copy");
+    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
+    std::fs::write(
+        backend_root.join("Cargo.toml"),
+        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .expect("write backend cargo toml");
+    std::fs::write(
+        backend_root.join("src/lib.rs"),
+        "#[derive(Clone)]\npub struct Tokenizer(pub String);\n",
+    )
+    .expect("write backend lib");
+
+    let generated = base_project_with_contracts(
+        vec![opaque_class_declaration_entry(vec![
+            target_argument("type", "native.Tokenizer"),
+            symbol_argument("clone", "copy"),
+        ])],
+        Vec::new(),
+    );
+    let context = package_context(
+        TrustPolicy::default(),
+        vec![backend_with_manifest(
+            "native",
+            backend_root.join("Cargo.toml"),
+        )],
+    );
+
+    let diagnostics = interop_errors(generated, Some(context), "Copy probe must fail");
+
+    assert_eq!(diagnostics[0].code, "SIFR-RUST-TYPE-0001");
+    assert!(diagnostics[0].message.contains("Rust bridge probe failed"));
+}
+
+#[test]
+#[doc = "sifr-evidence: executes-cargo-probe"]
+fn package_rust_interop_same_path_mapping_failure_is_structured() {
+    let backend_root = temp_package_root("rust_interop_same_path_mapping");
+    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
+    std::fs::write(
+        backend_root.join("Cargo.toml"),
+        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .expect("write backend cargo toml");
+    std::fs::write(backend_root.join("src/lib.rs"), "pub struct Tokenizer;\n")
+        .expect("write backend lib");
+
+    let generated = base_project_with_contracts(
+        vec![opaque_class_declaration_entry(vec![
+            target_argument("type", "native.Tokenizer"),
+            target_argument("structural", "native.Tokenizer"),
+        ])],
+        Vec::new(),
+    );
+    let context = package_context(
+        TrustPolicy::default(),
+        vec![backend_with_manifest(
+            "native",
+            backend_root.join("Cargo.toml"),
+        )],
+    );
+
+    let diagnostics = interop_errors(generated, Some(context), "mapping probe must fail");
+
+    assert_eq!(
+        diagnostics[0].code, "SIFR-RUST-TYPE-0001",
+        "{diagnostics:#?}"
+    );
+    assert!(diagnostics[0].message.contains("Rust bridge probe failed"));
+    assert!(diagnostics[0]
+        .children
+        .iter()
+        .any(|child| child.message.contains("StructuralMapping")));
+}
 
 #[test]
 fn package_rust_interop_opaque_close_policy_requires_close_method_contract() {

--- a/crates/sifr_driver/src/build/rust_interop_opaque_contract_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_opaque_contract_tests.rs
@@ -1,89 +1,12 @@
 use super::rust_interop::apply_package_rust_interop_metadata;
 use super::rust_interop_contract_tests::{
-    backend_with_manifest, base_project_with_contracts, bool_argument, interop_errors,
+    backend_with_manifest, base_project_with_contracts, interop_errors,
     opaque_class_declaration_entry, package_context, set_bridge_roots, symbol_argument,
     target_argument, temp_package_root, tokenizer_method_declaration_entry,
 };
 use sifr_ir::RustInteropDecoratorKind;
 use sifr_package::TrustPolicy;
 use std::path::PathBuf;
-
-#[test]
-#[doc = "sifr-evidence: executes-cargo-probe"]
-fn package_rust_interop_opaque_probe_accepts_declared_send_sync_copy() {
-    let backend_root = temp_package_root("rust_interop_opaque_send_sync_copy");
-    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
-    std::fs::write(
-        backend_root.join("Cargo.toml"),
-        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
-    )
-    .expect("write backend cargo toml");
-    std::fs::write(
-        backend_root.join("src/lib.rs"),
-        "#[derive(Clone, Copy)]\npub struct Tokenizer(pub u64);\n",
-    )
-    .expect("write backend lib");
-
-    let generated = base_project_with_contracts(
-        vec![opaque_class_declaration_entry(vec![
-            target_argument("type", "native.Tokenizer"),
-            bool_argument("send", true),
-            bool_argument("sync", true),
-            symbol_argument("clone", "copy"),
-        ])],
-        Vec::new(),
-    );
-    let context = package_context(
-        TrustPolicy::default(),
-        vec![backend_with_manifest(
-            "native",
-            backend_root.join("Cargo.toml"),
-        )],
-    );
-
-    let generated = apply_package_rust_interop_metadata(generated, Some(context))
-        .expect("opaque Send + Sync + Copy type should pass probe");
-    let probe = &generated.interop.rust.probe_plan.probes[0];
-    assert_eq!(probe.kind, sifr_codegen::RustBridgeProbeKind::OpaqueHandle);
-    assert!(probe.requires_send);
-    assert!(probe.requires_sync);
-}
-
-#[test]
-fn package_rust_interop_opaque_probe_rejects_unsatisfied_send_obligation() {
-    let backend_root = temp_package_root("rust_interop_opaque_not_send");
-    std::fs::create_dir_all(backend_root.join("src")).expect("create backend src");
-    std::fs::write(
-        backend_root.join("Cargo.toml"),
-        "[package]\nname = \"native\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
-    )
-    .expect("write backend cargo toml");
-    std::fs::write(
-        backend_root.join("src/lib.rs"),
-        "pub struct Tokenizer(pub std::rc::Rc<()>);\n",
-    )
-    .expect("write backend lib");
-
-    let generated = base_project_with_contracts(
-        vec![opaque_class_declaration_entry(vec![
-            target_argument("type", "native.Tokenizer"),
-            bool_argument("send", true),
-        ])],
-        Vec::new(),
-    );
-    let context = package_context(
-        TrustPolicy::default(),
-        vec![backend_with_manifest(
-            "native",
-            backend_root.join("Cargo.toml"),
-        )],
-    );
-
-    let diagnostics = interop_errors(generated, Some(context), "Send probe must fail");
-
-    assert_eq!(diagnostics[0].code, "SIFR-RUST-TYPE-0001");
-    assert!(diagnostics[0].message.contains("Rust bridge probe failed"));
-}
 
 #[test]
 fn package_rust_interop_opaque_probe_rejects_unsatisfied_copy_clone_policy() {

--- a/crates/sifr_driver/src/build/rust_interop_probe.rs
+++ b/crates/sifr_driver/src/build/rust_interop_probe.rs
@@ -78,7 +78,11 @@ pub(super) fn execute_direct_cargo_probe(
     let requires_structural_runtime = probe
         .signature
         .as_ref()
-        .is_some_and(|signature| !signature.structural_type_params.is_empty());
+        .is_some_and(|signature| !signature.structural_type_params.is_empty())
+        || sifr_ir::rust_opaque_structural_mapping(std::slice::from_ref(
+            &probe.declaration.declaration,
+        ))
+        .is_some();
     let probe_manifest = probe_cargo_toml(
         &probe.backend.dependency_name,
         &probe.backend.cargo_package_name,

--- a/crates/sifr_lowering/src/lower/rust_interop.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop.rs
@@ -28,29 +28,19 @@ pub(in crate::lower) fn collect_rust_opaque_close_methods(stmts: &[Stmt], ctx: &
         let Stmt::ClassDef(class_def) = stmt else {
             continue;
         };
-        let opaque = rust_opaque_decorator_call(&class_def.decorator_list);
-        let Some(opaque) = opaque else {
+        let Some(opaque) = rust_opaque_decorator_call(&class_def.decorator_list) else {
             continue;
         };
         ctx.rust_opaque_classes.insert(class_def.name.to_string());
-        if has_valid_rust_opaque_structural_mapping_syntax(opaque) {
+        let Some(declaration) = parse_rust_opaque_for_prescan(opaque, ctx) else {
+            continue;
+        };
+        let declaration = std::slice::from_ref(&declaration);
+        if sifr_ir::rust_opaque_structural_mapping(declaration).is_some() {
             ctx.rust_structural_classes
                 .insert(class_def.name.to_string());
         }
-        let close_method = opaque.arguments.keywords.iter().find_map(|keyword| {
-            if keyword
-                .arg
-                .as_ref()
-                .is_none_or(|name| name.as_str() != "close")
-            {
-                return None;
-            }
-            match &keyword.value {
-                Expr::Name(policy) if policy.id.as_str() == "close" => Some("close"),
-                Expr::Name(policy) if policy.id.as_str() == "async_close" => Some("aclose"),
-                _ => None,
-            }
-        });
+        let close_method = sifr_ir::rust_opaque_close_method(declaration);
         if let Some(close_method) = close_method {
             ctx.rust_consuming_methods
                 .insert(format!("{}.{}", class_def.name, close_method));
@@ -58,14 +48,24 @@ pub(in crate::lower) fn collect_rust_opaque_close_methods(stmts: &[Stmt], ctx: &
     }
 }
 
-fn has_valid_rust_opaque_structural_mapping_syntax(opaque: &ExprCall) -> bool {
-    opaque.arguments.keywords.iter().any(|keyword| {
-        keyword
-            .arg
-            .as_ref()
-            .is_some_and(|name| name.as_str() == "structural")
-            && target_path_segments(&keyword.value, RustInteropOwner::Class).is_ok()
-    })
+/// Use the canonical parser for pre-scan capabilities. Normal class lowering
+/// remains responsible for emitting any declaration diagnostic.
+fn parse_rust_opaque_for_prescan(
+    opaque: &ExprCall,
+    ctx: &mut LowerCtx,
+) -> Option<RustInteropDeclaration> {
+    let previous_error_count = ctx.errors.len();
+    let previous_error_taint = ctx.last_error_taint;
+    let declaration = parse_declaration(
+        RustInteropDecoratorKind::Opaque,
+        opaque,
+        RustInteropOwner::Class,
+        false,
+        ctx,
+    );
+    ctx.errors.truncate(previous_error_count);
+    ctx.last_error_taint = previous_error_taint;
+    declaration
 }
 
 pub(in crate::lower) fn has_rust_opaque_structural_mapping_syntax(
@@ -724,4 +724,51 @@ fn malformed(ctx: &mut LowerCtx, reason: impl std::fmt::Display, span: TextRange
         format!("malformed Rust interop decorator: {reason}"),
         span,
     );
+}
+
+#[cfg(test)]
+mod prescan_tests {
+    use super::{collect_rust_opaque_close_methods, LowerCtx};
+    use sifr_python_parser::parse_module;
+
+    fn prescan(source: &str) -> LowerCtx {
+        let parsed = parse_module(source).expect("source must parse");
+        let mut ctx = LowerCtx::new();
+        collect_rust_opaque_close_methods(parsed.suite(), &mut ctx);
+        ctx
+    }
+
+    #[test]
+    fn opaque_prescan_gates_capabilities_on_complete_declarations() {
+        let incomplete = prescan(
+            r#"
+@rust.opaque(
+    type=bridge.token.Token,
+    structural=bridge.token.TokenMapping,
+    close="invalid",
+)
+class Token:
+    pass
+"#,
+        );
+        assert!(incomplete.rust_opaque_classes.contains("Token"));
+        assert!(incomplete.rust_structural_classes.is_empty());
+        assert!(incomplete.rust_consuming_methods.is_empty());
+        assert!(incomplete.errors.is_empty());
+
+        let complete = prescan(
+            r"
+@rust.opaque(
+    type=bridge.token.Token,
+    structural=bridge.token.TokenMapping,
+    close=none,
+)
+class Token:
+    pass
+",
+        );
+        assert!(complete.rust_opaque_classes.contains("Token"));
+        assert!(complete.rust_structural_classes.contains("Token"));
+        assert!(complete.errors.is_empty());
+    }
 }

--- a/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
+++ b/crates/sifr_lowering/src/lower/rust_interop_structural_tests.rs
@@ -582,6 +582,28 @@ def use(value: Token) -> None:
 }
 
 #[test]
+fn incomplete_opaque_declaration_remains_diagnostic() {
+    let errors = lower_errors(
+        r#"
+@rust.opaque(
+    type=bridge.token.Token,
+    structural=bridge.token.TokenMapping,
+    close="invalid",
+)
+class Token:
+    pass
+"#,
+    );
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::RUST_CONFIG_MALFORMED_DECORATOR)
+            && error
+                .message
+                .contains("string decorator values are not part of the Rust interop grammar")
+    }));
+}
+
+#[test]
 fn structural_bound_rejects_enum_discriminant_overflow() {
     let errors = lower_errors(
         r"


### PR DESCRIPTION
Closes #3391

- keeps syntactic opaque-resource identity fail closed while granting structural and consuming pre-scan capabilities only from the canonical parsed declaration
- preserves malformed-decorator diagnostics during normal class lowering
- enables the sifr_runtime structural feature for mapped opaque cargo probes
- adds an end-to-end same-path missing StructuralMapping diagnostic
- moves opaque cargo-probe tests into the existing opaque-contract test module to preserve file-size headroom

Candidate: 117b90baf587795f209aafa013a659ccb818a006