### PR TITLE
Scope nested function signature metadata

### DIFF
--- a/crates/sifr/tests/e2e/pass/nested_function_signature_scope.sifr
+++ b/crates/sifr/tests/e2e/pass/nested_function_signature_scope.sifr
@@ -1,0 +1,19 @@
+def evaluate(flag: bool) -> int:
+    def helper(value: int = 40, *extra: int) -> int:
+        return value + len(extra)
+
+    if flag:
+        def helper(prefix: str, suffix: str = "!") -> str:
+            return prefix + suffix
+
+        assert helper("ok") == "ok!"
+
+    return helper() + helper(value=1) + helper(1, 2, 3)
+
+
+def main() -> None:
+    assert evaluate(False) == 44
+    assert evaluate(True) == 44
+
+
+main()

--- a/crates/sifr/tests/e2e/pass/nested_function_signature_scope.sifr
+++ b/crates/sifr/tests/e2e/pass/nested_function_signature_scope.sifr
@@ -11,9 +11,47 @@ def evaluate(flag: bool) -> int:
     return helper() + helper(value=1) + helper(1, 2, 3)
 
 
+def evaluate_loop(count: int) -> int:
+    def helper(value: int = 3, *rest: int) -> int:
+        return value + len(rest)
+
+    for i in range(count):
+        def helper(value: str) -> str:
+            return value
+
+        assert helper("x") == "x"
+
+    return helper() + helper(1, 2, 3)
+
+
+def evaluate_exiting_branch(flag: bool) -> int:
+    def helper(value: int = 3, *rest: int) -> int:
+        return value + len(rest)
+
+    if flag:
+        def helper(value: str) -> str:
+            return value
+
+        return len(helper("x"))
+
+    return helper() + helper(1, 2, 3)
+
+
+def inferred_vararg() -> int:
+    def helper(*extra):
+        return len(extra)
+
+    return helper(1, 2)
+
+
 def main() -> None:
     assert evaluate(False) == 44
     assert evaluate(True) == 44
+    assert evaluate_loop(0) == 6
+    assert evaluate_loop(1) == 6
+    assert evaluate_exiting_branch(False) == 6
+    assert evaluate_exiting_branch(True) == 1
+    assert inferred_vararg() == 2
 
 
 main()

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -71,6 +71,8 @@ mod multi_module_stdlib_feature_tests;
 #[cfg(test)]
 mod nested_container_capture_codegen_tests;
 #[cfg(test)]
+mod nested_function_signature_scope_codegen_tests;
+#[cfg(test)]
 mod performance_codegen_tests;
 #[cfg(test)]
 mod performance_nested_mutation_codegen_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/nested_function_signature_scope_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/nested_function_signature_scope_codegen_tests.rs
@@ -1,0 +1,23 @@
+use super::generate_rust_from_source;
+
+#[test]
+fn shadowed_nested_helper_restores_outer_calling_conventions() {
+    let generated = generate_rust_from_source(
+        r#"def evaluate(flag: bool) -> int:
+    def helper(value: int = 40, *extra: int) -> int:
+        return value + len(extra)
+
+    if flag:
+        def helper(prefix: str, suffix: str = "!") -> str:
+            return prefix + suffix
+        assert helper("ok") == "ok!"
+
+    return helper() + helper(value=1) + helper(1, 2, 3)
+"#,
+    );
+
+    assert!(generated.contains("helper(40_i64, &"));
+    assert!(generated.contains("helper(1_i64, &vec![2_i64, 3_i64])"));
+    assert!(!generated.contains("helper(&(40_i64)"));
+    syn::parse_file(&generated).expect("scoped nested-function calls should parse as Rust");
+}

--- a/crates/sifr_codegen/src/lib_codegen_tests/nested_function_signature_scope_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/nested_function_signature_scope_codegen_tests.rs
@@ -21,3 +21,45 @@ fn shadowed_nested_helper_restores_outer_calling_conventions() {
     assert!(!generated.contains("helper(&(40_i64)"));
     syn::parse_file(&generated).expect("scoped nested-function calls should parse as Rust");
 }
+
+#[test]
+fn loop_scopes_restore_outer_calling_conventions() {
+    let generated = generate_rust_from_source(
+        r#"def outer(n: int) -> int:
+    def helper(value: int = 3, *rest: int) -> int:
+        return value + len(rest)
+
+    for i in range(n):
+        def helper(value: str) -> str:
+            return value
+        assert helper("x") == "x"
+
+    return helper() + helper(1, 2, 3)
+"#,
+    );
+
+    assert!(generated.contains("helper(3_i64, &"));
+    assert!(generated.contains("helper(1_i64, &vec![2_i64, 3_i64])"));
+    syn::parse_file(&generated).expect("loop-scoped nested-function calls should parse as Rust");
+}
+
+#[test]
+fn exiting_branch_scopes_restore_outer_calling_conventions() {
+    let generated = generate_rust_from_source(
+        r#"def outer(flag: bool) -> int:
+    def helper(value: int = 3, *rest: int) -> int:
+        return value + len(rest)
+
+    if flag:
+        def helper(value: str) -> str:
+            return value
+        return len(helper("x"))
+
+    return helper() + helper(1, 2, 3)
+"#,
+    );
+
+    assert!(generated.contains("helper(3_i64, &"));
+    assert!(generated.contains("helper(1_i64, &vec![2_i64, 3_i64])"));
+    syn::parse_file(&generated).expect("exiting-branch nested-function calls should parse as Rust");
+}

