### PR TITLE
test(protocol): separate diagnostic fixture intent

### DIFF
--- a/crates/sifr/tests/e2e/fail/protocol_bound_unknown_forwarded_typevar.sifr
+++ b/crates/sifr/tests/e2e/fail/protocol_bound_unknown_forwarded_typevar.sifr
@@ -1,10 +1,14 @@
 # expect-error[col=12]: SIFR-PROTO-0001
-# Test: unknown protocol bounds are rejected when forwarding TypeVars through generic calls
+# Test: forwarded TypeVars must satisfy a resolved protocol bound
+
+class MissingBound(Protocol):
+    def required(self) -> int:
+        pass
 
 def take_missing[T: MissingBound](x: T) -> T:
     return x
 
-def relay_missing[U: MissingBound](x: U) -> U:
+def relay_missing[U](x: U) -> U:
     return take_missing(x)
 
 def main():

--- a/crates/sifr/tests/e2e/fail/typevar_unknown_bound_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/typevar_unknown_bound_rejected.sifr
@@ -1,5 +1,5 @@
-# expect-error: SIFR-PROTO-0001
-# Test: unknown TypeVar bound is rejected (no default-allow fallback)
+# expect-error[col=24]: SIFR-NAME-0003
+# Test: an unresolved TypeVar bound is a name-resolution error
 from typing import TypeVar
 
 T = TypeVar("T", bound=MissingBound)

--- a/crates/sifr_lowering/src/lower/expressions_tests/control_flow_and_strings.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/control_flow_and_strings.rs
@@ -633,28 +633,32 @@ pub(super) fn test_protocol_bound_forwarding_accepts_conforming_typevar() {
 }
 
 #[test]
-pub(super) fn test_generic_declaration_rejects_unknown_bound() {
+pub(super) fn test_generic_declaration_reports_only_unknown_bound_name() {
     let result = lower_source(
-        "def take_missing[T: MissingBound](x: T) -> T:\n    return x\n\ndef relay_missing[U: MissingBound](x: U) -> U:\n    return take_missing(x)\n\ndef main():\n    print(1)\n",
+        "def take_missing[T: MissingBound](x: T) -> T:\n    return x\n\ndef main():\n    print(1)\n",
     );
     assert!(result.is_err());
     let errors = result.unwrap_err();
-    assert!(errors.iter().any(|e| {
-        e.code == Some(DiagnosticCode::NAME_UNKNOWN_TYPE)
-            && e.message == "unknown type: 'MissingBound'"
-    }));
+    assert_eq!(errors.len(), 1, "unexpected diagnostics: {errors:?}");
+    assert_eq!(errors[0].code, Some(DiagnosticCode::NAME_UNKNOWN_TYPE));
+    assert_eq!(errors[0].message, "unknown type: 'MissingBound'");
 }
 
 #[test]
 pub(super) fn test_protocol_bound_forwarding_rejects_non_conforming_typevar() {
     let result = lower_source(
-        "class Readable(Protocol):\n    def read(self) -> str:\n        pass\n\nclass Closable(Protocol):\n    def close(self) -> None:\n        pass\n\ndef take_readable[T: Readable](x: T) -> T:\n    return x\n\ndef relay_bad[U: Closable](x: U) -> U:\n    return take_readable(x)\n\ndef main():\n    print(1)\n",
+        "class MissingBound(Protocol):\n    def required(self) -> int:\n        pass\n\ndef take_missing[T: MissingBound](x: T) -> T:\n    return x\n\ndef relay_missing[U](x: U) -> U:\n    return take_missing(x)\n\ndef main():\n    print(1)\n",
     );
     assert!(result.is_err());
     let errors = result.unwrap_err();
-    assert!(errors
-        .iter()
-        .any(|e| e.message.contains("does not implement protocol 'Readable'")));
+    assert_eq!(errors.len(), 1, "unexpected diagnostics: {errors:?}");
+    assert_eq!(
+        errors[0].code,
+        Some(DiagnosticCode::PROTO_BOUND_NOT_SATISFIED)
+    );
+    assert!(errors[0]
+        .message
+        .contains("does not implement protocol 'MissingBound'"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- make the forwarded-TypeVar fixture resolve its protocol before testing conformance
- assign the existing unresolved TypeVar bound fixture to the canonical name diagnostic
- strengthen focused lowering tests to require one exact diagnostic family

## Validation

- both focused lowering tests pass
- full sifr_lowering suite: 1,029 passed, 1 ignored
- broad fail suite: all 567 fixtures passed
- normal sifr_lowering Clippy with warnings denied
- cargo fmt --check
- git diff --check
- HIR maintainability guardrail
- first-party file-size guardrail

This changes only tests and fixtures. No production compiler file changed, so the Sifr create-PR and merge gates do not apply.
