### PR TITLE
Isolate nested try-finally discovery

### DIFF
--- a/crates/sifr/tests/e2e/pass/try_finally_nested_function_error_discovery.sifr
+++ b/crates/sifr/tests/e2e/pass/try_finally_nested_function_error_discovery.sifr
@@ -1,0 +1,46 @@
+def fail_value() -> Result[int, ValueError]:
+    raise ValueError("local")
+
+
+def run_sync() -> None:
+    try:
+        def inner() -> None:
+            try:
+                try:
+                    _: int = fail_value()
+                    assert False
+                except ValueError as error:
+                    assert error.message == "local"
+            finally:
+                marker: int = 1
+                assert marker == 1
+
+        inner()
+    finally:
+        marker: int = 2
+        assert marker == 2
+
+
+async def run_async() -> None:
+    try:
+        async def inner() -> None:
+            await task.sleep(0.0)
+            try:
+                try:
+                    _: int = fail_value()
+                    assert False
+                except ValueError as error:
+                    assert error.message == "local"
+            finally:
+                marker: int = 1
+                assert marker == 1
+
+        await inner()
+    finally:
+        marker: int = 2
+        assert marker == 2
+
+
+async def main() -> None:
+    run_sync()
+    await run_async()

--- a/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/sequential_try_binding_codegen_tests.rs
@@ -97,6 +97,58 @@ def run() -> None:
 }
 
 #[test]
+fn nested_function_errors_do_not_select_enclosing_try_finally_carriers() {
+    let generated = generate_rust_from_source(
+        r#"
+def fail_value() -> Result[int, ValueError]:
+    raise ValueError("local")
+
+def run_sync() -> None:
+    try:
+        def inner() -> None:
+            try:
+                try:
+                    _: int = fail_value()
+                except ValueError:
+                    pass
+            finally:
+                marker: int = 1
+
+        inner()
+    finally:
+        marker: int = 2
+
+async def run_async() -> None:
+    try:
+        async def inner() -> None:
+            try:
+                try:
+                    _: int = fail_value()
+                except ValueError:
+                    pass
+            finally:
+                marker: int = 1
+
+        await inner()
+    finally:
+        marker: int = 2
+"#,
+    );
+
+    assert_eq!(
+        generated.matches("Result<(), ()>").count(),
+        2,
+        "{generated}"
+    );
+    assert_eq!(
+        generated.matches("Result<(), ValueError>").count(),
+        4,
+        "{generated}"
+    );
+    syn::parse_file(&generated).expect("nested try/finally discovery Rust should parse");
+}
+
+#[test]
 fn try_body_return_and_fallthrough_binding_use_distinct_carriers() {
     let generated = generate_rust_from_source(&format!(
         r#"{PROBE_ERROR}

--- a/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
@@ -658,7 +658,7 @@ impl RustEmitter {
                 first_try_error_type_in_stmts(body)
                     .or_else(|| first_try_error_type_in_stmts(finalbody))
             })
-            .unwrap_or_else(|| "Error".to_string())
+            .unwrap_or_else(|| "()".to_string())
     }
 
     pub(crate) fn try_lower_try_finally_stmt_for_ir(

--- a/crates/sifr_codegen/src/stmt_support_emitter/try_error_helpers.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/try_error_helpers.rs
@@ -131,7 +131,7 @@ fn first_try_error_type_in_stmt(stmt: &HirStmt) -> Option<String> {
         HirStmt::With { body, .. }
         | HirStmt::AsyncWith { body, .. }
         | HirStmt::AsyncFor { body, .. } => first_try_error_type_in_stmts(body),
-        HirStmt::NestedFunction { func, .. } => first_try_error_type_in_stmts(&func.body),
+        HirStmt::NestedFunction { .. } => None,
         HirStmt::Match { arms, .. } => arms
             .iter()
             .find_map(|arm| first_try_error_type_in_stmts(&arm.body)),


### PR DESCRIPTION
Closes phase Item 10O. Enclosing try/finally carrier discovery now treats nested functions as scope boundaries, while nested bodies still discover their own errors when emitted. Infallible try/finally uses unit instead of an undefined Error fallback. Adds sync/async codegen regressions and a native fixture. Exact-SHA Opus review and the single permitted gates will be attached.