### PR TITLE
Preserve open IOError dispatch

### DIFF
--- a/crates/sifr/tests/e2e/fail/try_ioerror_subclasses_do_not_cover_base.sifr
+++ b/crates/sifr/tests/e2e/fail/try_ioerror_subclasses_do_not_cover_base.sifr
@@ -1,0 +1,22 @@
+# expect-error[col=5]: SIFR-RESULT-0005
+# Test: named IOError subclasses do not cover the open base IOError kind domain.
+
+def load_io() -> Result[str, IOError]:
+    raise IOError("other")
+
+
+def main() -> None:
+    try:
+        content: str = load_io()
+    except FileNotFoundError:
+        pass
+    except PermissionError:
+        pass
+    except FileExistsError:
+        pass
+    except IsADirectoryError:
+        pass
+    except NotADirectoryError:
+        pass
+    except DirectoryNotEmptyError:
+        pass

--- a/crates/sifr/tests/e2e/pass/try_ioerror_exhaustive_bindings.sifr
+++ b/crates/sifr/tests/e2e/pass/try_ioerror_exhaustive_bindings.sifr
@@ -1,14 +1,19 @@
-def load_io() -> Result[str, IOError]:
-    raise IOError("missing")
+from sifr.io import read_text
 
 
-def length_or_error(flag: bool) -> Result[int, IOError]:
+def load_io(use_subclass: bool) -> Result[str, IOError]:
+    if use_subclass:
+        return read_text("/tmp/sifr_try_ioerror_exhaustive_bindings_missing.txt")
+    raise IOError("other")
+
+
+def length_or_error(flag: bool, use_subclass: bool) -> Result[int, IOError]:
     try:
-        content: str = load_io()
+        content: str = load_io(use_subclass)
         if flag:
             return len(content)
-    except FileNotFoundError as error:
-        raise error
+    except FileNotFoundError:
+        raise IOError("file-handler")
     except PermissionError as error:
         raise error
     except FileExistsError as error:
@@ -19,13 +24,22 @@ def length_or_error(flag: bool) -> Result[int, IOError]:
         raise error
     except DirectoryNotEmptyError as error:
         raise error
+    except IOError as error:
+        raise error
     return len(content)
 
 
 def main() -> None:
     try:
-        value: int = length_or_error(False)
+        value: int = length_or_error(False, False)
         _ = value
         assert False
     except IOError as error:
-        assert error.message == "missing"
+        assert error.message == "other"
+
+    try:
+        value: int = length_or_error(False, True)
+        _ = value
+        assert False
+    except IOError as error:
+        assert error.message == "file-handler"

--- a/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
@@ -94,7 +94,7 @@ def conditional(flag: bool) -> Result[int, ProbeError]:
 }
 
 #[test]
