### PR TITLE
Preserve child upcasts through nominal relocation

### DIFF
--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -392,6 +392,11 @@ pub fn generate_rust_multi_with_metadata(
             module_name,
             &stdlib_nominal_plan,
             &crate_root_modules,
+            &module
+                .classes
+                .iter()
+                .map(|class| source_class_rust_name(&class.name))
+                .collect(),
         );
         let imports = [local_imports, union_imports]
             .into_iter()

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -125,6 +125,11 @@ pub fn generate_rust_test_project_with_metadata(
             module_name,
             &stdlib_nominal_plan,
             &crate_root_modules,
+            &module
+                .classes
+                .iter()
+                .map(|class| sifr_type_system::source_class_rust_name(&class.name))
+                .collect(),
         );
         support_rust_files.insert(
             (*module_name).to_string(),

--- a/crates/sifr_codegen/src/project_stdlib_nominals.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals.rs
@@ -1,6 +1,6 @@
 use crate::stdlib_filter::{
     partition_rust_items_by_name, rust_source_defined_item_names, rust_source_references_item_name,
-    strip_rust_items_by_name,
+    strip_relocated_rust_items_by_name, strip_rust_items_by_name,
 };
 use crate::{
     build_error_into_error_impl, generate_rust_with_stdlib_for_module_with_structural_policy,
@@ -61,6 +61,7 @@ pub(crate) fn relocate_project_stdlib_nominals(
     module_name: &str,
     plan: &ProjectStdlibNominalPlan,
     crate_root_modules: &HashSet<&str>,
+    local_class_rust_names: &HashSet<String>,
 ) -> String {
     if plan.registry.shared_rust_names.is_empty() && plan.registry.crate_root_rust_names.is_empty()
     {
@@ -73,7 +74,7 @@ pub(crate) fn relocate_project_stdlib_nominals(
         .chain(&plan.registry.crate_root_rust_names)
         .map(String::as_str)
         .collect();
-    let stripped = strip_rust_items_by_name(source, &names);
+    let stripped = strip_relocated_rust_items_by_name(source, &names, local_class_rust_names);
     if crate_root_modules.contains(module_name) {
         return stripped;
     }
@@ -806,5 +807,35 @@ mod tests {
             .contains("FileNotFoundError"));
         syn::parse_file(&generated.project_union_prelude)
             .expect("project nominal prelude should not contain a dangling re-export");
+    }
+
+    #[test]
+    fn relocation_retains_local_child_conversion_into_shared_parent() {
+        let mut plan = ProjectStdlibNominalPlan::empty();
+        plan.registry.register_shared(
+            "sifr.logging.Formatter".to_string(),
+            "Formatter".to_string(),
+        );
+        let source = r#"
+struct Formatter { template: String }
+struct ChildFormatter { formatter: Formatter }
+
+impl From<ChildFormatter> for Formatter {
+    fn from(value: ChildFormatter) -> Self { value.formatter }
+}
+"#;
+
+        let relocated = relocate_project_stdlib_nominals(
+            source,
+            "main",
+            &plan,
+            &HashSet::from(["main"]),
+            &HashSet::from(["ChildFormatter".to_string()]),
+        );
+
+        assert!(!relocated.contains("struct Formatter"));
+        assert!(relocated.contains("struct ChildFormatter"));
+        assert!(relocated.contains("From<ChildFormatter> for Formatter"));
+        syn::parse_file(&relocated).expect("retained local-child conversion should parse");
     }
 }

--- a/crates/sifr_codegen/src/stdlib_filter.rs
+++ b/crates/sifr_codegen/src/stdlib_filter.rs
@@ -1,4 +1,6 @@
 mod implementation;
 pub(crate) use implementation::*;
+mod relocation;
+pub(crate) use relocation::*;
 #[cfg(test)]
 mod tests;

--- a/crates/sifr_codegen/src/stdlib_filter/relocation.rs
+++ b/crates/sifr_codegen/src/stdlib_filter/relocation.rs
@@ -1,0 +1,62 @@
+use std::collections::HashSet;
+use syn::{GenericArgument, Item, PathArguments, Type};
+
+/// Remove relocated nominal items while retaining a local child's conversion
+/// into the canonical parent that replaces the removed definition.
+pub(crate) fn strip_relocated_rust_items_by_name(
+    rust_code: &str,
+    names: &HashSet<&str>,
+    local_conversion_sources: &HashSet<String>,
+) -> String {
+    let Ok(parsed) = syn::parse_file(rust_code) else {
+        return rust_code.to_string();
+    };
+    let kept_items = parsed
+        .items
+        .into_iter()
+        .filter(|item| {
+            let Some(name) = super::parse_item_name(item) else {
+                return true;
+            };
+            !names.contains(name.as_str())
+                || is_local_child_into_relocated_parent(item, local_conversion_sources, names)
+        })
+        .collect::<Vec<_>>();
+    super::render_items(&kept_items)
+}
+
+fn is_local_child_into_relocated_parent(
+    item: &Item,
+    local_conversion_sources: &HashSet<String>,
+    relocated_names: &HashSet<&str>,
+) -> bool {
+    let Item::Impl(item_impl) = item else {
+        return false;
+    };
+    let Some((_, trait_path, _)) = &item_impl.trait_ else {
+        return false;
+    };
+    let Some(segment) = trait_path
+        .segments
+        .last()
+        .filter(|segment| segment.ident == "From")
+    else {
+        return false;
+    };
+    let PathArguments::AngleBracketed(arguments) = &segment.arguments else {
+        return false;
+    };
+    let Some(GenericArgument::Type(Type::Path(source))) = arguments.args.first() else {
+        return false;
+    };
+    let Some(source_name) = source
+        .path
+        .segments
+        .last()
+        .map(|segment| segment.ident.to_string())
+    else {
+        return false;
+    };
+    local_conversion_sources.contains(&source_name)
+        && !relocated_names.contains(source_name.as_str())
+}

--- a/crates/sifr_codegen/src/stdlib_filter/tests.rs
+++ b/crates/sifr_codegen/src/stdlib_filter/tests.rs
@@ -2,6 +2,46 @@ use super::*;
 use std::collections::HashSet;
 
 #[test]
+fn relocation_keeps_local_child_conversion_into_canonical_parent() {
+    let code = r#"
+struct Parent {}
+struct RelocatedChild {}
+struct LocalChild {}
+
+impl Parent {
+    fn inherited() {}
+}
+
+impl From<String> for Parent {
+    fn from(_value: String) -> Self { Parent {} }
+}
+
+impl From<RelocatedChild> for Parent {
+    fn from(_value: RelocatedChild) -> Self { Parent {} }
+}
+
+impl From<LocalChild> for Parent {
+    fn from(_value: LocalChild) -> Self { Parent {} }
+}
+"#;
+    let relocated = HashSet::from(["Parent", "RelocatedChild"]);
+
+    let stripped = strip_relocated_rust_items_by_name(
+        code,
+        &relocated,
+        &HashSet::from(["LocalChild".to_string()]),
+    );
+
+    assert!(!stripped.contains("struct Parent"));
+    assert!(!stripped.contains("struct RelocatedChild"));
+    assert!(!stripped.contains("fn inherited"));
+    assert!(!stripped.contains("From<String>"));
+    assert!(!stripped.contains("From<RelocatedChild>"));
+    assert!(stripped.contains("struct LocalChild"));
+    assert!(stripped.contains("From<LocalChild> for Parent"));
+}
+
+#[test]
 fn filter_keeps_transitive_dependencies_in_item_order() {
     let code = r#"
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary
- retain a user child's `From<Child>` conversion when its checked-stdlib parent moves to the project nominal prelude
- remove parent-owned conversions and relocated child conversions as before
- derive eligible conversion sources from exact HIR user classes
- add focused relocation and project-plan regressions

## Validation
- 1,132 codegen unit tests passed
- `nominal_identity_alias_paths.sifr` built and ran release-native
- strict codegen Clippy
- formatting, HIR maintainability, file-size, and diff checks