### PR TITLE
fix(lowering): return CFG invariant diagnostics

### DIFF
--- a/crates/sifr_lowering/src/cfg.rs
+++ b/crates/sifr_lowering/src/cfg.rs
@@ -2,7 +2,8 @@
 
 use crate::{HirExpr, HirStmt};
 use sifr_ir::{
-    CfgBlock, CfgBlockId, CfgBlockLabel, CfgTerminator, ControlFlowGraph, FlowExitEffect, FlowFacts,
+    CfgBlock, CfgBlockId, CfgBlockLabel, CfgInvariantError, CfgTerminator, ControlFlowGraph,
+    FlowExitEffect, FlowFacts,
 };
 use sifr_type_system::Type;
 
@@ -185,14 +186,16 @@ impl CfgBuilder {
             }
             HirStmt::Match { arms, .. } => {
                 let block = self.new_block(CfgBlockLabel::Statement("match"), top_level_stmt_index);
-                if arms.is_empty() {
-                    self.set_terminator(block, CfgTerminator::Goto(next));
-                } else {
-                    let arm_entries: Vec<CfgBlockId> = arms
-                        .iter()
-                        .map(|arm| self.build_stmt_list(&arm.body, next, loop_targets, false))
-                        .collect();
-                    self.set_terminator(block, CfgTerminator::Branch(arm_entries));
+                let arm_entries: Vec<CfgBlockId> = arms
+                    .iter()
+                    .map(|arm| self.build_stmt_list(&arm.body, next, loop_targets, false))
+                    .collect();
+                match arm_entries.as_slice() {
+                    [] => self.set_terminator(block, CfgTerminator::Goto(next)),
+                    [only_arm] => {
+                        self.set_terminator(block, CfgTerminator::Goto(*only_arm));
+                    }
+                    _ => self.set_terminator(block, CfgTerminator::Branch(arm_entries)),
                 }
                 block
             }
@@ -243,15 +246,17 @@ impl CfgBuilder {
         }
     }
 
-    fn finish(mut self, root_entry: CfgBlockId) -> ControlFlowGraph {
+    fn finish(mut self, root_entry: CfgBlockId) -> Result<ControlFlowGraph, CfgInvariantError> {
         self.set_terminator(self.entry, CfgTerminator::Goto(root_entry));
         self.set_terminator(self.exit, CfgTerminator::Exit);
-        ControlFlowGraph::new(
+        let cfg = ControlFlowGraph::new(
             self.blocks,
             self.entry,
             self.exit,
             self.top_level_stmt_nodes,
-        )
+        );
+        cfg.validate()?;
+        Ok(cfg)
     }
 }
 
@@ -292,18 +297,14 @@ fn stmt_label(stmt: &HirStmt) -> &'static str {
     }
 }
 
-pub fn build_control_flow_graph(stmts: &[HirStmt]) -> ControlFlowGraph {
+pub fn build_control_flow_graph(stmts: &[HirStmt]) -> Result<ControlFlowGraph, CfgInvariantError> {
     let mut builder = CfgBuilder::new(stmts.len());
     let root_entry = builder.build_stmt_list(stmts, builder.exit, None, true);
-    let cfg = builder.finish(root_entry);
-    if let Err(err) = cfg.validate() {
-        panic!("internal compiler error: invalid control-flow graph: {err}");
-    }
-    cfg
+    builder.finish(root_entry)
 }
 
-pub fn flow_facts(stmts: &[HirStmt]) -> FlowFacts {
-    let cfg = build_control_flow_graph(stmts);
+pub fn flow_facts(stmts: &[HirStmt]) -> Result<FlowFacts, CfgInvariantError> {
+    let cfg = build_control_flow_graph(stmts)?;
     let flow_graph = crate::flow_graph::build_statement_flow_graph(stmts);
     let reachable = cfg.reachable_blocks();
 
@@ -349,7 +350,7 @@ pub fn flow_facts(stmts: &[HirStmt]) -> FlowFacts {
         FlowExitEffect::AlwaysExits
     };
 
-    FlowFacts::new(
+    Ok(FlowFacts::new(
         exit_effect,
         flow_graph,
         reachable_top_level_stmt_indices,
@@ -357,12 +358,20 @@ pub fn flow_facts(stmts: &[HirStmt]) -> FlowFacts {
         reachable_return_types,
         has_reachable_return,
         has_reachable_value_return,
-    )
+    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn valid_cfg(stmts: &[HirStmt]) -> ControlFlowGraph {
+        build_control_flow_graph(stmts).expect("test HIR must produce a valid CFG")
+    }
+
+    fn valid_flow_facts(stmts: &[HirStmt]) -> FlowFacts {
+        flow_facts(stmts).expect("test HIR must produce valid flow facts")
+    }
 
     #[test]
     fn flow_facts_reports_always_raises_for_raise_only_branch() {
@@ -387,7 +396,7 @@ mod tests {
             }]),
         }];
 
-        let facts = flow_facts(&stmts);
+        let facts = valid_flow_facts(&stmts);
         assert_eq!(facts.exit_effect(), FlowExitEffect::AlwaysRaises);
         assert!(facts.always_exits());
         assert!(!facts.has_reachable_return());
@@ -404,7 +413,7 @@ mod tests {
             },
         ];
 
-        let facts = flow_facts(&stmts);
+        let facts = valid_flow_facts(&stmts);
         assert_eq!(facts.reachable_top_level_stmt_indices(), &[0]);
         assert_eq!(facts.unreachable_top_level_stmt_indices(), &[1]);
     }
@@ -420,7 +429,7 @@ mod tests {
             },
         ];
 