-fn exhaustive_ioerror_subclass_handlers_end_in_a_diverging_arm() {
+fn ioerror_subclass_handlers_remain_guarded_before_base_handler() {
     let generated = generate_rust_from_source(
         r#"
 def load_io() -> Result[str, IOError]:
@@ -117,13 +117,15 @@ def length_or_error(flag: bool) -> Result[int, IOError]:
         raise error
     except DirectoryNotEmptyError as error:
         raise error
+    except IOError as error:
+        raise error
     return len(content)
 "#,
     );
 
     assert!(generated.contains("let Some((content,)) = __sifr_successful_try_bindings else"));
     assert!(generated.contains("\"NotADirectory\".to_string()"));
-    assert_eq!(generated.matches("__sifr_try_err.kind ==").count(), 5);
+    assert_eq!(generated.matches("__sifr_try_err.kind ==").count(), 6);
     assert!(!generated.contains(".unwrap()"));
     assert!(!generated.contains(".expect("));
     syn::parse_file(&generated).expect("exhaustive IOError handler Rust should parse");

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -47,15 +47,6 @@ pub(crate) struct NestedFnCapture {
     pub(crate) convention: ParamConvention,
 }
 
-const IO_ERROR_SUBCLASSES: &[&str] = &[
-    "FileNotFoundError",
-    "PermissionError",
-    "FileExistsError",
-    "IsADirectoryError",
-    "NotADirectoryError",
-    "DirectoryNotEmptyError",
-];
-
 /// Result of code generation, including the Rust source and metadata.
 pub struct CodegenResult {
     pub rust_source: String,
@@ -353,7 +344,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
     for &error_name in BUILTIN_ERROR_CLASSES {
         infra_skip_types.insert(error_name.to_string());
     }
-    for &error_name in IO_ERROR_SUBCLASSES {
+    for &(error_name, _) in &sifr_type_system::IO_ERROR_KIND_CASES {
         infra_skip_types.insert(error_name.to_string());
     }
     infra_skip_types.insert("__io_err".to_string());
@@ -495,9 +486,9 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
         .collect();
     let user_defined_file_handle_struct = module.classes.iter().any(|c| c.name == "FileHandle");
     let io_error_referenced = referenced_error_classes.contains("IOError")
-        || IO_ERROR_SUBCLASSES
+        || sifr_type_system::IO_ERROR_KIND_CASES
             .iter()
-            .any(|subclass| referenced_error_classes.contains(*subclass))
+            .any(|(subclass, _)| referenced_error_classes.contains(*subclass))
         || needs_file_handles;
 
     let mut preamble_items: Vec<RustItem> = Vec::new();
@@ -507,7 +498,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
 
     for &error_name in BUILTIN_ERROR_CLASSES {
         // Skip IOError and its subclasses (handled separately)
-        if error_name == "IOError" || IO_ERROR_SUBCLASSES.contains(&error_name) {
+        if error_name == "IOError" || sifr_type_system::io_error_kind(error_name).is_some() {
             continue;
         }
         let is_referenced = referenced_error_classes.contains(error_name);
@@ -580,7 +571,7 @@ pub(crate) fn generate_rust_with_stdlib_for_module_with_project_policy(
     }
     if referenced_error_classes.contains("Error") && !user_defined_error_classes.contains("Error") {
         for &error_name in BUILTIN_ERROR_CLASSES {
-            if error_name == "Error" || IO_ERROR_SUBCLASSES.contains(&error_name) {
+            if error_name == "Error" || sifr_type_system::io_error_kind(error_name).is_some() {
                 continue;
             }
             if referenced_error_classes.contains(error_name)

--- a/crates/sifr_codegen/src/stmt_support_emitter/try_handlers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/try_handlers.rs
@@ -5,25 +5,6 @@ use super::{
 use sifr_type_system::Type;
 
 impl RustEmitter {
-    fn handler_set_exhausts_error_type(handlers: &[HirExceptHandler], err_ty: &str) -> bool {
-        if handlers.iter().any(|handler| {
-            matches!(
-                Self::try_except_handler_condition_expr(handler, "__sifr_exhaustiveness", err_ty),
-                HandlerMatchCondition::Always
-            )
-        }) {
-            return true;
-        }
-        err_ty == "IOError"
-            && sifr_type_system::IO_ERROR_KIND_CASES
-                .iter()
-                .all(|(name, _)| {
-                    handlers
-                        .iter()
-                        .any(|handler| handler.error_type.as_deref() == Some(*name))
-                })
-    }
-
     pub(crate) fn try_except_handler_condition_expr(
         handler: &HirExceptHandler,
         err_ident: &str,
@@ -206,14 +187,6 @@ impl RustEmitter {
         if branches.is_empty() {
             return Ok(None);
         }
-        if Self::handler_set_exhausts_error_type(handlers, err_ty)
-            && branches.iter().all(|(condition, _)| condition.is_some())
-        {
-            if let Some((condition, _)) = branches.last_mut() {
-                *condition = None;
-            }
-        }
-
         let mut current_else: Option<Vec<RustStmt>> = None;
         for (cond, body) in branches.into_iter().rev() {
             if let Some(cond) = cond {

--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -158,8 +158,6 @@ pub(in crate::lower) struct LowerCtx {
     pub(in crate::lower) try_block_error_types: std::collections::HashSet<Type>,
     /// Set of class names that are error types (class Foo(Error))
     pub(in crate::lower) error_types: std::collections::HashSet<String>,
-    /// Map of parent error type -> list of known child error types (for exhaustiveness checking)
-    pub(in crate::lower) error_hierarchy: HashMap<String, Vec<String>>,
     /// Map of function names to the parameter index of their *args (vararg) parameter
     pub(in crate::lower) vararg_functions: HashMap<String, usize>,
     /// Declaration-first Python parameter kinds, retained for call-shape lowering.
@@ -319,7 +317,6 @@ impl LowerCtx {
             current_function_return_type: None,
             try_block_error_types: std::collections::HashSet::new(),
             error_types: std::collections::HashSet::new(),
-            error_hierarchy: HashMap::new(),
             vararg_functions: HashMap::new(),
             python_call_shapes: HashMap::new(),
             python_callback_call_policies: HashMap::new(),

--- a/crates/sifr_lowering/src/lower/statement_diagnostics_tests.rs
+++ b/crates/sifr_lowering/src/lower/statement_diagnostics_tests.rs
@@ -157,6 +157,38 @@ def main():
 }
 
 #[test]
+fn ioerror_subclass_handlers_do_not_cover_the_open_base_error() {
+    let source = "\
+def fallible() -> Result[int, IOError]:
+    raise IOError(\"other\")
+
+def main():
+    try:
+        value: int = fallible()
+    except FileNotFoundError:
+        pass
+    except PermissionError:
+        pass
+    except FileExistsError:
+        pass
+    except IsADirectoryError:
+        pass
+    except NotADirectoryError:
+        pass
+    except DirectoryNotEmptyError:
+        pass
+";
+    let errors = lower_errors(source);
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::RESULT_UNCOVERED_TRY_ERRORS)
+            && error.message == "except arms do not cover all error types from try body: IOError"
+            && error.primary_range.map(|range| range.start())
+                == Some(range_for(source, "try:").start())
+    }));
+}
+
+#[test]
 fn try_finally_without_except_preserves_cleanup_boundary() {
     let source = "\
 def main():

--- a/crates/sifr_lowering/src/lower/statements/statement_dispatch.rs
+++ b/crates/sifr_lowering/src/lower/statements/statement_dispatch.rs
@@ -582,30 +582,16 @@ pub(in crate::lower) fn lower_stmt(
                 });
             }
 
-            // Exhaustiveness checking: if no catch-all, all error types must be covered
-            // A parent type covers all its children (e.g., except IOError covers FileNotFoundError)
-            // Subclasses partially cover their parent (e.g., except FileNotFoundError covers IOError::FileNotFound)
+            // Exhaustiveness checking: if no catch-all, all error types must be covered.
+            // A parent handler covers a child error. Child handlers do not cover their parent:
+            // base errors can contain values outside the known child set.
             if !has_catch_all && !try_error_types.is_empty() {
                 let uncovered: Vec<String> = try_error_types
                     .iter()
                     .filter(|error_ty| {
-                        if covered_types
+                        !covered_types
                             .iter()
                             .any(|covered| error_ty.is_assignable_to(covered))
-                        {
-                            return false;
-                        }
-                        let error_name = error_ty.display_name();
-                        let Some(children) = ctx.error_hierarchy.get(&error_name) else {
-                            return true;
-                        };
-                        !children.iter().all(|child| {
-                            ctx.class_types.get(child).is_some_and(|child_ty| {
-                                covered_types
-                                    .iter()
-                                    .any(|covered| child_ty.is_assignable_to(covered))
-                            })
-                        })
                     })
                     .map(Type::display_name)
                     .collect();

--- a/crates/sifr_lowering/src/lower/typing_and_functions/signatures_and_effects.rs
+++ b/crates/sifr_lowering/src/lower/typing_and_functions/signatures_and_effects.rs
@@ -191,15 +191,7 @@ pub(in crate::lower) fn register_builtins(ctx: &mut LowerCtx) {
     }
 
     // --- IOError subclasses (parent: IOError) ---
-    let io_subclasses = [
-        "FileNotFoundError",
-        "PermissionError",
-        "FileExistsError",
-        "IsADirectoryError",
-        "NotADirectoryError",
-        "DirectoryNotEmptyError",
-    ];
-    for &error_name in &io_subclasses {
+    for &(error_name, _) in &sifr_type_system::IO_ERROR_KIND_CASES {
         let fields = vec![("message".to_string(), Type::Str)];
         let class_ty = Type::Class {
             identity: None,
@@ -291,15 +283,6 @@ pub(in crate::lower) fn register_builtins(ctx: &mut LowerCtx) {
             FunctionType::new(vec![("message".to_string(), Type::Str)], class_ty),
         );
     }
-
-    // Build error hierarchy for exhaustiveness checking
-    ctx.error_hierarchy.insert(
-        "IOError".to_string(),
-        sifr_type_system::IO_ERROR_KIND_CASES
-            .iter()
-            .map(|(name, _)| (*name).to_string())
-            .collect(),
-    );
 }
 
 pub(in crate::lower) fn ast_convention_to_param(

--- a/demos/additional_modules/emitted.rs
+++ b/demos/additional_modules/emitted.rs
@@ -2771,7 +2771,7 @@ mod __sifr_project_nominals {
                     continue;
                 }
                 let __sifr_try_res: Result<
-                    (),
+                    ((String, Option<String>),),
                     __SifrStdlib_sifr_x2econfigparser_x2eParsingError,
                 > = (|| {
                     let parsed_option_pair: (String, Option<String>) = _split_option_line(
@@ -2827,12 +2827,15 @@ mod __sifr_project_nominals {
                             break;
                         }
                     }
-                    Ok(())
+                    Ok((parsed_option_pair,))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(e);
-                }
+                let (parsed_option_pair,) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(e);
+                    }
+                };
             }
             Ok(())
         }
@@ -7268,26 +7271,18 @@ fn demo_configparser() {
         false,
         false,
     );
-    let __sifr_try_res: Result<
-        Option<()>,
-        __SifrStdlib_sifr_x2econfigparser_x2eParsingError,
-    > = (|| {
+    let __sifr_try_res: Result<(), __SifrStdlib_sifr_x2econfigparser_x2eParsingError> = (||
+    {
         let _ = config
             .read_string(
                 &"[database]\nhost = db.example.com\nport = 5432\n".to_string(),
             )?;
-        Ok(None)
+        Ok(())
     })();
-    match __sifr_try_res {
-        Ok(Some(__sifr_ret_val)) => {
-            return __sifr_ret_val;
-        }
-        Ok(None) => {}
-        Err(__sifr_try_err) => {
-            let e = __sifr_try_err.clone();
-            println!("{}", e.message.clone());
-            return;
-        }
+    if let Err(__sifr_try_err) = __sifr_try_res {
+        let e = __sifr_try_err.clone();
+        println!("{}", e.message.clone());
+        return;
     }
     let host_value: Option<String> = config
         .get(&"database".to_string(), &"host".to_string(), &None, false);

--- a/demos/advanced_class_libraries/emitted.rs
+++ b/demos/advanced_class_libraries/emitted.rs
@@ -4416,16 +4416,19 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(), ValueError> = (|| {
+                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok(())
+                    Ok((tz_text, target_offset))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(ValueError::new(e.message.clone()));
-                }
+                let (tz_text, target_offset) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(ValueError::new(e.message.clone()));
+                    }
+                };
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/class_libraries/emitted.rs
+++ b/demos/class_libraries/emitted.rs
@@ -297,8 +297,10 @@ mod __sifr_project_nominals {
                 return Ok(());
             }
             let mut prepare_ok: bool = false;
-            let __sifr_try_res: Result<(), __SifrStdlib_sifr_x2egraphlib_x2eCycleError> = (||
-            {
+            let __sifr_try_res: Result<
+                (Vec<i64>,),
+                __SifrStdlib_sifr_x2egraphlib_x2eCycleError,
+            > = (|| {
                 let order: Vec<i64> = topological_sort(
                     self.max_node + (1_i64),
                     &self.from_nodes,
@@ -307,17 +309,20 @@ mod __sifr_project_nominals {
                 self._ready_order = self._filter_order(&order);
                 self._prepared = true;
                 prepare_ok = true;
-                Ok(())
+                Ok((order,))
             })();
-            if let Err(__sifr_try_err) = __sifr_try_res {
-                let e = __sifr_try_err.clone();
-                self._prepared = false;
-                self._ready_order = vec![];
-                self._next_index = 0_i64;
-                return Err(
-                    __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
-                );
-            }
+            let (order,) = match __sifr_try_res {
+                Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                Err(__sifr_try_err) => {
+                    let e = __sifr_try_err.clone();
+                    self._prepared = false;
+                    self._ready_order = vec![];
+                    self._next_index = 0_i64;
+                    return Err(
+                        __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
+                    );
+                }
+            };
             if prepare_ok {
                 return Ok(());
             }
@@ -330,19 +335,24 @@ mod __sifr_project_nominals {
         ) -> Result<Vec<i64>, __SifrStdlib_sifr_x2egraphlib_x2eCycleError> {
             if !(self._prepared) {
                 let __sifr_try_res: Result<
-                    (),
+                    ((),),
                     __SifrStdlib_sifr_x2egraphlib_x2eCycleError,
                 > = (|| {
                     let _prepared: () = self.prepare()?;
                     let _ = _prepared;
-                    Ok(())
+                    Ok((_prepared,))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(
-                        __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
-                    );
-                }
+                let (_prepared,) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(
+                            __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(
+                                e.message.clone(),
+                            ),
+                        );
+                    }
+                };
             }
             if (self._next_index < (self._ready_order.len() as i64)) {
                 let current: Option<i64> = {

--- a/demos/codegen_structural_passes/emitted.rs
+++ b/demos/codegen_structural_passes/emitted.rs
@@ -366,16 +366,19 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(), ValueError> = (|| {
+                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok(())
+                    Ok((tz_text, target_offset))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(ValueError::new(e.message.clone()));
-                }
+                let (tz_text, target_offset) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(ValueError::new(e.message.clone()));
+                    }
+                };
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/collections_and_argparse/emitted.rs
+++ b/demos/collections_and_argparse/emitted.rs
@@ -922,6 +922,7 @@ mod __sifr_project_nominals {
             };
         }
         if _is_digit_string(nargs) {
+            let mut __sifr_successful_try_bindings: Option<(i64,)> = None;
             let __sifr_try_res: Result<Option<String>, ParseError> = (|| {
                 let parsed: i64 = (nargs)
                     .parse::<i64>()
@@ -931,6 +932,7 @@ mod __sifr_project_nominals {
                 if parsed > (0_i64) {
                     return Ok(Some(format!("{}", parsed)));
                 }
+                __sifr_successful_try_bindings = Some((parsed,));
                 Ok(None)
             })();
             match __sifr_try_res {
@@ -943,6 +945,9 @@ mod __sifr_project_nominals {
                     return "1".to_string();
                 }
             }
+            let Some((parsed,)) = __sifr_successful_try_bindings else {
+                unreachable!("successful try fallthrough must initialize promoted bindings");
+            };
         }
         "1".to_string()
     }
@@ -1515,6 +1520,7 @@ fn _normalize_nargs(nargs: &String) -> String {
         };
     }
     if _is_digit_string(nargs) {
+        let mut __sifr_successful_try_bindings: Option<(i64,)> = None;
         let __sifr_try_res: Result<Option<String>, ParseError> = (|| {
             let parsed: i64 = (nargs)
                 .parse::<i64>()
@@ -1524,6 +1530,7 @@ fn _normalize_nargs(nargs: &String) -> String {
             if parsed > (0_i64) {
                 return Ok(Some(format!("{}", parsed)));
             }
+            __sifr_successful_try_bindings = Some((parsed,));
             Ok(None)
         })();
         match __sifr_try_res {
@@ -1536,6 +1543,9 @@ fn _normalize_nargs(nargs: &String) -> String {
                 return "1".to_string();
             }
         }
+        let Some((parsed,)) = __sifr_successful_try_bindings else {
+            unreachable!("successful try fallthrough must initialize promoted bindings");
+        };
     }
     "1".to_string()
 }

--- a/demos/config_json_csv/emitted.rs
+++ b/demos/config_json_csv/emitted.rs
@@ -2773,7 +2773,7 @@ mod __sifr_project_nominals {
                     continue;
                 }
                 let __sifr_try_res: Result<
-                    (),
+                    ((String, Option<String>),),
                     __SifrStdlib_sifr_x2econfigparser_x2eParsingError,
                 > = (|| {
                     let parsed_option_pair: (String, Option<String>) = _split_option_line(
@@ -2829,12 +2829,15 @@ mod __sifr_project_nominals {
                             break;
                         }
                     }
-                    Ok(())
+                    Ok((parsed_option_pair,))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(e);
-                }
+                let (parsed_option_pair,) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(e);
+                    }
+                };
             }
             Ok(())
         }

--- a/demos/core_libraries/emitted.rs
+++ b/demos/core_libraries/emitted.rs
@@ -384,16 +384,19 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(), ValueError> = (|| {
+                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok(())
+                    Ok((tz_text, target_offset))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(ValueError::new(e.message.clone()));
-                }
+                let (tz_text, target_offset) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(ValueError::new(e.message.clone()));
+                    }
+                };
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/datetime/emitted.rs
+++ b/demos/datetime/emitted.rs
@@ -452,16 +452,19 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(), ValueError> = (|| {
+                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok(())
+                    Ok((tz_text, target_offset))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(ValueError::new(e.message.clone()));
-                }
+                let (tz_text, target_offset) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(ValueError::new(e.message.clone()));
+                    }
+                };
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/filesystem_and_archives/emitted.rs
+++ b/demos/filesystem_and_archives/emitted.rs
@@ -1434,7 +1434,7 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
             __indexed_char
         }) == ".")));
     let mut matches: Vec<String> = vec![];
-    let __sifr_try_res: Result<Option<Vec<String>>, IOError> = (|| {
+    let __sifr_try_res: Result<(Vec<String>,), IOError> = (|| {
         let entries: Vec<String> = listdir(directory)?;
         for entry in entries.iter().cloned() {
             let __sifr_chars_entry: Vec<char> = entry.chars().collect::<Vec<char>>();
@@ -1459,19 +1459,16 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
                 matches.push(entry.clone());
             }
         }
-        Ok(None)
+        Ok((entries,))
     })();
-    match __sifr_try_res {
-        Ok(Some(__sifr_ret_val)) => {
-            return __sifr_ret_val;
-        }
-        Ok(None) => {}
+    let (entries,) = match __sifr_try_res {
+        Ok(__sifr_try_bindings) => __sifr_try_bindings,
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
             let _ = format!("{}", e.message.clone());
             return vec![];
         }
-    }
+    };
     {
         let mut __sifr_sorted_v = (matches).iter().cloned().collect::<Vec<_>>();
         __sifr_sorted_v.sort();

--- a/demos/fixed_timezones/emitted.rs
+++ b/demos/fixed_timezones/emitted.rs
@@ -366,16 +366,19 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(), ValueError> = (|| {
+                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok(())
+                    Ok((tz_text, target_offset))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(ValueError::new(e.message.clone()));
-                }
+                let (tz_text, target_offset) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(ValueError::new(e.message.clone()));
+                    }
+                };
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/glob/emitted.rs
+++ b/demos/glob/emitted.rs
@@ -398,7 +398,7 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
             __indexed_char
         }) == ".")));
     let mut matches: Vec<String> = vec![];
-    let __sifr_try_res: Result<Option<Vec<String>>, IOError> = (|| {
+    let __sifr_try_res: Result<(Vec<String>,), IOError> = (|| {
         let entries: Vec<String> = listdir(directory)?;
         for entry in entries.iter().cloned() {
             let __sifr_chars_entry: Vec<char> = entry.chars().collect::<Vec<char>>();
@@ -423,19 +423,16 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
                 matches.push(entry.clone());
             }
         }
-        Ok(None)
+        Ok((entries,))
     })();
-    match __sifr_try_res {
-        Ok(Some(__sifr_ret_val)) => {
-            return __sifr_ret_val;
-        }
-        Ok(None) => {}
+    let (entries,) = match __sifr_try_res {
+        Ok(__sifr_try_bindings) => __sifr_try_bindings,
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
             let _ = format!("{}", e.message.clone());
             return vec![];
         }
-    }
+    };
     {
         let mut __sifr_sorted_v = (matches).iter().cloned().collect::<Vec<_>>();
         __sifr_sorted_v.sort();

--- a/demos/hashlib/emitted.rs
+++ b/demos/hashlib/emitted.rs
@@ -1131,23 +1131,33 @@ fn file_digest(
     path: &String,
     name: &String,
 ) -> Result<String, __SifrStdlib_sifr_x2ehashlib_x2eHashlibError> {
-    let __sifr_try_res: Result<(), IOError> = (|| {
+    let __sifr_try_res: Result<(__SifrIoNativeFileHandle,), IOError> = (|| {
         let handle: __SifrIoNativeFileHandle = open_file(path, &"rb".to_string())?;
-        Ok(())
+        Ok((handle,))
     })();
-    if let Err(__sifr_try_err) = __sifr_try_res {
-        let e = __sifr_try_err.clone();
-        return Err(__SifrStdlib_sifr_x2ehashlib_x2eHashlibError::new(e.message.clone()));
-    }
-    let __sifr_try_res: Result<(), IOError> = (|| {
+    let (handle,) = match __sifr_try_res {
+        Ok(__sifr_try_bindings) => __sifr_try_bindings,
+        Err(__sifr_try_err) => {
+            let e = __sifr_try_err.clone();
+            return Err(
+                __SifrStdlib_sifr_x2ehashlib_x2eHashlibError::new(e.message.clone()),
+            );
+        }
+    };
+    let __sifr_try_res: Result<(Vec<u8>,), IOError> = (|| {
         let data: Vec<u8> = file_read_bytes(&handle)?;
-        Ok(())
+        Ok((data,))
     })();
-    if let Err(__sifr_try_err) = __sifr_try_res {
-        let e = __sifr_try_err.clone();
-        file_close(&handle);
-        return Err(__SifrStdlib_sifr_x2ehashlib_x2eHashlibError::new(e.message.clone()));
-    }
+    let (data,) = match __sifr_try_res {
+        Ok(__sifr_try_bindings) => __sifr_try_bindings,
+        Err(__sifr_try_err) => {
+            let e = __sifr_try_err.clone();
+            file_close(&handle);
+            return Err(
+                __SifrStdlib_sifr_x2ehashlib_x2eHashlibError::new(e.message.clone()),
+            );
+        }
+    };
     file_close(&handle);
     let __sifr_try_res: Result<
         Result<String, __SifrStdlib_sifr_x2ehashlib_x2eHashlibError>,

--- a/demos/regex_and_filesystem/emitted.rs
+++ b/demos/regex_and_filesystem/emitted.rs
@@ -1633,7 +1633,7 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
             __indexed_char
         }) == ".")));
     let mut matches: Vec<String> = vec![];
-    let __sifr_try_res: Result<Option<Vec<String>>, IOError> = (|| {
+    let __sifr_try_res: Result<(Vec<String>,), IOError> = (|| {
         let entries: Vec<String> = listdir(directory)?;
         for entry in entries.iter().cloned() {
             let __sifr_chars_entry: Vec<char> = entry.chars().collect::<Vec<char>>();
@@ -1658,19 +1658,16 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
                 matches.push(entry.clone());
             }
         }
-        Ok(None)
+        Ok((entries,))
     })();
-    match __sifr_try_res {
-        Ok(Some(__sifr_ret_val)) => {
-            return __sifr_ret_val;
-        }
-        Ok(None) => {}
+    let (entries,) = match __sifr_try_res {
+        Ok(__sifr_try_bindings) => __sifr_try_bindings,
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
             let _ = format!("{}", e.message.clone());
             return vec![];
         }
-    }
+    };
     {
         let mut __sifr_sorted_v = (matches).iter().cloned().collect::<Vec<_>>();
         __sifr_sorted_v.sort();

--- a/demos/safe_edge_cases/emitted.rs
+++ b/demos/safe_edge_cases/emitted.rs
@@ -366,16 +366,19 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(), ValueError> = (|| {
+                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok(())
+                    Ok((tz_text, target_offset))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(ValueError::new(e.message.clone()));
-                }
+                let (tz_text, target_offset) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(ValueError::new(e.message.clone()));
+                    }
+                };
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/stdlib/emitted.rs
+++ b/demos/stdlib/emitted.rs
@@ -384,16 +384,19 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(), ValueError> = (|| {
+                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok(())
+                    Ok((tz_text, target_offset))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(ValueError::new(e.message.clone()));
-                }
+                let (tz_text, target_offset) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(ValueError::new(e.message.clone()));
+                    }
+                };
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/stdlib_fixes/emitted.rs
+++ b/demos/stdlib_fixes/emitted.rs
@@ -3520,16 +3520,19 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(), ValueError> = (|| {
+                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok(())
+                    Ok((tz_text, target_offset))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(ValueError::new(e.message.clone()));
-                }
+                let (tz_text, target_offset) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(ValueError::new(e.message.clone()));
+                    }
+                };
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/stdlib_tools/emitted.rs
+++ b/demos/stdlib_tools/emitted.rs
@@ -3233,7 +3233,7 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
             __indexed_char
         }) == ".")));
     let mut matches: Vec<String> = vec![];
