### PR TITLE
Certify installed static class adapters

### DIFF
--- a/crates/sifr/tests/sysroot_cli.rs
+++ b/crates/sifr/tests/sysroot_cli.rs
@@ -144,7 +144,7 @@ fn write_skeleton(root: &Path) {
     std::fs::write(
         root.join("Cargo.toml"),
         r#"[workspace]
-members = ["crates/sifr_runtime", "crates/sifr_stdlib"]
+members = ["crates/sifr_runtime", "crates/sifr_structural_identity", "crates/sifr_stdlib"]
 resolver = "2"
 "#,
     )
@@ -152,6 +152,7 @@ resolver = "2"
     std::fs::write(root.join("Cargo.lock"), "").expect("lockfile");
     std::fs::write(root.join(".cargo/config.toml"), "").expect("cargo config");
     write_minimal_crate(root, "sifr_runtime");
+    write_minimal_crate(root, "sifr_structural_identity");
     write_minimal_crate(root, "sifr_stdlib");
 }
 

--- a/crates/sifr_sysroot/src/layout.rs
+++ b/crates/sifr_sysroot/src/layout.rs
@@ -35,6 +35,8 @@ pub struct SysrootPaths {
     pub stdlib_private_sources: PathBuf,
     pub runtime_crate: PathBuf,
     pub runtime_crate_manifest: PathBuf,
+    pub structural_identity_crate: PathBuf,
+    pub structural_identity_crate_manifest: PathBuf,
     pub stdlib_crate: PathBuf,
     pub stdlib_crate_manifest: PathBuf,
     pub cargo_manifest: PathBuf,
@@ -47,6 +49,7 @@ impl SysrootPaths {
     #[must_use]
     pub fn from_root(root: &Path) -> Self {
         let runtime_crate = root.join("crates").join("sifr_runtime");
+        let structural_identity_crate = root.join("crates").join("sifr_structural_identity");
         let stdlib_crate = root.join("crates").join("sifr_stdlib");
         let stdlib_root = stdlib_source_root(root);
         Self {
@@ -56,6 +59,8 @@ impl SysrootPaths {
             stdlib_root,
             runtime_crate_manifest: runtime_crate.join("Cargo.toml"),
             runtime_crate,
+            structural_identity_crate_manifest: structural_identity_crate.join("Cargo.toml"),
+            structural_identity_crate,
             stdlib_crate_manifest: stdlib_crate.join("Cargo.toml"),
             stdlib_crate,
             cargo_manifest: root.join("Cargo.toml"),
@@ -88,6 +93,12 @@ impl SysrootPaths {
             root,
             &self.runtime_crate_manifest,
             "crates/sifr_runtime/Cargo.toml",
+        )?;
+        require_file(
+            binary_path,
+            root,
+            &self.structural_identity_crate_manifest,
+            "crates/sifr_structural_identity/Cargo.toml",
         )?;
         require_file(
             binary_path,
@@ -187,6 +198,13 @@ fn validate_workspace_manifest(
         ));
     };
     require_workspace_member(binary_path, root, manifest, members, "crates/sifr_runtime")?;
+    require_workspace_member(
+        binary_path,
+        root,
+        manifest,
+        members,
+        "crates/sifr_structural_identity",
+    )?;
     require_workspace_member(binary_path, root, manifest, members, "crates/sifr_stdlib")?;
     if workspace.get("resolver").and_then(toml::Value::as_str) != Some("2") {
         return Err(SysrootError::new(

--- a/crates/sifr_sysroot/src/tests.rs
+++ b/crates/sifr_sysroot/src/tests.rs
@@ -189,6 +189,10 @@ fn layout_validation_checks_all_skeleton_assets() {
         ("stdlib_private_sources", "lib/sifr/stdlib/_sifr"),
         ("vendor", "vendor"),
         ("runtime_manifest", "crates/sifr_runtime/Cargo.toml"),
+        (
+            "structural_identity_manifest",
+            "crates/sifr_structural_identity/Cargo.toml",
+        ),
         ("stdlib_manifest", "crates/sifr_stdlib/Cargo.toml"),
     ] {
         let root = complete_sysroot(label, COMPILER_SIFR_VERSION);
@@ -213,7 +217,7 @@ fn workspace_validation_requires_generated_stdlib_member() {
         root.path.join("Cargo.toml"),
         r#"
 [workspace]
-members = ["crates/sifr_runtime"]
+members = ["crates/sifr_runtime", "crates/sifr_structural_identity"]
 resolver = "2"
 "#,
     )
@@ -232,6 +236,35 @@ resolver = "2"
     assert!(error
         .message
         .contains("workspace member crates/sifr_stdlib"));
+}
+
+#[test]
+fn workspace_validation_requires_structural_identity_member() {
+    let root = complete_sysroot("missing_structural_identity_member", COMPILER_SIFR_VERSION);
+    fs::write(
+        root.path.join("Cargo.toml"),
+        r#"
+[workspace]
+members = ["crates/sifr_runtime", "crates/sifr_stdlib"]
+resolver = "2"
+"#,
+    )
+    .expect("workspace manifest");
+    let input = SysrootResolutionInput {
+        explicit_sysroot: Some(root.path.clone()),
+        env_sysroot: None,
+        current_exe: PathBuf::from("/tool/bin/sifr"),
+        current_dir: root.path.clone(),
+        allow_source_tree_development: false,
+    };
+
+    let error =
+        resolve_sysroot_with(&input).expect_err("missing structural identity member should fail");
+
+    assert_eq!(error.kind, SysrootErrorKind::InvalidWorkspace);
+    assert!(error
+        .message
+        .contains("workspace member crates/sifr_structural_identity"));
 }
 
 #[test]
@@ -310,7 +343,7 @@ fn write_complete_sysroot(root: &Path, version: &str) {
         root.join("Cargo.toml"),
         r#"
 [workspace]
-members = ["crates/sifr_runtime", "crates/sifr_stdlib"]
+members = ["crates/sifr_runtime", "crates/sifr_structural_identity", "crates/sifr_stdlib"]
 resolver = "2"
 "#,
     )
@@ -322,6 +355,7 @@ resolver = "2"
     fs::create_dir_all(root.join("lib/sifr/stdlib/sifr")).expect("public stdlib root");
     fs::create_dir_all(root.join("lib/sifr/stdlib/_sifr")).expect("private stdlib root");
     write_minimal_crate(root, "sifr_runtime");
+    write_minimal_crate(root, "sifr_structural_identity");
     write_minimal_crate(root, "sifr_stdlib");
 }
 

--- a/scripts/distribution/build_release_artifacts.sh
+++ b/scripts/distribution/build_release_artifacts.sh
@@ -259,6 +259,7 @@ package_toolchain() {
   copy_sysroot_file "Cargo.toml" "${package_root}/Cargo.toml"
   copy_sysroot_file "Cargo.lock" "${package_root}/Cargo.lock"
   copy_sysroot_dir "crates/sifr_runtime" "${package_root}/crates/sifr_runtime"
+  copy_sysroot_dir "crates/sifr_structural_identity" "${package_root}/crates/sifr_structural_identity"
   copy_sysroot_dir "crates/sifr_stdlib" "${package_root}/crates/sifr_stdlib"
   copy_sysroot_dir "stdlib/sifr" "${package_root}/lib/sifr/stdlib/sifr"
   copy_sysroot_dir "stdlib/_sifr" "${package_root}/lib/sifr/stdlib/_sifr"

--- a/scripts/distribution/generate_version_installer.sh
+++ b/scripts/distribution/generate_version_installer.sh
@@ -707,6 +707,7 @@ validate_extracted_toolchain() {
   require_extracted_file ".cargo/config.toml"
   require_extracted_dir "vendor"
   require_extracted_file "crates/sifr_runtime/Cargo.toml"
+  require_extracted_file "crates/sifr_structural_identity/Cargo.toml"
   require_extracted_file "crates/sifr_stdlib/Cargo.toml"
   require_extracted_dir "lib/sifr/stdlib/sifr"
   require_extracted_dir "lib/sifr/stdlib/_sifr"

--- a/scripts/distribution/verify_release_archive.py
+++ b/scripts/distribution/verify_release_archive.py
@@ -18,6 +18,7 @@ REQUIRED_FILES = (
     "sysroot.toml",
     ".cargo/config.toml",
     "crates/sifr_runtime/Cargo.toml",
+    "crates/sifr_structural_identity/Cargo.toml",
     "crates/sifr_stdlib/Cargo.toml",
 )
 
@@ -25,6 +26,7 @@ REQUIRED_DIR_PREFIXES = (
     "lib/sifr/stdlib/sifr/",
     "lib/sifr/stdlib/_sifr/",
     "crates/sifr_runtime/",
+    "crates/sifr_structural_identity/",
     "crates/sifr_stdlib/",
     "vendor/",
 )

--- a/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
+++ b/verification/areas/core_language/fixtures/static_class_adapter/src/app.sifr
@@ -89,7 +89,7 @@ def main() -> Result[None, ContractError | RustPanicError]:
     assert consumed.finish() == 43
     imported: ImportedAlias = ImportedAlias(11)
     plain: PlainAlias = PlainAlias(12)
-    assert ImportedAlias.describe() == "attached-contract"
+    assert ImportedAlias.describe() == AttachedModel.describe()
     assert ImportedAlias.echo("imported") == "imported"
     assert ImportedAlias.echo_strings("imported-strings") == "imported-strings"
     assert imported.inspect() == 41
@@ -97,8 +97,8 @@ def main() -> Result[None, ContractError | RustPanicError]:
     assert plain.value == 12
     concrete: ConcreteAttached = ConcreteAttached(13, "local")
     imported_concrete: ImportedConcrete = ImportedConcrete(14, "imported")
-    assert ConcreteAttached.describe() == "attached-contract"
-    assert ImportedConcrete.describe() == "attached-contract"
+    assert ConcreteAttached.describe() == AttachedModel.describe()
+    assert ImportedConcrete.describe() == AttachedModel.describe()
     assert concrete.value == 13
     assert concrete.label == "local"
     assert imported_concrete.value == 14

--- a/verification/areas/distribution_release/cases/artifact_broken_sysroot_archives_rejected.sh
+++ b/verification/areas/distribution_release/cases/artifact_broken_sysroot_archives_rejected.sh
@@ -83,6 +83,7 @@ PY
 for spec in \
   "manifest:sysroot.toml:missing required archive file: sysroot.toml" \
   "runtime:crates/sifr_runtime:missing required archive file: crates/sifr_runtime/Cargo.toml" \
+  "structural_identity:crates/sifr_structural_identity:missing required archive file: crates/sifr_structural_identity/Cargo.toml" \
   "stdlib:lib/sifr/stdlib/sifr:missing required archive directory: lib/sifr/stdlib/sifr" \
   "vendor:vendor:missing required archive directory: vendor" \
   "cargo_config:.cargo/config.toml:missing required archive file: .cargo/config.toml"

--- a/verification/areas/distribution_release/cases/artifact_generated_installer_all_preview_targets.sh
+++ b/verification/areas/distribution_release/cases/artifact_generated_installer_all_preview_targets.sh
@@ -50,6 +50,7 @@ do
   test -f "${install_root}/.cargo/config.toml" || { echo "missing installed cargo config" >&2; exit 1; }
   test -d "${install_root}/vendor" || { echo "missing installed vendor" >&2; exit 1; }
   test -f "${install_root}/crates/sifr_runtime/Cargo.toml" || { echo "missing installed runtime crate" >&2; exit 1; }
+  test -f "${install_root}/crates/sifr_structural_identity/Cargo.toml" || { echo "missing installed structural identity crate" >&2; exit 1; }
   test -f "${install_root}/crates/sifr_stdlib/Cargo.toml" || { echo "missing installed stdlib crate" >&2; exit 1; }
   test -d "${install_root}/lib/sifr/stdlib/sifr" || { echo "missing installed public stdlib" >&2; exit 1; }
   test -d "${install_root}/lib/sifr/stdlib/_sifr" || { echo "missing installed private stdlib" >&2; exit 1; }

--- a/verification/areas/distribution_release/cases/common.sh
+++ b/verification/areas/distribution_release/cases/common.sh
@@ -197,6 +197,7 @@ make_mock_sysroot_root() {
   mkdir -p \
     "${root}/.cargo" \
     "${root}/crates/sifr_runtime/src" \
+    "${root}/crates/sifr_structural_identity/src" \
     "${root}/crates/sifr_stdlib/src" \
     "${root}/stdlib/sifr" \
     "${root}/stdlib/_sifr" \
@@ -205,6 +206,7 @@ make_mock_sysroot_root() {
 [workspace]
 members = [
   "crates/sifr_runtime",
+  "crates/sifr_structural_identity",
   "crates/sifr_stdlib",
 ]
 resolver = "2"
@@ -231,6 +233,13 @@ version = "0.0.0-fixture"
 edition = "2021"
 EOF
   printf '%s\n' 'pub fn fixture() {}' >"${root}/crates/sifr_runtime/src/lib.rs"
+  cat >"${root}/crates/sifr_structural_identity/Cargo.toml" <<'EOF'
+[package]
+name = "sifr_structural_identity"
+version = "0.0.0-fixture"
+edition = "2021"
+EOF
+  printf '%s\n' 'pub fn fixture() {}' >"${root}/crates/sifr_structural_identity/src/lib.rs"
   cat >"${root}/crates/sifr_stdlib/Cargo.toml" <<'EOF'
 [package]
 name = "sifr_stdlib"

--- a/verification/areas/distribution_release/governance/qualification_fixture.py
+++ b/verification/areas/distribution_release/governance/qualification_fixture.py
@@ -442,6 +442,9 @@ def write_synthetic_target(
         "Cargo.lock": b"# fixture lock\n",
         ".cargo/config.toml": b"[net]\noffline = true\n",
         "crates/sifr_runtime/Cargo.toml": b'[package]\nname = "sifr_runtime"\n',
+        "crates/sifr_structural_identity/Cargo.toml": (
+            b'[package]\nname = "sifr_structural_identity"\n'
+        ),
         "crates/sifr_stdlib/Cargo.toml": b'[package]\nname = "sifr_stdlib"\n',
         "lib/sifr/stdlib/sifr/fixture.sifr": b"def fixture() -> int:\n    return 1\n",
         "lib/sifr/stdlib/_sifr/fixture.sifr": b"def fixture() -> int:\n    return 1\n",

--- a/verification/areas/sysroot_release/attached_api_certification.py
+++ b/verification/areas/sysroot_release/attached_api_certification.py
@@ -24,7 +24,7 @@ def bind_runtime_dependency(*, fixture: Path, runtime_crate: Path) -> str | None
         "sifr_runtime = { path = "
         f"{json.dumps(str(runtime_crate))}, features = [\"structural\"] }}"
     )
-    updated, replacements = RUNTIME_DEPENDENCY.subn(replacement, manifest)
+    updated, replacements = RUNTIME_DEPENDENCY.subn(lambda _match: replacement, manifest)
     if replacements != 1:
         return (
             "attached API Cargo manifest must contain exactly one structural "

--- a/verification/areas/sysroot_release/attached_api_certification.py
+++ b/verification/areas/sysroot_release/attached_api_certification.py
@@ -2,8 +2,39 @@
 
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
 from typing import Any, Callable
+
+
+RUNTIME_DEPENDENCY = re.compile(
+    r'^sifr_runtime = \{ path = "[^"]+", features = \["structural"\] \}$',
+    re.MULTILINE,
+)
+
+
+def bind_runtime_dependency(*, fixture: Path, runtime_crate: Path) -> str | None:
+    manifest_path = fixture / "Cargo.toml"
+    try:
+        manifest = manifest_path.read_text(encoding="utf-8")
+    except OSError as error:
+        return f"failed to read attached API Cargo manifest: {error}"
+    replacement = (
+        "sifr_runtime = { path = "
+        f"{json.dumps(str(runtime_crate))}, features = [\"structural\"] }}"
+    )
+    updated, replacements = RUNTIME_DEPENDENCY.subn(replacement, manifest)
+    if replacements != 1:
+        return (
+            "attached API Cargo manifest must contain exactly one structural "
+            "sifr_runtime path dependency"
+        )
+    try:
+        manifest_path.write_text(updated, encoding="utf-8")
+    except OSError as error:
+        return f"failed to bind attached API runtime dependency: {error}"
+    return None
 
 
 def run_attached_api_certification(
@@ -14,8 +45,14 @@ def run_attached_api_certification(
     output: Path,
     env: dict[str, str],
     label: str,
+    runtime_crate: Path,
     run_checked: Callable[..., Any],
 ) -> str | None:
+    dependency_error = bind_runtime_dependency(
+        fixture=fixture, runtime_crate=runtime_crate
+    )
+    if dependency_error is not None:
+        return dependency_error
     build_command = [
         str(compiler),
         *extra,

--- a/verification/areas/sysroot_release/runner.py
+++ b/verification/areas/sysroot_release/runner.py
@@ -196,13 +196,23 @@ def run_boundary_equivalence() -> tuple[int, list[str]]:
             work_root.mkdir()
             fixture = work_root / BOUNDARY_FIXTURE_PATH.name
             fixture.write_text(BOUNDARY_FIXTURE_PATH.read_text(encoding="utf-8"), encoding="utf-8")
-            attached_fixture = work_root / "static_class_adapter"
-            shutil.copytree(ATTACHED_API_FIXTURE_ROOT, attached_fixture)
             installed_sifr = install_root / "bin" / "sifr"
 
-            for label, compiler, output, extra in (
-                ("installed", installed_sifr, installed_output, []),
-                ("source-tree", source_sifr, source_output, ["--sysroot", str(REPO_ROOT)]),
+            for label, compiler, output, extra, runtime_crate in (
+                (
+                    "installed",
+                    installed_sifr,
+                    installed_output,
+                    [],
+                    install_root / "crates" / "sifr_runtime",
+                ),
+                (
+                    "source-tree",
+                    source_sifr,
+                    source_output,
+                    ["--sysroot", str(REPO_ROOT)],
+                    REPO_ROOT / "crates" / "sifr_runtime",
+                ),
             ):
                 env = installed_env(temp_root)
                 probe_cache = temp_root / "probe-cache" / label
@@ -222,6 +232,8 @@ def run_boundary_equivalence() -> tuple[int, list[str]]:
                 if "stdlib boundary recertification: pass" not in result.stdout:
                     return 1, [f"{label} boundary fixture did not execute successfully"]
 
+                attached_fixture = work_root / f"static_class_adapter-{label}"
+                shutil.copytree(ATTACHED_API_FIXTURE_ROOT, attached_fixture)
                 attached_error = run_attached_api_certification(
                     compiler=compiler,
                     extra=extra,
@@ -229,6 +241,7 @@ def run_boundary_equivalence() -> tuple[int, list[str]]:
                     output=temp_root / f"{label}-attached-output",
                     env=env,
                     label=label,
+                    runtime_crate=runtime_crate,
                     run_checked=run_checked,
                 )
                 if attached_error is not None:

--- a/verification/areas/sysroot_release/test_attached_api_certification.py
+++ b/verification/areas/sysroot_release/test_attached_api_certification.py
@@ -26,12 +26,12 @@ class BindRuntimeDependencyTests(unittest.TestCase):
 
             error = bind_runtime_dependency(
                 fixture=fixture,
-                runtime_crate=Path('/tmp/runtime "exact"'),
+                runtime_crate=Path('/tmp/runtime \\ "exact"'),
             )
 
             self.assertIsNone(error)
             self.assertIn(
-                'path = "/tmp/runtime \\"exact\\""',
+                'path = "/tmp/runtime \\\\ \\"exact\\""',
                 manifest.read_text(encoding="utf-8"),
             )
 

--- a/verification/areas/sysroot_release/test_attached_api_certification.py
+++ b/verification/areas/sysroot_release/test_attached_api_certification.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+AREA_ROOT = Path(__file__).resolve().parent
+if str(AREA_ROOT) not in sys.path:
+    sys.path.insert(0, str(AREA_ROOT))
+
+from attached_api_certification import bind_runtime_dependency  # noqa: E402
+
+
+class BindRuntimeDependencyTests(unittest.TestCase):
+    def test_binds_exact_runtime_crate_path(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            fixture = Path(raw_temp)
+            manifest = fixture / "Cargo.toml"
+            manifest.write_text(
+                '[dependencies]\n'
+                'sifr_runtime = { path = "../../crates/sifr_runtime", '
+                'features = ["structural"] }\n',
+                encoding="utf-8",
+            )
+
+            error = bind_runtime_dependency(
+                fixture=fixture,
+                runtime_crate=Path('/tmp/runtime "exact"'),
+            )
+
+            self.assertIsNone(error)
+            self.assertIn(
+                'path = "/tmp/runtime \\"exact\\""',
+                manifest.read_text(encoding="utf-8"),
+            )
+
+    def test_rejects_missing_or_duplicate_runtime_dependency(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_temp:
+            fixture = Path(raw_temp)
+            manifest = fixture / "Cargo.toml"
+            manifest.write_text("[dependencies]\n", encoding="utf-8")
+            missing = bind_runtime_dependency(
+                fixture=fixture, runtime_crate=Path("/tmp/runtime")
+            )
+            self.assertIn("exactly one", missing)
+
+            manifest.write_text(
+                '[dependencies]\n'
+                'sifr_runtime = { path = "one", features = ["structural"] }\n'
+                'sifr_runtime = { path = "two", features = ["structural"] }\n',
+                encoding="utf-8",
+            )
+            duplicate = bind_runtime_dependency(
+                fixture=fixture, runtime_crate=Path("/tmp/runtime")
+            )
+            self.assertIn("exactly one", duplicate)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3412

Completes the installed/source static-class-adapter certification boundary: binds temporary package fixtures to the selected sysroot runtime, packages and validates `sifr_structural_identity`, keeps toolchain copies independent, and makes the cache edit probe assertion-safe.

Exact reviewed candidate: `0d90ecb6eef2c25d7dcc0bc32ea80649bd52b07c`.