### PR TITLE
Upgrade Python minor dependency train

### DIFF
--- a/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
+++ b/plans/issues/active/ad-hoc-latest-stable-release-convergence.md
@@ -1,7 +1,7 @@
 # Ad Hoc Phase: Latest Stable Release Convergence
 
-Status: active on 2026-08-26. Items 0-23 are complete. Item 24 Rust Redis 1.6
-and graph reconciliation is next.
+Status: active on 2026-08-26. Items 0-24 are complete. Item 25 Python minor
+train is active.
 
 ## Objective
 
@@ -126,7 +126,8 @@ certification fixtures, and regenerated `vendor/` content. A broad unconstrained
 
 | Compatibility unit | Baseline | Stable target |
 | --- | --- | --- |
-| Minor train | `alembic 1.18.4`, `boto3 1.43.33`, `certifi 2026.6.17`, `polars 1.41.2`, `schwifty 2026.3.0`, `sqlalchemy 2.0.51`, `torch 2.12.1` | `1.19.1`, `1.43.78`, `2026.7.22`, `1.43.2`, `2026.7.3`, `2.0.52`, `2.13.0` |
+| Minor train | `alembic 1.18.4`, `boto3 1.43.33`, `certifi 2026.6.17`, `polars 1.41.2`, `schwifty 2026.3.0`, `sqlalchemy 2.0.51`, `torch 2.12.1` | `1.19.1`, `1.43.80`, `2026.7.22`, `1.44.1`, `2026.7.3`, `2.0.52`, `2.13.0` |
+| Boto3 service emulator | `localstack/localstack:2.0.1` | `localstack/localstack:4.14.0` at manifest digest `sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a` |
 | Crypto ABI | `cffi 1.17.1`, `cryptography 46.0.0` | `cffi 2.1.1`, then `cryptography 50.0.0` |
 | Web framework | `fastapi 0.138.0`, `starlette 0.52.1` | `fastapi 0.141.1`, then `starlette 1.6.0` |
 | Redis services | `redis 6.4.0`, `fakeredis 2.36.2`, `hiredis 3.4.0`, `testcontainers 4.13.3` | `8.1.0`, `2.37.1`, `3.4.1`, `4.15.0` |

--- a/verification/areas/python_interop/README.md
+++ b/verification/areas/python_interop/README.md
@@ -129,8 +129,8 @@ default; live suites must declare their own `network_mode` and resource classes.
   report output.
 - `env`: interpreter, venv, ABI, platform, lock/env freshness, and probe rejection fixture coverage.
 - `dependency-versions`: exact PyPI stable versions and audited artifact hashes
-  for the two Item 25 lock owners, plus stale-version, missing-artifact, and
-  missing-declaration mutation checks.
+  for the two Item 25 lock owners. Four mutations cover a stale version, a
+  missing artifact, a missing declaration, and a stale service emulator.
 - `minor-train-features`: direct runtime coverage for the new Schwifty 2026.7
   checksum-solving `BBAN.random` implementation.
 - `imports`: root imports and native extension load diagnostics.

--- a/verification/areas/python_interop/README.md
+++ b/verification/areas/python_interop/README.md
@@ -128,6 +128,11 @@ default; live suites must declare their own `network_mode` and resource classes.
 - `scaffold`: validates matrix files, fixture directories, runner modules, and
   report output.
 - `env`: interpreter, venv, ABI, platform, lock/env freshness, and probe rejection fixture coverage.
+- `dependency-versions`: exact PyPI stable versions and audited artifact hashes
+  for the two Item 25 lock owners, plus stale-version, missing-artifact, and
+  missing-declaration mutation checks.
+- `minor-train-features`: direct runtime coverage for the new Schwifty 2026.7
+  checksum-solving `BBAN.random` implementation.
 - `imports`: root imports and native extension load diagnostics.
 - `native`: trusted native Python package load/use smoke.
 - `async`: Python event-loop/client behavior under Sifr blocking semantics.
@@ -153,14 +158,15 @@ package execution gates exist.
 
 Dataframe examples are offline but executable. The `dataframe-examples` case
 links a temporary Sifr package to the area-local locked uv environment and runs
-real Sifr programs for NumPy, pandas, and Polars. These examples cover array or
-dataframe construction and library operations behind hermetic package-local
-bridges, typed declaration results, resource-diagnostic equality, and
-deterministic stdout markers checked by the runner. They are separate from the
-dataframes matrix case so reviewers can
-distinguish package-certification metadata from compiled Sifr execution
-evidence. Runner self-tests validate report aggregation and fixture drift; the
-actual Cargo/Sifr/venv execution path is covered by `--dataframe-examples`.
+real Sifr programs for NumPy, pandas, and Polars. The Polars 1.44 path also
+uses strict `struct.drop` projection on the live sorted dataframe. These
+examples cover array or dataframe construction through hermetic package-local
+bridges. The checks include typed declaration results, resource diagnostics,
+library operations, and deterministic output markers. The examples are separate
+from the dataframes matrix case. This separation distinguishes certification
+metadata from compiled Sifr execution evidence. Runner self-tests validate
+report aggregation and fixture drift. The `--dataframe-examples` option covers
+the actual Cargo, Sifr, and environment execution path.
 
 Typed buffer examples are offline, compiled, and blocking in every delivery
 profile. The `buffer-examples` suite runs declaration-first binaries for a
@@ -183,10 +189,12 @@ runner self-test.
 ML examples are offline but executable. The `ml-examples` suite uses the same
 temporary-package execution path and runs real Sifr programs for torch and
 scikit-learn through typed declarations over hermetic bridges. The torch bridge
-constructs a CPU `float32` tensor and validates tensor math and shape metadata;
-the scikit-learn bridge trains a deterministic decision tree and checks its
-predictions/classes. Both compiled Sifr callers require resource diagnostics to
-return to their baseline and emit deterministic markers.
+constructs a CPU `float32` tensor and validates tensor math and shape metadata.
+It also executes the fused PyTorch 2.13 `LinearCrossEntropyLoss` with fixed
+weights.
+The scikit-learn bridge trains a deterministic decision tree and validates its
+predictions and classes. Both compiled Sifr callers require resource diagnostics
+to return to their baseline and emit deterministic markers.
 
 DLPack declaration examples are offline, compiled, and blocking in every
 delivery profile. The `dlpack-examples` suite runs real PyTorch CPU transfers,
@@ -209,13 +217,13 @@ and verifies that ordinary object/leak diagnostics return to their baseline:
 - FastAPI app construction, Pydantic validation through pydantic-core, and
   Starlette JSON response rendering.
 - cryptography Fernet encrypt/decrypt, CFFI parser setup, and certifi CA bundle
-  discovery.
+  loading into an SSL trust store.
 - boto3 SQS client calls through botocore Stubber with no AWS credentials or
   network access.
 - redis client import, fakeredis in-process round trip, and hiredis RESP
   parsing.
-- SQLAlchemy in-memory query execution plus Alembic migration-context
-  construction and psycopg conninfo construction.
+- SQLAlchemy in-memory query execution plus Alembic 1.19 named CHECK-constraint
+  autogeneration and psycopg conninfo construction.
 
 Service-backed libraries remain in `live-examples`: Redis, Postgres/psycopg,
 Kafka, Pub/Sub-style SNS fanout, SNS, and SQS are exercised with testcontainers

