### PR TITLE
Isolate control-flow body cache state

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -81,6 +81,8 @@ mod recursive_node_codegen_tests;
 #[cfg(test)]
 mod string_char_cache_branch_codegen_tests;
 #[cfg(test)]
+mod string_char_cache_control_flow_codegen_tests;
+#[cfg(test)]
 mod string_concat_codegen_tests;
 #[cfg(test)]
 mod structural_impl_demand_codegen_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/string_char_cache_control_flow_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/string_char_cache_control_flow_codegen_tests.rs
@@ -1,0 +1,159 @@
+use super::generate_rust_from_source;
+
+fn cache_declaration_count(generated: &str, name: &str) -> usize {
+    generated
+        .matches(&format!(
+            "let __sifr_chars_{name}: Vec<char> = {name}.chars().collect"
+        ))
+        .count()
+}
+
+#[test]
+fn loop_bodies_do_not_suppress_enclosing_string_caches() {
+    let generated = generate_rust_from_source(
+        r#"
+def count_text(enabled: bool) -> int:
+    total: int = 0
+    if enabled:
+        while total < 1:
+            while_text: str = "while"
+            total += len(while_text)
+        while_text: str = "after while"
+        total += len(while_text)
+
+        while total < 0:
+            pass
+        else:
+            while_else_text: str = "while else"
+            total += len(while_else_text)
+        while_else_text: str = "after while else"
+        total += len(while_else_text)
+
+        for value in [1]:
+            for_text: str = "for"
+            total += value + len(for_text)
+        for_text: str = "after for"
+        total += len(for_text)
+
+    for value in [1]:
+        total += value
+    else:
+        for_else_text: str = "for else"
+        total += len(for_else_text)
+    if enabled:
+        for_else_text: str = "after for else"
+        total += len(for_else_text)
+    return total
+"#,
+    );
+
+    assert_eq!(
+        cache_declaration_count(&generated, "while_text"),
+        2,
+        "{generated}"
+    );
+    assert_eq!(
+        cache_declaration_count(&generated, "while_else_text"),
+        2,
+        "{generated}"
+    );
+    assert_eq!(
+        cache_declaration_count(&generated, "for_text"),
+        2,
+        "{generated}"
+    );
+    assert_eq!(
+        cache_declaration_count(&generated, "for_else_text"),
+        2,
+        "{generated}"
+    );
+}
+
+#[test]
+fn with_body_does_not_suppress_enclosing_string_cache() {
+    let generated = generate_rust_from_source(
+        r#"
+class Resource:
+    def __enter__(self) -> Resource:
+        return self
+
+    def __exit__(self) -> None:
+        pass
+
+def count_text(enabled: bool) -> int:
+    total: int = 0
+    if enabled:
+        with Resource() as resource:
+            with_text: str = "with"
+            total += len(with_text)
+        with_text: str = "after with"
+        total += len(with_text)
+    return total
+"#,
+    );
+
+    assert_eq!(cache_declaration_count(&generated, "with_text"), 2);
+}
+
+#[test]
+fn try_bodies_do_not_suppress_enclosing_string_caches() {
+    let generated = generate_rust_from_source(
+        r#"
+def count_text(enabled: bool, fail: bool) -> int:
+    total: int = 0
+    if enabled:
+        try:
+            body_text: str = "body"
+            total += len(body_text)
+            if fail:
+                raise ValueError("fail")
+        except ValueError:
+            handler_text: str = "handler"
+            total += len(handler_text)
+        finally:
+            final_text: str = "finally"
+            total += len(final_text)
+
+        body_text: str = "after body"
+        total += len(body_text)
+        handler_text: str = "after handler"
+        total += len(handler_text)
+        final_text: str = "after finally"
+        total += len(final_text)
+    return total
+"#,
+    );
+
+    assert_eq!(cache_declaration_count(&generated, "body_text"), 2);
+    assert_eq!(cache_declaration_count(&generated, "handler_text"), 2);
+    assert_eq!(cache_declaration_count(&generated, "final_text"), 2);
+}
+
+#[test]
+fn async_bodies_do_not_suppress_enclosing_string_caches() {
+    let generated = generate_rust_from_source(
+        r#"
+async def values() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+
+async def count_text(enabled: bool) -> Result[int, Error]:
+    total: int = 0
+    if enabled:
+        async with task.timeout(1.0):
+            with_text: str = "async with"
+            total += len(with_text)
+        with_text: str = "after async with"
+        total += len(with_text)
+
+        async for value in values():
+            for_text: str = "async for"
+            total += value + len(for_text)
+        for_text: str = "after async for"
+        total += len(for_text)
+    return total
+"#,
+    );
+
+    assert_eq!(cache_declaration_count(&generated, "with_text"), 2);
+    assert_eq!(cache_declaration_count(&generated, "for_text"), 2);
+}