-        let facts = flow_facts(&stmts);
+        let facts = valid_flow_facts(&stmts);
         assert_eq!(facts.reachable_return_types(), &[Type::Int]);
     }
 
@@ -436,8 +445,51 @@ mod tests {
                 value: Some(HirExpr::IntLiteral(2)),
             }]),
         }];
-        let cfg = build_control_flow_graph(&stmts);
+        let cfg = valid_cfg(&stmts);
         assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn single_arm_match_uses_goto_instead_of_incomplete_branch() {
+        let stmts = vec![HirStmt::Match {
+            subject: HirExpr::Name {
+                name: "value".to_string(),
+                binding_id: None,
+                ty: Type::Union(vec![Type::Int, Type::None]),
+            },
+            subject_ty: Type::Union(vec![Type::Int, Type::None]),
+            arms: vec![crate::HirMatchArm {
+                pattern: crate::HirPattern::Class {
+                    class_name: "int".to_string(),
+                    class_type: Type::Int,
+                    fields: Vec::new(),
+                },
+                guard: None,
+                body: vec![HirStmt::Return {
+                    value: Some(HirExpr::IntLiteral(1)),
+                }],
+            }],
+        }];
+
+        let cfg = valid_cfg(&stmts);
+        let match_block = cfg
+            .blocks()
+            .iter()
+            .find(|block| block.label == CfgBlockLabel::Statement("match"))
+            .expect("match block");
+        assert!(matches!(match_block.terminator, CfgTerminator::Goto(_)));
+    }
+
+    #[test]
+    fn cfg_builder_returns_invariant_error_instead_of_panicking() {
+        let mut builder = CfgBuilder::new(0);
+        let invalid = builder.new_block(CfgBlockLabel::Synthetic, None);
+        builder.set_terminator(invalid, CfgTerminator::Branch(vec![builder.exit]));
+
+        let error = builder
+            .finish(invalid)
+            .expect_err("one-target branch must return an invariant error");
+        assert!(error.to_string().contains("incomplete (1 target(s))"));
     }
 
     #[test]
@@ -495,10 +547,10 @@ mod tests {
             },
         ];
 
-        let cfg_one = build_control_flow_graph(&stmts);
-        let cfg_two = build_control_flow_graph(&stmts);
-        let facts_one = flow_facts(&stmts);
-        let facts_two = flow_facts(&stmts);
+        let cfg_one = valid_cfg(&stmts);
+        let cfg_two = valid_cfg(&stmts);
+        let facts_one = valid_flow_facts(&stmts);
+        let facts_two = valid_flow_facts(&stmts);
         assert_eq!(cfg_one.shape_fingerprint(), cfg_two.shape_fingerprint());
         assert_eq!(facts_one, facts_two);
     }
