### PR TITLE
build: upgrade Arrow 59 and DataFusion 55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "58.3.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+checksum = "61d285d16bce7d0be61912f7928342b673067b6b7d7ef6cc179258ba7de1fecf"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+checksum = "757ef1836251e88222542a7da2623bc1c9cb9e20afefa6db2c41e79991cd91d4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -231,21 +231,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
 dependencies = [
  "bytes",
  "half",
- "num-bigint 0.4.8",
+ "num-bigint 0.5.1",
  "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -254,7 +254,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "comfy-table",
  "half",
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0dd6d90d1955e9f9a014c1e563ee8aeffc21909085d25623e1da44d96eca26"
+checksum = "25011b52b346407d497ef0030e12b45e4f2d0cc279efc09c4f3d09106db30e36"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a908a11fcfb3fb2f6730f4ac15e367bc644e419155e96238f68cf3adde572b"
+checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a96aed3931c076adee39ec2a40d8219fc7f09e79bcdaca1df16272993e1e14"
+checksum = "f18b9123ccfec418a663f821c9a034af339711678c11ffe00d3ec07da5ff9f7e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+checksum = "bbec439386df71ad570e6758a946111322b9e9dc8db83b5527321f0b4c9119c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
 dependencies = [
  "serde_core",
  "serde_json",
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+checksum = "c838a25bb3691e919e0f617616ac51a4ff8517a952e29ca133cf0c22b2ce65b1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1602,9 +1602,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "datafusion"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754ef4e8f073922a26f5b23133b9db4829342362b09be0bc94309cf261c2f098"
+checksum = "96f76f0167ed0842b29a3d1e41be3c034c0a46409a3a703cc4cc84ee8c24abf4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1639,7 +1639,7 @@ dependencies = [
  "flate2",
  "futures",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "liblzma",
  "log",
  "object_store",
@@ -1655,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06afd1e38dd27bbb1258685a1fc6524df6aff4e07b25b393a47de59635178d99"
+checksum = "d79ec3460f6ed5c58f9b3f2d873fbc77748b82653bff1b4cdaf06de33bb4e05f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1671,7 +1671,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1680,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0668fb32c12065ec242be0e5b4bc62bd7a06a0be3ecd83791ef877e4be67e02"
+checksum = "b48cef241e2efcfd496fe05ae4d0d5de20793451862faefe406c397a467e12d4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1696,16 +1696,17 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
+ "percent-encoding",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca43b263cdff57042cfa8fb817fb3469f4878933380dccff25f5e793580abbf9"
+checksum = "3f72810485975c258f1b4d00baab31728470676c60c5546f366ebd0d99f05ab6"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1715,9 +1716,10 @@ dependencies = [
  "half",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "log",
+ "num-traits",
  "object_store",
  "parquet",
  "recursive",
@@ -1729,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f0ba2b864792bdca4d76c59a1de0ab6e1b61946596b9936888dbd6360035f2"
+checksum = "533c28e75dba52f41bde187d23a1cb24ab91c7c097966824fa471e67b60320ea"
 dependencies = [
  "futures",
  "log",
@@ -1740,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b840a8bce0bcbf5afad02946d438591e7c373f7afccaf3d874c04485772514dd"
+checksum = "5b00a1fa0da26f6087136a82fea7f13c76a672cbab452d4086952a7cf770a19b"
 dependencies = [
  "arrow",
  "async-compression",
@@ -1762,7 +1764,7 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "liblzma",
  "log",
  "object_store",
@@ -1776,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24cc0b9cf6e367f27f27406eff13abf48a11b72446aaa40b3105c0ded5c17d9"
+checksum = "5ad17ec881bff2ed7768b4bfe971d3efbf3473f2fd1f9d365447bccbdf908678"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1793,16 +1795,16 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "object_store",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1abe56b2a7a2d1d6de5117dd1a203181e267f28529faa5da546947621b697d7"
+checksum = "b5345285b0c3eaab412e7539b706973c083bd7e5bce575de5e0a3da488d08d1d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1823,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3e467f0611ad7bdd5aad17c63c9bb6182d04e5282e5496d897ea2b49c024ba"
+checksum = "da02fb9324f56bd8c53f1ee2e949547425cb66f76adc6832b10d44f80a1221d2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1846,11 +1848,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc35b92cd560082155e80d9c826929c852d3c51543f4affd3a51c464a0aab3a"
+checksum = "3c0b0dc1453952952fd5c69ad1c7f6042176e69ed233011d47e07cf74ed0949e"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1867,7 +1870,7 @@ dependencies = [
  "datafusion-pruning",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1877,19 +1880,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69bb69d8769e34f76839c960dbde24c1ac0c885a79b6c3c2287bdc56ec67891"
+checksum = "a88fd985bc0550c36f557db69543cc9d6393b1509783520b30e902f23c555da6"
 
 [[package]]
 name = "datafusion-execution"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8eac0a09bc8d263f52025cad9e001da4d8138d633fa288edda4d06b1772eae6"
+checksum = "a98f1052f91b4991f0bf2ce1e4e36dfbdcda454a956b8c8d562c7c845e8fce1d"
 dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
+ "bytes",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -1898,16 +1902,19 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
+ "pin-project-lite",
  "rand 0.9.5",
  "tempfile",
+ "tokio",
+ "tokio-util",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb14d374767ee0fc62dc79a5ba8bcf8a63c14e993c7d992d0e63adfa23d77d3"
+checksum = "464625a1f0e4b9df552d894fafcc8aac953ebbc8b0fa0acdaf20975fd615040e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1920,7 +1927,7 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "recursive",
  "serde_json",
  "sqlparser 0.62.0",
@@ -1928,25 +1935,25 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b19a8c95522bee8cbb313d74263b85e355d2b52f42e67ef5694bf5de9e9356"
+checksum = "2604994999d5aeca1d1df645ffc98bc787447aaff05dde27aad0342b48fc1fe0"
 dependencies = [
  "arrow",
  "datafusion-common",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f64c983bbbdcb729d921a2b2ac3375598719b5cc0c30345ad664936f3176fc7"
+checksum = "051e97533e6af53e4aa0a0667cadc886abcaf36c4a5925019c55c0aa4c218fde"
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64 0.22.1",
+ "base64 0.23.1",
  "blake2",
  "blake3",
  "chrono",
@@ -1959,7 +1966,7 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr-common",
  "hex",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "md-5 0.11.0",
  "memchr",
@@ -1972,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bc17041e424a47ed062f43df24d84aab8b57c4c3221e5c1a5eef46d6c5718b"
+checksum = "2d0f1bb166d3572b6ed40e1afb2faaacade962abc08c2fcf04babee74681c56b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1985,17 +1992,17 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "foldhash 0.2.0",
  "half",
+ "hashbrown 0.17.1",
  "log",
  "num-traits",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dd2a9e865c6108059f5b37b77934f84b50bfb108f837bd0e5c9536e03f0545"
+checksum = "7ed756770f5f98369e181d692fd5ee6b1127ffd7322caba92f3730f9f5c92333"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2005,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f0bdfeef16d96417b9632ef855645376b242e9006a126dfd0bedfc54a93f5f"
+checksum = "91173fdb5c0ff2a41169a8ffa1b385b8844f18728747bb0a37e35ad7d5772a4f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2022,7 +2029,7 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr-common",
  "hashbrown 0.17.1",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "itoa",
  "log",
  "memchr",
@@ -2030,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e4941673c917819616877e9993da4503e4f4739812be0bc32c5356184c6383"
+checksum = "b1bcdfb286a745461b126719c32700777e83df4f17cc44db5d71ebce5731e840"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2046,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dd2e16c12b84b6f6b41b19f55b366dd1c46876bb35b86896c6349067379e8d"
+checksum = "9ec4b508f1f93f00038ba3e737e894ec6c775528b4369413386655ae6125f0fc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2063,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdc5e4b6f8b6ef823cc1c761f85088ad4c884fe8df64df3cbcc6b2b84698441"
+checksum = "0b352020834140073fbf5b46ee0ceb926e5074a9d0bcae1dbd91d0586d999cde"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2073,20 +2080,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3614234dd93578c92428cb4f408e020874f0d2b7e6c90c928d9d28b5df2ceb"
+checksum = "15192effab05d38cce10e92a6fb48c967b5f166b27b7195a165a72b232569c58"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0635620b050b81bb92764e99250868f654e2cd5ad1bece413283b3f73c83179"
+checksum = "854445d9f7847e1e46089cf61b8d341a64382f14484e912c83a0f23b31216896"
 dependencies = [
  "arrow",
  "chrono",
@@ -2095,7 +2102,7 @@ dependencies = [
  "datafusion-expr-common",
  "datafusion-physical-expr",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "recursive",
  "regex",
@@ -2104,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cabf7a86eb70b816729e33c81bf7767c936ee1226f607a114f5dac2decac8d0"
+checksum = "671558dad1d2aa253c39c0a4c52515958b99eb91abf649f4b88d5e69cc55282f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2117,7 +2124,7 @@ dependencies = [
  "half",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "parking_lot",
  "petgraph",
  "recursive",
@@ -2126,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de222e04f7e6744501555a54ab0abe26bfdfebee380af79a9bdc175704246859"
+checksum = "ffae3d78c2da80ecc829cb58536cc5aca2e99cf1365eda694fc75bfe288861e0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2136,14 +2143,14 @@ dependencies = [
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "itertools 0.14.0",
+ "itertools 0.15.0",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d0d0057fc5a502d45c870cb6d47c66eb7bdd5edb1bd71ad6f3f724975ac2a8"
+checksum = "3d9092ed15e7203fbd0903215172f7c9d18f10d94cba35137f3b3836f7c46f16"
 dependencies = [
  "arrow",
  "chrono",
@@ -2151,16 +2158,16 @@ dependencies = [
  "datafusion-expr-common",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "parking_lot",
  "pin-project",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86046eed10950c5f9aaed9acfd148e9bd2e1dfdfe4f9aef607d1447b271e4183"
+checksum = "9005b6cf50b57b72d476c6ed4662b04be7ca6be5320ba9127c6d0b7e4218095b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2171,15 +2178,16 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-pruning",
- "itertools 0.14.0",
+ "datafusion-session",
+ "itertools 0.15.0",
  "recursive",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc84da934c903407ba297971ebcc020c4c1a38aafd765d6c144c76eff3fa6a1"
+checksum = "5787e4fcff4adc4fce8948441103a99705018b49c8dff0720b650bd7a15da112"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -2187,6 +2195,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "async-trait",
+ "bytes",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-execution",
@@ -2200,19 +2209,20 @@ dependencies = [
  "half",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "num-traits",
  "parking_lot",
  "pin-project-lite",
+ "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-pruning"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb63eeac6de19be40f487b65dd84e546195f783c5a9928618e0c4f2a3569b0d7"
+checksum = "9e651c8df0b90daed6a7be5921ec0ee379e6909705f063eeff70fd4e35010e4c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2226,10 +2236,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f961d209177f91bd014db5cbb2c33b7d28a2597b9003e77f17aeb712964315a"
+checksum = "fb56667ee38217efab19b895d9a936052cfb47ed438a19663351bdc42a6214a1"
 dependencies = [
+ "arrow-schema",
  "async-trait",
  "datafusion-common",
  "datafusion-execution",
@@ -2240,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d71cb454da682b2af7488e1fc1ddd72ee1b28f19297b8ccad73f0a21ee9a69"
+checksum = "9c29067cb9d32f8e603c45e15d61ea18f1069f96ceafeceb4e18466b8e5b31d9"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2255,6 +2266,7 @@ dependencies = [
  "recursive",
  "regex",
  "sqlparser 0.62.0",
+ "stacker",
 ]
 
 [[package]]
@@ -3679,12 +3691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "interpolator"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4090,9 +4096,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -4560,15 +4566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "ordermap"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4608,9 +4605,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d298093b2dec60289dce0684c986d0f7679e9dd15771c2c65406e1aaf604a704"
+checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -4619,7 +4616,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.22.1",
+ "base64 0.23.1",
  "brotli",
  "bytes",
  "chrono",
@@ -4628,15 +4625,13 @@ dependencies = [
  "half",
  "hashbrown 0.17.1",
  "lz4_flex",
- "num-bigint 0.4.8",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
  "object_store",
- "paste",
  "seq-macro",
  "simdutf8",
  "snap",
- "thrift",
  "tokio",
  "twox-hash",
  "zstd",
@@ -7809,7 +7804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7880,17 +7875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
 ]
 
 [[package]]

--- a/crates/sifr_driver/src/tests/package_rust_interop_advanced_data_support.rs
+++ b/crates/sifr_driver/src/tests/package_rust_interop_advanced_data_support.rs
@@ -29,7 +29,7 @@ fn test_build_advanced_data_crate_backed_arrow_tensor_roundtrips() {
 
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        "Ok(\"arrow=schema=value:float64;rows=6;datafusion=registered;polars=value:float64x6;polars-copy=explicit;copy=input->arrow:none;tensor=dtype=f64;rank=2;shape=2x3;layout=c;strides=3x1;device=cpu;ndarray-copy=none;candle-copy=none;dlpack=protocol=managed-tensor;ownership=transferred;dtype=f64;rank=2;shape=2x3;strides=3x1;device=cpu;copy=none;cleanup-before=arrow-released=0;active=1;tensor-released=0;active=1;cleanup-after=arrow-released=1;active=0;tensor-released=1;active=0\")"
+        "Ok(\"arrow=schema=value:float64;rows=6;datafusion=registered+fill-nan-planned;polars=value:float64x6;polars-copy=explicit;copy=input->arrow:none;tensor=dtype=f64;rank=2;shape=2x3;layout=c;strides=3x1;device=cpu;ndarray-copy=none;candle-copy=none;dlpack=protocol=managed-tensor;ownership=transferred;dtype=f64;rank=2;shape=2x3;strides=3x1;device=cpu;copy=none;cleanup-before=arrow-released=0;active=1;tensor-released=0;active=1;cleanup-after=arrow-released=1;active=0;tensor-released=1;active=0\")"
     );
     assert!(
         output.stderr.is_empty(),

--- a/crates/sifr_rust_interop_catalog/Cargo.toml
+++ b/crates/sifr_rust_interop_catalog/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 # ordinary development lanes. Row PRs enable only their owning dependencies.
 [dependencies]
 anyhow = { version = "=1.0.104", default-features = true, optional = true }
-arrow = { version = "=58.3.0", default-features = true, optional = true }
+arrow = { version = "=59.2.0", default-features = true, optional = true }
 axum = { version = "=0.8.9", default-features = true, optional = true }
 bindgen = { version = "=0.72.1", default-features = true, optional = true }
 blake3 = { version = "=1.8.7", default-features = true, optional = true }
@@ -21,7 +21,7 @@ cc = { version = "=1.4.4", default-features = true, optional = true }
 clap = { version = "=4.6.6", default-features = true, optional = true }
 crc32fast = { version = "=1.5.1", default-features = true, optional = true }
 cxx = { version = "=1.0.199", default-features = true, optional = true }
-datafusion = { version = "=54.1.0", default-features = true, optional = true }
+datafusion = { version = "=55.0.0", default-features = true, optional = true }
 flate2 = { version = "=1.1.9", default-features = false, features = ["rust_backend"], optional = true }
 futures = { version = "=0.3.34", default-features = true, optional = true }
 http = { version = "=1.5.0", default-features = true, optional = true }

--- a/crates/sifr_stdlib_manifest/tests/arrow_datafusion_dependency_versions.rs
+++ b/crates/sifr_stdlib_manifest/tests/arrow_datafusion_dependency_versions.rs
@@ -1,0 +1,252 @@
+#![allow(clippy::expect_used)]
+
+use std::collections::BTreeSet;
+
+const ARROW_VERSION: &str = "59.2.0";
+const ARROW_PACKAGE_HASH: &str = "61d285d16bce7d0be61912f7928342b673067b6b7d7ef6cc179258ba7de1fecf";
+const DATAFUSION_VERSION: &str = "55.0.0";
+const DATAFUSION_PACKAGE_HASH: &str =
+    "96f76f0167ed0842b29a3d1e41be3c034c0a46409a3a703cc4cc84ee8c24abf4";
+
+const CATALOG_MANIFEST: &str = include_str!("../../sifr_rust_interop_catalog/Cargo.toml");
+const FIXTURE_MANIFEST: &str = include_str!(
+    "../../../verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/Cargo.toml"
+);
+const BRIDGE_SOURCE: &str = include_str!(
+    "../../../verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/rust/sifr_arrow_bridge/src/record_batch.rs"
+);
+const WORKSPACE_LOCK: &str = include_str!("../../../Cargo.lock");
+const FIXTURE_LOCK: &str = include_str!(
+    "../../../verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/Cargo.lock"
+);
+
+const ARROW_PACKAGES: &[&str] = &[
+    "arrow",
+    "arrow-arith",
+    "arrow-array",
+    "arrow-buffer",
+    "arrow-cast",
+    "arrow-csv",
+    "arrow-data",
+    "arrow-ipc",
+    "arrow-json",
+    "arrow-ord",
+    "arrow-row",
+    "arrow-schema",
+    "arrow-select",
+    "arrow-string",
+];
+
+const DATAFUSION_PACKAGES: &[&str] = &[
+    "datafusion",
+    "datafusion-catalog",
+    "datafusion-catalog-listing",
+    "datafusion-common",
+    "datafusion-common-runtime",
+    "datafusion-datasource",
+    "datafusion-datasource-arrow",
+    "datafusion-datasource-csv",
+    "datafusion-datasource-json",
+    "datafusion-datasource-parquet",
+    "datafusion-doc",
+    "datafusion-execution",
+    "datafusion-expr",
+    "datafusion-expr-common",
+    "datafusion-functions",
+    "datafusion-functions-aggregate",
+    "datafusion-functions-aggregate-common",
+    "datafusion-functions-nested",
+    "datafusion-functions-table",
+    "datafusion-functions-window",
+    "datafusion-functions-window-common",
+    "datafusion-macros",
+    "datafusion-optimizer",
+    "datafusion-physical-expr",
+    "datafusion-physical-expr-adapter",
+    "datafusion-physical-expr-common",
+    "datafusion-physical-optimizer",
+    "datafusion-physical-plan",
+    "datafusion-pruning",
+    "datafusion-session",
+    "datafusion-sql",
+];
+
+#[test]
+fn maintained_manifests_select_the_latest_stable_analytical_stack() {
+    let catalog: toml::Value =
+        toml::from_str(CATALOG_MANIFEST).expect("catalog manifest must parse");
+    let catalog_dependencies = catalog
+        .get("dependencies")
+        .expect("catalog must declare dependencies");
+    assert_dependency(catalog_dependencies, "arrow", ARROW_VERSION, Some(true));
+    assert_dependency(
+        catalog_dependencies,
+        "datafusion",
+        DATAFUSION_VERSION,
+        Some(true),
+    );
+
+    let fixture: toml::Value =
+        toml::from_str(FIXTURE_MANIFEST).expect("fixture manifest must parse");
+    let fixture_dependencies = fixture
+        .get("workspace")
+        .and_then(|workspace| workspace.get("dependencies"))
+        .expect("fixture must declare workspace dependencies");
+    assert_dependency(fixture_dependencies, "arrow", ARROW_VERSION, None);
+    assert_dependency(fixture_dependencies, "datafusion", DATAFUSION_VERSION, None);
+}
+
+#[test]
+fn maintained_locks_use_one_current_arrow_and_datafusion_family() {
+    for (label, source) in [
+        ("workspace", WORKSPACE_LOCK),
+        ("advanced-data fixture", FIXTURE_LOCK),
+    ] {
+        let lock: toml::Value =
+            toml::from_str(source).unwrap_or_else(|error| panic!("{label} lock: {error}"));
+        let packages = lock_packages(&lock);
+        assert_package_hash(label, packages, "arrow", ARROW_VERSION, ARROW_PACKAGE_HASH);
+        assert_package_hash(
+            label,
+            packages,
+            "datafusion",
+            DATAFUSION_VERSION,
+            DATAFUSION_PACKAGE_HASH,
+        );
+        assert_family(label, packages, "arrow", ARROW_PACKAGES, ARROW_VERSION);
+        assert_family(
+            label,
+            packages,
+            "datafusion",
+            DATAFUSION_PACKAGES,
+            DATAFUSION_VERSION,
+        );
+
+        let parquet = package(packages, "parquet");
+        assert_eq!(
+            package_version(parquet),
+            Some(ARROW_VERSION),
+            "{label} Parquet must share the Arrow release"
+        );
+
+        let datafusion = package(packages, "datafusion");
+        let edges = dependency_edges(datafusion).collect::<BTreeSet<_>>();
+        for expected in ["arrow", "itertools 0.15.0", "parquet"] {
+            assert!(
+                edges.contains(expected),
+                "{label} DataFusion must depend on {expected}: {edges:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn runtime_bridge_uses_datafusion_55_nan_fill_and_propagates_catalog_errors() {
+    assert!(BRIDGE_SOURCE.contains("fill_nan(&ScalarValue::from(0.0), &[\"value\"])"));
+    assert!(BRIDGE_SOURCE.contains(".table_exist(\"input\")"));
+    assert!(BRIDGE_SOURCE.contains(".map_err(display_error)?"));
+    assert!(!BRIDGE_SOURCE.contains("unwrap_or(false)"));
+}
+
+fn assert_dependency(
+    dependencies: &toml::Value,
+    name: &str,
+    version: &str,
+    optional: Option<bool>,
+) {
+    let dependency = dependencies
+        .get(name)
+        .unwrap_or_else(|| panic!("manifest must declare {name}"));
+    let expected_version = format!("={version}");
+    assert_eq!(
+        dependency.get("version").and_then(toml::Value::as_str),
+        Some(expected_version.as_str()),
+        "{name} exact version"
+    );
+    assert_eq!(
+        dependency
+            .get("default-features")
+            .and_then(toml::Value::as_bool),
+        Some(true),
+        "{name} default-feature policy"
+    );
+    if let Some(expected) = optional {
+        assert_eq!(
+            dependency.get("optional").and_then(toml::Value::as_bool),
+            Some(expected),
+            "{name} optional policy"
+        );
+    }
+}
+
+fn assert_family(
+    label: &str,
+    packages: &[toml::Value],
+    prefix: &str,
+    expected_names: &[&str],
+    expected_version: &str,
+) {
+    let actual = packages
+        .iter()
+        .filter_map(|package| {
+            let name = package_name(package)?;
+            (name == prefix || name.starts_with(&format!("{prefix}-")))
+                .then_some((name, package_version(package)))
+        })
+        .collect::<BTreeSet<_>>();
+    let expected = expected_names
+        .iter()
+        .map(|name| (*name, Some(expected_version)))
+        .collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected, "{label} {prefix} package family");
+}
+
+fn assert_package_hash(
+    label: &str,
+    packages: &[toml::Value],
+    name: &str,
+    version: &str,
+    expected_hash: &str,
+) {
+    let matching = packages
+        .iter()
+        .filter(|package| package_name(package) == Some(name))
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1, "{label} must contain one {name}");
+    assert_eq!(package_version(matching[0]), Some(version));
+    assert_eq!(
+        matching[0].get("checksum").and_then(toml::Value::as_str),
+        Some(expected_hash),
+        "{label} {name} checksum"
+    );
+}
+
+fn lock_packages(lock: &toml::Value) -> &[toml::Value] {
+    lock.get("package")
+        .and_then(toml::Value::as_array)
+        .expect("lock packages must be an array")
+}
+
+fn package<'a>(packages: &'a [toml::Value], name: &str) -> &'a toml::Value {
+    packages
+        .iter()
+        .find(|package| package_name(package) == Some(name))
+        .unwrap_or_else(|| panic!("lock must contain {name}"))
+}
+
+fn dependency_edges(package: &toml::Value) -> impl Iterator<Item = &str> {
+    package
+        .get("dependencies")
+        .and_then(toml::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(toml::Value::as_str)
+}
+
+fn package_name(package: &toml::Value) -> Option<&str> {
+    package.get("name").and_then(toml::Value::as_str)
+}
+
+fn package_version(package: &toml::Value) -> Option<&str> {
+    package.get("version").and_then(toml::Value::as_str)
+}

--- a/crates/sifr_stdlib_manifest/tests/itertools_dependency_version.rs
+++ b/crates/sifr_stdlib_manifest/tests/itertools_dependency_version.rs
@@ -6,8 +6,8 @@ use itertools::{Itertools, Position};
 const ITERTOOLS_VERSION: &str = "0.15.0";
 const ITERTOOLS_PACKAGE_HASH: &str =
     "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc";
-const DATAFUSION_ITERTOOLS_VERSION: &str = "0.14.0";
-const DATAFUSION_ITERTOOLS_PACKAGE_HASH: &str =
+const TRANSITIVE_ITERTOOLS_VERSION: &str = "0.14.0";
+const TRANSITIVE_ITERTOOLS_PACKAGE_HASH: &str =
     "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285";
 
 const WORKSPACE_MANIFEST: &str = include_str!("../../../Cargo.toml");
@@ -17,9 +17,9 @@ const WORKSPACE_LOCK: &str = include_str!("../../../Cargo.lock");
 const ITERTOOLS_VENDOR_MANIFEST: &str = include_str!("../../../vendor/itertools/Cargo.toml");
 const ITERTOOLS_VENDOR_CHECKSUM: &str =
     include_str!("../../../vendor/itertools/.cargo-checksum.json");
-const DATAFUSION_ITERTOOLS_VENDOR_MANIFEST: &str =
+const TRANSITIVE_ITERTOOLS_VENDOR_MANIFEST: &str =
     include_str!("../../../vendor/itertools-0.14.0/Cargo.toml");
-const DATAFUSION_ITERTOOLS_VENDOR_CHECKSUM: &str =
+const TRANSITIVE_ITERTOOLS_VENDOR_CHECKSUM: &str =
     include_str!("../../../vendor/itertools-0.14.0/.cargo-checksum.json");
 
 #[test]
@@ -168,7 +168,7 @@ fn first_party_lock_edges_use_itertools_0_15() {
 }
 
 #[test]
-fn vendor_contains_current_and_datafusion_owned_itertools_releases() {
+fn vendor_contains_current_and_external_transitive_itertools_releases() {
     assert_vendor_release(
         ITERTOOLS_VENDOR_MANIFEST,
         ITERTOOLS_VENDOR_CHECKSUM,
@@ -176,10 +176,10 @@ fn vendor_contains_current_and_datafusion_owned_itertools_releases() {
         ITERTOOLS_PACKAGE_HASH,
     );
     assert_vendor_release(
-        DATAFUSION_ITERTOOLS_VENDOR_MANIFEST,
-        DATAFUSION_ITERTOOLS_VENDOR_CHECKSUM,
-        DATAFUSION_ITERTOOLS_VERSION,
-        DATAFUSION_ITERTOOLS_PACKAGE_HASH,
+        TRANSITIVE_ITERTOOLS_VENDOR_MANIFEST,
+        TRANSITIVE_ITERTOOLS_VENDOR_CHECKSUM,
+        TRANSITIVE_ITERTOOLS_VERSION,
+        TRANSITIVE_ITERTOOLS_PACKAGE_HASH,
     );
 
     let lock: toml::Value = toml::from_str(WORKSPACE_LOCK).expect("Cargo.lock must parse");
@@ -198,8 +198,23 @@ fn vendor_contains_current_and_datafusion_owned_itertools_releases() {
         .collect::<Vec<_>>();
     assert_eq!(
         dependencies,
-        ["itertools 0.14.0"],
-        "Item 22 owns the upstream DataFusion transition to Itertools 0.15"
+        ["itertools 0.15.0"],
+        "DataFusion 55 must use the maintained Itertools line directly"
+    );
+
+    let object_store = packages
+        .iter()
+        .find(|package| package_name(package) == Some("object_store"))
+        .expect("Cargo.lock must contain Object Store");
+    assert!(
+        object_store
+            .get("dependencies")
+            .and_then(toml::Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(toml::Value::as_str)
+            .any(|dependency| dependency == "itertools 0.14.0"),
+        "Object Store retains the external Itertools 0.14 edge"
     );
 }
 

--- a/verification/areas/coverage_matrix/data/cargo_metadata_classification.json
+++ b/verification/areas/coverage_matrix/data/cargo_metadata_classification.json
@@ -252,6 +252,7 @@
       "targets": [
         {"name": "sifr_stdlib_manifest", "kind": "lib", "classification": "first_party_compiler", "profile_assignment": "merge"},
         {"name": "base64_dependency_version", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},
+        {"name": "arrow_datafusion_dependency_versions", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},
         {"name": "concurrency_runtime_dependency_snapshots", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},
         {"name": "hash_sha2_dependency_versions", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},
         {"name": "itertools_dependency_version", "kind": "test", "classification": "test_fixture", "profile_assignment": "merge"},

--- a/verification/areas/rust_interop/checks/_scenario_advanced_data.py
+++ b/verification/areas/rust_interop/checks/_scenario_advanced_data.py
@@ -23,6 +23,8 @@ ADVANCED_DATA_SCENARIO_TOKENS = (
     "let polars_values = array.values().to_vec();",
     "MemTable::try_new",
     '.register_table("input"',
+    'fill_nan(&ScalarValue::from(0.0), &["value"])',
+    'map_err(display_error)?',
     "DataFrame::new",
     "Array2::from_shape_vec",
     "Tensor::from_vec",
@@ -90,7 +92,7 @@ def validate_advanced_data_scenario(
         raw_path,
         workspace_dependencies,
         "arrow",
-        {"version": "=58.3.0", "default-features": True},
+        {"version": "=59.2.0", "default-features": True},
     )
     _require_dependency_entry(
         failures,
@@ -98,7 +100,7 @@ def validate_advanced_data_scenario(
         raw_path,
         workspace_dependencies,
         "datafusion",
-        {"version": "=54.1.0", "default-features": True},
+        {"version": "=55.0.0", "default-features": True},
     )
     _require_dependency_entry(
         failures,
@@ -218,8 +220,8 @@ def run_advanced_data_self_test(
             (
                 "Arrow pin drift",
                 "examples/advanced_data_runtime/Cargo.toml",
-                'arrow = { version = "=58.3.0", default-features = true }',
-                'arrow = { version = "58.3.0", default-features = true }',
+                'arrow = { version = "=59.2.0", default-features = true }',
+                'arrow = { version = "59.2.0", default-features = true }',
                 "workspace dependency arrow",
             ),
             (
@@ -249,6 +251,14 @@ def run_advanced_data_self_test(
                 '.register_table("input"',
                 '.deregister_table("input"',
                 "missing scenario token '.register_table(\"input\"'",
+            ),
+            (
+                "DataFusion 55 NaN-fill planning drift",
+                "examples/advanced_data_runtime/rust/sifr_arrow_bridge/src/record_batch.rs",
+                'fill_nan(&ScalarValue::from(0.0), &["value"])',
+                'fill_null(&ScalarValue::from(0.0), &["value"])',
+                "missing scenario token 'fill_nan(&ScalarValue::from(0.0), "
+                '&["value"])\'',
             ),
             (
                 "Polars crossed-data derivation drift",

--- a/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/README.md
+++ b/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/README.md
@@ -3,7 +3,8 @@
 This runtime-observed fixture certifies generated package exchange through the
 exact root-lock versions of Arrow, DataFusion, Polars, ndarray, and CPU-only
 Candle. The positive direction observes Arrow/DataFusion/Polars schema
-identity, ndarray and Candle dtype/rank/shape/layout/stride/device identity,
+identity, DataFusion 55 NaN-fill planning through its borrowed API, ndarray and
+Candle dtype/rank/shape/layout/stride/device identity,
 allocation-preserving owned inputs, one-shot DLPack-style transfer, and
 deterministic cleanup before and after consuming close. The Polars dataframe
 is derived from the crossed Arrow values through an explicit copy; no
@@ -17,4 +18,5 @@ The existing `arrow_record_batch`, `tensor_dlpack_bridge`, and
 runtime evidence. The generated scenario's shared bridges use only safe Rust
 and its manifest grants only the seven-entry native-link envelope covering the
 locked default-feature graph on the supported arm64 and x86_64 validation
-hosts.
+hosts. DataFusion catalog errors remain typed failures; the bridge does not
+convert them to a missing-table value.

--- a/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/Cargo.lock
+++ b/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/Cargo.lock
@@ -110,9 +110,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "58.3.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+checksum = "61d285d16bce7d0be61912f7928342b673067b6b7d7ef6cc179258ba7de1fecf"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+checksum = "757ef1836251e88222542a7da2623bc1c9cb9e20afefa6db2c41e79991cd91d4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -164,21 +164,21 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
 dependencies = [
  "bytes",
  "half",
- "num-bigint 0.4.8",
+ "num-bigint 0.5.1",
  "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -187,7 +187,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "comfy-table",
  "half",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0dd6d90d1955e9f9a014c1e563ee8aeffc21909085d25623e1da44d96eca26"
+checksum = "25011b52b346407d497ef0030e12b45e4f2d0cc279efc09c4f3d09106db30e36"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a908a11fcfb3fb2f6730f4ac15e367bc644e419155e96238f68cf3adde572b"
+checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a96aed3931c076adee39ec2a40d8219fc7f09e79bcdaca1df16272993e1e14"
+checksum = "f18b9123ccfec418a663f821c9a034af339711678c11ffe00d3ec07da5ff9f7e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+checksum = "bbec439386df71ad570e6758a946111322b9e9dc8db83b5527321f0b4c9119c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
 dependencies = [
  "serde_core",
  "serde_json",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+checksum = "c838a25bb3691e919e0f617616ac51a4ff8517a952e29ca133cf0c22b2ce65b1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -430,6 +430,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bigdecimal"
@@ -985,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754ef4e8f073922a26f5b23133b9db4829342362b09be0bc94309cf261c2f098"
+checksum = "96f76f0167ed0842b29a3d1e41be3c034c0a46409a3a703cc4cc84ee8c24abf4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1022,7 +1028,7 @@ dependencies = [
  "flate2",
  "futures",
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
  "liblzma",
  "log",
  "object_store",
@@ -1038,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06afd1e38dd27bbb1258685a1fc6524df6aff4e07b25b393a47de59635178d99"
+checksum = "d79ec3460f6ed5c58f9b3f2d873fbc77748b82653bff1b4cdaf06de33bb4e05f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1054,7 +1060,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1063,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0668fb32c12065ec242be0e5b4bc62bd7a06a0be3ecd83791ef877e4be67e02"
+checksum = "b48cef241e2efcfd496fe05ae4d0d5de20793451862faefe406c397a467e12d4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1079,16 +1085,17 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "futures",
- "itertools",
+ "itertools 0.15.0",
  "log",
  "object_store",
+ "percent-encoding",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca43b263cdff57042cfa8fb817fb3469f4878933380dccff25f5e793580abbf9"
+checksum = "3f72810485975c258f1b4d00baab31728470676c60c5546f366ebd0d99f05ab6"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1098,9 +1105,10 @@ dependencies = [
  "half",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
  "libc",
  "log",
+ "num-traits",
  "object_store",
  "parquet",
  "recursive",
@@ -1112,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f0ba2b864792bdca4d76c59a1de0ab6e1b61946596b9936888dbd6360035f2"
+checksum = "533c28e75dba52f41bde187d23a1cb24ab91c7c097966824fa471e67b60320ea"
 dependencies = [
  "futures",
  "log",
@@ -1123,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b840a8bce0bcbf5afad02946d438591e7c373f7afccaf3d874c04485772514dd"
+checksum = "5b00a1fa0da26f6087136a82fea7f13c76a672cbab452d4086952a7cf770a19b"
 dependencies = [
  "arrow",
  "async-compression",
@@ -1145,7 +1153,7 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
- "itertools",
+ "itertools 0.15.0",
  "liblzma",
  "log",
  "object_store",
@@ -1159,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24cc0b9cf6e367f27f27406eff13abf48a11b72446aaa40b3105c0ded5c17d9"
+checksum = "5ad17ec881bff2ed7768b4bfe971d3efbf3473f2fd1f9d365447bccbdf908678"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1176,16 +1184,16 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.15.0",
  "object_store",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1abe56b2a7a2d1d6de5117dd1a203181e267f28529faa5da546947621b697d7"
+checksum = "b5345285b0c3eaab412e7539b706973c083bd7e5bce575de5e0a3da488d08d1d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1206,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3e467f0611ad7bdd5aad17c63c9bb6182d04e5282e5496d897ea2b49c024ba"
+checksum = "da02fb9324f56bd8c53f1ee2e949547425cb66f76adc6832b10d44f80a1221d2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1229,11 +1237,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc35b92cd560082155e80d9c826929c852d3c51543f4affd3a51c464a0aab3a"
+checksum = "3c0b0dc1453952952fd5c69ad1c7f6042176e69ed233011d47e07cf74ed0949e"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -1250,7 +1259,7 @@ dependencies = [
  "datafusion-pruning",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1260,19 +1269,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69bb69d8769e34f76839c960dbde24c1ac0c885a79b6c3c2287bdc56ec67891"
+checksum = "a88fd985bc0550c36f557db69543cc9d6393b1509783520b30e902f23c555da6"
 
 [[package]]
 name = "datafusion-execution"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8eac0a09bc8d263f52025cad9e001da4d8138d633fa288edda4d06b1772eae6"
+checksum = "a98f1052f91b4991f0bf2ce1e4e36dfbdcda454a956b8c8d562c7c845e8fce1d"
 dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
+ "bytes",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -1281,16 +1291,19 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
+ "pin-project-lite",
  "rand 0.9.5",
  "tempfile",
+ "tokio",
+ "tokio-util",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb14d374767ee0fc62dc79a5ba8bcf8a63c14e993c7d992d0e63adfa23d77d3"
+checksum = "464625a1f0e4b9df552d894fafcc8aac953ebbc8b0fa0acdaf20975fd615040e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1303,7 +1316,7 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
  "recursive",
  "serde_json",
  "sqlparser 0.62.0",
@@ -1311,25 +1324,25 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b19a8c95522bee8cbb313d74263b85e355d2b52f42e67ef5694bf5de9e9356"
+checksum = "2604994999d5aeca1d1df645ffc98bc787447aaff05dde27aad0342b48fc1fe0"
 dependencies = [
  "arrow",
  "datafusion-common",
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f64c983bbbdcb729d921a2b2ac3375598719b5cc0c30345ad664936f3176fc7"
+checksum = "051e97533e6af53e4aa0a0667cadc886abcaf36c4a5925019c55c0aa4c218fde"
 dependencies = [
  "arrow",
  "arrow-buffer",
- "base64 0.22.1",
+ "base64 0.23.1",
  "blake2",
  "blake3",
  "chrono",
@@ -1342,7 +1355,7 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr-common",
  "hex",
- "itertools",
+ "itertools 0.15.0",
  "log",
  "md-5",
  "memchr",
@@ -1355,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bc17041e424a47ed062f43df24d84aab8b57c4c3221e5c1a5eef46d6c5718b"
+checksum = "2d0f1bb166d3572b6ed40e1afb2faaacade962abc08c2fcf04babee74681c56b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1368,17 +1381,17 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "foldhash 0.2.0",
  "half",
+ "hashbrown 0.17.1",
  "log",
  "num-traits",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dd2a9e865c6108059f5b37b77934f84b50bfb108f837bd0e5c9536e03f0545"
+checksum = "7ed756770f5f98369e181d692fd5ee6b1127ffd7322caba92f3730f9f5c92333"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1388,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f0bdfeef16d96417b9632ef855645376b242e9006a126dfd0bedfc54a93f5f"
+checksum = "91173fdb5c0ff2a41169a8ffa1b385b8844f18728747bb0a37e35ad7d5772a4f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1405,7 +1418,7 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr-common",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.15.0",
  "itoa",
  "log",
  "memchr",
@@ -1413,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e4941673c917819616877e9993da4503e4f4739812be0bc32c5356184c6383"
+checksum = "b1bcdfb286a745461b126719c32700777e83df4f17cc44db5d71ebce5731e840"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1429,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dd2e16c12b84b6f6b41b19f55b366dd1c46876bb35b86896c6349067379e8d"
+checksum = "9ec4b508f1f93f00038ba3e737e894ec6c775528b4369413386655ae6125f0fc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1446,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdc5e4b6f8b6ef823cc1c761f85088ad4c884fe8df64df3cbcc6b2b84698441"
+checksum = "0b352020834140073fbf5b46ee0ceb926e5074a9d0bcae1dbd91d0586d999cde"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1456,20 +1469,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3614234dd93578c92428cb4f408e020874f0d2b7e6c90c928d9d28b5df2ceb"
+checksum = "15192effab05d38cce10e92a6fb48c967b5f166b27b7195a165a72b232569c58"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0635620b050b81bb92764e99250868f654e2cd5ad1bece413283b3f73c83179"
+checksum = "854445d9f7847e1e46089cf61b8d341a64382f14484e912c83a0f23b31216896"
 dependencies = [
  "arrow",
  "chrono",
@@ -1478,7 +1491,7 @@ dependencies = [
  "datafusion-expr-common",
  "datafusion-physical-expr",
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
  "log",
  "recursive",
  "regex",
@@ -1487,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cabf7a86eb70b816729e33c81bf7767c936ee1226f607a114f5dac2decac8d0"
+checksum = "671558dad1d2aa253c39c0a4c52515958b99eb91abf649f4b88d5e69cc55282f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1500,7 +1513,7 @@ dependencies = [
  "half",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
  "parking_lot",
  "petgraph",
  "recursive",
@@ -1509,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de222e04f7e6744501555a54ab0abe26bfdfebee380af79a9bdc175704246859"
+checksum = "ffae3d78c2da80ecc829cb58536cc5aca2e99cf1365eda694fc75bfe288861e0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1519,14 +1532,14 @@ dependencies = [
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "itertools",
+ "itertools 0.15.0",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d0d0057fc5a502d45c870cb6d47c66eb7bdd5edb1bd71ad6f3f724975ac2a8"
+checksum = "3d9092ed15e7203fbd0903215172f7c9d18f10d94cba35137f3b3836f7c46f16"
 dependencies = [
  "arrow",
  "chrono",
@@ -1534,16 +1547,16 @@ dependencies = [
  "datafusion-expr-common",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
  "parking_lot",
  "pin-project",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86046eed10950c5f9aaed9acfd148e9bd2e1dfdfe4f9aef607d1447b271e4183"
+checksum = "9005b6cf50b57b72d476c6ed4662b04be7ca6be5320ba9127c6d0b7e4218095b"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1554,15 +1567,16 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-pruning",
- "itertools",
+ "datafusion-session",
+ "itertools 0.15.0",
  "recursive",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc84da934c903407ba297971ebcc020c4c1a38aafd765d6c144c76eff3fa6a1"
+checksum = "5787e4fcff4adc4fce8948441103a99705018b49c8dff0720b650bd7a15da112"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -1570,6 +1584,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "async-trait",
+ "bytes",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-execution",
@@ -1583,19 +1598,20 @@ dependencies = [
  "half",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
  "log",
  "num-traits",
  "parking_lot",
  "pin-project-lite",
+ "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-pruning"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb63eeac6de19be40f487b65dd84e546195f783c5a9928618e0c4f2a3569b0d7"
+checksum = "9e651c8df0b90daed6a7be5921ec0ee379e6909705f063eeff70fd4e35010e4c"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1609,10 +1625,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f961d209177f91bd014db5cbb2c33b7d28a2597b9003e77f17aeb712964315a"
+checksum = "fb56667ee38217efab19b895d9a936052cfb47ed438a19663351bdc42a6214a1"
 dependencies = [
+ "arrow-schema",
  "async-trait",
  "datafusion-common",
  "datafusion-execution",
@@ -1623,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "54.1.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d71cb454da682b2af7488e1fc1ddd72ee1b28f19297b8ccad73f0a21ee9a69"
+checksum = "9c29067cb9d32f8e603c45e15d61ea18f1069f96ceafeceb4e18466b8e5b31d9"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1638,6 +1655,7 @@ dependencies = [
  "recursive",
  "regex",
  "sqlparser 0.62.0",
+ "stacker",
 ]
 
 [[package]]
@@ -1781,7 +1799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2554,12 +2572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,6 +2582,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -2762,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -3029,7 +3050,7 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
@@ -3083,15 +3104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.4.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d298093b2dec60289dce0684c986d0f7679e9dd15771c2c65406e1aaf604a704"
+checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -3133,7 +3145,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.22.1",
+ "base64 0.23.1",
  "brotli",
  "bytes",
  "chrono",
@@ -3142,15 +3154,13 @@ dependencies = [
  "half",
  "hashbrown 0.17.1",
  "lz4_flex",
- "num-bigint 0.4.8",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
  "object_store",
- "paste",
  "seq-macro",
  "simdutf8",
  "snap",
- "thrift",
  "tokio",
  "twox-hash",
  "zstd",
@@ -3995,7 +4005,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4116,7 +4126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -4294,7 +4304,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4464,6 +4474,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -4832,7 +4843,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4885,17 +4896,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4942,7 +4942,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -5421,7 +5421,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/Cargo.toml
+++ b/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/Cargo.toml
@@ -6,9 +6,9 @@ members = [
 resolver = "3"
 
 [workspace.dependencies]
-arrow = { version = "=58.3.0", default-features = true }
+arrow = { version = "=59.2.0", default-features = true }
 candle = { package = "candle-core", version = "=0.11.0", default-features = false }
-datafusion = { version = "=54.1.0", default-features = true }
+datafusion = { version = "=55.0.0", default-features = true }
 ndarray = { version = "=0.17.2", default-features = true }
 polars = { version = "=0.54.4", default-features = true }
 sifr_runtime = { path = "../../../../../../../crates/sifr_runtime" }

--- a/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/README.md
+++ b/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/README.md
@@ -4,10 +4,12 @@ This locked/offline package is the runtime-observed scenario for
 `advanced_data_runtime_matrix`. Two shared bridge crates use the exact root
 lock versions of Arrow, DataFusion, Polars, ndarray, and CPU-only Candle.
 
-The Arrow path moves the owned Sifr floating-point vector into an Arrow array without
-changing its address, preserves schema identity in a record batch registered
-with DataFusion, and derives the corresponding Polars dataframe through an
-explicit copy. The tensor path moves two owned vectors into ndarray and Candle
+The Arrow path moves the owned Sifr floating-point vector into an Arrow array
+without changing its address, preserves schema identity in a record batch
+registered with DataFusion, plans DataFusion 55's borrowed `fill_nan`
+operation, and derives the corresponding Polars dataframe through an explicit
+copy. Catalog lookup errors propagate as typed bridge errors. The tensor path
+moves two owned vectors into ndarray and Candle
 without changing either allocation, then transfers the ndarray owner into a
 one-shot, DLPack-style managed capsule without copying. Pre-close and
 post-close observations prove deterministic owner cleanup.

--- a/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/rust/sifr_arrow_bridge/src/record_batch.rs
+++ b/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/rust/sifr_arrow_bridge/src/record_batch.rs
@@ -1,9 +1,10 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use arrow::array::{Array, ArrayRef, Float64Array};
 use arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
+use datafusion::common::ScalarValue;
 use datafusion::datasource::MemTable;
 use datafusion::execution::context::SessionContext;
 use polars::prelude::{DataFrame, DataType as PolarsDataType, IntoColumn, NamedFrom, Series};
@@ -31,6 +32,7 @@ pub struct RecordBatchView {
 struct ArrowRuntimeState {
     record_batch: RecordBatch,
     datafusion: SessionContext,
+    datafusion_nan_fill_plan: String,
     polars: DataFrame,
     input_pointer: usize,
 }
@@ -40,6 +42,7 @@ impl std::fmt::Debug for ArrowRuntimeState {
         formatter
             .debug_struct("ArrowRuntimeState")
             .field("record_batch", &self.record_batch)
+            .field("datafusion_nan_fill_plan", &self.datafusion_nan_fill_plan)
             .field("polars", &self.polars)
             .field("input_pointer", &self.input_pointer)
             .finish_non_exhaustive()
@@ -103,6 +106,16 @@ fn build_state(input: Vec<f64>, input_pointer: usize) -> Result<ArrowRuntimeStat
     datafusion
         .register_table("input", Arc::new(table))
         .map_err(display_error)?;
+    let datafusion_nan_fill_plan = datafusion
+        .read_batch(record_batch.clone())
+        .and_then(|frame| frame.fill_nan(&ScalarValue::from(0.0), &["value"]))
+        .map_err(display_error)?
+        .logical_plan()
+        .display_indent()
+        .to_string();
+    if !datafusion_nan_fill_plan.contains("nanvl") {
+        return Err("DataFusion did not plan the requested NaN fill".to_string());
+    }
 
     let series = Series::new("value".into(), polars_values);
     let polars = DataFrame::new(record_batch.num_rows(), vec![series.into_column()])
@@ -111,6 +124,7 @@ fn build_state(input: Vec<f64>, input_pointer: usize) -> Result<ArrowRuntimeStat
     Ok(ArrowRuntimeState {
         record_batch,
         datafusion,
+        datafusion_nan_fill_plan,
         polars,
         input_pointer,
     })
@@ -133,18 +147,22 @@ fn observe_state(state: &ArrowRuntimeState) -> Result<String, String> {
     let Some(polars_column) = state.polars.columns().first() else {
         return Err("Polars dataframe lost its column".to_string());
     };
-    let datafusion_registered = state.datafusion.table_exist("input").unwrap_or(false);
+    let datafusion_registered = state
+        .datafusion
+        .table_exist("input")
+        .map_err(display_error)?;
     if arrow_field.name() != "value"
         || arrow_field.data_type() != &ArrowDataType::Float64
         || polars_column.name().as_str() != "value"
         || polars_column.dtype() != &PolarsDataType::Float64
         || state.polars.height() != state.record_batch.num_rows()
         || !datafusion_registered
+        || !state.datafusion_nan_fill_plan.contains("nanvl")
     {
         return Err("crate-backed schema identity mismatch".to_string());
     }
     Ok(format!(
-        "schema=value:float64;rows={};datafusion=registered;polars=value:float64x{};polars-copy=explicit;copy=input->arrow:none",
+        "schema=value:float64;rows={};datafusion=registered+fill-nan-planned;polars=value:float64x{};polars-copy=explicit;copy=input->arrow:none",
         state.record_batch.num_rows(),
         state.polars.height()
     ))

--- a/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/src/main.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/examples/advanced_data_runtime/src/main.sifr
@@ -72,7 +72,7 @@ def verify_advanced_data_runtime() -> Result[str, DataExchangeError]:
         arrow_after_close: str = arrow_release_observation()
         tensor_after_close: str = tensor_release_observation()
         summary: str = "arrow=" + arrow_summary + ";tensor=" + tensor_summary + ";dlpack=" + dlpack_summary + ";cleanup-before=" + arrow_before_close + ";" + tensor_before_close + ";cleanup-after=" + arrow_after_close + ";" + tensor_after_close
-        assert summary == "arrow=schema=value:float64;rows=6;datafusion=registered;polars=value:float64x6;polars-copy=explicit;copy=input->arrow:none;tensor=dtype=f64;rank=2;shape=2x3;layout=c;strides=3x1;device=cpu;ndarray-copy=none;candle-copy=none;dlpack=protocol=managed-tensor;ownership=transferred;dtype=f64;rank=2;shape=2x3;strides=3x1;device=cpu;copy=none;cleanup-before=arrow-released=0;active=1;tensor-released=0;active=1;cleanup-after=arrow-released=1;active=0;tensor-released=1;active=0"
+        assert summary == "arrow=schema=value:float64;rows=6;datafusion=registered+fill-nan-planned;polars=value:float64x6;polars-copy=explicit;copy=input->arrow:none;tensor=dtype=f64;rank=2;shape=2x3;layout=c;strides=3x1;device=cpu;ndarray-copy=none;candle-copy=none;dlpack=protocol=managed-tensor;ownership=transferred;dtype=f64;rank=2;shape=2x3;strides=3x1;device=cpu;copy=none;cleanup-before=arrow-released=0;active=1;tensor-released=0;active=1;cleanup-after=arrow-released=1;active=0;tensor-released=1;active=0"
         return summary
     except DataExchangeError as error:
         raise error

--- a/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/positive/crate_backed_arrow_tensor_roundtrips.sifr
+++ b/verification/areas/rust_interop/fixtures/advanced_data_runtime_matrix/positive/crate_backed_arrow_tensor_roundtrips.sifr
@@ -73,7 +73,7 @@ def verify_crate_backed_arrow_tensor_roundtrips() -> Result[str, DataExchangeErr
         arrow_after_close: str = arrow_release_observation()
         tensor_after_close: str = tensor_release_observation()
         summary: str = "arrow=" + arrow_summary + ";tensor=" + tensor_summary + ";dlpack=" + dlpack_summary + ";cleanup-before=" + arrow_before_close + ";" + tensor_before_close + ";cleanup-after=" + arrow_after_close + ";" + tensor_after_close
-        assert summary == "arrow=schema=value:float64;rows=6;datafusion=registered;polars=value:float64x6;polars-copy=explicit;copy=input->arrow:none;tensor=dtype=f64;rank=2;shape=2x3;layout=c;strides=3x1;device=cpu;ndarray-copy=none;candle-copy=none;dlpack=protocol=managed-tensor;ownership=transferred;dtype=f64;rank=2;shape=2x3;strides=3x1;device=cpu;copy=none;cleanup-before=arrow-released=0;active=1;tensor-released=0;active=1;cleanup-after=arrow-released=1;active=0;tensor-released=1;active=0"
+        assert summary == "arrow=schema=value:float64;rows=6;datafusion=registered+fill-nan-planned;polars=value:float64x6;polars-copy=explicit;copy=input->arrow:none;tensor=dtype=f64;rank=2;shape=2x3;layout=c;strides=3x1;device=cpu;ndarray-copy=none;candle-copy=none;dlpack=protocol=managed-tensor;ownership=transferred;dtype=f64;rank=2;shape=2x3;strides=3x1;device=cpu;copy=none;cleanup-before=arrow-released=0;active=1;tensor-released=0;active=1;cleanup-after=arrow-released=1;active=0;tensor-released=1;active=0"
         return summary
     except DataExchangeError as error:
         raise error


### PR DESCRIPTION
## Summary
- upgrade the coupled Arrow ecosystem to 59.2.0 and DataFusion ecosystem to 55.0.0
- adopt DataFusion 55's borrowed fill_nan API in the maintained advanced-data bridge and propagate catalog errors
- certify exact analytical package families, checksums, lock edges, runtime behavior, and policy mutations

## Validation
- Arrow/DataFusion dependency certification: 3 passed
- Itertools dependency certification: 4 passed
- advanced-data fixture cargo check --workspace --locked: passed
- advanced-data Rust-interop matrix: 2 variants and 242 mutation cases passed
- exact generated positive and negative advanced-data tests: passed
- stdlib manifest suite: passed
- coverage readiness: 4 variants passed
- Rust interop: 10 variants passed
- Python Arrow examples/runtime focused certification: passed
- cargo test -p sifr --locked -- --skip test_e2e_pass: passed
- cargo clippy --workspace -- -D warnings: passed
- cargo fmt --check: passed
- HIR maintainability and file-size guardrails: passed
- git diff --check: passed

Exact candidate: 61392c034d6c30216cc5a6bd2ceb67cfa01e925b