### PR TITLE
Canonicalize generic-call and attached-set lookups

### DIFF
--- a/crates/sifr_codegen/src/method_call_emitter.rs
+++ b/crates/sifr_codegen/src/method_call_emitter.rs
@@ -50,10 +50,32 @@ impl RustEmitter {
 
     /// Check if an expression is a call to a generator function
     pub(crate) fn is_generator_call(&self, expr: &HirExpr) -> bool {
-        if let HirExpr::Call { func, .. } = expr {
-            self.generator_functions.contains(func)
-        } else {
-            false
-        }
+        matches!(
+            expr,
+            HirExpr::Call { func, .. } | HirExpr::GenericCall { func, .. }
+                if self.generator_functions.contains(
+                    crate::stmt_support_emitter::canonical_plain_call_name_for_ir(func)
+                )
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generic_generator_calls_use_the_canonical_function_name() {
+        let mut emitter = RustEmitter::new();
+        emitter.generator_functions.insert("produce".to_string());
+        let expression = HirExpr::GenericCall {
+            func: "produce::<i64>".to_string(),
+            type_args: vec![Type::Int],
+            args: Vec::new(),
+            mutable_arg_places: Vec::new(),
+            ty: Type::Iterator(Box::new(Type::Int)),
+        };
+
+        assert!(emitter.is_generator_call(&expression));
     }
 }

--- a/crates/sifr_codegen/src/python_interop_plan.rs
+++ b/crates/sifr_codegen/src/python_interop_plan.rs
@@ -270,8 +270,13 @@ fn module_requires_raw_coroutine_loop(module: &HirModule) -> bool {
     }
     let mut required = false;
     let mut inspect = |expression: &sifr_ir::HirExpr| {
-        if matches!(expression, sifr_ir::HirExpr::Call { func, .. } if raw_call_names.contains(func))
-        {
+        if matches!(
+            expression,
+            sifr_ir::HirExpr::Call { func, .. } | sifr_ir::HirExpr::GenericCall { func, .. }
+                if raw_call_names.contains(
+                    crate::stmt_support_emitter::canonical_plain_call_name_for_ir(func)
+                )
+        ) {
             required = true;
         }
     };

--- a/crates/sifr_codegen/src/python_interop_plan_tests.rs
+++ b/crates/sifr_codegen/src/python_interop_plan_tests.rs
@@ -164,6 +164,32 @@ fn aliased_raw_coroutine_call_requires_the_owned_async_loop() {
 }
 
 #[test]
+fn generic_raw_coroutine_call_requires_the_owned_async_loop() {
+    let mut module = module_with_functions(vec![function(
+        "main",
+        vec![HirStmt::Expr {
+            expr: HirExpr::GenericCall {
+                mutable_arg_places: Vec::new(),
+                func: "run_coroutine_blocking::<Object>".to_string(),
+                type_args: vec![Type::Any],
+                args: Vec::new(),
+                ty: Type::None,
+            },
+        }],
+        Vec::new(),
+    )]);
+    module.imports.push(HirImport {
+        module: "sifr.python".to_string(),
+        names: vec!["run_coroutine_blocking".to_string()],
+        aliases: Vec::new(),
+    });
+
+    let plan = interop_build_plan_for_named_modules([(Some("main"), &module)]);
+
+    assert!(plan.python.requires_async_loop);
+}
+
+#[test]
 fn sync_python_declaration_does_not_require_the_owned_async_loop() {
     let module = module_with_functions(vec![function("main", Vec::new(), Vec::new())]);
     let plan = interop_build_plan_for_named_modules([(Some("main"), &module)]);

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_method_and_question_mark.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_method_and_question_mark.rs
@@ -4,6 +4,20 @@ use super::{
     is_result_int_division_error_type, unwrap_compiler_verified_nonempty_pop_result_for_ir,
     HirExpr, HirFStringPart, RustEmitter, Type,
 };
+
+fn is_imported_project_call_for_ir(
+    expression: &HirExpr,
+    imported_project_functions: &std::collections::HashSet<String>,
+) -> bool {
+    matches!(
+        expression,
+        HirExpr::Call { func, .. }
+            | HirExpr::GenericCall { func, .. }
+            | HirExpr::PythonCall { func, .. }
+            if imported_project_functions.contains(canonical_plain_call_name_for_ir(func))
+    )
+}
+
 macro_rules! stmt_expr_method_call {
     ($emitter:ident, $expr:ident) => {{
         if let HirExpr::MethodCall {
@@ -340,10 +354,9 @@ macro_rules! stmt_expr_question_mark {
                         .last()
                         .and_then(Option::as_ref)
                         .cloned();
-                    let imported_project_call = matches!(
+                    let imported_project_call = is_imported_project_call_for_ir(
                         inner.as_ref(),
-                        HirExpr::Call { func, .. } | HirExpr::PythonCall { func, .. }
-                            if $emitter.imported_project_functions.contains(func)
+                        &$emitter.imported_project_functions,
                     );
                     if imported_project_call
                         && inner_err_ty.is_python_error_contract()
@@ -353,9 +366,7 @@ macro_rules! stmt_expr_question_mark {
                     {
                         let target_name = target_error_info
                             .as_ref()
-                            .map(|ty| {
-                                crate::render_type(&crate::sifr_type_to_rust_type(ty))
-                            })
+                            .map(|ty| crate::render_type(&crate::sifr_type_to_rust_type(ty)))
                             .unwrap_or_else(|| target_err_ty.clone());
                         let field = |name: &str| crate::RustExpr::Field {
                             expr: Box::new(error_ident.clone()),
@@ -391,12 +402,12 @@ macro_rules! stmt_expr_question_mark {
                         ))));
                     }
                     let converted_error = target_error_info.as_ref().map(|target| {
-                            $emitter.consuming_value_upcast_for_ir(
-                                target,
-                                inner_err_ty,
-                                error_ident.clone(),
-                            )
-                        });
+                        $emitter.consuming_value_upcast_for_ir(
+                            target,
+                            inner_err_ty,
+                            error_ident.clone(),
+                        )
+                    });
                     if converted_error
                         .as_ref()
                         .is_some_and(|converted| converted != &error_ident)
@@ -456,6 +467,25 @@ macro_rules! stmt_expr_question_mark {
             return Ok(Some(crate::RustExpr::Try(Box::new(lowered_inner))));
         }
     }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generic_imported_project_calls_use_the_canonical_function_name() {
+        let expression = HirExpr::GenericCall {
+            func: "load::<i64>".to_string(),
+            type_args: vec![Type::Int],
+            args: Vec::new(),
+            mutable_arg_places: Vec::new(),
+            ty: Type::None,
+        };
+        let imported = std::collections::HashSet::from(["load".to_string()]);
+
+        assert!(is_imported_project_call_for_ir(&expression, &imported));
+    }
 }
 
 impl RustEmitter {

--- a/crates/sifr_lowering/src/lower/descriptor_declarations.rs
+++ b/crates/sifr_lowering/src/lower/descriptor_declarations.rs
@@ -247,9 +247,10 @@ fn import_bindings(stmts: &[Stmt], ctx: &mut LowerCtx) {
             }
             if ctx
                 .externals
-                .attached_api_sets
-                .get(&module)
-                .is_some_and(|exports| exports.contains_key(&original))
+                .contains_attached_api_set(&sifr_ir::AttachedApiSetIdentity {
+                    module: module.clone(),
+                    symbol: original,
+                })
             {
                 ctx.attached_api_set_bindings.insert(local.clone());
             }

--- a/crates/sifr_lowering/src/lower/name_import_diagnostics_tests.rs
+++ b/crates/sifr_lowering/src/lower/name_import_diagnostics_tests.rs
@@ -229,6 +229,43 @@ fn public_sysroot_stdlib_source_resolves_compiled_private_classes() {
 }
 
 #[test]
+fn attached_api_set_import_requires_the_stored_canonical_identity() {
+    let source = "from declared import Api\n\nclass Child(Api):\n    pass\n";
+    let parsed = parse_module(source).expect("parse failed");
+    let mut externals = ExternalDefs::default();
+    externals.classes.insert(
+        "declared".to_string(),
+        HashMap::from([(
+            "Api".to_string(),
+            Type::Class {
+                identity: None,
+                type_args: Vec::new(),
+                name: "Api".to_string(),
+                fields: Vec::new(),
+                methods: Vec::new(),
+                parent_class: None,
+            },
+        )]),
+    );
+    externals.attached_api_sets.insert(
+        "declared".to_string(),
+        HashMap::from([(
+            "Api".to_string(),
+            sifr_ir::AttachedApiSetDeclaration {
+                identity: sifr_ir::AttachedApiSetIdentity {
+                    module: "actual".to_string(),
+                    symbol: "Api".to_string(),
+                },
+                range: ruff_text_size::TextRange::default(),
+            },
+        )]),
+    );
+
+    lower_module_with_externals(parsed.suite(), &externals)
+        .expect("a mismatched stored identity must not erase the imported class");
+}
+
+#[test]
 fn builtin_open_preserves_an_aliased_imported_text_handle_identity() {
     let source = "from sifr.io import TextFileHandle as Handle\n\ndef main():\n    handle: Handle = open(\"out.txt\", \"w\", encoding=\"utf-8\")\n    handle.close()\n";
     let parsed = parse_module(source).expect("parse failed");


### PR DESCRIPTION
Closes #3394.

## Summary
- canonicalize generator, raw-coroutine, and imported-project call lookups across plain and generic HIR calls
- require exact stored identity before registering an imported attached-API set binding
- add focused regressions for every corrected lookup

## Validation
- `cargo test -p sifr_codegen`
- `cargo test -p sifr_lowering`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `python3 scripts/check_sifr_driver_maintainability_guardrails.py`
- `python3 scripts/check_file_size_guardrails.py`
- `git diff --check`

Exact-SHA Opus review and the one-time compiler gates remain pending.

Out of scope: the separate `pre_v1` session `01a01407-6090-7a53-8ebc-c1c8f8cf0eec` and its worktree, processes, artifacts, failures, and fixes.