-    let __sifr_try_res: Result<Option<Vec<String>>, IOError> = (|| {
+    let __sifr_try_res: Result<(Vec<String>,), IOError> = (|| {
         let entries: Vec<String> = listdir(directory)?;
         for entry in entries.iter().cloned() {
             let __sifr_chars_entry: Vec<char> = entry.chars().collect::<Vec<char>>();
@@ -3258,19 +3258,16 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
                 matches.push(entry.clone());
             }
         }
-        Ok(None)
+        Ok((entries,))
     })();
-    match __sifr_try_res {
-        Ok(Some(__sifr_ret_val)) => {
-            return __sifr_ret_val;
-        }
-        Ok(None) => {}
+    let (entries,) = match __sifr_try_res {
+        Ok(__sifr_try_bindings) => __sifr_try_bindings,
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
             let _ = format!("{}", e.message.clone());
             return vec![];
         }
-    }
+    };
     {
         let mut __sifr_sorted_v = (matches).iter().cloned().collect::<Vec<_>>();
         __sifr_sorted_v.sort();

--- a/demos/structured_parsing_serialization/emitted.rs
+++ b/demos/structured_parsing_serialization/emitted.rs
@@ -2773,7 +2773,7 @@ mod __sifr_project_nominals {
                     continue;
                 }
                 let __sifr_try_res: Result<
-                    (),
+                    ((String, Option<String>),),
                     __SifrStdlib_sifr_x2econfigparser_x2eParsingError,
                 > = (|| {
                     let parsed_option_pair: (String, Option<String>) = _split_option_line(
@@ -2829,12 +2829,15 @@ mod __sifr_project_nominals {
                             break;
                         }
                     }
-                    Ok(())
+                    Ok((parsed_option_pair,))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(e);
-                }
+                let (parsed_option_pair,) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(e);
+                    }
+                };
             }
             Ok(())
         }
