### PR TITLE
Reserve structural construction field temporaries

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_impl_demand_codegen_tests.rs
@@ -49,11 +49,12 @@ fn structural_construction_uses_checked_defaults_for_missing_fields() {
 fn structural_construction_checks_required_fields_before_default_factories() {
     let mut payload = payload_class();
     payload.fields = vec![
+        ("description".to_string(), Type::Str),
         ("names".to_string(), Type::List(Box::new(Type::Str))),
         ("required".to_string(), Type::Int),
     ];
     payload.field_defaults = vec![(
-        0,
+        1,
         HirExpr::Call {
             func: "description".to_string(),
             args: Vec::new(),
@@ -61,18 +62,27 @@ fn structural_construction_checks_required_fields_before_default_factories() {
             ty: Type::List(Box::new(Type::Str)),
         },
     )];
-    payload.field_default_identities = vec![(0, "callable[main.description]".to_string())];
+    payload.field_default_identities = vec![(1, "callable[main.description]".to_string())];
     let module = module(vec![structural_function()], vec![payload]);
 
     let generated = generate_rust(&module);
     let required_check = generated
-        .find("if __sifr_child_nodes[1].is_none()")
+        .find("if __sifr_child_nodes[2].is_none()")
         .unwrap_or_else(|| panic!("required-field precheck must be emitted: {generated}"));
     let factory_call = generated
         .find("None => description()")
         .expect("checked default factory must remain callable");
 
     assert!(required_check < factory_call, "{generated}");
+    let first_field = generated
+        .find("let (__sifr_field_0, __sifr_field_1, __sifr_field_2,) =")
+        .expect("field construction must use reserved tuple temporaries");
+    assert!(first_field < factory_call, "{generated}");
+    assert!(!generated.contains("let description ="), "{generated}");
+    assert!(
+        generated.contains("description: __sifr_field_0, names: __sifr_field_1"),
+        "record initialization must map reserved temporaries explicitly: {generated}"
+    );
     assert!(
         generated.contains("let __sifr_description = __sifr_source.node(__sifr_node)?;"),
         "generated locals must not shadow default callables: {generated}"
@@ -387,8 +397,8 @@ fn structural_impls_escape_rust_keyword_field_identifiers() {
     let generated = generate_rust_multi(&[("models", &models), ("api", &api)]);
     let models_rust = generated.get("models").expect("models module is generated");
 
-    assert!(models_rust.contains("let r#type ="));
-    assert!(models_rust.contains("Ok(Self { r#type })"));
+    assert!(models_rust.contains("let (__sifr_field_0,) ="));
+    assert!(models_rust.contains("Ok(Self { r#type: __sifr_field_0 })"));
     assert!(models_rust.contains("&self.r#type"));
     assert!(models_rust.contains("RecordField"));
     assert!(models_rust.contains("\"type\""));

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_inheritance_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_inheritance_codegen_tests.rs
@@ -78,7 +78,7 @@ fn concrete_generic_child_flattens_parent_fields_for_structural_bridge() {
     assert!(main_rust.contains("RecordField(\"value\")"), "{main_rust}");
     assert!(main_rust.contains("RecordField(\"label\")"), "{main_rust}");
     assert!(
-        main_rust.contains("genericparent: <GenericParent<i64>>::new(value)"),
+        main_rust.contains("genericparent: <GenericParent<i64>>::new(__sifr_field_0)"),
         "{main_rust}"
     );
 
@@ -144,7 +144,7 @@ fn plain_data_parent_flattens_into_structural_child_impls() {
     );
     assert!(generated.contains("RecordField(\"value\")"), "{generated}");
     assert!(
-        generated.contains("parent: <Parent>::new(value)"),
+        generated.contains("parent: <Parent>::new(__sifr_field_0)"),
         "{generated}"
     );
 }

--- a/crates/sifr_codegen/src/structural_impl_codegen.rs
+++ b/crates/sifr_codegen/src/structural_impl_codegen.rs
@@ -546,11 +546,10 @@ fn structural_construct_impl(
         })
         .collect::<Vec<_>>()
         .join("\n");
-    let mut field_values = Vec::with_capacity(fields.len());
+    let mut field_initializers = Vec::with_capacity(fields.len());
     for (index, field) in fields.iter().enumerate() {
         let name = field.name;
         let ty = field.ty;
-        let rust_name = crate::Renderer::render_identifier(name);
         let present = if matches!(ty.resolve_alias(), Type::Bytes) {
             format!(
                 "{STRUCTURAL}::construct_bytes_at(__sifr_source, __sifr_child, __sifr_construct_token)?"
@@ -574,11 +573,22 @@ fn structural_construct_impl(
                     crate::render::render_expr(&value)
                 },
             );
-        field_values.push(format!(
-            "let {rust_name} = match __sifr_child_nodes[{index}] {{ Some(__sifr_child) => {present}, None => {missing}, }};"
+        field_initializers.push(format!(
+            "match __sifr_child_nodes[{index}] {{ Some(__sifr_child) => {present}, None => {missing}, }}"
         ));
     }
-    let field_values = field_values.join("\n");
+    let field_values = if field_initializers.is_empty() {
+        String::new()
+    } else {
+        let local_names = (0..field_initializers.len())
+            .map(|index| format!("__sifr_field_{index}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "let ({local_names},) = ({},);",
+            field_initializers.join(", ")
+        )
+    };
     let required_prechecks = fields
         .iter()
         .enumerate()
@@ -595,10 +605,11 @@ fn structural_construct_impl(
         })
         .collect::<Vec<_>>()
         .join("\n");
-    let inherited_names = fields
+    let inherited_values = fields
         .iter()
-        .filter(|field| field.inherited)
-        .map(|field| crate::Renderer::render_identifier(field.name))
+        .enumerate()
+        .filter(|(_, field)| field.inherited)
+        .map(|(index, _)| format!("__sifr_field_{index}"))
         .collect::<Vec<_>>();
     let mut initializers = Vec::new();
     if let (Some(parent_name), Some(parent_type)) = (&class.parent_class, &class.parent_type) {
@@ -607,14 +618,20 @@ fn structural_construct_impl(
         initializers.push(format!(
             "{}: <{parent_rust_type}>::new({})",
             parent_name.to_lowercase(),
-            inherited_names.join(", ")
+            inherited_values.join(", ")
         ));
     }
     initializers.extend(
         fields
             .iter()
-            .filter(|field| !field.inherited)
-            .map(|field| crate::Renderer::render_identifier(field.name)),
+            .enumerate()
+            .filter(|(_, field)| !field.inherited)
+            .map(|(index, field)| {
+                format!(
+                    "{}: __sifr_field_{index}",
+                    crate::Renderer::render_identifier(field.name)
+                )
+            }),
     );
     if RustEmitter::class_needs_phantom_marker(class) {
         initializers.push("__sifr_type_marker: std::marker::PhantomData".to_string());

--- a/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
@@ -48,6 +48,7 @@ class StructuralDefaults(Contract):
     enabled: bool = contract_field(default=True)
     tags: list[str] = contract_field(default_factory=list)
     names: list[str] = contract_field(default_factory=make_names)
+    description: str = contract_field(default="field")
     descriptions: list[str] = contract_field(default_factory=description)
 
 
@@ -111,6 +112,7 @@ def main() -> Result[None, ContractError | RustPanicError]:
         assert defaulted.enabled
         assert defaulted.tags == []
         assert defaulted.names == []
+        assert defaulted.description == "field"
         assert defaulted.descriptions == []
         another: StructuralDefaults = StructuralDefaults.construct()
         defaulted.tags.append("one")


### PR DESCRIPTION
Closes #3400.

## Summary
- construct structural fields into one reserved tuple binding so no per-field local can shadow any default expression
- initialize record fields explicitly from indexed compiler temporaries
- retain inherited parent-constructor argument order and escaped Rust field names
- certify the real package-neutral fixture with a `description` field before `default_factory=description`

## Validation
- `cargo test -p sifr_codegen`: 1,080 passed
- `cargo test -p sifr_driver adapter_defaults`: 15 passed
- static-class-adapter fixture built and ran, printing `attached-contract`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- both maintainability guards
- 900-line file-size guard
- `git diff --check`

Exact-SHA Opus review and the one-time compiler gates remain pending.

Out of scope: the separate `pre_v1` session `01a01407-6090-7a53-8ebc-c1c8f8cf0eec` and its worktree, processes, artifacts, failures, and fixes.