### PR TITLE
Propagate unmatched conditional try errors

### DIFF
--- a/crates/sifr/tests/e2e/pass/try_unmatched_ioerror_propagation.sifr
+++ b/crates/sifr/tests/e2e/pass/try_unmatched_ioerror_propagation.sifr
@@ -1,0 +1,50 @@
+def bubble_other() -> Result[str, IOError]:
+    try:
+        raise IOError("result other")
+    except FileNotFoundError:
+        return "missing"
+
+
+def catch_outer() -> str:
+    try:
+        try:
+            raise IOError("outer other")
+        except FileNotFoundError:
+            return "missing"
+    except IOError as error:
+        return error.message
+
+
+def bubble_union(flag: bool) -> Result[str, IOError | ValueError]:
+    try:
+        if flag:
+            raise IOError("union other")
+        raise ValueError("union value")
+    except FileNotFoundError:
+        return "missing"
+
+
+def main() -> None:
+    try:
+        _: str = bubble_other()
+        assert False
+    except IOError as error:
+        assert error.message == "result other"
+
+    assert catch_outer() == "outer other"
+
+    try:
+        _: str = bubble_union(True)
+        assert False
+    except IOError as error:
+        assert error.message == "union other"
+    except ValueError:
+        assert False
+
+    try:
+        _: str = bubble_union(False)
+        assert False
+    except IOError:
+        assert False
+    except ValueError as error:
+        assert error.message == "union value"

--- a/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
@@ -400,3 +400,57 @@ def classify() -> str:
     assert!(!generated.contains("if let Err(__sifr_try_err) = __sifr_try_res"));
     syn::parse_file(&generated).expect("total raising try Rust should parse");
 }
+
+#[test]
+fn unmatched_ioerror_kind_returns_through_the_checked_error_channel() {
+    let generated = generate_rust_from_source(
+        r#"
+def classify() -> Result[str, IOError]:
+    try:
+        raise IOError("other")
+    except FileNotFoundError:
+        return "missing"
+"#,
+    );
+
+    assert!(generated.contains("__sifr_try_err.kind == \"FileNotFound\""));
+    assert!(generated.contains("return Err(__sifr_try_err);"));
+    syn::parse_file(&generated).expect("residual IOError propagation Rust should parse");
+}
+
+#[test]
+fn branchless_handler_member_returns_through_the_checked_error_channel() {
+    let generated = generate_rust_from_source(
+        r#"
+def classify() -> Result[str, IOError]:
+    try:
+        raise IOError("other")
+    except ValueError:
+        return "value"
+"#,
+    );
+
+    assert!(generated.contains("Err(__sifr_try_err) => {\n            return Err(__sifr_try_err);"));
+    assert!(!generated.contains("structured statement emission missing"));
+    syn::parse_file(&generated).expect("branchless residual Rust should parse");
+}
+
+#[test]
+fn union_member_without_a_handler_keeps_its_residual() {
+    let generated = generate_rust_from_source(
+        r#"
+def classify(flag: bool) -> Result[str, IOError | ValueError]:
+    try:
+        if flag:
+            raise IOError("other")
+        raise ValueError("value")
+    except FileNotFoundError:
+        return "missing"
+"#,
+    );
+
+    assert!(generated.contains("__sifr_try_variant_error.kind == \"FileNotFound\""));
+    assert!(generated.matches("return Err(").count() >= 2);
+    assert!(!generated.contains("structured statement emission missing"));
+    syn::parse_file(&generated).expect("union residual Rust should parse");
+}

--- a/crates/sifr_codegen/src/stmt_support_emitter/try_handlers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/try_handlers.rs
@@ -184,10 +184,23 @@ impl RustEmitter {
             branches.push((cond_expr, handler_body));
         }
 
+        let has_unconditional_branch = branches.iter().any(|(cond, _)| cond.is_none());
+        let mut current_else = if has_unconditional_branch {
+            None
+        } else {
+            let Some(source_error_type) = source_error_type else {
+                return Ok(None);
+            };
+            let Some(residual) =
+                self.unmatched_try_error_return_for_ir(err_ident, source_error_type)
+            else {
+                return Ok(None);
+            };
+            Some(vec![residual])
+        };
         if branches.is_empty() {
-            return Ok(None);
+            return Ok(current_else);
         }