@@ -10190,26 +10193,18 @@ fn main() {
         false,
         true,
     );
-    let __sifr_try_res: Result<
-        Option<()>,
-        __SifrStdlib_sifr_x2econfigparser_x2eParsingError,
-    > = (|| {
+    let __sifr_try_res: Result<(), __SifrStdlib_sifr_x2econfigparser_x2eParsingError> = (||
+    {
         let _ = parser
             .read_string(
                 &"[server]\nport = 8080\nenabled = true\nfeature\n".to_string(),
             )?;
-        Ok(None)
+        Ok(())
     })();
-    match __sifr_try_res {
-        Ok(Some(__sifr_ret_val)) => {
-            return __sifr_ret_val;
-        }
-        Ok(None) => {}
-        Err(__sifr_try_err) => {
-            let e = __sifr_try_err.clone();
-            println!("{}", e.message.clone());
-            return;
-        }
+    if let Err(__sifr_try_err) = __sifr_try_res {
+        let e = __sifr_try_err.clone();
+        println!("{}", e.message.clone());
+        return;
     }
     println!(
         "{}", (parser.getint(& "server".to_string(), & "port".to_string(), None))

--- a/demos/utility_classes/emitted.rs
+++ b/demos/utility_classes/emitted.rs
@@ -921,6 +921,7 @@ mod __sifr_project_nominals {
             };
         }
         if _is_digit_string(nargs) {
+            let mut __sifr_successful_try_bindings: Option<(i64,)> = None;
             let __sifr_try_res: Result<Option<String>, ParseError> = (|| {
                 let parsed: i64 = (nargs)
                     .parse::<i64>()
@@ -930,6 +931,7 @@ mod __sifr_project_nominals {
                 if parsed > (0_i64) {
                     return Ok(Some(format!("{}", parsed)));
                 }
+                __sifr_successful_try_bindings = Some((parsed,));
                 Ok(None)
             })();
             match __sifr_try_res {
@@ -942,6 +944,9 @@ mod __sifr_project_nominals {
                     return "1".to_string();
                 }
             }
+            let Some((parsed,)) = __sifr_successful_try_bindings else {
+                unreachable!("successful try fallthrough must initialize promoted bindings");
+            };
         }
         "1".to_string()
     }
@@ -1173,8 +1178,10 @@ mod __sifr_project_nominals {
                 return Ok(());
             }
             let mut prepare_ok: bool = false;
-            let __sifr_try_res: Result<(), __SifrStdlib_sifr_x2egraphlib_x2eCycleError> = (||
-            {
+            let __sifr_try_res: Result<
+                (Vec<i64>,),
+                __SifrStdlib_sifr_x2egraphlib_x2eCycleError,
+            > = (|| {
                 let order: Vec<i64> = topological_sort(
                     self.max_node + (1_i64),
                     &self.from_nodes,
@@ -1183,17 +1190,20 @@ mod __sifr_project_nominals {
                 self._ready_order = self._filter_order(&order);
                 self._prepared = true;
                 prepare_ok = true;
-                Ok(())
+                Ok((order,))
             })();
-            if let Err(__sifr_try_err) = __sifr_try_res {
-                let e = __sifr_try_err.clone();
-                self._prepared = false;
-                self._ready_order = vec![];
-                self._next_index = 0_i64;
-                return Err(
-                    __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
-                );
-            }
+            let (order,) = match __sifr_try_res {
+                Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                Err(__sifr_try_err) => {
+                    let e = __sifr_try_err.clone();
+                    self._prepared = false;
+                    self._ready_order = vec![];
+                    self._next_index = 0_i64;
+                    return Err(
+                        __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
+                    );
+                }
+            };
             if prepare_ok {
                 return Ok(());
             }
@@ -1206,19 +1216,24 @@ mod __sifr_project_nominals {
         ) -> Result<Vec<i64>, __SifrStdlib_sifr_x2egraphlib_x2eCycleError> {
             if !(self._prepared) {
                 let __sifr_try_res: Result<
-                    (),
+                    ((),),
                     __SifrStdlib_sifr_x2egraphlib_x2eCycleError,
                 > = (|| {
                     let _prepared: () = self.prepare()?;
                     let _ = _prepared;
-                    Ok(())
+                    Ok((_prepared,))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(
-                        __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
-                    );
-                }
+                let (_prepared,) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(
+                            __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(
+                                e.message.clone(),
+                            ),
+                        );
+                    }
+                };
             }
             if (self._next_index < (self._ready_order.len() as i64)) {
                 let current: Option<i64> = {
@@ -2042,6 +2057,7 @@ fn _normalize_nargs(nargs: &String) -> String {
         };
     }
     if _is_digit_string(nargs) {
+        let mut __sifr_successful_try_bindings: Option<(i64,)> = None;
         let __sifr_try_res: Result<Option<String>, ParseError> = (|| {
             let parsed: i64 = (nargs)
                 .parse::<i64>()
@@ -2051,6 +2067,7 @@ fn _normalize_nargs(nargs: &String) -> String {
             if parsed > (0_i64) {
                 return Ok(Some(format!("{}", parsed)));
             }
+            __sifr_successful_try_bindings = Some((parsed,));
             Ok(None)
         })();
         match __sifr_try_res {
@@ -2063,6 +2080,9 @@ fn _normalize_nargs(nargs: &String) -> String {
                 return "1".to_string();
             }
         }
+        let Some((parsed,)) = __sifr_successful_try_bindings else {
+            unreachable!("successful try fallthrough must initialize promoted bindings");
+        };
     }
     "1".to_string()
 }

--- a/demos/uuid_and_datetime/emitted.rs
+++ b/demos/uuid_and_datetime/emitted.rs
@@ -366,16 +366,19 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(), ValueError> = (|| {
+                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok(())
+                    Ok((tz_text, target_offset))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(ValueError::new(e.message.clone()));
-                }
+                let (tz_text, target_offset) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(ValueError::new(e.message.clone()));
+                    }
+                };
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/zipfile_io/emitted.rs
+++ b/demos/zipfile_io/emitted.rs
@@ -463,14 +463,17 @@ mod __sifr_project_nominals {
                 return Ok(());
             }
             if exists(&self._path) {
-                let __sifr_try_res: Result<(), IOError> = (|| {
+                let __sifr_try_res: Result<((),), IOError> = (|| {
                     let _rm_done: () = remove_file(&self._path)?;
-                    Ok(())
+                    Ok((_rm_done,))
                 })();
-                if let Err(__sifr_try_err) = __sifr_try_res {
-                    let e = __sifr_try_err.clone();
-                    return Err(IOError::new(e.message.clone()));
-                }
+                let (_rm_done,) = match __sifr_try_res {
+                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
+                    Err(__sifr_try_err) => {
+                        let e = __sifr_try_err.clone();
+                        return Err(IOError::new(e.message.clone()));
+                    }
+                };
             }
             self._cleaned = true;
             Ok(())


### PR DESCRIPTION
## Summary
- keep all named IOError handlers guarded and require a base or catch-all handler for open-domain coverage
- derive compiler IO subclass handling from the canonical type-system mapping
- refresh the 21 stale demo companions from the corrected compiler

## Validation
- focused IOError pass fixture checks, builds, and runs
- open-base fail fixture reports SIFR-RESULT-0005
- full sifr_lowering and sifr_codegen test suites
- affected-package clippy with warnings denied
- demo emitted-freshness, HIR maintainability, and file-size guardrails