### PR TITLE
test(interop): align method-slot verification

### DIFF
--- a/crates/sifr_driver/src/tests/package_rust_interop_method_slots.rs
+++ b/crates/sifr_driver/src/tests/package_rust_interop_method_slots.rs
@@ -31,7 +31,7 @@ fn test_method_slot_runtime() {
     );
     assert_eq!(
         run_built_package(&entrypoint),
-        "value-normalized\ninput-receiver\nvalue-no-context\nvalue-shared-2"
+        "value-normalized\ninput-receiver\ninput-serialized\nvalue-no-context\nvalue-shared-3"
     );
     let _ = std::fs::remove_dir_all(package_root);
 }

--- a/verification/areas/rust_interop/checks/_binding_helpers.py
+++ b/verification/areas/rust_interop/checks/_binding_helpers.py
@@ -99,5 +99,47 @@ def is_identifier_or_path_char(char: str) -> bool:
     return char.isalnum() or char in {"_", "."}
 
 
-def contains_empty_pass_body(text: str) -> bool:
-    return any(line.strip() == "pass" for line in text.splitlines())
+def contains_empty_placeholder_class(text: str) -> bool:
+    lines = text.splitlines()
+    decorators: list[tuple[int, str]] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            index += 1
+            continue
+        if stripped.startswith("@"):
+            decorators.append((len(line) - len(line.lstrip()), stripped))
+            index += 1
+            continue
+        if not stripped.startswith("class ") or not stripped.endswith(":"):
+            decorators.clear()
+            index += 1
+            continue
+
+        class_indent = len(line) - len(line.lstrip())
+        body: list[str] = []
+        body_index = index + 1
+        while body_index < len(lines):
+            body_line = lines[body_index]
+            body_stripped = body_line.strip()
+            if not body_stripped or body_stripped.startswith("#"):
+                body_index += 1
+                continue
+            body_indent = len(body_line) - len(body_line.lstrip())
+            if body_indent <= class_indent:
+                break
+            body.append(body_stripped)
+            body_index += 1
+
+        is_required_marker = any(
+            decorator_indent == class_indent
+            and decorator.startswith("@class_adapter_marker(")
+            for decorator_indent, decorator in decorators
+        )
+        if body == ["pass"] and not is_required_marker:
+            return True
+        decorators.clear()
+        index += 1
+    return False

--- a/verification/areas/rust_interop/checks/_scenario_checks.py
+++ b/verification/areas/rust_interop/checks/_scenario_checks.py
@@ -158,6 +158,23 @@ def run_self_test() -> tuple[int, str | None]:
         ):
             return cases, f"auxiliary placeholder was accepted: {placeholder_failures}"
         cases += 1
+
+        helper_path.write_text(
+            "@class_adapter_marker(\"fixture.contract\", \"adapt_contract\")\n"
+            "class Helper:\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+        marker_failures: list[str] = []
+        validate_scenario_examples(
+            marker_failures,
+            "bridge_type_matrix",
+            fixture_dir,
+            raw_examples,
+        )
+        if marker_failures:
+            return cases, f"required class-adapter marker was rejected: {marker_failures}"
+        cases += 1
         helper_path.unlink()
 
         mutation_cases = (

--- a/verification/areas/rust_interop/checks/_scenario_source_checks.py
+++ b/verification/areas/rust_interop/checks/_scenario_source_checks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from _binding_helpers import contains_empty_pass_body
+from _binding_helpers import contains_empty_placeholder_class
 from _binding_helpers import rust_bound_declarations
 from _binding_helpers import verifier_binds_call
 
@@ -42,7 +42,7 @@ def validate_scenario_sifr_source(
     for header in ("# execution-kind:", "# expected-result:"):
         if header not in text:
             failures.append(f"{fixture_id}: {raw_path} missing {header} header")
-    if contains_empty_pass_body(text):
+    if contains_empty_placeholder_class(text):
         failures.append(
             f"{fixture_id}: {raw_path} must not use empty placeholder class bodies"
         )
@@ -88,7 +88,7 @@ def validate_auxiliary_sifr_source(
     text: str,
 ) -> None:
     """Reject placeholders without imposing entrypoint-only evidence rules."""
-    if contains_empty_pass_body(text):
+    if contains_empty_placeholder_class(text):
         failures.append(
             f"{fixture_id}: {raw_path} must not use empty placeholder class bodies"
         )

--- a/verification/areas/rust_interop/checks/check_fixture_matrix.py
+++ b/verification/areas/rust_interop/checks/check_fixture_matrix.py
@@ -7,7 +7,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from _binding_helpers import contains_empty_pass_body as _contains_empty_pass_body
+from _binding_helpers import (
+    contains_empty_placeholder_class as _contains_empty_placeholder_class,
+)
 from _binding_helpers import decorated_function_name as _decorated_function_name
 from _binding_helpers import package_example_binding_token
 from _binding_helpers import rust_bound_declarations as _rust_bound_declarations
@@ -710,7 +712,7 @@ def _validate_package_example_text(
     for header in required_headers:
         if header not in text:
             failures.append(f"{fixture_id}: {raw_path} missing header {header!r}")
-    if _contains_empty_pass_body(text):
+    if _contains_empty_placeholder_class(text):
         failures.append(f"{fixture_id}: {raw_path} must not use empty placeholder class bodies")
     crate_token = crate.replace("-", "_")
     binding_token = package_example_binding_token(fixture_id, crate_token)
@@ -859,7 +861,7 @@ def _validate_evidence_example_text(
 ) -> None:
     if len(text.strip().splitlines()) < 9:
         failures.append(f"{fixture_id}: {raw_path} must include a binding and concrete verifier call site")
-    if _contains_empty_pass_body(text):
+    if _contains_empty_placeholder_class(text):
         failures.append(f"{fixture_id}: {raw_path} must not use empty placeholder class bodies")
     if (
         fixture_id == "proc_macro_trust"


### PR DESCRIPTION
## Summary

- distinguish compiler-required class-adapter marker bodies from real empty placeholder classes
- retain mutation coverage that rejects ordinary empty classes and add coverage that accepts required markers
- update the method-slot driver baseline to all five canonical output lines and final shared count 3

## Root cause

The matrix helper treated every line equal to pass as an empty class placeholder. A class-adapter marker is required by the compiler to be field-less and contain only pass, so the verification rule rejected a valid declaration. Method-slot runtime behavior was already canonical; only the driver expectation remained stale.

## Validation

- rust-interop fixture-matrix self-test: 237 cases passed
- focused ignored method-slot runtime test passed
- focused ignored lifetime/thread/shared-context rejection test passed
- full sifr_driver suite: 556 passed, 76 ignored
- full fixture matrix now stops only at linked delivery A's missing shared-bridge source; the method-slot row passes
- sifr_driver library Clippy passed with warnings denied
- Python syntax compilation for all changed checks
- cargo fmt --check
- git diff --check
- HIR maintainability guardrail
- first-party file-size guardrail

A broad driver Clippy probe found one pre-existing Rust 1.94 lint in the unrelated diagnostic-rendering binary. It is outside this diff. No production compiler file changed, so Sifr create-PR and merge gates do not apply.
