### PR TITLE
fix(codegen): make option union conversion single-pass

### DIFF
--- a/crates/sifr_codegen/src/intrinsic_method_emitters/narrowing_helpers.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/narrowing_helpers.rs
@@ -8,9 +8,7 @@ impl RustEmitter {
         lowered: RustExpr,
     ) -> RustExpr {
         let source_ty = self.effective_registry_expr_ty(argument);
-        let lowered =
-            crate::helpers::flatten_option_value_for_target(target_ty, &source_ty, lowered);
-        self.consuming_value_upcast_for_ir(target_ty, &source_ty, lowered)
+        self.consuming_value_conversion_for_ir(target_ty, &source_ty, lowered)
     }
 }
 

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
@@ -104,7 +104,7 @@ impl RustEmitter {
             let coercion_probe = RustExpr::Ident("__sifr_coercion_probe".to_string());
             let needs_borrowed_structural_coercion = convention.is_shared_borrow()
                 && registry_needs_structural_value_coercion(param_ty, &effective_arg_ty)
-                && self.consuming_value_upcast_for_ir(
+                && self.consuming_value_conversion_for_ir(
                     param_ty,
                     &effective_arg_ty,
                     coercion_probe.clone(),
@@ -113,10 +113,8 @@ impl RustEmitter {
             let mut consuming_value_adapted = false;
             if convention.is_owned() {
                 (lowered_arg, consuming_value_adapted) = self.adapt_consuming_call_argument_for_ir(
-                    arg,
                     param_ty,
                     &effective_arg_ty,
-                    *convention,
                     lowered_arg,
                     borrowed_name_arg,
                 );
@@ -128,8 +126,11 @@ impl RustEmitter {
                         args: Vec::new(),
                     };
                 }
-                lowered_arg =
-                    self.consuming_value_upcast_for_ir(param_ty, &effective_arg_ty, lowered_arg);
+                lowered_arg = self.consuming_value_conversion_for_ir(
+                    param_ty,
+                    &effective_arg_ty,
+                    lowered_arg,
+                );
                 consuming_value_adapted = true;
             } else if let Type::Union(_) = resolved_param {
                 if !crate::helpers::is_option_type(resolved_param)

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/registry_helpers.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/registry_helpers.rs
@@ -551,12 +551,8 @@ pub(super) fn registry_call_callable_with_owned_args(
         let mut lowered_arg = RustExpr::Ident(name.clone());
         let arg_is_option = crate::helpers::is_option_type(arg_ty);
         let param_is_option = crate::helpers::is_option_type(param_ty);
-        let mut adapted_arg =
-            crate::helpers::flatten_option_value_for_target(param_ty, arg_ty, lowered_arg.clone());
-        if adapted_arg == lowered_arg {
-            adapted_arg =
-                emitter.consuming_value_upcast_for_ir(param_ty, arg_ty, lowered_arg.clone());
-        }
+        let adapted_arg =
+            emitter.consuming_value_conversion_for_ir(param_ty, arg_ty, lowered_arg.clone());
         let option_value_adapted = adapted_arg != lowered_arg;
         lowered_arg = adapted_arg;
         if param_is_option && !arg_is_option {

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/registry_method_arg_conventions.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/registry_method_arg_conventions.rs
@@ -20,10 +20,8 @@ impl RustEmitter {
         let unadapted_option_arg = lowered_arg.clone();
         if convention.is_owned() {
             (lowered_arg, _) = self.adapt_consuming_call_argument_for_ir(
-                arg,
                 param_ty,
                 &effective_arg_ty,
-                convention,
                 lowered_arg,
                 borrowed_name_arg,
             );

--- a/crates/sifr_codegen/src/lib_codegen_tests/union_representation_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/union_representation_codegen_tests.rs
@@ -85,6 +85,40 @@ def forward(values: dict[str, int | str | None]) -> bool:
 }
 
 #[test]
+fn safe_nullable_union_boundaries_convert_each_value_once() {
+    let rust_code = generate_rust_from_source(
+        r#"def consume(value: int | str | None) -> bool:
+    return value is None
+
+def select(
+    values: dict[str, int | str | None],
+    choose_safe: bool,
+    fallback: int | str | None = None,
+) -> int | str | None:
+    assigned: int | str | None = values.get("assigned")
+    stored: list[int | str | None] = []
+    stored.append(values.get("stored"))
+    joined = values.get("joined") if choose_safe else fallback
+    assert consume(values.get("argument"))
+    if assigned is not None:
+        return assigned
+    return joined
+"#,
+    );
+
+    assert_eq!(
+        rust_code.matches(".unwrap_or(").count(),
+        4,
+        "each safe read must materialize its nullable union exactly once:\n{rust_code}"
+    );
+    assert_eq!(
+        rust_code.matches(".map(").count(),
+        0,
+        "exact nullable-union conversions do not need a payload map:\n{rust_code}"
+    );
+}
+
+#[test]
 fn nested_option_represented_union_payload_widens_recursively() {
     let payload = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
     let target = sifr_type_system::make_union(vec![Type::Bool, Type::Int, Type::Str, Type::None]);

--- a/crates/sifr_codegen/src/stmt_support_emitter/await_and_async_comprehension.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/await_and_async_comprehension.rs
@@ -164,10 +164,9 @@ impl RustEmitter {
             });
         }
         let upcasted_value =
-            self.consuming_value_upcast_for_ir(target_ty, value_ty, lowered_value.clone());
+            self.consuming_value_conversion_for_ir(target_ty, value_ty, lowered_value.clone());
         let value_was_upcasted = upcasted_value != lowered_value;
-        let lowered_value =
-            crate::helpers::flatten_option_value_for_target(target_ty, value_ty, upcasted_value);
+        let lowered_value = upcasted_value;
         let wrapped_member = if matches!(value, HirExpr::NoneLiteral) {
             &Type::None
         } else {

--- a/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
@@ -75,10 +75,8 @@ impl RustEmitter {
             let mut consuming_value_adapted = false;
             if convention.is_owned() {
                 (lowered_arg, consuming_value_adapted) = self.adapt_consuming_call_argument_for_ir(
-                    hir_arg,
                     param_ty,
                     &effective_arg_ty,
-                    *convention,
                     lowered_arg,
                     borrowed_name_arg,
                 );

--- a/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/class_upcasts.rs
@@ -1,28 +1,15 @@
-use super::{HirExpr, RustEmitter, Type};
-use crate::ParamConvention;
+use super::{RustEmitter, Type};
 
 impl RustEmitter {
     pub(crate) fn adapt_consuming_call_argument_for_ir(
         &self,
-        arg: &HirExpr,
         target_ty: &Type,
         source_ty: &Type,
-        convention: ParamConvention,
         lowered: crate::RustExpr,
         borrowed_source: bool,
     ) -> (crate::RustExpr, bool) {
-        let flattened = Self::flatten_option_argument_for_ir(
-            arg,
-            target_ty,
-            source_ty,
-            convention,
-            lowered.clone(),
-        );
-        if flattened != lowered {
-            return (flattened, true);
-        }
         let probe = crate::RustExpr::Ident("__sifr_consuming_upcast_probe".to_string());
-        if self.consuming_value_upcast_for_ir(target_ty, source_ty, probe.clone()) == probe {
+        if self.consuming_value_conversion_for_ir(target_ty, source_ty, probe.clone()) == probe {
             return (lowered, false);
         }
         let lowered = if borrowed_source && !crate::helpers::is_copy_type_for_codegen(source_ty) {
@@ -35,12 +22,31 @@ impl RustEmitter {
             lowered
         };
         (
-            self.consuming_value_upcast_for_ir(target_ty, source_ty, lowered),
+            self.consuming_value_conversion_for_ir(target_ty, source_ty, lowered),
             true,
         )
     }
 
-    pub(crate) fn consuming_value_upcast_for_ir(
+    /// Convert between the source and target runtime representations exactly once.
+    ///
+    /// Optional-wrapper adaptation and recursive union upcasting overlap for an
+    /// `Option<Union>` source. Keep their source/target representation pair under
+    /// one authority so a caller cannot apply both transitions to the same value.
+    pub(crate) fn consuming_value_conversion_for_ir(
+        &self,
+        target_ty: &Type,
+        source_ty: &Type,
+        lowered: crate::RustExpr,
+    ) -> crate::RustExpr {
+        let wrapper_adapted =
+            crate::helpers::flatten_option_value_for_target(target_ty, source_ty, lowered.clone());
+        if wrapper_adapted != lowered {
+            return wrapper_adapted;
+        }
+        self.consuming_value_upcast_for_ir(target_ty, source_ty, lowered)
+    }
+
+    fn consuming_value_upcast_for_ir(
         &self,
         target_ty: &Type,
         source_ty: &Type,
@@ -244,6 +250,53 @@ impl RustEmitter {
     }
 }
 
+#[cfg(test)]
+mod representation_tests {
+    use super::*;
+
+    fn render_conversion(target: &Type, source: &Type) -> String {
+        let emitter = RustEmitter::new();
+        crate::render_expr(&emitter.consuming_value_conversion_for_ir(
+            target,
+            source,
+            crate::RustExpr::Ident("value".to_string()),
+        ))
+    }
+
+    #[test]
+    fn representation_conversion_flattens_nested_option_once() {
+        let target = sifr_type_system::make_union(vec![Type::Str, Type::None]);
+        let source = Type::Union(vec![target.clone(), Type::None]);
+        let rendered = render_conversion(&target, &source);
+
+        assert_eq!(rendered.matches(".flatten(").count(), 1, "{rendered}");
+        assert_eq!(rendered.matches(".map(").count(), 0, "{rendered}");
+        assert_eq!(rendered.matches(".unwrap_or(").count(), 0, "{rendered}");
+    }
+
+    #[test]
+    fn representation_conversion_maps_option_union_once() {
+        let payload = sifr_type_system::make_union(vec![Type::Int, Type::Str]);
+        let source = sifr_type_system::safe_optional_result(payload);
+        let target =
+            sifr_type_system::make_union(vec![Type::Bool, Type::Int, Type::Str, Type::None]);
+        let rendered = render_conversion(&target, &source);
+
+        assert_eq!(rendered.matches(".map(").count(), 1, "{rendered}");
+        assert_eq!(rendered.matches(".unwrap_or(").count(), 1, "{rendered}");
+    }
+
+    #[test]
+    fn representation_conversion_materializes_nullable_union_once() {
+        let target = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
+        let source = sifr_type_system::safe_optional_result(target.clone());
+        let rendered = render_conversion(&target, &source);
+
+        assert_eq!(rendered.matches(".map(").count(), 0, "{rendered}");
+        assert_eq!(rendered.matches(".unwrap_or(").count(), 1, "{rendered}");
+    }
+}
+
 fn render_ancestor_rust_type(current_module: Option<&str>, ancestor: &str) -> String {
     let Some((module, name)) = ancestor.rsplit_once('.') else {
         return sifr_type_system::source_class_rust_name(ancestor);
@@ -305,10 +358,10 @@ mod tests {
         let value = RustExpr::Ident("value".to_string());
 
         assert_eq!(
-            RustEmitter::new().consuming_class_upcast_for_ir(
+            RustEmitter::new().consuming_value_conversion_for_ir(
                 &unrelated_root,
                 &source,
-                value.clone()
+                value.clone(),
             ),
             value
         );

--- a/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
@@ -547,7 +547,8 @@ impl RustEmitter {
         let Some(target) = target else {
             return source;
         };
-        let converted = self.consuming_value_upcast_for_ir(target, &source_type, source.clone());
+        let converted =
+            self.consuming_value_conversion_for_ir(target, &source_type, source.clone());
         if converted != source {
             return converted;
         }

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_method_and_question_mark.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_method_and_question_mark.rs
@@ -402,7 +402,7 @@ macro_rules! stmt_expr_question_mark {
                         ))));
                     }
                     let converted_error = target_error_info.as_ref().map(|target| {
-                        $emitter.consuming_value_upcast_for_ir(
+                        $emitter.consuming_value_conversion_for_ir(
                             target,
                             inner_err_ty,
                             error_ident.clone(),

--- a/crates/sifr_codegen/src/stmt_support_emitter/structured_return_if_while.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/structured_return_if_while.rs
@@ -181,7 +181,8 @@ impl RustEmitter {
         let Some(target) = target else {
             return lowered;
         };
-        let converted = self.consuming_value_upcast_for_ir(target, source_type, lowered.clone());
+        let converted =
+            self.consuming_value_conversion_for_ir(target, source_type, lowered.clone());
         if converted != lowered {
             return converted;
         }

--- a/crates/sifr_codegen/src/stmt_support_emitter/try_handlers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/try_handlers.rs
@@ -133,7 +133,7 @@ impl RustEmitter {
                                     }],
                                 };
                             }
-                            let converted = self.consuming_value_upcast_for_ir(
+                            let converted = self.consuming_value_conversion_for_ir(
                                 target,
                                 source,
                                 cloned_error.clone(),


### PR DESCRIPTION
## Summary
- centralize optional-wrapper adaptation and recursive union upcasting under one source/target representation conversion
- prevent assignment and collection-argument paths from applying both conversions to one lowered value
- cover nested Option, Option-of-union, assignments, arguments, returns, defaults, and narrowing joins

## Validation
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/nested_optional_safe_operations.sifr
- cargo run -q -p sifr -- build crates/sifr/tests/e2e/pass/nested_optional_safe_operations.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/nested_optional_safe_operations.sifr
- cargo test -p sifr_codegen (1,101 passed)
- cargo clippy -p sifr_codegen -- -D warnings
- cargo fmt --check
- Python maintainability and file-size guardrails

Phase item: Item 7 in plans/issues/active/ad-hoc-pre-v1-canonical-contract-regression-closure.md