### PR TITLE
build: require uv 0.12.5 exactly

### DIFF
--- a/.github/workflows/local-first-validation.yml
+++ b/.github/workflows/local-first-validation.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  SIFR_MIN_UV_VERSION: "0.9.28"
-
 jobs:
   lint-and-format:
     name: lint-and-format
@@ -43,9 +40,10 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@1.98.0
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: ${{ env.SIFR_MIN_UV_VERSION }}
+          version-file: verification/pyproject.toml
+          checksum: 68a509da24b06b4223a1c0175fb5eb5bc79342b76cbeff0cfe51ac3f5b17b6b2
       - name: Install pinned buffer compatibility interpreter
         run: uv python install 3.11
       - name: Run local-first profile
@@ -60,9 +58,10 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@1.98.0
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: ${{ env.SIFR_MIN_UV_VERSION }}
+          version-file: verification/pyproject.toml
+          checksum: 68a509da24b06b4223a1c0175fb5eb5bc79342b76cbeff0cfe51ac3f5b17b6b2
       - name: Run smoke fuzz/property checks
         run: uv run --project verification --locked python -m sifr_verify areas run --area fuzz_property --suite cargo-smoke --suite property --suite fuzz-smoke
 
@@ -76,8 +75,9 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@1.98.0
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: ${{ env.SIFR_MIN_UV_VERSION }}
+          version-file: verification/pyproject.toml
+          checksum: 68a509da24b06b4223a1c0175fb5eb5bc79342b76cbeff0cfe51ac3f5b17b6b2
       - name: Verify deterministic report signature
         run: bash verification/runner/e2e/check_report_determinism.sh --profile merge

--- a/demos/m12_dlpack_demo/pyproject.toml
+++ b/demos/m12_dlpack_demo/pyproject.toml
@@ -6,3 +6,4 @@ dependencies = ["numpy>=2,<3", "torch>=2.5,<3"]
 
 [tool.uv]
 package = false
+required-version = "==0.12.5"

--- a/demos/m13_python_read_only/pyproject.toml
+++ b/demos/m13_python_read_only/pyproject.toml
@@ -6,3 +6,4 @@ dependencies = []
 
 [tool.uv]
 package = false
+required-version = "==0.12.5"

--- a/demos/m14_python_authoring/pyproject.toml
+++ b/demos/m14_python_authoring/pyproject.toml
@@ -6,3 +6,4 @@ dependencies = []
 
 [tool.uv]
 package = false
+required-version = "==0.12.5"

--- a/demos/m16_raw_api/pyproject.toml
+++ b/demos/m16_raw_api/pyproject.toml
@@ -6,3 +6,4 @@ dependencies = []
 
 [tool.uv]
 package = false
