### PR TITLE
fix(codegen): make raising try control flow total

### DIFF
--- a/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
@@ -243,3 +243,22 @@ def replace_first() -> Result[int, ProbeError]:
     assert!(generated.contains("let (mut data,) = match __sifr_try_res"));
     syn::parse_file(&generated).expect("subscript-live try binding Rust should parse");
 }
+
+#[test]
+fn always_raising_try_body_uses_total_result_match() {
+    let generated = generate_rust_from_source(&format!(
+        r#"{PROBE_ERROR}
+def classify() -> str:
+    try:
+        raise ProbeError("bad")
+    except ProbeError as error:
+        return error.message
+"#
+    ));
+
+    assert!(generated.contains("match __sifr_try_res"));
+    assert!(generated.contains("Ok(()) =>"));
+    assert!(generated.contains("sifr try/except raising body returned success"));
+    assert!(!generated.contains("if let Err(__sifr_try_err) = __sifr_try_res"));
+    syn::parse_file(&generated).expect("total raising try Rust should parse");
+}

--- a/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
@@ -254,6 +254,10 @@ impl RustEmitter {
         // only returns from the closure-backed try body need a carrier.
         let capture_returns =
             self.current_return_type.is_some() && queries::body_contains_return(body);
+        let body_always_raises = matches!(
+            queries::block_control_flow_effect(body),
+            sifr_ir::HirControlFlowEffect::AlwaysRaises
+        );
         let direct_return_capture = capture_returns
             && queries::block_control_flow_effect(body).always_exits()
             && handlers
@@ -360,6 +364,12 @@ impl RustEmitter {
                         .collect(),
                 )],
             })));
+        } else if body_always_raises {
+            closure_body.push(RustStmt::Expr(RustExpr::FormatMacro {
+                name: "unreachable".to_string(),
+                format_str: "sifr try/except raising body fell through".to_string(),
+                args: vec![],
+            }));
         } else if !capture_returns {
             closure_body.push(RustStmt::Return(Some(RustExpr::FnCall {
                 func: Box::new(RustExpr::Ident("Ok".to_string())),
@@ -498,6 +508,37 @@ impl RustEmitter {
                     })],
                 });
             }
+        } else if body_always_raises {
+            let Some(handler_chain) = self.lower_try_except_handler_chain_for_ir(
+                handlers,
+                "__sifr_try_err",
+                error_carrier.as_ref(),
+                &err_ty,
+            )?
+            else {
+                return Ok(None);
+            };
+            lowered.push(RustStmt::Match {
+                expr: RustExpr::Ident("__sifr_try_res".to_string()),
+                arms: vec![
+                    crate::RustMatchArm {
+                        pattern: "Ok(())".to_string(),
+                        bindings: vec![],
+                        guard: None,
+                        body: vec![RustStmt::Expr(RustExpr::FormatMacro {
+                            name: "unreachable".to_string(),
+                            format_str: "sifr try/except raising body returned success".to_string(),
+                            args: vec![],
+                        })],
+                    },
+                    crate::RustMatchArm {
+                        pattern: "Err(__sifr_try_err)".to_string(),
+                        bindings: vec!["__sifr_try_err".to_string()],
+                        guard: None,
+                        body: handler_chain,
+                    },
+                ],
+            });
         } else {
             let Some(handler_chain) = self.lower_try_except_handler_chain_for_ir(
                 handlers,

--- a/demos/error_subclasses/emitted.rs
+++ b/demos/error_subclasses/emitted.rs
@@ -5427,11 +5427,16 @@ fn demo_user_defined_error() {
     println!("=== 7. User-Defined Error ===");
     let __sifr_try_res: Result<(), ValueError> = (|| {
         return Err(ValueError::new("connection timed out after 30s".to_string()));
-        Ok(())
+        unreachable!("sifr try/except raising body fell through");
     })();
-    if let Err(__sifr_try_err) = __sifr_try_res {
-        let e = __sifr_try_err.clone();
-        println!("ValueError: {}", e.message.clone());
+    match __sifr_try_res {
+        Ok(()) => {
+            unreachable!("sifr try/except raising body returned success");
+        }
+        Err(__sifr_try_err) => {
+            let e = __sifr_try_err.clone();
+            println!("ValueError: {}", e.message.clone());
+        }
     }
     println!("User-defined errors inherit message from Error");
 }


### PR DESCRIPTION
## Summary
- classify always-raising `try` bodies with the canonical HIR control-flow effect
- emit an impossible-success arm and total result match instead of a one-sided `if let`
- add focused codegen coverage and refresh the affected generated demo

## Validation
- 1,108 `sifr_codegen` tests passed
- `imported_error_not_catch_all.sifr` builds and runs natively
- demo freshness, affected Clippy, formatting, HIR maintainability, file-size, and diff checks passed
- exact-SHA Opus review: SATISFIED
- create-PR and merge gates passed all preceding checks and stopped only at linked delivery A