### PR TITLE
test: correct reachable dependency feature assertion

### DIFF
--- a/crates/sifr_driver/src/build/entrypoint_tests.rs
+++ b/crates/sifr_driver/src/build/entrypoint_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use sifr_frontend::DiskSourceProvider;
-use sifr_stdlib_manifest::StdlibFeature;
+use sifr_stdlib_manifest::{planned_sifr_stdlib_features, StdlibFeature};
 
 fn mktemp_dir(name: &str) -> PathBuf {
     let unique = format!(
@@ -117,8 +117,17 @@ fn test_project_entrypoint_plan_aggregates_reachable_dependency_metadata() {
     .expect("main should be written");
     std::fs::write(
         dir.join("helper.sifr"),
-        "from sifr.statistics import mean\n\n\
-def helper() -> int:\n    return 1\n",
+        concat!(
+            "from sifr.statistics import mean, StatisticsError\n",
+            "\n",
+            "def helper() -> float:\n",
+            "    try:\n",
+            "        value: float = mean([1.0, 2.0])\n",
+            "        return value\n",
+            "    except StatisticsError as error:\n",
+            "        _ = error.message\n",
+            "        return 0.0\n",
+        ),
     )
     .expect("helper should be written");
 
@@ -135,12 +144,18 @@ def helper() -> int:\n    return 1\n",
         .used_stdlib_modules
         .contains("sifr.statistics"));
     assert!(generated_project.used_stdlib_modules.contains("sifr.math"));
-    assert!(generated_project
-        .required_features
-        .contains(&StdlibFeature::NumBigint));
-    assert!(generated_project
+    let stdlib_features = planned_sifr_stdlib_features(
+        &generated_project.used_stdlib_modules,
+        &generated_project.required_features,
+    );
+    assert!(stdlib_features.contains("math"));
+    assert!(!stdlib_features.contains("numeric"));
+    assert!(!generated_project
         .required_features
         .contains(&StdlibFeature::NumTraits));
+    assert!(!generated_project
+        .required_features
+        .contains(&StdlibFeature::NumBigint));
 
     let _ = std::fs::remove_dir_all(dir);
 }

--- a/plans/issues/active/ad-hoc-pre-v1-canonical-contract-regression-closure.md
+++ b/plans/issues/active/ad-hoc-pre-v1-canonical-contract-regression-closure.md
@@ -467,16 +467,17 @@ Purpose: Make the driver test match reachable module metadata.
 Scope:
 
 - Keep the production dependency aggregation path unchanged unless evidence finds a defect.
-- Require `NumTraits` for the selected statistics project.
-- Assert that `NumBigint` is absent for that project.
+- Require the transitive `math` feature for the selected statistics project.
+- Assert that `NumTraits`, `NumBigint`, and the broad `numeric` feature are
+  absent for that project.
 - Add a separate positive `NumBigint` case only if current coverage is absent.
 
 Acceptance criteria:
 
 - The focused project-entrypoint tests pass.
-- A reachable feature appears in the generated dependency plan.
-- An unreachable feature does not appear in that plan.
-- The test does not use an unrelated module to request `NumBigint`.
+- The reachable `math` feature appears in the generated dependency plan.
+- The unreachable numeric features do not appear in that plan.
+- The test does not use an unrelated module to request a numeric feature.
 
 ## Item 5: Preserve Successful Sequential `try` Bindings
 


### PR DESCRIPTION
## Summary

- make the project-entrypoint fixture execute `sifr.statistics.mean` instead of importing an unused function
- assert the reachable transitive `math` feature and reject redundant `numeric`, `NumTraits`, and `NumBigint` requirements
- keep production dependency aggregation unchanged and align the Item 4 contract with generated Rust evidence

## Root cause

The test required `NumBigint` before it checked any valid positive dependency. After removing that assertion, the hidden `NumTraits` expectation also failed. A real `mean` call emits neither numeric crate, while its transitive `sifr.math` module produces the canonical `math` feature. Requiring `NumTraits` would add an unused direct dependency and restore the duplication that pre-v1 cleanup removed.

Existing `_bigint` metadata authority coverage still pins the positive `NumBigint` plus `NumTraits` case.

## Validation

- `cargo test -p sifr_driver test_project_entrypoint_plan_ -- --include-ignored`
- `cargo test -p sifr former_module_inference_inventory_is_owned_by_typed_production_metadata`
- `cargo fmt --check`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `python3 scripts/check_sifr_driver_maintainability_guardrails.py`
- `git diff --check`

The exactly-once create-PR and merge gates will run after the exact-SHA blocking review.