### PR TITLE
Close pre-v1 nested-default traversal regressions

### DIFF
--- a/crates/sifr/tests/e2e/pass/try_nested_function_default_binding.sifr
+++ b/crates/sifr/tests/e2e/pass/try_nested_function_default_binding.sifr
@@ -1,0 +1,27 @@
+class ProbeError(Error):
+    message: str
+
+
+def load_value() -> Result[int, ProbeError]:
+    return 42
+
+
+def read_after_try() -> Result[int, ProbeError]:
+    try:
+        value: int = load_value()
+    except ProbeError as error:
+        raise error
+
+    def read_value(candidate: int = 1) -> int:
+        return candidate
+
+    return value + read_value() + read_value(candidate=5)
+
+
+def main() -> None:
+    try:
+        result: int = read_after_try()
+    except ProbeError:
+        assert False
+        return
+    assert result == 48

--- a/crates/sifr_codegen/src/function_emitter/scope_and_function_types.rs
+++ b/crates/sifr_codegen/src/function_emitter/scope_and_function_types.rs
@@ -387,10 +387,7 @@ impl RustEmitter {
         if func.method_kind != sifr_ir::MethodKind::Regular
             || !func.decorators.is_empty()
             || !func.type_params.is_empty()
-            || func
-                .params
-                .iter()
-                .any(|param| param.default.is_some() || param.keyword_only)
+            || func.params.iter().any(|param| param.keyword_only)
         {
             return false;
         }

--- a/crates/sifr_codegen/src/hir_analysis/queries.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries.rs
@@ -3,6 +3,8 @@ pub(crate) use queries_impl::*;
 mod value_liveness;
 pub(crate) use value_liveness::*;
 #[cfg(test)]
+mod default_expression_tests;
+#[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod type_and_operator_tests;

--- a/crates/sifr_codegen/src/hir_analysis/queries/default_expression_tests.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries/default_expression_tests.rs
@@ -1,0 +1,51 @@
+use super::{stmts_reference_var, stmts_reference_var_including_nested_functions};
+use sifr_ir::{HirExpr, HirFunction, HirParam, HirStmt, MethodKind};
+use sifr_type_system::{ParamConvention, Type};
+
+#[test]
+fn nested_function_defaults_use_the_defining_scope_and_parameters_shadow_the_body() {
+    let nested = HirFunction {
+        name: "inner".to_string(),
+        params: vec![HirParam {
+            name: "value".to_string(),
+            ty: Type::Int,
+            default: Some(HirExpr::Name {
+                name: "default_source".to_string(),
+                binding_id: None,
+                ty: Type::Int,
+            }),
+            keyword_only: false,
+            convention: ParamConvention::own(),
+        }],
+        return_type: Type::Int,
+        body: vec![HirStmt::Return {
+            value: Some(HirExpr::Name {
+                name: "value".to_string(),
+                binding_id: None,
+                ty: Type::Int,
+            }),
+        }],
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        receiver: None,
+        decorators: vec![],
+        rust_interop: Vec::new(),
+        python_interop: Vec::new(),
+        compiler_intrinsic: None,
+        type_params: vec![],
+    };
+    let stmts = vec![HirStmt::NestedFunction {
+        func: nested,
+        move_captures: false,
+        capture_clones: Vec::new(),
+    }];
+
+    assert!(stmts_reference_var(&stmts, "default_source"));
+    assert!(stmts_reference_var_including_nested_functions(
+        &stmts,
+        "default_source"
+    ));
+    assert!(!stmts_reference_var_including_nested_functions(
+        &stmts, "value"
+    ));
+}

--- a/crates/sifr_codegen/src/hir_analysis/queries/queries_impl.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries/queries_impl.rs
@@ -98,6 +98,16 @@ fn stmts_reference_var_with_config(
     config: TraversalConfig,
 ) -> bool {
     let mut on_stmt = |stmt: &HirStmt| {
+        if config.descend_nested_functions {
+            if let HirStmt::NestedFunction { func, .. } = stmt {
+                let parameter_shadows_var = func.params.iter().any(|param| param.name == var_name);
+                if !parameter_shadows_var
+                    && stmts_reference_var_with_config(&func.body, var_name, config)
+                {
+                    return TraversalControl::Stop;
+                }
+            }
+        }
         let target_references_var = match stmt {
             HirStmt::Assign { name, .. } | HirStmt::AugAssign { name, .. } => name == var_name,
             HirStmt::FieldAssign { object, .. }
@@ -133,7 +143,12 @@ fn stmts_reference_var_with_config(
         TraversalControl::Continue
     };
     matches!(
-        traversal::walk_stmts_until(stmts, config, &mut on_stmt, &mut on_expr,),
+        traversal::walk_stmts_until(
+            stmts,
+            TraversalConfig::LOCAL_SCOPE_ONLY,
+            &mut on_stmt,
+            &mut on_expr,
+        ),
         TraversalControl::Stop
     )
 }

--- a/crates/sifr_codegen/src/hir_analysis/queries/value_liveness.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries/value_liveness.rs
@@ -408,9 +408,16 @@ fn stmt_requires_value(stmt: &HirStmt, var_name: &str, live_after: bool) -> bool
                 || live_after
         }
         HirStmt::NestedFunction { func, .. } => {
+            let defaults_reference_value = func.params.iter().any(|param| {
+                param
+                    .default
+                    .as_ref()
+                    .is_some_and(|default| expr_references_var(default, var_name))
+            });
             let parameter_shadows_value = func.params.iter().any(|param| param.name == var_name);
-            (!parameter_shadows_value
-                && super::stmts_reference_var_including_nested_functions(&func.body, var_name))
+            defaults_reference_value
+                || (!parameter_shadows_value
+                    && super::stmts_reference_var_including_nested_functions(&func.body, var_name))
                 || live_after
         }
         HirStmt::Match { subject, arms, .. } => {
@@ -479,8 +486,8 @@ mod tests {
         declaration_only_binding_needs_mutability,
         stmts_require_var_value_at_entry_including_nested_functions,
     };
-    use sifr_ir::{HirExpr, HirStmt};
-    use sifr_type_system::Type;
+    use sifr_ir::{HirExpr, HirFunction, HirParam, HirStmt, MethodKind};
+    use sifr_type_system::{ParamConvention, Type};
 
     fn name(value: &str) -> HirExpr {
         HirExpr::Name {
@@ -599,5 +606,39 @@ mod tests {
         }];
 
         assert!(!declaration_only_binding_needs_mutability(&stmts, "value"));
+    }
+
+    #[test]
+    fn nested_function_default_reads_the_value_in_the_defining_scope() {
+        let stmts = vec![HirStmt::NestedFunction {
+            func: HirFunction {
+                name: "read_value".to_string(),
+                params: vec![HirParam {
+                    name: "candidate".to_string(),
+                    ty: Type::Str,
+                    default: Some(name("value")),
+                    keyword_only: false,
+                    convention: ParamConvention::own(),
+                }],
+                return_type: Type::Str,
+                body: vec![HirStmt::Return {
+                    value: Some(name("candidate")),
+                }],
+                is_async: false,
+                method_kind: MethodKind::Regular,
+                receiver: None,
+                decorators: vec![],
+                rust_interop: Vec::new(),
+                python_interop: Vec::new(),
+                compiler_intrinsic: None,
+                type_params: vec![],
+            },
+            move_captures: false,
+            capture_clones: Vec::new(),
+        }];
+
+        assert!(stmts_require_var_value_at_entry_including_nested_functions(
+            &stmts, "value"
+        ));
     }
 }

--- a/crates/sifr_codegen/src/hir_analysis/traversal/tests.rs
+++ b/crates/sifr_codegen/src/hir_analysis/traversal/tests.rs
@@ -135,7 +135,18 @@ fn walk_stmts_covers_try_handlers_loop_else_and_match_patterns() {
 fn walk_stmts_respects_nested_function_scope_boundary() {
     let nested = HirFunction {
         name: "inner".to_string(),
-        params: vec![],
+        params: vec![HirParam {
+            name: "value".to_string(),
+            ty: Type::Int,
+            default: Some(HirExpr::Call {
+                mutable_arg_places: Vec::new(),
+                func: "default_only".to_string(),
+                args: vec![],
+                ty: Type::Int,
+            }),
+            keyword_only: false,
+            convention: ParamConvention::own(),
+        }],
         return_type: Type::None,
         body: vec![HirStmt::Expr {
             expr: HirExpr::Call {
@@ -160,13 +171,11 @@ fn walk_stmts_respects_nested_function_scope_boundary() {
         capture_clones: Vec::new(),
     }];
 
-    let mut saw_nested_call = false;
+    let mut local_calls = Vec::new();
     let mut on_stmt = |_stmt: &HirStmt| {};
     let mut on_expr = |expr: &HirExpr| {
         if let HirExpr::Call { func, .. } = expr {
-            if func == "nested_only" {
-                saw_nested_call = true;
-            }
+            local_calls.push(func.clone());
         }
     };
 
@@ -177,7 +186,24 @@ fn walk_stmts_respects_nested_function_scope_boundary() {
         &mut on_expr,
     );
 
-    assert!(!saw_nested_call);
+    assert_eq!(local_calls, vec!["default_only".to_string()]);
+
+    let mut inclusive_calls = Vec::new();
+    walk_stmts(
+        &stmts,
+        TraversalConfig::INCLUDE_NESTED_FUNCTIONS,
+        &mut |_stmt| {},
+        &mut |expr| {
+            if let HirExpr::Call { func, .. } = expr {
+                inclusive_calls.push(func.clone());
+            }
+        },
+    );
+
+    assert_eq!(
+        inclusive_calls,
+        vec!["default_only".to_string(), "nested_only".to_string()]
+    );
 }
 
 #[test]

--- a/crates/sifr_codegen/src/hir_analysis/traversal/traversal_impl.rs
+++ b/crates/sifr_codegen/src/hir_analysis/traversal/traversal_impl.rs
@@ -4,7 +4,8 @@ use sifr_ir::{HirExpr, HirFStringPart, HirPattern, HirStmt};
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct TraversalConfig {
     /// When false, nested function bodies are treated as scope boundaries and
-    /// not traversed. When true, nested function bodies are included.
+    /// not traversed. Definition-time parameter defaults are always visited.
+    /// When true, nested function bodies are also included.
     pub descend_nested_functions: bool,
 }
 
@@ -31,7 +32,8 @@ pub(crate) enum TraversalControl {
 /// - Expression/statement recursion for analysis must flow through this module.
 /// - `on_stmt` is invoked once for each visited statement before children.
 /// - `on_expr` is invoked once for each visited expression before children.
-/// - Nested function recursion is controlled only by `TraversalConfig`.
+/// - Nested function defaults are visited in the defining scope.
+/// - Nested function body recursion is controlled only by `TraversalConfig`.
 /// - `_until` walkers stop recursively as soon as callbacks return `Stop`.
 ///
 /// Extension rules for future HIR variants:
@@ -627,6 +629,13 @@ where
             }
         }
         HirStmt::NestedFunction { func, .. } => {
+            for param in &func.params {
+                if let Some(default) = &param.default {
+                    if matches!(walk_expr_until(default, on_expr), TraversalControl::Stop) {
+                        return TraversalControl::Stop;
+                    }
+                }
+            }
             if config.descend_nested_functions {
                 if matches!(
                     walk_stmts_until(&func.body, config, on_stmt, on_expr),

--- a/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
@@ -1,4 +1,9 @@
 use super::generate_rust_from_source;
+use crate::generate_rust;
+use sifr_ir::{HirExpr, HirStmt};
+use sifr_lowering::lower_module;
+use sifr_python_parser::parse_module;
+use sifr_type_system::Type;
 
 const PROBE_ERROR: &str = r#"
 class ProbeError(Error):
@@ -206,6 +211,91 @@ def outer() -> Result[int, ProbeError]:
 
     assert!(generated.contains("let (value,) = match __sifr_try_res"));
     syn::parse_file(&generated).expect("captured live try binding Rust should parse");
+}
+
+#[test]
+fn nested_function_with_literal_default_uses_structured_codegen() {
+    let generated = generate_rust_from_source(
+        r#"
+def outer() -> int:
+    def read_value(candidate: int = 42) -> int:
+        return candidate
+
+    return read_value() + read_value(candidate=5)
+"#,
+    );
+
+    assert!(generated.contains("let read_value = |candidate: i64|"));
+    assert!(generated.contains("read_value(42_i64)"));
+    assert!(generated.contains("read_value(5_i64)"));
+    syn::parse_file(&generated).expect("nested literal default Rust should parse");
+}
+
+#[test]
+fn post_try_hir_default_reference_keeps_the_binding_live() {
+    let source = format!(
+        r#"{PROBE_ERROR}
+def outer() -> Result[int, ProbeError]:
+    try:
+        value: int = load_int(42)
+    except ProbeError as error:
+        raise error
+
+    def read_value(candidate: int = 1) -> int:
+        return candidate
+
+    return read_value()
+"#
+    );
+    let parsed = parse_module(&source).expect("parse failed");
+    let mut module = lower_module(parsed.suite())
+        .expect("lowering failed")
+        .module;
+    let outer = module
+        .functions
+        .iter_mut()
+        .find(|function| function.name == "outer")
+        .expect("outer function should lower");
+    let nested = outer
+        .body
+        .iter_mut()
+        .find_map(|stmt| match stmt {
+            HirStmt::NestedFunction { func, .. } if func.name == "read_value" => Some(func),
+            _ => None,
+        })
+        .expect("nested function should lower");
+    nested.params[0].default = Some(HirExpr::Name {
+        name: "value".to_string(),
+        binding_id: None,
+        ty: Type::Int,
+    });
+
+    let generated = generate_rust(&module);
+
+    assert!(generated.contains("let (value,) = match __sifr_try_res"));
+    syn::parse_file(&generated).expect("post-try HIR default Rust should parse");
+}
+
+#[test]
+fn shadowing_nested_parameter_does_not_keep_try_binding_live() {
+    let generated = generate_rust_from_source(&format!(
+        r#"{PROBE_ERROR}
+def outer() -> Result[int, ProbeError]:
+    try:
+        value: int = load_int(42)
+    except ProbeError as error:
+        raise error
+
+    def read_value(value: int) -> int:
+        return value
+
+    return read_value(7)
+"#
+    ));
+
+    assert!(!generated.contains("Ok((value,))"));
+    assert!(!generated.contains("let value: i64;"));
+    syn::parse_file(&generated).expect("shadowing nested parameter Rust should parse");
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
+++ b/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
@@ -532,11 +532,7 @@ pub(super) fn try_lower_simple_nested_function_stmt(
     {
         return None;
     }
-    if func
-        .params
-        .iter()
-        .any(|param| param.default.is_some() || param.keyword_only)
-    {
+    if func.params.iter().any(|param| param.keyword_only) {
         return None;
     }
 

--- a/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
@@ -105,42 +105,81 @@ pub(super) fn lower_regular_call(
                 conventions.clone(),
                 *ret_type.clone(),
                 false,
+                info.is_function_binding(),
             )),
             Type::AsyncCallable(param_types, conventions, ret_type) => Some((
                 param_types.clone(),
                 conventions.clone(),
                 *ret_type.clone(),
                 true,
+                info.is_function_binding(),
             )),
             _ => None,
         });
-    if let Some((param_types, conventions, ret_type, is_async_callable)) = callable_info {
-        // Lower arguments
-        let mut args = Vec::new();
-        for arg in &call.arguments.args {
-            let expr = lower_expr(arg, ctx)?;
-            args.push(expr);
-        }
-        if args.len() != param_types.len() {
-            let range = if args.len() > param_types.len() {
-                call.arguments.args[param_types.len()].range()
-            } else {
-                call.func.range()
+    if let Some((param_types, conventions, ret_type, is_async_callable, is_declared_function)) =
+        callable_info
+    {
+        let (args, arg_ranges) = if is_declared_function {
+            let Some(function_type) = ctx.functions.get(&func_name).cloned() else {
+                ctx.error_with_code_at(
+                    DiagnosticCode::INTERNAL_COMPILER_PANIC,
+                    format!(
+                        "internal compiler error: declared function binding '{func_name}' has no signature"
+                    ),
+                    call.func.range(),
+                );
+                return None;
             };
-            expression_diagnostics::call_not_callable_or_arity(
+            let defaults = ctx.function_defaults.get(&func_name).cloned();
+            let vararg_index = ctx.vararg_functions.get(&func_name).copied();
+            let args = lower_function_call_args(
+                call,
+                &func_name,
+                &function_type,
+                defaults.as_deref(),
+                vararg_index,
                 ctx,
-                format!(
-                    "callable '{}' expects {} argument(s), got {}",
-                    func_name,
-                    param_types.len(),
-                    args.len()
-                ),
-                range,
-            );
-            return None;
-        }
+            )?;
+            let ranges = call_argument_ranges_by_param(call, &function_type);
+            (args, ranges)
+        } else {
+            let mut args = Vec::new();
+            for arg in &call.arguments.args {
+                args.push(lower_expr(arg, ctx)?);
+            }
+            if args.len() != param_types.len() {
+                let range = if args.len() > param_types.len() {
+                    call.arguments.args[param_types.len()].range()
+                } else {
+                    call.func.range()
+                };
+                expression_diagnostics::call_not_callable_or_arity(
+                    ctx,
+                    format!(
+                        "callable '{}' expects {} argument(s), got {}",
+                        func_name,
+                        param_types.len(),
+                        args.len()
+                    ),
+                    range,
+                );
+                return None;
+            }
+            let ranges = call
+                .arguments
+                .args
+                .iter()
+                .map(|arg| Some(arg.range()))
+                .collect::<Vec<_>>();
+            (args, ranges)
+        };
         // Type check arguments and apply convention-aware move tracking
         for (i, (arg, param_ty)) in args.iter().zip(param_types.iter()).enumerate() {
+            let arg_range = arg_ranges
+                .get(i)
+                .copied()
+                .flatten()
+                .unwrap_or_else(|| call.func.range());
             if !arg.ty().is_assignable_to(param_ty) {
                 expression_diagnostics::type_mismatch(
                     ctx,
@@ -151,7 +190,7 @@ pub(super) fn lower_regular_call(
                         param_ty.display_name(),
                         arg.ty().display_name()
                     ),
-                    call.arguments.args[i].range(),
+                    arg_range,
                 );
             }
             // Apply move tracking based on convention
@@ -159,17 +198,11 @@ pub(super) fn lower_regular_call(
                 .get(i)
                 .copied()
                 .unwrap_or(ParamConvention::borrow());
-            validate_borrowed_structural_coercion(
-                arg.ty(),
-                param_ty,
-                convention,
-                call.arguments.args[i].range(),
-                ctx,
-            );
+            validate_borrowed_structural_coercion(arg.ty(), param_ty, convention, arg_range, ctx);
             if convention.is_owned() {
                 // Own convention transfers every affine candidate contained in
                 // a conditional or wrapper expression.
-                consume_owned_value(arg, call.arguments.args[i].range(), ctx);
+                consume_owned_value(arg, arg_range, ctx);
             }
             // Borrow/MutBorrow: no move, variable remains usable
         }
@@ -191,12 +224,7 @@ pub(super) fn lower_regular_call(
                 .collect(),
             return_type: Box::new(ret_type.clone()),
         };
-        let ranges = call
-            .arguments
-            .args
-            .iter()
-            .map(|arg| Some(arg.range()))
-            .collect::<Vec<_>>();
+        let ranges = arg_ranges;
         let mutable_arg_places =
             super::super::method_receiver_places::validate_regular_call_arguments(
                 &args,

--- a/crates/sifr_lowering/src/lower/expressions_tests/callable_and_builtin_diagnostics.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/callable_and_builtin_diagnostics.rs
@@ -23,6 +23,44 @@ pub(super) fn test_callable_variable_call_errors_have_codes() {
 }
 
 #[test]
+pub(super) fn rebound_nested_function_does_not_reuse_its_declared_default() {
+    let source = "\
+def required(value: int) -> int:
+    return value
+
+def outer() -> int:
+    def local(value: int = 1) -> int:
+        return value
+    local = required
+    return local()
+";
+    let errors = lower_source(source).expect_err("rebound callable must require its argument");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::CALL_NOT_CALLABLE_OR_ARITY)
+            && error.message == "callable 'local' expects 1 argument(s), got 0"
+    }));
+
+    let tuple_source = "\
+def required(value: int) -> int:
+    return value
+
+def outer() -> int:
+    def local(value: int = 1) -> int:
+        return value
+    local, count = (required, 2)
+    return local()
+";
+    let tuple_errors =
+        lower_source(tuple_source).expect_err("tuple-rebound callable must require its argument");
+
+    assert!(tuple_errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::CALL_NOT_CALLABLE_OR_ARITY)
+            && error.message == "callable 'local' expects 1 argument(s), got 0"
+    }));
+}
+
+#[test]
 pub(super) fn test_async_callable_is_distinct_and_produces_awaitable_call() {
     let source = "async def apply(f: AsyncCallable[[int], int]) -> int:\n    return await f(4)\n";
     let module = lower_source(source).expect("AsyncCallable call should lower");

--- a/crates/sifr_lowering/src/lower/method_receiver_places.rs
+++ b/crates/sifr_lowering/src/lower/method_receiver_places.rs
@@ -381,6 +381,7 @@ fn prove_mutable_place(
     }
     match fact.binding_kind {
         BindingKind::Local => Ok(place),
+        BindingKind::Function => Err(InvalidPlace::Unsupported),
         BindingKind::ModuleConstant => Err(InvalidPlace::Unsupported),
         BindingKind::EphemeralLocal(_) => Err(InvalidPlace::Unsupported),
         BindingKind::Parameter => {

--- a/crates/sifr_lowering/src/lower/statements/patterns_and_assignments.rs
+++ b/crates/sifr_lowering/src/lower/statements/patterns_and_assignments.rs
@@ -310,6 +310,7 @@ pub(super) fn failed_initializer_taint(
 }
 
 pub(super) fn invalidate_rebound_binding_facts(ctx: &mut LowerCtx, name: &str) {
+    ctx.scope.mark_rebound_local(name);
     ctx.clear_narrowing_with_flow(name);
     ctx.scope.clear_const_integer_value(name);
     ctx.clear_sequence_guards_for_binding(name);

--- a/crates/sifr_lowering/src/lower/tuple_unpack.rs
+++ b/crates/sifr_lowering/src/lower/tuple_unpack.rs
@@ -177,6 +177,7 @@ pub(in crate::lower) fn lower_tuple_unpack_assign(
                             range,
                         );
                     }
+                    ctx.scope.mark_rebound_local(&name);
                     ctx.reset_moved_with_flow(&name);
                     ctx.clear_narrowing_with_flow(&name);
                     ctx.clear_sequence_guards_for_binding(&name);

--- a/crates/sifr_lowering/src/lower/typing_and_functions/signatures_and_effects.rs
+++ b/crates/sifr_lowering/src/lower/typing_and_functions/signatures_and_effects.rs
@@ -611,7 +611,8 @@ pub(in crate::lower) fn register_local_function_signature(
         ctx.function_defaults
             .insert(function_name.clone(), defaults);
     }
-    ctx.scope.define(function_name.clone(), callable_ty);
+    ctx.scope
+        .define_function(function_name.clone(), callable_ty);
     ctx.functions.insert(function_name.clone(), ft.clone());
     if let Some(workload) =
         workload_annotations::annotation_for_decorators(func.decorator_list.iter())

--- a/crates/sifr_lowering/src/scope.rs
+++ b/crates/sifr_lowering/src/scope.rs
@@ -18,6 +18,7 @@ pub enum EphemeralOrigin {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BindingKind {
     Local,
+    Function,
     ModuleConstant,
     Parameter,
     Receiver,
@@ -96,6 +97,10 @@ impl VarInfo {
 
     pub fn is_parameter_binding(&self) -> bool {
         matches!(self.binding_kind, BindingKind::Parameter)
+    }
+
+    pub fn is_function_binding(&self) -> bool {
+        matches!(self.binding_kind, BindingKind::Function)
     }
 
     pub fn is_mutable_binding(&self) -> bool {
@@ -199,6 +204,11 @@ impl Scope {
     /// Define a variable in the current (innermost) scope.
     pub fn define(&mut self, name: String, ty: Type) {
         self.define_binding(name, ty, true, BindingKind::Local, false);
+    }
+
+    /// Define a local function so callable dispatch can preserve its defaults.
+    pub fn define_function(&mut self, name: String, ty: Type) {
+        self.define_binding(name, ty, true, BindingKind::Function, true);
     }
 
     /// Define an immutable module-level value that codegen re-materializes on access.
@@ -443,6 +453,20 @@ impl Scope {
             fact.ty = ty;
         }
         true
+    }
+
+    pub fn mark_rebound_local(&mut self, name: &str) {
+        let Some(info) = self.lookup_var_mut(name) else {
+            return;
+        };
+        if info.binding_kind != BindingKind::Function {
+            return;
+        }
+        let binding_id = info.binding_id;
+        info.binding_kind = BindingKind::Local;
+        if let Some(fact) = self.retained_bindings.get_mut(&binding_id) {
+            fact.binding_kind = BindingKind::Local;
+        }
     }
 
     pub(crate) fn set_const_integer_value(&mut self, name: &str, value: BigInt) -> bool {
@@ -703,198 +727,5 @@ impl Default for Scope {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_define_and_lookup() {
-        let mut scope = Scope::new();
-        scope.define("x".to_string(), Type::Int);
-        let info = scope.lookup("x").unwrap();
-        assert_eq!(info.ty, Type::Int);
-        assert!(!info.is_moved);
-    }
-
-    #[test]
-    fn test_nested_scopes() {
-        let mut scope = Scope::new();
-        scope.define("x".to_string(), Type::Int);
-        scope.push();
-        scope.define("y".to_string(), Type::Str);
-        assert!(scope.lookup("x").is_some()); // visible from outer
-        assert!(scope.lookup("y").is_some());
-        scope.pop();
-        assert!(scope.lookup("x").is_some());
-        assert!(scope.lookup("y").is_none()); // no longer visible
-    }
-
-    #[test]
-    fn binding_ids_distinguish_shadowed_names_and_outlive_frames() {
-        let mut scope = Scope::new();
-        scope.define("value".to_string(), Type::Int);
-        let outer = scope.lookup("value").unwrap().binding_id;
-
-        scope.push();
-        scope.define("value".to_string(), Type::Str);
-        let inner = scope.lookup("value").unwrap().binding_id;
-        assert_ne!(outer, inner);
-        scope.pop();
-
-        assert_eq!(scope.lookup("value").unwrap().binding_id, outer);
-        assert_eq!(scope.retained_binding(inner).unwrap().name, "value");
-        assert_eq!(
-            scope.retained_binding(inner).unwrap().binding_kind,
-            BindingKind::Local
-        );
-    }
-
-    #[test]
-    fn module_constants_have_distinct_immutable_binding_facts() {
-        let mut scope = Scope::new();
-        scope.define_module_constant("VALUES".to_string(), Type::List(Box::new(Type::Int)));
-
-        let info = scope.lookup("VALUES").unwrap();
-        assert_eq!(info.binding_kind, BindingKind::ModuleConstant);
-        assert_eq!(info.mutability, BindingMutability::Immutable);
-        assert_eq!(
-            scope
-                .retained_binding(info.binding_id)
-                .unwrap()
-                .binding_kind,
-            BindingKind::ModuleConstant
-        );
-    }
-
-    #[test]
-    fn retained_receiver_and_ephemeral_facts_keep_final_conventions() {
-        let mut scope = Scope::new();
-        scope.push();
-        let receiver = scope.define_receiver(
-            "self".to_string(),
-            Type::Any,
-            ReceiverConvention::SharedBorrow,
-        );
-        scope.define_ephemeral("item".to_string(), Type::Int, EphemeralOrigin::Iteration);
-        let item = scope.lookup("item").unwrap().binding_id;
-        scope.pop();
-
-        scope.patch_receiver_convention(receiver, ReceiverConvention::MutableBorrow);
-        let receiver_fact = scope.retained_binding(receiver).unwrap();
-        assert_eq!(receiver_fact.binding_kind, BindingKind::Receiver);
-        assert_eq!(
-            receiver_fact.receiver_convention,
-            Some(ReceiverConvention::MutableBorrow)
-        );
-        assert_eq!(receiver_fact.mutability, BindingMutability::Mutable);
-        assert_eq!(
-            scope.retained_binding(item).unwrap().binding_kind,
-            BindingKind::EphemeralLocal(EphemeralOrigin::Iteration)
-        );
-    }
-
-    #[test]
-    fn test_move_tracking() {
-        let mut scope = Scope::new();
-        scope.define("s".to_string(), Type::Str);
-        assert!(!scope.is_moved("s"));
-        scope.mark_moved("s");
-        assert!(scope.is_moved("s"));
-    }
-
-    #[test]
-    fn test_copy_types_not_moved() {
-        let mut scope = Scope::new();
-        scope.define("x".to_string(), Type::Int);
-        let moved = scope.mark_moved("x");
-        assert!(!moved); // Int is Copy, not moved
-        assert!(!scope.is_moved("x"));
-    }
-
-    #[test]
-    fn test_specialized_copy_binding_can_be_marked_moved() {
-        let mut scope = Scope::new();
-        scope.define("handler".to_string(), Type::Int);
-
-        assert!(scope.mark_binding_moved("handler"));
-        assert!(scope.is_moved("handler"));
-        scope.reset_moved("handler");
-        assert!(scope.mark_moved("handler"));
-        assert!(scope.is_moved("handler"));
-    }
-
-    // --- Narrowing tests ---
-
-    #[test]
-    fn test_narrowing() {
-        let mut scope = Scope::new();
-        let union_type = Type::Union(vec![Type::Int, Type::Str]);
-        scope.define("x".to_string(), union_type.clone());
-
-        // Before narrowing, effective type is declared type
-        assert_eq!(scope.effective_type("x"), Some(&union_type));
-
-        // Narrow to Int
-        scope.narrow_var("x", Type::Int);
-        assert_eq!(scope.effective_type("x"), Some(&Type::Int));
-
-        // Clear narrowing
-        scope.clear_narrowing("x");
-        assert_eq!(scope.effective_type("x"), Some(&union_type));
-    }
-
-    #[test]
-    fn test_narrowing_save_restore() {
-        let mut scope = Scope::new();
-        let union_type = Type::Union(vec![Type::Int, Type::Str]);
-        scope.define("x".to_string(), union_type.clone());
-
-        // Save state before branch
-        let snapshot = scope.save_narrowing_state();
-
-        // Narrow in branch
-        scope.narrow_var("x", Type::Int);
-        assert_eq!(scope.effective_type("x"), Some(&Type::Int));
-
-        // Restore state
-        scope.restore_narrowing_state(&snapshot);
-        assert_eq!(scope.effective_type("x"), Some(&union_type));
-    }
-
-    #[test]
-    fn test_type_alias() {
-        let mut scope = Scope::new();
-        scope.define_type_alias("UserId".to_string(), Type::Int);
-        assert_eq!(scope.lookup_type_alias("UserId"), Some(&Type::Int));
-        assert_eq!(scope.lookup_type_alias("Unknown"), None);
-    }
-
-    // --- Moved state snapshot tests ---
-
-    #[test]
-    fn test_save_restore_moved_state() {
-        let mut scope = Scope::new();
-        scope.define("s".to_string(), Type::Str);
-        assert!(!scope.is_moved("s"));
-
-        let snapshot = scope.save_moved_state();
-        scope.mark_moved("s");
-        assert!(scope.is_moved("s"));
-
-        scope.restore_moved_state(&snapshot);
-        assert!(!scope.is_moved("s"));
-    }
-
-    #[test]
-    fn test_moved_since() {
-        let mut scope = Scope::new();
-        scope.define("s".to_string(), Type::Str);
-        scope.define("x".to_string(), Type::Int);
-
-        let snapshot = scope.save_moved_state();
-        scope.mark_moved("s"); // Move type — should appear in moved_since
-        scope.mark_moved("x"); // Copy type — should NOT appear
-
-        let newly = scope.moved_since(&snapshot);
-        assert_eq!(newly, vec!["s".to_string()]);
-    }
-}
+#[path = "scope_tests.rs"]
+mod tests;

--- a/crates/sifr_lowering/src/scope_tests.rs
+++ b/crates/sifr_lowering/src/scope_tests.rs
@@ -1,0 +1,196 @@
+use super::*;
+
+#[test]
+fn test_define_and_lookup() {
+    let mut scope = Scope::new();
+    scope.define("x".to_string(), Type::Int);
+    let info = scope.lookup("x").unwrap();
+    assert_eq!(info.ty, Type::Int);
+    assert!(!info.is_moved);
+}
+
+#[test]
+fn test_nested_scopes() {
+    let mut scope = Scope::new();
+    scope.define("x".to_string(), Type::Int);
+    scope.push();
+    scope.define("y".to_string(), Type::Str);
+    assert!(scope.lookup("x").is_some());
+    assert!(scope.lookup("y").is_some());
+    scope.pop();
+    assert!(scope.lookup("x").is_some());
+    assert!(scope.lookup("y").is_none());
+}
+
+#[test]
+fn binding_ids_distinguish_shadowed_names_and_outlive_frames() {
+    let mut scope = Scope::new();
+    scope.define("value".to_string(), Type::Int);
+    let outer = scope.lookup("value").unwrap().binding_id;
+
+    scope.push();
+    scope.define("value".to_string(), Type::Str);
+    let inner = scope.lookup("value").unwrap().binding_id;
+    assert_ne!(outer, inner);
+    scope.pop();
+
+    assert_eq!(scope.lookup("value").unwrap().binding_id, outer);
+    assert_eq!(scope.retained_binding(inner).unwrap().name, "value");
+    assert_eq!(
+        scope.retained_binding(inner).unwrap().binding_kind,
+        BindingKind::Local
+    );
+}
+
+#[test]
+fn module_constants_have_distinct_immutable_binding_facts() {
+    let mut scope = Scope::new();
+    scope.define_module_constant("VALUES".to_string(), Type::List(Box::new(Type::Int)));
+
+    let info = scope.lookup("VALUES").unwrap();
+    assert_eq!(info.binding_kind, BindingKind::ModuleConstant);
+    assert_eq!(info.mutability, BindingMutability::Immutable);
+    assert_eq!(
+        scope
+            .retained_binding(info.binding_id)
+            .unwrap()
+            .binding_kind,
+        BindingKind::ModuleConstant
+    );
+}
+
+#[test]
+fn retained_receiver_and_ephemeral_facts_keep_final_conventions() {
+    let mut scope = Scope::new();
+    scope.push();
+    let receiver = scope.define_receiver(
+        "self".to_string(),
+        Type::Any,
+        ReceiverConvention::SharedBorrow,
+    );
+    scope.define_ephemeral("item".to_string(), Type::Int, EphemeralOrigin::Iteration);
+    let item = scope.lookup("item").unwrap().binding_id;
+    scope.pop();
+
+    scope.patch_receiver_convention(receiver, ReceiverConvention::MutableBorrow);
+    let receiver_fact = scope.retained_binding(receiver).unwrap();
+    assert_eq!(receiver_fact.binding_kind, BindingKind::Receiver);
+    assert_eq!(
+        receiver_fact.receiver_convention,
+        Some(ReceiverConvention::MutableBorrow)
+    );
+    assert_eq!(receiver_fact.mutability, BindingMutability::Mutable);
+    assert_eq!(
+        scope.retained_binding(item).unwrap().binding_kind,
+        BindingKind::EphemeralLocal(EphemeralOrigin::Iteration)
+    );
+}
+
+#[test]
+fn test_move_tracking() {
+    let mut scope = Scope::new();
+    scope.define("s".to_string(), Type::Str);
+    assert!(!scope.is_moved("s"));
+    scope.mark_moved("s");
+    assert!(scope.is_moved("s"));
+}
+
+#[test]
+fn test_copy_types_not_moved() {
+    let mut scope = Scope::new();
+    scope.define("x".to_string(), Type::Int);
+    let moved = scope.mark_moved("x");
+    assert!(!moved);
+    assert!(!scope.is_moved("x"));
+}
+
+#[test]
+fn test_specialized_copy_binding_can_be_marked_moved() {
+    let mut scope = Scope::new();
+    scope.define("handler".to_string(), Type::Int);
+
+    assert!(scope.mark_binding_moved("handler"));
+    assert!(scope.is_moved("handler"));
+    scope.reset_moved("handler");
+    assert!(scope.mark_moved("handler"));
+    assert!(scope.is_moved("handler"));
+}
+
+#[test]
+fn rebound_function_binding_becomes_an_ordinary_local() {
+    let mut scope = Scope::new();
+    scope.define_function("callback".to_string(), Type::Int);
+
+    assert!(scope
+        .lookup("callback")
+        .is_some_and(VarInfo::is_function_binding));
+    scope.mark_rebound_local("callback");
+    assert!(!scope
+        .lookup("callback")
+        .is_some_and(VarInfo::is_function_binding));
+    assert_eq!(
+        scope.lookup("callback").map(|info| info.binding_kind),
+        Some(BindingKind::Local)
+    );
+}
+
+#[test]
+fn test_narrowing() {
+    let mut scope = Scope::new();
+    let union_type = Type::Union(vec![Type::Int, Type::Str]);
+    scope.define("x".to_string(), union_type.clone());
+
+    assert_eq!(scope.effective_type("x"), Some(&union_type));
+    scope.narrow_var("x", Type::Int);
+    assert_eq!(scope.effective_type("x"), Some(&Type::Int));
+    scope.clear_narrowing("x");
+    assert_eq!(scope.effective_type("x"), Some(&union_type));
+}
+
+#[test]
+fn test_narrowing_save_restore() {
+    let mut scope = Scope::new();
+    let union_type = Type::Union(vec![Type::Int, Type::Str]);
+    scope.define("x".to_string(), union_type.clone());
+
+    let snapshot = scope.save_narrowing_state();
+    scope.narrow_var("x", Type::Int);
+    assert_eq!(scope.effective_type("x"), Some(&Type::Int));
+    scope.restore_narrowing_state(&snapshot);
+    assert_eq!(scope.effective_type("x"), Some(&union_type));
+}
+
+#[test]
+fn test_type_alias() {
+    let mut scope = Scope::new();
+    scope.define_type_alias("UserId".to_string(), Type::Int);
+    assert_eq!(scope.lookup_type_alias("UserId"), Some(&Type::Int));
+    assert_eq!(scope.lookup_type_alias("Unknown"), None);
+}
+
+#[test]
+fn test_save_restore_moved_state() {
+    let mut scope = Scope::new();
+    scope.define("s".to_string(), Type::Str);
+    assert!(!scope.is_moved("s"));
+
+    let snapshot = scope.save_moved_state();
+    scope.mark_moved("s");
+    assert!(scope.is_moved("s"));
+    scope.restore_moved_state(&snapshot);
+    assert!(!scope.is_moved("s"));
+}
+
+#[test]
+fn test_moved_since() {
+    let mut scope = Scope::new();
+    scope.define("s".to_string(), Type::Str);
+    scope.define("x".to_string(), Type::Int);
+
+    let snapshot = scope.save_moved_state();
+    scope.mark_moved("s");
+    scope.mark_moved("x");
+
+    let newly = scope.moved_since(&snapshot);
+    assert_eq!(newly, vec!["s".to_string()]);
+}


### PR DESCRIPTION
## Summary

- traverse nested function defaults in their defining scope while keeping body descent configurable
- preserve try-bound values referenced only by nested defaults and suppress parameter-shadow false positives
- route declared nested-function calls through canonical argument resolution, including keyword/default handling
- demote declared-function provenance on scalar and tuple rebinding
- add structured codegen, lowering, query, liveness, traversal, and native regression coverage

## Exact candidate

- Base: 218ba6029ff3de4ab75803925e15536c5bdeed0b
- Candidate: 76a19d209d875906b0d7c9751d7216b206a58976

## Review

- First exact-SHA Opus review on a7e0a8e4a0809d01445a37cbaebbd73c742e31f5: BLOCKED on keyword/default resolution and tuple-unpack provenance.
- One permitted remediation exact-SHA Opus review on 76a19d209d875906b0d7c9751d7216b206a58976: SATISFIED.
- A new non-blocking risk involving the unscoped name-keyed function registry will be recorded as a later phase item. No third review was run.

## Validation

Targeted validation passed before the final commit:
- sifr_codegen: 1121 passed
- sifr_lowering: 1032 passed, 1 ignored
- native nested-default fixture built and ran
- affected clippy passed with warnings denied
- generated demo freshness passed
- HIR maintainability guardrail passed
- file-size guardrail passed for 3217 files
- formatting and diff checks passed

Exact-SHA gates were each run once on 76a19d209d875906b0d7c9751d7216b206a58976:
- create-PR gate: all preceding checks passed; stopped only on linked delivery A stale Rust-interop evidence path negative/package_generated_type_import_rejected.sifr
- merge gate: same bounded external failure after all preceding checks passed

The stale Rust-interop fixture is outside Item 10E and remains owned by the linked delivery.