### PR TITLE
Match user error parent handlers by ancestry

### DIFF
--- a/crates/sifr/tests/e2e/pass/try_user_error_parent_handler.sifr
+++ b/crates/sifr/tests/e2e/pass/try_user_error_parent_handler.sifr
@@ -1,0 +1,58 @@
+class BaseError(Error):
+    message: str
+
+
+class ChildError(BaseError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class OtherError(Error):
+    message: str
+
+
+def classify(child: bool) -> Result[str, ChildError | OtherError]:
+    if child:
+        raise ChildError("child")
+    raise OtherError("other")
+
+
+def handle_child() -> str:
+    try:
+        value: str = classify(True)
+        return value
+    except BaseError as error:
+        return "base:" + error.message
+    except OtherError as error:
+        return "other:" + error.message
+
+
+def handle_other() -> str:
+    try:
+        value: str = classify(False)
+        return value
+    except BaseError as error:
+        return "wrong:" + error.message
+    except OtherError as error:
+        return "other:" + error.message
+
+
+def propagate_other() -> Result[str, OtherError]:
+    try:
+        value: str = classify(False)
+        return value
+    except BaseError as error:
+        return "wrong:" + error.message
+
+
+def main() -> None:
+    assert handle_child() == "base:child"
+    assert handle_other() == "other:other"
+    try:
+        _: str = propagate_other()
+        assert False
+    except OtherError as error:
+        assert error.message == "other"
+
+
+main()

--- a/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
@@ -474,3 +474,36 @@ def classify(flag: bool) -> Result[str, IOError | ValueError]:
     assert!(!generated.contains("structured statement emission missing"));
     syn::parse_file(&generated).expect("union residual Rust should parse");
 }
