### PR TITLE
Fix moved try binding declaration liveness

### DIFF
--- a/crates/sifr/tests/e2e/pass/try_moved_binding_reinitialized.sifr
+++ b/crates/sifr/tests/e2e/pass/try_moved_binding_reinitialized.sifr
@@ -1,0 +1,29 @@
+class ProbeError(Error):
+    message: str
+
+
+def load_text() -> Result[str, ProbeError]:
+    return "old"
+
+
+def consume(own value: str) -> None:
+    assert value == "old"
+
+
+def replace_text() -> Result[str, ProbeError]:
+    try:
+        text: str = load_text()
+        consume(text)
+    except ProbeError as error:
+        raise error
+    text = "new"
+    return text
+
+
+def main() -> None:
+    try:
+        result: str = replace_text()
+    except ProbeError:
+        assert False
+        return
+    assert result == "new"

--- a/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
@@ -551,6 +551,19 @@ impl RustEmitter {
                     value,
                 }
             }
+            crate::RustStmt::LetDecl {
+                mutable,
+                name,
+                mut ty,
+            } => {
+                if is_plain_i64_storage_type(Some(&ty)) && self.is_forced_sifr_int_local(&name) {
+                    ty = crate::RustType::Named("SifrInt".to_string());
+                    self.sifr_int_local_bindings
+                        .borrow_mut()
+                        .insert(name.clone());
+                }
+                crate::RustStmt::LetDecl { mutable, name, ty }
+            }
             crate::RustStmt::LetPattern { pattern, value } => crate::RustStmt::LetPattern {
                 pattern,
                 value: self.rewrite_stdlib_constant_idents_in_expr(value),

--- a/crates/sifr_codegen/src/hir_analysis/queries.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries.rs
@@ -1,5 +1,7 @@
 mod queries_impl;
 pub(crate) use queries_impl::*;
+mod value_liveness;
+pub(crate) use value_liveness::*;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/crates/sifr_codegen/src/hir_analysis/queries/value_liveness.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries/value_liveness.rs
@@ -1,0 +1,603 @@
+use super::expr_references_var;
+use crate::hir_analysis::traversal::{self, TraversalConfig};
+use sifr_ir::{
+    HirAsyncWithKind, HirExpr, HirPattern, HirStmt, HirTupleTargetBinding, MutableArgumentTarget,
+};
+use sifr_type_system::ReceiverConvention;
+use std::cell::Cell;
+
+pub(crate) fn stmts_require_var_value_at_entry_including_nested_functions(
+    stmts: &[HirStmt],
+    var_name: &str,
+) -> bool {
+    block_requires_value(stmts, var_name, false)
+}
+
+pub(crate) fn declaration_only_binding_needs_mutability(stmts: &[HirStmt], var_name: &str) -> bool {
+    max_reassignments_on_path(stmts, var_name) > 1 || stmts_mutate_existing_value(stmts, var_name)
+}
+
+fn max_reassignments_on_path(stmts: &[HirStmt], var_name: &str) -> usize {
+    stmts.iter().fold(0, |total, stmt| {
+        (total + stmt_max_reassignments(stmt, var_name)).min(2)
+    })
+}
+
+fn stmt_max_reassignments(stmt: &HirStmt, var_name: &str) -> usize {
+    match stmt {
+        HirStmt::Let { name, .. }
+        | HirStmt::Assign { name, .. }
+        | HirStmt::AugAssign { name, .. } => usize::from(name == var_name),
+        HirStmt::If {
+            then_body,
+            elif_clauses,
+            else_body,
+            ..
+        } => std::iter::once(max_reassignments_on_path(then_body, var_name))
+            .chain(
+                elif_clauses
+                    .iter()
+                    .map(|(_, body)| max_reassignments_on_path(body, var_name)),
+            )
+            .chain(
+                else_body
+                    .as_deref()
+                    .map(|body| max_reassignments_on_path(body, var_name)),
+            )
+            .max()
+            .unwrap_or(0),
+        HirStmt::While {
+            body, else_body, ..
+        } => {
+            let body_count = max_reassignments_on_path(body, var_name);
+            let repeated_body_count = if body_count > 0 { 2 } else { 0 };
+            (repeated_body_count
+                + else_body
+                    .as_deref()
+                    .map_or(0, |body| max_reassignments_on_path(body, var_name)))
+            .min(2)
+        }
+        HirStmt::For {
+            target,
+            body,
+            else_body,
+            ..
+        }
+        | HirStmt::AsyncFor {
+            target,
+            body,
+            else_body,
+            ..
+        } => {
+            let body_count =
+                max_reassignments_on_path(body, var_name) + usize::from(target == var_name);
+            let repeated_body_count = if body_count > 0 { 2 } else { 0 };
+            (repeated_body_count
+                + else_body
+                    .as_deref()
+                    .map_or(0, |body| max_reassignments_on_path(body, var_name)))
+            .min(2)
+        }
+        HirStmt::TupleUnpack { targets, .. } => usize::from(targets.iter().any(|target| {
+            matches!(
+                &target.binding,
+                HirTupleTargetBinding::Name(name)
+                    if target.rebind_existing && name == var_name
+            )
+        })),
+        HirStmt::StarUnpack {
+            before,
+            star,
+            after,
+            ..
+        } => usize::from(
+            before.iter().chain(after).any(|(name, _)| name == var_name) || star.0 == var_name,
+        ),
+        HirStmt::TryExcept { body, handlers, .. } => {
+            let body_count = max_reassignments_on_path(body, var_name);
+            let handler_count = handlers
+                .iter()
+                .map(|handler| max_reassignments_on_path(&handler.body, var_name))
+                .max()
+                .unwrap_or(0);
+            (body_count + handler_count).min(2)
+        }
+        HirStmt::TryFinally { body, finalbody } => (max_reassignments_on_path(body, var_name)
+            + max_reassignments_on_path(finalbody, var_name))
+        .min(2),
+        HirStmt::With { body, .. } | HirStmt::AsyncWith { body, .. } => {
+            max_reassignments_on_path(body, var_name)
+        }
+        HirStmt::NestedFunction { func, .. } => usize::from(
+            !func.params.iter().any(|param| param.name == var_name)
+                && max_reassignments_on_path(&func.body, var_name) > 0,
+        ),
+        HirStmt::Match { arms, .. } => arms
+            .iter()
+            .map(|arm| max_reassignments_on_path(&arm.body, var_name))
+            .max()
+            .unwrap_or(0),
+        HirStmt::Return { .. }
+        | HirStmt::Expr { .. }
+        | HirStmt::Break
+        | HirStmt::Continue
+        | HirStmt::Pass
+        | HirStmt::Assert { .. }
+        | HirStmt::Raise { .. }
+        | HirStmt::FieldAssign { .. }
+        | HirStmt::NestedFieldAssign { .. }
+        | HirStmt::SubscriptAssign { .. }
+        | HirStmt::NestedSubscriptAssign { .. }
+        | HirStmt::AttributeNestedSubscriptAssign { .. }
+        | HirStmt::SubscriptAugAssign { .. }
+        | HirStmt::AttributeAugAssign { .. }
+        | HirStmt::AttributeSubscriptAssign { .. }
+        | HirStmt::Delete { .. }
+        | HirStmt::Yield { .. } => 0,
+    }
+}
+
+fn stmts_mutate_existing_value(stmts: &[HirStmt], var_name: &str) -> bool {
+    let mutates = Cell::new(false);
+    let mut on_stmt = |stmt: &HirStmt| {
+        mutates.set(
+            mutates.get()
+                || match stmt {
+                    HirStmt::AugAssign { name, .. } => name == var_name,
+                    HirStmt::SubscriptAssign { object, .. }
+                    | HirStmt::NestedSubscriptAssign { object, .. }
+                    | HirStmt::AttributeNestedSubscriptAssign { object, .. }
+                    | HirStmt::SubscriptAugAssign { object, .. }
+                    | HirStmt::AttributeAugAssign { object, .. }
+                    | HirStmt::FieldAssign { object, .. }
+                    | HirStmt::NestedFieldAssign { object, .. }
+                    | HirStmt::AttributeSubscriptAssign { object, .. } => object == var_name,
+                    HirStmt::Delete {
+                        object: HirExpr::Name { name, .. },
+                        ..
+                    } => name == var_name,
+                    _ => false,
+                },
+        );
+    };
+    let mut on_expr = |expr: &HirExpr| {
+        mutates.set(mutates.get() || expr_mutates_var(expr, var_name));
+    };
+    traversal::walk_stmts(
+        stmts,
+        TraversalConfig::INCLUDE_NESTED_FUNCTIONS,
+        &mut on_stmt,
+        &mut on_expr,
+    );
+    mutates.get()
+}
+
+fn expr_mutates_var(expr: &HirExpr, var_name: &str) -> bool {
+    match expr {
+        HirExpr::MethodCall {
+            object,
+            args,
+            receiver_convention,
+            mutable_arg_places,
+            ..
+        } => {
+            (*receiver_convention == Some(ReceiverConvention::MutableBorrow)
+                && expression_root_name(object) == Some(var_name))
+                || mutable_args_include_var(args, mutable_arg_places, var_name)
+        }
+        HirExpr::Call {
+            args,
+            mutable_arg_places,
+            ..
+        }
+        | HirExpr::GenericCall {
+            args,
+            mutable_arg_places,
+            ..
+        }
+        | HirExpr::IteratorCall {
+            args,
+            mutable_arg_places,
+            ..
+        } => mutable_args_include_var(args, mutable_arg_places, var_name),
+        _ => false,
+    }
+}
+
+fn mutable_args_include_var(
+    args: &[HirExpr],
+    targets: &[Option<MutableArgumentTarget>],
+    var_name: &str,
+) -> bool {
+    args.iter()
+        .zip(targets)
+        .any(|(arg, target)| target.is_some() && expression_root_name(arg) == Some(var_name))
+}
+
+fn expression_root_name(expr: &HirExpr) -> Option<&str> {
+    match expr {
+        HirExpr::Name { name, .. } => Some(name),
+        HirExpr::FieldAccess { object, .. } | HirExpr::Index { object, .. } => {
+            expression_root_name(object)
+        }
+        _ => None,
+    }
+}
+
+fn block_requires_value(stmts: &[HirStmt], var_name: &str, mut live: bool) -> bool {
+    for stmt in stmts.iter().rev() {
+        live = stmt_requires_value(stmt, var_name, live);
+    }
+    live
+}
+
+fn stmt_requires_value(stmt: &HirStmt, var_name: &str, live_after: bool) -> bool {
+    match stmt {
+        HirStmt::Let { name, value, .. } | HirStmt::Assign { name, value } => {
+            expr_references_var(value, var_name) || (name != var_name && live_after)
+        }
+        HirStmt::AugAssign { name, value, .. } => {
+            expr_references_var(value, var_name) || name == var_name || live_after
+        }
+        HirStmt::Return { value } => value
+            .as_ref()
+            .is_some_and(|value| expr_references_var(value, var_name)),
+        HirStmt::Expr { expr } => expr_references_var(expr, var_name) || live_after,
+        HirStmt::If {
+            condition,
+            then_body,
+            elif_clauses,
+            else_body,
+        } => {
+            let conditions_reference_value = expr_references_var(condition, var_name)
+                || elif_clauses
+                    .iter()
+                    .any(|(condition, _)| expr_references_var(condition, var_name));
+            let then_live = block_requires_value(then_body, var_name, live_after);
+            let elif_live = elif_clauses
+                .iter()
+                .any(|(_, body)| block_requires_value(body, var_name, live_after));
+            let else_live = else_body.as_deref().map_or(live_after, |body| {
+                block_requires_value(body, var_name, live_after)
+            });
+            conditions_reference_value || then_live || elif_live || else_live
+        }
+        HirStmt::While {
+            condition,
+            body,
+            else_body,
+        } => {
+            live_after
+                || expr_references_var(condition, var_name)
+                || block_requires_value(body, var_name, live_after)
+                || else_body
+                    .as_deref()
+                    .is_some_and(|body| block_requires_value(body, var_name, live_after))
+        }
+        HirStmt::For {
+            target,
+            iter,
+            body,
+            else_body,
+            ..
+        }
+        | HirStmt::AsyncFor {
+            target,
+            iter,
+            body,
+            else_body,
+            ..
+        } => {
+            live_after
+                || expr_references_var(iter, var_name)
+                || (target != var_name && block_requires_value(body, var_name, live_after))
+                || else_body
+                    .as_deref()
+                    .is_some_and(|body| block_requires_value(body, var_name, live_after))
+        }
+        HirStmt::Break | HirStmt::Continue => live_after,
+        HirStmt::TupleUnpack { targets, value } => {
+            let target_reads_value = targets.iter().any(|target| match &target.binding {
+                HirTupleTargetBinding::Name(_) => false,
+                HirTupleTargetBinding::Field { object, .. } => object == var_name,
+            });
+            let rebinds_value = targets.iter().any(|target| {
+                matches!(
+                    &target.binding,
+                    HirTupleTargetBinding::Name(name)
+                        if target.rebind_existing && name == var_name
+                )
+            });
+            expr_references_var(value, var_name)
+                || target_reads_value
+                || (live_after && !rebinds_value)
+        }
+        HirStmt::StarUnpack {
+            before,
+            star,
+            after,
+            value,
+        } => {
+            let rebinds_value =
+                before.iter().chain(after).any(|(name, _)| name == var_name) || star.0 == var_name;
+            expr_references_var(value, var_name) || (live_after && !rebinds_value)
+        }
+        HirStmt::Pass => live_after,
+        HirStmt::Assert { test, msg } => {
+            expr_references_var(test, var_name)
+                || msg
+                    .as_ref()
+                    .is_some_and(|message| expr_references_var(message, var_name))
+                || live_after
+        }
+        HirStmt::Raise { value } => expr_references_var(value, var_name),
+        HirStmt::TryExcept { body, handlers, .. } => {
+            block_requires_value(body, var_name, live_after)
+                || handlers
+                    .iter()
+                    .any(|handler| block_requires_value(&handler.body, var_name, live_after))
+        }
+        HirStmt::TryFinally { body, finalbody } => {
+            let final_live = block_requires_value(finalbody, var_name, live_after);
+            final_live || block_requires_value(body, var_name, final_live)
+        }
+        HirStmt::FieldAssign { object, value, .. }
+        | HirStmt::NestedFieldAssign { object, value, .. }
+        | HirStmt::AttributeAugAssign { object, value, .. } => {
+            object == var_name || expr_references_var(value, var_name) || live_after
+        }
+        HirStmt::SubscriptAssign {
+            object,
+            index,
+            value,
+            ..
+        }
+        | HirStmt::SubscriptAugAssign {
+            object,
+            index,
+            value,
+            ..
+        }
+        | HirStmt::AttributeSubscriptAssign {
+            object,
+            index,
+            value,
+            ..
+        } => {
+            object == var_name
+                || expr_references_var(index, var_name)
+                || expr_references_var(value, var_name)
+                || live_after
+        }
+        HirStmt::NestedSubscriptAssign {
+            object,
+            outer_index,
+            inner_index,
+            value,
+            ..
+        }
+        | HirStmt::AttributeNestedSubscriptAssign {
+            object,
+            outer_index,
+            inner_index,
+            value,
+            ..
+        } => {
+            object == var_name
+                || expr_references_var(outer_index, var_name)
+                || expr_references_var(inner_index, var_name)
+                || expr_references_var(value, var_name)
+                || live_after
+        }
+        HirStmt::Delete { object, index } => {
+            expr_references_var(object, var_name)
+                || expr_references_var(index, var_name)
+                || live_after
+        }
+        HirStmt::Yield { value } => expr_references_var(value, var_name) || live_after,
+        HirStmt::With { items, body } => {
+            items
+                .iter()
+                .any(|item| expr_references_var(&item.context, var_name))
+                || block_requires_value(body, var_name, live_after)
+        }
+        HirStmt::AsyncWith { kind, target, body } => {
+            async_with_references_var(kind, var_name)
+                || (target.as_deref() != Some(var_name)
+                    && block_requires_value(body, var_name, live_after))
+                || live_after
+        }
+        HirStmt::NestedFunction { func, .. } => {
+            let parameter_shadows_value = func.params.iter().any(|param| param.name == var_name);
+            (!parameter_shadows_value
+                && super::stmts_reference_var_including_nested_functions(&func.body, var_name))
+                || live_after
+        }
+        HirStmt::Match { subject, arms, .. } => {
+            expr_references_var(subject, var_name)
+                || live_after
+                || arms.iter().any(|arm| {
+                    pattern_references_var(&arm.pattern, var_name)
+                        || (!pattern_captures_var(&arm.pattern, var_name)
+                            && (arm
+                                .guard
+                                .as_ref()
+                                .is_some_and(|guard| expr_references_var(guard, var_name))
+                                || block_requires_value(&arm.body, var_name, live_after)))
+                })
+        }
+    }
+}
+
+fn async_with_references_var(kind: &HirAsyncWithKind, var_name: &str) -> bool {
+    match kind {
+        HirAsyncWithKind::TaskScope => false,
+        HirAsyncWithKind::TaskGroup { context } => context
+            .as_ref()
+            .is_some_and(|context| expr_references_var(context, var_name)),
+        HirAsyncWithKind::TaskTimeout { duration } => expr_references_var(duration, var_name),
+        HirAsyncWithKind::UserDefined { context, .. }
+        | HirAsyncWithKind::Python { context, .. } => expr_references_var(context, var_name),
+    }
+}
+
+fn pattern_captures_var(pattern: &HirPattern, var_name: &str) -> bool {
+    match pattern {
+        HirPattern::Capture { name, .. } => name == var_name,
+        HirPattern::Or { patterns } | HirPattern::Tuple { elements: patterns } => patterns
+            .iter()
+            .any(|pattern| pattern_captures_var(pattern, var_name)),
+        HirPattern::Class { fields, .. } => fields
+            .iter()
+            .any(|(_, pattern)| pattern_captures_var(pattern, var_name)),
+        HirPattern::Wildcard
+        | HirPattern::Literal { .. }
+        | HirPattern::None
+        | HirPattern::Value { .. } => false,
+    }
+}
+
+fn pattern_references_var(pattern: &HirPattern, var_name: &str) -> bool {
+    match pattern {
+        HirPattern::Literal { value } => expr_references_var(value, var_name),
+        HirPattern::Or { patterns } | HirPattern::Tuple { elements: patterns } => patterns
+            .iter()
+            .any(|pattern| pattern_references_var(pattern, var_name)),
+        HirPattern::Class { fields, .. } => fields
+            .iter()
+            .any(|(_, pattern)| pattern_references_var(pattern, var_name)),
+        HirPattern::Wildcard
+        | HirPattern::Capture { .. }
+        | HirPattern::None
+        | HirPattern::Value { .. } => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        declaration_only_binding_needs_mutability,
+        stmts_require_var_value_at_entry_including_nested_functions,
+    };
+    use sifr_ir::{HirExpr, HirStmt};
+    use sifr_type_system::Type;
+
+    fn name(value: &str) -> HirExpr {
+        HirExpr::Name {
+            name: value.to_string(),
+            binding_id: None,
+            ty: Type::Str,
+        }
+    }
+
+    #[test]
+    fn unconditional_replacement_kills_the_incoming_value() {
+        let stmts = vec![
+            HirStmt::Assign {
+                name: "value".to_string(),
+                value: HirExpr::StringLiteral("new".to_string()),
+            },
+            HirStmt::Return {
+                value: Some(name("value")),
+            },
+        ];
+
+        assert!(!stmts_require_var_value_at_entry_including_nested_functions(&stmts, "value"));
+    }
+
+    #[test]
+    fn replacement_rhs_can_keep_the_incoming_value_live() {
+        let stmts = vec![HirStmt::Assign {
+            name: "value".to_string(),
+            value: name("value"),
+        }];
+
+        assert!(stmts_require_var_value_at_entry_including_nested_functions(
+            &stmts, "value"
+        ));
+    }
+
+    #[test]
+    fn every_continuing_branch_must_replace_the_incoming_value() {
+        let complete = vec![
+            HirStmt::If {
+                condition: HirExpr::BoolLiteral(true),
+                then_body: vec![HirStmt::Assign {
+                    name: "value".to_string(),
+                    value: HirExpr::StringLiteral("then".to_string()),
+                }],
+                elif_clauses: vec![],
+                else_body: Some(vec![HirStmt::Assign {
+                    name: "value".to_string(),
+                    value: HirExpr::StringLiteral("else".to_string()),
+                }]),
+            },
+            HirStmt::Return {
+                value: Some(name("value")),
+            },
+        ];
+        let partial = vec![
+            HirStmt::If {
+                condition: HirExpr::BoolLiteral(true),
+                then_body: vec![HirStmt::Assign {
+                    name: "value".to_string(),
+                    value: HirExpr::StringLiteral("then".to_string()),
+                }],
+                elif_clauses: vec![],
+                else_body: None,
+            },
+            HirStmt::Return {
+                value: Some(name("value")),
+            },
+        ];
+
+        assert!(!stmts_require_var_value_at_entry_including_nested_functions(&complete, "value"));
+        assert!(stmts_require_var_value_at_entry_including_nested_functions(
+            &partial, "value"
+        ));
+    }
+
+    #[test]
+    fn one_unconditional_replacement_does_not_need_mutability() {
+        let stmts = vec![HirStmt::Assign {
+            name: "value".to_string(),
+            value: HirExpr::IntLiteral(1),
+        }];
+
+        assert!(!declaration_only_binding_needs_mutability(&stmts, "value"));
+    }
+
+    #[test]
+    fn repeated_replacement_on_one_path_needs_mutability() {
+        let stmts = vec![
+            HirStmt::Assign {
+                name: "value".to_string(),
+                value: HirExpr::IntLiteral(1),
+            },
+            HirStmt::Assign {
+                name: "value".to_string(),
+                value: HirExpr::IntLiteral(2),
+            },
+        ];
+
+        assert!(declaration_only_binding_needs_mutability(&stmts, "value"));
+    }
+
+    #[test]
+    fn alternative_branch_replacements_do_not_need_mutability() {
+        let stmts = vec![HirStmt::If {
+            condition: HirExpr::BoolLiteral(true),
+            then_body: vec![HirStmt::Assign {
+                name: "value".to_string(),
+                value: HirExpr::IntLiteral(1),
+            }],
+            elif_clauses: vec![],
+            else_body: Some(vec![HirStmt::Assign {
+                name: "value".to_string(),
+                value: HirExpr::IntLiteral(2),
+            }]),
+        }];
+
+        assert!(!declaration_only_binding_needs_mutability(&stmts, "value"));
+    }
+}

--- a/crates/sifr_codegen/src/ir_imports.rs
+++ b/crates/sifr_codegen/src/ir_imports.rs
@@ -120,6 +120,7 @@ fn collect_stmt(stmt: &RustStmt, needs: &mut IrImportNeeds) {
             }
             collect_expr(value, needs);
         }