-        let mut current_else: Option<Vec<RustStmt>> = None;
         for (cond, body) in branches.into_iter().rev() {
             if let Some(cond) = cond {
                 current_else = Some(vec![RustStmt::If {
@@ -200,5 +213,29 @@ impl RustEmitter {
             }
         }
         Ok(Some(current_else.unwrap_or_default()))
+    }
+
+    fn unmatched_try_error_return_for_ir(
+        &self,
+        err_ident: &str,
+        source_error_type: &Type,
+    ) -> Option<RustStmt> {
+        let target_error_type = self
+            .try_closure_error_type_info
+            .last()
+            .and_then(Clone::clone)
+            .or_else(
+                || match self.current_return_type.as_ref()?.resolve_alias() {
+                    Type::Result(_, error_type) => Some(error_type.as_ref().clone()),
+                    _ => None,
+                },
+            )?;
+        let error = RustExpr::Ident(err_ident.to_string());
+        let converted =
+            self.consuming_value_conversion_for_ir(&target_error_type, source_error_type, error);
+        Some(RustStmt::Return(Some(RustExpr::FnCall {
+            func: Box::new(RustExpr::Ident("Err".to_string())),
+            args: vec![converted],
+        })))
     }
 }

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -190,6 +190,7 @@ mod task_join_set_calls;
 mod task_owner_scope_state;
 mod task_scope_calls;
 mod task_scope_offload_calls;
+mod try_error_propagation;
 mod tuple_unpack;
 #[cfg(test)]
 mod type_alias_tests;

--- a/crates/sifr_lowering/src/lower/statement_diagnostics_tests.rs
+++ b/crates/sifr_lowering/src/lower/statement_diagnostics_tests.rs
@@ -189,6 +189,57 @@ def main():
 }
 
 #[test]
+fn result_error_channel_accepts_an_unmatched_conditional_handler_error() {
+    let source = "\
+def classify() -> Result[str, IOError]:
+    try:
+        raise IOError(\"other\")
+    except FileNotFoundError:
+        return \"missing\"
+";
+    let parsed = parse_module(source).expect("parse failed");
+    lower_module(parsed.suite()).expect("Result channel should accept the unmatched error");
+}
+
+#[test]
+fn outer_try_accepts_an_unmatched_conditional_handler_error() {
+    let source = "\
+def classify() -> str:
+    try:
+        try:
+            raise IOError(\"other\")
+        except FileNotFoundError:
+            return \"missing\"
+    except IOError as error:
+        return error.message
+";
+    let parsed = parse_module(source).expect("parse failed");
+    lower_module(parsed.suite()).expect("outer try should accept the unmatched error");
+}
+
+#[test]
+fn outer_try_does_not_accept_an_error_from_a_nested_function() {
+    let source = "\
+def outer() -> str:
+    try:
+        def inner() -> str:
+            try:
+                raise IOError(\"leak\")
+            except FileNotFoundError:
+                return \"missing\"
+        return inner()
+    except IOError as error:
+        return error.message
+";
+    let errors = lower_errors(source);
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::RESULT_UNCOVERED_TRY_ERRORS)
+            && error.message == "except arms do not cover all error types from try body: IOError"
+    }));
+}
+
+#[test]
 fn try_finally_without_except_preserves_cleanup_boundary() {
     let source = "\
 def main():

--- a/crates/sifr_lowering/src/lower/statements.rs
+++ b/crates/sifr_lowering/src/lower/statements.rs
@@ -48,7 +48,8 @@ use super::{
     append_growth_shapes, async_for, async_generator_advances, async_with,
     container_literal_specialization, diagnostics, expressions, fallback_error_type,
     flow_diagnostics, function_flow, match_lowering, nested_function_inference, nonlocal_support,
-    numeric_sentinels, result_diagnostics, return_lowering, str, typing_and_functions,
+    numeric_sentinels, result_diagnostics, return_lowering, str, try_error_propagation,
+    typing_and_functions,
 };
 use crate::hir_nodes::{HirExpr, HirIteratorOp, HirPattern, HirStmt};
 use ruff_text_size::{Ranged, TextRange};

--- a/crates/sifr_lowering/src/lower/statements/function_body.rs
+++ b/crates/sifr_lowering/src/lower/statements/function_body.rs
@@ -7,7 +7,11 @@ pub(in crate::lower) fn lower_function_stmts(
     ctx: &mut LowerCtx,
 ) -> Vec<HirStmt> {
     let previous_handlers = std::mem::take(&mut ctx.rust_threadsafe_callback_move_handlers);
+    let previous_in_try_block = std::mem::replace(&mut ctx.in_try_block, false);
+    let previous_try_block_error_types = std::mem::take(&mut ctx.try_block_error_types);
     let result = lower_stmts(stmts, func_type, ctx);
+    ctx.try_block_error_types = previous_try_block_error_types;
+    ctx.in_try_block = previous_in_try_block;
     ctx.rust_threadsafe_callback_move_handlers = previous_handlers;
     result
 }

--- a/crates/sifr_lowering/src/lower/statements/statement_dispatch.rs
+++ b/crates/sifr_lowering/src/lower/statements/statement_dispatch.rs
@@ -592,29 +592,18 @@ pub(in crate::lower) fn lower_stmt(
                 });
             }
 
