### PR TITLE
Preserve nested try/finally error propagation

### DIFF
--- a/crates/sifr/tests/e2e/pass/try_nested_finally_error_propagation.sifr
+++ b/crates/sifr/tests/e2e/pass/try_nested_finally_error_propagation.sifr
@@ -1,0 +1,26 @@
+class CleanupError(Error):
+    message: str
+
+
+def fail() -> Result[None, CleanupError]:
+    raise CleanupError("expected")
+
+
+def main() -> None:
+    cleanup_markers: list[int] = []
+    caught: bool = False
+
+    try:
+        try:
+            _value: None = fail()
+        finally:
+            cleanup_markers.append(1)
+    except CleanupError as error:
+        assert error.message == "expected"
+        caught = True
+
+    assert caught
+    assert cleanup_markers == [1]
+
+
+main()

--- a/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
@@ -77,6 +77,26 @@ def value_or_zero() -> int:
 }
 
 #[test]
+fn nested_try_finally_uses_enclosing_try_error_channel_without_return_capture() {
+    let generated = generate_rust_from_source(&format!(
+        r#"{PROBE_ERROR}
+def run() -> None:
+    try:
+        try:
+            _value: int = load_int(-1)
+        finally:
+            marker: int = 1
+    except ProbeError:
+        marker = 2
+"#
+    ));
+
+    assert!(generated.contains("return Err(__sifr_finally_err.into());"));
+    assert!(!generated.contains("sifr try/finally error propagation in non-Result function"));
+    syn::parse_file(&generated).expect("nested try/finally Rust should parse");
+}
+
+#[test]
 fn try_body_return_and_fallthrough_binding_use_distinct_carriers() {
     let generated = generate_rust_from_source(&format!(
         r#"{PROBE_ERROR}

--- a/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
@@ -669,7 +669,7 @@ impl RustEmitter {
         finalbody: &[HirStmt],
     ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
         let err_ty = self.try_finally_error_type_name_for_ir(body, finalbody);
-        let can_return_error = self.try_closure_depth > 0
+        let can_return_error = !self.try_closure_error_type.is_empty()
             || self.current_return_type.as_ref().is_some_and(|return_ty| {
                 matches!(
                     crate::resolve_alias_type_for_plain_call(return_ty),


### PR DESCRIPTION
## Summary
- recognize active closure error carriers independently of return capture
- propagate nested try/finally failures through an enclosing try closure
- add code-generation and native regressions for one-time cleanup and outer handling

## Validation
- `cargo test -p sifr_lowering try_finally -- --nocapture`
- `cargo test -p sifr_codegen --lib`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/try_nested_finally_error_propagation.sifr`
- `cargo clippy -p sifr_codegen -- -D warnings`
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `python3 scripts/check_file_size_guardrails.py`

Exact-SHA review and compiler gates are pending.