+        RustStmt::LetDecl { ty, .. } => collect_type(ty, needs),
         RustStmt::LetPattern { value, .. } => collect_expr(value, needs),
         RustStmt::LetElse {
             value, else_body, ..

--- a/crates/sifr_codegen/src/ir_optimize/mutability_and_clone_rewrites.rs
+++ b/crates/sifr_codegen/src/ir_optimize/mutability_and_clone_rewrites.rs
@@ -102,7 +102,7 @@ pub(super) fn remove_nested_unneeded_mutability(
     protected_names: &HashSet<String>,
 ) -> usize {
     match stmt {
-        RustStmt::Verbatim(_) => 0,
+        RustStmt::Verbatim(_) | RustStmt::LetDecl { .. } => 0,
         RustStmt::Let { value, .. } | RustStmt::LetPattern { value, .. } => {
             remove_expr_unneeded_mutability(value, protected_names)
         }
@@ -394,7 +394,10 @@ pub(super) fn stmt_mutates_name(stmt: &RustStmt, name: &str) -> bool {
         RustStmt::Loop { body } | RustStmt::Block(body) | RustStmt::LocalFn { body, .. } => {
             stmts_mutate_name(body, name)
         }
-        RustStmt::Return(None) | RustStmt::Break | RustStmt::Continue => false,
+        RustStmt::LetDecl { .. }
+        | RustStmt::Return(None)
+        | RustStmt::Break
+        | RustStmt::Continue => false,
     }
 }
 
@@ -573,7 +576,7 @@ pub(super) fn is_self_assignment(stmt: &RustStmt) -> bool {
 
 pub(super) fn optimize_stmt(stmt: &mut RustStmt) -> usize {
     match stmt {
-        RustStmt::Verbatim(_) => 0,
+        RustStmt::Verbatim(_) | RustStmt::LetDecl { .. } => 0,
         RustStmt::Let { value, .. } => optimize_expr(value),
         RustStmt::LetPattern { value, .. } => optimize_expr(value),
         RustStmt::LetElse {

--- a/crates/sifr_codegen/src/ir_optimize/string_key_loop_rewrite.rs
+++ b/crates/sifr_codegen/src/ir_optimize/string_key_loop_rewrite.rs
@@ -142,7 +142,10 @@ fn stmt_uses_name_only_as_set_key(stmt: &RustStmt, name: &str, found: &mut bool)
                     }) && block_uses_name_only_as_set_key_with_found(&arm.body, name, found)
                 })
         }
-        RustStmt::Return(None) | RustStmt::Break | RustStmt::Continue => true,
+        RustStmt::LetDecl { .. }
+        | RustStmt::Return(None)
+        | RustStmt::Break
+        | RustStmt::Continue => true,
     }
 }
 

