### PR TITLE
Isolate ordinary if branch cache state

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -79,6 +79,8 @@ mod receiver_codegen_tests;
 #[cfg(test)]
 mod recursive_node_codegen_tests;
 #[cfg(test)]
+mod string_char_cache_branch_codegen_tests;
+#[cfg(test)]
 mod string_concat_codegen_tests;
 #[cfg(test)]
 mod structural_impl_demand_codegen_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/string_char_cache_branch_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/string_char_cache_branch_codegen_tests.rs
@@ -24,3 +24,28 @@ def count_text(enabled: bool, flag: bool) -> int:
         "branch and outer declarations need separate caches:\n{generated}"
     );
 }
+
+#[test]
+fn walrus_if_branch_string_cache_does_not_suppress_later_declaration() {
+    let generated = generate_rust_from_source(
+        r#"
+def count_text(enabled: bool) -> int:
+    selected: int = 0
+    if enabled:
+        if (value := 1) > 0:
+            text: str = "left"
+            selected = len(text)
+        text: str = "right"
+        selected += len(text)
+    return selected
+"#,
+    );
+
+    assert_eq!(
+        generated
+            .matches("let __sifr_chars_text: Vec<char> = text.chars().collect")
+            .count(),
+        2,
+        "walrus branch and outer declarations need separate caches:\n{generated}"
+    );
+}

--- a/crates/sifr_codegen/src/lib_codegen_tests/string_char_cache_branch_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/string_char_cache_branch_codegen_tests.rs
@@ -1,0 +1,26 @@
+use super::generate_rust_from_source;
+
+#[test]
+fn branch_local_string_cache_does_not_suppress_later_declaration() {
+    let generated = generate_rust_from_source(
+        r#"
+def count_text(enabled: bool, flag: bool) -> int:
+    selected: int = 0
+    if enabled:
+        if flag:
+            text: str = "left"
+            selected = len(text)
+        text: str = "right"
+        selected += len(text)
+    return selected
+"#,
+    );
+
+    assert_eq!(
+        generated
+            .matches("let __sifr_chars_text: Vec<char> = text.chars().collect")
+            .count(),
+        2,
+        "branch and outer declarations need separate caches:\n{generated}"
+    );
+}

--- a/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
@@ -582,7 +582,7 @@ impl RustEmitter {
         }))
     }
 
-    fn try_lower_if_branch_for_ir(
+    pub(crate) fn try_lower_if_branch_for_ir(
         &mut self,
         body: &[HirStmt],
     ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {

--- a/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
@@ -358,8 +358,7 @@ impl RustEmitter {
                                     .collect::<Vec<_>>()
                             })
                             .unwrap_or_default();
-                        let Some(lowered_else_body) =
-                            self.try_lower_speculative_branch_for_ir(else_body)?
+                        let Some(lowered_else_body) = self.try_lower_if_branch_for_ir(else_body)?
                         else {
                             return Ok(None);
                         };
@@ -400,8 +399,7 @@ impl RustEmitter {
                         } else {
                             var_name.clone()
                         };
-                        let Some(lowered_body) = self.try_lower_speculative_branch_for_ir(body)?
-                        else {
+                        let Some(lowered_body) = self.try_lower_if_branch_for_ir(body)? else {
                             return Ok(None);
                         };
                         nested_else = Some(vec![RustStmt::IfLet {
@@ -488,7 +486,7 @@ impl RustEmitter {
         }
 
         let mut nested_else = if let Some(else_body) = else_body {
-            let Some(lowered_else) = self.try_lower_stmt_block_for_ir(else_body)? else {
+            let Some(lowered_else) = self.try_lower_if_branch_for_ir(else_body)? else {
                 return Ok(None);
             };
             Some(lowered_else)
@@ -514,7 +512,7 @@ impl RustEmitter {
         then_body: &[HirStmt],
         nested_else: Option<Vec<RustStmt>>,
     ) -> Result<Option<RustStmt>, crate::CodegenError> {
-        let Some(lowered_then_body) = self.try_lower_stmt_block_for_ir(then_body)? else {
+        let Some(lowered_then_body) = self.try_lower_if_branch_for_ir(then_body)? else {
             return Ok(None);
         };
 
@@ -584,7 +582,7 @@ impl RustEmitter {
         }))
     }
 
-    fn try_lower_speculative_branch_for_ir(
+    fn try_lower_if_branch_for_ir(
         &mut self,
         body: &[HirStmt],
     ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
@@ -699,7 +697,7 @@ mod tests {
         ];
 
         let lowered = emitter
-            .try_lower_speculative_branch_for_ir(&body)
+            .try_lower_if_branch_for_ir(&body)
             .expect("speculative lowering must not error");
 
         assert!(lowered.is_none());
@@ -721,7 +719,7 @@ mod tests {
         }];
 
         let lowered = emitter
-            .try_lower_speculative_branch_for_ir(&body)
+            .try_lower_if_branch_for_ir(&body)
             .expect("speculative lowering must not error");
 
         assert!(lowered.is_some());

--- a/crates/sifr_codegen/src/stmt_support_emitter/structured_return_if_while.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/structured_return_if_while.rs
@@ -239,7 +239,7 @@ impl RustEmitter {
                     else {
                         return Ok(false);
                     };
-                    let Some(lowered_then_body) = self.try_lower_stmt_block_for_ir(then_body)?
+                    let Some(lowered_then_body) = self.try_lower_if_branch_for_ir(then_body)?
                     else {
                         return Ok(false);
                     };


### PR DESCRIPTION
Closes #3403.

Makes string-character cache bookkeeping transactional for every lowered if branch, including ordinary non-union then/elif/else bodies. A focused source regression verifies that a branch-local cache cannot suppress a later same-named cache declaration in its enclosing block.

Validation before freeze:
- cargo test -p sifr_codegen (1081 passed)
- cargo clippy -p sifr_codegen -- -D warnings
- cargo fmt --check
- python3 scripts/check_hir_maintainability_guardrails.py
- git diff --check
- touched first-party files remain below 900 lines