### PR TITLE
M2: unify test and build materialization

### DIFF
--- a/crates/sifr/src/check_and_package_commands.rs
+++ b/crates/sifr/src/check_and_package_commands.rs
@@ -384,11 +384,15 @@ pub(super) fn emit_success_message(diagnostic_format: DiagnosticFormat, message:
     }
 }
 
-pub(super) fn cmd_test(dir: &Path, diagnostic_format: DiagnosticFormat) -> i32 {
+pub(super) fn cmd_test(
+    dir: &Path,
+    lock_mode: sifr_package::CargoLockMode,
+    diagnostic_format: DiagnosticFormat,
+) -> i32 {
     let mut provider = DiskSourceProvider::new();
     let run_result = match run_with_panic_boundary(
         "internal compiler panic during test command execution",
-        || run_tests(dir, &mut provider),
+        || run_tests(dir, &mut provider, lock_mode),
     ) {
         Ok(result) => result,
         Err(internal) => return render_diagnostics(&[*internal], diagnostic_format),

--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -325,6 +325,15 @@ pub(crate) enum Commands {
         /// Directory containing test files (default: current directory)
         #[arg(default_value = ".")]
         dir: PathBuf,
+        /// Require Cargo.lock to remain unchanged
+        #[arg(long)]
+        locked: bool,
+        /// Disallow network access while resolving Rust dependencies
+        #[arg(long)]
+        offline: bool,
+        /// Combine --locked and --offline
+        #[arg(long)]
+        frozen: bool,
     },
     /// Manage a standalone Sifr installation
     #[command(name = "self")]
@@ -619,7 +628,16 @@ fn run_cli(cli: Cli) -> i32 {
         Commands::Lsp { stdio, parent_pid } => cmd_lsp(stdio, parent_pid),
         Commands::Trace { file } => cmd_trace(&file, diagnostic_format),
         Commands::Emit { file } => cmd_emit(&file, diagnostic_format),
-        Commands::Test { dir } => cmd_test(&dir, diagnostic_format),
+        Commands::Test {
+            dir,
+            locked,
+            offline,
+            frozen,
+        } => cmd_test(
+            &dir,
+            lock_mode_from_flags(locked, offline, frozen),
+            diagnostic_format,
+        ),
         Commands::SelfCommand(args) => cmd_self(&args, diagnostic_format),
     }
 }

--- a/crates/sifr/src/mode_resolution_tests.rs
+++ b/crates/sifr/src/mode_resolution_tests.rs
@@ -14,6 +14,25 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 
 static CWD_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+#[test]
+fn test_command_preserves_frozen_cargo_resolution_mode() {
+    let cli = Cli::try_parse_from(["sifr", "test", "tests", "--frozen"])
+        .expect("test command should parse");
+    let Some(Commands::Test {
+        dir,
+        locked,
+        offline,
+        frozen,
+    }) = cli.command
+    else {
+        panic!("expected test command");
+    };
+    assert_eq!(dir, PathBuf::from("tests"));
+    assert!(!locked);
+    assert!(!offline);
+    assert!(frozen);
+}
+
 struct CurrentDirGuard {
     previous: PathBuf,
     _lock: MutexGuard<'static, ()>,

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -21,6 +21,7 @@ pub struct TestProjectCodegenResult {
     pub project_union_prelude: String,
     pub used_stdlib_modules: HashSet<String>,
     pub required_features: HashSet<StdlibFeature>,
+    pub interop: crate::InteropBuildPlan,
 }
 
 /// Generate support modules and root-level test bodies under one project union policy.
@@ -162,5 +163,10 @@ pub fn generate_rust_test_project_with_metadata(
         project_union_prelude,
         used_stdlib_modules,
         required_features,
+        interop: crate::rust_interop_plan::interop_build_plan_for_named_modules(
+            all_modules
+                .iter()
+                .map(|(module_name, module)| (Some(*module_name), *module)),
+        ),
     }
 }

--- a/crates/sifr_driver/src/build/cargo_resolution.rs
+++ b/crates/sifr_driver/src/build/cargo_resolution.rs
@@ -17,7 +17,7 @@ type RegistryEntry = (String, String, String, String);
 type RegistryCompatibilityFamily = (String, String, String);
 
 #[derive(Clone, Debug)]
-pub(super) struct CargoResolutionPolicy {
+pub(crate) struct CargoResolutionPolicy {
     pub(super) lock_mode: CargoLockMode,
     pub(super) cargo_vendor_mode: CargoVendorMode,
     pub(super) authoritative_locks: Vec<PathBuf>,
@@ -37,6 +37,36 @@ impl CargoResolutionPolicy {
     pub(super) const fn uses_sysroot_vendor(&self) -> bool {
         matches!(self.cargo_vendor_mode, CargoVendorMode::SysrootOnly)
     }
+
+    pub(crate) fn for_test_scope(
+        test_scope: &Path,
+        lock_mode: CargoLockMode,
+        dependency_plan: &sifr_stdlib_manifest::SysrootDependencyPlan,
+    ) -> Self {
+        let mut authoritative_locks = Vec::new();
+        if lock_mode != CargoLockMode::Normal {
+            if let Some(lock) = nearest_ancestor_file(test_scope, "Cargo.lock") {
+                authoritative_locks.push(lock);
+            }
+            let sysroot_lock = dependency_plan.sysroot_root.join("Cargo.lock");
+            if !authoritative_locks.contains(&sysroot_lock) {
+                authoritative_locks.push(sysroot_lock);
+            }
+        }
+        Self {
+            lock_mode,
+            cargo_vendor_mode: dependency_plan.cargo_vendor_mode,
+            authoritative_locks,
+            trusted_vendor_dirs: vec![dependency_plan.vendor_dir.clone()],
+        }
+    }
+}
+
+fn nearest_ancestor_file(start: &Path, file_name: &str) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .map(|ancestor| ancestor.join(file_name))
+        .find(|candidate| candidate.is_file())
 }
 
 pub(super) struct PreparedCargoResolution {
@@ -116,7 +146,7 @@ fn prepare_constrained_cargo_resolution(
     })
 }
 
-pub(super) fn cargo_resolution_cache_key_fragment(
+pub(crate) fn cargo_resolution_cache_key_fragment(
     policy: &CargoResolutionPolicy,
 ) -> Result<String, Vec<RenderedDiagnostic>> {
     let mut fragment = format!(

--- a/crates/sifr_driver/src/build/generated_cargo_project.rs
+++ b/crates/sifr_driver/src/build/generated_cargo_project.rs
@@ -31,6 +31,13 @@ pub(crate) enum GeneratedCargoCommand {
     Test,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct GeneratedCargoExecution<'a> {
+    pub(crate) python_interpreter: Option<&'a Path>,
+    pub(crate) target_directory: Option<&'a Path>,
+    pub(crate) additional_trusted_native_links: &'a BTreeSet<String>,
+}
+
 impl GeneratedCargoCommand {
     fn phase(self) -> &'static str {
         match self {
@@ -123,8 +130,7 @@ fn declare_bridge_module(source: &str) -> String {
 pub(crate) fn run_generated_cargo_command(
     project_path: &Path,
     command_kind: GeneratedCargoCommand,
-    python_interpreter: Option<&Path>,
-    additional_trusted_native_links: &BTreeSet<String>,
+    execution: GeneratedCargoExecution<'_>,
     interop: &InteropBuildPlan,
     dependency_plan: &SysrootDependencyPlan,
     cargo_resolution: &CargoResolutionPolicy,
@@ -140,9 +146,13 @@ pub(crate) fn run_generated_cargo_command(
     if let Some(argument) = cargo_resolution.lock_mode.cargo_arg() {
         command.arg(argument);
     }
-    command.env_remove("CARGO_TARGET_DIR");
+    if let Some(target_directory) = execution.target_directory {
+        command.env("CARGO_TARGET_DIR", target_directory);
+    } else {
+        command.env_remove("CARGO_TARGET_DIR");
+    }
     configure_hermetic_build_environment(&mut command);
-    if let Some(python_interpreter) = python_interpreter {
+    if let Some(python_interpreter) = execution.python_interpreter {
         command.env("PYO3_PYTHON", python_interpreter);
     }
     record_cargo_invocation(command_kind.phase(), cargo_resolution.lock_mode, &command);
@@ -153,10 +163,9 @@ pub(crate) fn run_generated_cargo_command(
         ))]
     })?;
 
-    if should_validate_native_link_evidence(interop) || !additional_trusted_native_links.is_empty()
-    {
+    if should_validate_native_link_evidence(interop) {
         let mut trusted_native_links = trusted_native_links(interop, dependency_plan);
-        trusted_native_links.extend(additional_trusted_native_links.iter().cloned());
+        trusted_native_links.extend(execution.additional_trusted_native_links.iter().cloned());
         validate_native_link_evidence(&output.stdout, &trusted_native_links)?;
     }
     prepared_resolution.assert_unchanged()?;

--- a/crates/sifr_driver/src/build/generated_cargo_project.rs
+++ b/crates/sifr_driver/src/build/generated_cargo_project.rs
@@ -1,0 +1,433 @@
+use super::cargo_invocation_trace::record_cargo_invocation;
+use super::cargo_manifest::{
+    generate_dependency_cargo_toml_with_interop, sysroot_cargo_config_args,
+};
+use super::cargo_resolution::{
+    CargoResolutionPolicy, cargo_lock_mode_diagnostic, prepare_cargo_resolution,
+};
+use super::rust_interop_bridge_sources::generated_bridge_sources;
+use super::rust_interop_sqlx_offline::configure_hermetic_build_environment;
+use crate::diagnostics::RenderedDiagnostic;
+use crate::project::{namespace_module_files, rust_module_file_path};
+use sifr_codegen::{InteropBuildPlan, RustInteropTrustRequirementKind};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_stdlib_manifest::{SysrootCrate, SysrootDependencyPlan};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+pub(crate) struct GeneratedCargoProject {
+    pub(crate) name: String,
+    pub(crate) crate_root_file: PathBuf,
+    pub(crate) crate_root_source: String,
+    pub(crate) support_modules: BTreeMap<String, String>,
+    pub(crate) support_main_alias: Option<PathBuf>,
+    pub(crate) interop: InteropBuildPlan,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum GeneratedCargoCommand {
+    BuildRelease,
+    Test,
+}
+
+impl GeneratedCargoCommand {
+    fn phase(self) -> &'static str {
+        match self {
+            Self::BuildRelease => "final-build",
+            Self::Test => "test-build",
+        }
+    }
+
+    fn context(self) -> &'static str {
+        match self {
+            Self::BuildRelease => "cargo build",
+            Self::Test => "cargo test",
+        }
+    }
+
+    fn args(self) -> &'static [&'static str] {
+        match self {
+            Self::BuildRelease => &[
+                "build",
+                "--release",
+                "--quiet",
+                "--message-format=json-render-diagnostics",
+            ],
+            Self::Test => &["test", "--message-format=json-render-diagnostics"],
+        }
+    }
+}
+
+pub(crate) fn generated_cargo_manifest(
+    project_name: &str,
+    dependency_plan: &SysrootDependencyPlan,
+    interop: &InteropBuildPlan,
+) -> String {
+    generate_dependency_cargo_toml_with_interop(project_name, dependency_plan, interop)
+}
+
+pub(crate) fn materialize_generated_cargo_project(
+    project_path: &Path,
+    project: GeneratedCargoProject,
+    dependency_plan: &SysrootDependencyPlan,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let src_dir = project_path.join("src");
+    std::fs::create_dir_all(&src_dir).map_err(|error| {
+        vec![materialization_error(format!(
+            "failed to create output directory: {error}"
+        ))]
+    })?;
+
+    let cargo_toml = generated_cargo_manifest(&project.name, dependency_plan, &project.interop);
+    write_project_file(&project_path.join("Cargo.toml"), cargo_toml, "Cargo.toml")?;
+
+    let bridge_sources =
+        generated_bridge_sources(&project.interop.rust.bridge_contracts.generated_types);
+    let crate_root_source = if bridge_sources.is_empty() {
+        project.crate_root_source
+    } else {
+        declare_bridge_module(&project.crate_root_source)
+    };
+    write_project_file(
+        &src_dir.join(&project.crate_root_file),
+        crate_root_source,
+        &project.crate_root_file.display().to_string(),
+    )?;
+    for (path, source) in bridge_sources {
+        write_project_file(&src_dir.join(&path), source, &path.display().to_string())?;
+    }
+
+    materialize_support_modules(
+        &src_dir,
+        project.support_modules,
+        project.support_main_alias.as_deref(),
+    )
+}
+
+fn declare_bridge_module(source: &str) -> String {
+    let mut insertion = 0;
+    for line in source.split_inclusive('\n') {
+        if !line.trim_start().starts_with("#![") {
+            break;
+        }
+        insertion += line.len();
+    }
+    let mut result = String::with_capacity(source.len() + 24);
+    result.push_str(&source[..insertion]);
+    result.push_str("pub mod __sifr_bridge;\n");
+    result.push_str(&source[insertion..]);
+    result
+}
+
+pub(crate) fn run_generated_cargo_command(
+    project_path: &Path,
+    command_kind: GeneratedCargoCommand,
+    python_interpreter: Option<&Path>,
+    additional_trusted_native_links: &BTreeSet<String>,
+    interop: &InteropBuildPlan,
+    dependency_plan: &SysrootDependencyPlan,
+    cargo_resolution: &CargoResolutionPolicy,
+) -> Result<Output, Vec<RenderedDiagnostic>> {
+    let cargo_prefix_args = sysroot_cargo_config_args(dependency_plan);
+    let prepared_resolution =
+        prepare_cargo_resolution(project_path, cargo_resolution, &cargo_prefix_args)?;
+    let mut command = Command::new("cargo");
+    command
+        .args(&cargo_prefix_args)
+        .args(command_kind.args())
+        .current_dir(project_path);
+    if let Some(argument) = cargo_resolution.lock_mode.cargo_arg() {
+        command.arg(argument);
+    }
+    command.env_remove("CARGO_TARGET_DIR");
+    configure_hermetic_build_environment(&mut command);
+    if let Some(python_interpreter) = python_interpreter {
+        command.env("PYO3_PYTHON", python_interpreter);
+    }
+    record_cargo_invocation(command_kind.phase(), cargo_resolution.lock_mode, &command);
+    let output = command.output().map_err(|error| {
+        vec![cargo_execution_error(format!(
+            "failed to run {}: {error}",
+            command_kind.context()
+        ))]
+    })?;
+
+    if should_validate_native_link_evidence(interop) || !additional_trusted_native_links.is_empty()
+    {
+        let mut trusted_native_links = trusted_native_links(interop, dependency_plan);
+        trusted_native_links.extend(additional_trusted_native_links.iter().cloned());
+        validate_native_link_evidence(&output.stdout, &trusted_native_links)?;
+    }
+    prepared_resolution.assert_unchanged()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if let Some(diagnostic) = cargo_lock_mode_diagnostic(command_kind.context(), &stderr) {
+            return Err(vec![diagnostic]);
+        }
+    }
+    Ok(output)
+}
+
+fn materialize_support_modules(
+    src_dir: &Path,
+    support_modules: BTreeMap<String, String>,
+    support_main_alias: Option<&Path>,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let support_module_names = support_modules.keys().cloned().collect::<Vec<_>>();
+    let mut namespace_contents = namespace_module_files(&support_module_names)
+        .into_iter()
+        .map(|namespace| {
+            let mut contents = String::new();
+            for declaration in namespace.declarations {
+                contents.push_str("pub mod ");
+                contents.push_str(&declaration);
+                contents.push_str(";\n");
+            }
+            (
+                remap_support_main_path(namespace.path, support_main_alias),
+                contents,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for (module_name, code) in support_modules {
+        let namespace_path =
+            remap_support_main_path(namespace_module_file_path(&module_name), support_main_alias);
+        if let Some(contents) = namespace_contents.get_mut(&namespace_path) {
+            if !contents.is_empty() && !contents.ends_with('\n') {
+                contents.push('\n');
+            }
+            contents.push_str(&code);
+            continue;
+        }
+        let file_name =
+            remap_support_main_path(rust_module_file_path(&module_name), support_main_alias);
+        write_project_file(
+            &src_dir.join(&file_name),
+            code,
+            &file_name.display().to_string(),
+        )?;
+    }
+
+    for (namespace_path, contents) in namespace_contents {
+        write_project_file(
+            &src_dir.join(&namespace_path),
+            contents,
+            &namespace_path.display().to_string(),
+        )?;
+    }
+    Ok(())
+}
+
+fn remap_support_main_path(path: PathBuf, support_main_alias: Option<&Path>) -> PathBuf {
+    let Some(alias) = support_main_alias else {
+        return path;
+    };
+    if path == Path::new("main.rs") {
+        return alias.to_path_buf();
+    }
+    let mut components = path.components();
+    let Some(first) = components.next() else {
+        return path;
+    };
+    if first.as_os_str() != "main" {
+        return path;
+    }
+    let remainder = components.collect::<PathBuf>();
+    if remainder.as_os_str().is_empty() || remainder == Path::new("mod.rs") {
+        return alias.to_path_buf();
+    }
+    alias.with_extension("").join(remainder)
+}
+
+fn namespace_module_file_path(module_name: &str) -> PathBuf {
+    let mut path = PathBuf::new();
+    for component in module_name.split('.') {
+        path.push(component);
+    }
+    path.push("mod.rs");
+    path
+}
+
+pub(super) fn trusted_native_links(
+    interop: &InteropBuildPlan,
+    dependency_plan: &SysrootDependencyPlan,
+) -> BTreeSet<String> {
+    let mut trusted = interop
+        .rust
+        .trust_requirements
+        .iter()
+        .filter(|requirement| {
+            requirement.trusted && requirement.kind == RustInteropTrustRequirementKind::NativeLinks
+        })
+        .map(|requirement| requirement.required_entry.clone())
+        .collect::<BTreeSet<_>>();
+    trusted.extend(sysroot_trusted_native_links(dependency_plan));
+    trusted
+}
+
+pub(super) fn should_validate_native_link_evidence(interop: &InteropBuildPlan) -> bool {
+    let rust = &interop.rust;
+    !rust.declarations.is_empty()
+        || !rust.resolved_targets.is_empty()
+        || !rust.trust_requirements.is_empty()
+        || !rust.probe_plan.probes.is_empty()
+        || !rust.bridge_sources.is_empty()
+        || rust.cargo_inputs.is_some()
+}
+
+pub(super) fn sysroot_trusted_native_links(
+    dependency_plan: &SysrootDependencyPlan,
+) -> BTreeSet<String> {
+    let tls_selected = dependency_plan.crates.iter().any(|dependency| {
+        matches!(
+            dependency.krate,
+            SysrootCrate::SifrRuntime | SysrootCrate::SifrStdlib
+        ) && (dependency.features.contains("tls") || dependency.features.contains("http"))
+    });
+    if tls_selected {
+        return BTreeSet::from(["aws_lc_0_44_0_crypto".to_string()]);
+    }
+    BTreeSet::new()
+}
+
+pub(super) fn validate_native_link_evidence(
+    stdout: &[u8],
+    trusted_native_links: &BTreeSet<String>,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    for line in String::from_utf8_lossy(stdout).lines() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if value.get("reason").and_then(serde_json::Value::as_str) != Some("build-script-executed")
+        {
+            continue;
+        }
+        let Some(linked_libs) = value
+            .get("linked_libs")
+            .and_then(serde_json::Value::as_array)
+        else {
+            continue;
+        };
+        for linked_lib in linked_libs {
+            let Some(linked_lib) = linked_lib.as_str() else {
+                continue;
+            };
+            let link_name = linked_lib
+                .rsplit_once('=')
+                .map_or(linked_lib, |(_, name)| name);
+            if !trusted_native_links.contains(link_name) {
+                return Err(vec![crate::diagnostics::diagnostic_with_code(
+                    format!(
+                        "untrusted native link evidence `{link_name}` emitted by Rust build script"
+                    ),
+                    DiagnosticCode::RUST_TRUST_MISSING,
+                )]);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn write_project_file(
+    path: &Path,
+    contents: impl AsRef<[u8]>,
+    label: &str,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            vec![materialization_error(format!(
+                "failed to create {label}: {error}"
+            ))]
+        })?;
+    }
+    std::fs::write(path, contents).map_err(|error| {
+        vec![materialization_error(format!(
+            "failed to write {label}: {error}"
+        ))]
+    })
+}
+
+fn materialization_error(message: String) -> RenderedDiagnostic {
+    crate::diagnostics::diagnostic_with_code(message, DiagnosticCode::BUILD_MATERIALIZATION_FAILURE)
+}
+
+pub(super) fn cargo_execution_error(message: String) -> RenderedDiagnostic {
+    crate::diagnostics::diagnostic_with_code(message, DiagnosticCode::BUILD_RUSTC_OR_CARGO_FAILURE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{materialize_support_modules, validate_native_link_evidence};
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn shared_support_materializer_combines_namespace_source_and_children() {
+        let root = temp_dir("support_namespace");
+        materialize_support_modules(
+            &root,
+            BTreeMap::from([
+                ("helpers".to_string(), "pub fn root() {}\n".to_string()),
+                (
+                    "helpers.nodes".to_string(),
+                    "pub fn child() {}\n".to_string(),
+                ),
+            ]),
+            None,
+        )
+        .expect("support modules should materialize");
+
+        let namespace = std::fs::read_to_string(root.join("helpers/mod.rs"))
+            .expect("namespace module should exist");
+        assert_eq!(namespace, "pub mod nodes;\npub fn root() {}\n");
+        assert!(root.join("helpers/nodes.rs").is_file());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn shared_support_materializer_remaps_test_main_namespace_to_alias() {
+        let root = temp_dir("support_main_alias");
+        materialize_support_modules(
+            &root,
+            BTreeMap::from([
+                ("main".to_string(), "pub fn root() {}\n".to_string()),
+                ("main.child".to_string(), "pub fn child() {}\n".to_string()),
+            ]),
+            Some(Path::new("__sifr_support_main.rs")),
+        )
+        .expect("support main modules should materialize");
+
+        let main = std::fs::read_to_string(root.join("__sifr_support_main.rs"))
+            .expect("support main alias should exist");
+        assert_eq!(main, "pub mod child;\npub fn root() {}\n");
+        assert!(root.join("__sifr_support_main/child.rs").is_file());
+        assert!(!root.join("main").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn native_link_evidence_rejects_untrusted_build_script_output() {
+        let stdout = br#"{"reason":"build-script-executed","linked_libs":["dylib=ssl"]}"#;
+        let diagnostics = validate_native_link_evidence(stdout, &BTreeSet::new())
+            .expect_err("untrusted link evidence should fail");
+        assert_eq!(diagnostics[0].code, "SIFR-RUST-TRUST-0001");
+        validate_native_link_evidence(stdout, &BTreeSet::from(["ssl".to_string()]))
+            .expect("trusted link should pass");
+    }
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let unique = format!(
+            "sifr_generated_project_{label}_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time should move forward")
+                .as_nanos()
+        );
+        let root = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&root).expect("temporary directory should be created");
+        root
+    }
+}

--- a/crates/sifr_driver/src/build/materialize.rs
+++ b/crates/sifr_driver/src/build/materialize.rs
@@ -3,7 +3,7 @@ use super::cargo_manifest::{
 };
 use super::cargo_resolution::{CargoResolutionPolicy, cargo_resolution_cache_key_fragment};
 use super::generated_cargo_project::{
-    GeneratedCargoCommand, GeneratedCargoProject, cargo_execution_error,
+    GeneratedCargoCommand, GeneratedCargoExecution, GeneratedCargoProject, cargo_execution_error,
     materialize_generated_cargo_project, run_generated_cargo_command,
 };
 use super::project_codegen::GeneratedBinaryProject;
@@ -159,8 +159,11 @@ fn materialize_binary_project_at_path(
     let output = run_generated_cargo_command(
         project_path,
         GeneratedCargoCommand::BuildRelease,
-        python_interpreter.as_deref(),
-        &additional_trusted_native_links,
+        GeneratedCargoExecution {
+            python_interpreter: python_interpreter.as_deref(),
+            target_directory: None,
+            additional_trusted_native_links: &additional_trusted_native_links,
+        },
         &interop,
         dependency_plan,
         cargo_resolution,

--- a/crates/sifr_driver/src/build/materialize.rs
+++ b/crates/sifr_driver/src/build/materialize.rs
@@ -1,25 +1,19 @@
-use super::cargo_invocation_trace::record_cargo_invocation;
 use super::cargo_manifest::{
-    generate_dependency_cargo_toml_with_interop, sysroot_cargo_config_args,
-    try_generate_sysroot_dependency_plan,
+    generate_dependency_cargo_toml_with_interop, try_generate_sysroot_dependency_plan,
 };
-use super::cargo_resolution::{
-    CargoResolutionPolicy, cargo_lock_mode_diagnostic, cargo_resolution_cache_key_fragment,
-    prepare_cargo_resolution,
+use super::cargo_resolution::{CargoResolutionPolicy, cargo_resolution_cache_key_fragment};
+use super::generated_cargo_project::{
+    GeneratedCargoCommand, GeneratedCargoProject, cargo_execution_error,
+    materialize_generated_cargo_project, run_generated_cargo_command,
 };
 use super::project_codegen::GeneratedBinaryProject;
 use super::report::BuildSysrootReport;
-use super::rust_interop_bridge_sources::generated_bridge_sources;
-use super::rust_interop_sqlx_offline::configure_hermetic_build_environment;
 use super::{CachedArtifactEntry, PreparedArtifactCache, prepare_cached_artifact};
 use crate::diagnostics::RenderedDiagnostic;
-use crate::project::{namespace_module_files, rust_module_file_path};
-use sifr_codegen::RustInteropTrustRequirementKind;
 use sifr_diagnostics::DiagnosticCode;
-use sifr_stdlib_manifest::{CargoVendorMode, SysrootCrate, SysrootDependencyPlan};
-use std::collections::{BTreeMap, BTreeSet};
+use sifr_stdlib_manifest::{CargoVendorMode, SysrootDependencyPlan};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::Duration;
 
 pub(super) struct MaterializedBinaryProject {
@@ -139,30 +133,44 @@ fn materialize_binary_project_at_path(
         .as_ref()
         .map(|runtime| runtime.interpreter().to_path_buf());
     let sysroot = sysroot_report(dependency_plan);
-    let validate_native_links = should_validate_native_link_evidence(&generated_project);
-    let trusted_native_links = trusted_native_links(&generated_project, dependency_plan);
+    let additional_trusted_native_links = generated_project
+        .python_runtime
+        .as_ref()
+        .map_or_else(BTreeSet::new, |runtime| {
+            runtime.trusted_native_link_names().into_iter().collect()
+        });
+    let interop = generated_project.interop.clone();
     let materialize_start = std::time::Instant::now();
-    materialize_binary_project_files(
+    materialize_generated_cargo_project(
         project_path,
-        project_name,
-        generated_project,
+        GeneratedCargoProject {
+            name: project_name.to_string(),
+            crate_root_file: PathBuf::from("main.rs"),
+            crate_root_source: generated_project.main_rs,
+            support_modules: generated_project.support_modules,
+            support_main_alias: None,
+            interop: generated_project.interop,
+        },
         dependency_plan,
     )?;
     let materialize_elapsed = materialize_start.elapsed();
 
     let cargo_start = std::time::Instant::now();
-    let cargo_prefix_args = sysroot_cargo_config_args(dependency_plan);
-    let prepared_resolution =
-        prepare_cargo_resolution(project_path, cargo_resolution, &cargo_prefix_args)?;
-    run_cargo_build(
+    let output = run_generated_cargo_command(
         project_path,
+        GeneratedCargoCommand::BuildRelease,
         python_interpreter.as_deref(),
-        validate_native_links,
-        &trusted_native_links,
+        &additional_trusted_native_links,
+        &interop,
         dependency_plan,
         cargo_resolution,
     )?;
-    prepared_resolution.assert_unchanged()?;
+    if !output.status.success() {
+        return Err(vec![cargo_execution_error(format!(
+            "cargo build failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        ))]);
+    }
     let cargo_elapsed = cargo_start.elapsed();
 
     Ok(MaterializedBinaryProject {
@@ -180,253 +188,8 @@ fn sysroot_report(dependency_plan: &SysrootDependencyPlan) -> BuildSysrootReport
     BuildSysrootReport::from_dependency_plan(dependency_plan)
 }
 
-fn materialize_binary_project_files(
-    project_path: &Path,
-    project_name: &str,
-    generated_project: GeneratedBinaryProject,
-    dependency_plan: &SysrootDependencyPlan,
-) -> Result<(), Vec<RenderedDiagnostic>> {
-    let src_dir = project_path.join("src");
-    std::fs::create_dir_all(&src_dir).map_err(|error| {
-        vec![build_error(format!(
-            "failed to create output directory: {error}"
-        ))]
-    })?;
-
-    let cargo_toml = generate_dependency_cargo_toml_with_interop(
-        project_name,
-        dependency_plan,
-        &generated_project.interop,
-    );
-
-    write_project_file(&project_path.join("Cargo.toml"), cargo_toml, "Cargo.toml")?;
-
-    let bridge_sources = generated_bridge_sources(
-        &generated_project
-            .interop
-            .rust
-            .bridge_contracts
-            .generated_types,
-    );
-    let main_rs = if bridge_sources.is_empty() {
-        generated_project.main_rs
-    } else {
-        format!("pub mod __sifr_bridge;\n{}", generated_project.main_rs)
-    };
-    write_project_file(&src_dir.join("main.rs"), main_rs, "main.rs")?;
-
-    for (path, source) in bridge_sources {
-        write_project_file(&src_dir.join(&path), source, &path.display().to_string())?;
-    }
-
-    let mut support_modules = generated_project.support_modules;
-    let support_module_names: Vec<String> = support_modules.keys().cloned().collect();
-    let mut namespace_contents: BTreeMap<PathBuf, String> = BTreeMap::new();
-    for namespace_file in namespace_module_files(&support_module_names) {
-        let mut contents = String::new();
-        for module_name in &namespace_file.declarations {
-            contents.push_str("pub mod ");
-            contents.push_str(module_name);
-            contents.push_str(";\n");
-        }
-        namespace_contents.insert(namespace_file.path, contents);
-    }
-
-    for (module_name, code) in std::mem::take(&mut support_modules) {
-        let namespace_path = namespace_module_file_path(&module_name);
-        if let Some(contents) = namespace_contents.get_mut(&namespace_path) {
-            if !contents.is_empty() && !contents.ends_with('\n') {
-                contents.push('\n');
-            }
-            contents.push_str(&code);
-            continue;
-        }
-        let file_name = rust_module_file_path(&module_name);
-        write_project_file(
-            &src_dir.join(&file_name),
-            code,
-            &file_name.display().to_string(),
-        )?;
-    }
-
-    for (namespace_path, contents) in namespace_contents {
-        write_project_file(
-            &src_dir.join(&namespace_path),
-            contents,
-            &namespace_path.display().to_string(),
-        )?;
-    }
-
-    Ok(())
-}
-
-fn run_cargo_build(
-    project_path: &Path,
-    python_interpreter: Option<&Path>,
-    validate_native_links: bool,
-    trusted_native_links: &BTreeSet<String>,
-    dependency_plan: &SysrootDependencyPlan,
-    cargo_resolution: &CargoResolutionPolicy,
-) -> Result<(), Vec<RenderedDiagnostic>> {
-    let mut command = Command::new("cargo");
-    command.args(sysroot_cargo_config_args(dependency_plan));
-    command
-        .args([
-            "build",
-            "--release",
-            "--quiet",
-            "--message-format=json-render-diagnostics",
-        ])
-        .current_dir(project_path);
-    if let Some(argument) = cargo_resolution.lock_mode.cargo_arg() {
-        command.arg(argument);
-    }
-    // Generated projects are materialized and cached with their own `target/`
-    // directory. Inheriting an outer CARGO_TARGET_DIR moves binaries away from
-    // the reported artifact paths and breaks cache completeness checks.
-    command.env_remove("CARGO_TARGET_DIR");
-    configure_hermetic_build_environment(&mut command);
-    if let Some(python_interpreter) = python_interpreter {
-        command.env("PYO3_PYTHON", python_interpreter);
-    }
-    record_cargo_invocation("final-build", cargo_resolution.lock_mode, &command);
-    let output = command.output().map_err(|error| {
-        vec![cargo_build_error(format!(
-            "failed to run cargo build: {error}"
-        ))]
-    })?;
-
-    if validate_native_links {
-        validate_native_link_evidence(&output.stdout, trusted_native_links)?;
-    }
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if let Some(diagnostic) = cargo_lock_mode_diagnostic("cargo build", &stderr) {
-            return Err(vec![diagnostic]);
-        }
-        return Err(vec![cargo_build_error(format!(
-            "cargo build failed:\n{stderr}"
-        ))]);
-    }
-    Ok(())
-}
-
-fn trusted_native_links(
-    generated_project: &GeneratedBinaryProject,
-    dependency_plan: &SysrootDependencyPlan,
-) -> BTreeSet<String> {
-    let mut trusted = generated_project
-        .interop
-        .rust
-        .trust_requirements
-        .iter()
-        .filter(|requirement| {
-            requirement.trusted && requirement.kind == RustInteropTrustRequirementKind::NativeLinks
-        })
-        .map(|requirement| requirement.required_entry.clone())
-        .collect::<BTreeSet<_>>();
-    if let Some(python_runtime) = &generated_project.python_runtime {
-        trusted.extend(python_runtime.trusted_native_link_names());
-    }
-    trusted.extend(sysroot_trusted_native_links(dependency_plan));
-    trusted
-}
-
-fn sysroot_trusted_native_links(dependency_plan: &SysrootDependencyPlan) -> BTreeSet<String> {
-    let tls_selected = dependency_plan.crates.iter().any(|dependency| {
-        matches!(
-            dependency.krate,
-            SysrootCrate::SifrRuntime | SysrootCrate::SifrStdlib
-        ) && (dependency.features.contains("tls") || dependency.features.contains("http"))
-    });
-    if tls_selected {
-        return BTreeSet::from(["aws_lc_0_44_0_crypto".to_string()]);
-    }
-    BTreeSet::new()
-}
-
-fn should_validate_native_link_evidence(generated_project: &GeneratedBinaryProject) -> bool {
-    let rust = &generated_project.interop.rust;
-    !rust.declarations.is_empty()
-        || !rust.resolved_targets.is_empty()
-        || !rust.trust_requirements.is_empty()
-        || !rust.probe_plan.probes.is_empty()
-        || !rust.bridge_sources.is_empty()
-        || rust.cargo_inputs.is_some()
-}
-
-fn validate_native_link_evidence(
-    stdout: &[u8],
-    trusted_native_links: &BTreeSet<String>,
-) -> Result<(), Vec<RenderedDiagnostic>> {
-    for line in String::from_utf8_lossy(stdout).lines() {
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-        if value.get("reason").and_then(serde_json::Value::as_str) != Some("build-script-executed")
-        {
-            continue;
-        }
-        let Some(linked_libs) = value
-            .get("linked_libs")
-            .and_then(serde_json::Value::as_array)
-        else {
-            continue;
-        };
-        for linked_lib in linked_libs {
-            let Some(linked_lib) = linked_lib.as_str() else {
-                continue;
-            };
-            let link_name = normalized_link_name(linked_lib);
-            if !trusted_native_links.contains(&link_name) {
-                return Err(vec![crate::diagnostics::diagnostic_with_code(
-                    format!(
-                        "untrusted native link evidence `{link_name}` emitted by Rust build script"
-                    ),
-                    DiagnosticCode::RUST_TRUST_MISSING,
-                )]);
-            }
-        }
-    }
-    Ok(())
-}
-
-fn normalized_link_name(linked_lib: &str) -> String {
-    linked_lib
-        .rsplit_once('=')
-        .map_or(linked_lib, |(_, name)| name)
-        .to_string()
-}
-
-fn namespace_module_file_path(module_name: &str) -> PathBuf {
-    let mut path = PathBuf::new();
-    for component in module_name.split('.') {
-        path.push(component);
-    }
-    path.push("mod.rs");
-    path
-}
-
-fn write_project_file(
-    path: &Path,
-    contents: impl AsRef<[u8]>,
-    label: &str,
-) -> Result<(), Vec<RenderedDiagnostic>> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| vec![build_error(format!("failed to create {label}: {error}"))])?;
-    }
-    std::fs::write(path, contents)
-        .map_err(|error| vec![build_error(format!("failed to write {label}: {error}"))])
-}
-
 fn build_error(message: String) -> RenderedDiagnostic {
     crate::diagnostics::diagnostic_with_code(message, DiagnosticCode::BUILD_MATERIALIZATION_FAILURE)
-}
-
-fn cargo_build_error(message: String) -> RenderedDiagnostic {
-    crate::diagnostics::diagnostic_with_code(message, DiagnosticCode::BUILD_RUSTC_OR_CARGO_FAILURE)
 }
 
 fn binary_project_cache_key(
@@ -464,9 +227,10 @@ fn binary_project_cache_key(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        CargoResolutionPolicy, binary_project_cache_key, should_validate_native_link_evidence,
-        sysroot_trusted_native_links, trusted_native_links, validate_native_link_evidence,
+    use super::{CargoResolutionPolicy, binary_project_cache_key};
+    use crate::build::generated_cargo_project::{
+        should_validate_native_link_evidence, sysroot_trusted_native_links, trusted_native_links,
+        validate_native_link_evidence,
     };
     use crate::build::project_codegen::GeneratedBinaryProject;
     use crate::build::python_runtime::PackagePythonRuntime;
@@ -587,7 +351,7 @@ mod tests {
     #[test]
     fn native_link_evidence_policy_skips_non_rust_interop_projects() {
         let mut project = base_project();
-        assert!(!should_validate_native_link_evidence(&project));
+        assert!(!should_validate_native_link_evidence(&project.interop));
 
         project
             .interop
@@ -600,7 +364,7 @@ mod tests {
                 required_entry: "ssl".to_string(),
                 evidence: "links=ssl".to_string(),
             });
-        assert!(should_validate_native_link_evidence(&project));
+        assert!(should_validate_native_link_evidence(&project.interop));
     }
 
     #[test]
@@ -623,11 +387,17 @@ mod tests {
             });
 
         let stdout = br#"{"reason":"build-script-executed","linked_libs":["dylib=python3.14"]}"#;
-        validate_native_link_evidence(
-            stdout,
-            &trusted_native_links(&project, &test_dependency_plan("fingerprint-a")),
-        )
-        .expect("selected Python runtime link should be trusted");
+        let mut trusted =
+            trusted_native_links(&project.interop, &test_dependency_plan("fingerprint-a"));
+        trusted.extend(
+            project
+                .python_runtime
+                .as_ref()
+                .expect("Python runtime should be configured")
+                .trusted_native_link_names(),
+        );
+        validate_native_link_evidence(stdout, &trusted)
+            .expect("selected Python runtime link should be trusted");
     }
 
     #[test]

--- a/crates/sifr_driver/src/build/mod.rs
+++ b/crates/sifr_driver/src/build/mod.rs
@@ -7,6 +7,7 @@ mod entrypoint_artifact;
 mod entrypoint_resolution;
 mod entrypoint_single_file;
 mod entrypoint_stages;
+mod generated_cargo_project;
 mod materialize;
 mod project_codegen;
 mod python_bridges;
@@ -96,6 +97,7 @@ pub use report::{
 pub(crate) use cargo_manifest::{
     generate_dependency_cargo_toml_with_interop, try_generate_sysroot_dependency_plan,
 };
+pub(crate) use cargo_resolution::{CargoResolutionPolicy, cargo_resolution_cache_key_fragment};
 pub(crate) use entrypoint::{
     RootedEntrypoint, build_cached_package_project_binary, build_cached_project_binary,
     build_cached_single_file_binary, build_rooted_entrypoint_binary_with_report,
@@ -103,9 +105,12 @@ pub(crate) use entrypoint::{
     compile_single_file_frontend, emit_project_entrypoint, resolve_package_project_entrypoint_plan,
     resolve_project_entrypoint_plan,
 };
+pub(crate) use generated_cargo_project::{
+    GeneratedCargoCommand, GeneratedCargoProject, materialize_generated_cargo_project,
+    run_generated_cargo_command,
+};
 pub(crate) use workspace::{
     ArtifactCacheReport, CachedArtifactEntry, PreparedArtifactCache, prepare_cached_artifact,
 };
 
-#[cfg(test)]
 pub(crate) use workspace::create_invocation_workspace;

--- a/crates/sifr_driver/src/build/mod.rs
+++ b/crates/sifr_driver/src/build/mod.rs
@@ -106,8 +106,8 @@ pub(crate) use entrypoint::{
     resolve_project_entrypoint_plan,
 };
 pub(crate) use generated_cargo_project::{
-    GeneratedCargoCommand, GeneratedCargoProject, materialize_generated_cargo_project,
-    run_generated_cargo_command,
+    GeneratedCargoCommand, GeneratedCargoExecution, GeneratedCargoProject,
+    materialize_generated_cargo_project, run_generated_cargo_command,
 };
 pub(crate) use workspace::{
     ArtifactCacheReport, CachedArtifactEntry, PreparedArtifactCache, prepare_cached_artifact,

--- a/crates/sifr_driver/src/build/workspace.rs
+++ b/crates/sifr_driver/src/build/workspace.rs
@@ -186,15 +186,6 @@ pub(crate) enum PreparedArtifactCache {
     Miss(PendingCachedArtifact),
 }
 
-impl PreparedArtifactCache {
-    pub(crate) fn workspace_root(&self) -> &Path {
-        match self {
-            Self::Hit(entry) => entry.workspace_root(),
-            Self::Miss(entry) => entry.workspace_root(),
-        }
-    }
-}
-
 pub(crate) fn prepare_cached_artifact(
     namespace: &str,
     scope: &Path,

--- a/crates/sifr_driver/src/test_runner/artifacts.rs
+++ b/crates/sifr_driver/src/test_runner/artifacts.rs
@@ -1,14 +1,13 @@
 use crate::build::{
     generate_dependency_cargo_toml_with_interop, try_generate_sysroot_dependency_plan,
 };
-use crate::project::{rust_module_file_path, top_level_module_declarations};
+use crate::project::top_level_module_declarations;
 use sifr_codegen::InteropBuildPlan;
 #[cfg(test)]
 use sifr_stdlib_manifest::try_sysroot_dependency_plan;
 use sifr_stdlib_manifest::{CargoVendorMode, StdlibFeature, SysrootDependencyPlan};
 use sifr_sysroot::SysrootError;
 use std::collections::HashSet;
-use std::path::PathBuf;
 
 const SUPPORT_MAIN_RUST_FILE: &str = "__sifr_support_main.rs";
 
@@ -39,13 +38,6 @@ pub(crate) fn compose_test_runner_lib(
     test_lib
 }
 
-pub(crate) fn test_support_module_file_path(module_name: &str) -> PathBuf {
-    if module_name == "main" {
-        return PathBuf::from(SUPPORT_MAIN_RUST_FILE);
-    }
-    rust_module_file_path(module_name)
-}
-
 #[cfg(test)]
 pub(crate) fn generate_test_runner_cargo_toml(
     stdlib_modules: &HashSet<String>,
@@ -67,16 +59,16 @@ pub(crate) fn generate_test_runner_cargo_toml(
 pub(crate) fn try_generate_test_runner_cargo_plan(
     stdlib_modules: &HashSet<String>,
     required_features: &HashSet<StdlibFeature>,
+    interop: &InteropBuildPlan,
 ) -> Result<TestRunnerCargoPlan, SysrootError> {
-    let interop = InteropBuildPlan::default();
     let dependency_plan = try_generate_sysroot_dependency_plan(
         stdlib_modules,
         required_features,
-        &interop,
+        interop,
         CargoVendorMode::SysrootOnly,
     )?;
     let cargo_toml =
-        generate_dependency_cargo_toml_with_interop("sifr_tests", &dependency_plan, &interop);
+        generate_dependency_cargo_toml_with_interop("sifr_tests", &dependency_plan, interop);
     Ok(TestRunnerCargoPlan {
         cargo_toml,
         dependency_plan,

--- a/crates/sifr_driver/src/test_runner/execution.rs
+++ b/crates/sifr_driver/src/test_runner/execution.rs
@@ -1,15 +1,16 @@
-use super::artifacts::{
-    compose_test_runner_lib, test_support_module_file_path, try_generate_test_runner_cargo_plan,
-};
+use super::artifacts::{compose_test_runner_lib, try_generate_test_runner_cargo_plan};
 use super::orchestrator::GeneratedTestRunnerProject;
 use crate::build::{
-    ArtifactCacheReport, PreparedArtifactCache, prepare_cached_artifact, sysroot_cargo_config_args,
+    ArtifactCacheReport, CargoResolutionPolicy, GeneratedCargoCommand, GeneratedCargoProject,
+    PreparedArtifactCache, cargo_resolution_cache_key_fragment, create_invocation_workspace,
+    materialize_generated_cargo_project, prepare_cached_artifact, run_generated_cargo_command,
 };
 use crate::diagnostics::{RenderedDiagnostic, write_stderr, write_stderr_line};
-use crate::project::namespace_module_files;
 use sifr_diagnostics::DiagnosticCode;
+use sifr_package::CargoLockMode;
 use sifr_stdlib_manifest::SysrootDependencyPlan;
-use std::path::Path;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 
 pub(crate) struct TestRunnerExecutionOutcome {
     pub(crate) success: bool,
@@ -19,10 +20,12 @@ pub(crate) struct TestRunnerExecutionOutcome {
 
 pub(crate) fn execute_test_runner_project(
     generated_project: &GeneratedTestRunnerProject,
+    lock_mode: CargoLockMode,
 ) -> Result<TestRunnerExecutionOutcome, Vec<RenderedDiagnostic>> {
     let cargo_plan = try_generate_test_runner_cargo_plan(
         &generated_project.all_stdlib_modules,
         &generated_project.all_required_features,
+        &generated_project.interop,
     )
     .map_err(|error| {
         vec![crate::diagnostics::diagnostic_with_code(
@@ -34,121 +37,62 @@ pub(crate) fn execute_test_runner_project(
         &generated_project.support_module_names,
         &generated_project.all_rust_code,
     );
+    let cargo_resolution = CargoResolutionPolicy::for_test_scope(
+        &generated_project.cache_scope,
+        lock_mode,
+        &cargo_plan.dependency_plan,
+    );
     let cache_key = test_runner_cache_key(
         generated_project,
         &cargo_plan.cargo_toml,
         &test_lib,
         &cargo_plan.dependency_plan,
-    );
-    let required_paths = [
-        Path::new("Cargo.toml"),
-        Path::new("src/lib.rs"),
-        Path::new("target"),
-    ];
+        &cargo_resolution,
+    )?;
+    let required_paths = [Path::new("Cargo.toml"), Path::new("src/lib.rs")];
     let prepared = prepare_cached_artifact(
         "test_runner",
         &generated_project.cache_scope,
         &cache_key,
         &required_paths,
     )?;
-    let project_dir = prepared.workspace_root().to_path_buf();
-    if let PreparedArtifactCache::Miss(_) = &prepared {
-        let src_dir = project_dir.join("src");
-        std::fs::create_dir_all(&src_dir).map_err(|error| {
-            vec![crate::diagnostics::diagnostic_with_code(
-                format!("failed to create test directory: {error}"),
-                DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
-            )]
-        })?;
-
-        std::fs::write(project_dir.join("Cargo.toml"), &cargo_plan.cargo_toml).map_err(
-            |error| {
-                vec![crate::diagnostics::diagnostic_with_code(
-                    format!("failed to write Cargo.toml: {error}"),
-                    DiagnosticCode::BUILD_CARGO_MANIFEST_FAILURE,
-                )]
-            },
-        )?;
-
-        for module_name in &generated_project.support_module_names {
-            if let Some(code) = generated_project.support_rust_files.get(module_name) {
-                let module_path = test_support_module_file_path(module_name);
-                let output_path = src_dir.join(&module_path);
-                if let Some(parent) = output_path.parent() {
-                    std::fs::create_dir_all(parent).map_err(|error| {
-                        vec![crate::diagnostics::diagnostic_with_code(
-                            format!(
-                                "failed to create test support module directory '{}': {error}",
-                                parent.display()
-                            ),
-                            DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
-                        )]
-                    })?;
-                }
-                std::fs::write(&output_path, code).map_err(|error| {
-                    vec![crate::diagnostics::diagnostic_with_code(
-                        format!(
-                            "failed to write test support module '{}': {error}",
-                            output_path.display()
-                        ),
-                        DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
-                    )]
-                })?;
-            }
+    let cache_entry = match prepared {
+        PreparedArtifactCache::Hit(entry) => entry,
+        PreparedArtifactCache::Miss(pending) => {
+            materialize_generated_cargo_project(
+                pending.workspace_root(),
+                GeneratedCargoProject {
+                    name: "sifr_tests".to_string(),
+                    crate_root_file: PathBuf::from("lib.rs"),
+                    crate_root_source: test_lib,
+                    support_modules: generated_project
+                        .support_rust_files
+                        .iter()
+                        .map(|(name, source)| (name.clone(), source.clone()))
+                        .collect::<BTreeMap<_, _>>(),
+                    support_main_alias: Some(PathBuf::from("__sifr_support_main.rs")),
+                    interop: generated_project.interop.clone(),
+                },
+                &cargo_plan.dependency_plan,
+            )?;
+            pending.commit(&required_paths)?
         }
+    };
+    let cache_report = cache_entry.report().clone();
+    let invocation = TestInvocationWorkspace::create()?;
+    let project_dir = invocation.root().join("sifr_tests");
+    copy_cached_project(cache_entry.workspace_root(), &project_dir)?;
+    let output = run_generated_cargo_command(
+        &project_dir,
+        GeneratedCargoCommand::Test,
+        None,
+        &BTreeSet::new(),
+        &generated_project.interop,
+        &cargo_plan.dependency_plan,
+        &cargo_resolution,
+    )?;
 
-        for namespace_file in namespace_module_files(&generated_project.support_module_names) {
-            let output_path = src_dir.join(&namespace_file.path);
-            if let Some(parent) = output_path.parent() {
-                std::fs::create_dir_all(parent).map_err(|error| {
-                    vec![crate::diagnostics::diagnostic_with_code(
-                        format!(
-                            "failed to create test support namespace directory '{}': {error}",
-                            parent.display()
-                        ),
-                        DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
-                    )]
-                })?;
-            }
-            let mut contents = String::new();
-            for declaration in namespace_file.declarations {
-                contents.push_str("pub mod ");
-                contents.push_str(&declaration);
-                contents.push_str(";\n");
-            }
-            std::fs::write(&output_path, contents).map_err(|error| {
-                vec![crate::diagnostics::diagnostic_with_code(
-                    format!(
-                        "failed to write test support namespace '{}': {error}",
-                        output_path.display()
-                    ),
-                    DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
-                )]
-            })?;
-        }
-
-        std::fs::write(src_dir.join("lib.rs"), &test_lib).map_err(|error| {
-            vec![crate::diagnostics::diagnostic_with_code(
-                format!("failed to write lib.rs: {error}"),
-                DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
-            )]
-        })?;
-    }
-
-    let mut command = std::process::Command::new("cargo");
-    command
-        .args(sysroot_cargo_config_args(&cargo_plan.dependency_plan))
-        .args(["test"])
-        .current_dir(&project_dir);
-    command.env_remove("CARGO_TARGET_DIR");
-    let output = command.output().map_err(|error| {
-        vec![crate::diagnostics::diagnostic_with_code(
-            format!("failed to run cargo test: {error}"),
-            DiagnosticCode::BUILD_RUSTC_OR_CARGO_FAILURE,
-        )]
-    })?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = user_facing_cargo_stdout(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !stdout.is_empty() {
         write_stderr(&stdout);
@@ -157,10 +101,6 @@ pub(crate) fn execute_test_runner_project(
         write_stderr(&stderr);
     }
 
-    let cache_report = match prepared {
-        PreparedArtifactCache::Hit(entry) => entry.report().clone(),
-        PreparedArtifactCache::Miss(entry) => entry.commit(&required_paths)?.report().clone(),
-    };
     write_stderr_line(&cache_report.status_line());
 
     Ok(TestRunnerExecutionOutcome {
@@ -169,12 +109,25 @@ pub(crate) fn execute_test_runner_project(
     })
 }
 
+fn user_facing_cargo_stdout(stdout: &[u8]) -> String {
+    let mut output = String::new();
+    for line in String::from_utf8_lossy(stdout).lines() {
+        if serde_json::from_str::<serde_json::Value>(line).is_ok() {
+            continue;
+        }
+        output.push_str(line);
+        output.push('\n');
+    }
+    output
+}
+
 fn test_runner_cache_key(
     generated_project: &GeneratedTestRunnerProject,
     cargo_toml: &str,
     test_lib: &str,
     dependency_plan: &SysrootDependencyPlan,
-) -> String {
+    cargo_resolution: &CargoResolutionPolicy,
+) -> Result<String, Vec<RenderedDiagnostic>> {
     let mut support_modules: Vec<(&str, &str)> = generated_project
         .support_rust_files
         .iter()
@@ -186,18 +139,122 @@ fn test_runner_cache_key(
         .map(|(name, code)| format!("{name}\n{code}"))
         .collect::<Vec<_>>()
         .join("\n===\n");
-    format!(
-        "[scope]\n{}\n[Cargo.toml]\n{cargo_toml}\n[src/lib.rs]\n{test_lib}\n[support]\n{support_modules}\n[sysroot-dependency-inputs]\n{}[sysroot-dependency-plan]\n{}",
+    let cargo_resolution = cargo_resolution_cache_key_fragment(cargo_resolution)?;
+    Ok(format!(
+        "[scope]\n{}\n[Cargo.toml]\n{cargo_toml}\n[src/lib.rs]\n{test_lib}\n[support]\n{support_modules}\n[sysroot-dependency-inputs]\n{}[sysroot-dependency-plan]\n{}\n[cargo-resolution]\n{cargo_resolution}",
         generated_project.cache_scope.display(),
         dependency_plan.dependency_input_fingerprint(),
         dependency_plan.cache_fingerprint
-    )
+    ))
+}
+
+struct TestInvocationWorkspace {
+    root: PathBuf,
+}
+
+impl TestInvocationWorkspace {
+    fn create() -> Result<Self, Vec<RenderedDiagnostic>> {
+        create_invocation_workspace("test_runner").map(|root| Self { root })
+    }
+
+    fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl Drop for TestInvocationWorkspace {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn copy_cached_project(source: &Path, destination: &Path) -> Result<(), Vec<RenderedDiagnostic>> {
+    std::fs::create_dir_all(destination).map_err(|error| {
+        vec![materialization_error(format!(
+            "failed to create test execution directory '{}': {error}",
+            destination.display()
+        ))]
+    })?;
+    copy_project_file(source, destination, Path::new("Cargo.toml"))?;
+    copy_project_directory(&source.join("src"), &destination.join("src"))
+}
+
+fn copy_project_directory(
+    source: &Path,
+    destination: &Path,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    std::fs::create_dir_all(destination).map_err(|error| {
+        vec![materialization_error(format!(
+            "failed to create test source directory '{}': {error}",
+            destination.display()
+        ))]
+    })?;
+    let entries = std::fs::read_dir(source).map_err(|error| {
+        vec![materialization_error(format!(
+            "failed to read cached test source directory '{}': {error}",
+            source.display()
+        ))]
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            vec![materialization_error(format!(
+                "failed to read cached test source entry: {error}"
+            ))]
+        })?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type().map_err(|error| {
+            vec![materialization_error(format!(
+                "failed to inspect cached test source '{}': {error}",
+                source_path.display()
+            ))]
+        })?;
+        if file_type.is_dir() {
+            copy_project_directory(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&source_path, &destination_path).map_err(|error| {
+                vec![materialization_error(format!(
+                    "failed to copy cached test source '{}': {error}",
+                    source_path.display()
+                ))]
+            })?;
+        } else {
+            return Err(vec![materialization_error(format!(
+                "cached test source '{}' is not a regular file or directory",
+                source_path.display()
+            ))]);
+        }
+    }
+    Ok(())
+}
+
+fn copy_project_file(
+    source_root: &Path,
+    destination_root: &Path,
+    relative: &Path,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    std::fs::copy(source_root.join(relative), destination_root.join(relative)).map_err(
+        |error| {
+            vec![materialization_error(format!(
+                "failed to copy cached test project file '{}': {error}",
+                relative.display()
+            ))]
+        },
+    )?;
+    Ok(())
+}
+
+fn materialization_error(message: String) -> RenderedDiagnostic {
+    crate::diagnostics::diagnostic_with_code(message, DiagnosticCode::BUILD_MATERIALIZATION_FAILURE)
 }
 
 #[cfg(test)]
 mod tests {
     use super::test_runner_cache_key;
+    use crate::build::CargoResolutionPolicy;
     use crate::test_runner::orchestrator::GeneratedTestRunnerProject;
+    use sifr_codegen::InteropBuildPlan;
+    use sifr_package::CargoLockMode;
     use sifr_stdlib_manifest::{
         CargoVendorMode, StdlibFeature, SysrootCrate, SysrootCrateDependency, SysrootDependencyPlan,
     };
@@ -213,6 +270,7 @@ mod tests {
             all_rust_code: "#[test]\nfn test_case() {}\n".to_string(),
             all_stdlib_modules: HashSet::from(["sifr.json".to_string()]),
             all_required_features: HashSet::from([StdlibFeature::SerdeJson]),
+            interop: InteropBuildPlan::default(),
         };
         let dependency_plan = SysrootDependencyPlan {
             stdlib_modules: BTreeSet::from(["sifr.json".to_string()]),
@@ -232,12 +290,19 @@ mod tests {
             cache_fingerprint: "fingerprint-a".to_string(),
         };
 
+        let cargo_resolution = CargoResolutionPolicy::for_test_scope(
+            PathBuf::from("/tmp/sifr-tests").as_path(),
+            CargoLockMode::Normal,
+            &dependency_plan,
+        );
         let cache_key = test_runner_cache_key(
             &generated_project,
             "[package]\nname = \"sifr_tests\"\n",
             "#[test]\nfn test_case() {}\n",
             &dependency_plan,
-        );
+            &cargo_resolution,
+        )
+        .expect("normal Cargo resolution should have a cache identity");
 
         assert!(cache_key.contains(
             "[sysroot-dependency-inputs]\n[stdlib]\nsifr.json\n[features]\nserde_json\n"

--- a/crates/sifr_driver/src/test_runner/execution.rs
+++ b/crates/sifr_driver/src/test_runner/execution.rs
@@ -1,9 +1,10 @@
 use super::artifacts::{compose_test_runner_lib, try_generate_test_runner_cargo_plan};
 use super::orchestrator::GeneratedTestRunnerProject;
 use crate::build::{
-    ArtifactCacheReport, CargoResolutionPolicy, GeneratedCargoCommand, GeneratedCargoProject,
-    PreparedArtifactCache, cargo_resolution_cache_key_fragment, create_invocation_workspace,
-    materialize_generated_cargo_project, prepare_cached_artifact, run_generated_cargo_command,
+    ArtifactCacheReport, CargoResolutionPolicy, GeneratedCargoCommand, GeneratedCargoExecution,
+    GeneratedCargoProject, PreparedArtifactCache, cargo_resolution_cache_key_fragment,
+    create_invocation_workspace, materialize_generated_cargo_project, prepare_cached_artifact,
+    run_generated_cargo_command,
 };
 use crate::diagnostics::{RenderedDiagnostic, write_stderr, write_stderr_line};
 use sifr_diagnostics::DiagnosticCode;
@@ -82,11 +83,15 @@ pub(crate) fn execute_test_runner_project(
     let invocation = TestInvocationWorkspace::create()?;
     let project_dir = invocation.root().join("sifr_tests");
     copy_cached_project(cache_entry.workspace_root(), &project_dir)?;
+    let target_directory = test_target_directory(cache_entry.workspace_root());
     let output = run_generated_cargo_command(
         &project_dir,
         GeneratedCargoCommand::Test,
-        None,
-        &BTreeSet::new(),
+        GeneratedCargoExecution {
+            python_interpreter: None,
+            target_directory: Some(&target_directory),
+            additional_trusted_native_links: &BTreeSet::new(),
+        },
         &generated_project.interop,
         &cargo_plan.dependency_plan,
         &cargo_resolution,
@@ -112,13 +117,22 @@ pub(crate) fn execute_test_runner_project(
 fn user_facing_cargo_stdout(stdout: &[u8]) -> String {
     let mut output = String::new();
     for line in String::from_utf8_lossy(stdout).lines() {
-        if serde_json::from_str::<serde_json::Value>(line).is_ok() {
+        let is_cargo_message = serde_json::from_str::<serde_json::Value>(line).is_ok_and(|value| {
+            value
+                .as_object()
+                .is_some_and(|object| object.contains_key("reason"))
+        });
+        if is_cargo_message {
             continue;
         }
         output.push_str(line);
         output.push('\n');
     }
     output
+}
+
+fn test_target_directory(cache_workspace: &Path) -> PathBuf {
+    cache_workspace.with_extension("target")
 }
 
 fn test_runner_cache_key(
@@ -250,7 +264,7 @@ fn materialization_error(message: String) -> RenderedDiagnostic {
 
 #[cfg(test)]
 mod tests {
-    use super::test_runner_cache_key;
+    use super::{test_runner_cache_key, user_facing_cargo_stdout};
     use crate::build::CargoResolutionPolicy;
     use crate::test_runner::orchestrator::GeneratedTestRunnerProject;
     use sifr_codegen::InteropBuildPlan;
@@ -260,6 +274,23 @@ mod tests {
     };
     use std::collections::{BTreeSet, HashMap, HashSet};
     use std::path::PathBuf;
+
+    #[test]
+    fn cargo_stdout_filter_preserves_user_json_values() {
+        let stdout = br#"{"reason":"compiler-artifact","fresh":true}
+42
+true
+null
+"done"
+{"payload":1}
+plain text
+"#;
+
+        assert_eq!(
+            user_facing_cargo_stdout(stdout),
+            "42\ntrue\nnull\n\"done\"\n{\"payload\":1}\nplain text\n"
+        );
+    }
 
     #[test]
     fn test_runner_cache_key_uses_sysroot_dependency_plan_inputs() {

--- a/crates/sifr_driver/src/test_runner/orchestrator.rs
+++ b/crates/sifr_driver/src/test_runner/orchestrator.rs
@@ -23,11 +23,13 @@ pub(crate) struct GeneratedTestRunnerProject {
     pub(crate) all_rust_code: String,
     pub(crate) all_stdlib_modules: HashSet<String>,
     pub(crate) all_required_features: HashSet<StdlibFeature>,
+    pub(crate) interop: sifr_codegen::InteropBuildPlan,
 }
 
 pub fn run_tests(
     test_dir: &Path,
     provider: &mut dyn SourceProvider,
+    lock_mode: sifr_package::CargoLockMode,
 ) -> Result<bool, Vec<RenderedDiagnostic>> {
     let test_files_by_module = discover_test_root_modules(test_dir, provider);
 
@@ -42,7 +44,7 @@ pub fn run_tests(
     ));
 
     let generated_project = build_test_runner_project(test_dir, &test_files_by_module, provider)?;
-    execute_test_runner_project(&generated_project).map(|outcome| outcome.success)
+    execute_test_runner_project(&generated_project, lock_mode).map(|outcome| outcome.success)
 }
 
 pub(crate) fn build_test_runner_project(
@@ -167,5 +169,6 @@ pub(crate) fn build_test_runner_project(
         all_rust_code,
         all_stdlib_modules: generated.used_stdlib_modules,
         all_required_features: generated.required_features,
+        interop: generated.interop,
     })
 }

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -1,9 +1,11 @@
 use crate::{
-    build_test_runner_project, compose_test_runner_lib, discover_test_root_modules,
-    execute_test_runner_project, generate_test_runner_cargo_toml, run_tests,
+    build_test_runner_project, capture_cargo_invocations, compose_test_runner_lib,
+    discover_test_root_modules, execute_test_runner_project, generate_test_runner_cargo_toml,
+    run_tests,
 };
 use sifr_diagnostics::DiagnosticCode;
 use sifr_frontend::DiskSourceProvider;
+use sifr_package::CargoLockMode;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Barrier};
@@ -42,8 +44,12 @@ def test_import_parity():
     )
     .expect("test module should be written");
 
-    let result = run_tests(&test_dir, &mut DiskSourceProvider::new())
-        .expect("test runner should compile and execute");
+    let result = run_tests(
+        &test_dir,
+        &mut DiskSourceProvider::new(),
+        CargoLockMode::Normal,
+    )
+    .expect("test runner should compile and execute");
     assert!(result, "sifr test run should succeed");
 
     let _ = std::fs::remove_dir_all(&test_dir);
@@ -81,8 +87,12 @@ def test_dotted_import():
     )
     .expect("test module should be written");
 
-    let result = run_tests(&test_dir, &mut DiskSourceProvider::new())
-        .expect("test runner should compile dotted support modules");
+    let result = run_tests(
+        &test_dir,
+        &mut DiskSourceProvider::new(),
+        CargoLockMode::Normal,
+    )
+    .expect("test runner should compile dotted support modules");
     assert!(result, "sifr test run should succeed");
 
     let _ = std::fs::remove_dir_all(&test_dir);
@@ -116,8 +126,12 @@ fn test_run_tests_support_module_named_main_imports_root_owned_unions() {
     )
     .expect("test module should be written");
 
-    let result = run_tests(&test_dir, &mut DiskSourceProvider::new())
-        .expect("test runner should compile unions and upcasts");
+    let result = run_tests(
+        &test_dir,
+        &mut DiskSourceProvider::new(),
+        CargoLockMode::Normal,
+    )
+    .expect("test runner should compile unions and upcasts");
     assert!(result, "sifr test run should succeed");
     let _ = std::fs::remove_dir_all(&test_dir);
 }
@@ -149,18 +163,72 @@ fn test_run_tests_reuses_cached_workspace_for_unchanged_project() {
     let generated_project =
         build_test_runner_project(&test_dir, &discovered, &mut DiskSourceProvider::new())
             .expect("generated project should build");
-    let first = execute_test_runner_project(&generated_project)
-        .expect("first test execution should succeed");
+    let (first, invocations) = capture_cargo_invocations(|| {
+        execute_test_runner_project(&generated_project, CargoLockMode::Normal)
+    });
+    let first = first.expect("first test execution should succeed");
     assert!(first.success);
     assert!(!first.cache_report.cache_hit());
+    assert!(
+        !first.cache_report.workspace_root().join("target").exists(),
+        "test execution must not write build output into the reusable source cache"
+    );
+    assert!(
+        invocations
+            .iter()
+            .any(|invocation| invocation.phase == "test-build"
+                && invocation.args.iter().any(|argument| argument == "test")),
+        "test execution must be present in the shared Cargo invocation trace: {invocations:?}"
+    );
+    assert!(
+        !first
+            .cache_report
+            .workspace_root()
+            .join("Cargo.lock")
+            .exists(),
+        "test execution must not write a lockfile into the reusable source cache"
+    );
 
-    let second = execute_test_runner_project(&generated_project)
+    let second = execute_test_runner_project(&generated_project, CargoLockMode::Normal)
         .expect("second test execution should succeed");
     assert!(second.success);
     assert!(second.cache_report.cache_hit());
     assert_eq!(
         first.cache_report.workspace_root(),
         second.cache_report.workspace_root()
+    );
+    assert!(!second.cache_report.workspace_root().join("target").exists());
+    assert!(
+        !second
+            .cache_report
+            .workspace_root()
+            .join("Cargo.lock")
+            .exists()
+    );
+
+    let (frozen, invocations) = capture_cargo_invocations(|| {
+        execute_test_runner_project(&generated_project, CargoLockMode::Frozen)
+    });
+    let frozen = frozen.expect("frozen test execution should use the shared lock authority");
+    assert!(frozen.success);
+    assert!(
+        invocations.iter().any(|invocation| {
+            invocation.phase == "test-build"
+                && invocation.lock_mode == CargoLockMode::Frozen
+                && invocation
+                    .args
+                    .iter()
+                    .any(|argument| argument == "--frozen")
+        }),
+        "frozen test execution must preserve the requested Cargo mode: {invocations:?}"
+    );
+    assert!(!frozen.cache_report.workspace_root().join("target").exists());
+    assert!(
+        !frozen
+            .cache_report
+            .workspace_root()
+            .join("Cargo.lock")
+            .exists()
     );
 
     let _ = std::fs::remove_dir_all(&test_dir);
@@ -192,8 +260,8 @@ fn test_run_tests_invalidates_cached_workspace_when_sources_change() {
     let first_project =
         build_test_runner_project(&test_dir, &first_discovered, &mut DiskSourceProvider::new())
             .expect("generated project should build");
-    let first =
-        execute_test_runner_project(&first_project).expect("first test execution should succeed");
+    let first = execute_test_runner_project(&first_project, CargoLockMode::Normal)
+        .expect("first test execution should succeed");
     assert!(first.success);
     let first_root = first.cache_report.workspace_root().to_path_buf();
     let first_key = first.cache_report.key().to_string();
@@ -212,8 +280,8 @@ fn test_run_tests_invalidates_cached_workspace_when_sources_change() {
         &mut DiskSourceProvider::new(),
     )
     .expect("updated generated project should build");
-    let second =
-        execute_test_runner_project(&second_project).expect("second test execution should succeed");
+    let second = execute_test_runner_project(&second_project, CargoLockMode::Normal)
+        .expect("second test execution should succeed");
     assert!(second.success);
     assert!(!second.cache_report.cache_hit());
     assert_ne!(first_root, second.cache_report.workspace_root());
@@ -258,14 +326,22 @@ fn test_run_tests_parallel_invocations_are_isolated() {
     let first_path = first_dir.clone();
     let first = std::thread::spawn(move || {
         first_barrier.wait();
-        run_tests(&first_path, &mut DiskSourceProvider::new())
+        run_tests(
+            &first_path,
+            &mut DiskSourceProvider::new(),
+            CargoLockMode::Normal,
+        )
     });
 
     let second_barrier = Arc::clone(&barrier);
     let second_path = second_dir.clone();
     let second = std::thread::spawn(move || {
         second_barrier.wait();
-        run_tests(&second_path, &mut DiskSourceProvider::new())
+        run_tests(
+            &second_path,
+            &mut DiskSourceProvider::new(),
+            CargoLockMode::Normal,
+        )
     });
 
     barrier.wait();
@@ -310,8 +386,12 @@ fn test_run_tests_ignores_unrelated_non_closure_parse_errors() {
     std::fs::write(test_dir.join("unrelated_bad.sifr"), "def unrelated(:\n")
         .expect("unrelated sibling should be written");
 
-    let result = run_tests(&test_dir, &mut DiskSourceProvider::new())
-        .expect("unrelated sibling parse errors should be ignored");
+    let result = run_tests(
+        &test_dir,
+        &mut DiskSourceProvider::new(),
+        CargoLockMode::Normal,
+    )
+    .expect("unrelated sibling parse errors should be ignored");
     assert!(result, "sifr test run should succeed");
 
     let _ = std::fs::remove_dir_all(&test_dir);
@@ -335,38 +415,44 @@ fn test_run_tests_reports_deterministic_parse_error_order() {
     std::fs::write(test_dir.join("test_a_bad.sifr"), "def a(:\n")
         .expect("test_a_bad should be written");
 
-    let first_diagnostics: Vec<(String, Vec<String>)> =
-        run_tests(&test_dir, &mut DiskSourceProvider::new())
-            .err()
-            .expect("parse errors should be reported")
-            .into_iter()
-            .map(|error| {
-                (
-                    error.message,
-                    error
-                        .children
-                        .into_iter()
-                        .map(|child| child.message)
-                        .collect(),
-                )
-            })
-            .collect();
-    let second_diagnostics: Vec<(String, Vec<String>)> =
-        run_tests(&test_dir, &mut DiskSourceProvider::new())
-            .err()
-            .expect("parse errors should be deterministic")
-            .into_iter()
-            .map(|error| {
-                (
-                    error.message,
-                    error
-                        .children
-                        .into_iter()
-                        .map(|child| child.message)
-                        .collect(),
-                )
-            })
-            .collect();
+    let first_diagnostics: Vec<(String, Vec<String>)> = run_tests(
+        &test_dir,
+        &mut DiskSourceProvider::new(),
+        CargoLockMode::Normal,
+    )
+    .err()
+    .expect("parse errors should be reported")
+    .into_iter()
+    .map(|error| {
+        (
+            error.message,
+            error
+                .children
+                .into_iter()
+                .map(|child| child.message)
+                .collect(),
+        )
+    })
+    .collect();
+    let second_diagnostics: Vec<(String, Vec<String>)> = run_tests(
+        &test_dir,
+        &mut DiskSourceProvider::new(),
+        CargoLockMode::Normal,
+    )
+    .err()
+    .expect("parse errors should be deterministic")
+    .into_iter()
+    .map(|error| {
+        (
+            error.message,
+            error
+                .children
+                .into_iter()
+                .map(|child| child.message)
+                .collect(),
+        )
+    })
+    .collect();
 
     assert_eq!(first_diagnostics, second_diagnostics);
     assert!(
@@ -405,8 +491,12 @@ fn test_run_tests_frontend_type_errors_use_single_path_prefix() {
     )
     .expect("bad test module should be written");
 
-    let errors = run_tests(&test_dir, &mut DiskSourceProvider::new())
-        .expect_err("type errors in test module should fail frontend");
+    let errors = run_tests(
+        &test_dir,
+        &mut DiskSourceProvider::new(),
+        CargoLockMode::Normal,
+    )
+    .expect_err("type errors in test module should fail frontend");
     let messages: Vec<String> = errors.iter().map(|error| error.message.clone()).collect();
     assert!(
         messages

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -188,6 +188,11 @@ fn test_run_tests_reuses_cached_workspace_for_unchanged_project() {
             .exists(),
         "test execution must not write a lockfile into the reusable source cache"
     );
+    let shared_target = first.cache_report.workspace_root().with_extension("target");
+    assert!(
+        shared_target.is_dir(),
+        "compiled test artifacts should persist outside the immutable source cache"
+    );
 
     let second = execute_test_runner_project(&generated_project, CargoLockMode::Normal)
         .expect("second test execution should succeed");
@@ -204,6 +209,14 @@ fn test_run_tests_reuses_cached_workspace_for_unchanged_project() {
             .workspace_root()
             .join("Cargo.lock")
             .exists()
+    );
+    assert_eq!(
+        shared_target,
+        second
+            .cache_report
+            .workspace_root()
+            .with_extension("target"),
+        "warm runs should reuse the cache-key-owned Cargo target directory"
     );
 
     let (frozen, invocations) = capture_cargo_invocations(|| {

--- a/plans/issues/active/ad-hoc-architecture-correctness-and-agent-workflow-closure.md
+++ b/plans/issues/active/ad-hoc-architecture-correctness-and-agent-workflow-closure.md
@@ -44,8 +44,8 @@ The following review claims are explicitly excluded:
 | ID | Milestone | Status | PR | Candidate |
 | --- | --- | --- | --- | --- |
 | M1 | Warm-cache lock correctness and serialization failures | implementation complete; merge deferred | [#3553](https://github.com/sifr-lang/sifr/pull/3553) | `1c43fe34847925a269288b4073f5ca7ca7d6063e` |
-| M2 | Canonical test/build materialization | in progress | | |
-| M3 | Verification gate integrity | pending | | |
+| M2 | Canonical test/build materialization | implementation complete; merge deferred | [#3554](https://github.com/sifr-lang/sifr/pull/3554) | `16024325813dbee56e84a838e42679340f0f829a` |
+| M3 | Verification gate integrity | in progress | | |
 | M4 | Architecture documentation accuracy and generated crate map | pending | | |
 | M5 | Structural generated-code safety | pending | | |
 | M6 | Structured codegen error propagation | pending | | |
@@ -172,6 +172,13 @@ Deferred M1 review follow-ups:
 - Normalize the safe-but-unstable cache misses caused when a policy path changes
   from non-canonical to canonical after the path is created.
 
+Deferred M2 remediation-review follow-up:
+
+- Replace the fresh per-invocation test execution path with a stable
+  per-cache-key execution root, and reclaim its external Cargo target when the
+  owning source-cache key is invalidated. This preserves full warm reuse and
+  prevents fingerprint/target siblings from growing without bound.
+
 ## M11 Real Fuzz And Semantic Property Targets
 
 Add coverage-guided targets for parser, lowering, ownership, codegen validation,
@@ -230,3 +237,28 @@ tree and are keyed by candidate SHA.
   update stacked bases if repository governance changes, and reuse unchanged M1
   evidence. Validate only the affected distribution boundary unless the user
   explicitly authorizes a second full gate.
+
+### M2 Deferred Integration Handoff
+
+- Branch: `codex/architecture-audit-closure-m2`
+- Stacked draft PR: [#3554](https://github.com/sifr-lang/sifr/pull/3554), based
+  on the M1 branch.
+- Initial candidate: `ec77ce12fa05e4497d160a7b9dc8e39ade3a43dc`.
+- Initial exact-SHA Opus review: `BLOCKERS`. It found JSON-valued test output
+  suppression, discarded warm Cargo artifacts, and an unintended Python-only
+  native-link policy expansion. All three were remediated.
+- Final candidate: `16024325813dbee56e84a838e42679340f0f829a`.
+- One permitted remediation review: `SATISFIED`. The review also reported the
+  non-blocking stable-execution-root/cache-reclamation mechanism recorded for
+  M10 above; no third M2 review was run.
+- Targeted validation: 17 test-runner tests; frozen resolution, cache, and Cargo
+  trace coverage; JSON stdout preservation; warm external-target reuse; CLI
+  frozen-mode parsing; shared materializer and support-main integration tests;
+  workspace Clippy; formatting; and the HIR/file-size guardrail passed.
+- An optional cold all-codegen/all-driver run completed the 1,142 codegen tests
+  but was stopped during unrelated nested driver Cargo-probe contention after
+  more than 15 minutes. It is not claimed as passing evidence.
+- Compiler create-PR/merge gates and integration remain deferred with M1 under
+  the user's instruction to maximize later phase implementation while the known
+  distinct-human-reviewer dependency is unavailable. Do not rerun unchanged M2
+  validation during final integration unless its stacked diff changes.


### PR DESCRIPTION
## Summary

- route generated binary builds and `sifr test` through one Cargo-project materializer and executor
- preserve Cargo lock modes, resolution preparation, hermetic environment, invocation tracing, bridge sources, namespace layout, and native-link checks for tests
- execute tests from invocation-owned copies so reusable source-cache entries remain immutable

## Validation

- `cargo test -p sifr_driver test_runner --no-fail-fast`
- `cargo test -p sifr_driver test_run_tests_reuses_cached_workspace_for_unchanged_project -- --nocapture`
- `cargo test -p sifr test_command_preserves_frozen_cargo_resolution_mode`
- `cargo test -p sifr_driver build::generated_cargo_project::tests`
- `cargo test -p sifr_driver test_run_tests_support_module_named_main_imports_root_owned_unions`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`

The optional all-codegen/all-driver run was stopped after the codegen suite completed because unrelated cold nested Cargo probes remained in contention; it is not claimed as passing evidence. Full compiler gates and merge remain deferred behind the phase-wide human-review dependency recorded by M1.