### PR TITLE
Preserve nested helper receiver mutation

### DIFF
--- a/crates/sifr/tests/e2e/pass/nested_helper_receiver_mutation.sifr
+++ b/crates/sifr/tests/e2e/pass/nested_helper_receiver_mutation.sifr
@@ -1,0 +1,26 @@
+class Bucket:
+    values: list[int]
+
+    def __init__(self) -> None:
+        self.values = []
+
+    def update(mut self) -> None:
+        def helper(values: list[int]) -> None:
+            values.append(1)
+
+        helper(self.values)
+
+    def size(self) -> int:
+        def helper(values: list[int]) -> int:
+            return len(values)
+
+        return helper(self.values)
+
+
+def main() -> None:
+    bucket = Bucket()
+    bucket.update()
+    assert bucket.size() == 1
+
+
+main()

--- a/crates/sifr_codegen/src/lib_codegen_tests/receiver_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/receiver_codegen_tests.rs
@@ -80,6 +80,39 @@ fn test_mut_on_local_nested_function_mutborrow_call_argument() {
 }
 
 #[test]
+fn nested_helper_receiver_mutation_uses_lexical_call_metadata() {
+    let rust_code = generate_rust_from_source(
+        r#"
+class Bucket:
+    values: list[int]
+
+    def __init__(self) -> None:
+        self.values = []
+
+    def update(mut self) -> None:
+        def helper(values: list[int]) -> None:
+            values.append(1)
+
+        helper(self.values)
+
+    def size(self) -> int:
+        def helper(values: list[int]) -> int:
+            return len(values)
+
+        return helper(self.values)
+"#,
+    );
+
+    assert!(rust_code.contains("fn update(&mut self)"), "{rust_code}");
+    assert!(
+        rust_code.contains("helper(&mut self.values)"),
+        "{rust_code}"
+    );
+    assert!(rust_code.contains("fn size(&self) -> i64"), "{rust_code}");
+    assert!(rust_code.contains("helper(&self.values)"), "{rust_code}");
+}
+
+#[test]
 fn explicit_class_receiver_signatures_are_emitted_from_hir_metadata() {
     let rust_code = generate_rust_from_source(
         r#"

--- a/crates/sifr_lowering/src/lower/method_receiver_analysis.rs
+++ b/crates/sifr_lowering/src/lower/method_receiver_analysis.rs
@@ -184,17 +184,20 @@ fn collect_method_facts(
                 call_mutates_receiver = true;
             }
         }
-        HirExpr::Call { func, args, .. } => {
+        HirExpr::Call {
+            func,
+            args,
+            mutable_arg_places,
+            ..
+        } => {
             if func == "anext" && args.first().is_some_and(|arg| receiver_rooted(arg, ctx)) {
                 call_mutates_receiver = true;
             }
-            if ctx.functions.get(func).is_some_and(|signature| {
-                args.iter()
-                    .zip(&signature.params)
-                    .any(|(arg, (_, _, convention))| {
-                        convention.is_mut_borrow() && receiver_rooted(arg, ctx)
-                    })
-            }) {
+            if args
+                .iter()
+                .zip(mutable_arg_places)
+                .any(|(arg, target)| target.is_some() && receiver_rooted(arg, ctx))
+            {
                 call_mutates_receiver = true;
             }
         }

--- a/crates/sifr_lowering/src/lower/method_receiver_nested_helper_tests.rs
+++ b/crates/sifr_lowering/src/lower/method_receiver_nested_helper_tests.rs
@@ -1,0 +1,84 @@
+use crate::{lower_module, HirExpr, HirFunction, HirModule, HirStmt};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_parser::parse_module;
+use sifr_type_system::ReceiverConvention;
+
+fn lower(source: &str) -> HirModule {
+    let parsed = parse_module(source).expect("source should parse");
+    lower_module(parsed.suite())
+        .expect("source should lower")
+        .module
+}
+
+fn method<'a>(module: &'a HirModule, class: &str, name: &str) -> &'a HirFunction {
+    module
+        .classes
+        .iter()
+        .find(|candidate| candidate.name == class)
+        .and_then(|class| {
+            class
+                .methods
+                .iter()
+                .find(|candidate| candidate.name == name)
+        })
+        .expect("method should exist")
+}
+
+#[test]
+fn nested_mutating_helper_requires_a_mutable_method_receiver() {
+    let source = r#"
+class Bucket:
+    values: list[int]
+
+    def update(self) -> None:
+        def helper(values: list[int]) -> None:
+            values.append(1)
+
+        helper(self.values)
+"#;
+    let parsed = parse_module(source).expect("source should parse");
+    let errors = match lower_module(parsed.suite()) {
+        Ok(_) => panic!("nested mutable call must require mut self"),
+        Err(errors) => errors,
+    };
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::OWN_IMMUTABLE_PARAMETER_MUTATION)
+            && error.message.contains("self")
+    }));
+}
+
+#[test]
+fn nested_helper_receiver_analysis_uses_checked_lexical_call_metadata() {
+    let source = r#"
+class Bucket:
+    values: list[int]
+
+    def update(mut self) -> None:
+        def helper(values: list[int]) -> None:
+            values.append(1)
+
+        helper(self.values)
+
+    def size(self) -> int:
+        def helper(values: list[int]) -> int:
+            return len(values)
+
+        return helper(self.values)
+"#;
+    let module = lower(source);
+    let update = method(&module, "Bucket", "update");
+    let size = method(&module, "Bucket", "size");
+
+    assert_eq!(update.receiver, Some(ReceiverConvention::MutableBorrow));
+    assert_eq!(size.receiver, Some(ReceiverConvention::SharedBorrow));
+    let HirStmt::Expr {
+        expr: HirExpr::Call {
+            mutable_arg_places, ..
+        },
+    } = &update.body[1]
+    else {
+        panic!("nested helper call should remain in the method body");
+    };
+    assert!(mutable_arg_places[0].is_some());
+}

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -101,6 +101,8 @@ mod method_receiver_diagnostics;
 mod method_receiver_diagnostics_tests;
 #[cfg(test)]
 mod method_receiver_footprint_tests;
+#[cfg(test)]
+mod method_receiver_nested_helper_tests;
 mod method_receiver_places;
 mod min_max_validation;
 mod mod_impl;


### PR DESCRIPTION
Closes phase Item 10N. Method receiver analysis now consumes checked per-call mutable-place metadata resolved from the lexical callable binding, instead of re-looking up plain calls in the module function map. Adds focused lowering/codegen regressions and a native sibling-helper fixture. Exact-SHA Opus review and the single permitted gates will be attached.