### PR TITLE
Probe mapped opaque types against their value type

### DIFF
--- a/crates/sifr_driver/src/build/rust_interop.rs
+++ b/crates/sifr_driver/src/build/rust_interop.rs
@@ -439,46 +439,14 @@ impl<'a> RustInteropResolver<'a> {
                     sysroot_trust.is_some(),
                 );
                 self.validate_backend_generated_bridge_imports(declaration, backend);
-                let signature =
-                    target_resolution::is_primary_target(&declaration.declaration, path)
-                        .then(|| {
-                            self.signature_contracts
-                                .get(&canonical_target_path)
-                                .cloned()
-                        })
-                        .flatten();
-                let async_thread_affinity = self.async_thread_affinity_for_probe(declaration);
-                let Some(sysroot_runtime_crate) = self.context.sysroot_runtime_crate.clone() else {
-                    self.push_diagnostic(
-                        declaration,
-                        path.span,
-                        DiagnosticCode::RUST_CARGO_METADATA,
-                        "Rust bridge probe requires a resolved Sifr sysroot runtime crate",
-                        vec![("target", path.dotted())],
-                        vec!["Direct Rust bridge probes must use the same resolved sysroot runtime crate as generated Cargo projects.".to_string()],
-                        None,
-                    );
+                if !self.plan_direct_backend_probe(
+                    declaration,
+                    path,
+                    backend,
+                    sysroot_trust.as_ref(),
+                ) {
                     return;
-                };
-                self.pending_direct_probes.push(PendingRustBridgeProbe {
-                    declaration: declaration.clone(),
-                    path: path.clone(),
-                    backend: backend.clone(),
-                    source_prefix: None,
-                    signature,
-                    async_thread_affinity,
-                    zero_copy_obligations: self
-                        .zero_copy_probe_obligations
-                        .get(&canonical_target_path)
-                        .copied()
-                        .unwrap_or((false, false)),
-                    trusted_sysroot: sysroot_trust.is_some(),
-                    sysroot_runtime_crate,
-                    sysroot_vendor_dir: sysroot_trust
-                        .as_ref()
-                        .map(|trust| trust.vendor_dir.clone()),
-                    cargo_resolution: self.cargo_resolution.clone(),
-                });
+                }
                 if let Some(trust) = &sysroot_trust {
                     resolved_sysroot_crate_root(&backend.dependency_name, backend, trust)
                         .unwrap_or_else(|| RustInteropResolvedRoot::DirectCargoDependency {

--- a/crates/sifr_driver/src/build/rust_interop/probe_planning.rs
+++ b/crates/sifr_driver/src/build/rust_interop/probe_planning.rs
@@ -53,6 +53,9 @@ impl RustInteropResolver<'_> {
         sysroot_trust: Option<&SysrootRustInteropTrust>,
     ) -> Option<String> {
         let dependency_name = package_bridge_dependency_name(package);
+        if !super::target_resolution::is_concrete_probe_path(&declaration.declaration, path) {
+            return Some(dependency_name);
+        }
         let signature = super::target_resolution::is_primary_target(&declaration.declaration, path)
             .then(|| {
                 self.signature_contracts
@@ -108,5 +111,58 @@ impl RustInteropResolver<'_> {
             cargo_resolution: self.cargo_resolution.clone(),
         });
         Some(dependency_name)
+    }
+
+    pub(super) fn plan_direct_backend_probe(
+        &mut self,
+        declaration: &RustInteropPlanDeclaration,
+        path: &RustTargetPath,
+        backend: &BackendCrateMetadata,
+        sysroot_trust: Option<&SysrootRustInteropTrust>,
+    ) -> bool {
+        if !super::target_resolution::is_concrete_probe_path(&declaration.declaration, path) {
+            return true;
+        }
+
+        let canonical_target_path =
+            super::target_resolution::canonical_sifr_target_path(declaration);
+        let signature = super::target_resolution::is_primary_target(&declaration.declaration, path)
+            .then(|| {
+                self.signature_contracts
+                    .get(&canonical_target_path)
+                    .cloned()
+            })
+            .flatten();
+        let async_thread_affinity = self.async_thread_affinity_for_probe(declaration);
+        let Some(sysroot_runtime_crate) = self.context.sysroot_runtime_crate.clone() else {
+            self.push_diagnostic(
+                declaration,
+                path.span,
+                DiagnosticCode::RUST_CARGO_METADATA,
+                "Rust bridge probe requires a resolved Sifr sysroot runtime crate",
+                vec![("target", path.dotted())],
+                vec!["Direct Rust bridge probes must use the same resolved sysroot runtime crate as generated Cargo projects.".to_string()],
+                None,
+            );
+            return false;
+        };
+        self.pending_direct_probes.push(PendingRustBridgeProbe {
+            declaration: declaration.clone(),
+            path: path.clone(),
+            backend: backend.clone(),
+            source_prefix: None,
+            signature,
+            async_thread_affinity,
+            zero_copy_obligations: self
+                .zero_copy_probe_obligations
+                .get(&canonical_target_path)
+                .copied()
+                .unwrap_or((false, false)),
+            trusted_sysroot: sysroot_trust.is_some(),
+            sysroot_runtime_crate,
+            sysroot_vendor_dir: sysroot_trust.map(|trust| trust.vendor_dir.clone()),
+            cargo_resolution: self.cargo_resolution.clone(),
+        });
+        true
     }
 }

--- a/crates/sifr_driver/src/build/rust_interop/target_resolution.rs
+++ b/crates/sifr_driver/src/build/rust_interop/target_resolution.rs
@@ -1,5 +1,5 @@
 use sifr_codegen::{RustInteropOwner, RustInteropPlanDeclaration, RustInteropTrustRequirementKind};
-use sifr_ir::{RustInteropDeclaration, RustInteropValue, RustTargetPath};
+use sifr_ir::{RustInteropDeclaration, RustInteropDecoratorKind, RustInteropValue, RustTargetPath};
 use sifr_package::{BackendCrateMetadata, SifrPackageGraph, SifrPackageId};
 
 pub(super) fn declaration_paths(declaration: &RustInteropDeclaration) -> Vec<&RustTargetPath> {
@@ -21,6 +21,23 @@ pub(super) fn is_primary_target(
         .target
         .as_ref()
         .is_some_and(|target| target.span == path.span && target.segments == path.segments)
+}
+
+pub(super) fn is_concrete_probe_path(
+    declaration: &RustInteropDeclaration,
+    path: &RustTargetPath,
+) -> bool {
+    if declaration.kind != RustInteropDecoratorKind::Opaque {
+        return true;
+    }
+
+    declaration.arguments.iter().any(|argument| {
+        argument.name.as_deref() == Some("type")
+            && matches!(
+                &argument.value,
+                RustInteropValue::TargetPath(type_path) if std::ptr::eq(type_path, path)
+            )
+    })
 }
 
 fn collect_value_paths<'a>(value: &'a RustInteropValue, paths: &mut Vec<&'a RustTargetPath>) {
@@ -104,5 +121,63 @@ pub(super) fn trust_allowlist_name(kind: &RustInteropTrustRequirementKind) -> &'
         RustInteropTrustRequirementKind::UnsafeBridge => "unsafe-rust-bridges",
         RustInteropTrustRequirementKind::NoPanic => "rust-no-panic",
         RustInteropTrustRequirementKind::PanicAbort => "rust-panic-abort",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{declaration_paths, is_concrete_probe_path};
+    use ruff_text_size::TextRange;
+    use sifr_ir::{
+        RustInteropAbiRequirements, RustInteropArgument, RustInteropDeclaration,
+        RustInteropDecoratorKind, RustInteropEffect, RustInteropValue, RustTargetPath,
+    };
+
+    fn target_path(path: &str) -> RustTargetPath {
+        RustTargetPath {
+            segments: path.split('.').map(str::to_string).collect(),
+            span: TextRange::default(),
+        }
+    }
+
+    fn opaque_declaration(type_path: &str, mapping_path: &str) -> RustInteropDeclaration {
+        RustInteropDeclaration {
+            kind: RustInteropDecoratorKind::Opaque,
+            target: None,
+            arguments: vec![
+                RustInteropArgument {
+                    name: Some("type".to_string()),
+                    value: RustInteropValue::TargetPath(target_path(type_path)),
+                    span: TextRange::default(),
+                },
+                RustInteropArgument {
+                    name: Some("structural".to_string()),
+                    value: RustInteropValue::TargetPath(target_path(mapping_path)),
+                    span: TextRange::default(),
+                },
+            ],
+            span: TextRange::default(),
+            effect: RustInteropEffect::Sync,
+            abi_requirements: RustInteropAbiRequirements::default(),
+            consumes_receiver: false,
+        }
+    }
+
+    #[test]
+    fn opaque_probe_selects_only_the_declared_value_type() {
+        let declaration = opaque_declaration("bridge.Value", "bridge.Mapping");
+        let paths = declaration_paths(&declaration);
+
+        assert!(is_concrete_probe_path(&declaration, paths[0]));
+        assert!(!is_concrete_probe_path(&declaration, paths[1]));
+    }
+
+    #[test]
+    fn opaque_probe_does_not_duplicate_equal_type_and_mapping_paths() {
+        let declaration = opaque_declaration("bridge.Value", "bridge.Value");
+        let paths = declaration_paths(&declaration);
+
+        assert!(is_concrete_probe_path(&declaration, paths[0]));
+        assert!(!is_concrete_probe_path(&declaration, paths[1]));
     }
 }


### PR DESCRIPTION
Closes #3418.\n\nOpaque declarations with a distinct `structural=` mapping now resolve every declared Rust path but schedule the concrete opaque probe only for `type=`. Package-local and direct-backend probe planning share the same exact path-role selector.\n\nFocused validation includes the structural bridge runtime regression and the exact Pydantic package check.