@@ -566,10 +618,10 @@ mod tests {
         ];
 
         for stmts in corpus {
-            let cfg_first = build_control_flow_graph(&stmts);
-            let cfg_second = build_control_flow_graph(&stmts);
-            let facts_first = flow_facts(&stmts);
-            let facts_second = flow_facts(&stmts);
+            let cfg_first = valid_cfg(&stmts);
+            let cfg_second = valid_cfg(&stmts);
+            let facts_first = valid_flow_facts(&stmts);
+            let facts_second = valid_flow_facts(&stmts);
             assert_eq!(
                 cfg_first.shape_fingerprint(),
                 cfg_second.shape_fingerprint()

--- a/crates/sifr_lowering/src/lower/flow_helpers.rs
+++ b/crates/sifr_lowering/src/lower/flow_helpers.rs
@@ -2,7 +2,7 @@ use crate::hir_nodes::HirStmt;
 use sifr_python_ast::{Expr, Number};
 
 pub(in crate::lower) fn then_body_always_exits(stmts: &[HirStmt]) -> bool {
-    crate::cfg::flow_facts(stmts).always_exits()
+    crate::cfg::flow_facts(stmts).is_ok_and(|facts| facts.always_exits())
 }
 
 pub(in crate::lower) fn body_always_leaves_current_path(stmts: &[HirStmt]) -> bool {

--- a/crates/sifr_lowering/src/lower/function_flow.rs
+++ b/crates/sifr_lowering/src/lower/function_flow.rs
@@ -4,8 +4,8 @@ use sifr_type_system::{make_union, Type};
 /// Collect all return types from a list of HIR statements (recursively).
 pub(in crate::lower) fn collect_return_types(stmts: &[HirStmt]) -> Vec<Type> {
     crate::cfg::flow_facts(stmts)
-        .reachable_return_types()
-        .to_vec()
+        .map(|facts| facts.reachable_return_types().to_vec())
+        .unwrap_or_default()
 }
 
 /// Collect all yielded expression types from a list of HIR statements (recursively).

--- a/crates/sifr_lowering/src/lower/match_diagnostics/tests.rs
+++ b/crates/sifr_lowering/src/lower/match_diagnostics/tests.rs
@@ -55,12 +55,27 @@ pub(super) fn union_non_exhaustive_match_has_match_code() {
         "def describe(x: int | None) -> str:\n    match x:\n        case int():\n            return \"integer\"\n";
     let errors = lower_errors(source);
 
+    assert_eq!(errors.len(), 1, "unexpected diagnostics: {errors:?}");
     assert!(errors.iter().any(|error| {
         error.message
             == "non-exhaustive match: type 'None | int' has uncovered variants: None — add matching case(s) or `case _:`"
             && error.code == Some(DiagnosticCode::MATCH_NON_EXHAUSTIVE)
             && error.primary_range == Some(range_for_after(source, "match ", "x"))
     }));
+}
+
+#[test]
+pub(super) fn optional_non_exhaustive_match_has_only_match_code() {
+    let source =
+        "def describe(x: str | None) -> str:\n    match x:\n        case str():\n            return \"has value\"\n";
+    let errors = lower_errors(source);
+
+    assert_eq!(errors.len(), 1, "unexpected diagnostics: {errors:?}");
+    assert_eq!(errors[0].code, Some(DiagnosticCode::MATCH_NON_EXHAUSTIVE));
+    assert_eq!(
+        errors[0].primary_range,
+        Some(range_for_after(source, "match ", "x"))
+    );
 }
 
 #[test]

--- a/crates/sifr_lowering/src/lower/statements/statement_dispatch.rs
+++ b/crates/sifr_lowering/src/lower/statements/statement_dispatch.rs
@@ -74,9 +74,19 @@ pub(in crate::lower) fn lower_stmts(
 
     let mut result = Vec::new();
     for stmt in stmts {
-        if crate::cfg::flow_facts(&result).always_exits() {
-            ctx.warn_unreachable_statement(stmt.range());
-            continue;
+        match crate::cfg::flow_facts(&result) {
+            Ok(facts) if facts.always_exits() => {
+                ctx.warn_unreachable_statement(stmt.range());
+                continue;
+            }
+            Ok(_) => {}
+            Err(error) => {
+                ctx.error_with_code_at(
+                    DiagnosticCode::INTERNAL_COMPILER_PANIC,
+                    format!("internal compiler error: invalid control-flow graph: {error}"),
+                    stmt.range(),
+                );
+            }
         }
         // Handle chained assignment (x = y = z = 0) by expanding into multiple statements
         if let Stmt::Assign(assign) = stmt {

--- a/crates/sifr_lowering/src/lower/typing_and_functions/annotations_and_function_lowering.rs
+++ b/crates/sifr_lowering/src/lower/typing_and_functions/annotations_and_function_lowering.rs
@@ -298,10 +298,8 @@ pub(in crate::lower) fn lower_function(
         && !has_yield
         && requires_exhaustive_return_annotation(func, ft.return_type.as_ref())
     {
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            crate::cfg::flow_facts(&body).always_exits()
-        })) {
-            Ok(false) => {
+        match crate::cfg::flow_facts(&body) {
+            Ok(facts) if !facts.always_exits() => {
                 let return_type = ft.return_type.display_name();
                 super::flow_diagnostics::missing_return_value(
                     ctx,
@@ -310,15 +308,15 @@ pub(in crate::lower) fn lower_function(
                     func.name.range(),
                 );
             }
-            Ok(true) => {}
-            Err(_) => {
+            Ok(_) => {}
+            Err(error) => {
                 // Fail closed: skipping return-completeness validation after an
                 // invalid CFG would let an unsound function compile.
                 ctx.error_with_code_at(
                     DiagnosticCode::INTERNAL_COMPILER_PANIC,
                     format!(
-                        "internal compiler error: invalid control-flow graph while validating exhaustive return for '{}'",
-                        func.name
+                        "internal compiler error: invalid control-flow graph while validating exhaustive return for '{}': {error}",
+                        func.name,
                     ),
                     func.name.range(),
                 );

--- a/verification/areas/regression/data/crashes.json
+++ b/verification/areas/regression/data/crashes.json
@@ -5,12 +5,13 @@
       "id": "CR-0001",
       "issue": "diagnostic panic hardening record",
       "owner": "verification_hardening_rules",
-      "status": "unresolved",
+      "status": "promoted",
       "root_cause_category": "cfg-invariant-panic-path",
       "source_reference": "crates/sifr_lowering/src/cfg.rs",
       "reproducer_fixture": "verification/areas/regression/fixtures/crashes/CR-0001_cfg_invariant_minimized.sifr",
       "promotion_target_suite": "fixedbugs",
-      "note": "Track HIR CFG invariant panic conversion into typed diagnostics. Promote to fixedbugs with minimized reproducer when resolved."
+      "promoted_fixedbug_id": "FB-0004",
+      "note": "Item 8 made one-arm match CFG construction valid and changed CFG validation to return a typed invariant error."
     },
     {
       "id": "CR-0002",

--- a/verification/areas/regression/data/fixedbugs.json
+++ b/verification/areas/regression/data/fixedbugs.json
@@ -27,6 +27,15 @@
       "command": "check",
       "expect_exit_code": 1,
       "note": "Regression lock for decimal invalid literal diagnostics."
+    },
+    {
+      "id": "FB-0004",
+      "issue": "pre-v1 canonical contract regression closure Item 8",
+      "root_cause_category": "cfg-invariant-panic-path",
+      "suite_location": "verification/areas/regression/fixtures/crashes/CR-0001_cfg_invariant_minimized.sifr",
+      "command": "check",
+      "expect_exit_code": 1,
+      "note": "Regression lock for a one-arm non-exhaustive match diagnostic without a CFG invariant panic."
     }
   ]
 }

--- a/verification/areas/regression/fixtures/crashes/CR-0001_cfg_invariant_minimized.sifr
+++ b/verification/areas/regression/fixtures/crashes/CR-0001_cfg_invariant_minimized.sifr
@@ -1,8 +1,6 @@
-# CR-0001 minimized sentinel fixture.
-# Intent: preserve a minimal structural shape for CFG-invariant panic-path investigations.
+# CR-0001 minimized one-arm match CFG regression.
 
-def main():
-    i: int = 0
-    while i < 1:
-        if i == 0:
-            i = i + 1
+def describe(value: int | None) -> int:
+    match value:
+        case int():
+            return 1


### PR DESCRIPTION
## Summary

- lower one-arm `match` control flow as a complete `goto` instead of an invalid one-target branch
- return CFG invariant failures through lowering as structured internal compiler diagnostics
- promote the minimized CFG crash regression and add exact negative-diagnostic coverage

## Validation

- `cargo test -p sifr_lowering cfg -- --nocapture`
- `cargo test -p sifr_lowering match_diagnostics -- --nocapture`
- `cargo test -p sifr_lowering`
- `cargo clippy -p sifr_lowering -- -D warnings`
- direct `sifr check` for both non-exhaustive one-arm fixtures
- `cargo test -p sifr test_e2e_fail -- --nocapture` (CFG cases pass; stops at the separately owned Item 9 protocol diagnostic mismatch)
- `uv run --project verification --locked python verification/areas/regression/runner.py --suite fixedbugs --suite crashes`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- first-party source file-size guardrail
