### PR TITLE
Close diagnostic harness strict Clippy

### DIFF
--- a/crates/sifr_driver/src/bin/diagnostic_rendering_harness.rs
+++ b/crates/sifr_driver/src/bin/diagnostic_rendering_harness.rs
@@ -263,6 +263,7 @@ fn check_cycle_runtime_rules(root: &Path) -> Result<(), String> {
     Ok(())
 }
 
+#[derive(Clone, Copy)]
 enum FixtureLayout {
     Flat,
     SourceRoot,


### PR DESCRIPTION
## Summary
- declare the data-free fixture-layout mode as a copyable value
- preserve existing by-value call sites and canonical fixture-path behavior
- close the strict `needless_pass_by_value` workspace Clippy failure

## Validation
- `cargo clippy --workspace -- -D warnings`
- both diagnostic-rendering target seed commands
- `python3 verification/areas/developer_tooling/check_diagnostic_source_canonicalization_rules.py`
- `cargo fmt --check`
- `python3 scripts/check_file_size_guardrails.py`

Exact-SHA review and compiler gates are pending.