### PR TITLE
fix(codegen): filter dead try continuation bindings

### DIFF
--- a/crates/sifr_codegen/src/class_emitter.rs
+++ b/crates/sifr_codegen/src/class_emitter.rs
@@ -424,8 +424,10 @@ impl RustEmitter {
         self.register_local_body_binding_types(&str_func.body);
 
         let mut body = Vec::new();
-        for stmt in &str_func.body {
-            let lowered = self.capture_structured_stmts(|inner| inner.emit_stmt(stmt));
+        for (stmt_index, stmt) in str_func.body.iter().enumerate() {
+            let lowered = self.capture_structured_stmts(|inner| {
+                inner.emit_stmt_with_following(stmt, Some(&str_func.body[stmt_index + 1..]));
+            });
             body.extend(lowered);
         }
 

--- a/crates/sifr_codegen/src/class_method_emitter.rs
+++ b/crates/sifr_codegen/src/class_method_emitter.rs
@@ -121,9 +121,18 @@ impl RustEmitter {
     pub(crate) fn lower_class_stmt_strict(
         &mut self,
         stmt: &HirStmt,
+        context: &str,
+    ) -> Vec<RustStmt> {
+        self.lower_class_stmt_strict_with_following(stmt, None, context)
+    }
+
+    pub(crate) fn lower_class_stmt_strict_with_following(
+        &mut self,
+        stmt: &HirStmt,
+        following_stmts: Option<&[HirStmt]>,
         _context: &str,
     ) -> Vec<RustStmt> {
-        self.capture_structured_stmts(|inner| inner.emit_stmt(stmt))
+        self.capture_structured_stmts(|inner| inner.emit_stmt_with_following(stmt, following_stmts))
     }
 
     pub(crate) fn lower_class_expr_strict(&mut self, expr: &HirExpr, context: &str) -> RustExpr {
@@ -279,11 +288,13 @@ impl RustEmitter {
         let mut field_inits = Vec::<(String, RustExpr)>::new();
         let mut instance_materialized = false;
 
-        for stmt in &method.body {
+        for (stmt_index, stmt) in method.body.iter().enumerate() {
+            let following_stmts = Some(&method.body[stmt_index + 1..]);
             if instance_materialized {
                 let rewritten = Self::rewrite_constructor_self(stmt);
-                body.extend(self.lower_class_stmt_strict(
+                body.extend(self.lower_class_stmt_strict_with_following(
                     &rewritten,
+                    following_stmts,
                     "class constructor post-initialization statement lowering",
                 ));
                 continue;
@@ -388,15 +399,17 @@ impl RustEmitter {
                 });
                 instance_materialized = true;
                 let rewritten = Self::rewrite_constructor_self(stmt);
-                body.extend(self.lower_class_stmt_strict(
+                body.extend(self.lower_class_stmt_strict_with_following(
                     &rewritten,
+                    following_stmts,
                     "class constructor post-initialization statement lowering",
                 ));
                 continue;
             }
 
-            body.extend(self.lower_class_stmt_strict(
+            body.extend(self.lower_class_stmt_strict_with_following(
                 stmt,
+                following_stmts,
                 "class constructor pre-initialization statement lowering",
             ));
         }
@@ -753,9 +766,12 @@ impl RustEmitter {
             self.lower_constructor_body(method, class, uses_python_error_bridge)
         } else {
             let mut lowered = Vec::new();
-            for stmt in &method.body {
-                lowered
-                    .extend(self.lower_class_stmt_strict(stmt, "class method statement lowering"));
+            for (stmt_index, stmt) in method.body.iter().enumerate() {
+                lowered.extend(self.lower_class_stmt_strict_with_following(
+                    stmt,
+                    Some(&method.body[stmt_index + 1..]),
+                    "class method statement lowering",
+                ));
             }
             lowered
         };

--- a/crates/sifr_codegen/src/function_emitter/generator_bodies.rs
+++ b/crates/sifr_codegen/src/function_emitter/generator_bodies.rs
@@ -93,9 +93,10 @@ impl RustEmitter {
                 args: vec![],
             },
         }];
-        for stmt in &func.body {
-            materialize_body.extend(self.lower_stmt_strict_for_function(
+        for (stmt_index, stmt) in func.body.iter().enumerate() {
+            materialize_body.extend(self.lower_stmt_strict_for_function_with_following(
                 stmt,
+                Some(&func.body[stmt_index + 1..]),
                 "generator materialization statement lowering",
             ));
         }
@@ -210,9 +211,10 @@ impl RustEmitter {
                 args: vec![],
             },
         });
-        for stmt in &func.body {
-            materialize_body.extend(self.lower_stmt_strict_for_function(
+        for (stmt_index, stmt) in func.body.iter().enumerate() {
+            materialize_body.extend(self.lower_stmt_strict_for_function_with_following(
                 stmt,
+                Some(&func.body[stmt_index + 1..]),
                 "async generator lazy materialization statement lowering",
             ));
         }
@@ -371,10 +373,12 @@ impl RustEmitter {
         } else {
             let mut lowered = Self::emit_mutable_param_shadow_stmts(&mutable_param_shadows);
             lowered.extend(self.prepare_string_char_cache_stmts(func, &reassigned_vars));
-            for stmt in &func.body {
-                lowered.extend(
-                    self.lower_stmt_strict_for_function(stmt, "function body statement lowering"),
-                );
+            for (stmt_index, stmt) in func.body.iter().enumerate() {
+                lowered.extend(self.lower_stmt_strict_for_function_with_following(
+                    stmt,
+                    Some(&func.body[stmt_index + 1..]),
+                    "function body statement lowering",
+                ));
             }
             lowered
         };

--- a/crates/sifr_codegen/src/function_emitter/scope_and_function_types.rs
+++ b/crates/sifr_codegen/src/function_emitter/scope_and_function_types.rs
@@ -552,9 +552,10 @@ impl RustEmitter {
         self.register_local_body_binding_types(&func.body);
 
         let mut lowered_body = Vec::new();
-        for body_stmt in &func.body {
-            lowered_body.extend(self.lower_stmt_strict_for_function(
+        for (stmt_index, body_stmt) in func.body.iter().enumerate() {
+            lowered_body.extend(self.lower_stmt_strict_for_function_with_following(
                 body_stmt,
+                Some(&func.body[stmt_index + 1..]),
                 "nested function body statement lowering",
             ));
         }
@@ -813,8 +814,17 @@ impl RustEmitter {
     pub(crate) fn lower_stmt_strict_for_function(
         &mut self,
         stmt: &HirStmt,
+        context: &str,
+    ) -> Vec<RustStmt> {
+        self.lower_stmt_strict_for_function_with_following(stmt, None, context)
+    }
+
+    pub(crate) fn lower_stmt_strict_for_function_with_following(
+        &mut self,
+        stmt: &HirStmt,
+        following_stmts: Option<&[HirStmt]>,
         _context: &str,
     ) -> Vec<RustStmt> {
-        self.capture_structured_stmts(|inner| inner.emit_stmt(stmt))
+        self.capture_structured_stmts(|inner| inner.emit_stmt_with_following(stmt, following_stmts))
     }
 }

--- a/crates/sifr_codegen/src/hir_analysis/queries/queries_impl.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries/queries_impl.rs
@@ -82,7 +82,48 @@ pub(crate) fn expr_references_var(expr: &HirExpr, var_name: &str) -> bool {
 }
 
 pub(crate) fn stmts_reference_var(stmts: &[HirStmt], var_name: &str) -> bool {
-    let mut on_stmt = |_stmt: &HirStmt| TraversalControl::Continue;
+    stmts_reference_var_with_config(stmts, var_name, TraversalConfig::LOCAL_SCOPE_ONLY)
+}
+
+pub(crate) fn stmts_reference_var_including_nested_functions(
+    stmts: &[HirStmt],
+    var_name: &str,
+) -> bool {
+    stmts_reference_var_with_config(stmts, var_name, TraversalConfig::INCLUDE_NESTED_FUNCTIONS)
+}
+
+fn stmts_reference_var_with_config(
+    stmts: &[HirStmt],
+    var_name: &str,
+    config: TraversalConfig,
+) -> bool {
+    let mut on_stmt = |stmt: &HirStmt| {
+        let target_references_var = match stmt {
+            HirStmt::Assign { name, .. } | HirStmt::AugAssign { name, .. } => name == var_name,
+            HirStmt::FieldAssign { object, .. }
+            | HirStmt::NestedFieldAssign { object, .. }
+            | HirStmt::SubscriptAssign { object, .. }
+            | HirStmt::NestedSubscriptAssign { object, .. }
+            | HirStmt::AttributeNestedSubscriptAssign { object, .. }
+            | HirStmt::SubscriptAugAssign { object, .. }
+            | HirStmt::AttributeAugAssign { object, .. }
+            | HirStmt::AttributeSubscriptAssign { object, .. } => object == var_name,
+            HirStmt::TupleUnpack { targets, .. } => {
+                targets.iter().any(|target| match &target.binding {
+                    sifr_ir::HirTupleTargetBinding::Name(name) => {
+                        target.rebind_existing && name == var_name
+                    }
+                    sifr_ir::HirTupleTargetBinding::Field { object, .. } => object == var_name,
+                })
+            }
+            _ => false,
+        };
+        if target_references_var {
+            TraversalControl::Stop
+        } else {
+            TraversalControl::Continue
+        }
+    };
     let mut on_expr = |expr: &HirExpr| {
         if let HirExpr::Name { name, .. } = expr {
             if name == var_name {
@@ -92,12 +133,7 @@ pub(crate) fn stmts_reference_var(stmts: &[HirStmt], var_name: &str) -> bool {
         TraversalControl::Continue
     };
     matches!(
-        traversal::walk_stmts_until(
-            stmts,
-            TraversalConfig::LOCAL_SCOPE_ONLY,
-            &mut on_stmt,
-            &mut on_expr,
-        ),
+        traversal::walk_stmts_until(stmts, config, &mut on_stmt, &mut on_expr,),
         TraversalControl::Stop
     )
 }

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -39,6 +39,7 @@ mod class_method_emitter;
 mod class_method_receiver_analysis;
 mod class_trait_capabilities;
 mod context;
+mod structured_stmt_entrypoints;
 pub use context::*;
 mod entrypoints;
 mod error_refs;

--- a/crates/sifr_codegen/src/lib_codegen_tests/async_runtime_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/async_runtime_codegen_tests.rs
@@ -220,10 +220,11 @@ fn test_module_body_flows_through_assembled_body_items() {
 
 #[test]
 fn test_generator_init_emission_is_structured_only() {
-    let emitter_state_src = include_str!("../lib_emitter_state.rs");
+    let stmt_entrypoints_src = include_str!("../structured_stmt_entrypoints.rs");
     let statement_output_src = include_str!("../stmt_support_emitter/statement_output.rs");
     assert!(statement_output_src.contains("self.lower_stmt_expr_for_ir(value)"));
-    assert!(emitter_state_src.contains("self.try_lower_structured_stmt(stmt)"));
+    assert!(stmt_entrypoints_src
+        .contains("self.try_lower_structured_stmt_with_following(stmt, following_stmts)"));
     assert!(statement_output_src
         .contains("structured generator-init expression emission missing for production path"));
     assert!(statement_output_src

--- a/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
@@ -160,3 +160,86 @@ def text_length() -> Result[int, ProbeError]:
     assert_eq!(generated.matches("let __sifr_chars_text").count(), 1);
     syn::parse_file(&generated).expect("promoted string binding Rust should parse");
 }
+
+#[test]
+fn dead_partially_moved_try_binding_is_not_returned_from_closure() {
+    let generated = generate_rust_from_source(&format!(
+        r#"{PROBE_ERROR}
+def load_pair() -> Result[tuple[str, str], ProbeError]:
+    return ("left", "right")
+
+def consume(own value: str) -> None:
+    _ = value
+
+def parse_pair() -> Result[int, ProbeError]:
+    try:
+        parsed_pair: tuple[str, str] = load_pair()
+        left, right = parsed_pair
+        consume(left)
+        consume(right)
+    except ProbeError as error:
+        raise error
+    return 1
+"#
+    ));
+
+    assert!(!generated.contains("Ok((parsed_pair,))"), "{generated}");
+    syn::parse_file(&generated).expect("dead try binding Rust should parse");
+}
+
+#[test]
+fn try_binding_captured_by_following_nested_function_remains_live() {
+    let generated = generate_rust_from_source(&format!(
+        r#"{PROBE_ERROR}
+def outer() -> Result[int, ProbeError]:
+    try:
+        value: int = load_int(42)
+    except ProbeError as error:
+        raise error
+
+    def read_value() -> int:
+        return value
+
+    return read_value()
+"#
+    ));
+
+    assert!(generated.contains("let (value,) = match __sifr_try_res"));
+    syn::parse_file(&generated).expect("captured live try binding Rust should parse");
+}
+
+#[test]
+fn try_binding_used_only_as_following_assignment_target_remains_live() {
+    let generated = generate_rust_from_source(&format!(
+        r#"{PROBE_ERROR}
+def replace_value() -> Result[int, ProbeError]:
+    try:
+        total: int = load_int(3)
+    except ProbeError as error:
+        raise error
+    total = 9
+    return 0
+"#
+    ));
+
+    assert!(generated.contains("let (mut total,) = match __sifr_try_res"));
+    syn::parse_file(&generated).expect("assigned live try binding Rust should parse");
+}
+
+#[test]
+fn try_binding_used_only_as_following_subscript_target_remains_live() {
+    let generated = generate_rust_from_source(&format!(
+        r#"{PROBE_ERROR}
+def replace_first() -> Result[int, ProbeError]:
+    try:
+        data: list[int] = [1]
+    except ProbeError as error:
+        raise error
+    data[0] = 5
+    return 0
+"#
+    ));
+
+    assert!(generated.contains("let (mut data,) = match __sifr_try_res"));
+    syn::parse_file(&generated).expect("subscript-live try binding Rust should parse");
+}

--- a/crates/sifr_codegen/src/lib_codegen_tests/structured_lowering_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structured_lowering_codegen_tests.rs
@@ -671,7 +671,7 @@ fn test_emit_expr_borrowed_compare_is_structured() {
 #[test]
 fn test_lib_decomposition_guards_keep_stmt_expr_logic_out_of_lib_rs() {
     let lib_src = include_str!("../lib.rs");
-    let emitter_state_src = include_str!("../lib_emitter_state.rs");
+    let stmt_entrypoints_src = include_str!("../structured_stmt_entrypoints.rs");
 
     assert!(!lib_src.contains("mod stmt_emitter;"));
     assert!(!lib_src.contains("mod expr_emitter;"));
@@ -683,14 +683,14 @@ fn test_lib_decomposition_guards_keep_stmt_expr_logic_out_of_lib_rs() {
     assert!(!lib_src.contains("fn try_lower_structured_expr("));
     assert!(!lib_src.contains("fn emit_stmt(&mut self, stmt: &HirStmt) {"));
 
-    let emit_stmt_start = emitter_state_src
+    let emit_stmt_start = stmt_entrypoints_src
         .find("fn emit_stmt(&mut self, stmt: &HirStmt) {")
         .expect("emit_stmt wrapper should exist");
-    let impl_end = emitter_state_src[emit_stmt_start..]
+    let impl_end = stmt_entrypoints_src[emit_stmt_start..]
         .find("\n    }\n}")
         .map(|offset| emit_stmt_start + offset)
         .expect("emit_stmt wrapper should end before impl close");
-    let emit_stmt_wrapper = &emitter_state_src[emit_stmt_start..impl_end];
+    let emit_stmt_wrapper = &stmt_entrypoints_src[emit_stmt_start..impl_end];
     assert!(emit_stmt_wrapper.contains("structured statement emission missing for production path"));
     assert!(!emit_stmt_wrapper.contains("self.try_emit_stmt_string_"));
     assert!(

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -1,10 +1,10 @@
 use super::{
     body_contains_await, collect_locally_defined_vars, collect_mutated_vars_with_sigs,
     collect_referenced_vars_with_types, default_param_convention, hir_analysis,
-    is_simple_stmt_candidate, resolve_alias_type_for_plain_call,
-    try_lower_simple_stmt_with_scope_result_and_bindings, Cell, ClassScope, HashMap, HashSet,
-    HirExpr, HirFunction, HirModule, HirStmt, LoweringStats, NestedFnCapture, ParamConvention,
-    RefCell, RustExpr, RustItem, RustLiteral, RustStmt, RustType, ScopeContext, Type,
+    resolve_alias_type_for_plain_call, try_lower_simple_stmt_with_scope_result_and_bindings, Cell,
+    ClassScope, HashMap, HashSet, HirExpr, HirFunction, HirModule, HirStmt, LoweringStats,
+    NestedFnCapture, ParamConvention, RefCell, RustExpr, RustItem, RustStmt, RustType,
+    ScopeContext, Type,
 };
 use crate::stmt_support_emitter::performance_lowering_gate::stmt_needs_performance_lowering;
 pub struct RustEmitter {
@@ -383,6 +383,14 @@ impl RustEmitter {
     pub(crate) fn try_lower_structured_stmt(
         &mut self,
         stmt: &HirStmt,
+    ) -> Result<bool, crate::CodegenError> {
+        self.try_lower_structured_stmt_with_following(stmt, None)
+    }
+
+    pub(crate) fn try_lower_structured_stmt_with_following(
+        &mut self,
+        stmt: &HirStmt,
+        following_stmts: Option<&[HirStmt]>,
     ) -> Result<bool, crate::CodegenError> {
         let scope_ctx = ScopeContext {
             function_return_type: self.current_return_type.clone(),
@@ -813,7 +821,7 @@ impl RustEmitter {
             self.lowering_stats.stmt_candidate_structured += 1;
             return Ok(true);
         }
-        if self.try_lower_structured_try_except_stmt(stmt) {
+        if self.try_lower_structured_try_except_stmt_with_following(stmt, following_stmts) {
             self.lowering_stats.stmt_structured += 1;
             self.lowering_stats.stmt_candidate_structured += 1;
             return Ok(true);
@@ -865,33 +873,6 @@ impl RustEmitter {
             }
         }
         Ok(false)
-    }
-    pub(crate) fn emit_stmt(&mut self, stmt: &HirStmt) {
-        self.lowering_stats.stmt_total += 1;
-        if is_simple_stmt_candidate(stmt) {
-            self.lowering_stats.stmt_candidate_total += 1;
-        }
-        match self.try_lower_structured_stmt(stmt) {
-            Ok(true) => {}
-            Ok(false) => {
-                self.lowering_stats.stmt_lowering_errors += 1;
-                self.push_captured_stmt(&RustStmt::Expr(RustExpr::MacroCall {
-                    name: "compile_error".to_string(),
-                    args: vec![RustExpr::Literal(RustLiteral::Str(format!(
-                        "structured statement emission missing for production path: {stmt:?}"
-                    )))],
-                }));
-            }
-            Err(err) => {
-                self.lowering_stats.stmt_lowering_errors += 1;
-                self.push_captured_stmt(&RustStmt::Expr(RustExpr::MacroCall {
-                    name: "compile_error".to_string(),
-                    args: vec![RustExpr::Literal(RustLiteral::Str(format!(
-                        "structured statement lowering failed for production path: {stmt:?}; error={err}"
-                    )))],
-                }));
-            }
-        }
     }
 }
 

--- a/crates/sifr_codegen/src/lower_stmt/try_tuple_flow.rs
+++ b/crates/sifr_codegen/src/lower_stmt/try_tuple_flow.rs
@@ -11,7 +11,7 @@ pub(super) fn try_lower_simple_try_except_stmt(
     bindings: SimpleStmtBindings<'_>,
     ctx: SimpleStmtLoweringCtx<'_>,
 ) -> Option<Vec<RustStmt>> {
-    if !crate::stmt_support_emitter::successful_try_bindings(body, handlers).is_empty() {
+    if !crate::stmt_support_emitter::successful_try_bindings(body, handlers, None).is_empty() {
         return None;
     }
     if crate::try_error_carrier::exact_try_error_carrier(body_error_types).is_some_and(|carrier| {

--- a/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
@@ -188,10 +188,19 @@ impl RustEmitter {
     }
 
     pub(crate) fn try_lower_structured_try_except_stmt(&mut self, stmt: &HirStmt) -> bool {
-        let lowered = match self.try_lower_try_except_hir_stmt_for_ir(stmt) {
-            Ok(Some(lowered)) => lowered,
-            Ok(None) | Err(_) => return false,
-        };
+        self.try_lower_structured_try_except_stmt_with_following(stmt, None)
+    }
+
+    pub(crate) fn try_lower_structured_try_except_stmt_with_following(
+        &mut self,
+        stmt: &HirStmt,
+        following_stmts: Option<&[HirStmt]>,
+    ) -> bool {
+        let lowered =
+            match self.try_lower_try_except_hir_stmt_for_ir_with_following(stmt, following_stmts) {
+                Ok(Some(lowered)) => lowered,
+                Ok(None) | Err(_) => return false,
+            };
         for lowered_stmt in lowered {
             self.push_captured_stmt(&lowered_stmt);
         }
@@ -202,6 +211,14 @@ impl RustEmitter {
         &mut self,
         stmt: &HirStmt,
     ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
+        self.try_lower_try_except_hir_stmt_for_ir_with_following(stmt, None)
+    }
+
+    pub(crate) fn try_lower_try_except_hir_stmt_for_ir_with_following(
+        &mut self,
+        stmt: &HirStmt,
+        following_stmts: Option<&[HirStmt]>,
+    ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
         let HirStmt::TryExcept {
             body,
             handlers,
@@ -210,7 +227,7 @@ impl RustEmitter {
         else {
             return Ok(None);
         };
-        self.try_lower_try_except_stmt_for_ir(body, handlers, body_error_types)
+        self.try_lower_try_except_stmt_for_ir(body, handlers, body_error_types, following_stmts)
     }
 
     pub(crate) fn try_lower_try_except_stmt_for_ir(
@@ -218,6 +235,7 @@ impl RustEmitter {
         body: &[HirStmt],
         handlers: &[HirExceptHandler],
         body_error_types: &[Type],
+        following_stmts: Option<&[HirStmt]>,
     ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
         if handlers.is_empty() {
             return Ok(None);
@@ -241,7 +259,7 @@ impl RustEmitter {
             && handlers
                 .iter()
                 .all(|handler| queries::block_control_flow_effect(&handler.body).always_exits());
-        let successful_bindings = successful_try_bindings(body, handlers)
+        let successful_bindings = successful_try_bindings(body, handlers, following_stmts)
             .into_iter()
             .map(|(name, ty)| {
                 let ty = self.local_binding_types.get(&name).cloned().unwrap_or(ty);

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
@@ -857,7 +857,11 @@ impl RustEmitter {
                 };
                 (vec![lowered_async_with], true)
             } else if matches!(stmt, HirStmt::TryExcept { .. }) {
-                let Some(lowered_try_except) = self.try_lower_try_except_hir_stmt_for_ir(stmt)?
+                let Some(lowered_try_except) = self
+                    .try_lower_try_except_hir_stmt_for_ir_with_following(
+                        stmt,
+                        Some(&stmts[stmt_index + 1..]),
+                    )?
                 else {
                     return Ok(None);
                 };

--- a/crates/sifr_codegen/src/stmt_support_emitter/try_error_helpers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/try_error_helpers.rs
@@ -3,6 +3,7 @@ use super::{HirExceptHandler, HirStmt, RustExpr, Type};
 pub(crate) fn successful_try_bindings(
     body: &[HirStmt],
     handlers: &[HirExceptHandler],
+    following_stmts: Option<&[HirStmt]>,
 ) -> Vec<(String, Type)> {
     if crate::hir_analysis::queries::block_control_flow_effect(body).always_exits()
         || handlers.iter().any(|handler| {
@@ -18,7 +19,14 @@ pub(crate) fn successful_try_bindings(
             let HirStmt::Let { name, ty, .. } = stmt else {
                 return None;
             };
-            (name != "_" && names.insert(name.clone())).then(|| (name.clone(), ty.clone()))
+            (name != "_"
+                && names.insert(name.clone())
+                && following_stmts.is_none_or(|following| {
+                    crate::hir_analysis::queries::stmts_reference_var_including_nested_functions(
+                        following, name,
+                    )
+                }))
+            .then(|| (name.clone(), ty.clone()))
         })
         .collect()
 }

--- a/crates/sifr_codegen/src/structured_stmt_entrypoints.rs
+++ b/crates/sifr_codegen/src/structured_stmt_entrypoints.rs
@@ -1,0 +1,39 @@
+use crate::{is_simple_stmt_candidate, HirStmt, RustEmitter, RustExpr, RustLiteral, RustStmt};
+
+impl RustEmitter {
+    pub(crate) fn emit_stmt(&mut self, stmt: &HirStmt) {
+        self.emit_stmt_with_following(stmt, None);
+    }
+
+    pub(crate) fn emit_stmt_with_following(
+        &mut self,
+        stmt: &HirStmt,
+        following_stmts: Option<&[HirStmt]>,
+    ) {
+        self.lowering_stats.stmt_total += 1;
+        if is_simple_stmt_candidate(stmt) {
+            self.lowering_stats.stmt_candidate_total += 1;
+        }
+        match self.try_lower_structured_stmt_with_following(stmt, following_stmts) {
+            Ok(true) => {}
+            Ok(false) => {
+                self.lowering_stats.stmt_lowering_errors += 1;
+                self.push_captured_stmt(&RustStmt::Expr(RustExpr::MacroCall {
+                    name: "compile_error".to_string(),
+                    args: vec![RustExpr::Literal(RustLiteral::Str(format!(
+                        "structured statement emission missing for production path: {stmt:?}"
+                    )))],
+                }));
+            }
+            Err(err) => {
+                self.lowering_stats.stmt_lowering_errors += 1;
+                self.push_captured_stmt(&RustStmt::Expr(RustExpr::MacroCall {
+                    name: "compile_error".to_string(),
+                    args: vec![RustExpr::Literal(RustLiteral::Str(format!(
+                        "structured statement lowering failed for production path: {stmt:?}; error={err}"
+                    )))],
+                }));
+            }
+        }
+    }
+}

--- a/demos/additional_modules/emitted.rs
+++ b/demos/additional_modules/emitted.rs
@@ -2771,7 +2771,7 @@ mod __sifr_project_nominals {
                     continue;
                 }
                 let __sifr_try_res: Result<
-                    ((String, Option<String>),),
+                    (),
                     __SifrStdlib_sifr_x2econfigparser_x2eParsingError,
                 > = (|| {
                     let parsed_option_pair: (String, Option<String>) = _split_option_line(
@@ -2827,15 +2827,12 @@ mod __sifr_project_nominals {
                             break;
                         }
                     }
-                    Ok((parsed_option_pair,))
+                    Ok(())
                 })();
-                let (parsed_option_pair,) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(e);
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(e);
+                }
             }
             Ok(())
         }

--- a/demos/advanced_class_libraries/emitted.rs
+++ b/demos/advanced_class_libraries/emitted.rs
@@ -4416,19 +4416,16 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
+                let __sifr_try_res: Result<(), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok((tz_text, target_offset))
+                    Ok(())
                 })();
-                let (tz_text, target_offset) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(ValueError::new(e.message.clone()));
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(ValueError::new(e.message.clone()));
+                }
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/class_libraries/emitted.rs
+++ b/demos/class_libraries/emitted.rs
@@ -297,10 +297,8 @@ mod __sifr_project_nominals {
                 return Ok(());
             }
             let mut prepare_ok: bool = false;
-            let __sifr_try_res: Result<
-                (Vec<i64>,),
-                __SifrStdlib_sifr_x2egraphlib_x2eCycleError,
-            > = (|| {
+            let __sifr_try_res: Result<(), __SifrStdlib_sifr_x2egraphlib_x2eCycleError> = (||
+            {
                 let order: Vec<i64> = topological_sort(
                     self.max_node + (1_i64),
                     &self.from_nodes,
@@ -309,20 +307,17 @@ mod __sifr_project_nominals {
                 self._ready_order = self._filter_order(&order);
                 self._prepared = true;
                 prepare_ok = true;
-                Ok((order,))
+                Ok(())
             })();
-            let (order,) = match __sifr_try_res {
-                Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                Err(__sifr_try_err) => {
-                    let e = __sifr_try_err.clone();
-                    self._prepared = false;
-                    self._ready_order = vec![];
-                    self._next_index = 0_i64;
-                    return Err(
-                        __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
-                    );
-                }
-            };
+            if let Err(__sifr_try_err) = __sifr_try_res {
+                let e = __sifr_try_err.clone();
+                self._prepared = false;
+                self._ready_order = vec![];
+                self._next_index = 0_i64;
+                return Err(
+                    __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
+                );
+            }
             if prepare_ok {
                 return Ok(());
             }
@@ -335,24 +330,19 @@ mod __sifr_project_nominals {
         ) -> Result<Vec<i64>, __SifrStdlib_sifr_x2egraphlib_x2eCycleError> {
             if !(self._prepared) {
                 let __sifr_try_res: Result<
-                    ((),),
+                    (),
                     __SifrStdlib_sifr_x2egraphlib_x2eCycleError,
                 > = (|| {
                     let _prepared: () = self.prepare()?;
                     let _ = _prepared;
-                    Ok((_prepared,))
+                    Ok(())
                 })();
-                let (_prepared,) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(
-                            __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(
-                                e.message.clone(),
-                            ),
-                        );
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(
+                        __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
+                    );
+                }
             }
             if (self._next_index < (self._ready_order.len() as i64)) {
                 let current: Option<i64> = {

--- a/demos/codegen_structural_passes/emitted.rs
+++ b/demos/codegen_structural_passes/emitted.rs
@@ -366,19 +366,16 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
+                let __sifr_try_res: Result<(), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok((tz_text, target_offset))
+                    Ok(())
                 })();
-                let (tz_text, target_offset) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(ValueError::new(e.message.clone()));
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(ValueError::new(e.message.clone()));
+                }
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/collections_and_argparse/emitted.rs
+++ b/demos/collections_and_argparse/emitted.rs
@@ -922,7 +922,6 @@ mod __sifr_project_nominals {
             };
         }
         if _is_digit_string(nargs) {
-            let mut __sifr_successful_try_bindings: Option<(i64,)> = None;
             let __sifr_try_res: Result<Option<String>, ParseError> = (|| {
                 let parsed: i64 = (nargs)
                     .parse::<i64>()
@@ -932,7 +931,6 @@ mod __sifr_project_nominals {
                 if parsed > (0_i64) {
                     return Ok(Some(format!("{}", parsed)));
                 }
-                __sifr_successful_try_bindings = Some((parsed,));
                 Ok(None)
             })();
             match __sifr_try_res {
@@ -945,9 +943,6 @@ mod __sifr_project_nominals {
                     return "1".to_string();
                 }
             }
-            let Some((parsed,)) = __sifr_successful_try_bindings else {
-                unreachable!("successful try fallthrough must initialize promoted bindings");
-            };
         }
         "1".to_string()
     }
@@ -1521,7 +1516,6 @@ fn _normalize_nargs(nargs: &String) -> String {
         };
     }
     if _is_digit_string(nargs) {
-        let mut __sifr_successful_try_bindings: Option<(i64,)> = None;
         let __sifr_try_res: Result<Option<String>, ParseError> = (|| {
             let parsed: i64 = (nargs)
                 .parse::<i64>()
@@ -1531,7 +1525,6 @@ fn _normalize_nargs(nargs: &String) -> String {
             if parsed > (0_i64) {
                 return Ok(Some(format!("{}", parsed)));
             }
-            __sifr_successful_try_bindings = Some((parsed,));
             Ok(None)
         })();
         match __sifr_try_res {
@@ -1544,9 +1537,6 @@ fn _normalize_nargs(nargs: &String) -> String {
                 return "1".to_string();
             }
         }
-        let Some((parsed,)) = __sifr_successful_try_bindings else {
-            unreachable!("successful try fallthrough must initialize promoted bindings");
-        };
     }
     "1".to_string()
 }

--- a/demos/config_json_csv/emitted.rs
+++ b/demos/config_json_csv/emitted.rs
@@ -2773,7 +2773,7 @@ mod __sifr_project_nominals {
                     continue;
                 }
                 let __sifr_try_res: Result<
-                    ((String, Option<String>),),
+                    (),
                     __SifrStdlib_sifr_x2econfigparser_x2eParsingError,
                 > = (|| {
                     let parsed_option_pair: (String, Option<String>) = _split_option_line(
@@ -2829,15 +2829,12 @@ mod __sifr_project_nominals {
                             break;
                         }
                     }
-                    Ok((parsed_option_pair,))
+                    Ok(())
                 })();
-                let (parsed_option_pair,) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(e);
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(e);
+                }
             }
             Ok(())
         }

--- a/demos/core_libraries/emitted.rs
+++ b/demos/core_libraries/emitted.rs
@@ -384,19 +384,16 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
+                let __sifr_try_res: Result<(), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok((tz_text, target_offset))
+                    Ok(())
                 })();
-                let (tz_text, target_offset) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(ValueError::new(e.message.clone()));
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(ValueError::new(e.message.clone()));
+                }
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/datetime/emitted.rs
+++ b/demos/datetime/emitted.rs
@@ -452,19 +452,16 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
+                let __sifr_try_res: Result<(), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok((tz_text, target_offset))
+                    Ok(())
                 })();
-                let (tz_text, target_offset) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(ValueError::new(e.message.clone()));
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(ValueError::new(e.message.clone()));
+                }
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/filesystem_and_archives/emitted.rs
+++ b/demos/filesystem_and_archives/emitted.rs
@@ -1434,7 +1434,7 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
             __indexed_char
         }) == ".")));
     let mut matches: Vec<String> = vec![];
-    let __sifr_try_res: Result<(Vec<String>,), IOError> = (|| {
+    let __sifr_try_res: Result<(), IOError> = (|| {
         let entries: Vec<String> = listdir(directory)?;
         for entry in entries.iter().cloned() {
             let __sifr_chars_entry: Vec<char> = entry.chars().collect::<Vec<char>>();
@@ -1459,16 +1459,13 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
                 matches.push(entry.clone());
             }
         }
-        Ok((entries,))
+        Ok(())
     })();
-    let (entries,) = match __sifr_try_res {
-        Ok(__sifr_try_bindings) => __sifr_try_bindings,
-        Err(__sifr_try_err) => {
-            let e = __sifr_try_err.clone();
-            let _ = format!("{}", e.message.clone());
-            return vec![];
-        }
-    };
+    if let Err(__sifr_try_err) = __sifr_try_res {
+        let e = __sifr_try_err.clone();
+        let _ = format!("{}", e.message.clone());
+        return vec![];
+    }
     {
         let mut __sifr_sorted_v = (matches).iter().cloned().collect::<Vec<_>>();
         __sifr_sorted_v.sort();

--- a/demos/fixed_timezones/emitted.rs
+++ b/demos/fixed_timezones/emitted.rs
@@ -366,19 +366,16 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
+                let __sifr_try_res: Result<(), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok((tz_text, target_offset))
+                    Ok(())
                 })();
-                let (tz_text, target_offset) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(ValueError::new(e.message.clone()));
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(ValueError::new(e.message.clone()));
+                }
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/glob/emitted.rs
+++ b/demos/glob/emitted.rs
@@ -437,7 +437,7 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
             __indexed_char
         }) == ".")));
     let mut matches: Vec<String> = vec![];
-    let __sifr_try_res: Result<(Vec<String>,), IOError> = (|| {
+    let __sifr_try_res: Result<(), IOError> = (|| {
         let entries: Vec<String> = listdir(directory)?;
         for entry in entries.iter().cloned() {
             let __sifr_chars_entry: Vec<char> = entry.chars().collect::<Vec<char>>();
@@ -462,16 +462,13 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
                 matches.push(entry.clone());
             }
         }
-        Ok((entries,))
+        Ok(())
     })();
-    let (entries,) = match __sifr_try_res {
-        Ok(__sifr_try_bindings) => __sifr_try_bindings,
-        Err(__sifr_try_err) => {
-            let e = __sifr_try_err.clone();
-            let _ = format!("{}", e.message.clone());
-            return vec![];
-        }
-    };
+    if let Err(__sifr_try_err) = __sifr_try_res {
+        let e = __sifr_try_err.clone();
+        let _ = format!("{}", e.message.clone());
+        return vec![];
+    }
     {
         let mut __sifr_sorted_v = (matches).iter().cloned().collect::<Vec<_>>();
         __sifr_sorted_v.sort();

--- a/demos/regex_and_filesystem/emitted.rs
+++ b/demos/regex_and_filesystem/emitted.rs
@@ -1633,7 +1633,7 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
             __indexed_char
         }) == ".")));
     let mut matches: Vec<String> = vec![];
-    let __sifr_try_res: Result<(Vec<String>,), IOError> = (|| {
+    let __sifr_try_res: Result<(), IOError> = (|| {
         let entries: Vec<String> = listdir(directory)?;
         for entry in entries.iter().cloned() {
             let __sifr_chars_entry: Vec<char> = entry.chars().collect::<Vec<char>>();
@@ -1658,16 +1658,13 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
                 matches.push(entry.clone());
             }
         }
-        Ok((entries,))
+        Ok(())
     })();
-    let (entries,) = match __sifr_try_res {
-        Ok(__sifr_try_bindings) => __sifr_try_bindings,
-        Err(__sifr_try_err) => {
-            let e = __sifr_try_err.clone();
-            let _ = format!("{}", e.message.clone());
-            return vec![];
-        }
-    };
+    if let Err(__sifr_try_err) = __sifr_try_res {
+        let e = __sifr_try_err.clone();
+        let _ = format!("{}", e.message.clone());
+        return vec![];
+    }
     {
         let mut __sifr_sorted_v = (matches).iter().cloned().collect::<Vec<_>>();
         __sifr_sorted_v.sort();

--- a/demos/safe_edge_cases/emitted.rs
+++ b/demos/safe_edge_cases/emitted.rs
@@ -366,19 +366,16 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
+                let __sifr_try_res: Result<(), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok((tz_text, target_offset))
+                    Ok(())
                 })();
-                let (tz_text, target_offset) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(ValueError::new(e.message.clone()));
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(ValueError::new(e.message.clone()));
+                }
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/stdlib/emitted.rs
+++ b/demos/stdlib/emitted.rs
@@ -384,19 +384,16 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
+                let __sifr_try_res: Result<(), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok((tz_text, target_offset))
+                    Ok(())
                 })();
-                let (tz_text, target_offset) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(ValueError::new(e.message.clone()));
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(ValueError::new(e.message.clone()));
+                }
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/stdlib_fixes/emitted.rs
+++ b/demos/stdlib_fixes/emitted.rs
@@ -3520,19 +3520,16 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
+                let __sifr_try_res: Result<(), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok((tz_text, target_offset))
+                    Ok(())
                 })();
-                let (tz_text, target_offset) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(ValueError::new(e.message.clone()));
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(ValueError::new(e.message.clone()));
+                }
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/stdlib_tools/emitted.rs
+++ b/demos/stdlib_tools/emitted.rs
@@ -3282,7 +3282,7 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
             __indexed_char
         }) == ".")));
     let mut matches: Vec<String> = vec![];
-    let __sifr_try_res: Result<(Vec<String>,), IOError> = (|| {
+    let __sifr_try_res: Result<(), IOError> = (|| {
         let entries: Vec<String> = listdir(directory)?;
         for entry in entries.iter().cloned() {
             let __sifr_chars_entry: Vec<char> = entry.chars().collect::<Vec<char>>();
@@ -3307,16 +3307,13 @@ fn glob(directory: &String, pattern: &String) -> Vec<String> {
                 matches.push(entry.clone());
             }
         }
-        Ok((entries,))
+        Ok(())
     })();
-    let (entries,) = match __sifr_try_res {
-        Ok(__sifr_try_bindings) => __sifr_try_bindings,
-        Err(__sifr_try_err) => {
-            let e = __sifr_try_err.clone();
-            let _ = format!("{}", e.message.clone());
-            return vec![];
-        }
-    };
+    if let Err(__sifr_try_err) = __sifr_try_res {
+        let e = __sifr_try_err.clone();
+        let _ = format!("{}", e.message.clone());
+        return vec![];
+    }
     {
         let mut __sifr_sorted_v = (matches).iter().cloned().collect::<Vec<_>>();
         __sifr_sorted_v.sort();

--- a/demos/structured_parsing_serialization/emitted.rs
+++ b/demos/structured_parsing_serialization/emitted.rs
@@ -2773,7 +2773,7 @@ mod __sifr_project_nominals {
                     continue;
                 }
                 let __sifr_try_res: Result<
-                    ((String, Option<String>),),
+                    (),
                     __SifrStdlib_sifr_x2econfigparser_x2eParsingError,
                 > = (|| {
                     let parsed_option_pair: (String, Option<String>) = _split_option_line(
@@ -2829,15 +2829,12 @@ mod __sifr_project_nominals {
                             break;
                         }
                     }
-                    Ok((parsed_option_pair,))
+                    Ok(())
                 })();
-                let (parsed_option_pair,) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(e);
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(e);
+                }
             }
             Ok(())
         }

--- a/demos/utility_classes/emitted.rs
+++ b/demos/utility_classes/emitted.rs
@@ -921,7 +921,6 @@ mod __sifr_project_nominals {
             };
         }
         if _is_digit_string(nargs) {
-            let mut __sifr_successful_try_bindings: Option<(i64,)> = None;
             let __sifr_try_res: Result<Option<String>, ParseError> = (|| {
                 let parsed: i64 = (nargs)
                     .parse::<i64>()
@@ -931,7 +930,6 @@ mod __sifr_project_nominals {
                 if parsed > (0_i64) {
                     return Ok(Some(format!("{}", parsed)));
                 }
-                __sifr_successful_try_bindings = Some((parsed,));
                 Ok(None)
             })();
             match __sifr_try_res {
@@ -944,9 +942,6 @@ mod __sifr_project_nominals {
                     return "1".to_string();
                 }
             }
-            let Some((parsed,)) = __sifr_successful_try_bindings else {
-                unreachable!("successful try fallthrough must initialize promoted bindings");
-            };
         }
         "1".to_string()
     }
@@ -1178,10 +1173,8 @@ mod __sifr_project_nominals {
                 return Ok(());
             }
             let mut prepare_ok: bool = false;
-            let __sifr_try_res: Result<
-                (Vec<i64>,),
-                __SifrStdlib_sifr_x2egraphlib_x2eCycleError,
-            > = (|| {
+            let __sifr_try_res: Result<(), __SifrStdlib_sifr_x2egraphlib_x2eCycleError> = (||
+            {
                 let order: Vec<i64> = topological_sort(
                     self.max_node + (1_i64),
                     &self.from_nodes,
@@ -1190,20 +1183,17 @@ mod __sifr_project_nominals {
                 self._ready_order = self._filter_order(&order);
                 self._prepared = true;
                 prepare_ok = true;
-                Ok((order,))
+                Ok(())
             })();
-            let (order,) = match __sifr_try_res {
-                Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                Err(__sifr_try_err) => {
-                    let e = __sifr_try_err.clone();
-                    self._prepared = false;
-                    self._ready_order = vec![];
-                    self._next_index = 0_i64;
-                    return Err(
-                        __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
-                    );
-                }
-            };
+            if let Err(__sifr_try_err) = __sifr_try_res {
+                let e = __sifr_try_err.clone();
+                self._prepared = false;
+                self._ready_order = vec![];
+                self._next_index = 0_i64;
+                return Err(
+                    __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
+                );
+            }
             if prepare_ok {
                 return Ok(());
             }
@@ -1216,24 +1206,19 @@ mod __sifr_project_nominals {
         ) -> Result<Vec<i64>, __SifrStdlib_sifr_x2egraphlib_x2eCycleError> {
             if !(self._prepared) {
                 let __sifr_try_res: Result<
-                    ((),),
+                    (),
                     __SifrStdlib_sifr_x2egraphlib_x2eCycleError,
                 > = (|| {
                     let _prepared: () = self.prepare()?;
                     let _ = _prepared;
-                    Ok((_prepared,))
+                    Ok(())
                 })();
-                let (_prepared,) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(
-                            __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(
-                                e.message.clone(),
-                            ),
-                        );
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(
+                        __SifrStdlib_sifr_x2egraphlib_x2eCycleError::new(e.message.clone()),
+                    );
+                }
             }
             if (self._next_index < (self._ready_order.len() as i64)) {
                 let current: Option<i64> = {
@@ -2080,7 +2065,6 @@ fn _normalize_nargs(nargs: &String) -> String {
         };
     }
     if _is_digit_string(nargs) {
-        let mut __sifr_successful_try_bindings: Option<(i64,)> = None;
         let __sifr_try_res: Result<Option<String>, ParseError> = (|| {
             let parsed: i64 = (nargs)
                 .parse::<i64>()
@@ -2090,7 +2074,6 @@ fn _normalize_nargs(nargs: &String) -> String {
             if parsed > (0_i64) {
                 return Ok(Some(format!("{}", parsed)));
             }
-            __sifr_successful_try_bindings = Some((parsed,));
             Ok(None)
         })();
         match __sifr_try_res {
@@ -2103,9 +2086,6 @@ fn _normalize_nargs(nargs: &String) -> String {
                 return "1".to_string();
             }
         }
-        let Some((parsed,)) = __sifr_successful_try_bindings else {
-            unreachable!("successful try fallthrough must initialize promoted bindings");
-        };
     }
     "1".to_string()
 }

--- a/demos/uuid_and_datetime/emitted.rs
+++ b/demos/uuid_and_datetime/emitted.rs
@@ -366,19 +366,16 @@ mod __sifr_project_nominals {
                 0_i64,
             );
             if let Some(tz) = tz.as_ref() {
-                let __sifr_try_res: Result<(String, i64), ValueError> = (|| {
+                let __sifr_try_res: Result<(), ValueError> = (|| {
                     let tz_text: String = format!("{}", tz);
                     let target_offset: i64 = _timezone_offset_from_text(&tz_text)?;
                     target = __SifrStdlib_sifr_x2edatetime_x2etimezone::new(target_offset);
-                    Ok((tz_text, target_offset))
+                    Ok(())
                 })();
-                let (tz_text, target_offset) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(ValueError::new(e.message.clone()));
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(ValueError::new(e.message.clone()));
+                }
             }
             _from_timestamp_microseconds_with_tz(
                 self.timestamp_microseconds(),

--- a/demos/zipfile_io/emitted.rs
+++ b/demos/zipfile_io/emitted.rs
@@ -463,17 +463,14 @@ mod __sifr_project_nominals {
                 return Ok(());
             }
             if exists(&self._path) {
-                let __sifr_try_res: Result<((),), IOError> = (|| {
+                let __sifr_try_res: Result<(), IOError> = (|| {
                     let _rm_done: () = remove_file(&self._path)?;
-                    Ok((_rm_done,))
+                    Ok(())
                 })();
-                let (_rm_done,) = match __sifr_try_res {
-                    Ok(__sifr_try_bindings) => __sifr_try_bindings,
-                    Err(__sifr_try_err) => {
-                        let e = __sifr_try_err.clone();
-                        return Err(IOError::new(e.message.clone()));
-                    }
-                };
+                if let Err(__sifr_try_err) = __sifr_try_res {
+                    let e = __sifr_try_err.clone();
+                    return Err(IOError::new(e.message.clone()));
+                }
             }
             self._cleaned = true;
             Ok(())


### PR DESCRIPTION
## Item 10B

Preserve ownership across generated try continuations by promoting only bindings referenced after the try statement.

Base: `cbf256719ff6dc1ed800c878ad50390c046fa400`
Candidate: `42cbe6ef798c8047b33289c9779dde94852e0046`

## Validation

- focused sequential try binding tests: 10 passed
- full sifr_codegen suite: 1,107 passed
- config-parser fixture family: builds
- cpython_configparser_subset: runs
- network_http_tls_loopback_split: builds and runs
- demo emitted freshness: pass
- sifr_codegen Clippy with warnings denied: pass
- format, HIR maintainability, file-size, and diff checks: pass

## Review remediation

The first exact-SHA Opus review found that assignment-target-only uses were absent from the liveness query. The query now covers scalar, field, subscript, attribute, nested-subscript, augmented, and tuple-rebind targets. Focused scalar and subscript regressions pass.

## Gate note

The one create-PR gate attempt on the pre-demo-refresh implementation SHA stopped at demo freshness. The 20 generated companions are now refreshed and independently pass freshness. A process exception is required before any second create-PR gate.