--- a/crates/sifr_codegen/src/ir_validate.rs
+++ b/crates/sifr_codegen/src/ir_validate.rs
@@ -122,6 +122,7 @@ fn validate_stmt(stmt: &RustStmt, issues: &mut Vec<IrValidationIssue>, in_functi
             }
             validate_expr(value, issues, in_function);
         }
+        RustStmt::LetDecl { ty, .. } => validate_type(ty, issues),
         RustStmt::LetPattern { value, .. } => {
             validate_expr(value, issues, in_function);
         }

--- a/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
@@ -209,7 +209,7 @@ def outer() -> Result[int, ProbeError]:
 }
 
 #[test]
-fn try_binding_used_only_as_following_assignment_target_remains_live() {
+fn try_binding_replaced_before_read_keeps_only_its_declaration() {
     let generated = generate_rust_from_source(&format!(
         r#"{PROBE_ERROR}
 def replace_value() -> Result[int, ProbeError]:
@@ -222,8 +222,56 @@ def replace_value() -> Result[int, ProbeError]:
 "#
     ));
 
-    assert!(generated.contains("let (mut total,) = match __sifr_try_res"));
-    syn::parse_file(&generated).expect("assigned live try binding Rust should parse");
+    assert!(generated.contains("let total: i64;"));
+    assert!(!generated.contains("Ok((total,))"));
+    assert!(!generated.contains("let (mut total,) = match __sifr_try_res"));
+    syn::parse_file(&generated).expect("declaration-only try binding Rust should parse");
+}
+
+#[test]
+fn moved_try_binding_can_be_replaced_without_value_transport() {
+    let generated = generate_rust_from_source(&format!(
+        r#"{PROBE_ERROR}
+def load_text() -> Result[str, ProbeError]:
+    return "old"
+
+def consume(own value: str) -> None:
+    _ = value
+
+def replace_text() -> Result[str, ProbeError]:
+    try:
+        text: str = load_text()
+        consume(text)
+    except ProbeError as error:
+        raise error
+    text = "new"
+    return text
+"#
+    ));
+
+    assert!(generated.contains("let text: String;"));
+    assert!(!generated.contains("Ok((text,))"));
+    syn::parse_file(&generated).expect("replaced moved try binding Rust should parse");
+}
+
+#[test]
+fn declaration_only_try_binding_is_mutable_for_repeated_replacement() {
+    let generated = generate_rust_from_source(&format!(
+        r#"{PROBE_ERROR}
+def replace_twice() -> Result[int, ProbeError]:
+    try:
+        value: int = load_int(1)
+    except ProbeError as error:
+        raise error
+    value = 2
+    value = 3
+    return value
+"#
+    ));
+
+    assert!(generated.contains("let mut value: i64;"));
+    assert!(!generated.contains("Ok((value,))"));
+    syn::parse_file(&generated).expect("mutable declaration-only try binding Rust should parse");
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
+++ b/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
@@ -746,7 +746,10 @@ pub(super) fn append_recursive_capture_args_to_stmts(
             RustStmt::LocalFn { body, .. } => {
                 append_recursive_capture_args_to_stmts(body, fn_name, capture_names);
             }
-            RustStmt::Return(None) | RustStmt::Break | RustStmt::Continue => {}
+            RustStmt::LetDecl { .. }
+            | RustStmt::Return(None)
+            | RustStmt::Break
+            | RustStmt::Continue => {}
         }
     }
 }

