### PR TITLE
fix(codegen): unify emitted builtin nominal ownership

### DIFF
--- a/crates/sifr_codegen/src/project_stdlib_nominals.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals.rs
@@ -212,6 +212,7 @@ pub(crate) fn project_stdlib_nominal_plan(
     );
     let probe_name_refs = probe_names.iter().map(String::as_str).collect();
     let shared_source = strip_rust_items_by_name(&generated.rust_source, &probe_name_refs);
+    register_emitted_builtin_nominals(&shared_source, &mut registry);
     register_transitive_stdlib_nominals(&shared_source, stdlib_code, &mut registry);
     let crate_root_candidates = SHARED_MODULE_CRATE_ROOT_NOMINAL_IDENTITIES
         .iter()
@@ -321,6 +322,16 @@ fn register_transitive_stdlib_nominals(
     }
 }
 
+fn register_emitted_builtin_nominals(shared_source: &str, registry: &mut ProjectNominalRegistry) {
+    let defined_names = rust_source_defined_item_names(shared_source);
+    for name in crate::BUILTIN_ERROR_CLASSES {
+        if sifr_type_system::io_error_kind(name).is_some() || !defined_names.contains(*name) {
+            continue;
+        }
+        registry.register_shared((*name).to_string(), class_rust_name(None, name));
+    }
+}
+
 fn collect_function_nominals(
     function: &FunctionType,
     declarations: &mut BTreeMap<String, HashSet<String>>,
@@ -387,7 +398,9 @@ fn collect_shared_nominals(
             methods,
             ..
         } => {
-            if crate::BUILTIN_ERROR_CLASSES.contains(&name.as_str()) {
+            if crate::BUILTIN_ERROR_CLASSES.contains(&name.as_str())
+                && sifr_type_system::io_error_kind(name).is_none()
+            {
                 builtin_types
                     .entry(name.clone())
                     .or_insert_with(|| class.clone());
@@ -623,6 +636,49 @@ mod tests {
             registry.rust_paths.get("sifr.io.BinaryFileHandle"),
             Some(&"crate::__sifr_project_nominals::__SifrIoBinaryFileHandle".to_string())
         );
+    }
+
+    #[test]
+    fn emitted_builtin_nominals_join_the_project_registry() {
+        let shared_source = "pub struct ParseError;\npub struct FileNotFoundError;\n";
+        let mut registry = ProjectNominalRegistry::default();
+
+        register_emitted_builtin_nominals(shared_source, &mut registry);
+
+        assert!(registry.shared_rust_names.contains("ParseError"));
+        assert_eq!(
+            registry.rust_paths.get("ParseError"),
+            Some(&"crate::__sifr_project_nominals::ParseError".to_string())
+        );
+        assert!(!registry.shared_rust_names.contains("FileNotFoundError"));
+        assert!(!registry.rust_paths.contains_key("FileNotFoundError"));
+    }
+
+    #[test]
+    fn direct_io_error_kind_type_does_not_create_a_project_nominal() {
+        let direct_kind = Type::Class {
+            identity: Some("sifr.builtin.FileNotFoundError".to_string()),
+            type_args: Vec::new(),
+            name: "FileNotFoundError".to_string(),
+            fields: vec![
+                ("message".to_string(), Type::Str),
+                ("kind".to_string(), Type::Str),
+            ],
+            methods: Vec::new(),
+            parent_class: Some("IOError".to_string()),
+        };
+        let unions = HashMap::from([("DirectKind".to_string(), vec![direct_kind])]);
+
+        let plan = project_stdlib_nominal_plan(&unions, &StdlibCode::default(), &[], false);
+
+        assert!(!plan.prelude.contains("FileNotFoundError"));
+        assert!(!plan.registry.rust_paths.contains_key("FileNotFoundError"));
+        assert!(!plan
+            .registry
+            .rust_paths
+            .contains_key("sifr.builtin.FileNotFoundError"));
+        syn::parse_file(&plan.prelude)
+            .expect("project nominal prelude should not contain a dangling re-export");
     }
 
     #[test]

--- a/demos/additional_modules/emitted.rs
+++ b/demos/additional_modules/emitted.rs
@@ -4016,7 +4016,9 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
 pub use __sifr_project_nominals::__SifrIoTextFileHandle;
@@ -5717,46 +5719,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn demo_operator() {
     println!("=== operator ===");

--- a/demos/advanced_class_libraries/emitted.rs
+++ b/demos/advanced_class_libraries/emitted.rs
@@ -6218,7 +6218,9 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::RegexError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
@@ -9050,56 +9052,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     let mut d: __SifrStdlib_sifr_x2ecollections_x2edeque<i64> = __SifrStdlib_sifr_x2ecollections_x2edeque::new(

--- a/demos/binary_files/emitted.rs
+++ b/demos/binary_files/emitted.rs
@@ -1708,6 +1708,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
 pub use __sifr_project_nominals::JsonIntegerRangeError;
@@ -2732,71 +2733,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TimeoutError> for Error {
-    fn from(err: TimeoutError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ScopeFailure> for Error {
-    fn from(err: ScopeFailure) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     let path: String = "/tmp/sifr_runtime_binary_files_demo.bin".to_string();

--- a/demos/binary_hashing/emitted.rs
+++ b/demos/binary_hashing/emitted.rs
@@ -563,6 +563,7 @@ mod __sifr_project_nominals {
     }
     impl ::std::error::Error for ValueError {}
 }
+pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2ehashlib_x2eHashObject;
@@ -1147,25 +1148,6 @@ fn new(
     }
     Ok(_build_hash(name, data))
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct IOError {
-    message: String,
-    kind: String,
-}
-impl IOError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            kind: "Other".to_string(),
-        }
-    }
-}
-impl ::std::fmt::Display for IOError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for IOError {}
 fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     let msg = e.to_string();
     let kind = {

--- a/demos/binary_storage/emitted.rs
+++ b/demos/binary_storage/emitted.rs
@@ -1708,6 +1708,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
 pub use __sifr_project_nominals::JsonIntegerRangeError;
@@ -2732,71 +2733,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TimeoutError> for Error {
-    fn from(err: TimeoutError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ScopeFailure> for Error {
-    fn from(err: ScopeFailure) -> Self {
-        Self::new(err.message)
-    }
 }
 fn sum_bytes(data: &Vec<u8>) -> i64 {
     let mut total: i64 = 0_i64;

--- a/demos/bytes_file_io/emitted.rs
+++ b/demos/bytes_file_io/emitted.rs
@@ -1708,6 +1708,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
 pub use __sifr_project_nominals::JsonIntegerRangeError;
@@ -2732,71 +2733,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TimeoutError> for Error {
-    fn from(err: TimeoutError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ScopeFailure> for Error {
-    fn from(err: ScopeFailure) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     let path: String = "/tmp/sifr_bytes_bytes_file_io.bin".to_string();

--- a/demos/class_libraries/emitted.rs
+++ b/demos/class_libraries/emitted.rs
@@ -4651,7 +4651,11 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
+pub use __sifr_project_nominals::RegexError;
+pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
 pub use __sifr_project_nominals::__SifrIoTextFileHandle;
@@ -6685,90 +6689,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ValueError {
-    message: String,
-}
-impl ValueError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ValueError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ValueError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct RegexError {
-    message: String,
-    detail: String,
-}
-impl RegexError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            detail: String::new(),
-        }
-    }
-}
-impl ::std::fmt::Display for RegexError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for RegexError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     println!("=== TopologicalSorter ===");

--- a/demos/codegen_preamble/emitted.rs
+++ b/demos/codegen_preamble/emitted.rs
@@ -3341,6 +3341,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
 pub use __sifr_project_nominals::JsonIntegerRangeError;
@@ -4568,71 +4569,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TimeoutError> for Error {
-    fn from(err: TimeoutError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ScopeFailure> for Error {
-    fn from(err: ScopeFailure) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     let path: String = "/tmp/sifr_codegen_preamble_demo.txt".to_string();

--- a/demos/codegen_structural_passes/emitted.rs
+++ b/demos/codegen_structural_passes/emitted.rs
@@ -835,6 +835,7 @@ mod __sifr_project_nominals {
     }
     impl ::std::error::Error for ValueError {}
 }
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2edate;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2edatetime;
@@ -1387,21 +1388,6 @@ fn from_timestamp(
 ) -> Result<__SifrStdlib_sifr_x2edatetime_x2edatetime, ValueError> {
     _from_timestamp_with_tz(ts, tz)
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
 fn main() {
     let current: __SifrStdlib_sifr_x2edatetime_x2edatetime = now(&None);
     let current_iso: String = current.isoformat();

--- a/demos/collections_and_argparse/emitted.rs
+++ b/demos/collections_and_argparse/emitted.rs
@@ -1439,6 +1439,7 @@ mod __sifr_project_nominals {
     }
     impl ::std::error::Error for ParseError {}
 }
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2eargparse_x2eArgumentParser;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2eargparse_x2eArgumentSpec;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2eargparse_x2eNamespace;
@@ -1668,21 +1669,6 @@ fn _is_option_like_token(
     }
     false
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
 fn main() {
     let counter: __SifrStdlib_sifr_x2ecollections_x2eCounter<String> = __SifrStdlib_sifr_x2ecollections_x2eCounter::new(
         None,

--- a/demos/config_json_csv/emitted.rs
+++ b/demos/config_json_csv/emitted.rs
@@ -5216,6 +5216,9 @@ mod __sifr_project_nominals {
 pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
+pub use __sifr_project_nominals::JsonIntegerRangeError;
+pub use __sifr_project_nominals::JsonLimitError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
 pub use __sifr_project_nominals::__SifrIoTextFileHandle;
@@ -7665,58 +7668,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     };
     IOError { message: msg, kind }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonIntegerRangeError {
-    message: String,
-    path: String,
-    profile: String,
-}
-impl JsonIntegerRangeError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            path: String::new(),
-            profile: String::new(),
-        }
-    }
-}
-impl ::std::fmt::Display for JsonIntegerRangeError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonIntegerRangeError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonLimitError {
-    message: String,
-    limit: i64,
-}
-impl JsonLimitError {
-    fn new(message: String) -> Self {
-        Self { message, limit: 0 }
-    }
-}
-impl ::std::fmt::Display for JsonLimitError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonLimitError {}
 fn main() {
     let encoder: __SifrStdlib_sifr_x2ejson_x2eJSONEncoder = __SifrStdlib_sifr_x2ejson_x2eJSONEncoder::new(
         Some(2_i64),

--- a/demos/core_libraries/emitted.rs
+++ b/demos/core_libraries/emitted.rs
@@ -1330,6 +1330,8 @@ mod __sifr_project_nominals {
     }
     impl ::std::error::Error for RegexError {}
 }
+pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::RegexError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2edatetime;
@@ -2986,25 +2988,6 @@ fn mean(
     let total: f64 = _sum(data);
     Ok(total / (count as f64))
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct IOError {
-    message: String,
-    kind: String,
-}
-impl IOError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            kind: "Other".to_string(),
-        }
-    }
-}
-impl ::std::fmt::Display for IOError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for IOError {}
 fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     let msg = e.to_string();
     let kind = {
@@ -3042,21 +3025,6 @@ impl ::std::fmt::Display for Error {
     }
 }
 impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
 impl From<IOError> for Error {
     fn from(err: IOError) -> Self {
         Self::new(err.message)

--- a/demos/core_stdlib/emitted.rs
+++ b/demos/core_stdlib/emitted.rs
@@ -3171,8 +3171,12 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
+pub use __sifr_project_nominals::JsonIntegerRangeError;
+pub use __sifr_project_nominals::JsonLimitError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
 pub use __sifr_project_nominals::__SifrIoTextFileHandle;
@@ -5214,98 +5218,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonIntegerRangeError {
-    message: String,
-    path: String,
-    profile: String,
-}
-impl JsonIntegerRangeError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            path: String::new(),
-            profile: String::new(),
-        }
-    }
-}
-impl ::std::fmt::Display for JsonIntegerRangeError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonIntegerRangeError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonLimitError {
-    message: String,
-    limit: i64,
-}
-impl JsonLimitError {
-    fn new(message: String) -> Self {
-        Self { message, limit: 0 }
-    }
-}
-impl ::std::fmt::Display for JsonLimitError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonLimitError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     println!("=== sifr.io ===");

--- a/demos/csv/emitted.rs
+++ b/demos/csv/emitted.rs
@@ -3309,7 +3309,9 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
 pub use __sifr_project_nominals::__SifrIoTextFileHandle;
@@ -5047,46 +5049,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn collect_parse_actual() -> Vec<bool> {
     let mut actual: Vec<bool> = vec![];

--- a/demos/datetime/emitted.rs
+++ b/demos/datetime/emitted.rs
@@ -865,6 +865,7 @@ mod __sifr_project_nominals {
     }
     impl ::std::error::Error for ValueError {}
 }
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2edatetime;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2etimedelta;
@@ -1421,21 +1422,6 @@ fn assert_bool_vector_eq(actual: &Vec<bool>, expected: &Vec<bool>) {
         i += 1_i64;
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
 fn collect_positive_actual() -> Vec<bool> {
     let mut actual: Vec<bool> = vec![];
     let dt: __SifrStdlib_sifr_x2edatetime_x2edatetime = __SifrStdlib_sifr_x2edatetime_x2edatetime::new(

--- a/demos/dependency_manifest/emitted.rs
+++ b/demos/dependency_manifest/emitted.rs
@@ -2880,6 +2880,9 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
+pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::TOMLDecodeError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
@@ -2910,6 +2913,8 @@ fn main() {
 }
 
 // src/helper.rs
+pub use crate::IOError;
+pub use crate::ParseError;
 pub use crate::TOMLDecodeError;
 pub use crate::__SifrIoBinaryFileHandle;
 pub use crate::__SifrIoFileHandle;
@@ -4457,25 +4462,6 @@ pub fn loads(
         }
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct IOError {
-    pub message: String,
-    pub kind: String,
-}
-impl IOError {
-    pub fn new(message: String) -> Self {
-        Self {
-            message,
-            kind: "Other".to_string(),
-        }
-    }
-}
-impl ::std::fmt::Display for IOError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for IOError {}
 pub fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     let msg = e.to_string();
     let kind = {
@@ -4497,51 +4483,6 @@ pub fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Error {
-    pub message: String,
-}
-impl Error {
-    pub fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ParseError {
-    pub message: String,
-}
-impl ParseError {
-    pub fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
 }
 pub fn render() -> String {
     let __sifr_try_res: Result<String, TOMLDecodeError> = (|| {

--- a/demos/error_subclasses/emitted.rs
+++ b/demos/error_subclasses/emitted.rs
@@ -3215,8 +3215,12 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
+pub use __sifr_project_nominals::JsonIntegerRangeError;
+pub use __sifr_project_nominals::JsonLimitError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::RegexError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
@@ -5314,108 +5318,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonIntegerRangeError {
-    message: String,
-    path: String,
-    profile: String,
-}
-impl JsonIntegerRangeError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            path: String::new(),
-            profile: String::new(),
-        }
-    }
-}
-impl ::std::fmt::Display for JsonIntegerRangeError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonIntegerRangeError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonLimitError {
-    message: String,
-    limit: i64,
-}
-impl JsonLimitError {
-    fn new(message: String) -> Self {
-        Self { message, limit: 0 }
-    }
-}
-impl ::std::fmt::Display for JsonLimitError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonLimitError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn has_match(pattern: &String, text: &String) -> Result<bool, RegexError> {
     let __sifr_try_res: Result<Result<bool, RegexError>, RegexError> = (|| {

--- a/demos/file_streams/emitted.rs
+++ b/demos/file_streams/emitted.rs
@@ -1708,6 +1708,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
 pub use __sifr_project_nominals::JsonIntegerRangeError;
@@ -2732,71 +2733,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TimeoutError> for Error {
-    fn from(err: TimeoutError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ScopeFailure> for Error {
-    fn from(err: ScopeFailure) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     let path: String = "/tmp/sifr_runtime_file_streams_demo.txt".to_string();

--- a/demos/fixed_timezones/emitted.rs
+++ b/demos/fixed_timezones/emitted.rs
@@ -779,6 +779,7 @@ mod __sifr_project_nominals {
     }
     impl ::std::error::Error for ValueError {}
 }
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2edatetime;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2etimezone;
@@ -1320,21 +1321,6 @@ fn now(
         }
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
 fn main() {
     let zero: __SifrStdlib_sifr_x2edatetime_x2etimezone = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(
         0_i64,

--- a/demos/hashlib/emitted.rs
+++ b/demos/hashlib/emitted.rs
@@ -564,6 +564,7 @@ mod __sifr_project_nominals {
     impl ::std::error::Error for ValueError {}
 }
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2ehashlib_x2eHashObject;
 fn random_int(min: i64, max: i64) -> i64 {
@@ -2289,21 +2290,6 @@ impl ::std::fmt::Display for Error {
     }
 }
 impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
 impl From<IOError> for Error {
     fn from(err: IOError) -> Self {
         Self::new(err.message)

--- a/demos/in_memory_streams/emitted.rs
+++ b/demos/in_memory_streams/emitted.rs
@@ -1904,7 +1904,9 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2eencoding_x2eDecodeError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2eencoding_x2eDecodeErrorHandler;
@@ -2959,46 +2961,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     let path: String = "/tmp/sifr_runtime_in_memory_streams.bin".to_string();

--- a/demos/io/emitted.rs
+++ b/demos/io/emitted.rs
@@ -1930,6 +1930,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
 pub use __sifr_project_nominals::JsonIntegerRangeError;
@@ -2971,71 +2972,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TimeoutError> for Error {
-    fn from(err: TimeoutError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ScopeFailure> for Error {
-    fn from(err: ScopeFailure) -> Self {
-        Self::new(err.message)
-    }
 }
 fn collect_io_roundtrip_actual() -> Vec<bool> {
     let mut actual: Vec<bool> = vec![];

--- a/demos/json/emitted.rs
+++ b/demos/json/emitted.rs
@@ -3171,7 +3171,12 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
+pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
+pub use __sifr_project_nominals::JsonIntegerRangeError;
+pub use __sifr_project_nominals::JsonLimitError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
 pub use __sifr_project_nominals::__SifrIoTextFileHandle;
@@ -4958,25 +4963,6 @@ fn assert_bool_vector_eq(actual: &Vec<bool>, expected: &Vec<bool>) {
         i += 1_i64;
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct IOError {
-    message: String,
-    kind: String,
-}
-impl IOError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            kind: "Other".to_string(),
-        }
-    }
-}
-impl ::std::fmt::Display for IOError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for IOError {}
 fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     let msg = e.to_string();
     let kind = {
@@ -4998,98 +4984,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonIntegerRangeError {
-    message: String,
-    path: String,
-    profile: String,
-}
-impl JsonIntegerRangeError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            path: String::new(),
-            profile: String::new(),
-        }
-    }
-}
-impl ::std::fmt::Display for JsonIntegerRangeError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonIntegerRangeError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonLimitError {
-    message: String,
-    limit: i64,
-}
-impl JsonLimitError {
-    fn new(message: String) -> Self {
-        Self { message, limit: 0 }
-    }
-}
-impl ::std::fmt::Display for JsonLimitError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonLimitError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn collect_positive_actual() -> Vec<bool> {
     let mut actual: Vec<bool> = vec![];

--- a/demos/json_values/emitted.rs
+++ b/demos/json_values/emitted.rs
@@ -3171,7 +3171,12 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
+pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
+pub use __sifr_project_nominals::JsonIntegerRangeError;
+pub use __sifr_project_nominals::JsonLimitError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
 pub use __sifr_project_nominals::__SifrIoTextFileHandle;
@@ -4995,25 +5000,6 @@ fn dumps(
         }
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct IOError {
-    message: String,
-    kind: String,
-}
-impl IOError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            kind: "Other".to_string(),
-        }
-    }
-}
-impl ::std::fmt::Display for IOError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for IOError {}
 fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     let msg = e.to_string();
     let kind = {
@@ -5035,98 +5021,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonIntegerRangeError {
-    message: String,
-    path: String,
-    profile: String,
-}
-impl JsonIntegerRangeError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            path: String::new(),
-            profile: String::new(),
-        }
-    }
-}
-impl ::std::fmt::Display for JsonIntegerRangeError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonIntegerRangeError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonLimitError {
-    message: String,
-    limit: i64,
-}
-impl JsonLimitError {
-    fn new(message: String) -> Self {
-        Self { message, limit: 0 }
-    }
-}
-impl ::std::fmt::Display for JsonLimitError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonLimitError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     let wrapper_payload: __SifrStdlib_sifr_x2ejson_x2eJsonValue = from_object(

--- a/demos/logging/emitted.rs
+++ b/demos/logging/emitted.rs
@@ -3158,7 +3158,9 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
 pub use __sifr_project_nominals::__SifrIoTextFileHandle;
@@ -4655,36 +4657,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     IOError { message: msg, kind }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ValueError {
     message: String,
 }
@@ -4699,21 +4671,6 @@ impl ::std::fmt::Display for ValueError {
     }
 }
 impl ::std::error::Error for ValueError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
 fn collect_logger_actual(base: &String) -> Vec<bool> {
     let mut actual: Vec<bool> = vec![];
     let app_log: String = {

--- a/demos/logging_and_timers/emitted.rs
+++ b/demos/logging_and_timers/emitted.rs
@@ -3438,7 +3438,10 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
+pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
 pub use __sifr_project_nominals::__SifrIoTextFileHandle;
@@ -5114,66 +5117,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ValueError {
-    message: String,
-}
-impl ValueError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ValueError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ValueError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn workload() {
     let mut i: i64 = 0_i64;

--- a/demos/no_runtime_panics/emitted.rs
+++ b/demos/no_runtime_panics/emitted.rs
@@ -3215,8 +3215,12 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
+pub use __sifr_project_nominals::JsonIntegerRangeError;
+pub use __sifr_project_nominals::JsonLimitError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::RegexError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
@@ -6798,108 +6802,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonIntegerRangeError {
-    message: String,
-    path: String,
-    profile: String,
-}
-impl JsonIntegerRangeError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            path: String::new(),
-            profile: String::new(),
-        }
-    }
-}
-impl ::std::fmt::Display for JsonIntegerRangeError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonIntegerRangeError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonLimitError {
-    message: String,
-    limit: i64,
-}
-impl JsonLimitError {
-    fn new(message: String) -> Self {
-        Self { message, limit: 0 }
-    }
-}
-impl ::std::fmt::Display for JsonLimitError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonLimitError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn has_match(pattern: &String, text: &String) -> Result<bool, RegexError> {
     let __sifr_try_res: Result<Result<bool, RegexError>, RegexError> = (|| {

--- a/demos/ordering_rules/emitted.rs
+++ b/demos/ordering_rules/emitted.rs
@@ -3195,7 +3195,12 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
+pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
+pub use __sifr_project_nominals::JsonIntegerRangeError;
+pub use __sifr_project_nominals::JsonLimitError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::RegexError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
@@ -5298,25 +5303,6 @@ fn findall(pattern: &String, text: &String) -> Result<Vec<String>, RegexError> {
 fn split(pattern: &String, text: &String) -> Result<Vec<String>, RegexError> {
     re_split(pattern, text)
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct IOError {
-    message: String,
-    kind: String,
-}
-impl IOError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            kind: "Other".to_string(),
-        }
-    }
-}
-impl ::std::fmt::Display for IOError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for IOError {}
 fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     let msg = e.to_string();
     let kind = {
@@ -5338,103 +5324,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonIntegerRangeError {
-    message: String,
-    path: String,
-    profile: String,
-}
-impl JsonIntegerRangeError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            path: String::new(),
-            profile: String::new(),
-        }
-    }
-}
-impl ::std::fmt::Display for JsonIntegerRangeError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonIntegerRangeError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonLimitError {
-    message: String,
-    limit: i64,
-}
-impl JsonLimitError {
-    fn new(message: String) -> Self {
-        Self { message, limit: 0 }
-    }
-}
-impl ::std::fmt::Display for JsonLimitError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonLimitError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
 }
 struct Processor {
     name: String,

--- a/demos/python_regressions/emitted.rs
+++ b/demos/python_regressions/emitted.rs
@@ -3805,6 +3805,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
 pub use __sifr_project_nominals::JsonIntegerRangeError;
@@ -7483,71 +7484,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TimeoutError> for Error {
-    fn from(err: TimeoutError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ScopeFailure> for Error {
-    fn from(err: ScopeFailure) -> Self {
-        Self::new(err.message)
-    }
 }
 fn has_match(pattern: &String, text: &String) -> Result<bool, RegexError> {
     let __sifr_try_res: Result<Result<bool, RegexError>, RegexError> = (|| {

--- a/demos/random_state/emitted.rs
+++ b/demos/random_state/emitted.rs
@@ -991,6 +991,7 @@ mod __sifr_project_nominals {
     }
     impl ::std::error::Error for ValueError {}
 }
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2erandom_x2eRandom;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2erandom_x2eRandomState;
@@ -1756,21 +1757,6 @@ fn random() -> f64 {
     _sync_module_random(&mut generator);
     value
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
 fn main() {
     let mut rng: __SifrStdlib_sifr_x2erandom_x2eRandom = __SifrStdlib_sifr_x2erandom_x2eRandom::new(
         Some(77_i64),

--- a/demos/readonly_bytes/emitted.rs
+++ b/demos/readonly_bytes/emitted.rs
@@ -1708,6 +1708,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
 pub use __sifr_project_nominals::JsonIntegerRangeError;
@@ -2732,71 +2733,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TimeoutError> for Error {
-    fn from(err: TimeoutError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ScopeFailure> for Error {
-    fn from(err: ScopeFailure) -> Self {
-        Self::new(err.message)
-    }
 }
 fn sum_bytes(data: &Vec<u8>) -> i64 {
     let mut total: i64 = 0_i64;

--- a/demos/safe_edge_cases/emitted.rs
+++ b/demos/safe_edge_cases/emitted.rs
@@ -925,6 +925,7 @@ mod __sifr_project_nominals {
     }
     impl ::std::error::Error for ValueError {}
 }
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2edatetime;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2etimezone;
@@ -3578,21 +3579,6 @@ impl ::std::fmt::Display for Error {
     }
 }
 impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
 impl From<ParseError> for Error {
     fn from(err: ParseError) -> Self {
         Self::new(err.message)

--- a/demos/stdlib/emitted.rs
+++ b/demos/stdlib/emitted.rs
@@ -3785,6 +3785,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
 pub use __sifr_project_nominals::JsonIntegerRangeError;
@@ -7167,71 +7168,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TimeoutError> for Error {
-    fn from(err: TimeoutError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ScopeFailure> for Error {
-    fn from(err: ScopeFailure) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     assert!(TAU > (6.0_f64));

--- a/demos/stdlib_error_types/emitted.rs
+++ b/demos/stdlib_error_types/emitted.rs
@@ -480,6 +480,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2egraphlib_x2eCycleError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2estatistics_x2eStatisticsError;
@@ -934,26 +935,6 @@ fn modf_integral(x: f64) -> f64 {
 }
 fn pow(x: f64, y: f64) -> f64 {
     pow_val(x, y)
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
 }
 fn compute_mean(
     data: &Vec<f64>,

--- a/demos/stdlib_fixes/emitted.rs
+++ b/demos/stdlib_fixes/emitted.rs
@@ -5516,6 +5516,7 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
 pub use __sifr_project_nominals::JSONDecodeError;
 pub use __sifr_project_nominals::JsonIntegerRangeError;
@@ -9455,71 +9456,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
         }
     };
     IOError { message: msg, kind }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JSONDecodeError> for Error {
-    fn from(err: JSONDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonIntegerRangeError> for Error {
-    fn from(err: JsonIntegerRangeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<JsonLimitError> for Error {
-    fn from(err: JsonLimitError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<RegexError> for Error {
-    fn from(err: RegexError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TimeoutError> for Error {
-    fn from(err: TimeoutError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ScopeFailure> for Error {
-    fn from(err: ScopeFailure) -> Self {
-        Self::new(err.message)
-    }
 }
 fn main() {
     let path: String = "/tmp/sifr_demo_remediation.txt".to_string();

--- a/demos/stdlib_tools/emitted.rs
+++ b/demos/stdlib_tools/emitted.rs
@@ -2880,7 +2880,9 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::TOMLDecodeError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
@@ -4834,36 +4836,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     IOError { message: msg, kind }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ValueError {
     message: String,
 }
@@ -4878,26 +4850,6 @@ impl ::std::fmt::Display for ValueError {
     }
 }
 impl ::std::error::Error for ValueError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<TOMLDecodeError> for Error {
-    fn from(err: TOMLDecodeError) -> Self {
-        Self::new(err.message)
-    }
-}
 fn do_work() {
     let mut total: i64 = 0_i64;
     let mut i: i64 = 0_i64;

--- a/demos/structured_parsing_serialization/emitted.rs
+++ b/demos/structured_parsing_serialization/emitted.rs
@@ -5382,6 +5382,10 @@ mod __sifr_project_nominals {
 }
 pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::JSONDecodeError;
+pub use __sifr_project_nominals::JsonIntegerRangeError;
+pub use __sifr_project_nominals::JsonLimitError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::TOMLDecodeError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
@@ -8555,79 +8559,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     };
     IOError { message: msg, kind }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JSONDecodeError {
-    message: String,
-    line: i64,
-    column: i64,
-}
-impl JSONDecodeError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            line: 0,
-            column: 0,
-        }
-    }
-}
-impl ::std::fmt::Display for JSONDecodeError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JSONDecodeError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonIntegerRangeError {
-    message: String,
-    path: String,
-    profile: String,
-}
-impl JsonIntegerRangeError {
-    fn new(message: String) -> Self {
-        Self {
-            message,
-            path: String::new(),
-            profile: String::new(),
-        }
-    }
-}
-impl ::std::fmt::Display for JsonIntegerRangeError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonIntegerRangeError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct JsonLimitError {
-    message: String,
-    limit: i64,
-}
-impl JsonLimitError {
-    fn new(message: String) -> Self {
-        Self { message, limit: 0 }
-    }
-}
-impl ::std::fmt::Display for JsonLimitError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for JsonLimitError {}
 fn main() {
     println!("structured-parsing-sample structured parsing and serialization demo");
     let __sifr_try_res: Result<

--- a/demos/system_tools/emitted.rs
+++ b/demos/system_tools/emitted.rs
@@ -3158,7 +3158,9 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::__SifrIoBinaryFileHandle;
 pub use __sifr_project_nominals::__SifrIoFileHandle;
 pub use __sifr_project_nominals::__SifrIoTextFileHandle;
@@ -4595,36 +4597,6 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
     IOError { message: msg, kind }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ValueError {
     message: String,
 }
@@ -4639,21 +4611,6 @@ impl ::std::fmt::Display for ValueError {
     }
 }
 impl ::std::error::Error for ValueError {}
-impl From<IOError> for Error {
-    fn from(err: IOError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
-    }
-}
 fn workload() {
     let mut i: i64 = 0_i64;
     let mut total: i64 = 0_i64;

--- a/demos/utility_classes/emitted.rs
+++ b/demos/utility_classes/emitted.rs
@@ -1994,6 +1994,8 @@ mod __sifr_project_nominals {
         }
     }
 }
+pub use __sifr_project_nominals::Error;
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2eargparse_x2eArgumentParser;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2eargparse_x2eArgumentSpec;
@@ -3018,46 +3020,6 @@ fn uuid_from_hex(
             let e = __sifr_try_err.clone();
             return Err(ValueError::new(e.message.clone()));
         }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct Error {
-    message: String,
-}
-impl Error {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-impl From<ParseError> for Error {
-    fn from(err: ParseError) -> Self {
-        Self::new(err.message)
-    }
-}
-impl From<ValueError> for Error {
-    fn from(err: ValueError) -> Self {
-        Self::new(err.message)
     }
 }
 fn main() {

--- a/demos/uuid_and_datetime/emitted.rs
+++ b/demos/uuid_and_datetime/emitted.rs
@@ -925,6 +925,7 @@ mod __sifr_project_nominals {
     }
     impl ::std::error::Error for ValueError {}
 }
+pub use __sifr_project_nominals::ParseError;
 pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2edatetime;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2edatetime_x2etimezone;
@@ -1553,21 +1554,6 @@ fn NAMESPACE_DNS() -> __SifrStdlib_sifr_x2euuid_x2eUUID {
         "6ba7b810-9dad-11d1-80b4-00c04fd430c8".to_string(),
     )
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
 fn main() {
     let name_v3: __SifrStdlib_sifr_x2euuid_x2eUUID = uuid3(
         &NAMESPACE_DNS(),

--- a/demos/zipfile_io/emitted.rs
+++ b/demos/zipfile_io/emitted.rs
@@ -939,6 +939,8 @@ mod __sifr_project_nominals {
     impl ::std::error::Error for ValueError {}
 }
 pub use __sifr_project_nominals::IOError;
+pub use __sifr_project_nominals::ParseError;
+pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2etempfile_x2eNamedTemporaryFile;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2ezipfile_x2eZipFile;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2ezipfile_x2eZipInfo;
@@ -2585,36 +2587,6 @@ impl ::std::fmt::Display for Error {
     }
 }
 impl ::std::error::Error for Error {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ParseError {
-    message: String,
-}
-impl ParseError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ParseError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ParseError {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ValueError {
-    message: String,
-}
-impl ValueError {
-    fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-impl ::std::fmt::Display for ValueError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::std::fmt::Display::fmt(&self.message, f)
-    }
-}
-impl ::std::error::Error for ValueError {}
 impl From<IOError> for Error {
     fn from(err: IOError) -> Self {
         Self::new(err.message)


### PR DESCRIPTION
## Summary

- exclude IOError kind aliases from direct project nominal collection
- register builtin definitions emitted by the shared synthetic prelude before relocating module code
- remove duplicate local builtin definitions from 41 generated demo companions

## Root causes

A direct Type::Class for an IOError kind entered the builtin nominal map even though code generation represents all six kinds through IOError and emits no subclass struct. Separately, builtin definitions emitted transitively in the shared synthetic prelude were not registered, so relocation retained duplicate local definitions.

## Validation

- six focused project nominal registry tests passed
- full sifr_codegen suite: 1,103 passed
- sifr_codegen Clippy with warnings denied
- demos/uuid_and_datetime and the UUID/date-time E2E fixture built and ran
- all generated demo companions are fresh
- every shared demo re-export resolves to exactly one struct, enum, or type definition
- no demo exports an IOError kind alias from the project nominal module
- cargo fmt --check
- git diff --check
- HIR maintainability guardrail
- first-party file-size guardrail
