### PR TITLE
ci: pin latest stable GitHub Actions

### DIFF
--- a/.github/workflows/local-first-validation.yml
+++ b/.github/workflows/local-first-validation.yml
@@ -12,11 +12,11 @@ jobs:
     name: lint-and-format
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@1.98.0
+      - uses: dtolnay/rust-toolchain@f8be11a05b1d4f3fcebe6410cc16743212b999b0 # Rust 1.98.0
       # Advisory until legacy workspace lint debt is burned down by a dedicated cleanup.
       - name: Rustfmt check (advisory)
         continue-on-error: true
@@ -35,11 +35,11 @@ jobs:
       matrix:
         profile: [create-pr, merge, release]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@1.98.0
+      - uses: dtolnay/rust-toolchain@f8be11a05b1d4f3fcebe6410cc16743212b999b0 # Rust 1.98.0
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: verification/pyproject.toml
@@ -53,11 +53,11 @@ jobs:
     name: smoke-fuzz-property
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@1.98.0
+      - uses: dtolnay/rust-toolchain@f8be11a05b1d4f3fcebe6410cc16743212b999b0 # Rust 1.98.0
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: verification/pyproject.toml
@@ -70,11 +70,11 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@1.98.0
+      - uses: dtolnay/rust-toolchain@f8be11a05b1d4f3fcebe6410cc16743212b999b0 # Rust 1.98.0
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version-file: verification/pyproject.toml

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -54,7 +54,7 @@ jobs:
       governance_mode: ${{ steps.validate.outputs.governance_mode }}
       bootstrap_alpha_version: ${{ steps.validate.outputs.bootstrap_alpha_version }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.base_ref || 'main' }}
           fetch-depth: 0
@@ -150,13 +150,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate.outputs.source_sha }}
           submodules: recursive
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@1.98.0
+      - uses: dtolnay/rust-toolchain@f8be11a05b1d4f3fcebe6410cc16743212b999b0 # Rust 1.98.0
         with:
           targets: ${{ matrix.target }}
 