--- a/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/if_condition_lowering.rs
@@ -421,9 +421,8 @@ impl RustEmitter {
             && else_body.is_none()
             && crate::helpers::codegen_body_always_exits(then_body)
         {
-            let speculative_string_char_cache_vars = self.string_char_cache_vars.clone();
-            let Some(lowered_then_body) = self.try_lower_stmt_block_for_ir(then_body)? else {
-                self.string_char_cache_vars = speculative_string_char_cache_vars;
+            let Some(lowered_then_body) = self.try_lower_scoped_stmt_block_for_ir(then_body)?
+            else {
                 return Ok(None);
             };
             if let Some(option_vars) = self.detect_or_is_none_vars_with_bindings_for_ir(condition) {
@@ -441,7 +440,6 @@ impl RustEmitter {
                         .map(|option_var| self.option_binding_value_expr_for_ir(option_var))
                         .collect(),
                 );
-                self.string_char_cache_vars = speculative_string_char_cache_vars;
                 return Ok(Some(RustStmt::LetElse {
                     pattern,
                     value,
@@ -451,7 +449,6 @@ impl RustEmitter {
             if let Some(option_var) = crate::helpers::detect_is_none_var(condition)
                 .or_else(|| crate::helpers::detect_not_option_truthiness(condition))
             {
-                self.string_char_cache_vars = speculative_string_char_cache_vars;
                 return Ok(Some(RustStmt::LetElse {
                     pattern: self.option_binding_pattern_for_ir(&option_var),
                     value: self.option_binding_value_expr_for_ir(&option_var),
@@ -475,14 +472,12 @@ impl RustEmitter {
                         .map(|option_var| self.option_binding_value_expr_for_ir(option_var))
                         .collect(),
                 );
-                self.string_char_cache_vars = speculative_string_char_cache_vars;
                 return Ok(Some(RustStmt::LetElse {
                     pattern,
                     value,
                     else_body: lowered_then_body,
                 }));
             }
-            self.string_char_cache_vars = speculative_string_char_cache_vars;
         }
 
         let mut nested_else = if let Some(else_body) = else_body {

--- a/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
@@ -113,14 +113,12 @@ impl RustEmitter {
 
         self.loop_else_stack.push(has_else);
         let lowered_iter = self.try_lower_for_iter_expr_for_ir(iter, target_ty)?;
-        let string_char_cache_vars = self.string_char_cache_vars.clone();
         let target_cache_init = if target.contains(',') {
             None
         } else {
             self.string_char_cache_init_stmt_for_loop_target(target, target_ty)
         };
-        let lowered_body = self.try_lower_stmt_block_for_ir(body);
-        self.string_char_cache_vars = string_char_cache_vars;
+        let lowered_body = self.try_lower_scoped_stmt_block_for_ir(body);
         let lowered_body = lowered_body?;
         let popped = self.loop_else_stack.pop();
         debug_assert!(popped.is_some(), "loop_else_stack should not underflow");

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
@@ -785,15 +785,13 @@ impl RustEmitter {
                 }) else {
                     return Ok(None);
                 };
-                let string_char_cache_vars = self.string_char_cache_vars.clone();
                 let target_cache_init = if char_set_loop || target.contains(',') {
                     None
                 } else {
                     self.string_char_cache_init_stmt_for_loop_target(target, target_ty)
                 };
                 self.loop_else_stack.push(false);
-                let lowered_body_result = self.try_lower_stmt_block_for_ir(body);
-                self.string_char_cache_vars = string_char_cache_vars;
+                let lowered_body_result = self.try_lower_scoped_stmt_block_for_ir(body);
                 let popped = self.loop_else_stack.pop();
                 debug_assert!(popped.is_some(), "loop_else_stack should not underflow");
                 let lowered_body_result = lowered_body_result?;

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_block_helpers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_block_helpers.rs
@@ -507,8 +507,12 @@ impl RustEmitter {
         stmts: &[HirStmt],
     ) -> Result<Option<Vec<crate::RustStmt>>, crate::CodegenError> {
         let string_char_cache_vars = self.string_char_cache_vars.clone();
+        let callable_var_conventions = self.callable_var_conventions.clone();
+        let nested_fn_captures = self.nested_fn_captures.clone();
         let result = self.try_lower_stmt_block_for_ir(stmts);
         self.string_char_cache_vars = string_char_cache_vars;
+        self.callable_var_conventions = callable_var_conventions;
+        self.nested_fn_captures = nested_fn_captures;
         result
     }
 

--- a/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
@@ -105,22 +105,22 @@ pub(super) fn lower_regular_call(
                 conventions.clone(),
                 *ret_type.clone(),
                 false,
-                info.is_function_binding(),
+                info.is_function_binding().then_some(info.binding_id),
             )),
             Type::AsyncCallable(param_types, conventions, ret_type) => Some((
                 param_types.clone(),
                 conventions.clone(),
                 *ret_type.clone(),
                 true,
-                info.is_function_binding(),
+                info.is_function_binding().then_some(info.binding_id),
             )),
             _ => None,
         });
-    if let Some((param_types, conventions, ret_type, is_async_callable, is_declared_function)) =
+    if let Some((param_types, conventions, ret_type, is_async_callable, function_binding_id)) =
         callable_info
     {
-        let (args, arg_ranges) = if is_declared_function {
-            let Some(function_type) = ctx.functions.get(&func_name).cloned() else {
+        let (args, arg_ranges) = if let Some(binding_id) = function_binding_id {
+            let Some(metadata) = ctx.local_function_metadata.get(&binding_id).cloned() else {
                 ctx.error_with_code_at(
                     DiagnosticCode::INTERNAL_COMPILER_PANIC,
                     format!(
@@ -130,17 +130,15 @@ pub(super) fn lower_regular_call(
                 );
                 return None;
             };
-            let defaults = ctx.function_defaults.get(&func_name).cloned();
-            let vararg_index = ctx.vararg_functions.get(&func_name).copied();
             let args = lower_function_call_args(
                 call,
                 &func_name,
-                &function_type,
-                defaults.as_deref(),
-                vararg_index,
+                &metadata.signature,
+                Some(&metadata.defaults),
+                metadata.vararg_index,
                 ctx,
             )?;
-            let ranges = call_argument_ranges_by_param(call, &function_type);
+            let ranges = call_argument_ranges_by_param(call, &metadata.signature);
             (args, ranges)
         } else {
             let mut args = Vec::new();

--- a/crates/sifr_lowering/src/lower/mod_context.rs
+++ b/crates/sifr_lowering/src/lower/mod_context.rs
@@ -20,10 +20,20 @@ use sifr_type_system::{FunctionType, Type};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use workload_annotations::WorkloadKind;
 
+#[derive(Clone)]
+pub(in crate::lower) struct LocalFunctionMetadata {
+    pub(in crate::lower) signature: FunctionType,
+    pub(in crate::lower) defaults: Vec<(usize, HirExpr)>,
+    pub(in crate::lower) vararg_index: Option<usize>,
+    pub(in crate::lower) workload: Option<WorkloadKind>,
+}
+
 /// The lowering context that tracks state during AST->HIR conversion.
 pub(in crate::lower) struct LowerCtx {
     /// Function signatures (name -> type)
     pub(in crate::lower) functions: HashMap<String, FunctionType>,
+    /// Nested-function metadata keyed by the lexical function binding.
+    pub(in crate::lower) local_function_metadata: HashMap<BindingId, LocalFunctionMetadata>,
     /// Resolved local callable name -> typed compiler intrinsic identity.
     pub(in crate::lower) compiler_intrinsics: HashMap<String, CompilerIntrinsicId>,
     pub(in crate::lower) async_functions: std::collections::HashSet<String>,
@@ -239,6 +249,7 @@ impl LowerCtx {
     pub(in crate::lower) fn new() -> Self {
         Self {
             functions: HashMap::new(),
+            local_function_metadata: HashMap::new(),
             compiler_intrinsics: HashMap::new(),
             async_functions: std::collections::HashSet::new(),
             async_generator_functions: std::collections::HashSet::new(),
@@ -363,6 +374,17 @@ impl LowerCtx {
             const_integer_values: HashMap::new(),
             flow_effects: Vec::new(),
         }
+    }
+
+    pub(in crate::lower) fn visible_local_function_metadata(
+        &self,
+        name: &str,
+    ) -> Option<&LocalFunctionMetadata> {
+        let binding = self.scope.lookup(name)?;
+        binding
+            .is_function_binding()
+            .then(|| self.local_function_metadata.get(&binding.binding_id))
+            .flatten()
     }
 
     pub(in crate::lower) fn is_stdlib_lowering(&self) -> bool {

--- a/crates/sifr_lowering/src/lower/nested_function_inference.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference.rs
@@ -25,6 +25,8 @@ use type_unification::{
 };
 mod generic_call_inference;
 use generic_call_inference::infer_registered_call;
+mod call_argument_inference;
+use call_argument_inference::unify_inferred_call_arguments;
 mod return_inference;
 use return_inference::unify_function_return;
 mod compound_statement_inference;

--- a/crates/sifr_lowering/src/lower/nested_function_inference/call_argument_inference.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/call_argument_inference.rs
@@ -1,0 +1,110 @@
+use super::{
+    generic_call_inference::InferredCall, has_conflicting_inference, unify_types, HashMap,
+    LocalFunctionState, ParamKind, Type,
+};
+
+pub(super) fn unify_inferred_call_arguments(
+    function_name: &str,
+    state: &LocalFunctionState<'_>,
+    inferred: InferredCall,
+    states: &mut HashMap<String, LocalFunctionState<'_>>,
+) {
+    let positional_params = state
+        .params
+        .iter()
+        .filter(|param| param.kind == ParamKind::Positional)
+        .collect::<Vec<_>>();
+    let vararg = state
+        .params
+        .iter()
+        .find(|param| param.kind == ParamKind::Vararg);
+    for (index, arg_ty) in inferred.positional_types.into_iter().enumerate() {
+        if let Some(param) = positional_params.get(index) {
+            unify_function_param(function_name, param.name.as_str(), arg_ty, states);
+        } else if let Some(param) = vararg {
+            unify_variadic_param_value(function_name, param.name.as_str(), arg_ty, states);
+        }
+    }
+
+    let kwarg = state
+        .params
+        .iter()
+        .find(|param| param.kind == ParamKind::Kwarg);
+    for (name, keyword_ty) in inferred.keyword_types {
+        let Some(name) = name else {
+            if let Some(param) = kwarg {
+                unify_function_param(function_name, param.name.as_str(), keyword_ty, states);
+            }
+            continue;
+        };
+        if let Some(param) = state.params.iter().find(|param| {
+            param.name == name
+                && matches!(param.kind, ParamKind::Positional | ParamKind::KeywordOnly)
+        }) {
+            unify_function_param(function_name, param.name.as_str(), keyword_ty, states);
+        } else if let Some(param) = kwarg {
+            unify_variadic_param_value(function_name, param.name.as_str(), keyword_ty, states);
+        }
+    }
+}
+
+fn unify_function_param(
+    function_name: &str,
+    param_name: &str,
+    incoming: Type,
+    states: &mut HashMap<String, LocalFunctionState<'_>>,
+) {
+    let Some(state) = states.get_mut(function_name) else {
+        return;
+    };
+    let Some(param) = state
+        .params
+        .iter_mut()
+        .find(|param| param.name == param_name)
+    else {
+        return;
+    };
+    if !param.explicit && has_conflicting_inference(&param.ty, &incoming) {
+        param.ty = Type::Unknown;
+        state.inference_failed = true;
+    } else {
+        param.ty = unify_types(param.ty.clone(), incoming);
+    }
+}
+
+fn unify_variadic_param_value(
+    function_name: &str,
+    param_name: &str,
+    incoming: Type,
+    states: &mut HashMap<String, LocalFunctionState<'_>>,
+) {
+    let Some(state) = states.get_mut(function_name) else {
+        return;
+    };
+    let Some(param) = state
+        .params
+        .iter_mut()
+        .find(|param| param.name == param_name)
+    else {
+        return;
+    };
+    let existing = match param.ty.clone() {
+        Type::List(element) => *element,
+        Type::Dict(_, value) => *value,
+        _ => return,
+    };
+    if !param.explicit && has_conflicting_inference(&existing, &incoming) {
+        param.ty = variadic_container_type(param.kind, Type::Unknown);
+        state.inference_failed = true;
+        return;
+    }
+    param.ty = variadic_container_type(param.kind, unify_types(existing, incoming));
+}
+
+fn variadic_container_type(kind: ParamKind, element: Type) -> Type {
+    match kind {
+        ParamKind::Vararg => Type::List(Box::new(element)),
+        ParamKind::Kwarg => Type::Dict(Box::new(Type::Str), Box::new(element)),
+        ParamKind::Positional | ParamKind::KeywordOnly => element,
+    }
+}

--- a/crates/sifr_lowering/src/lower/nested_function_inference/expression_inference.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/expression_inference.rs
@@ -1,9 +1,9 @@
 use super::{
     defaultdict_shape_expr_is_lowering_exact, has_conflicting_inference,
     infer_defaultdict_call_type, infer_registered_call, refine_defaultdict_method_call,
-    refine_defaultdict_subscript, str, type_check_binary_op, unify_function_return, unify_types,
-    CmpOp, DefaultdictMethodCall, Expr, ExprCall, FunctionEnv, HashMap, LocalFunctionState,
-    LowerCtx, Operator, Type,
+    refine_defaultdict_subscript, str, type_check_binary_op, unify_function_return,
+    unify_inferred_call_arguments, unify_types, CmpOp, DefaultdictMethodCall, Expr, ExprCall,
+    FunctionEnv, HashMap, LocalFunctionState, LowerCtx, Operator, Type,
 };
 pub(super) fn analyze_assign(
     targets: &[Expr],
@@ -391,14 +391,9 @@ pub(super) fn infer_call_type(
                     current_function,
                     ctx,
                 );
-                for (index, arg_ty) in inferred.positional_types.into_iter().enumerate() {
-                    if let Some(param_name) =
-                        state.params.get(index).map(|param| param.name.clone())
-                    {
-                        unify_function_param(name.id.as_str(), param_name.as_str(), arg_ty, states);
-                    }
-                }
-                return inferred.return_type;
+                let return_type = inferred.return_type.clone();
+                unify_inferred_call_arguments(name.id.as_str(), &state, inferred, states);
+                return return_type;
             }
             let function_type = ctx
                 .visible_local_function_metadata(name.id.as_str())
@@ -837,29 +832,5 @@ pub(super) fn unify_name_binding(
 
     if let Some(callee_name) = env.call_return_origins.get(name).cloned() {
         unify_function_return(callee_name.as_str(), merged, states);
-    }
-}
-
-pub(super) fn unify_function_param(
-    function_name: &str,
-    param_name: &str,
-    incoming: Type,
-    states: &mut HashMap<String, LocalFunctionState<'_>>,
-) {
-    let Some(state) = states.get_mut(function_name) else {
-        return;
-    };
-    let Some(param) = state
-        .params
-        .iter_mut()
-        .find(|param| param.name == param_name)
-    else {
-        return;
-    };
-    if !param.explicit && has_conflicting_inference(&param.ty, &incoming) {
-        param.ty = Type::Unknown;
-        state.inference_failed = true;
-    } else {
-        param.ty = unify_types(param.ty.clone(), incoming);
     }
 }

--- a/crates/sifr_lowering/src/lower/nested_function_inference/expression_inference.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/expression_inference.rs
@@ -400,7 +400,11 @@ pub(super) fn infer_call_type(
                 }
                 return inferred.return_type;
             }
-            if let Some(function_type) = ctx.functions.get(name.id.as_str()).cloned() {
+            let function_type = ctx
+                .visible_local_function_metadata(name.id.as_str())
+                .map(|metadata| metadata.signature.clone())
+                .or_else(|| ctx.functions.get(name.id.as_str()).cloned());
+            if let Some(function_type) = function_type {
                 return infer_registered_call(
                     call,
                     &function_type,

--- a/crates/sifr_lowering/src/lower/nested_function_inference/generic_call_inference.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/generic_call_inference.rs
@@ -5,6 +5,7 @@ use super::{
 
 pub(super) struct InferredCall {
     pub(super) positional_types: Vec<Type>,
+    pub(super) keyword_types: Vec<(Option<String>, Type)>,
     pub(super) return_type: Type,
 }
 
@@ -26,21 +27,32 @@ pub(super) fn infer_registered_call(
     for (argument, (_, parameter, _)) in positional_types.iter().zip(&function_type.params) {
         infer_type_var_bindings(parameter, argument, &mut bindings);
     }
-    for keyword in &call.arguments.keywords {
-        let keyword_type = infer_expr_type(&keyword.value, env, states, current_function, ctx);
-        let Some(name) = keyword.arg.as_ref() else {
+    let keyword_types = call
+        .arguments
+        .keywords
+        .iter()
+        .map(|keyword| {
+            (
+                keyword.arg.as_ref().map(ToString::to_string),
+                infer_expr_type(&keyword.value, env, states, current_function, ctx),
+            )
+        })
+        .collect::<Vec<_>>();
+    for (name, keyword_type) in &keyword_types {
+        let Some(name) = name else {
             continue;
         };
         if let Some((_, parameter, _)) = function_type
             .params
             .iter()
-            .find(|(parameter_name, _, _)| parameter_name == name.as_str())
+            .find(|(parameter_name, _, _)| parameter_name == name)
         {
-            infer_type_var_bindings(parameter, &keyword_type, &mut bindings);
+            infer_type_var_bindings(parameter, keyword_type, &mut bindings);
         }
     }
     InferredCall {
         positional_types,
+        keyword_types,
         return_type: substitute_type_vars(&function_type.return_type, &bindings),
     }
 }

--- a/crates/sifr_lowering/src/lower/nested_function_inference/state_collection.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/state_collection.rs
@@ -290,24 +290,68 @@ fn collect_function_states<'a>(
             continue;
         };
 
-        let mut params = Vec::new();
-        let resolved_params = func
-            .parameters
-            .args
-            .iter()
-            .map(|param| {
-                let name = param.parameter.name.to_string();
-                let (ty, explicit) = if let Some(annotation) = &param.parameter.annotation {
-                    (resolve_annotation_expr(annotation, ctx), true)
-                } else {
-                    (Type::Unknown, false)
-                };
-                (name, ty, explicit)
-            })
-            .collect::<Vec<_>>();
+        let mut resolved_params = Vec::new();
+        for param in &func.parameters.args {
+            let name = param.parameter.name.to_string();
+            let (ty, explicit) = if let Some(annotation) = &param.parameter.annotation {
+                (resolve_annotation_expr(annotation, ctx), true)
+            } else {
+                (Type::Unknown, false)
+            };
+            resolved_params.push((
+                name,
+                param.parameter.name.range(),
+                ty,
+                explicit,
+                param.parameter.convention,
+            ));
+        }
+        if let Some(vararg) = &func.parameters.vararg {
+            let (element_ty, explicit) = if let Some(annotation) = &vararg.annotation {
+                (resolve_annotation_expr(annotation, ctx), true)
+            } else {
+                (Type::Unknown, false)
+            };
+            resolved_params.push((
+                vararg.name.to_string(),
+                vararg.name.range(),
+                Type::List(Box::new(element_ty)),
+                explicit,
+                vararg.convention,
+            ));
+        }
+        for param in &func.parameters.kwonlyargs {
+            let name = param.parameter.name.to_string();
+            let (ty, explicit) = if let Some(annotation) = &param.parameter.annotation {
+                (resolve_annotation_expr(annotation, ctx), true)
+            } else {
+                (Type::Unknown, false)
+            };
+            resolved_params.push((
+                name,
+                param.parameter.name.range(),
+                ty,
+                explicit,
+                param.parameter.convention,
+            ));
+        }
+        if let Some(kwarg) = &func.parameters.kwarg {
+            let (value_ty, explicit) = if let Some(annotation) = &kwarg.annotation {
+                (resolve_annotation_expr(annotation, ctx), true)
+            } else {
+                (Type::Unknown, false)
+            };
+            resolved_params.push((
+                kwarg.name.to_string(),
+                kwarg.name.range(),
+                Type::Dict(Box::new(Type::Str), Box::new(value_ty)),
+                explicit,
+                kwarg.convention,
+            ));
+        }
         let param_types = resolved_params
             .iter()
-            .map(|(name, ty, _)| {
+            .map(|(name, _, ty, _, _)| {
                 let candidate = if ty.is_unknown() {
                     MutationCandidate::InferFromUsage
                 } else {
@@ -317,14 +361,16 @@ fn collect_function_states<'a>(
             })
             .collect::<HashMap<_, _>>();
         let mutated_params = collect_mutated_binding_names(&func.body, &param_types);
-        for (param, (name, ty, explicit)) in func.parameters.args.iter().zip(resolved_params) {
+        let mut params = Vec::with_capacity(resolved_params.len());
+        for (name, name_range, ty, explicit, convention) in resolved_params {
+            let mutated = mutated_params.contains(&name);
             params.push(ParamState {
                 name,
-                name_range: param.parameter.name.range(),
+                name_range,
                 ty,
                 explicit,
-                convention: param.parameter.convention,
-                mutated: mutated_params.contains(param.parameter.name.as_str()),
+                convention,
+                mutated,
             });
         }
 

--- a/crates/sifr_lowering/src/lower/nested_function_inference/state_collection.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/state_collection.rs
@@ -34,7 +34,16 @@ pub(super) struct ParamState {
     pub(super) ty: Type,
     pub(super) explicit: bool,
     pub(super) convention: sifr_python_ast::AstParamConvention,
+    pub(super) kind: ParamKind,
     pub(super) mutated: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParamKind {
+    Positional,
+    Vararg,
+    KeywordOnly,
+    Kwarg,
 }
 
 #[derive(Clone)]
@@ -304,6 +313,7 @@ fn collect_function_states<'a>(
                 ty,
                 explicit,
                 param.parameter.convention,
+                ParamKind::Positional,
             ));
         }
         if let Some(vararg) = &func.parameters.vararg {
@@ -318,6 +328,7 @@ fn collect_function_states<'a>(
                 Type::List(Box::new(element_ty)),
                 explicit,
                 vararg.convention,
+                ParamKind::Vararg,
             ));
         }
         for param in &func.parameters.kwonlyargs {
@@ -333,6 +344,7 @@ fn collect_function_states<'a>(
                 ty,
                 explicit,
                 param.parameter.convention,
+                ParamKind::KeywordOnly,
             ));
         }
         if let Some(kwarg) = &func.parameters.kwarg {
@@ -347,11 +359,12 @@ fn collect_function_states<'a>(
                 Type::Dict(Box::new(Type::Str), Box::new(value_ty)),
                 explicit,
                 kwarg.convention,
+                ParamKind::Kwarg,
             ));
         }
         let param_types = resolved_params
             .iter()
-            .map(|(name, _, ty, _, _)| {
+            .map(|(name, _, ty, _, _, _)| {
                 let candidate = if ty.is_unknown() {
                     MutationCandidate::InferFromUsage
                 } else {
@@ -362,7 +375,7 @@ fn collect_function_states<'a>(
             .collect::<HashMap<_, _>>();
         let mutated_params = collect_mutated_binding_names(&func.body, &param_types);
         let mut params = Vec::with_capacity(resolved_params.len());
-        for (name, name_range, ty, explicit, convention) in resolved_params {
+        for (name, name_range, ty, explicit, convention, kind) in resolved_params {
             let mutated = mutated_params.contains(&name);
             params.push(ParamState {
                 name,
@@ -370,6 +383,7 @@ fn collect_function_states<'a>(
                 ty,
                 explicit,
                 convention,
+                kind,
                 mutated,
             });
         }
@@ -421,7 +435,7 @@ pub(super) fn finalize_nested_function_types(
 
     for state in states.values_mut() {
         for param in &mut state.params {
-            if !param.explicit && param.ty.is_unknown() {
+            if !param.explicit && param.ty.contains_unknown_or_any() {
                 state.inference_failed = true;
                 ctx.error_with_code_at(
                     DiagnosticCode::TYPE_MISSING_ANNOTATION,

--- a/crates/sifr_lowering/src/lower/nested_function_tests.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_tests.rs
@@ -121,6 +121,32 @@ fn same_named_nested_helpers_keep_lexical_mutable_call_metadata() {
 }
 
 #[test]
+fn shadowed_nested_helper_restores_defaults_keywords_and_varargs() {
+    let result = lower_source(
+        "def outer(flag: bool) -> int:\n    def helper(value: int = 40, *extra: int) -> int:\n        return value + len(extra)\n\n    if flag:\n        def helper(prefix: str, suffix: str = \"!\") -> str:\n            return prefix + suffix\n        assert helper(\"ok\") == \"ok!\"\n\n    return helper() + helper(value=1) + helper(1, 2, 3)\n",
+    );
+    assert!(
+        result.is_ok(),
+        "calls after a shadowing block must use the restored outer signature: {result:?}"
+    );
+}
+
+#[test]
+fn shadowed_nested_helper_does_not_inherit_outer_default_or_vararg() {
+    let errors = lower_source(
+        "def outer(flag: bool) -> int:\n    def helper(value: int = 1, *extra: int) -> int:\n        return value + len(extra)\n\n    if flag:\n        def helper(value: int) -> int:\n            return value\n        helper()\n        helper(1, 2)\n\n    return 0\n",
+    )
+    .expect_err("the inner helper must retain its required fixed-arity signature");
+
+    assert!(errors
+        .iter()
+        .any(|error| error.message == "helper() missing required argument 'value'"));
+    assert!(errors
+        .iter()
+        .any(|error| error.message == "helper() takes at most 1 argument(s), got 2"));
+}
+
+#[test]
 fn test_conflicting_nested_helper_call_sites_fail_inference_explicitly() {
     let result = lower_source(
         "def outer(flag: bool) -> None:\n    def helper(value):\n        print(value)\n\n    if flag:\n        helper(1)\n    else:\n        helper(\"x\")\n",

--- a/crates/sifr_lowering/src/lower/nested_function_tests.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_tests.rs
@@ -147,6 +147,17 @@ fn shadowed_nested_helper_does_not_inherit_outer_default_or_vararg() {
 }
 
 #[test]
+fn inferred_nested_vararg_keeps_its_list_shape() {
+    let result = lower_source(
+        "def outer() -> int:\n    def helper(*extra):\n        return len(extra)\n\n    return helper(1, 2)\n",
+    );
+    assert!(
+        result.is_ok(),
+        "vararg call sites must infer the packed list element type: {result:?}"
+    );
+}
+
+#[test]
 fn test_conflicting_nested_helper_call_sites_fail_inference_explicitly() {
     let result = lower_source(
         "def outer(flag: bool) -> None:\n    def helper(value):\n        print(value)\n\n    if flag:\n        helper(1)\n    else:\n        helper(\"x\")\n",

--- a/crates/sifr_lowering/src/lower/statements/statement_dispatch.rs
+++ b/crates/sifr_lowering/src/lower/statements/statement_dispatch.rs
@@ -658,9 +658,8 @@ pub(in crate::lower) fn lower_stmt(
             }
             // Extract the function type (params + return type)
             let ft = ctx
-                .functions
-                .get(func.name.as_str())
-                .cloned()
+                .visible_local_function_metadata(func.name.as_str())
+                .map(|metadata| metadata.signature.clone())
                 .unwrap_or_else(|| register_local_function_symbol(func, ctx));
 
             reject_unsupported_nested_async_generator(func, ft.return_type.as_ref(), ctx);

--- a/crates/sifr_lowering/src/lower/typing_and_functions/signatures_and_effects.rs
+++ b/crates/sifr_lowering/src/lower/typing_and_functions/signatures_and_effects.rs
@@ -606,24 +606,20 @@ pub(in crate::lower) fn register_local_function_signature(
         func.is_async && !function_body_contains_yield(&func.body),
     );
     let defaults = collect_function_defaults(func, ctx);
-
-    if !defaults.is_empty() {
-        ctx.function_defaults
-            .insert(function_name.clone(), defaults);
-    }
-    ctx.scope
-        .define_function(function_name.clone(), callable_ty);
-    ctx.functions.insert(function_name.clone(), ft.clone());
-    if let Some(workload) =
-        workload_annotations::annotation_for_decorators(func.decorator_list.iter())
-    {
-        ctx.function_workload_annotations
-            .insert(function_name.clone(), workload);
-    }
-    if func.parameters.vararg.is_some() {
-        ctx.vararg_functions
-            .insert(function_name, func.parameters.args.len());
-    }
+    let binding_id = ctx.scope.define_function(function_name, callable_ty);
+    ctx.local_function_metadata.insert(
+        binding_id,
+        super::super::LocalFunctionMetadata {
+            signature: ft.clone(),
+            defaults,
+            vararg_index: func
+                .parameters
+                .vararg
+                .as_ref()
+                .map(|_| func.parameters.args.len()),
+            workload: workload_annotations::annotation_for_decorators(func.decorator_list.iter()),
+        },
+    );
 
     ft
 }
@@ -632,10 +628,8 @@ pub(in crate::lower) fn register_local_function_symbol(
     func: &StmtFunctionDef,
     ctx: &mut LowerCtx,
 ) -> FunctionType {
-    if let Some(existing) = ctx.functions.get(func.name.as_str()) {
-        if ctx.scope.lookup(func.name.as_str()).is_some() {
-            return existing.clone();
-        }
+    if let Some(existing) = ctx.visible_local_function_metadata(func.name.as_str()) {
+        return existing.signature.clone();
     }
 
     register_local_function_signature(func, extract_function_type(func, ctx), ctx)

--- a/crates/sifr_lowering/src/lower/workload_annotations.rs
+++ b/crates/sifr_lowering/src/lower/workload_annotations.rs
@@ -101,7 +101,7 @@ pub(in crate::lower) fn reject_async_direct_call(
     if !ctx.current_function_is_async {
         return;
     }
-    let Some(workload) = ctx.function_workload_annotations.get(function).copied() else {
+    let Some(workload) = declared_workload(ctx, function) else {
         return;
     };
     ctx.error_with_code_at(
@@ -164,9 +164,7 @@ pub(in crate::lower) fn reject_unclassified_offload_target(
         );
         return true;
     };
-    if ctx.function_workload_annotations.contains_key(function)
-        || known_stdlib_offload_target(function).is_some()
-    {
+    if offload_workload(ctx, function).is_some() {
         return false;
     }
     ctx.error_with_code_at(
@@ -196,11 +194,7 @@ pub(in crate::lower) fn reject_offload_target_without_kind(
         );
         return true;
     };
-    let actual = ctx
-        .function_workload_annotations
-        .get(function)
-        .copied()
-        .or_else(|| known_stdlib_offload_target(function));
+    let actual = offload_workload(ctx, function);
     let Some(actual) = actual else {
         ctx.error_with_code_at(
             DiagnosticCode::ASYNC_UNCLASSIFIED_BLOCKING_OFFLOAD_TARGET,
@@ -226,6 +220,27 @@ pub(in crate::lower) fn reject_offload_target_without_kind(
         return true;
     }
     false
+}
+
+fn declared_workload(ctx: &LowerCtx, function: &str) -> Option<WorkloadKind> {
+    if ctx.scope.lookup(function).is_some() {
+        return ctx
+            .visible_local_function_metadata(function)
+            .and_then(|metadata| metadata.workload);
+    }
+    ctx.function_workload_annotations.get(function).copied()
+}
+
+fn offload_workload(ctx: &LowerCtx, function: &str) -> Option<WorkloadKind> {
+    if ctx.scope.lookup(function).is_some() {
+        return ctx
+            .visible_local_function_metadata(function)
+            .and_then(|metadata| metadata.workload);
+    }
+    ctx.function_workload_annotations
+        .get(function)
+        .copied()
+        .or_else(|| known_stdlib_offload_target(function))
 }
 
 fn target_name(target: &Expr) -> Option<&str> {

--- a/crates/sifr_lowering/src/scope.rs
+++ b/crates/sifr_lowering/src/scope.rs
@@ -207,8 +207,8 @@ impl Scope {
     }
 
     /// Define a local function so callable dispatch can preserve its defaults.
-    pub fn define_function(&mut self, name: String, ty: Type) {
-        self.define_binding(name, ty, true, BindingKind::Function, true);
+    pub fn define_function(&mut self, name: String, ty: Type) -> BindingId {
+        self.define_binding_with_taint(name, ty, true, BindingKind::Function, true, None)
     }
 
     /// Define an immutable module-level value that codegen re-materializes on access.


### PR DESCRIPTION
## Summary
- key nested-function metadata by lexical binding identity
- preserve full parameter shape during nested-function inference
- restore codegen callable metadata at scoped block boundaries
- add lowering, codegen, and native regressions for same-named helpers

## Validation
- `cargo test -q -p sifr_lowering --lib`
- `cargo test -q -p sifr_codegen --lib`
- `cargo clippy -q -p sifr_lowering -p sifr_codegen -- -D warnings`
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `python3 scripts/check_file_size_guardrails.py`
- `git diff --check`
- native fixture `nested_function_signature_scope.sifr`