--- a/crates/sifr_codegen/src/stmt_support_emitter/async_with_and_for.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/async_with_and_for.rs
@@ -53,7 +53,7 @@ impl RustEmitter {
                 class_name,
             });
         }
-        let Some(lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
+        let Some(lowered_body) = self.try_lower_scoped_stmt_block_for_ir(body)? else {
             return Ok(None);
         };
         Ok(Some(RustStmt::With {
@@ -92,7 +92,7 @@ impl RustEmitter {
         }
         if let sifr_ir::HirAsyncWithKind::UserDefined { context, .. } = kind {
             let body_always_exits = queries::block_control_flow_effect(body).always_exits();
-            let Some(mut lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
+            let Some(mut lowered_body) = self.try_lower_scoped_stmt_block_for_ir(body)? else {
                 return Ok(None);
             };
             if let HirExpr::Name { name, .. } = context {
@@ -195,7 +195,7 @@ impl RustEmitter {
         if let Some(duration) = timeout_duration.clone() {
             self.active_timeout_durations.push(duration);
         }
-        let lowered_body_result = self.try_lower_stmt_block_for_ir(body);
+        let lowered_body_result = self.try_lower_scoped_stmt_block_for_ir(body);
         if timeout_duration.is_some() {
             let _ = self.active_timeout_durations.pop();
         }
@@ -264,7 +264,7 @@ impl RustEmitter {
         close_error_ty: Option<&Type>,
         body: &[HirStmt],
     ) -> Result<Option<RustStmt>, crate::CodegenError> {
-        let Some(lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
+        let Some(lowered_body) = self.try_lower_scoped_stmt_block_for_ir(body)? else {
             return Ok(None);
         };
         let target_pattern = if queries::stmts_reference_var(body, target) {

--- a/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
@@ -586,21 +586,7 @@ impl RustEmitter {
         &mut self,
         body: &[HirStmt],
     ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
-        let string_char_cache_vars = self.string_char_cache_vars.clone();
-        match self.try_lower_stmt_block_for_ir(body) {
-            Ok(Some(lowered)) => {
-                self.string_char_cache_vars = string_char_cache_vars;
-                Ok(Some(lowered))
-            }
-            Ok(None) => {
-                self.string_char_cache_vars = string_char_cache_vars;
-                Ok(None)
-            }
-            Err(error) => {
-                self.string_char_cache_vars = string_char_cache_vars;
-                Err(error)
-            }
-        }
+        self.try_lower_scoped_stmt_block_for_ir(body)
     }
 
     pub(crate) fn detect_or_is_none_vars_with_bindings_for_ir(

--- a/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
@@ -37,7 +37,7 @@ impl RustEmitter {
             return Ok(false);
         };
         self.loop_else_stack.push(has_else);
-        let lowered_body = self.try_lower_stmt_block_for_ir(body)?;
+        let lowered_body = self.try_lower_scoped_stmt_block_for_ir(body)?;
         let popped = self.loop_else_stack.pop();
         debug_assert!(popped.is_some(), "loop_else_stack should not underflow");
         let Some(lowered_body) = lowered_body else {
@@ -45,7 +45,8 @@ impl RustEmitter {
         };
 
         if let Some(else_body) = else_body {
-            let Some(lowered_else_body) = self.try_lower_stmt_block_for_ir(else_body)? else {
+            let Some(lowered_else_body) = self.try_lower_scoped_stmt_block_for_ir(else_body)?
+            else {
                 return Ok(false);
             };
             self.push_captured_stmt(&RustStmt::Block(vec![
@@ -112,18 +113,15 @@ impl RustEmitter {
 
         self.loop_else_stack.push(has_else);
         let lowered_iter = self.try_lower_for_iter_expr_for_ir(iter, target_ty)?;
-        let previous_target_cache = self.string_char_cache_vars.get(target).cloned();
+        let string_char_cache_vars = self.string_char_cache_vars.clone();
         let target_cache_init = if target.contains(',') {
             None
         } else {
             self.string_char_cache_init_stmt_for_loop_target(target, target_ty)
         };
-        let lowered_body = self.try_lower_stmt_block_for_ir(body)?;
-        if let Some(previous) = previous_target_cache {
-            self.string_char_cache_vars.insert(target.clone(), previous);
-        } else {
-            self.string_char_cache_vars.remove(target);
-        }
+        let lowered_body = self.try_lower_stmt_block_for_ir(body);
+        self.string_char_cache_vars = string_char_cache_vars;
+        let lowered_body = lowered_body?;
         let popped = self.loop_else_stack.pop();
         debug_assert!(popped.is_some(), "loop_else_stack should not underflow");
         let Some(lowered_iter) = lowered_iter else {
@@ -137,7 +135,8 @@ impl RustEmitter {
         }
 
         if let Some(else_body) = else_body {
-            let Some(lowered_else_body) = self.try_lower_stmt_block_for_ir(else_body)? else {
+            let Some(lowered_else_body) = self.try_lower_scoped_stmt_block_for_ir(else_body)?
+            else {
                 return Ok(false);
             };
             self.push_captured_stmt(&RustStmt::Block(vec![
@@ -267,7 +266,7 @@ impl RustEmitter {
             }
             self.try_closure_error_type.push(err_ty.clone());
             self.try_closure_error_type_info.push(error_carrier.clone());
-            let lowered = self.try_lower_stmt_block_for_ir(body)?;
+            let lowered = self.try_lower_scoped_stmt_block_for_ir(body)?;
             if capture_returns {
                 self.try_closure_depth -= 1;
                 self.try_closure_option_wrap.pop();
@@ -516,7 +515,7 @@ impl RustEmitter {
             }
             self.try_closure_error_type.push(err_ty.clone());
             self.try_closure_error_type_info.push(active_error_type);
-            let lowered = self.try_lower_stmt_block_for_ir(body)?;
+            let lowered = self.try_lower_scoped_stmt_block_for_ir(body)?;
             if capture_returns {
                 self.try_closure_depth -= 1;
                 self.try_closure_option_wrap.pop();
@@ -574,7 +573,7 @@ impl RustEmitter {
         }];
 
         let saved_timeout_durations = std::mem::take(&mut self.active_timeout_durations);
-        let finalbody_result = self.try_lower_stmt_block_for_ir(finalbody);
+        let finalbody_result = self.try_lower_scoped_stmt_block_for_ir(finalbody);
         self.active_timeout_durations = saved_timeout_durations;
         let Some(finalbody_lowered) = finalbody_result? else {
             return Ok(None);

--- a/crates/sifr_codegen/src/stmt_support_emitter/python_context/async_context.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/python_context/async_context.rs
@@ -72,7 +72,7 @@ impl RustEmitter {
         };
         let converted = crate::render_expr(&converted);
         self.python_context_envelope_depth += 1;
-        let lowered_body = self.try_lower_stmt_block_for_ir(body);
+        let lowered_body = self.try_lower_scoped_stmt_block_for_ir(body);
         self.python_context_envelope_depth -= 1;
         let mut rewritten = rewrite_context_control_flow(
             lowered_body?.ok_or_else(|| {

--- a/crates/sifr_codegen/src/stmt_support_emitter/python_context/sync.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/python_context/sync.rs
@@ -12,7 +12,7 @@ impl RustEmitter {
         body: &[HirStmt],
     ) -> Result<Option<RustStmt>, crate::CodegenError> {
         self.python_context_envelope_depth += 1;
-        let lowered_body = self.try_lower_stmt_block_for_ir(body);
+        let lowered_body = self.try_lower_scoped_stmt_block_for_ir(body);
         self.python_context_envelope_depth -= 1;
         let Some(lowered_body) = lowered_body? else {
             return Ok(None);

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
@@ -716,7 +716,7 @@ impl RustEmitter {
                     return Ok(None);
                 };
                 self.loop_else_stack.push(has_else);
-                let Some(lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
+                let Some(lowered_body) = self.try_lower_scoped_stmt_block_for_ir(body)? else {
                     let popped = self.loop_else_stack.pop();
                     debug_assert!(popped.is_some(), "loop_else_stack should not underflow");
                     return Ok(None);
@@ -724,7 +724,8 @@ impl RustEmitter {
                 let popped = self.loop_else_stack.pop();
                 debug_assert!(popped.is_some(), "loop_else_stack should not underflow");
                 if let Some(else_body) = else_body {
-                    let Some(lowered_else_body) = self.try_lower_stmt_block_for_ir(else_body)?
+                    let Some(lowered_else_body) =
+                        self.try_lower_scoped_stmt_block_for_ir(else_body)?
                     else {
                         return Ok(None);
                     };
@@ -784,31 +785,23 @@ impl RustEmitter {
                 }) else {
                     return Ok(None);
                 };
-                let previous_target_cache = self.string_char_cache_vars.get(target).cloned();
+                let string_char_cache_vars = self.string_char_cache_vars.clone();
                 let target_cache_init = if char_set_loop || target.contains(',') {
                     None
                 } else {
                     self.string_char_cache_init_stmt_for_loop_target(target, target_ty)
                 };
                 self.loop_else_stack.push(false);
-                let lowered_body_result = self.try_lower_stmt_block_for_ir(body)?;
+                let lowered_body_result = self.try_lower_stmt_block_for_ir(body);
+                self.string_char_cache_vars = string_char_cache_vars;
                 let popped = self.loop_else_stack.pop();
                 debug_assert!(popped.is_some(), "loop_else_stack should not underflow");
+                let lowered_body_result = lowered_body_result?;
                 let Some(mut lowered_body) = lowered_body_result else {
-                    if let Some(previous) = previous_target_cache {
-                        self.string_char_cache_vars.insert(target.clone(), previous);
-                    } else {
-                        self.string_char_cache_vars.remove(target);
-                    }
                     return Ok(None);
                 };
                 if let Some(cache_stmt) = target_cache_init {
                     lowered_body.insert(0, cache_stmt);
-                }
-                if let Some(previous) = previous_target_cache {
-                    self.string_char_cache_vars.insert(target.clone(), previous);
-                } else {
-                    self.string_char_cache_vars.remove(target);
                 }
                 let var = if target.contains(',') {
                     let names = target

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_block_helpers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_block_helpers.rs
@@ -502,6 +502,16 @@ impl RustEmitter {
         result
     }
 
+    pub(crate) fn try_lower_scoped_stmt_block_for_ir(
+        &mut self,
+        stmts: &[HirStmt],
+    ) -> Result<Option<Vec<crate::RustStmt>>, crate::CodegenError> {
+        let string_char_cache_vars = self.string_char_cache_vars.clone();
+        let result = self.try_lower_stmt_block_for_ir(stmts);
+        self.string_char_cache_vars = string_char_cache_vars;
+        result
+    }
+
     pub(crate) fn stmt_block_scope_context(&self) -> crate::ScopeContext {
         crate::ScopeContext {
             function_return_type: self.current_return_type.clone(),

--- a/crates/sifr_codegen/src/stmt_support_emitter/try_handlers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/try_handlers.rs
@@ -159,7 +159,8 @@ impl RustEmitter {
                     );
                 Some(binding_value)
             };
-            let lowered_handler_body = match self.try_lower_stmt_block_for_ir(&handler.body) {
+            let lowered_handler_body = match self.try_lower_scoped_stmt_block_for_ir(&handler.body)
+            {
                 Ok(Some(lowered_handler_body)) => lowered_handler_body,
                 Ok(None) => return Ok(None),
                 Err(err) => return Err(err),


### PR DESCRIPTION
Closes #3409.

Adds one shared scoped statement-block transaction for string-character cache state and applies it across loops, loop else bodies, with/async-with bodies, async-for bodies, try closures, handlers, final bodies, and Python contexts. For-loop target cache setup is included in the same rollback boundary. Focused source regressions cover while/for/loop-else, native with, try/handler/finally, async with, and async for.

Validation before freeze:
- cargo test -p sifr_codegen (1087 passed)
- cargo clippy --workspace -- -D warnings
- cargo fmt --check
- maintainability and diff checks
- file-size guardrails: 3202 files pass; touched files remain below 900 lines