### PR TITLE
Upgrade SQLx certification to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,13 +2483,12 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3094,11 +3093,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3130,20 +3129,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -3991,10 +3981,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.13.1",
  "libc",
- "plain",
- "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -4614,7 +4601,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -4807,12 +4794,6 @@ name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "planus"
@@ -5468,7 +5449,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac 0.13.0",
+ "hmac",
  "md-5 0.11.0",
  "memchr",
  "rand 0.10.2",
@@ -6067,15 +6048,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.13.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -7533,9 +7505,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -7544,12 +7516,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "crc",
  "crossbeam-queue",
  "either",
@@ -7558,12 +7531,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
- "hashlink 0.10.0",
+ "hashbrown 0.16.1",
+ "hashlink 0.11.1",
  "indexmap",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
@@ -7575,14 +7547,14 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7593,15 +7565,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -7616,9 +7588,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -7632,23 +7604,21 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac 0.12.1",
- "home",
+ "hmac",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.2",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.20",
  "tracing",
- "whoami 1.6.1",
+ "whoami",
 ]
 
 [[package]]
@@ -7838,7 +7808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8071,7 +8041,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-util",
- "whoami 2.1.2",
+ "whoami",
 ]
 
 [[package]]
@@ -8589,12 +8559,6 @@ dependencies = [
 
 [[package]]
 name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
-name = "wasite"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
@@ -8736,30 +8700,11 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "whoami"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite 0.1.0",
 ]
 
 [[package]]
@@ -8771,7 +8716,7 @@ dependencies = [
  "libc",
  "libredox",
  "objc2-system-configuration",
- "wasite 1.0.2",
+ "wasite",
  "web-sys",
 ]
 