+required-version = "==0.12.5"

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIN_UV_VERSION="${SIFR_MIN_UV_VERSION:-0.9.28}"
+UV_PROJECT_FILE="${SCRIPT_DIR}/../verification/pyproject.toml"
 
 usage() {
   cat <<'EOF'
@@ -61,30 +61,27 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-version_gte() {
-  python3 - "$1" "$2" <<'PY'
+required_uv_version() {
+  python3 - "${UV_PROJECT_FILE}" <<'PY'
 import re
 import sys
+import tomllib
 
-
-def parse(value: str) -> tuple[int, ...]:
-    parts = [int(part) for part in re.findall(r"\d+", value)]
-    return tuple(parts)
-
-
-actual = parse(sys.argv[1])
-minimum = parse(sys.argv[2])
-width = max(len(actual), len(minimum))
-actual += (0,) * (width - len(actual))
-minimum += (0,) * (width - len(minimum))
-raise SystemExit(0 if actual >= minimum else 1)
+with open(sys.argv[1], "rb") as project_file:
+    requirement = tomllib.load(project_file)["tool"]["uv"]["required-version"]
+if re.fullmatch(r"==\d+\.\d+\.\d+", requirement) is None:
+    raise SystemExit("verification uv required-version must be an exact == pin")
+print(requirement.removeprefix("=="))
 PY
 }
 
 require_uv() {
+  local expected_version
+  expected_version="$(required_uv_version)"
+
   if ! command -v uv >/dev/null 2>&1; then
     cat >&2 <<EOF
-error: uv ${MIN_UV_VERSION} or newer is required for verification tooling.
+error: uv ${expected_version} is required for verification tooling.
 Install uv and re-run this facade; see verification/README.md.
 EOF
     exit 2
@@ -92,10 +89,10 @@ EOF
 
   local uv_version
   uv_version="$(uv --version | awk '{print $2}')"
-  if ! version_gte "${uv_version}" "${MIN_UV_VERSION}"; then
+  if [[ "${uv_version}" != "${expected_version}" ]]; then
     cat >&2 <<EOF
-error: uv ${MIN_UV_VERSION} or newer is required for verification tooling; found ${uv_version}.
-Upgrade uv and re-run this facade; see verification/README.md.
+error: uv ${expected_version} is required for verification tooling; found ${uv_version}.
+Install the exact uv release and re-run this facade; see verification/README.md.
 EOF
     exit 2
   fi

--- a/verification/README.md
+++ b/verification/README.md
@@ -14,7 +14,9 @@ uv run --project verification python -m sifr_verify doctor
 uv lock --project verification --check
 ```
 
-Minimum supported `uv` version: `0.9.28`.
+Required `uv` version: `0.12.5`. Every maintained uv project carries the exact
+native `required-version` pin, and CI reads the same pin from this project's
+`pyproject.toml`.
 
 The public validation entrypoint remains:
 
@@ -25,7 +27,7 @@ scripts/run_all_tests.sh --profile merge --emit-plan
 
 `scripts/run_all_tests.sh` is a thin public facade over
 `uv run --project verification --locked python -m sifr_verify profiles run`.
-It fail-fasts when `uv` is missing or below the minimum version so profile
+It fail-fasts when `uv` is missing or differs from the exact version so profile
 execution stays reproducible for local and CI validation.
 
 `--emit-plan` prints the selected profile's machine-readable execution plan

--- a/verification/areas/distribution_release/governance/selftest.py
+++ b/verification/areas/distribution_release/governance/selftest.py
@@ -310,7 +310,7 @@ def valid_report() -> dict[str, Any]:
         "toolchain": {
             "rustc": "rustc 1.90.0",
             "cargo": "cargo 1.90.0",
-            "uv": "uv 0.9.28",
+            "uv": "uv 0.12.5",
             "python": "Python 3.13.0",
         },
         "overall_status": "pass",

--- a/verification/areas/python_interop/cpython311/pyproject.toml
+++ b/verification/areas/python_interop/cpython311/pyproject.toml
@@ -6,3 +6,4 @@ dependencies = ["numpy>=2,<3", "pyarrow>=22,<23"]
 
 [tool.uv]
 package = false
+required-version = "==0.12.5"

--- a/verification/areas/python_interop/pyproject.toml
+++ b/verification/areas/python_interop/pyproject.toml
@@ -34,3 +34,4 @@ dependencies = [
 
 [tool.uv]
 package = false
+required-version = "==0.12.5"

--- a/verification/pyproject.toml
+++ b/verification/pyproject.toml
@@ -14,3 +14,4 @@ packages = ["runner/sifr_verify"]
 
 [tool.uv]
 package = true
+required-version = "==0.12.5"


### PR DESCRIPTION
## Summary
- require uv 0.12.5 exactly in all seven maintained uv projects
- replace the local gate minimum-version fallback with exact native-policy enforcement
- pin setup-uv v10.0.1 by immutable SHA and source its uv version from the canonical verification project
- regenerate all seven locks sequentially with uv 0.12.5; all remain byte-for-byte unchanged

## New stable behavior adopted
- native `required-version` enforcement
- setup-uv v10 secure cache defaults for sensitive events
- setup-uv `version-file` selection from the canonical project
- uv 0.12 strict resolver/archive/project-path behavior; maintained surfaces require no legacy flags or fallbacks

## Validation
- seven sequential `uv lock --check --offline` passes
- exact toolchain consistency audit (7 projects, 7 locks, 3 immutable action uses)
- verification runner self-test, profile check, and area check
- uv-aware doctor
- Python interop `env` and `self-test` suites
- distribution release representative suite: 56/56
- profile plan emission, Bash syntax, diff check, file-size guardrail

No compiler inputs changed, so the phase rules prohibit Sifr create-PR and merge gates for this item.