-            // Exhaustiveness checking: if no catch-all, all error types must be covered.
             // A parent handler covers a child error. Child handlers do not cover their parent:
-            // base errors can contain values outside the known child set.
-            if !has_catch_all && !try_error_types.is_empty() {
-                let uncovered: Vec<String> = try_error_types
-                    .iter()
-                    .filter(|error_ty| {
-                        !covered_types
-                            .iter()
-                            .any(|covered| error_ty.is_assignable_to(covered))
-                    })
-                    .map(Type::display_name)
-                    .collect();
-                if !uncovered.is_empty() {
-                    let mut sorted = uncovered;
-                    sorted.sort();
-                    super::result_diagnostics::uncovered_try_errors(
-                        ctx,
-                        &sorted.join(", "),
-                        try_stmt.range(),
-                    );
-                }
-            }
+            // base errors can contain values outside the known child set. Preserve unmatched
+            // errors when an outer try or the function result channel can carry them.
+            super::try_error_propagation::record_or_reject_unmatched_try_errors(
+                &try_error_types,
+                &covered_types,
+                has_catch_all,
+                prev_in_try,
+                func_type,
+                ctx,
+                try_stmt.range(),
+            );
 
             let handlers_exit = handler_moved_states.iter().all(|(_, exits)| *exits);
             if handlers_exit {

--- a/crates/sifr_lowering/src/lower/try_error_propagation.rs
+++ b/crates/sifr_lowering/src/lower/try_error_propagation.rs
@@ -1,0 +1,54 @@
+use super::LowerCtx;
+use ruff_text_size::TextRange;
+use sifr_type_system::{FunctionType, Type};
+use std::collections::HashSet;
+
+pub(super) fn record_or_reject_unmatched_try_errors(
+    try_error_types: &HashSet<Type>,
+    covered_types: &HashSet<Type>,
+    has_catch_all: bool,
+    enclosing_try_accepts_errors: bool,
+    func_type: &FunctionType,
+    ctx: &mut LowerCtx,
+    range: TextRange,
+) {
+    if has_catch_all || try_error_types.is_empty() {
+        return;
+    }
+
+    let unmatched = try_error_types
+        .iter()
+        .filter(|error_ty| {
+            !covered_types
+                .iter()
+                .any(|covered| error_ty.is_assignable_to(covered))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    if unmatched.is_empty() {
+        return;
+    }
+
+    if enclosing_try_accepts_errors {
+        ctx.try_block_error_types.extend(unmatched);
+        return;
+    }
+
+    let return_error_type = match func_type.return_type.resolve_alias() {
+        Type::Result(_, error_type) => Some(error_type.as_ref()),
+        _ => None,
+    };
+    let mut rejected = unmatched
+        .into_iter()
+        .filter(|error_ty| {
+            !return_error_type.is_some_and(|target| error_ty.is_assignable_to(target))
+        })
+        .map(|error_ty| error_ty.display_name())
+        .collect::<Vec<_>>();
+    if rejected.is_empty() {
+        return;
+    }
+
+    rejected.sort();
+    super::result_diagnostics::uncovered_try_errors(ctx, &rejected.join(", "), range);
+}


### PR DESCRIPTION
## Summary

- preserve unmatched conditional-handler errors through an enclosing try or compatible Result channel
- retain SIFR-RESULT-0005 when no checked channel accepts the error
- emit explicit residual Err returns for conditional, branchless, single, and union carrier members
- isolate lowering try state at every function boundary
- add lowering, codegen, and native regression coverage

## Exact candidate

- Base: d25f897d9ccd1b90fd8c9cda6e2221fd15413df3
- Candidate: 00e67dc56ce27ec6ce2a64ac91216b19afbf87b3

## Review

- First exact-SHA Opus review on f2e7df701: BLOCKED on branchless carrier members and nested-function lowering state leakage.
- One permitted remediation exact-SHA review on 00e67dc56ce27ec6ce2a64ac91216b19afbf87b3: SATISFIED.
- Per the phase rule, two new mechanisms from the second review will be recorded as later Items 10L and 10M. No third review ran.

## Validation

- lowering: 1035 passed, 1 ignored
- codegen: 1126 passed
- existing IOError subclass fixture and expanded residual propagation fixture ran natively
- affected Clippy, formatting, HIR maintainability, and the 3220-file size guardrail passed

Each exact-SHA gate ran once. Both passed all preceding checks and stopped only on linked delivery A stale Rust-interop evidence path negative/package_generated_type_import_rejected.sifr.