@@ -8947,15 +8892,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -8988,21 +8924,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -9049,12 +8970,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -9067,12 +8982,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -9082,12 +8991,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9115,12 +9018,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -9130,12 +9027,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9151,12 +9042,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -9166,12 +9051,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/sifr_driver/src/build/rust_interop_sqlx_offline_tests.rs
+++ b/crates/sifr_driver/src/build/rust_interop_sqlx_offline_tests.rs
@@ -41,7 +41,7 @@ fn real_dependency_table_controls_sqlx_preflight() {
     assert_eq!(validate_sqlx_offline_metadata(&fixture.0), Ok(()));
 
     fixture
-        .write_manifest("[dependencies]\ndatabase = { package = \"sqlx\", version = \"0.8\" }\n");
+        .write_manifest("[dependencies]\ndatabase = { package = \"sqlx\", version = \"0.9\" }\n");
     fixture.write_source("fn query() { let _ = database::query!(\"SELECT 13\"); }\n");
     assert!(
         validate_sqlx_offline_metadata(&fixture.0)
@@ -388,7 +388,7 @@ mod r#type {
 fn cargo_entrypoint_selection_follows_lib_path_then_main_fallback() {
     let library_fixture = SqlxFixture::new();
     library_fixture.write_manifest(
-        "[lib]\npath = \"source/entry.rs\"\n\n[dependencies]\nsqlx = { version = \"0.8\", features = [\"macros\"] }\n",
+        "[lib]\npath = \"source/entry.rs\"\n\n[dependencies]\nsqlx = { version = \"0.9\", features = [\"macros\"] }\n",
     );
     library_fixture.write_rust_file(
         "source/entry.rs",
@@ -503,7 +503,7 @@ impl SqlxFixture {
         let fixture = Self(root);
         fixture.write_source("fn query() { let _ = sqlx::query!(\"SELECT 13\"); }\n");
         fixture.write_manifest(
-            "[dependencies]\nsqlx = { version = \"0.8\", features = [\"macros\"] }\n",
+            "[dependencies]\nsqlx = { version = \"0.9\", features = [\"macros\"] }\n",
         );
         fixture
     }
@@ -518,7 +518,7 @@ impl SqlxFixture {
         std::fs::create_dir_all(root.join("src")).expect("source directory should exist");
         std::fs::write(
             workspace.join("Cargo.toml"),
-            "[workspace]\nmembers = [\"member\"]\nresolver = \"3\"\n\n[workspace.dependencies]\ndatabase = { package = \"sqlx\", version = \"0.8\", features = [\"macros\"] }\n",
+            "[workspace]\nmembers = [\"member\"]\nresolver = \"3\"\n\n[workspace.dependencies]\ndatabase = { package = \"sqlx\", version = \"0.9\", features = [\"macros\"] }\n",
         )
         .expect("workspace manifest should be written");
         let fixture = Self(root);

--- a/crates/sifr_driver/src/tests/package_rust_interop_backend_ecosystem_support.rs
+++ b/crates/sifr_driver/src/tests/package_rust_interop_backend_ecosystem_support.rs
@@ -37,7 +37,7 @@ fn test_build_backend_loopback_and_sqlx_offline_metadata() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains(
-            "axum=0.8.9;loopback=127.0.0.1:ephemeral;status=200;tower-http=0.7.0;middleware=response-header;sqlx=0.8.6;offline=true;query-value=13;query-hash=f2d6fe08dd19c716c98c45307c0649a03c0bf6d52c5d16c2375913d7a0f2f508;shutdown=clean"
+            "axum=0.8.9;loopback=127.0.0.1:ephemeral;status=200;tower-http=0.7.0;middleware=response-header;sqlx=0.9.0;runtime=tokio;tls=rustls-ring-webpki;offline=true;query-value=13;query-hash=f2d6fe08dd19c716c98c45307c0649a03c0bf6d52c5d16c2375913d7a0f2f508;shutdown=clean"
         ),
         "real backend execution marker must be observed: {stdout}"
     );
@@ -292,14 +292,27 @@ fn assert_exact_backend_dependency_graph(package_root: &Path) {
         "axum v0.8.9",
         "tower-http v0.7.0",
         "tower-http feature \"set-header\"",
-        "sqlx v0.8.6",
-        "sqlx feature \"runtime-tokio-rustls\"",
+        "sqlx v0.9.0",
+        "sqlx feature \"runtime-tokio\"",
+        "sqlx feature \"tls-rustls-ring-webpki\"",
         "sqlx feature \"postgres\"",
         "sqlx feature \"macros\"",
     ] {
         assert!(
             tree.contains(package),
             "locked graph must contain {package}: {tree}"
+        );
+    }
+    for inactive in [
+        "sqlx feature \"runtime-tokio-rustls\"",
+        "sqlx feature \"tls-rustls\"",
+        "sqlx feature \"tls-rustls-ring\"",
+        "sqlx-mysql v",
+        "sqlx-sqlite v",
+    ] {
+        assert!(
+            !tree.contains(inactive),
+            "locked graph must not activate {inactive}: {tree}"
         );
     }
 }

--- a/crates/sifr_rust_interop_catalog/Cargo.toml
+++ b/crates/sifr_rust_interop_catalog/Cargo.toml
@@ -41,7 +41,9 @@ serde = { version = "=1.0.229", default-features = true, optional = true }
 serde_derive = { version = "=1.0.229", default-features = true, optional = true }
 serde_json = { version = "=1.0.151", default-features = true, optional = true }
 sha2 = { version = "=0.11.0", default-features = true, optional = true }
-sqlx = { version = "=0.8.6", default-features = false, features = ["runtime-tokio-rustls", "postgres", "macros"], optional = true }
+# The backend fixture owns query-macro certification. Enabling `macros` here
+# would lock SQLx's inactive SQLite driver beside the catalog's Rusqlite line.
+sqlx = { version = "=0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres"], optional = true }
 thiserror = { version = "=2.0.20", default-features = true, optional = true }
 tokio = { version = "=1.53.1", default-features = true, optional = true }
 tokio-postgres = { version = "=0.7.18", default-features = false, features = ["runtime"], optional = true }

--- a/crates/sifr_stdlib_manifest/tests/sqlx_dependency_version.rs
+++ b/crates/sifr_stdlib_manifest/tests/sqlx_dependency_version.rs
@@ -144,12 +144,6 @@ fn assert_dependency(label: &str, dependency: &toml::Value, expected_features: &
         .filter_map(toml::Value::as_str)
         .collect::<Vec<_>>();
     assert_eq!(features, expected_features, "{label} SQLx features");
-    for legacy in ["runtime-tokio-rustls", "tls-rustls", "tls-rustls-ring"] {
-        assert!(
-            !features.contains(&legacy),
-            "{label} must not use legacy feature {legacy}"
-        );
-    }
 }
 
 fn assert_json_policy(label: &str, policy: &serde_json::Value) {

--- a/crates/sifr_stdlib_manifest/tests/sqlx_dependency_version.rs
+++ b/crates/sifr_stdlib_manifest/tests/sqlx_dependency_version.rs
@@ -1,0 +1,216 @@
+#![allow(clippy::expect_used)]
+
+const CATALOG_MANIFEST: &str = include_str!("../../sifr_rust_interop_catalog/Cargo.toml");
+const FIXTURE_MANIFEST: &str = include_str!(
+    "../../../verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/Cargo.toml"
+);
+const FIXTURE_POLICY: &str = include_str!(
+    "../../../verification/areas/rust_interop/fixtures/ecosystem_backend_certification/fixture.json"
+);
+const MATRIX_POLICY: &str =
+    include_str!("../../../verification/areas/rust_interop/data/rust_interop_fixture_matrix.json");
+
+const WORKSPACE_LOCK: &str = include_str!("../../../Cargo.lock");
+const FIXTURE_LOCK: &str = include_str!(
+    "../../../verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/Cargo.lock"
+);
+
+const SQLX_VERSION: &str = "0.9.0";
+const SQLX_PACKAGE_HASH: &str = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71";
+const SQLX_CORE_PACKAGE_HASH: &str =
+    "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb";
+const SQLX_MACROS_PACKAGE_HASH: &str =
+    "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf";
+const SQLX_MACROS_CORE_PACKAGE_HASH: &str =
+    "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3";
+const SQLX_POSTGRES_PACKAGE_HASH: &str =
+    "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e";
+
+const CATALOG_FEATURES: &[&str] = &["runtime-tokio", "tls-rustls-ring-webpki", "postgres"];
+const FIXTURE_FEATURES: &[&str] = &[
+    "runtime-tokio",
+    "tls-rustls-ring-webpki",
+    "postgres",
+    "macros",
+];
+
+#[test]
+fn maintained_sqlx_dependencies_use_the_latest_stable_policy() {
+    let catalog = dependency(CATALOG_MANIFEST, "catalog");
+    assert_dependency("catalog", &catalog, CATALOG_FEATURES);
+    assert_eq!(
+        catalog.get("optional").and_then(toml::Value::as_bool),
+        Some(true),
+        "catalog SQLx must remain optional"
+    );
+
+    let fixture = dependency(FIXTURE_MANIFEST, "backend fixture");
+    assert_dependency("backend fixture", &fixture, FIXTURE_FEATURES);
+
+    let fixture_policy: serde_json::Value =
+        serde_json::from_str(FIXTURE_POLICY).expect("fixture policy must parse");
+    let fixture_sqlx = fixture_policy
+        .get("features")
+        .and_then(|features| features.get("sqlx"))
+        .expect("fixture must declare SQLx policy");
+    assert_json_policy("fixture", fixture_sqlx);
+
+    let matrix: serde_json::Value =
+        serde_json::from_str(MATRIX_POLICY).expect("matrix policy must parse");
+    let matrix_sqlx = matrix
+        .get("fixtures")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .find(|fixture| {
+            fixture.get("id").and_then(serde_json::Value::as_str)
+                == Some("ecosystem_backend_certification")
+        })
+        .and_then(|fixture| fixture.get("features"))
+        .and_then(|features| features.get("sqlx"))
+        .expect("matrix must declare SQLx policy");
+    assert_json_policy("matrix", matrix_sqlx);
+}
+
+#[test]
+fn maintained_locks_use_the_official_sqlx_0_9_0_packages() {
+    for (label, source) in [
+        ("workspace", WORKSPACE_LOCK),
+        ("backend fixture", FIXTURE_LOCK),
+    ] {
+        let lock: toml::Value =
+            toml::from_str(source).unwrap_or_else(|error| panic!("{label} lock: {error}"));
+        let packages = lock_packages(&lock);
+        assert_package(packages, "sqlx", SQLX_PACKAGE_HASH);
+        assert_package(packages, "sqlx-core", SQLX_CORE_PACKAGE_HASH);
+        assert_package(packages, "sqlx-macros", SQLX_MACROS_PACKAGE_HASH);
+        assert_package(packages, "sqlx-macros-core", SQLX_MACROS_CORE_PACKAGE_HASH);
+        assert_package(packages, "sqlx-postgres", SQLX_POSTGRES_PACKAGE_HASH);
+    }
+}
+
+#[test]
+fn workspace_catalog_keeps_inactive_database_drivers_out_of_the_shared_lock() {
+    let lock: toml::Value = toml::from_str(WORKSPACE_LOCK).expect("workspace lock must parse");
+    let packages = lock_packages(&lock);
+    for inactive_driver in ["sqlx-mysql", "sqlx-sqlite"] {
+        assert!(
+            packages
+                .iter()
+                .all(|package| package_name(package) != Some(inactive_driver)),
+            "workspace lock must not contain inactive {inactive_driver}"
+        );
+    }
+
+    let sqlx = package(packages, "sqlx");
+    let edges = dependency_edges(sqlx).collect::<Vec<_>>();
+    assert_eq!(
+        edges,
+        ["sqlx-core", "sqlx-macros", "sqlx-postgres"],
+        "workspace SQLx lock edges"
+    );
+}
+
+fn dependency(source: &str, label: &str) -> toml::Value {
+    let manifest: toml::Value =
+        toml::from_str(source).unwrap_or_else(|error| panic!("{label} must parse: {error}"));
+    manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("dependencies"))
+        .or_else(|| manifest.get("dependencies"))
+        .and_then(|dependencies| dependencies.get("sqlx"))
+        .unwrap_or_else(|| panic!("{label} must declare SQLx"))
+        .clone()
+}
+
+fn assert_dependency(label: &str, dependency: &toml::Value, expected_features: &[&str]) {
+    assert_eq!(
+        dependency.get("version").and_then(toml::Value::as_str),
+        Some("=0.9.0"),
+        "{label} SQLx version"
+    );
+    assert_eq!(
+        dependency
+            .get("default-features")
+            .and_then(toml::Value::as_bool),
+        Some(false),
+        "{label} must disable SQLx default features"
+    );
+    let features = dependency
+        .get("features")
+        .and_then(toml::Value::as_array)
+        .expect("SQLx features must be an array")
+        .iter()
+        .filter_map(toml::Value::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(features, expected_features, "{label} SQLx features");
+    for legacy in ["runtime-tokio-rustls", "tls-rustls", "tls-rustls-ring"] {
+        assert!(
+            !features.contains(&legacy),
+            "{label} must not use legacy feature {legacy}"
+        );
+    }
+}
+
+fn assert_json_policy(label: &str, policy: &serde_json::Value) {
+    assert_eq!(
+        policy
+            .get("default_features")
+            .and_then(serde_json::Value::as_bool),
+        Some(false),
+        "{label} must disable SQLx default features"
+    );
+    let features = policy
+        .get("features")
+        .and_then(serde_json::Value::as_array)
+        .expect("SQLx policy features must be an array")
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(features, FIXTURE_FEATURES, "{label} SQLx features");
+}
+
+fn lock_packages(lock: &toml::Value) -> &[toml::Value] {
+    lock.get("package")
+        .and_then(toml::Value::as_array)
+        .expect("lock packages must be an array")
+}
+
+fn assert_package(packages: &[toml::Value], name: &str, checksum: &str) {
+    let matching = packages
+        .iter()
+        .filter(|package| {
+            package_name(package) == Some(name)
+                && package.get("version").and_then(toml::Value::as_str) == Some(SQLX_VERSION)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1, "lock must contain one {name} 0.9.0");
+    assert_eq!(
+        matching[0].get("checksum").and_then(toml::Value::as_str),
+        Some(checksum),
+        "{name} checksum"
+    );
+}
+
+fn package<'a>(packages: &'a [toml::Value], name: &str) -> &'a toml::Value {
+    packages
+        .iter()
+        .find(|package| {
+            package_name(package) == Some(name)
+                && package.get("version").and_then(toml::Value::as_str) == Some(SQLX_VERSION)
+        })
+        .unwrap_or_else(|| panic!("lock must contain {name} {SQLX_VERSION}"))
+}
+
+fn dependency_edges(package: &toml::Value) -> impl Iterator<Item = &str> {
+    package
+        .get("dependencies")
+        .and_then(toml::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(toml::Value::as_str)
+}
+
+fn package_name(package: &toml::Value) -> Option<&str> {
+    package.get("name").and_then(toml::Value::as_str)
+}

--- a/docs/rust-interop.mdx
+++ b/docs/rust-interop.mdx
@@ -253,8 +253,9 @@ rejected as `SIFR-RUST-TYPE-0001`. This is
 support for arbitrary CLI crate APIs or `anyhow::Error` values.
 
 The `ecosystem_backend_certification` evidence builds and runs an exact-pinned
-generated package with `axum 0.8.9`, `tower-http 0.7.0`, and `sqlx 0.8.6`
-using only `runtime-tokio-rustls`, `postgres`, and `macros` for SQLx. The
+generated package with `axum 0.8.9`, `tower-http 0.7.0`, and `sqlx 0.9.0`.
+SQLx uses separate `runtime-tokio` and `tls-rustls-ring-webpki` features. It
+also uses `postgres` and `macros`, with default features disabled. The
 package binds an Axum server to `127.0.0.1:0`, observes a tower-http response
 header through a raw loopback request, and shuts the task down cleanly. Its
 SQLx query macro compiles from a checked-in `.sqlx/` artifact whose query and

--- a/internal_docs/rust_interop_architecture.md
+++ b/internal_docs/rust_interop_architecture.md
@@ -1802,11 +1802,18 @@ isolate the representation diagnostic.
 
 `ecosystem_backend_certification` is a tier-4 `cargo-probe` claim scoped to an
 exact package-local bridge. Its authoritative package lock builds
-`axum 0.8.9`, `tower-http 0.7.0` with only `set-header`, and `sqlx 0.8.6`
-with default features disabled and only
-`runtime-tokio-rustls`/`postgres`/`macros`. Executable evidence binds an Axum
+`axum 0.8.9`, `tower-http 0.7.0` with only `set-header`, and `sqlx 0.9.0`.
+SQLx disables default features. It uses separate `runtime-tokio` and
+`tls-rustls-ring-webpki` features plus `postgres` and `macros`. Executable
+evidence binds an Axum
 listener to `127.0.0.1:0`, sends a raw HTTP request, observes the tower-http
 response header and body, and completes graceful shutdown.
+
+The workspace catalog locks the SQLx PostgreSQL runtime without `macros`.
+SQLx 0.9 query macros add inactive MySQL and SQLite offline edges to a lock.
+The SQLite edge cannot share a Cargo lock with the current Rusqlite native
+link. The backend fixture has an independent lock and owns the complete query
+macro graph and executable evidence.
 
 The same bridge expands a real SQLx query macro from one checked-in `.sqlx/`
 file. The validator binds the filename, SQL text, PostgreSQL description, and
@@ -2028,7 +2035,7 @@ Feature-sensitive fixtures must pin Cargo features in `rust_interop_fixture_matr
 - `rusqlite`: `default-features = false`, `features = ["bundled"]`; the Rust interop scope certifies only the bundled native SQLite provider.
 - `redis`: `default-features = false`, `features = ["tokio-comp"]`; pub/sub fixtures use loopback service infrastructure.
 - `tokio-tungstenite`: `default-features = false`; add `features = ["rustls-tls-webpki-roots"]` only for explicit network/TLS coverage.
-- `sqlx`: `default-features = false`, `features = ["runtime-tokio-rustls", "postgres", "macros"]`; query-macro fixtures must use checked-in `.sqlx/` offline artifacts instead of requiring `DATABASE_URL` during Cargo execution.
+- `sqlx`: `default-features = false`, `features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres", "macros"]`; query-macro fixtures must use checked-in `.sqlx/` offline artifacts instead of requiring `DATABASE_URL` during Cargo execution.
 - `axum`: the backend certification uses only `http1` and `tokio`.
 - `tower-http`: the backend certification disables defaults and uses only
   `set-header` so middleware execution is directly observable.

--- a/plans/phases/39_rust_interop.md
+++ b/plans/phases/39_rust_interop.md
@@ -368,7 +368,7 @@ Pinned fixture feature policy:
 - `rusqlite`: `default-features = false`, `features = ["bundled"]`; Phase 39 certifies only the bundled native SQLite provider.
 - `redis`: `default-features = false`, `features = ["tokio-comp"]`; pub/sub fixtures use loopback service infrastructure.
 - `tokio-tungstenite`: `default-features = false`; add `features = ["rustls-tls-webpki-roots"]` only for explicit network/TLS coverage.
-- `sqlx`: `default-features = false`, `features = ["runtime-tokio-rustls", "postgres", "macros"]`; this is ecosystem certification, not the primary opaque-resource fixture, and query-macro fixtures must use checked-in `.sqlx/` offline artifacts instead of requiring `DATABASE_URL` during Cargo execution.
+- `sqlx`: `default-features = false`, `features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres", "macros"]`; this is ecosystem certification, not the primary opaque-resource fixture, and query-macro fixtures must use checked-in `.sqlx/` offline artifacts instead of requiring `DATABASE_URL` during Cargo execution.
 - `axum`: the backend certification uses only `http1` and `tokio`.
 - `tower-http`: the backend certification disables defaults and uses only
   `set-header` so middleware execution is directly observable.

--- a/verification/areas/coverage_matrix/data/cargo_metadata_classification.json
+++ b/verification/areas/coverage_matrix/data/cargo_metadata_classification.json
@@ -259,6 +259,7 @@
         {"name": "num_bigint_dependency_versions", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},
         {"name": "reqwest_dependency_version", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},
         {"name": "rusqlite_dependency_version", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},
+        {"name": "sqlx_dependency_version", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},
         {"name": "syn_prettyplease_dependency_versions", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},
         {"name": "text_i18n_icu_dependency_versions", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},
         {"name": "text_i18n_dependency_snapshots", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"}

--- a/verification/areas/rust_interop/checks/_crate_catalog.py
+++ b/verification/areas/rust_interop/checks/_crate_catalog.py
@@ -9,6 +9,10 @@ from pathlib import Path
 from typing import Any
 
 EXPECTED_PACKAGE_ALIASES = {"candle": "candle-core"}
+# The independent backend fixture owns SQLx query-macro activation.
+CATALOG_FEATURE_OVERRIDES = {
+    "sqlx": ["runtime-tokio", "tls-rustls-ring-webpki", "postgres"],
+}
 
 
 def validate_crate_catalog(
@@ -47,7 +51,9 @@ def validate_crate_catalog(
     )
     if proc.returncode != 0:
         detail = proc.stderr.strip() or proc.stdout.strip()
-        failures.append(f"Rust interop crate catalog is not cacheable offline: {detail}")
+        failures.append(
+            f"Rust interop crate catalog is not cacheable offline: {detail}"
+        )
 
 
 def _validate_catalog_data(
@@ -99,7 +105,9 @@ def _validate_dependency(
     policy: dict[str, Any],
 ) -> None:
     if not isinstance(dependency, dict):
-        failures.append(f"Rust interop crate catalog {crate} must use a dependency table")
+        failures.append(
+            f"Rust interop crate catalog {crate} must use a dependency table"
+        )
         return
     if dependency.get("optional") is not True:
         failures.append(f"Rust interop crate catalog {crate} must be optional")
@@ -122,7 +130,10 @@ def _validate_dependency(
         failures.append(
             f"Rust interop crate catalog {crate} default-features must be {expected_default}"
         )
-    expected_features = policy.get("features", [])
+    expected_features = CATALOG_FEATURE_OVERRIDES.get(
+        crate,
+        policy.get("features", []),
+    )
     if dependency.get("features", []) != expected_features:
         failures.append(
             f"Rust interop crate catalog {crate} features must be {expected_features!r}"
@@ -243,7 +254,7 @@ def run_self_test() -> tuple[int, str | None]:
                         **catalog["dependencies"]["reqwest"],
                         "version": "0.13.4",
                     },
-                }
+                },
             },
             lock,
             "must pin an exact version",

--- a/verification/areas/rust_interop/checks/_crate_catalog.py
+++ b/verification/areas/rust_interop/checks/_crate_catalog.py
@@ -165,13 +165,22 @@ def _validate_non_cargo_policies(
 
 def run_self_test() -> tuple[int, str | None]:
     """Mutation-test exact catalog membership, pinning, and lockfile binding."""
-    required = {"candle", "prost-build", "reqwest"}
+    required = {"candle", "prost-build", "reqwest", "sqlx"}
     policies = {
         "candle": {"backend": "cpu-only", "default_features": False},
         "prost-build": {"generated_output": "deterministic"},
         "reqwest": {
             "default_features": False,
             "features": ["rustls", "json"],
+        },
+        "sqlx": {
+            "default_features": False,
+            "features": [
+                "runtime-tokio",
+                "tls-rustls-ring-webpki",
+                "postgres",
+                "macros",
+            ],
         },
     }
     catalog = {
@@ -193,6 +202,16 @@ def run_self_test() -> tuple[int, str | None]:
                 "features": ["rustls", "json"],
                 "optional": True,
             },
+            "sqlx": {
+                "version": "=0.9.0",
+                "default-features": False,
+                "features": [
+                    "runtime-tokio",
+                    "tls-rustls-ring-webpki",
+                    "postgres",
+                ],
+                "optional": True,
+            },
         },
         "package": {
             "metadata": {
@@ -209,6 +228,7 @@ def run_self_test() -> tuple[int, str | None]:
             {"name": "candle-core", "version": "0.11.0"},
             {"name": "prost-build", "version": "0.14.4"},
             {"name": "reqwest", "version": "0.13.4"},
+            {"name": "sqlx", "version": "0.9.0"},
         ]
     }
     control: list[str] = []
@@ -277,6 +297,25 @@ def run_self_test() -> tuple[int, str | None]:
             },
             lock,
             "features must be",
+        ),
+        (
+            {
+                **catalog,
+                "dependencies": {
+                    **catalog["dependencies"],
+                    "sqlx": {
+                        **catalog["dependencies"]["sqlx"],
+                        "features": [
+                            "runtime-tokio",
+                            "tls-rustls-ring-webpki",
+                            "postgres",
+                            "macros",
+                        ],
+                    },
+                },
+            },
+            lock,
+            "sqlx features must be",
         ),
         (
             {

--- a/verification/areas/rust_interop/checks/_matrix_inventory.py
+++ b/verification/areas/rust_interop/checks/_matrix_inventory.py
@@ -134,7 +134,12 @@ EXPECTED_FEATURE_POLICIES = {
     "rusqlite": {"default_features": False, "features": ["bundled"]},
     "sqlx": {
         "default_features": False,
-        "features": ["runtime-tokio-rustls", "postgres", "macros"],
+        "features": [
+            "runtime-tokio",
+            "tls-rustls-ring-webpki",
+            "postgres",
+            "macros",
+        ],
     },
     "tokio-postgres": {"default_features": False, "features": ["runtime"]},
     "tokio-tungstenite": {"default_features": False},

--- a/verification/areas/rust_interop/checks/_scenario_backend.py
+++ b/verification/areas/rust_interop/checks/_scenario_backend.py
@@ -149,7 +149,7 @@ def run_backend_self_test(
                 "Cargo.lock",
                 "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c",
                 "0000000000000000000000000000000000000000000000000000000000000000",
-                "not present in root Cargo.lock",
+                "no longer contains allowed fixture-only package",
             ),
             (
                 "SQLx TLS provider feature",

--- a/verification/areas/rust_interop/checks/_scenario_backend.py
+++ b/verification/areas/rust_interop/checks/_scenario_backend.py
@@ -23,9 +23,14 @@ EXPECTED_WORKSPACE_DEPENDENCIES = {
         "features": ["http1", "tokio"],
     },
     "sqlx": {
-        "version": "=0.8.6",
+        "version": "=0.9.0",
         "default-features": False,
-        "features": ["runtime-tokio-rustls", "postgres", "macros"],
+        "features": [
+            "runtime-tokio",
+            "tls-rustls-ring-webpki",
+            "postgres",
+            "macros",
+        ],
     },
     "tower-http": {
         "version": "=0.7.0",
@@ -86,8 +91,7 @@ def validate_backend_scenario(
         )
     if trust != EXPECTED_TRUST:
         failures.append(
-            f"{fixture_id}: {raw_path}/sifr.toml trust must equal "
-            f"{EXPECTED_TRUST!r}"
+            f"{fixture_id}: {raw_path}/sifr.toml trust must equal {EXPECTED_TRUST!r}"
         )
 
     _validate_cargo_environment(failures, fixture_id, raw_path, example_dir)
@@ -137,14 +141,21 @@ def run_backend_self_test(
 
         mutations = (
             ("axum pin", "Cargo.toml", '"=0.8.9"', '"0.8.9"', "exact-pin"),
-            ("sqlx pin", "Cargo.toml", '"=0.8.6"', '"0.8.6"', "exact-pin"),
+            ("sqlx pin", "Cargo.toml", '"=0.9.0"', '"0.9.0"', "exact-pin"),
             ("tower pin", "Cargo.toml", '"=0.7.0"', '"0.7.0"', "exact-pin"),
             ("tokio pin", "Cargo.toml", '"=1.53.1"', '"1.53.1"', "exact-pin"),
             (
-                "SQLx feature",
+                "inactive SQLx driver lock identity",
+                "Cargo.lock",
+                "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c",
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                "not present in root Cargo.lock",
+            ),
+            (
+                "SQLx TLS provider feature",
                 "Cargo.toml",
-                '"runtime-tokio-rustls", "postgres", "macros"',
-                '"runtime-tokio", "postgres", "macros"',
+                '"runtime-tokio", "tls-rustls-ring-webpki", "postgres", "macros"',
+                '"runtime-tokio", "tls-rustls", "postgres", "macros"',
                 "exact-pin",
             ),
             (
@@ -309,9 +320,7 @@ def _validate_query_metadata(
         )
         return
     if data.get("query") != QUERY:
-        failures.append(
-            f"{fixture_id}: {raw_path}/.sqlx query must equal {QUERY!r}"
-        )
+        failures.append(f"{fixture_id}: {raw_path}/.sqlx query must equal {QUERY!r}")
     if data.get("hash") != QUERY_HASH:
         failures.append(
             f"{fixture_id}: {raw_path}/.sqlx hash must equal SHA-256 {QUERY_HASH}"

--- a/verification/areas/rust_interop/checks/_scenario_lock_checks.py
+++ b/verification/areas/rust_interop/checks/_scenario_lock_checks.py
@@ -8,6 +8,60 @@ from pathlib import Path
 from typing import Any
 
 
+# SQLx 0.9 query macros lock weak MySQL and SQLite edges. The exact backend
+# fixture owns these entries because SQLite cannot share the Rusqlite lock.
+SQLX_QUERY_MACRO_FIXTURE_ONLY_LOCK_PACKAGES = {
+    (
+        "chacha20",
+        "0.10.1",
+        "registry+https://github.com/rust-lang/crates.io-index",
+        "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81",
+    ),
+    (
+        "getrandom",
+        "0.4.3",
+        "registry+https://github.com/rust-lang/crates.io-index",
+        "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099",
+    ),
+    (
+        "flume",
+        "0.12.0",
+        "registry+https://github.com/rust-lang/crates.io-index",
+        "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be",
+    ),
+    (
+        "libsqlite3-sys",
+        "0.37.0",
+        "registry+https://github.com/rust-lang/crates.io-index",
+        "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1",
+    ),
+    (
+        "spin",
+        "0.9.9",
+        "registry+https://github.com/rust-lang/crates.io-index",
+        "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e",
+    ),
+    (
+        "sqlx-mysql",
+        "0.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index",
+        "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27",
+    ),
+    (
+        "sqlx-sqlite",
+        "0.9.0",
+        "registry+https://github.com/rust-lang/crates.io-index",
+        "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c",
+    ),
+    (
+        "whoami",
+        "2.1.3",
+        "registry+https://github.com/rust-lang/crates.io-index",
+        "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c",
+    ),
+}
+
+
 @lru_cache(maxsize=1)
 def _load_root_lock(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     if not path.is_file():
@@ -50,6 +104,12 @@ def require_root_lock_subset(
         for package in root_lock.get("package", [])
         if isinstance(package, dict) and package.get("source")
     }
+    allowed_fixture_only = (
+        SQLX_QUERY_MACRO_FIXTURE_ONLY_LOCK_PACKAGES
+        if fixture_id == "ecosystem_backend_certification"
+        and raw_path == "examples/backend_feature_package"
+        else set()
+    )
     for package in scenario_lock.get("package", []):
         if not isinstance(package, dict) or not package.get("source"):
             continue
@@ -59,7 +119,7 @@ def require_root_lock_subset(
             str(package.get("source")),
             str(package.get("checksum")),
         )
-        if identity not in root_packages:
+        if identity not in root_packages and identity not in allowed_fixture_only:
             failures.append(
                 f"{fixture_id}: {raw_path}/Cargo.lock package "
                 f"{identity[0]} {identity[1]} is not present in root Cargo.lock "

--- a/verification/areas/rust_interop/checks/_scenario_lock_checks.py
+++ b/verification/areas/rust_interop/checks/_scenario_lock_checks.py
@@ -12,18 +12,6 @@ from typing import Any
 # fixture owns these entries because SQLite cannot share the Rusqlite lock.
 SQLX_QUERY_MACRO_FIXTURE_ONLY_LOCK_PACKAGES = {
     (
-        "chacha20",
-        "0.10.1",
-        "registry+https://github.com/rust-lang/crates.io-index",
-        "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81",
-    ),
-    (
-        "getrandom",
-        "0.4.3",
-        "registry+https://github.com/rust-lang/crates.io-index",
-        "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099",
-    ),
-    (
         "flume",
         "0.12.0",
         "registry+https://github.com/rust-lang/crates.io-index",
@@ -52,12 +40,6 @@ SQLX_QUERY_MACRO_FIXTURE_ONLY_LOCK_PACKAGES = {
         "0.9.0",
         "registry+https://github.com/rust-lang/crates.io-index",
         "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c",
-    ),
-    (
-        "whoami",
-        "2.1.3",
-        "registry+https://github.com/rust-lang/crates.io-index",
-        "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c",
     ),
 }
 
@@ -104,12 +86,27 @@ def require_root_lock_subset(
         for package in root_lock.get("package", [])
         if isinstance(package, dict) and package.get("source")
     }
+    scenario_packages = {
+        (
+            str(package.get("name")),
+            str(package.get("version")),
+            str(package.get("source")),
+            str(package.get("checksum")),
+        )
+        for package in scenario_lock.get("package", [])
+        if isinstance(package, dict) and package.get("source")
+    }
     allowed_fixture_only = (
         SQLX_QUERY_MACRO_FIXTURE_ONLY_LOCK_PACKAGES
         if fixture_id == "ecosystem_backend_certification"
         and raw_path == "examples/backend_feature_package"
         else set()
     )
+    for identity in sorted(allowed_fixture_only - scenario_packages):
+        failures.append(
+            f"{fixture_id}: {raw_path}/Cargo.lock no longer contains allowed "
+            f"fixture-only package {identity[0]} {identity[1]} with the exact identity"
+        )
     for package in scenario_lock.get("package", []):
         if not isinstance(package, dict) or not package.get("source"):
             continue

--- a/verification/areas/rust_interop/checks/_scenario_registry.py
+++ b/verification/areas/rust_interop/checks/_scenario_registry.py
@@ -58,7 +58,8 @@ REQUIRED_SCENARIO_EXAMPLES = {
     "ecosystem_backend_certification": {
         "backend_feature_package": {
             "tokens": (
-                "runtime-tokio-rustls",
+                "runtime-tokio",
+                "tls-rustls-ring-webpki",
                 "postgres",
                 "macros",
                 "tower-http",

--- a/verification/areas/rust_interop/data/rust_interop_fixture_matrix.json
+++ b/verification/areas/rust_interop/data/rust_interop_fixture_matrix.json
@@ -360,7 +360,7 @@
       "capability": "backend/service ecosystem certification",
       "required_crates": ["axum", "tower-http", "sqlx"],
       "features": {
-        "sqlx": {"default_features": false, "features": ["runtime-tokio-rustls", "postgres", "macros"]},
+        "sqlx": {"default_features": false, "features": ["runtime-tokio", "tls-rustls-ring-webpki", "postgres", "macros"]},
         "tower-http": {"default_features": false, "features": ["set-header"]}
       },
       "execution_kind": "cargo-probe",

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/Cargo.lock
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,9 +155,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -351,6 +357,12 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -458,14 +470,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "rand_core",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -476,7 +499,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -697,6 +720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +754,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -732,6 +763,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -900,6 +937,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.3",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
@@ -1002,6 +1049,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1551,6 +1604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1652,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "windows-link"
@@ -1694,6 +1805,100 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/Cargo.lock
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/Cargo.lock
@@ -97,6 +97,9 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -105,6 +108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -136,6 +148,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +178,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -194,14 +232,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -247,13 +313,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -274,10 +339,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
+name = "flume"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -303,6 +379,17 @@ name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-intrusive"
@@ -370,10 +457,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.15.5"
+name = "getrandom"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -388,11 +487,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -409,29 +508,20 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -478,6 +568,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -641,15 +740,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "libredox"
-version = "0.1.18"
+name = "libsqlite3-sys"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.9.0",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -681,12 +778,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -770,7 +867,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -788,10 +885,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
+name = "pkg-config"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "potential_utf"
@@ -800,15 +897,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -830,49 +918,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.6"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
  "bitflags",
 ]
@@ -885,7 +957,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -975,14 +1047,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1027,24 +1121,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlx"
-version = "0.8.6"
+name = "spin"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
+ "sqlx-mysql",
  "sqlx-postgres",
+ "sqlx-sqlite",
 ]
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64",
  "bytes",
+ "cfg-if",
  "crc",
  "crossbeam-queue",
  "either",
@@ -1053,31 +1159,30 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1088,32 +1193,58 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-postgres",
  "syn 2.0.117",
+ "thiserror",
  "tokio",
  "url",
 ]
 
 [[package]]
-name = "sqlx-postgres"
-version = "0.8.6"
+name = "sqlx-mysql"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sha1",
+ "sha2 0.11.0",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
@@ -1128,22 +1259,44 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "home",
  "itoa",
  "log",
  "md-5",
  "memchr",
- "once_cell",
  "rand",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
  "thiserror",
  "tracing",
  "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+dependencies = [
+ "atoi",
+ "flume",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1422,6 +1575,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,21 +1593,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,13 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 
 [[package]]
 name = "windows-link"
@@ -1475,20 +1615,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1502,40 +1633,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1545,21 +1655,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1575,21 +1673,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1599,21 +1685,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1648,26 +1722,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/Cargo.toml
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 
 [workspace.dependencies]
 axum = { version = "=0.8.9", default-features = false, features = ["http1", "tokio"] }
-sqlx = { version = "=0.8.6", default-features = false, features = ["runtime-tokio-rustls", "postgres", "macros"] }
+sqlx = { version = "=0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres", "macros"] }
 tower-http = { version = "=0.7.0", default-features = false, features = ["set-header"] }
 tokio = { version = "=1.53.1", default-features = false, features = ["io-util", "net", "rt", "sync", "time"] }
 

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/README.md
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/README.md
@@ -1,10 +1,13 @@
 # fixture: ecosystem_backend_certification
 # scenario-example: backend_feature_package
 
-This scenario models backend ecosystem feature policy. The package pins `sqlx`
-to `runtime-tokio-rustls`, `postgres`, and `macros` with default features off.
-It executes an Axum server bound to `127.0.0.1:0`, observes a response header
-installed by tower-http, and compiles a SQLx query macro exclusively from the
-checked-in `.sqlx/` metadata under the `SQLX_OFFLINE=true` environment forced
-by Sifr. The fixture does not set that variable itself. No external service,
-inherited `DATABASE_URL`, or registry access is part of the evidence.
+This scenario models backend ecosystem feature policy. The package pins SQLx
+0.9.0 with default features off. It selects `runtime-tokio` and
+`tls-rustls-ring-webpki` separately. It also selects `postgres` and `macros`.
+The removed combined runtime and TLS feature is not accepted.
+
+The scenario executes an Axum server bound to `127.0.0.1:0`. It observes a
+response header installed by tower-http. It compiles a SQLx query macro only
+from the checked-in `.sqlx/` metadata. Sifr forces `SQLX_OFFLINE=true`. The
+fixture does not set that variable. No external service, inherited
+`DATABASE_URL`, or registry access is part of the evidence.

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/src/bridges/backend.rs
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/examples/backend_feature_package/src/bridges/backend.rs
@@ -98,7 +98,7 @@ async fn execute_loopback(path: &str) -> Result<String, BackendErrorBridge> {
     }
     let offline_value = query_compile_time()?;
     Ok(format!(
-        "axum=0.8.9;loopback=127.0.0.1:ephemeral;status=200;tower-http=0.7.0;middleware=response-header;sqlx=0.8.6;offline=true;query-value={offline_value};query-hash={QUERY_HASH};shutdown=clean"
+        "axum=0.8.9;loopback=127.0.0.1:ephemeral;status=200;tower-http=0.7.0;middleware=response-header;sqlx=0.9.0;runtime=tokio;tls=rustls-ring-webpki;offline=true;query-value={offline_value};query-hash={QUERY_HASH};shutdown=clean"
     ))
 }
 

--- a/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/fixture.json
+++ b/verification/areas/rust_interop/fixtures/ecosystem_backend_certification/fixture.json
@@ -35,7 +35,8 @@
     "sqlx": {
       "default_features": false,
       "features": [
-        "runtime-tokio-rustls",
+        "runtime-tokio",
+        "tls-rustls-ring-webpki",
         "postgres",
         "macros"
       ]


### PR DESCRIPTION
Closes Item 20 of the latest-stable convergence phase.

- upgrades SQLx to exact 0.9.0
- replaces the removed combined runtime/TLS feature with runtime-tokio and tls-rustls-ring-webpki
- keeps the shared catalog PostgreSQL-only while the independently locked backend fixture owns query-macro certification
- validates exact official checksums, active feature edges, offline query metadata, and loopback execution

Exact candidate: fa88364ba1e39186d2af70a929d7c5df205c9144