--- a/verification/areas/python_interop/data/latest_stable_minor_train.json
+++ b/verification/areas/python_interop/data/latest_stable_minor_train.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": 1,
+  "audited_at": "2026-08-26",
+  "source": "https://pypi.org/pypi/{project}/{version}/json",
+  "python": "3.14.7",
+  "projects": [
+    {
+      "pyproject": "verification/areas/python_interop/pyproject.toml",
+      "lock": "verification/areas/python_interop/uv.lock",
+      "packages": ["alembic", "boto3", "certifi", "polars", "schwifty", "sqlalchemy", "torch"]
+    },
+    {
+      "pyproject": "demos/m12_dlpack_demo/pyproject.toml",
+      "lock": "demos/m12_dlpack_demo/uv.lock",
+      "packages": ["torch"]
+    }
+  ],
+  "service_emulators": [
+    {
+      "name": "localstack-community",
+      "image": "localstack/localstack",
+      "latest_stable": "4.14.0",
+      "released_at": "2026-02-26T16:57:42Z",
+      "official_release": "https://github.com/localstack/localstack/releases/tag/v4.14.0",
+      "manifest_digest": "sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a"
+    }
+  ],
+  "packages": [
+    {
+      "name": "alembic",
+      "latest_stable": "1.19.1",
+      "released_at": "2026-08-08T16:32:01.565070Z",
+      "requires_python": ">=3.10",
+      "official_release": "https://pypi.org/project/alembic/1.19.1/",
+      "artifact": {
+        "filename": "alembic-1.19.1-py3-none-any.whl",
+        "sha256": "b39018cb3d9413a19cbd54cf3c02ad33998641f0538eb77413a488a21c3e14be"
+      }
+    },
+    {
+      "name": "boto3",
+      "latest_stable": "1.43.80",
+      "released_at": "2026-08-25T20:38:33.021775Z",
+      "requires_python": ">=3.10",
+      "official_release": "https://pypi.org/project/boto3/1.43.80/",
+      "artifact": {
+        "filename": "boto3-1.43.80-py3-none-any.whl",
+        "sha256": "26afe3b950ca1cc722c7fa5544991c222919c98355f82300a55b6315a2c4995e"
+      }
+    },
+    {
+      "name": "certifi",
+      "latest_stable": "2026.7.22",
+      "released_at": "2026-07-22T03:35:11.276376Z",
+      "requires_python": ">=3.7",
+      "official_release": "https://pypi.org/project/certifi/2026.7.22/",
+      "artifact": {
+        "filename": "certifi-2026.7.22-py3-none-any.whl",
+        "sha256": "62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775"
+      }
+    },
+    {
+      "name": "polars",
+      "latest_stable": "1.44.1",
+      "released_at": "2026-08-26T07:07:44.646805Z",
+      "requires_python": ">=3.10",
+      "official_release": "https://pypi.org/project/polars/1.44.1/",
+      "artifact": {
+        "filename": "polars-1.44.1-py3-none-any.whl",
+        "sha256": "1fa62fc1c88fba77a68b28291b5aabdd69e5f38b34e59721a064ae3169b59bb5"
+      }
+    },
+    {
+      "name": "schwifty",
+      "latest_stable": "2026.7.3",
+      "released_at": "2026-07-23T09:35:13.488528Z",
+      "requires_python": ">=3.10",
+      "official_release": "https://pypi.org/project/schwifty/2026.7.3/",
+      "artifact": {
+        "filename": "schwifty-2026.7.3-py3-none-any.whl",
+        "sha256": "795d51771dbc79a2eeb3e1784d94a60426eda316141acebdea1a1207ddff9daa"
+      }
+    },
+    {
+      "name": "sqlalchemy",
+      "latest_stable": "2.0.52",
+      "released_at": "2026-08-11T19:07:09.829565Z",
+      "requires_python": ">=3.7",
+      "official_release": "https://pypi.org/project/sqlalchemy/2.0.52/",
+      "artifact": {
+        "filename": "sqlalchemy-2.0.52-cp314-cp314-macosx_11_0_arm64.whl",
+        "sha256": "410d52be41d17f1a236d19520fbe776257dc16516ed06bd16d433311842aefd9"
+      }
+    },
+    {
+      "name": "torch",
+      "latest_stable": "2.13.0",
+      "released_at": "2026-07-08T16:01:59.348299Z",
+      "requires_python": ">=3.10",
+      "official_release": "https://pypi.org/project/torch/2.13.0/",
+      "artifact": {
+        "filename": "torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl",
+        "sha256": "d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c"
+      }
+    }
+  ]
+}

--- a/verification/areas/python_interop/fixtures/cryptography_tls/python_bridges/cryptography_cffi_example.py
+++ b/verification/areas/python_interop/fixtures/cryptography_tls/python_bridges/cryptography_cffi_example.py
@@ -1,3 +1,5 @@
+import ssl
+
 import certifi
 import cffi
 from cryptography.fernet import Fernet
@@ -10,6 +12,9 @@ def run() -> str:
         raise RuntimeError("Fernet round trip failed")
     ffi = cffi.FFI()
     ffi.cdef("int add(int, int);")
-    if not certifi.where():
-        raise RuntimeError("certifi returned an empty certificate path")
-    return "sifr-python-interop:cryptography-cffi:roundtrip=sifr-secret:certifi=ok"
+    trust_store = ssl.create_default_context(cafile=certifi.where())
+    if trust_store.cert_store_stats()["x509_ca"] <= 100:
+        raise RuntimeError("certifi did not populate the platform trust store")
+    return (
+        "sifr-python-interop:cryptography-cffi:roundtrip=sifr-secret:certifi=ca-store"
+    )

--- a/verification/areas/python_interop/fixtures/cryptography_tls/python_bridges/cryptography_cffi_example.py
+++ b/verification/areas/python_interop/fixtures/cryptography_tls/python_bridges/cryptography_cffi_example.py
@@ -13,7 +13,7 @@ def run() -> str:
     ffi = cffi.FFI()
     ffi.cdef("int add(int, int);")
     trust_store = ssl.create_default_context(cafile=certifi.where())
-    if trust_store.cert_store_stats()["x509_ca"] <= 100:
+    if trust_store.cert_store_stats()["x509_ca"] == 0:
         raise RuntimeError("certifi did not populate the platform trust store")
     return (
         "sifr-python-interop:cryptography-cffi:roundtrip=sifr-secret:certifi=ca-store"

--- a/verification/areas/python_interop/fixtures/polars_arrow/python_bridges/polars_example.py
+++ b/verification/areas/python_interop/fixtures/polars_arrow/python_bridges/polars_example.py
@@ -4,8 +4,17 @@ import polars as pl
 def run() -> str:
     frame = pl.DataFrame({"city": ["paris", "oslo", "rome"], "value": [5, 2, 3]})
     sorted_frame = frame.sort("value")
+    city_rows = sorted_frame.with_columns(
+        pl.struct("city", "value").alias("row")
+    ).select(pl.col("row").struct.drop(["value"]))
     values = sorted_frame["value"].to_list()
     cities = sorted_frame["city"].to_list()
-    if values != [2, 3, 5] or cities[0] != "oslo" or int(sum(values)) != 10:
+    projected_cities = city_rows["row"].struct.field("city").to_list()
+    if (
+        values != [2, 3, 5]
+        or cities[0] != "oslo"
+        or projected_cities != cities
+        or int(sum(values)) != 10
+    ):
         raise RuntimeError("Polars full example did not round-trip expected values")
-    return "sifr-python-interop:polars:sum=10:first-city=oslo"
+    return "sifr-python-interop:polars:sum=10:first-city=oslo:struct-drop=ok"

--- a/verification/areas/python_interop/fixtures/sqlalchemy_psycopg/python_bridges/sqlalchemy_psycopg_example.py
+++ b/verification/areas/python_interop/fixtures/sqlalchemy_psycopg/python_bridges/sqlalchemy_psycopg_example.py
@@ -1,3 +1,4 @@
+from alembic.autogenerate import compare_metadata
 from alembic.runtime.migration import MigrationContext
 import psycopg
 from psycopg.conninfo import make_conninfo
@@ -8,9 +9,40 @@ def run() -> str:
     engine = sqlalchemy.create_engine("sqlite+pysqlite:///:memory:")
     with engine.connect() as connection:
         scalar = connection.execute(sqlalchemy.text("select 40 + 2")).scalar_one()
-        dialect_name = MigrationContext.configure(connection).dialect.name
+        base = sqlalchemy.MetaData()
+        sqlalchemy.Table(
+            "account",
+            base,
+            sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+            sqlalchemy.Column("balance", sqlalchemy.Integer),
+        )
+        base.create_all(connection)
+        target = sqlalchemy.MetaData()
+        sqlalchemy.Table(
+            "account",
+            target,
+            sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+            sqlalchemy.Column("balance", sqlalchemy.Integer),
+            sqlalchemy.CheckConstraint("balance >= 0", name="ck_account_balance"),
+        )
+        context = MigrationContext.configure(connection)
+        dialect_name = context.dialect.name
+        differences = compare_metadata(context, target)
     engine.dispose()
     conninfo = make_conninfo(host="localhost", dbname="postgres")
-    if scalar != 42 or dialect_name != "sqlite" or not psycopg.__version__ or not conninfo:
+    named_check_added = any(
+        difference[0] == "add_constraint" and difference[1].name == "ck_account_balance"
+        for difference in differences
+    )
+    if (
+        scalar != 42
+        or dialect_name != "sqlite"
+        or not named_check_added
+        or not psycopg.__version__
+        or not conninfo
+    ):
         raise RuntimeError("SQLAlchemy/psycopg full example failed")
-    return "sifr-python-interop:sqlalchemy-psycopg:scalar=42:dialect=sqlite:conninfo=ok"
+    return (
+        "sifr-python-interop:sqlalchemy-psycopg:scalar=42:dialect=sqlite:"
+        "named-check=add:conninfo=ok"
+    )

--- a/verification/areas/python_interop/fixtures/torch_dlpack/python_bridges/torch_example.py
+++ b/verification/areas/python_interop/fixtures/torch_dlpack/python_bridges/torch_example.py
@@ -4,6 +4,13 @@ import torch
 def run() -> str:
     tensor = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=torch.float32)
     doubled = torch.mul(tensor.reshape(2, 3), 2.0)
