### PR TITLE
Isolate statement-level union branch cache state

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests/string_char_cache_branch_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/string_char_cache_branch_codegen_tests.rs
@@ -49,3 +49,31 @@ def count_text(enabled: bool) -> int:
         "walrus branch and outer declarations need separate caches:\n{generated}"
     );
 }
+
+#[test]
+fn statement_union_branches_use_separate_string_caches() {
+    let generated = generate_rust_from_source(
+        r#"
+def count_text(value: int | str | float) -> int:
+    selected: int = 0
+    if isinstance(value, int):
+        text: str = "int"
+        selected = len(text)
+    elif isinstance(value, str):
+        text: str = "string"
+        selected = len(text)
+    else:
+        text: str = "float"
+        selected = len(text)
+    return selected
+"#,
+    );
+
+    assert_eq!(
+        generated
+            .matches("let __sifr_chars_text: Vec<char> = text.chars().collect")
+            .count(),
+        3,
+        "each union branch needs its own cache declaration:\n{generated}"
+    );
+}

--- a/crates/sifr_codegen/src/stmt_support_emitter/structured_return_if_while.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/structured_return_if_while.rs
@@ -294,7 +294,7 @@ impl RustEmitter {
                                 .collect::<Vec<_>>()
                         })
                         .unwrap_or_default();
-                    let Some(lowered_else_body) = self.try_lower_stmt_block_for_ir(else_body)?
+                    let Some(lowered_else_body) = self.try_lower_if_branch_for_ir(else_body)?
                     else {
                         return Ok(false);
                     };
@@ -334,7 +334,7 @@ impl RustEmitter {
                     } else {
                         var_name.clone()
                     };
-                    let Some(lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
+                    let Some(lowered_body) = self.try_lower_if_branch_for_ir(body)? else {
                         return Ok(false);
                     };
                     nested_else = Some(vec![RustStmt::IfLet {
@@ -367,7 +367,7 @@ impl RustEmitter {
                 } else {
                     var_name.clone()
                 };
-                let Some(lowered_then_body) = self.try_lower_stmt_block_for_ir(then_body)? else {
+                let Some(lowered_then_body) = self.try_lower_if_branch_for_ir(then_body)? else {
                     return Ok(false);
                 };
 
@@ -385,7 +385,7 @@ impl RustEmitter {
                     } else {
                         var_name.clone()
                     };
-                    let Some(lowered_else_body) = self.try_lower_stmt_block_for_ir(else_body)?
+                    let Some(lowered_else_body) = self.try_lower_if_branch_for_ir(else_body)?
                     else {
                         return Ok(false);
                     };


### PR DESCRIPTION
Closes #3406.

Routes every statement-level isinstance-union body through the shared transactional if-branch lowering helper. The source regression proves separate cache declarations for narrowed then, elif, and remaining else scopes.

Validation before freeze:
- cargo test -p sifr_codegen (1083 passed)
- cargo clippy --workspace -- -D warnings
- cargo fmt --check
- python3 scripts/check_hir_maintainability_guardrails.py
- git diff --check
- touched files remain below 900 lines