@@ -175,7 +175,7 @@ jobs:
             --binary "target/${{ matrix.target }}/release/sifr" \
             --target "${{ matrix.target }}"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sifr-${{ needs.validate.outputs.version }}-${{ matrix.target }}
           path: dist/*

--- a/.github/workflows/release-publication-drill.yml
+++ b/.github/workflows/release-publication-drill.yml
@@ -23,8 +23,9 @@ jobs:
     env:
       DRILL_MODE: ${{ inputs.mode }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          submodules: recursive
           persist-credentials: false
 
       - name: Validate drill boundary
@@ -74,7 +75,7 @@ jobs:
             --require-canonical
 
       - name: Retain immutable drill evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: stable-release-drill-${{ github.run_id }}-${{ github.run_attempt }}
           path: drill-evidence/protected-drill.json

--- a/.github/workflows/release-publication-prepare.yml
+++ b/.github/workflows/release-publication-prepare.yml
@@ -111,19 +111,21 @@ jobs:
       PUBLICATION_MODE: ${{ inputs.publication_mode }}
       LEGACY_INDEX_SHA256: 71b3243925670f56dc510b8f45b6614a622f58097a0fea9492f61d20dc4bf9ef
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ inputs.governance_mode != 'ga-activation' && inputs.governance_mode != 'normal' && inputs.governance_mode != 'rollback' && inputs.governance_mode != 'incident-roll-forward' }}
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 0
+          submodules: recursive
           persist-credentials: false
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ inputs.governance_mode != 'ga-activation' && inputs.governance_mode != 'normal' && inputs.governance_mode != 'rollback' && inputs.governance_mode != 'incident-roll-forward' }}
         with:
           pattern: sifr-${{ inputs.version }}-*
           path: prepare-assets
           merge-multiple: true
+          digest-mismatch: error
 
       - name: Validate read-only prepare inputs and artifact bytes
         if: ${{ inputs.governance_mode != 'ga-activation' && inputs.governance_mode != 'normal' && inputs.governance_mode != 'rollback' && inputs.governance_mode != 'incident-roll-forward' }}
@@ -279,28 +281,31 @@ jobs:
             fi
           } >>"${GITHUB_STEP_SUMMARY}"
 
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ inputs.governance_mode == 'ga-activation' || inputs.governance_mode == 'normal' || inputs.governance_mode == 'rollback' || inputs.governance_mode == 'incident-roll-forward' }}
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
           path: governance-source
+          submodules: recursive
           persist-credentials: false
 
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ inputs.governance_mode == 'ga-activation' || inputs.governance_mode == 'normal' || inputs.governance_mode == 'incident-roll-forward' }}
         with:
           ref: ${{ inputs.evidence_commit }}
           fetch-depth: 0
           path: stable-evidence
+          submodules: recursive
           persist-credentials: false
 
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ inputs.governance_mode == 'rollback' || inputs.governance_mode == 'incident-roll-forward' }}
         with:
           ref: ${{ inputs.incident_commit }}
           fetch-depth: 0
           path: incident-evidence
+          submodules: recursive
           persist-credentials: false
 
       - name: Resolve exact incident request identity
@@ -373,7 +378,7 @@ jobs:
             echo "source_commit=${source_commit}"
           } >>"${GITHUB_OUTPUT}"
 
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ inputs.governance_mode == 'ga-activation' || inputs.governance_mode == 'normal' || inputs.governance_mode == 'incident-roll-forward' }}
         with:
           ref: ${{ steps.stable.outputs.source_commit }}
@@ -580,7 +585,7 @@ jobs:
             echo "site_base_commit=$(jq -r '.site.base_commit // ""' prepare/summary.json)"
           } >>"${GITHUB_OUTPUT}"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.outputs.outputs.summary_artifact_name }}
           path: prepare/summary.json

--- a/.github/workflows/release-publication.yml
+++ b/.github/workflows/release-publication.yml
@@ -150,18 +150,18 @@ jobs:
       SINGLE_MAINTAINER_APPROVAL_WAIVER: plans/releases/single-maintainer-approval-waiver.json
       SINGLE_MAINTAINER_APPROVAL_WAIVER_SHA256: b9630cc060ca281946da76a9cb9bc67564759c8d5446b6a33157a7d138080008
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.STABLE_MUTATION_OPERATION != 'true'
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.STABLE_MUTATION_OPERATION == 'true'
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.STABLE_CANDIDATE_OPERATION == 'true'
         with:
           ref: ${{ needs.prepare.outputs.source_commit }}
@@ -169,31 +169,33 @@ jobs:
           path: stable-source
           submodules: recursive
           persist-credentials: false
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.STABLE_CANDIDATE_OPERATION == 'true'
         with:
           ref: ${{ inputs.evidence_commit }}
           fetch-depth: 0
           path: stable-evidence
           persist-credentials: false
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.INCIDENT_OPERATION == 'true'
         with:
           ref: ${{ inputs.incident_commit }}
           fetch-depth: 0
           path: incident-evidence
           persist-credentials: false
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: env.STABLE_MUTATION_OPERATION != 'true'
         with:
           pattern: sifr-${{ inputs.version }}-*
           path: release-assets
           merge-multiple: true
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+          digest-mismatch: error
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.prepare.outputs.summary_artifact_name }}
           path: protected-prepare
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+          digest-mismatch: error
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: env.STABLE_CANDIDATE_OPERATION == 'true'
         with:
           node-version-file: stable-source/editor_integrations/vscode/.node-version

--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -62,7 +62,7 @@ jobs:
           echo "version=${VERSION}" >>"${GITHUB_OUTPUT}"
           echo "rollback_version=${ROLLBACK_VERSION}" >>"${GITHUB_OUTPUT}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.identity.outputs.source_commit }}
           fetch-depth: 1
@@ -101,13 +101,13 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate.outputs.source_commit }}
           fetch-depth: 1
           submodules: recursive
 
-      - uses: dtolnay/rust-toolchain@1.98.0
+      - uses: dtolnay/rust-toolchain@f8be11a05b1d4f3fcebe6410cc16743212b999b0 # Rust 1.98.0
         with:
           targets: ${{ matrix.target }}
 
@@ -137,7 +137,7 @@ jobs:
             --out-dir qualification
           cp "${archive}" "${archive}.sha256" qualification/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sifr-stable-candidate-${{ needs.validate.outputs.version }}-${{ needs.validate.outputs.source_commit }}-${{ matrix.target }}
           path: qualification/*
@@ -152,23 +152,24 @@ jobs:
       - build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate.outputs.source_commit }}
           fetch-depth: 1
           submodules: recursive
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: editor_integrations/vscode/.node-version
           cache: npm
           cache-dependency-path: editor_integrations/vscode/package-lock.json
 
       - name: Download exact x86_64 Linux candidate
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sifr-stable-candidate-${{ needs.validate.outputs.version }}-${{ needs.validate.outputs.source_commit }}-x86_64-unknown-linux-gnu
           path: candidate-toolchain
+          digest-mismatch: error
 
       - name: Build, test, and package VSIX
         shell: bash
@@ -204,7 +205,7 @@ jobs:
             --vsix "qualification-editor/$(basename "${built[0]}")" \
             --out qualification-editor/qualification-editor.json
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sifr-stable-candidate-${{ needs.validate.outputs.version }}-${{ needs.validate.outputs.source_commit }}-editor
           path: qualification-editor/*
@@ -219,35 +220,39 @@ jobs:
       - build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate.outputs.source_commit }}
           fetch-depth: 1
           submodules: recursive
 
       - name: Download aarch64 macOS candidate
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sifr-stable-candidate-${{ needs.validate.outputs.version }}-${{ needs.validate.outputs.source_commit }}-aarch64-apple-darwin
           path: target-artifacts
+          digest-mismatch: error
 
       - name: Download x86_64 macOS candidate
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sifr-stable-candidate-${{ needs.validate.outputs.version }}-${{ needs.validate.outputs.source_commit }}-x86_64-apple-darwin
           path: target-artifacts
+          digest-mismatch: error
 
       - name: Download aarch64 Linux candidate
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sifr-stable-candidate-${{ needs.validate.outputs.version }}-${{ needs.validate.outputs.source_commit }}-aarch64-unknown-linux-gnu
           path: target-artifacts
+          digest-mismatch: error
 
       - name: Download x86_64 Linux candidate
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sifr-stable-candidate-${{ needs.validate.outputs.version }}-${{ needs.validate.outputs.source_commit }}-x86_64-unknown-linux-gnu
           path: target-artifacts
+          digest-mismatch: error
 
       - name: Verify matrix and assemble aggregate assets
         shell: bash
@@ -288,7 +293,7 @@ jobs:
             done
           ) | LC_ALL=C sort >qualification-assemble/checksums.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sifr-stable-candidate-${{ needs.validate.outputs.version }}-${{ needs.validate.outputs.source_commit }}-assemble
           path: qualification-assemble/*
@@ -305,17 +310,18 @@ jobs:
       - assemble
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.validate.outputs.source_commit }}
           fetch-depth: 1
           submodules: recursive
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: sifr-stable-candidate-${{ needs.validate.outputs.version }}-${{ needs.validate.outputs.source_commit }}-*
           path: collected
           merge-multiple: false
+          digest-mismatch: error
 
       - name: Collect run metadata and recursive submodules
         shell: bash
@@ -373,7 +379,7 @@ jobs:
 
       - name: Upload qualification artifact index
         id: upload-index
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sifr-stable-candidate-${{ needs.validate.outputs.version }}-${{ needs.validate.outputs.source_commit }}-index
           path: qualification-artifact-index.json

--- a/.github/workflows/schema-bootstrap-recovery.yml
+++ b/.github/workflows/schema-bootstrap-recovery.yml
@@ -81,9 +81,10 @@ jobs:
       ORIGINAL_PREPARE_SUMMARY: plans/releases/schema-bootstrap-recovery/prepare-summary-${{ inputs.original_run_id }}-${{ inputs.original_run_attempt }}.json
       WAIVER_SHA256: b9630cc060ca281946da76a9cb9bc67564759c8d5446b6a33157a7d138080008
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          submodules: recursive
           persist-credentials: false
 
       - name: Validate failed mutation run and exact source identity
@@ -190,7 +191,7 @@ jobs:
             echo "This recovery performs no release, tag, snapshot, or index mutation."
           } >>"${GITHUB_STEP_SUMMARY}"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.summary.outputs.summary_artifact_name }}
           path: recovery/summary.json
@@ -230,15 +231,17 @@ jobs:
       SITE_WORKFLOW_SHA256: a9360c82395f6e9d9822f201e56cc0f2eabab1bacda01c31e4e9f22d0202b3af
       WAIVER_SHA256: b9630cc060ca281946da76a9cb9bc67564759c8d5446b6a33157a7d138080008
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          submodules: recursive
           persist-credentials: false
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.prepare.outputs.summary_artifact_name }}
           path: protected-prepare
+          digest-mismatch: error
 
       - name: Revalidate both protected approvals and failed site identity
         shell: bash
@@ -495,7 +498,7 @@ jobs:
             exit 2
           }
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bootstrap-recovery-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/scripts/check_github_action_pins.py
+++ b/scripts/check_github_action_pins.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Validate every maintained third-party GitHub Action selection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / "verification/policy/github_actions.json"
+USE_RE = re.compile(
+    r"^(?P<indent>\s*)(?:-\s*)?uses:\s*(?P<target>\S+?)"
+    r"(?:\s+#\s*(?P<label>.+?))?\s*$"
+)
+SHA_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def load_policy() -> dict[str, Any]:
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def policy_pins(policy: dict[str, Any]) -> tuple[dict[str, tuple[str, str]], list[str]]:
+    failures: list[str] = []
+    if set(policy) != {"schema_version", "maintained_workflow_roots", "actions"}:
+        failures.append("policy top-level fields drifted")
+    if policy.get("schema_version") != 1:
+        failures.append("policy schema_version must be 1")
+
+    pins: dict[str, tuple[str, str]] = {}
+    for item in policy.get("actions", []):
+        if not isinstance(item, dict) or set(item) != {"name", "version", "sha"}:
+            failures.append(
+                "every action policy entry must contain name, version, and sha"
+            )
+            continue
+        name = item.get("name")
+        version = item.get("version")
+        sha = item.get("sha")
+        if (
+            not isinstance(name, str)
+            or re.fullmatch(r"[^/@\s]+/[^/@\s]+", name) is None
+        ):
+            failures.append(f"invalid action name: {name!r}")
+            continue
+        if name in pins:
+            failures.append(f"duplicate action policy: {name}")
+            continue
+        if not isinstance(version, str) or not version:
+            failures.append(f"{name}: version label must be non-empty")
+            continue
+        if not isinstance(sha, str) or SHA_RE.fullmatch(sha) is None:
+            failures.append(f"{name}: sha must be one lowercase 40-character commit")
+            continue
+        pins[name] = (sha, version)
+    return pins, failures
+
+
+def step_has_digest_error(lines: list[str], use_index: int) -> bool:
+    use_line = lines[use_index]
+    use_indent = len(use_line) - len(use_line.lstrip())
+    step_indent = use_indent
+    if not use_line.lstrip().startswith("- uses:"):
+        for earlier in reversed(lines[:use_index]):
+            stripped = earlier.lstrip()
+            indent = len(earlier) - len(stripped)
+            if stripped.startswith("- ") and indent < use_indent:
+                step_indent = indent
+                break
+
+    for line in lines[use_index + 1 :]:
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+        if stripped.startswith("- ") and indent == step_indent:
+            break
+        if stripped == "digest-mismatch: error":
+            return True
+    return False
+
+
+def validate_workflow_text(
+    path: str,
+    text: str,
+    pins: dict[str, tuple[str, str]],
+    seen: set[str],
+) -> list[str]:
+    failures: list[str] = []
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        match = USE_RE.match(line)
+        if match is None:
+            continue
+        target = match.group("target")
+        if target.startswith("./"):
+            continue
+        if "@" not in target:
+            failures.append(f"{path}:{index + 1}: external action has no selector")
+            continue
+        name, selector = target.rsplit("@", 1)
+        expected = pins.get(name)
+        if expected is None:
+            failures.append(f"{path}:{index + 1}: unowned external action {name}")
+            continue
+        expected_sha, expected_version = expected
+        if selector != expected_sha:
+            failures.append(
+                f"{path}:{index + 1}: {name} must use {expected_sha}, got {selector}"
+            )
+        if match.group("label") != expected_version:
+            failures.append(
+                f"{path}:{index + 1}: {name} comment must be {expected_version!r}"
+            )
+        if name == "actions/download-artifact" and not step_has_digest_error(
+            lines, index
+        ):
+            failures.append(
+                f"{path}:{index + 1}: download-artifact must fail on digest mismatch"
+            )
+        seen.add(name)
+    return failures
+
+
+def validate_repository(
+    policy: dict[str, Any], pins: dict[str, tuple[str, str]]
+) -> tuple[list[str], int]:
+    failures: list[str] = []
+    seen: set[str] = set()
+    reference_count = 0
+    roots = policy.get("maintained_workflow_roots", [])
+    if not isinstance(roots, list) or len(roots) != len(set(roots)):
+        return ["maintained_workflow_roots must be a unique list"], 0
+
+    for relative_root in roots:
+        if not isinstance(relative_root, str):
+            failures.append("maintained workflow roots must be strings")
+            continue
+        workflow_dir = REPO_ROOT / relative_root / ".github/workflows"
+        if not workflow_dir.is_dir():
+            failures.append(
+                f"maintained workflow root is unavailable: {relative_root}; "
+                "initialize recursive submodules"
+            )
+            continue
+        paths = sorted((*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml")))
+        for path in paths:
+            text = path.read_text(encoding="utf-8")
+            path_failures = validate_workflow_text(
+                str(path.relative_to(REPO_ROOT)), text, pins, seen
+            )
+            failures.extend(path_failures)
+            reference_count += sum(
+                1
+                for line in text.splitlines()
+                if (match := USE_RE.match(line)) is not None
+                and not match.group("target").startswith("./")
+            )
+
+    unused = sorted(set(pins).difference(seen))
+    if unused:
+        failures.append(f"policy actions have no maintained consumer: {unused}")
+    return failures, reference_count
+
+
+def run_self_test() -> None:
+    pins = {
+        "actions/checkout": ("a" * 40, "v7.0.1"),
+        "actions/download-artifact": ("b" * 40, "v8.0.1"),
+    }
+    valid = """steps:
+  - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v7.0.1
+  - uses: actions/download-artifact@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # v8.0.1
+    with:
+      digest-mismatch: error
+"""
+    seen: set[str] = set()
+    if validate_workflow_text("valid.yml", valid, pins, seen):
+        raise SystemExit("GitHub Action pin self-test rejected valid pins")
+    invalid = valid.replace("@" + "a" * 40, "@v7").replace(
+        "      digest-mismatch: error\n", ""
+    )
+    failures = validate_workflow_text("invalid.yml", invalid, pins, set())
+    if len(failures) != 2:
+        raise SystemExit("GitHub Action pin self-test accepted mutable or weak pins")
+    print("GitHub Action pin self-test: PASS")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        run_self_test()
+        return 0
+
+    policy = load_policy()
+    pins, failures = policy_pins(policy)
+    repository_failures, reference_count = validate_repository(policy, pins)
+    failures.extend(repository_failures)
+    if failures:
+        print("GitHub Action pins: FAIL", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print(
+        f"GitHub Action pins: PASS (actions={len(pins)}, references={reference_count})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_submodule_ownership.py
+++ b/scripts/check_submodule_ownership.py
@@ -10,7 +10,6 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -22,8 +21,16 @@ class ExpectedSubmodule:
 
 
 EXPECTED_SUBMODULES = [
-    ExpectedSubmodule("third_party/ruff", "https://github.com/sifr-lang/ruff.git", "sifr/0.15.12-maintenance"),
-    ExpectedSubmodule("editor_integrations", "https://github.com/sifr-lang/editor-integrations.git", "main"),
+    ExpectedSubmodule(
+        "third_party/ruff",
+        "https://github.com/sifr-lang/ruff.git",
+        "sifr/0.15.12-maintenance",
+    ),
+    ExpectedSubmodule(
+        "editor_integrations",
+        "https://github.com/sifr-lang/editor-integrations.git",
+        "main",
+    ),
     ExpectedSubmodule(
         "verification/areas/algorithmic_compatibility/corpora/leetcode",
         "https://github.com/sifr-lang/leetcode.git",
@@ -74,7 +81,9 @@ STALE_SUBMODULE_PATHS = {
 }
 
 WORKFLOW_STEP_RE = re.compile(r"(?ms)^(\s*)-\s+(?P<body>.*?)(?=^\1-\s+|\Z)")
-CHECKOUT_USES_RE = re.compile(r"(?m)^\s*uses:\s+actions/checkout@\S+\s*$")
+CHECKOUT_USES_RE = re.compile(
+    r"(?m)^\s*uses:\s+actions/checkout@[^\s#]+(?:\s+#.*)?\s*$"
+)
 SUBMODULES_RECURSIVE_RE = re.compile(r"(?m)^\s+submodules:\s+[\"']?recursive[\"']?\s*$")
 
 
@@ -108,7 +117,9 @@ def validate_gitmodules(text: str) -> list[str]:
             failures.append(f"missing submodule entry: {expected.path}")
             continue
         if actual["url"] != expected.url:
-            failures.append(f"submodule {expected.path} has unexpected url: {actual['url']}")
+            failures.append(
+                f"submodule {expected.path} has unexpected url: {actual['url']}"
+            )
         if actual["branch"] != expected.branch:
             failures.append(f"submodule {expected.path} must track {expected.branch}")
 
@@ -136,7 +147,9 @@ def validate_clone_script(text: str) -> list[str]:
 def validate_workflow(path: Path, text: str) -> list[str]:
     failures: list[str] = []
     checkout_blocks = [
-        match for match in WORKFLOW_STEP_RE.finditer(text) if CHECKOUT_USES_RE.search(match.group("body"))
+        match
+        for match in WORKFLOW_STEP_RE.finditer(text)
+        if CHECKOUT_USES_RE.search(match.group("body"))
     ]
     if not checkout_blocks:
         return failures
@@ -147,14 +160,22 @@ def validate_workflow(path: Path, text: str) -> list[str]:
         pass
     for index, match in enumerate(checkout_blocks, start=1):
         if not SUBMODULES_RECURSIVE_RE.search(match.group("body")):
-            failures.append(f"{display_path} checkout #{index} does not initialize submodules recursively")
+            failures.append(
+                f"{display_path} checkout #{index} does not initialize submodules recursively"
+            )
     return failures
 
 
 def validate_repo(root: Path) -> list[str]:
     failures: list[str] = []
-    failures.extend(validate_gitmodules((root / ".gitmodules").read_text(encoding="utf-8")))
-    failures.extend(validate_clone_script((root / "scripts" / "clone_subrepos.sh").read_text(encoding="utf-8")))
+    failures.extend(
+        validate_gitmodules((root / ".gitmodules").read_text(encoding="utf-8"))
+    )
+    failures.extend(
+        validate_clone_script(
+            (root / "scripts" / "clone_subrepos.sh").read_text(encoding="utf-8")
+        )
+    )
     workflow_paths = sorted((root / ".github" / "workflows").glob("*.yml"))
     workflow_paths.extend(sorted((root / ".github" / "workflows").glob("*.yaml")))
     for path in workflow_paths:
@@ -171,7 +192,9 @@ def run_self_test() -> None:
         for entry in EXPECTED_SUBMODULES
     )
     if validate_gitmodules(valid_gitmodules):
-        raise SystemExit("submodule ownership self-test failed: valid metadata rejected")
+        raise SystemExit(
+            "submodule ownership self-test failed: valid metadata rejected"
+        )
     missing_entry = valid_gitmodules.replace(
         f'[submodule "{EXPECTED_SUBMODULES[0].path}"]\n'
         f"\tpath = {EXPECTED_SUBMODULES[0].path}\n"
@@ -179,21 +202,34 @@ def run_self_test() -> None:
         f"\tbranch = {EXPECTED_SUBMODULES[0].branch}\n",
         "",
     )
-    if not any("missing submodule entry" in failure for failure in validate_gitmodules(missing_entry)):
+    if not any(
+        "missing submodule entry" in failure
+        for failure in validate_gitmodules(missing_entry)
+    ):
         raise SystemExit("submodule ownership self-test failed: missing entry accepted")
-    wrong_url = valid_gitmodules.replace(EXPECTED_SUBMODULES[0].url, "https://example.invalid/ruff.git", 1)
-    if not any("unexpected url" in failure for failure in validate_gitmodules(wrong_url)):
+    wrong_url = valid_gitmodules.replace(
+        EXPECTED_SUBMODULES[0].url, "https://example.invalid/ruff.git", 1
+    )
+    if not any(
+        "unexpected url" in failure for failure in validate_gitmodules(wrong_url)
+    ):
         raise SystemExit("submodule ownership self-test failed: wrong url accepted")
     missing_branch = valid_gitmodules.replace("\tbranch = main\n", "", 1)
-    if not any("must track" in failure for failure in validate_gitmodules(missing_branch)):
-        raise SystemExit("submodule ownership self-test failed: missing branch accepted")
+    if not any(
+        "must track" in failure for failure in validate_gitmodules(missing_branch)
+    ):
+        raise SystemExit(
+            "submodule ownership self-test failed: missing branch accepted"
+        )
     stale_path = valid_gitmodules + (
         '[submodule "audits/leetcode"]\n'
         "\tpath = audits/leetcode\n"
         "\turl = https://github.com/sifr-lang/leetcode.git\n"
         "\tbranch = main\n"
     )
-    if not any("stale submodule path" in failure for failure in validate_gitmodules(stale_path)):
+    if not any(
+        "stale submodule path" in failure for failure in validate_gitmodules(stale_path)
+    ):
         raise SystemExit("submodule ownership self-test failed: stale path accepted")
     unclassified_path = valid_gitmodules + (
         '[submodule "verification/new-corpus"]\n'
@@ -201,32 +237,62 @@ def run_self_test() -> None:
         "\turl = https://github.com/sifr-lang/new-corpus.git\n"
         "\tbranch = main\n"
     )
-    if not any("unclassified submodule path" in failure for failure in validate_gitmodules(unclassified_path)):
-        raise SystemExit("submodule ownership self-test failed: unclassified path accepted")
-    valid_clone_script = "\n".join(
-        [
-            "git submodule sync --recursive",
-            "git submodule update --init --recursive",
-            "git submodule update --init --recursive --remote",
-            "git submodule status --recursive",
-        ]
+    if not any(
+        "unclassified submodule path" in failure
+        for failure in validate_gitmodules(unclassified_path)
+    ):
+        raise SystemExit(
+            "submodule ownership self-test failed: unclassified path accepted"
+        )
+    valid_clone_script = (
+        "git submodule sync --recursive\n"
+        "git submodule update --init --recursive\n"
+        "git submodule update --init --recursive --remote\n"
+        "git submodule status --recursive"
     )
     if validate_clone_script(valid_clone_script):
-        raise SystemExit("submodule ownership self-test failed: valid clone script rejected")
-    invalid_clone_script = valid_clone_script.replace("git submodule status --recursive", "")
-    if not any("missing" in failure for failure in validate_clone_script(invalid_clone_script)):
-        raise SystemExit("submodule ownership self-test failed: incomplete clone script accepted")
+        raise SystemExit(
+            "submodule ownership self-test failed: valid clone script rejected"
+        )
+    invalid_clone_script = valid_clone_script.replace(
+        "git submodule status --recursive", ""
+    )
+    if not any(
+        "missing" in failure for failure in validate_clone_script(invalid_clone_script)
+    ):
+        raise SystemExit(
+            "submodule ownership self-test failed: incomplete clone script accepted"
+        )
     workflow = "- uses: actions/checkout@v5\n"
     with tempfile.TemporaryDirectory() as tmpdir:
         path = Path(tmpdir) / "workflow.yml"
         if not validate_workflow(path, workflow):
-            raise SystemExit("submodule ownership self-test failed: checkout without submodules accepted")
+            raise SystemExit(
+                "submodule ownership self-test failed: checkout without submodules accepted"
+            )
+        pinned_checkout = (
+            "- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 "
+            "# v7.0.1\n"
+        )
+        if not validate_workflow(path, pinned_checkout):
+            raise SystemExit(
+                "submodule ownership self-test failed: commented pin bypassed validation"
+            )
         named_checkout = "- name: Checkout\n  uses: actions/checkout@0123456789abcdef\n"
         if not validate_workflow(path, named_checkout):
-            raise SystemExit("submodule ownership self-test failed: named checkout without submodules accepted")
-        valid_workflow = "- name: Checkout\n  uses: actions/checkout@v5\n  with:\n    submodules: 'recursive'\n"
+            raise SystemExit(
+                "submodule ownership self-test failed: named checkout without submodules accepted"
+            )
+        valid_workflow = (
+            "- name: Checkout\n"
+            "  uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n"
+            "  with:\n"
+            "    submodules: 'recursive'\n"
+        )
         if validate_workflow(path, valid_workflow):
-            raise SystemExit("submodule ownership self-test failed: valid workflow rejected")
+            raise SystemExit(
+                "submodule ownership self-test failed: valid workflow rejected"
+            )
     print("submodule ownership self-test: PASS")
 
 

--- a/verification/README.md
+++ b/verification/README.md
@@ -71,6 +71,11 @@ lanes.
   `diagnostics` is migrated and can be run with
   `uv run --project verification python -m sifr_verify areas run --area diagnostics`.
 - `policy/` contains machine-facing runner policy such as guardrail mappings.
+  `github_actions.json` owns the exact release label and commit for each
+  external action in maintained workflows. Use
+  `python3 scripts/check_github_action_pins.py` to validate all references.
+  The validator rejects mutable refs, unknown actions, label drift, and weak
+  artifact-digest behavior.
 
 ## Profile Ownership
 

--- a/verification/areas/distribution_release/cases/github_action_pins.sh
+++ b/verification/areas/distribution_release/cases/github_action_pins.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+python3 "${REPO_ROOT}/scripts/check_github_action_pins.py" --self-test
+python3 "${REPO_ROOT}/scripts/check_github_action_pins.py"

--- a/verification/areas/distribution_release/cases/release_qualification_workflow_contract.sh
+++ b/verification/areas/distribution_release/cases/release_qualification_workflow_contract.sh
@@ -48,7 +48,7 @@ unless editor_env["ROLLBACK_VERSION"] == "${{ needs.validate.outputs.rollback_ve
 end
 
 uploads = jobs.values.flat_map { |job| job.fetch("steps", []) }.select {
-  |step| step["uses"] == "actions/upload-artifact@v4"
+  |step| step["uses"] == "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 }
 abort "release qualification upload step count drifted" unless uploads.length == 4
 uploads.each do |upload|

--- a/verification/areas/distribution_release/cases/stable_publication_workflow_contract.sh
+++ b/verification/areas/distribution_release/cases/stable_publication_workflow_contract.sh
@@ -44,7 +44,7 @@ for fragment in (
     "path: stable-source",
     "path: stable-evidence",
     "submodules: recursive",
-    "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+    "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
     "node-version-file: stable-source/editor_integrations/vscode/.node-version",
     "npm ci --ignore-scripts --include=dev --prefix stable-source/editor_integrations/vscode",
     "node_modules/.bin/vsce",

--- a/verification/policy/github_actions.json
+++ b/verification/policy/github_actions.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "maintained_workflow_roots": [
+    ".",
+    "editor_integrations/vscode"
+  ],
+  "actions": [
+    {
+      "name": "actions/checkout",
+      "version": "v7.0.1",
+      "sha": "3d3c42e5aac5ba805825da76410c181273ba90b1"
+    },
+    {
+      "name": "actions/setup-node",
+      "version": "v7.0.0",
+      "sha": "820762786026740c76f36085b0efc47a31fe5020"
+    },
+    {
+      "name": "actions/upload-artifact",
+      "version": "v7.0.1",
+      "sha": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+    },
+    {
+      "name": "actions/download-artifact",
+      "version": "v8.0.1",
+      "sha": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+    },
+    {
+      "name": "astral-sh/setup-uv",
+      "version": "v10.0.1",
+      "sha": "20cfd1bf945f4377ade1205e4dbc17946fc9a30d"
+    },
+    {
+      "name": "dtolnay/rust-toolchain",
+      "version": "Rust 1.98.0",
+      "sha": "f8be11a05b1d4f3fcebe6410cc16743212b999b0"
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Item 6 of the latest-stable convergence phase.

- pin every maintained external action to the exact commit for its latest stable release
- advance checkout 7.0.1, setup-node 7.0.0, upload-artifact 7.0.1, and download-artifact 8.0.1
- retain current setup-uv 10.0.1 and bind the Rust 1.98 toolchain action to its exact commit
- use download-artifact v8 fail-closed digest mismatch handling
- add one policy and checker for all root and extension workflow references
- repair commented-SHA recognition in the submodule checkout guardrail
- advance the sifr-vscode -> editor-integrations -> root pointer chain sequentially

Leaf PRs:
- sifr-lang/sifr-vscode#14 (`732bcdc3ae2a494753025710dd138aa23a39b6e4`)
- sifr-lang/editor-integrations#12 (`d202b8c60240b6d2897c9deeda59be899bf47e24`)

## Validation

- official GitHub release/tag refs independently resolved for all six actions
- immutable-pin policy and negative self-test: 6 actions / 56 references
- submodule ownership guardrail and negative self-test
- all workflow YAML parses
- download-artifact v8 exact metadata confirms Node 24 and digest-mismatch:error
- distribution-release representative 58/58 on final state
- verification runner self-test, profile check, and area check
- Ruff 0.16.4 check/format, Bash syntax, diff check, and 900-line guardrail

No compiler input changed, so the phase rules prohibit Sifr create-PR and merge gates.