+    criterion = torch.nn.LinearCrossEntropyLoss(3, 2)
+    with torch.no_grad():
+        criterion.linear.weight.copy_(torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]))
+    loss = criterion(
+        torch.tensor([[2.0, 1.0, 0.0]], dtype=torch.float32),
+        torch.tensor([0], dtype=torch.int64),
+    )
     values = doubled.flatten().tolist()
     if values != [2.0, 4.0, 6.0, 8.0, 10.0, 12.0]:
         raise RuntimeError("Torch values did not round-trip")
@@ -11,6 +18,7 @@ def run() -> str:
         float(doubled.sum().item()) != 42.0
         or list(doubled.shape) != [2, 3]
         or doubled.dtype != torch.float32
+        or abs(float(loss.item()) - 0.31326166) >= 1e-6
     ):
         raise RuntimeError("Torch metadata did not match")
-    return "sifr-python-interop:torch:sum=42.0:shape=2x3:dtype=float32"
+    return "sifr-python-interop:torch:sum=42.0:shape=2x3:dtype=float32:linear-xent=ok"

--- a/verification/areas/python_interop/manifest.json
+++ b/verification/areas/python_interop/manifest.json
@@ -51,6 +51,32 @@
       ]
     },
     {
+      "name": "dependency-versions",
+      "kind": "adapter",
+      "cases": [
+        {
+          "id": "dependency-versions",
+          "entry": "verification/areas/python_interop/runner/dependency_versions.py",
+          "command": "python-interop-dependency-versions",
+          "expect_exit_code": 0,
+          "diagnostic_formats": []
+        }
+      ]
+    },
+    {
+      "name": "minor-train-features",
+      "kind": "adapter",
+      "cases": [
+        {
+          "id": "minor-train-features",
+          "entry": "verification/areas/python_interop/runner/minor_train_features.py",
+          "command": "python-interop-minor-train-features",
+          "expect_exit_code": 0,
+          "diagnostic_formats": []
+        }
+      ]
+    },
+    {
       "name": "readonly-check-doctor",
       "kind": "adapter",
       "cases": [

--- a/verification/areas/python_interop/runner.py
+++ b/verification/areas/python_interop/runner.py
@@ -42,6 +42,8 @@ COMMAND_ARGS: dict[str, list[str]] = {
         "--report",
         "../../../target/verification/areas/python_interop/env.latest.json",
     ],
+    "python-interop-dependency-versions": ["--self-test"],
+    "python-interop-minor-train-features": [],
     "python-interop-readonly-check-doctor": [],
     "python-interop-binding-authoring": [],
     "python-interop-lsp-declaration-authoring": [],
@@ -150,6 +152,7 @@ COMMAND_ARGS: dict[str, list[str]] = {
 }
 
 AREA_PROJECT_COMMANDS = {
+    "python-interop-minor-train-features",
     "python-interop-callback-examples",
     "python-interop-dataframe-examples",
     "python-interop-buffer-examples",

--- a/verification/areas/python_interop/runner/dataframe_examples.py
+++ b/verification/areas/python_interop/runner/dataframe_examples.py
@@ -24,7 +24,7 @@ DATAFRAME_EXAMPLE_CASES = {
     "polars": ExampleCase(
         case_id="polars",
         relative_source="polars_arrow/polars_full_example.sifr",
-        stdout_marker="sifr-python-interop:polars:sum=10:first-city=oslo",
+        stdout_marker="sifr-python-interop:polars:sum=10:first-city=oslo:struct-drop=ok",
         import_roots=("polars",),
         bridge_files=("polars_example.py",),
     ),
@@ -50,7 +50,12 @@ def run_dataframe_examples_self_tests(paths: RunnerPaths) -> None:
         cases_by_id=DATAFRAME_EXAMPLE_CASES,
     )
     observed_policy = {
-        case_id: (case.import_roots, case.native_roots, case.copy_bridges, case.bridge_files)
+        case_id: (
+            case.import_roots,
+            case.native_roots,
+            case.copy_bridges,
+            case.bridge_files,
+        )
         for case_id, case in DATAFRAME_EXAMPLE_CASES.items()
     }
     expected_policy = {

--- a/verification/areas/python_interop/runner/dependency_versions.py
+++ b/verification/areas/python_interop/runner/dependency_versions.py
@@ -6,6 +6,7 @@ import copy
 import json
 import re
 import tomllib
+from datetime import date
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -176,8 +177,13 @@ def validate_project(
 def validate_repository(audit: dict[str, object]) -> list[str]:
     if audit.get("schema_version") != 1:
         raise ValueError("unsupported Item 25 audit schema")
-    if audit.get("audited_at") != "2026-08-26":
-        raise ValueError("Item 25 audit date drifted")
+    audited_at = audit.get("audited_at")
+    if not isinstance(audited_at, str):
+        raise ValueError("Item 25 audit date must be a string")
+    try:
+        date.fromisoformat(audited_at)
+    except ValueError as error:
+        raise ValueError("Item 25 audit date must use ISO 8601 format") from error
     if audit.get("python") != "3.14.7":
         raise ValueError("Item 25 audit must target Python 3.14.7")
     releases = release_map(audit)
@@ -216,7 +222,7 @@ def validate_service_emulator(audit: dict[str, object]) -> list[str]:
     return []
 
 
-def run_self_tests(audit: dict[str, object]) -> None:
+def run_self_tests(audit: dict[str, object]) -> int:
     releases = release_map(audit)
     projects = project_map(audit)
     pyproject_path = "verification/areas/python_interop/pyproject.toml"
@@ -257,6 +263,7 @@ def run_self_tests(audit: dict[str, object]) -> None:
     stale_emulator["service_emulators"][0]["latest_stable"] = "4.13.1"
     if not validate_service_emulator(stale_emulator):
         raise AssertionError("stale service-emulator mutation was not rejected")
+    return 4
 
 
 def main() -> int:
@@ -269,11 +276,16 @@ def main() -> int:
         for error in errors:
             print(f"python dependency audit error: {error}")
         return 1
-    if args.self_test:
-        run_self_tests(audit)
+    mutation_count = run_self_tests(audit) if args.self_test else 0
+    releases = release_map(audit)
+    projects = project_map(audit)
+    lock_count = len({lock for lock, _ in projects.values()})
+    emulators = audit.get("service_emulators")
+    emulator_count = len(emulators) if isinstance(emulators, list) else 0
     print(
-        "python dependency audit ok: projects=2 packages=7 locks=2 emulators=1 "
-        f"mutations={4 if args.self_test else 0}"
+        f"python dependency audit ok: projects={len(projects)} "
+        f"packages={len(releases)} locks={lock_count} emulators={emulator_count} "
+        f"mutations={mutation_count}"
     )
     return 0
 

--- a/verification/areas/python_interop/runner/dependency_versions.py
+++ b/verification/areas/python_interop/runner/dependency_versions.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import copy
+import json
+import re
+import tomllib
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+AUDIT_PATH = (
+    REPO_ROOT / "verification/areas/python_interop/data/latest_stable_minor_train.json"
+)
+LIVE_CASE_CONFIG_PATH = (
+    REPO_ROOT / "verification/areas/python_interop/runner/live_case_config.py"
+)
+EXPECTED_PROJECTS = {
+    "verification/areas/python_interop/pyproject.toml": frozenset(
+        {"alembic", "boto3", "certifi", "polars", "schwifty", "sqlalchemy", "torch"}
+    ),
+    "demos/m12_dlpack_demo/pyproject.toml": frozenset({"torch"}),
+}
+NORMALIZED_NAME = re.compile(r"[-_.]+")
+REQUIREMENT_NAME = re.compile(r"^[A-Za-z0-9._-]+")
+
+
+def normalize_name(name: str) -> str:
+    return NORMALIZED_NAME.sub("-", name).lower()
+
+
+def load_toml(path: Path) -> dict[str, object]:
+    with path.open("rb") as source:
+        return tomllib.load(source)
+
+
+def load_literal_assignment(path: Path, name: str) -> object:
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for statement in module.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        if any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in statement.targets
+        ):
+            return ast.literal_eval(statement.value)
+    raise ValueError(f"{path}: missing literal assignment {name}")
+
+
+def release_map(audit: dict[str, object]) -> dict[str, dict[str, object]]:
+    packages = audit.get("packages")
+    if not isinstance(packages, list):
+        raise ValueError("audit packages must be a list")
+    releases: dict[str, dict[str, object]] = {}
+    for package in packages:
+        if not isinstance(package, dict) or not isinstance(package.get("name"), str):
+            raise ValueError("every audited package must have a string name")
+        name = normalize_name(package["name"])
+        if name in releases:
+            raise ValueError(f"duplicate audited package: {name}")
+        artifact = package.get("artifact")
+        if not isinstance(artifact, dict):
+            raise ValueError(f"{name}: artifact must be an object")
+        digest = artifact.get("sha256")
+        if not isinstance(digest, str) or len(digest) != 64:
+            raise ValueError(f"{name}: artifact SHA-256 must contain 64 characters")
+        if any(character not in "0123456789abcdef" for character in digest):
+            raise ValueError(f"{name}: artifact SHA-256 must be lowercase hexadecimal")
+        releases[name] = package
+    expected = frozenset().union(*EXPECTED_PROJECTS.values())
+    if releases.keys() != expected:
+        raise ValueError("audited package set differs from the Item 25 package set")
+    return releases
+
+
+def project_map(audit: dict[str, object]) -> dict[str, tuple[str, frozenset[str]]]:
+    projects = audit.get("projects")
+    if not isinstance(projects, list):
+        raise ValueError("audit projects must be a list")
+    mapped: dict[str, tuple[str, frozenset[str]]] = {}
+    for project in projects:
+        if not isinstance(project, dict):
+            raise ValueError("every audited project must be an object")
+        pyproject = project.get("pyproject")
+        lock = project.get("lock")
+        packages = project.get("packages")
+        if not isinstance(pyproject, str) or not isinstance(lock, str):
+            raise ValueError("every audited project must name its pyproject and lock")
+        if not isinstance(packages, list) or not all(
+            isinstance(package, str) for package in packages
+        ):
+            raise ValueError(f"{pyproject}: packages must be strings")
+        if pyproject in mapped:
+            raise ValueError(f"duplicate audited project: {pyproject}")
+        mapped[pyproject] = (lock, frozenset(normalize_name(name) for name in packages))
+    if mapped.keys() != EXPECTED_PROJECTS.keys():
+        raise ValueError("audited project set differs from the Item 25 project set")
+    for pyproject, expected in EXPECTED_PROJECTS.items():
+        if mapped[pyproject][1] != expected:
+            raise ValueError(f"{pyproject}: audited package ownership drifted")
+    return mapped
+
+
+def direct_dependency_names(project: dict[str, object]) -> frozenset[str]:
+    metadata = project.get("project")
+    if not isinstance(metadata, dict):
+        return frozenset()
+    dependencies = metadata.get("dependencies")
+    if not isinstance(dependencies, list):
+        return frozenset()
+    names = set()
+    for requirement in dependencies:
+        if not isinstance(requirement, str):
+            continue
+        match = REQUIREMENT_NAME.match(requirement)
+        if match is not None:
+            names.add(normalize_name(match.group()))
+    return frozenset(names)
+
+
+def validate_project(
+    label: str,
+    expected: frozenset[str],
+    releases: dict[str, dict[str, object]],
+    project: dict[str, object],
+    lock: dict[str, object],
+) -> list[str]:
+    errors: list[str] = []
+    direct = direct_dependency_names(project)
+    for name in sorted(expected.difference(direct)):
+        errors.append(f"{label}: missing direct dependency {name}")
+
+    locked_packages = lock.get("package")
+    if not isinstance(locked_packages, list):
+        return [*errors, f"{label}: uv.lock packages must be a list"]
+    for name in sorted(expected):
+        matching = [
+            package
+            for package in locked_packages
+            if isinstance(package, dict)
+            and normalize_name(str(package.get("name", ""))) == name
+        ]
+        if len(matching) != 1:
+            errors.append(
+                f"{label}: expected one locked {name} package, found {len(matching)}"
+            )
+            continue
+        package = matching[0]
+        release = releases[name]
+        if package.get("version") != release.get("latest_stable"):
+            errors.append(
+                f"{label}: {name} lock version {package.get('version')!r} is not "
+                f"latest stable {release.get('latest_stable')!r}"
+            )
+        artifact = release["artifact"]
+        assert isinstance(artifact, dict)
+        filename = artifact["filename"]
+        digest = f"sha256:{artifact['sha256']}"
+        candidates = []
+        sdist = package.get("sdist")
+        if isinstance(sdist, dict):
+            candidates.append(sdist)
+        wheels = package.get("wheels")
+        if isinstance(wheels, list):
+            candidates.extend(wheel for wheel in wheels if isinstance(wheel, dict))
+        if not any(
+            Path(urlparse(str(candidate.get("url", ""))).path).name == filename
+            and candidate.get("hash") == digest
+            for candidate in candidates
+        ):
+            errors.append(f"{label}: {name} lock lacks audited artifact {filename}")
+    return errors
+
+
+def validate_repository(audit: dict[str, object]) -> list[str]:
+    if audit.get("schema_version") != 1:
+        raise ValueError("unsupported Item 25 audit schema")
+    if audit.get("audited_at") != "2026-08-26":
+        raise ValueError("Item 25 audit date drifted")
+    if audit.get("python") != "3.14.7":
+        raise ValueError("Item 25 audit must target Python 3.14.7")
+    releases = release_map(audit)
+    projects = project_map(audit)
+    errors: list[str] = []
+    for pyproject_path, (lock_path, expected) in projects.items():
+        errors.extend(
+            validate_project(
+                pyproject_path,
+                expected,
+                releases,
+                load_toml(REPO_ROOT / pyproject_path),
+                load_toml(REPO_ROOT / lock_path),
+            )
+        )
+    errors.extend(validate_service_emulator(audit))
+    return errors
+
+
+def validate_service_emulator(audit: dict[str, object]) -> list[str]:
+    emulators = audit.get("service_emulators")
+    if not isinstance(emulators, list) or len(emulators) != 1:
+        return ["audit must contain one service emulator"]
+    emulator = emulators[0]
+    if not isinstance(emulator, dict) or emulator.get("name") != "localstack-community":
+        return ["audit service emulator must be localstack-community"]
+    image = emulator.get("image")
+    version = emulator.get("latest_stable")
+    digest = emulator.get("manifest_digest")
+    if not all(isinstance(value, str) for value in (image, version, digest)):
+        return ["LocalStack audit must contain image, version, and digest strings"]
+    expected = f"{image}:{version}@{digest}"
+    live_images = load_literal_assignment(LIVE_CASE_CONFIG_PATH, "LIVE_IMAGES")
+    if not isinstance(live_images, dict) or live_images.get("localstack") != expected:
+        return [f"LocalStack image pin does not match audited stable image {expected}"]
+    return []
+
+
+def run_self_tests(audit: dict[str, object]) -> None:
+    releases = release_map(audit)
+    projects = project_map(audit)
+    pyproject_path = "verification/areas/python_interop/pyproject.toml"
+    lock_path, expected = projects[pyproject_path]
+    project = load_toml(REPO_ROOT / pyproject_path)
+    lock = load_toml(REPO_ROOT / lock_path)
+
+    stale_lock = copy.deepcopy(lock)
+    next(
+        package
+        for package in stale_lock["package"]
+        if isinstance(package, dict) and package.get("name") == "polars"
+    )["version"] = "1.44.0"
+    if not validate_project(pyproject_path, expected, releases, project, stale_lock):
+        raise AssertionError("stale lock mutation was not rejected")
+
+    missing_artifact = copy.deepcopy(lock)
+    next(
+        package
+        for package in missing_artifact["package"]
+        if isinstance(package, dict) and package.get("name") == "torch"
+    )["wheels"] = []
+    if not validate_project(
+        pyproject_path, expected, releases, project, missing_artifact
+    ):
+        raise AssertionError("artifact mutation was not rejected")
+
+    missing_direct = copy.deepcopy(project)
+    missing_direct["project"]["dependencies"] = [
+        requirement
+        for requirement in missing_direct["project"]["dependencies"]
+        if not str(requirement).startswith("schwifty")
+    ]
+    if not validate_project(pyproject_path, expected, releases, missing_direct, lock):
+        raise AssertionError("direct-dependency mutation was not rejected")
+
+    stale_emulator = copy.deepcopy(audit)
+    stale_emulator["service_emulators"][0]["latest_stable"] = "4.13.1"
+    if not validate_service_emulator(stale_emulator):
+        raise AssertionError("stale service-emulator mutation was not rejected")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    audit = json.loads(AUDIT_PATH.read_text(encoding="utf-8"))
+    errors = validate_repository(audit)
+    if errors:
+        for error in errors:
+            print(f"python dependency audit error: {error}")
+        return 1
+    if args.self_test:
+        run_self_tests(audit)
+    print(
+        "python dependency audit ok: projects=2 packages=7 locks=2 emulators=1 "
+        f"mutations={4 if args.self_test else 0}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/python_interop/runner/library_examples.py
+++ b/verification/areas/python_interop/runner/library_examples.py
@@ -33,8 +33,11 @@ LIBRARY_EXAMPLE_CASES = {
     "cryptography-cffi": ExampleCase(
         case_id="cryptography-cffi",
         relative_source="cryptography_tls/cryptography_cffi_full_example.sifr",
-        stdout_marker="sifr-python-interop:cryptography-cffi:roundtrip=sifr-secret:certifi=ok",
-        import_roots=("certifi", "cffi", "cryptography"),
+        stdout_marker=(
+            "sifr-python-interop:cryptography-cffi:roundtrip=sifr-secret:"
+            "certifi=ca-store"
+        ),
+        import_roots=("certifi", "cffi", "cryptography", "ssl"),
         native_roots=("cffi", "cryptography"),
         bridge_files=("cryptography_cffi_example.py",),
     ),
@@ -57,7 +60,10 @@ LIBRARY_EXAMPLE_CASES = {
     "sqlalchemy-psycopg": ExampleCase(
         case_id="sqlalchemy-psycopg",
         relative_source="sqlalchemy_psycopg/sqlalchemy_psycopg_full_example.sifr",
-        stdout_marker="sifr-python-interop:sqlalchemy-psycopg:scalar=42:dialect=sqlite:conninfo=ok",
+        stdout_marker=(
+            "sifr-python-interop:sqlalchemy-psycopg:scalar=42:dialect=sqlite:"
+            "named-check=add:conninfo=ok"
+        ),
         import_roots=("alembic", "psycopg", "sqlalchemy"),
         native_roots=("psycopg", "sqlalchemy"),
         bridge_files=("sqlalchemy_psycopg_example.py",),

--- a/verification/areas/python_interop/runner/live_case_config.py
+++ b/verification/areas/python_interop/runner/live_case_config.py
@@ -18,7 +18,10 @@ LIVE_IMAGES = {
     "redis": "redis:7.2-alpine",
     "postgres": "postgres:16-alpine",
     "kafka": "docker.redpanda.com/redpandadata/redpanda:v23.1.13",
-    "localstack": "localstack/localstack:2.0.1",
+    "localstack": (
+        "localstack/localstack:4.14.0@"
+        "sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a"
+    ),
 }
 
 LIVE_CASES = {

--- a/verification/areas/python_interop/runner/minor_train_features.py
+++ b/verification/areas/python_interop/runner/minor_train_features.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import random
+
+from schwifty import BBAN
+
+
+def main() -> int:
+    random.seed(25)
+    generated = [BBAN.random("DE") for _ in range(16)]
+    if not all(bban.validate_national_checksum() for bban in generated):
+        raise RuntimeError(
+            "Schwifty generated a BBAN with an invalid national checksum"
+        )
+    print("python minor train features ok: schwifty-bban-checksums=16")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/areas/python_interop/runner/minor_train_features.py
+++ b/verification/areas/python_interop/runner/minor_train_features.py
@@ -7,12 +7,15 @@ from schwifty import BBAN
 
 def main() -> int:
     random.seed(25)
-    generated = [BBAN.random("DE") for _ in range(16)]
+    country_codes = ("BE", "DE", "ES", "FR", "IT", "NL", "NO", "PL")
+    generated = [
+        BBAN.random(country_code) for country_code in country_codes for _ in range(4)
+    ]
     if not all(bban.validate_national_checksum() for bban in generated):
         raise RuntimeError(
             "Schwifty generated a BBAN with an invalid national checksum"
         )
-    print("python minor train features ok: schwifty-bban-checksums=16")
+    print("python minor train features ok: countries=8 schwifty-bban-checksums=32")
     return 0
 
 

--- a/verification/areas/python_interop/runner/ml_examples.py
+++ b/verification/areas/python_interop/runner/ml_examples.py
@@ -10,7 +10,9 @@ ML_EXAMPLE_CASES = {
     "torch": ExampleCase(
         case_id="torch",
         relative_source="torch_dlpack/torch_full_example.sifr",
-        stdout_marker="sifr-python-interop:torch:sum=42.0:shape=2x3:dtype=float32",
+        stdout_marker=(
+            "sifr-python-interop:torch:sum=42.0:shape=2x3:dtype=float32:linear-xent=ok"
+        ),
         import_roots=("torch",),
         bridge_files=("torch_example.py",),
     ),

--- a/verification/areas/python_interop/uv.lock
+++ b/verification/areas/python_interop/uv.lock
@@ -13,16 +13,16 @@ wheels = [
 
 [[package]]
 name = "alembic"
-version = "1.18.4"
+version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/2b/e4153978368de59918115c9e01d3ebf58a558a7285efa7e960c383c4b59a/alembic-1.19.1.tar.gz", hash = "sha256:e0fca0518118c78acc493e31bcb5402f190057aaf6df8b5b95ce94c4789cf648", size = 2070816, upload-time = "2026-08-08T16:32:01.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+    { url = "https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl", hash = "sha256:b39018cb3d9413a19cbd54cf3c02ad33998641f0538eb77413a488a21c3e14be", size = 265946, upload-time = "2026-08-08T16:32:03.153Z" },
 ]
 
 [[package]]
@@ -66,39 +66,39 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.33"
+version = "1.43.80"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/9d/794d03504b8c72bf978a1ef93bc9e7d0867951bf5fbbe50881cd50fb26d5/boto3-1.43.33.tar.gz", hash = "sha256:da6e400b2d11eb041fbbb2743ef3ffe6540889676ffdff0e628628e9b4f04cde", size = 113152, upload-time = "2026-06-18T19:35:00.57Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/97/9ef9b949f253b197c813c57ab58578572d20dbacedceb5a5f4516ea628cb/boto3-1.43.80.tar.gz", hash = "sha256:384d522e2ce722266afceea8ab3e618e16695b358ebe32b45e0a2109fcd53a28", size = 112674, upload-time = "2026-08-25T20:38:34.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/42/bb88180fe1e46f77fe9507083a256dad243747e29aa0f2fbf6ff421b4132/boto3-1.43.33-py3-none-any.whl", hash = "sha256:97b563127f7678ad20249f9bf99877b7a3a78f6fcdcf222c6e25d27d4406ce0d", size = 140534, upload-time = "2026-06-18T19:34:58.062Z" },
+    { url = "https://files.pythonhosted.org/packages/79/66/415da75a7846e46156a4746aae72a8e4b0c4d263e2c2559a083ad247ba39/boto3-1.43.80-py3-none-any.whl", hash = "sha256:26afe3b950ca1cc722c7fa5544991c222919c98355f82300a55b6315a2c4995e", size = 140024, upload-time = "2026-08-25T20:38:33.021Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.33"
+version = "1.43.80"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/d5/8ec6df4e82bec2be4ac417f542736dc6cfe89152693337152421b336eb71/botocore-1.43.33.tar.gz", hash = "sha256:74b3d5626ebeb2677fac1ca12ac975faf328e54349ceb4dcda17f50674d5b9b4", size = 15586539, upload-time = "2026-06-18T19:34:48.44Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/94/de291ad81495365682722efa9397c54c7b666f7bf1ae4064d26e40a55296/botocore-1.43.80.tar.gz", hash = "sha256:c021e60df26d17e9a8db05fa5071669449c8fd15e0fb4374f56a6c17d553f89b", size = 16003031, upload-time = "2026-08-25T20:38:29.86Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/f5/55fc2d15a81ae39115ebcf8db876f54e78f834446b468e178c9de8e7977e/botocore-1.43.33-py3-none-any.whl", hash = "sha256:4292bb2cc645e5cb404515c54b5b164563f2b4218c52aeee3f1ce851724e177a", size = 15272140, upload-time = "2026-06-18T19:34:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/93/7bba357266450f7d3e3075ee4d2f1e1d96c1617e40d8065c558485baed78/botocore-1.43.80-py3-none-any.whl", hash = "sha256:461bce2159eadd758d0651d2a11dced3450169383e6ca8ef65f5c250f8b7ebd4", size = 15695640, upload-time = "2026-08-25T20:38:26.76Z" },
 ]
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -210,42 +210,51 @@ wheels = [
 
 [[package]]
 name = "cuda-toolkit"
-version = "13.0.2"
+version = "13.0.3.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
 ]
 
 [package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -741,30 +750,30 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.41.2"
+version = "1.44.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "polars-runtime-32" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/f9/aeda46259b0669247a160315d2d51269de9504b9dd2f70acadbcb22f46b7/polars-1.41.2.tar.gz", hash = "sha256:256d6731162371b77f3f29a55eacb8c0fc740ddb1a293a01d2ef5b5393c5c708", size = 737996, upload-time = "2026-05-29T17:39:15.604Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/73/258a1fe17bb2744a507199566ed712663144fdd0811b615b59a47dfa38d2/polars-1.44.1.tar.gz", hash = "sha256:ef3c89e9ebbbe8eb343c06873f1945683f8b6f97a1bdf001c60551c6c5e3cda1", size = 765660, upload-time = "2026-08-26T07:09:12.704Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/22/28f62d24f7db56ac4343588f9362d49b7b4177e55ac47a466fe696b0099b/polars-1.41.2-py3-none-any.whl", hash = "sha256:23ce9a2910b6e3e8d4258770bf44aa17170958df7af6e85feedf4458a04d8d29", size = 833445, upload-time = "2026-05-29T17:37:05.576Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f1/59154659081930fbde291ea6225607956b500a71b0ce45d88217b7d32da2/polars-1.44.1-py3-none-any.whl", hash = "sha256:1fa62fc1c88fba77a68b28291b5aabdd69e5f38b34e59721a064ae3169b59bb5", size = 865208, upload-time = "2026-08-26T07:07:44.646Z" },
 ]
 
 [[package]]
 name = "polars-runtime-32"
-version = "1.41.2"
+version = "1.44.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/56/54e3ea0e9b64f327179049e4742241cc6b1d3e8fa414b05a057dd26df367/polars_runtime_32-1.41.2.tar.gz", hash = "sha256:7af09ec1ab053da2c9669e8d15f809a4083a29be05db57111688b8051062af56", size = 2989474, upload-time = "2026-05-29T17:39:17.257Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/b2/2a76415d047a45df05489f2334c91ff120a274cf655d4ca030c7f54a8743/polars_runtime_32-1.44.1.tar.gz", hash = "sha256:abd10a54ed1caff42228610fcba0f93251f9870bd7cffb0c78bc26f5e0718ce4", size = 3171156, upload-time = "2026-08-26T07:09:14.243Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/9b/fe72a3811c0357cdb06c67bdc7695fa1623ad47948fc523195f5ac31037f/polars_runtime_32-1.41.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:95a08346dac337357cdb825c8076df7d36da54c4caa59a5cb41d0a30691c5edd", size = 52265283, upload-time = "2026-05-29T17:37:09.407Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/93/fab9da803fd80d9e83ef88c20932f637a10bc611b20415fc322eec84bc44/polars_runtime_32-1.41.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:dedfaeec2c7f995298da7319dd9431d662e5dd1d0ec51b1459df4a0234ceff52", size = 46571222, upload-time = "2026-05-29T17:37:13.698Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/2a/8843f34a8ac57acd058a39b87b03b580dd352a490e9dae0415e02033bdd4/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18eea22c5cc34e27f8a60950458ad81e6a9ea75e89363ca1367e14e7e7f781fc", size = 50409372, upload-time = "2026-05-29T17:37:17.875Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/c6/92b352fe88cf51bd0a19fb99e1c0cbe46aa26c14dcf7995b89869cd932ae/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2630540dfdfb0f36f9b04a07c7c2e3f50bf2ad384113263c1c812007ee9141e0", size = 56405484, upload-time = "2026-05-29T17:37:22.684Z" },
-    { url = "https://files.pythonhosted.org/packages/74/c4/bae3174c3b02f6b441d2e58594387abcd509f67a098f682a83b195f08966/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:20e969e08f9b137e233c04cc04de73d9795f89eb77d34854e40a025965a43763", size = 50603512, upload-time = "2026-05-29T17:37:27.422Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/ed/f2d26ae02d92c2689056838ed59e2a626326ad23c2831d58637d25f6c82a/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e7016a3deb641b64a31447abbbee0f34bd020a6a9ae34ee6b743837def15e2a4", size = 54328561, upload-time = "2026-05-29T17:37:32.587Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/c4/9c3831cc885dc7769e59abf8f583821a5fb4403fd0e4eba0ccc6d47a3d4b/polars_runtime_32-1.41.2-cp310-abi3-win_amd64.whl", hash = "sha256:1e5e5377c315e0dcafdfb2a31adc546abbaeb3f9cb1864e6536523d2af473265", size = 51978643, upload-time = "2026-05-29T17:37:37.443Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/c6/79e9f3f270270d7ed5575d92b7bfef49f01abd9275447161275b23b553a8/polars_runtime_32-1.41.2-cp310-abi3-win_arm64.whl", hash = "sha256:843d96f69d18eca53429c1198e58891db7f18111f83b9c419bb45ad9d73eaed5", size = 46006901, upload-time = "2026-05-29T17:37:42.522Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/93/ef9344dcec16757cf21027dc907ef989197e50742cfe4407f2e87edb0a7f/polars_runtime_32-1.44.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1dfccb2b52aa50468a7d28e3e61c8338a13fb5bffc8646e388a649f5bdc6b463", size = 53962370, upload-time = "2026-08-26T07:07:47.21Z" },
+    { url = "https://files.pythonhosted.org/packages/10/da/38b32b7901af33f1fee2172ceaa39e9159825657920064298917392d78fa/polars_runtime_32-1.44.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0580807dc3eed258f0db70bb65d905dd43f0135392119ec25308033ae24258fb", size = 48620468, upload-time = "2026-08-26T07:07:50.436Z" },
+    { url = "https://files.pythonhosted.org/packages/49/51/185af877d1d2236671493cf72bd3327a6046240eeea69c0696d1af2a5acb/polars_runtime_32-1.44.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0627f9aa82cb869725235e5188f698862fd9ada0c8c1cf65c3dc5a49a4a0ec26", size = 52455947, upload-time = "2026-08-26T07:07:53.776Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/0a/0858f60cb5a6f8f73ec4cdd73eccd9f748d66bfc23304c5c23fa3468094a/polars_runtime_32-1.44.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea4283be8e60822d890dbda20588fe59b4172b508bd5ebf3471e531ca9f50d7", size = 58561262, upload-time = "2026-08-26T07:07:57.508Z" },
+    { url = "https://files.pythonhosted.org/packages/73/08/de4774b5612d7c8739f89ac01b601486b4f057b1da35a5b876bf9276fd95/polars_runtime_32-1.44.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:04e2c0f46e7a9906fffb1897f18f23b079b74f83c56b50060bace9e7b9b49b1a", size = 52636064, upload-time = "2026-08-26T07:08:06.337Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ac/769c598dd106e2a6647798da3ed25ddeee67f2d12c04f5da316cb3da6360/polars_runtime_32-1.44.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0956f0cae632d8fad3a04b4315bf2bb69b56d10c83c79a75c2c4c5a13b9ce5cc", size = 56447612, upload-time = "2026-08-26T07:08:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ee/98408296e15388020b6183323fdbe78ccab4f72c20d8e0d7092c062d3ad2/polars_runtime_32-1.44.1-cp310-abi3-win_amd64.whl", hash = "sha256:159334184e6fbb074c9f4692221ea19970a5e2bed2a479f9d7bdb00b7f3eedb9", size = 53702970, upload-time = "2026-08-26T07:08:15.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9d/8b17e075aac73c881a50b6c1f690d20df46db2f3bcabc99f600ecdee1290/polars_runtime_32-1.44.1-cp310-abi3-win_arm64.whl", hash = "sha256:3ba28d638d0513e0b4afbcdab5c0059a85021e5f81d62b5f793e7e23badb2cf7", size = 47281050, upload-time = "2026-08-26T07:08:18.43Z" },
 ]
 
 [[package]]
@@ -985,15 +994,15 @@ wheels = [
 
 [[package]]
 name = "schwifty"
-version = "2026.3.0"
+version = "2026.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycountry" },
     { name = "rstr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/68/9f4db75844c0d328f19e08e682fc9866ce7a522d3f44c9534057e47be242/schwifty-2026.3.0.tar.gz", hash = "sha256:f0ee1b45c11847a9ddccaed95320e36d3d32200641014e98be60df246d16d6cd", size = 844970, upload-time = "2026-03-04T08:19:06.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/d3/5dd968f7829c57f13b5ec6578216672b96f200aa60546c9dd86cb8e4d8cf/schwifty-2026.7.3.tar.gz", hash = "sha256:0c66adeadc94fb4ee0d1146cf1797ee8f606fb5b0cc27429bc062e18e23024e3", size = 849487, upload-time = "2026-07-23T09:35:14.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/53/88a50624bf142325fb3429f15540b2f38d85019306423f16f9300294af26/schwifty-2026.3.0-py3-none-any.whl", hash = "sha256:b3664ed82d0900857942f368729ab39079984b59cac728c486854844efe644f9", size = 343882, upload-time = "2026-03-04T08:19:07.752Z" },
+    { url = "https://files.pythonhosted.org/packages/59/3d/dc62f80aab65fc695ac317f3161d122b05d0b2560ff16ef52927694cbe46/schwifty-2026.7.3-py3-none-any.whl", hash = "sha256:795d51771dbc79a2eeb3e1784d94a60426eda316141acebdea1a1207ddff9daa", size = 348204, upload-time = "2026-07-23T09:35:13.488Z" },
 ]
 
 [[package]]
@@ -1146,29 +1155,23 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.51"
+version = "2.0.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/f1/a7a892f18d4d224e6b26f706531eafccc41e37594d37d304786969ee13cb/sqlalchemy-2.0.51.tar.gz", hash = "sha256:804dccd8a4a6242c4e30ad961e540e18a588f6527202f2d6791b01845d59fdc9", size = 9912201, upload-time = "2026-06-15T15:41:20.012Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/21/77b4c147963073040dc3c3a5cb7a8c3001a1893c0209432cb77f9df836aa/sqlalchemy-2.0.52.tar.gz", hash = "sha256:5e2d46356ac2ccb7d268ab6c2319ac6a2b42f1b8d5fd8bd3d46855cd82abee97", size = 9945637, upload-time = "2026-08-11T19:07:09.829Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/49/a739be2e1d02a96a658eb71ab45d921c874249252358ad24a5bffdd02525/sqlalchemy-2.0.51-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6ea306caaae6bd5afd0a46050003c88f6bf33227377a49298c498c3cb88ff491", size = 2158999, upload-time = "2026-06-15T16:08:51.759Z" },
-    { url = "https://files.pythonhosted.org/packages/23/6b/2e0e38cf75c8780eca78d9b2e78164f8bcfd70125e5caa588ff5cbb9c9f4/sqlalchemy-2.0.51-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c45a496d6bc05dec41dcd4c3a2b183723f47473255c159cd80b503c8f246424d", size = 3282539, upload-time = "2026-06-15T16:19:51.065Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/a1/e77854cb5336fd37dc3c6ae3b71de242c98caac5725120be0b526b31cbd0/sqlalchemy-2.0.51-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4004ada0aafe8ae1991b2cd1d99c6d9146126e123bd6f883c260d974aa012e54", size = 3287545, upload-time = "2026-06-15T16:26:44.735Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/ab/9e17272fd4dac8df3b83c4fbe52b998a1c9d89a843c8c35ff29b74ff7364/sqlalchemy-2.0.51-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f6bcad487aee1c638d707235682fc96f741de00663619881ab235400d03289e", size = 3230929, upload-time = "2026-06-15T16:19:52.625Z" },
-    { url = "https://files.pythonhosted.org/packages/02/3c/52f408ea701781caee975606beccc48845f2aee8711ac29843d612c0306c/sqlalchemy-2.0.51-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:39a76529db6305693d8d4affa58ad5b5e2e18edd62daea628b29b97930b3513d", size = 3252888, upload-time = "2026-06-15T16:26:46.454Z" },
-    { url = "https://files.pythonhosted.org/packages/24/16/3efd2ee6bc4ca4693a30a1dd17a91b606cae15d517d2a4746611d9b73ce8/sqlalchemy-2.0.51-cp314-cp314-win32.whl", hash = "sha256:08a204d8b5638717c26a24df18fcf40af45a6b22e35b70b1d62f0113c2e278e8", size = 2120551, upload-time = "2026-06-15T16:23:15.629Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/78/55b12e70f45bccc40d9e483925c065027b3b98ea4cbbdf6f8c2546feaf6c/sqlalchemy-2.0.51-cp314-cp314-win_amd64.whl", hash = "sha256:96747bfbadb055466e5b46d572618170046b45ce5a4879167f50d70a5319a499", size = 2146318, upload-time = "2026-06-15T16:23:17.108Z" },
-    { url = "https://files.pythonhosted.org/packages/21/db/a9574ed40fed418924b1b1a3e54f47ee3963053b3d3d325a0d36b41f2c08/sqlalchemy-2.0.51-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e5ea1a213be1fcd5e49d9904c3b9939211ded90bc2a64e93f4c01963474285de", size = 2178920, upload-time = "2026-06-15T15:59:56.285Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/90/a1bb5c7cbba76b7bc1fbd586d0a5479a7bc9c27b4a8298f22ec9423b2bb3/sqlalchemy-2.0.51-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c6b36ed71f41942bdcd2ad2522be46bfce09d5705be5640ecf19bbc7660e4b7", size = 3566534, upload-time = "2026-06-15T15:58:35.024Z" },
-    { url = "https://files.pythonhosted.org/packages/15/4b/481f1fed30e0e9e8dd24aecbb49f29eb57fe7657ece5cf06ee9b84bb97d8/sqlalchemy-2.0.51-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c2c62877097e1a0db401fba5cb4debee33265e5b2a55c4ccb489c02c53b4f72", size = 3535844, upload-time = "2026-06-15T16:02:43.973Z" },
-    { url = "https://files.pythonhosted.org/packages/02/71/0aa64aeda645510af0a43f7d9ee70932f0d1dc4263aed34c50ee891d9df3/sqlalchemy-2.0.51-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0378d055e9e8cd6ce4d8dff683bdd3d7d413533c4ee51d67a2b1e0f9eacc0f23", size = 3475355, upload-time = "2026-06-15T15:58:36.592Z" },
-    { url = "https://files.pythonhosted.org/packages/05/db/6061db32316446135a3abae5f308d144ab988a34234726042da3e58b1c63/sqlalchemy-2.0.51-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6e46fc36029eff666391e0531e5387b62ce6c4f1d8e50b3fb3099eaca1b42522", size = 3486591, upload-time = "2026-06-15T16:02:45.346Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c9/f14fdf71bb8957e0c7e39db69bbdf12b5c80f4ef775fdfa127bf4e0d6760/sqlalchemy-2.0.51-cp314-cp314t-win32.whl", hash = "sha256:9161cfc9efce70d1715f47d6ff40f79c6778c00d53be4fbc09d70301e4b83ba7", size = 2151313, upload-time = "2026-06-15T16:03:39.127Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c6/673e618e6f4f297e126d9b56ea2f6478708f6c1af4e3223835c22e2c3697/sqlalchemy-2.0.51-cp314-cp314t-win_amd64.whl", hash = "sha256:159bb6ba32059f57ad7375a8f50d844dd2f19d14954ecf820cd33e20debd46b2", size = 2186280, upload-time = "2026-06-15T16:03:40.569Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/22/dbf013a12ec759e54a34a119e9e217435b3f71b2dd5c61a7ade0a25dae87/sqlalchemy-2.0.51-py3-none-any.whl", hash = "sha256:bb024d8b621d0be75f4f44ecc7c950450026e76d66dc8f791bb5331d7fed59d5", size = 1944334, upload-time = "2026-06-15T16:09:22.418Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f5/71cb30af58c9b80a4e1fac0b73bb48f86d497a774a6a2eb6d2f1e657bb73/sqlalchemy-2.0.52-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:410d52be41d17f1a236d19520fbe776257dc16516ed06bd16d433311842aefd9", size = 2169537, upload-time = "2026-08-11T20:58:13.855Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/93/d07ebd645d1b07b6b5ed63450a70f063a346a7e0f2c8810daf2e532400cb/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfe9ce533dbe4d0a2ae1486546619bd30b76bcd670539a44d910361376175f5e", size = 3319606, upload-time = "2026-08-11T21:02:45.829Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/5c/290c84c7c2566ecd3b65baaae0fddec9bc33b033b398a06123bb86fbfc6e/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:812bae5138bfc0aa46fb0686da0fc7f581f68e2bbb05bc24c3713bebaedd1437", size = 3323642, upload-time = "2026-08-11T21:17:05.675Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f5/2cc160590ca49173359557880b92a0572293ccb899e8f6cedf150c5a3ddf/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:50bff43b632a56fbf5ed9afdd76307e1512b62051bcd5afb341ae67205bbb6c8", size = 3268125, upload-time = "2026-08-11T21:02:47.649Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f3/ea8933fc9f7d1353e9c2ff9965eae687c4cef181120574591ed2fa0633e1/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:49565daf5af554f538e23aef1fc81a95a4e49658f152285e45c02f5fc44f04cd", size = 3289516, upload-time = "2026-08-11T21:17:07.267Z" },
+    { url = "https://files.pythonhosted.org/packages/45/67/05cf86541c1e1716fca1e4a996954a439cd74501707cda607fb7cb02ef50/sqlalchemy-2.0.52-cp314-cp314-win32.whl", hash = "sha256:ab9da41e61b9979b910499d633b241df20c51ee5037e5405b11c2faac3cbe1a2", size = 2130249, upload-time = "2026-08-11T21:14:57.273Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d7/8ac6ffa1e36169e762ef65bd835046abb2251b1bc17f8f6708e14ed8d31f/sqlalchemy-2.0.52-cp314-cp314-win_amd64.whl", hash = "sha256:a593db51b3bae75db17a5738ad5f992244b3a03863f83c28117ee482c6a3f76d", size = 2156718, upload-time = "2026-08-11T21:14:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4b/e01a737eef378e734cc6394a82248a6ce13b167dfa36c731075ce9fc9c64/sqlalchemy-2.0.52-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1e61d08bdf4ee2f41024569e3400de7d6734ba498144766b11260936ccfa582", size = 2190344, upload-time = "2026-08-11T19:53:21.393Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
 ]
 
 [[package]]
@@ -1230,16 +1233,15 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
@@ -1250,14 +1252,14 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/b7/1b49fe7086ea36839cc80abc43174c43d0ab6f676c0891c871c162f44fe3/torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e9b6f7d2dd66ea87a3ae620069d31335d594c06effb1a383bdd21cfe61e44ece", size = 88010025, upload-time = "2026-06-17T21:07:03.934Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/06/5b44063a6545036dcc680d2d303b137d9176cfb2cc1e1863e3ef94abeb52/torch-2.12.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:7973ccd3d2cd35c74449213f7bded199bec6c6247e705cbeda7407af79703d91", size = 426392891, upload-time = "2026-06-17T21:05:52.261Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/dd/c9ce9a4b0eb3c5bb92d9ea56766e2c22559f0b45171149188494edcce80f/torch-2.12.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c64ac4aac16be5e296dcd912305605804b203333c690bf98c55bc09494ee92ad", size = 532272494, upload-time = "2026-06-17T21:06:22.72Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7c/f3a601fc1b1f663ff269bfe553654e638651939aa6563e8daa7167c33098/torch-2.12.1-cp314-cp314-win_amd64.whl", hash = "sha256:f6dc4caf7eb4adb38a2d9f536b51db56310fdd1254e69a2d96767e1367c892b3", size = 122987254, upload-time = "2026-06-17T21:06:33.199Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8c/b8087556cf81ddd808dbeb34afb8396d7ae7a1694ab489f08b1a0004e7d0/torch-2.12.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2afbb2bdaa8a95040e733f05492ddf133c3967c9b7ce0abd218d704b6cab437d", size = 88303173, upload-time = "2026-06-17T21:05:06.603Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/07/fe09d1699fbed2afa10ebc692ff2b99d113f2605b6748cea633989e2789a/torch-2.12.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:97eba061fcb042fed191400b15568990073d67eaacaa6ee9b7ca01dd8b790fe9", size = 426404009, upload-time = "2026-06-17T21:04:57.557Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/f7/0ce4f6c1962c60ded7270e0a9eb560fb615c92b89d332cf9e3dff36d5ecc/torch-2.12.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3867b861391701012adb2df93360efb88494dca245a185e3bb7624495cfe3f33", size = 532184292, upload-time = "2026-06-17T21:05:17.526Z" },
-    { url = "https://files.pythonhosted.org/packages/70/db/e384c12aba30320ca92aaaf557456cbcb26f04b4df307728bb8f019f5000/torch-2.12.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dd15595f8fc764cffde8c6361a3beb6ef69a028c851b1b3e70e077f615980d4e", size = 123231142, upload-time = "2026-06-17T21:05:27.061Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
 ]
 
 [[package]]

--- a/verification/profiles/create-pr.json
+++ b/verification/profiles/create-pr.json
@@ -599,6 +599,8 @@
         "self-test",
         "scaffold",
         "env",
+        "dependency-versions",
+        "minor-train-features",
         "readonly-check-doctor",
         "binding-authoring",
         "lsp-declaration-authoring",

--- a/verification/profiles/merge.json
+++ b/verification/profiles/merge.json
@@ -514,6 +514,8 @@
         "self-test",
         "scaffold",
         "env",
+        "dependency-versions",
+        "minor-train-features",
         "readonly-check-doctor",
         "binding-authoring",
         "lsp-declaration-authoring",

--- a/verification/profiles/nightly.json
+++ b/verification/profiles/nightly.json
@@ -527,6 +527,8 @@
         "self-test",
         "scaffold",
         "env",
+        "dependency-versions",
+        "minor-train-features",
         "readonly-check-doctor",
         "binding-authoring",
         "lsp-declaration-authoring",

--- a/verification/profiles/release.json
+++ b/verification/profiles/release.json
@@ -512,6 +512,8 @@
         "self-test",
         "scaffold",
         "env",
+        "dependency-versions",
+        "minor-train-features",
         "readonly-check-doctor",
         "binding-authoring",
         "lsp-declaration-authoring",


### PR DESCRIPTION
## Item 25

Advance Alembic, Boto3, Certifi, Polars, Schwifty, SQLAlchemy, and Torch sequentially to their latest stable releases. Advance the Boto3 service emulator to the latest stable LocalStack Community release and pin its manifest digest.

Adopt current stable APIs in executable verification: Alembic named CHECK autogeneration, Polars struct.drop, Schwifty checksum-solving BBAN.random, Certifi SSL trust-store loading, and PyTorch LinearCrossEntropyLoss.

Add a machine-checked official-release and artifact audit for both lock owners and the LocalStack image.

## Validation

- Both uv locks resolve with uv 0.12.5 and pass uv lock --check.
- Python dependency audit passes with four negative mutations.
- Python minor-train feature suite passes.
- Complete Python-interop area passed every offline, compiled, and native case; its initial live-service pass exposed LocalStack 2.0.1 protocol incompatibility.
- Focused live-service certification passes all six cases with LocalStack Community 4.14.0 at its immutable manifest digest.
- Ruff check/format, JSON checks, HIR maintainability, file-size guardrail, and git diff checks pass.

No compiler input changed, so the phase rules prohibit Sifr create-PR and merge gates for this item.