+
+#[test]
+fn user_error_parent_handler_converts_child_and_preserves_unrelated_residual() {
+    let generated = generate_rust_from_source(
+        r#"
+class BaseError(Error):
+    message: str
+
+class ChildError(BaseError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+class OtherError(Error):
+    message: str
+
+def classify(flag: bool) -> Result[str, ChildError | OtherError]:
+    if flag:
+        raise ChildError("child")
+    raise OtherError("other")
+
+def handle(flag: bool) -> Result[str, OtherError]:
+    try:
+        value: str = classify(flag)
+        return value
+    except BaseError as error:
+        return error.message
+"#,
+    );
+
+    assert!(generated.contains("Into::<BaseError>::into(__sifr_try_variant_error.clone())"));
+    assert!(generated.contains("return Err(__sifr_try_variant_error);"));
+    syn::parse_file(&generated).expect("user error parent-handler Rust should parse");
+}

--- a/crates/sifr_codegen/src/stmt_support_emitter/try_handlers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/try_handlers.rs
@@ -9,6 +9,7 @@ impl RustEmitter {
         handler: &HirExceptHandler,
         err_ident: &str,
         err_ty: &str,
+        source_error_type: Option<&Type>,
     ) -> HandlerMatchCondition {
         let Some(error_type) = handler.error_type.as_deref() else {
             return HandlerMatchCondition::Always;
@@ -42,6 +43,14 @@ impl RustEmitter {
             .error_resolved_type
             .as_ref()
             .map(|ty| crate::render_type(&crate::sifr_type_to_rust_type(ty)));
+        if let Some((source, target)) = source_error_type.zip(handler.error_resolved_type.as_ref())
+        {
+            return if source.is_assignable_to(target) {
+                HandlerMatchCondition::Always
+            } else {
+                HandlerMatchCondition::Unsupported
+            };
+        }
         if resolved_error_type.as_deref() == Some(err_ty) || error_type == err_ty {
             return HandlerMatchCondition::Always;
         }
@@ -97,7 +106,12 @@ impl RustEmitter {
     ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
         let mut branches: Vec<(Option<RustExpr>, Vec<RustStmt>)> = Vec::new();
         for handler in handlers {
-            let condition = Self::try_except_handler_condition_expr(handler, err_ident, err_ty);
+            let condition = Self::try_except_handler_condition_expr(
+                handler,
+                err_ident,
+                err_ty,
+                source_error_type,
+            );
             if matches!(condition, HandlerMatchCondition::Unsupported) {
                 continue;
             }
@@ -237,5 +251,53 @@ impl RustEmitter {
             func: Box::new(RustExpr::Ident("Err".to_string())),
             args: vec![converted],
         })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn error(identity: &str, name: &str, parent_class: Option<&str>) -> Type {
+        Type::Class {
+            identity: Some(identity.to_string()),
+            type_args: Vec::new(),
+            name: name.to_string(),
+            fields: vec![("message".to_string(), Type::Str)],
+            methods: Vec::new(),
+            parent_class: parent_class.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn handler_matching_uses_exact_user_error_ancestry() {
+        let base = error("pkg.BaseError", "BaseError", Some("Error"));
+        let child = error("pkg.ChildError", "ChildError", Some("pkg.BaseError|Error"));
+        let unrelated = error("other.BaseError", "BaseError", Some("Error"));
+        let handler = HirExceptHandler {
+            error_type: Some("BaseError".to_string()),
+            error_resolved_type: Some(base),
+            name: Some("error".to_string()),
+            body: Vec::new(),
+        };
+
+        assert!(matches!(
+            RustEmitter::try_except_handler_condition_expr(
+                &handler,
+                "error",
+                "ChildError",
+                Some(&child),
+            ),
+            HandlerMatchCondition::Always
+        ));
+        assert!(matches!(
+            RustEmitter::try_except_handler_condition_expr(
+                &handler,
+                "error",
+                "BaseError",
+                Some(&unrelated),
+            ),
+            HandlerMatchCondition::Unsupported
+        ));
     }
 }

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -10,8 +10,8 @@ use super::super::declared_class_identity;
 use super::async_await::coroutine_result_type;
 use super::class_field_inference::collect_constructor_self_field_assignments;
 use super::diagnostics::{
-    collect_enum_variants, get_newtype_inner, has_decorator, is_enum_class, is_error_class,
-    is_protocol_class,
+    collect_enum_variants, get_newtype_inner, has_decorator, is_enum_class,
+    is_error_class_with_ctx, is_protocol_class,
 };
 use super::parameter_conventions::{
     class_declared_method_param_convention, class_method_param_convention,
@@ -112,7 +112,7 @@ pub(in crate::lower) fn collect_class_type(
     let mut fields: Vec<(String, Type)> = Vec::new();
     let mut methods: Vec<(String, FunctionType)> = Vec::new();
     let mut method_ranges: HashMap<String, ruff_text_size::TextRange> = HashMap::new();
-    let is_error = is_error_class(class_def);
+    let is_error = is_error_class_with_ctx(class_def, &ctx.error_types);
     let is_protocol = is_protocol_class(class_def);
     let newtype_inner = get_newtype_inner(class_def);
 

--- a/crates/sifr_lowering/src/lower/diagnostics.rs
+++ b/crates/sifr_lowering/src/lower/diagnostics.rs
@@ -6,7 +6,6 @@ use sifr_type_system::Type;
 
 use super::LowerCtx;
 
-#[allow(dead_code)]
 pub(in crate::lower) fn is_error_class_with_ctx(
     class_def: &StmtClassDef,
     error_types: &std::collections::HashSet<String>,
@@ -15,18 +14,6 @@ pub(in crate::lower) fn is_error_class_with_ctx(
         if let Expr::Name(n) = base {
             let base_name = n.id.as_str();
             if base_name == "Error" || error_types.contains(base_name) {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// Check if a class definition has `(Error)` as its base class.
-pub(in crate::lower) fn is_error_class(class_def: &StmtClassDef) -> bool {
-    for base in class_def.bases() {
-        if let Expr::Name(n) = base {
-            if n.id.as_str() == "Error" {
                 return true;
             }
         }

--- a/crates/sifr_lowering/src/lower/statement_diagnostics_tests.rs
+++ b/crates/sifr_lowering/src/lower/statement_diagnostics_tests.rs
@@ -240,6 +240,26 @@ def outer() -> str:
 }
 
 #[test]
+fn user_error_parent_handler_covers_its_child() {
+    let source = r#"
+class BaseError(Error):
+    message: str
+
+class ChildError(BaseError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+def classify() -> str:
+    try:
+        raise ChildError("child")
+    except BaseError as error:
+        return error.message
+"#;
+    let parsed = parse_module(source).expect("parse failed");
+    lower_module(parsed.suite()).expect("the parent handler should cover the child error");
+}
+
+#[test]
 fn try_finally_without_except_preserves_cleanup_boundary() {
     let source = "\
 def main():


### PR DESCRIPTION
## Summary
- recognize transitive user-defined error subclasses through the canonical error registry
- match handlers with exact nominal ancestry when resolved source and target types are available
- convert child bindings to the declared parent and preserve unrelated residuals
- add lowering, codegen, exact-identity, and native regressions

## Validation
- 1,039 lowering tests passed; one ignored
- 1,134 codegen tests passed
- new `try_user_error_parent_handler.sifr` release-native pass
- existing `imported_error_not_catch_all.sifr` release-native pass
- strict targeted Clippy, fmt, HIR maintainability, file-size, and diff checks