### PR TITLE
fix: emit canonical generated Rust traits

### DIFF
--- a/crates/sifr_codegen/src/class_emitter.rs
+++ b/crates/sifr_codegen/src/class_emitter.rs
@@ -691,12 +691,42 @@ impl RustEmitter {
         }
         self.current_class_name = saved_class_name;
         if !constructor_items.is_empty() {
+            let constructor_type_params =
+                Self::class_constructor_impl_type_params(class, &constructor_items);
+            let has_zero_argument_constructor = constructor_items.iter().any(|item| {
+                matches!(
+                    item,
+                    RustItem::Fn { name, params, .. } if name == "new" && params.is_empty()
+                )
+            });
             self.body_items.push(RustItem::Impl {
                 target: Self::class_impl_target(class),
-                type_params: Self::class_constructor_impl_type_params(class, &constructor_items),
+                type_params: constructor_type_params.clone(),
                 trait_: None,
                 items: constructor_items,
             });
+            if has_zero_argument_constructor {
+                self.body_items.push(RustItem::Impl {
+                    target: Self::class_impl_target(class),
+                    type_params: constructor_type_params,
+                    trait_: Some("std::default::Default".to_string()),
+                    items: vec![RustItem::Fn {
+                        name: "default".to_string(),
+                        visibility: Visibility::Private,
+                        type_params: Vec::new(),
+                        params: Vec::new(),
+                        ret: Some(RustType::Named("Self".to_string())),
+                        body: vec![RustStmt::Return(Some(RustExpr::FnCall {
+                            func: Box::new(RustExpr::Path(vec![
+                                "Self".to_string(),
+                                "new".to_string(),
+                            ])),
+                            args: Vec::new(),
+                        }))],
+                        is_async: false,
+                    }],
+                });
+            }
         }
         if method_items.is_empty() && class.type_params.is_empty() {
             self.body_items.push(RustItem::Impl {

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -51,6 +51,8 @@ mod async_task_runtime_codegen_tests;
 #[cfg(test)]
 mod class_trait_codegen_tests;
 #[cfg(test)]
+mod class_trait_contract_codegen_tests;
+#[cfg(test)]
 mod classes_and_basics_codegen_tests;
 #[cfg(test)]
 mod collections_and_stdlib_codegen_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/class_trait_contract_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/class_trait_contract_codegen_tests.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+#[test]
+fn zero_argument_constructor_implements_default_by_delegation() {
+    let rust_code = generate_rust_from_source(
+        r#"class Marker:
+    pass
+
+class Explicit:
+    def __init__(self) -> None:
+        pass
+"#,
+    );
+
+    for class_name in ["Marker", "Explicit"] {
+        assert!(
+            rust_code.contains(&format!("impl ::std::default::Default for {class_name} {{")),
+            "{rust_code}"
+        );
+        assert!(
+            rust_code.contains("fn default() -> Self {\n        Self::new()"),
+            "{rust_code}"
+        );
+    }
+    assert_eq!(rust_code.matches("fn new() -> Self {").count(), 2);
+    assert_eq!(rust_code.matches("fn default() -> Self {").count(), 2);
+}
+
+#[test]
+fn sync_channel_runtime_exposes_clone_only_through_clone_trait() {
+    let runtime = crate::lib_runtime_needs::sync_channel_runtime_rust_code();
+
+    assert!(runtime.contains("impl<T: Clone> Clone for Channel<T>"));
+    assert!(runtime.contains("impl<T: Clone> Clone for ChannelSender<T>"));
+    assert!(!runtime.contains("fn clone(&self) -> Channel<T>"));
+    assert!(!runtime.contains("fn clone(&self) -> ChannelSender<T>"));
+}

--- a/crates/sifr_codegen/src/lib_runtime_needs.rs
+++ b/crates/sifr_codegen/src/lib_runtime_needs.rs
@@ -100,10 +100,6 @@ impl<T: Clone> Channel<T> {
         self._recv_notify.notify_waiters();
     }
 
-    fn clone(&self) -> Channel<T> {
-        return Clone::clone(self);
-    }
-
     fn register_sender(&self) {
         self.with_state(|state| {
             state.sender_count += 1;
@@ -213,10 +209,6 @@ impl<T: Clone> ChannelSender<T> {
 
     fn close(&mut self) {
         self._channel.close();
-    }
-
-    fn clone(&self) -> ChannelSender<T> {
-        return ChannelSender::new(self._channel.clone());
     }
 }
 

--- a/demos/additional_modules/emitted.rs
+++ b/demos/additional_modules/emitted.rs
@@ -1356,6 +1356,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1926,6 +1931,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1974,6 +1984,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/advanced_class_libraries/emitted.rs
+++ b/demos/advanced_class_libraries/emitted.rs
@@ -1836,6 +1836,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -2406,6 +2411,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2454,6 +2464,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/class_libraries/emitted.rs
+++ b/demos/class_libraries/emitted.rs
@@ -239,6 +239,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2egraphlib_x2eTopologicalSorter {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2egraphlib_x2eTopologicalSorter {
         pub fn _record_node(&mut self, node: i64) {
             if !(_contains_int(&self.nodes, node)) {
@@ -1883,6 +1888,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -2453,6 +2463,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2501,6 +2516,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/codegen_preamble/emitted.rs
+++ b/demos/codegen_preamble/emitted.rs
@@ -1355,6 +1355,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1925,6 +1930,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1973,6 +1983,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/collections_and_argparse/emitted.rs
+++ b/demos/collections_and_argparse/emitted.rs
@@ -93,6 +93,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eargparse_x2eNamespace {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eargparse_x2eNamespace {
         pub fn set(&mut self, name: &String, value: &String) {
             let mut updated: Vec<(String, String)> = vec![];

--- a/demos/config_json_csv/emitted.rs
+++ b/demos/config_json_csv/emitted.rs
@@ -1358,6 +1358,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1928,6 +1933,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1976,6 +1986,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {
@@ -3709,6 +3724,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2ecsv_x2eDialectRegistry {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2ecsv_x2eDialectRegistry {
         pub fn register(
             &mut self,
@@ -4457,6 +4477,11 @@ mod __sifr_project_nominals {
     impl __SifrStdlib_sifr_x2ejson_x2eJSONDecoder {
         pub fn new() -> Self {
             Self {}
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2ejson_x2eJSONDecoder {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2ejson_x2eJSONDecoder {

--- a/demos/core_stdlib/emitted.rs
+++ b/demos/core_stdlib/emitted.rs
@@ -1394,6 +1394,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1964,6 +1969,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2012,6 +2022,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/csv/emitted.rs
+++ b/demos/csv/emitted.rs
@@ -1355,6 +1355,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1925,6 +1930,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1973,6 +1983,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/decimal_conversions/emitted.rs
+++ b/demos/decimal_conversions/emitted.rs
@@ -1398,6 +1398,11 @@ impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         }
     }
 }
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl __SifrStdlib_sifr_x2eio_x2eIOBase {
     fn close(&mut self) {
         self._closed = true;
@@ -1968,6 +1973,11 @@ impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         }
     }
 }
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl __SifrStdlib_sifr_x2eio_x2eTextReader {
     fn read(&self) -> Result<String, IOError> {
         Err(
@@ -2016,6 +2026,11 @@ impl __SifrStdlib_sifr_x2eio_x2eTextWriter {
         Self {
             _closed: __sifr_field_init_0,
         }
+    }
+}
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/decimal_verification/emitted.rs
+++ b/demos/decimal_verification/emitted.rs
@@ -1390,6 +1390,11 @@ impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         }
     }
 }
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl __SifrStdlib_sifr_x2eio_x2eIOBase {
     fn close(&mut self) {
         self._closed = true;
@@ -1960,6 +1965,11 @@ impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         }
     }
 }
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl __SifrStdlib_sifr_x2eio_x2eTextReader {
     fn read(&self) -> Result<String, IOError> {
         Err(
@@ -2008,6 +2018,11 @@ impl __SifrStdlib_sifr_x2eio_x2eTextWriter {
         Self {
             _closed: __sifr_field_init_0,
         }
+    }
+}
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/dependency_manifest/emitted.rs
+++ b/demos/dependency_manifest/emitted.rs
@@ -1362,6 +1362,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1932,6 +1937,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1980,6 +1990,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/error_subclasses/emitted.rs
+++ b/demos/error_subclasses/emitted.rs
@@ -1394,6 +1394,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1964,6 +1969,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2012,6 +2022,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/inheritance/emitted.rs
+++ b/demos/inheritance/emitted.rs
@@ -196,6 +196,12 @@ impl MathHelper {
     }
 }
 
+impl ::std::default::Default for MathHelper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MathHelper {
     fn clamp(value: f64, low: f64, high: f64) -> f64 {
         if value < low {

--- a/demos/iterators_and_randomness/emitted.rs
+++ b/demos/iterators_and_randomness/emitted.rs
@@ -1270,6 +1270,11 @@ impl __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
         Self {}
     }
 }
+impl ::std::default::Default for __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
     fn seed(&self, _seed_value: Option<i64>) {}
 }
@@ -1766,6 +1771,11 @@ struct Doubler {}
 impl Doubler {
     fn new() -> Self {
         Self {}
+    }
+}
+impl ::std::default::Default for Doubler {
+    fn default() -> Self {
+        Self::new()
     }
 }
 impl Doubler {

--- a/demos/json/emitted.rs
+++ b/demos/json/emitted.rs
@@ -1394,6 +1394,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1964,6 +1969,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2012,6 +2022,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/json_values/emitted.rs
+++ b/demos/json_values/emitted.rs
@@ -1394,6 +1394,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1964,6 +1969,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2012,6 +2022,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/logging/emitted.rs
+++ b/demos/logging/emitted.rs
@@ -1363,6 +1363,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1933,6 +1938,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1981,6 +1991,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/logging_and_timers/emitted.rs
+++ b/demos/logging_and_timers/emitted.rs
@@ -1363,6 +1363,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1933,6 +1938,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1981,6 +1991,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {
@@ -3285,6 +3300,11 @@ mod __sifr_project_nominals {
     impl __SifrStdlib_sifr_x2etimeit_x2eTimer {
         pub fn new() -> Self {
             Self {}
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2etimeit_x2eTimer {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2etimeit_x2eTimer {

--- a/demos/no_runtime_panics/emitted.rs
+++ b/demos/no_runtime_panics/emitted.rs
@@ -1394,6 +1394,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1964,6 +1969,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2012,6 +2022,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/ordering_rules/emitted.rs
+++ b/demos/ordering_rules/emitted.rs
@@ -1394,6 +1394,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1964,6 +1969,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2012,6 +2022,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/parse_safety/emitted.rs
+++ b/demos/parse_safety/emitted.rs
@@ -1357,6 +1357,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1927,6 +1932,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1975,6 +1985,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {
@@ -2894,6 +2909,11 @@ mod __sifr_project_nominals {
     impl __SifrStdlib_sifr_x2ejson_x2eJSONDecoder {
         pub fn new() -> Self {
             Self {}
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2ejson_x2eJSONDecoder {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2ejson_x2eJSONDecoder {

--- a/demos/python_regressions/emitted.rs
+++ b/demos/python_regressions/emitted.rs
@@ -1918,6 +1918,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -2488,6 +2493,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2536,6 +2546,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/safe_edge_cases/emitted.rs
+++ b/demos/safe_edge_cases/emitted.rs
@@ -2483,6 +2483,11 @@ impl __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
         Self {}
     }
 }
+impl ::std::default::Default for __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
     fn seed(&self, _seed_value: Option<i64>) {}
 }

--- a/demos/stdlib/emitted.rs
+++ b/demos/stdlib/emitted.rs
@@ -2107,6 +2107,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -2677,6 +2682,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2725,6 +2735,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/stdlib_expansion/emitted.rs
+++ b/demos/stdlib_expansion/emitted.rs
@@ -1712,6 +1712,11 @@ impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         }
     }
 }
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl __SifrStdlib_sifr_x2eio_x2eIOBase {
     fn close(&mut self) {
         self._closed = true;
@@ -2282,6 +2287,11 @@ impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         }
     }
 }
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl __SifrStdlib_sifr_x2eio_x2eTextReader {
     fn read(&self) -> Result<String, IOError> {
         Err(
@@ -2330,6 +2340,11 @@ impl __SifrStdlib_sifr_x2eio_x2eTextWriter {
         Self {
             _closed: __sifr_field_init_0,
         }
+    }
+}
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 impl __SifrStdlib_sifr_x2eio_x2eTextWriter {
@@ -4738,6 +4753,11 @@ struct __SifrStdlib_sifr_x2erandom_x2eSystemRandom {}
 impl __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
     fn new() -> Self {
         Self {}
+    }
+}
+impl ::std::default::Default for __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
+    fn default() -> Self {
+        Self::new()
     }
 }
 impl __SifrStdlib_sifr_x2erandom_x2eSystemRandom {

--- a/demos/stdlib_fixes/emitted.rs
+++ b/demos/stdlib_fixes/emitted.rs
@@ -1592,6 +1592,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -2162,6 +2167,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -2210,6 +2220,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/stdlib_modules/emitted.rs
+++ b/demos/stdlib_modules/emitted.rs
@@ -1590,6 +1590,11 @@ impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         }
     }
 }
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl __SifrStdlib_sifr_x2eio_x2eIOBase {
     fn close(&mut self) {
         self._closed = true;
@@ -2160,6 +2165,11 @@ impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         }
     }
 }
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl __SifrStdlib_sifr_x2eio_x2eTextReader {
     fn read(&self) -> Result<String, IOError> {
         Err(
@@ -2208,6 +2218,11 @@ impl __SifrStdlib_sifr_x2eio_x2eTextWriter {
         Self {
             _closed: __sifr_field_init_0,
         }
+    }
+}
+impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+    fn default() -> Self {
+        Self::new()
     }
 }
 impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/stdlib_tools/emitted.rs
+++ b/demos/stdlib_tools/emitted.rs
@@ -1362,6 +1362,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1932,6 +1937,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1980,6 +1990,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/structured_parsing_serialization/emitted.rs
+++ b/demos/structured_parsing_serialization/emitted.rs
@@ -1358,6 +1358,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1928,6 +1933,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1976,6 +1986,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/system_tools/emitted.rs
+++ b/demos/system_tools/emitted.rs
@@ -1363,6 +1363,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eIOBase {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eIOBase {
         pub fn close(&mut self) {
             self._closed = true;
@@ -1933,6 +1938,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextReader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eio_x2eTextReader {
         pub fn read(&self) -> Result<String, IOError> {
             Err(
@@ -1981,6 +1991,11 @@ mod __sifr_project_nominals {
             Self {
                 _closed: __sifr_field_init_0,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eio_x2eTextWriter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2eio_x2eTextWriter {

--- a/demos/text_and_patterns/emitted.rs
+++ b/demos/text_and_patterns/emitted.rs
@@ -70,6 +70,11 @@ mod __sifr_project_nominals {
             Self {}
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2estring_x2eFormatter {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2estring_x2eFormatter {
         pub fn format(
             &self,

--- a/demos/utility_classes/emitted.rs
+++ b/demos/utility_classes/emitted.rs
@@ -92,6 +92,11 @@ mod __sifr_project_nominals {
             }
         }
     }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2eargparse_x2eNamespace {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl __SifrStdlib_sifr_x2eargparse_x2eNamespace {
         pub fn set(&mut self, name: &String, value: &String) {
             let mut updated: Vec<(String, String)> = vec![];
@@ -1113,6 +1118,11 @@ mod __sifr_project_nominals {
                 _ready_order: __sifr_field_init_5,
                 _next_index: __sifr_field_init_6,
             }
+        }
+    }
+    impl ::std::default::Default for __SifrStdlib_sifr_x2egraphlib_x2eTopologicalSorter {
+        fn default() -> Self {
+            Self::new()
         }
     }
     impl __SifrStdlib_sifr_x2egraphlib_x2eTopologicalSorter {


### PR DESCRIPTION
## Summary
- implement `Default` by delegating to every generated zero-argument `new` constructor
- remove duplicate inherent sync-channel `clone` methods while preserving canonical `Clone` implementations and Sifr call behavior
- refresh all affected checked-in demo companions
- add focused mutation-sensitive codegen coverage

## Validation
- 1,140/1,140 `sifr_codegen` tests pass
- strict `sifr_codegen` Clippy passes
- all seven concurrency generated-code Clippy cases pass under Rust 1.94
- `sync_channel_demo` and `channel_sender_close_clone_closes_all` build and run release-native
- demo freshness passes after updating 32 affected companions
- formatting, HIR maintainability, diff, and file-size checks pass

## Gate provenance
- the single create-PR gate ran on initial candidate `9453b3780e971e21aca14c2316457edb34c9bb50` and stopped only on the 32 stale demo companions
- those in-scope generated outputs are refreshed in final candidate `3d9f26a9b3018957b5f09b4c275e444d815af076`
- per the phase rule, the create-PR gate will not be repeated; the one merge gate will run on the final reviewed candidate