--- a/crates/sifr_codegen/src/preamble/io_bytes_methods.rs
+++ b/crates/sifr_codegen/src/preamble/io_bytes_methods.rs
@@ -525,6 +525,7 @@ mod tests {
             RustStmt::Let { ty, value, .. } => {
                 ty.as_ref().map(count_raw_in_type).unwrap_or(0) + count_raw_in_expr(value)
             }
+            RustStmt::LetDecl { ty, .. } => count_raw_in_type(ty),
             RustStmt::LetPattern { value, .. } => count_raw_in_expr(value),
             RustStmt::LetElse {
                 value, else_body, ..

--- a/crates/sifr_codegen/src/render/render_core.rs
+++ b/crates/sifr_codegen/src/render/render_core.rs
@@ -386,6 +386,14 @@ impl Renderer {
                     value = Self::render_expr_string(value)
                 ));
             }
+            RustStmt::LetDecl { mutable, name, ty } => {
+                let mutability = if *mutable { "mut " } else { "" };
+                self.emit_line(&format!(
+                    "let {mutability}{name}: {ty};",
+                    name = Self::render_identifier(name),
+                    ty = Self::render_type_string(ty),
+                ));
+            }
             RustStmt::LetPattern { pattern, value } => {
                 self.emit_line(&format!(
                     "let {pattern} = {value};",

--- a/crates/sifr_codegen/src/render/render_helpers.rs
+++ b/crates/sifr_codegen/src/render/render_helpers.rs
@@ -497,6 +497,11 @@ mod tests {
                 ty: Some(RustType::I64),
                 value: RustExpr::Literal(RustLiteral::Int(1)),
             },
+            RustStmt::LetDecl {
+                mutable: true,
+                name: "pending".to_string(),
+                ty: RustType::String_,
+            },
             RustStmt::LetPattern {
                 pattern: "(a, b)".to_string(),
                 value: RustExpr::Tuple(vec![
@@ -512,6 +517,7 @@ mod tests {
         let rendered = render_stmts(&stmts);
         assert_snapshot!(rendered, @r###"
         let x: i64 = 1;
+        let mut pending: String;
         let (a, b) = (2, true);
         may_fail()?;
         "###);

--- a/crates/sifr_codegen/src/rust_ir.rs
+++ b/crates/sifr_codegen/src/rust_ir.rs
@@ -89,6 +89,11 @@ pub enum RustStmt {
         ty: Option<RustType>,
         value: RustExpr,
     },
+    LetDecl {
+        mutable: bool,
+        name: String,
+        ty: RustType,
+    },
     LetPattern {
         pattern: String,
         value: RustExpr,

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -60,8 +60,8 @@ use result_type_helpers::{
     is_none_like_result_value, is_result_int_division_error_type, result_int_to_sifr_int_rust_type,
 };
 pub(crate) use stmt_expr_binop_option::binop_with_optional_operands;
-pub(crate) use try_error_helpers::successful_try_bindings;
 use try_error_helpers::{
     can_construct_error_from_message_for_ir, first_try_error_type_in_stmts,
     io_error_kind_for_handler, select_try_error_type, HandlerMatchCondition,
 };
+pub(crate) use try_error_helpers::{declaration_only_try_bindings, successful_try_bindings};

--- a/crates/sifr_codegen/src/stmt_support_emitter/iterator_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/iterator_lowering.rs
@@ -627,7 +627,10 @@ impl RustEmitter {
                 Self::rust_expr_contains_await(cond)
                     || msg.as_ref().is_some_and(Self::rust_expr_contains_await)
             }
-            RustStmt::Return(None) | RustStmt::Break | RustStmt::Continue => false,
+            RustStmt::LetDecl { .. }
+            | RustStmt::Return(None)
+            | RustStmt::Break
+            | RustStmt::Continue => false,
             RustStmt::If {
                 cond,
                 then_body,

--- a/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
@@ -1,6 +1,6 @@
 use super::{
-    first_try_error_type_in_stmts, queries, select_try_error_type, successful_try_bindings,
-    HirExceptHandler, HirStmt, RustEmitter, RustExpr, RustStmt, Type,
+    declaration_only_try_bindings, first_try_error_type_in_stmts, queries, select_try_error_type,
+    successful_try_bindings, HirExceptHandler, HirStmt, RustEmitter, RustExpr, RustStmt, Type,
 };
 impl RustEmitter {
     pub(crate) fn lower_loop_control_stmt_for_ir(&self, stmt: &HirStmt) -> Option<RustStmt> {
@@ -263,6 +263,14 @@ impl RustEmitter {
             && handlers
                 .iter()
                 .all(|handler| queries::block_control_flow_effect(&handler.body).always_exits());
+        let declaration_only_bindings =
+            declaration_only_try_bindings(body, handlers, following_stmts)
+                .into_iter()
+                .map(|(name, ty)| {
+                    let ty = self.local_binding_types.get(&name).cloned().unwrap_or(ty);
+                    (name, ty)
+                })
+                .collect::<Vec<_>>();
         let successful_bindings = successful_try_bindings(body, handlers, following_stmts)
             .into_iter()
             .map(|(name, ty)| {
@@ -311,7 +319,7 @@ impl RustEmitter {
         let mut closure_body = {
             let saved_cache_requirements = self.string_char_cache_required_names.clone();
             let body_cache_uses = crate::string_char_cache_scan::string_cache_uses_in_stmts(body);
-            for (name, _) in &successful_bindings {
+            for (name, _) in successful_bindings.iter().chain(&declaration_only_bindings) {
                 if !body_cache_uses.contains(name) {
                     self.string_char_cache_required_names.remove(name);
                 }
@@ -405,6 +413,18 @@ impl RustEmitter {
         };
 
         let mut lowered = Vec::new();
+        lowered.extend(
+            declaration_only_bindings
+                .iter()
+                .map(|(name, ty)| RustStmt::LetDecl {
+                    mutable: queries::declaration_only_binding_needs_mutability(
+                        following_stmts.unwrap_or_default(),
+                        name,
+                    ) || super::should_force_mutable_binding(ty, &self.recursive_fields),
+                    name: name.clone(),
+                    ty: crate::sifr_type_to_rust_type(ty),
+                }),
+        );
         if capture_returns && !successful_bindings.is_empty() {
             lowered.push(RustStmt::Let {
                 mutable: true,

--- a/crates/sifr_codegen/src/stmt_support_emitter/try_error_helpers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/try_error_helpers.rs
@@ -5,6 +5,42 @@ pub(crate) fn successful_try_bindings(
     handlers: &[HirExceptHandler],
     following_stmts: Option<&[HirStmt]>,
 ) -> Vec<(String, Type)> {
+    successful_try_binding_candidates(body, handlers)
+        .into_iter()
+        .filter(|(name, _)| {
+            following_stmts.is_none_or(|following| {
+                crate::hir_analysis::queries::stmts_require_var_value_at_entry_including_nested_functions(
+                    following, name,
+                )
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn declaration_only_try_bindings(
+    body: &[HirStmt],
+    handlers: &[HirExceptHandler],
+    following_stmts: Option<&[HirStmt]>,
+) -> Vec<(String, Type)> {
+    let Some(following) = following_stmts else {
+        return Vec::new();
+    };
+    successful_try_binding_candidates(body, handlers)
+        .into_iter()
+        .filter(|(name, _)| {
+            crate::hir_analysis::queries::stmts_reference_var_including_nested_functions(
+                following, name,
+            ) && !crate::hir_analysis::queries::stmts_require_var_value_at_entry_including_nested_functions(
+                following, name,
+            )
+        })
+        .collect()
+}
+
+fn successful_try_binding_candidates(
+    body: &[HirStmt],
+    handlers: &[HirExceptHandler],
+) -> Vec<(String, Type)> {
     if crate::hir_analysis::queries::block_control_flow_effect(body).always_exits()
         || handlers.iter().any(|handler| {
             !crate::hir_analysis::queries::block_control_flow_effect(&handler.body).always_exits()
@@ -19,14 +55,7 @@ pub(crate) fn successful_try_bindings(
             let HirStmt::Let { name, ty, .. } = stmt else {
                 return None;
             };
-            (name != "_"
-                && names.insert(name.clone())
-                && following_stmts.is_none_or(|following| {
-                    crate::hir_analysis::queries::stmts_reference_var_including_nested_functions(
-                        following, name,
-                    )
-                }))
-            .then(|| (name.clone(), ty.clone()))
+            (name != "_" && names.insert(name.clone())).then(|| (name.clone(), ty.clone()))
         })
         .collect()
 }

--- a/crates/sifr_lowering/src/lower/binding_mutability.rs
+++ b/crates/sifr_lowering/src/lower/binding_mutability.rs
@@ -6,6 +6,10 @@ pub(in crate::lower) fn ensure_mutable_parameter_binding(
     name: &str,
     range: TextRange,
 ) -> bool {
+    if ctx.scope.is_moved(name) {
+        super::ownership_diagnostics::use_after_move(ctx, name, range);
+        return false;
+    }
     if ctx
         .scope
         .lookup(name)

--- a/crates/sifr_lowering/src/lower/statement_diagnostics_tests.rs
+++ b/crates/sifr_lowering/src/lower/statement_diagnostics_tests.rs
@@ -283,3 +283,29 @@ def main() -> Result[str, ValueError]:
             && error.message == "use of moved value: 'value'"
     }));
 }
+
+#[test]
+fn moved_try_binding_rejects_value_dependent_subscript_assignment() {
+    let source = "\
+def fallible() -> Result[list[int], ValueError]:
+    return [1]
+
+def consume(own value: list[int]) -> None:
+    pass
+
+def main() -> Result[int, ValueError]:
+    try:
+        values: list[int] = fallible()
+        consume(values)
+    except ValueError as error:
+        raise error
+    values[0] = 2
+    return 0
+";
+    let errors = lower_errors(source);
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::OWN_USE_AFTER_MOVE)
+            && error.message == "use of moved value: 'values'"
+    }));
+}


### PR DESCRIPTION
## Summary

- separate declaration liveness from value liveness after sequential try lowering
- emit a typed enclosing declaration without transporting a moved value
- reject value-dependent mutation of moved bindings during lowering
- add focused liveness, code-generation, lowering, and native-run coverage

## Candidate

- base: `65a350884388d76d807bbf5a03dfaeca16840a55`
- candidate: `f87b5f7e03c54d85b0a08b01ecc0130a16379bff`

## Validation

- full `sifr_codegen` and `sifr_lowering` test suites pass
- native moved-binding replacement fixture builds and runs
- generated Rust passes `rustc -D unused-mut`
- affected Clippy, formatting, demo freshness, HIR maintainability, file-size, and diff checks pass
- exact-SHA Opus review: SATISFIED
- create-PR and merge gates each passed preceding guardrails and stopped only at linked delivery A stale Rust-interop evidence path