### PR TITLE
Harden verification subprocess group cleanup

### DIFF
--- a/verification/runner/sifr_verify/__main__.py
+++ b/verification/runner/sifr_verify/__main__.py
@@ -8,13 +8,18 @@ import sys
 from . import areas, profiles, reports
 from .doctor import run_doctor
 from .errors import VerificationError
+from .profile_commands import install_terminal_signal_handlers
 from .selftest import run_all
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--self-test", action="store_true", help="Run runner foundation self-tests.")
-    parser.add_argument("--list-areas", action="store_true", help="List discovered verification areas as JSON.")
+    parser.add_argument(
+        "--list-areas",
+        action="store_true",
+        help="List discovered verification areas as JSON.",
+    )
     parser.add_argument("--profile", help="Execute a validation profile.")
     parser.add_argument("--case", help="Reserved case selector for failure reproduction.")
     parser.add_argument("command", nargs="?", help="Subcommand: profiles, reports, areas, or doctor.")
@@ -23,6 +28,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    install_terminal_signal_handlers()
     args = parse_args()
     try:
         if args.self_test:

--- a/verification/runner/sifr_verify/hardening/__main__.py
+++ b/verification/runner/sifr_verify/hardening/__main__.py
@@ -2,7 +2,9 @@
 """Verification hardening runner entrypoint."""
 
 from . import main
+from ..profile_commands import install_terminal_signal_handlers
 
 
 if __name__ == "__main__":
+    install_terminal_signal_handlers()
     raise SystemExit(main())

--- a/verification/runner/sifr_verify/hardening/core.py
+++ b/verification/runner/sifr_verify/hardening/core.py
@@ -11,7 +11,11 @@ import time
 from pathlib import Path
 from typing import Any
 
-from ..profile_commands import terminate_process_group
+from ..profile_commands import (
+    register_process_group,
+    terminate_process_group,
+    unregister_process_group,
+)
 
 TMP_PATTERNS = (
     re.compile(r"/private/var/folders/[^\s\"']+"),
@@ -93,11 +97,7 @@ def normalize_string(value: str, repo_root: Path) -> str:
     normalized = normalized.replace(str(repo_root), "<WORKSPACE>")
     for pattern in TMP_PATTERNS:
         normalized = pattern.sub("<TMP>", normalized)
-    normalized = "\n".join(
-        line.rstrip()
-        for line in normalized.split("\n")
-        if not ARTIFACT_CACHE_LINE_PATTERN.fullmatch(line.strip())
-    )
+    normalized = "\n".join(line.rstrip() for line in normalized.split("\n") if not ARTIFACT_CACHE_LINE_PATTERN.fullmatch(line.strip()))
     if normalized and not normalized.endswith("\n"):
         normalized += "\n"
     return normalized
@@ -105,12 +105,15 @@ def normalize_string(value: str, repo_root: Path) -> str:
 
 def normalize_json_text(value: str, repo_root: Path) -> str:
     parsed = json.loads(value)
-    return json.dumps(
-        normalize_json_value(parsed, repo_root),
-        indent=2,
-        sort_keys=True,
-        ensure_ascii=False,
-    ) + "\n"
+    return (
+        json.dumps(
+            normalize_json_value(parsed, repo_root),
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        + "\n"
+    )
 
 
 def normalize_json_value(value: Any, repo_root: Path) -> Any:
@@ -168,23 +171,39 @@ def run_variant(
 
 
 def run_captured_command(
-    *, args: list[str], cwd: Path, timeout_secs: float
+    *,
+    args: list[str],
+    cwd: Path,
+    timeout_secs: float,
+    env: dict[str, str] | None = None,
 ) -> tuple[int, str, str]:
-    proc = subprocess.Popen(
-        args,
-        cwd=cwd,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        start_new_session=True,
-    )
     try:
-        stdout, stderr = proc.communicate(timeout=timeout_secs)
-        return proc.returncode, stdout, stderr
-    except subprocess.TimeoutExpired:
-        terminate_process_group(proc)
-        stdout, stderr = proc.communicate()
-        return 124, stdout, stderr + f"\ncommand timed out after {timeout_secs} seconds"
+        proc = subprocess.Popen(
+            args,
+            cwd=cwd,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+    except FileNotFoundError as error:
+        return 127, "", str(error)
+    register_process_group(proc)
+    try:
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout_secs)
+            return proc.returncode, stdout, stderr
+        except subprocess.TimeoutExpired:
+            terminate_process_group(proc)
+            stdout, stderr = proc.communicate()
+            return (
+                124,
+                stdout,
+                stderr + f"\ncommand timed out after {timeout_secs} seconds",
+            )
+    finally:
+        unregister_process_group(proc)
 
 
 def canonicalize_output(
@@ -220,10 +239,7 @@ def validate_unique_diagnostic_formats(
     for diagnostic_format in formats:
         if diagnostic_format in seen:
             display = "default" if diagnostic_format is None else diagnostic_format
-            raise SystemExit(
-                f"suite '{suite_name}' case '{case_id}' lists diagnostic_format "
-                f"'{display}' more than once"
-            )
+            raise SystemExit(f"suite '{suite_name}' case '{case_id}' lists diagnostic_format '{display}' more than once")
         seen.add(diagnostic_format)
 
 
@@ -289,9 +305,7 @@ def baseline_case_metadata(
     if Path(case_entry).is_absolute():
         raise SystemExit(f"suite '{suite_name}' case '{case_id}' entry must be repo-relative")
     if command_name not in BASELINE_COMMANDS:
-        raise SystemExit(
-            f"suite '{suite_name}' case '{case_id}' has unsupported command '{command_name}'"
-        )
+        raise SystemExit(f"suite '{suite_name}' case '{case_id}' has unsupported command '{command_name}'")
     formats = parse_formats(diagnostic_formats)
     if not formats:
         raise SystemExit(f"suite '{suite_name}' case '{case_id}' has invalid diagnostic_formats")
@@ -305,9 +319,7 @@ def baseline_case_metadata(
     try:
         entry_path.relative_to(repo_root)
     except ValueError as error:
-        raise SystemExit(
-            f"suite '{suite_name}' case '{case_id}' entry must stay under repo root"
-        ) from error
+        raise SystemExit(f"suite '{suite_name}' case '{case_id}' entry must stay under repo root") from error
     return case_id, entry_path, command_name, formats
 
 
@@ -332,10 +344,7 @@ def validate_unique_baseline_artifact_paths(
                 owner = f"{case_id}:{label}"
                 if previous is not None:
                     rel = format_repo_relative_path(key, repo_root)
-                    raise SystemExit(
-                        f"suite '{suite_name}' baseline artifact path collision for {rel}: "
-                        f"{previous} and {owner}"
-                    )
+                    raise SystemExit(f"suite '{suite_name}' baseline artifact path collision for {rel}: {previous} and {owner}")
                 seen[key] = owner
 
 
@@ -345,8 +354,6 @@ def assert_self_test_failure(description: str, expected: str, callback: Any) -> 
     except SystemExit as error:
         message = str(error)
         if expected not in message:
-            raise AssertionError(
-                f"{description}: expected failure containing {expected!r}, got {message!r}"
-            ) from error
+            raise AssertionError(f"{description}: expected failure containing {expected!r}, got {message!r}") from error
         return
     raise AssertionError(f"{description}: expected SystemExit")

--- a/verification/runner/sifr_verify/hardening/core.py
+++ b/verification/runner/sifr_verify/hardening/core.py
@@ -161,7 +161,7 @@ def run_variant(
     args.extend([command_name, str(entry)])
 
     started = time.perf_counter()
-    exit_code, stdout, stderr = run_captured_command(
+    exit_code, stdout, stderr, _timed_out = run_captured_command(
         args=args,
         cwd=repo_root,
         timeout_secs=timeout_secs,
@@ -176,7 +176,7 @@ def run_captured_command(
     cwd: Path,
     timeout_secs: float,
     env: dict[str, str] | None = None,
-) -> tuple[int, str, str]:
+) -> tuple[int, str, str, bool]:
     try:
         proc = subprocess.Popen(
             args,
@@ -188,20 +188,16 @@ def run_captured_command(
             start_new_session=True,
         )
     except FileNotFoundError as error:
-        return 127, "", str(error)
+        return 127, "", str(error), False
     register_process_group(proc)
     try:
         try:
             stdout, stderr = proc.communicate(timeout=timeout_secs)
-            return proc.returncode, stdout, stderr
+            return proc.returncode, stdout, stderr, False
         except subprocess.TimeoutExpired:
             terminate_process_group(proc)
             stdout, stderr = proc.communicate()
-            return (
-                124,
-                stdout,
-                stderr + f"\ncommand timed out after {timeout_secs} seconds",
-            )
+            return 124, stdout, stderr + f"\ncommand timed out after {timeout_secs} seconds", True
     finally:
         unregister_process_group(proc)
 

--- a/verification/runner/sifr_verify/hardening/coverage_fuzz.py
+++ b/verification/runner/sifr_verify/hardening/coverage_fuzz.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import time
 from pathlib import Path
 from typing import Any
 
 from .fixedbugs_and_crashes import contains_internal_panic
+from .core import run_captured_command
 
 OUTPUT_TAIL_BYTES = 16 * 1024
 
@@ -78,10 +78,7 @@ def run_sustained_fuzz_suite(
         return result
 
     assert isinstance(budget, int)
-    print(
-        f"  suite={suite_name} owner={suite.get('owner', 'unknown')} "
-        f"profile={profile} seconds_per_target={budget}"
-    )
+    print(f"  suite={suite_name} owner={suite.get('owner', 'unknown')} profile={profile} seconds_per_target={budget}")
     build_case = build_fuzz_project(repo_root=repo_root)
     result["cases"].append(build_case)
     result["total_variants"] += 1
@@ -114,33 +111,16 @@ def build_fuzz_project(*, repo_root: Path) -> dict[str, Any]:
         "verification/fuzz",
     ]
     started = time.perf_counter()
-    timed_out = False
-    output = ""
-    try:
-        proc = subprocess.run(
-            argv,
-            cwd=repo_root,
-            env={**os.environ, "CARGO_NET_OFFLINE": "true"},
-            text=True,
-            capture_output=True,
-            check=False,
-            timeout=1_200,
-        )
-        exit_code = proc.returncode
-        output = proc.stdout + proc.stderr
-    except FileNotFoundError as error:
-        exit_code = 127
-        output = str(error)
-    except subprocess.TimeoutExpired as error:
-        exit_code = 124
-        timed_out = True
-        output = (error.stdout or "") + (error.stderr or "")
-    elapsed_ms = (time.perf_counter() - started) * 1000.0
-    mismatches = (
-        []
-        if exit_code == 0
-        else [classify_build_failure(exit_code, output, timed_out)]
+    exit_code, stdout, stderr = run_captured_command(
+        args=argv,
+        cwd=repo_root,
+        env={**os.environ, "CARGO_NET_OFFLINE": "true"},
+        timeout_secs=1_200,
     )
+    timed_out = exit_code == 124
+    output = stdout + stderr
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    mismatches = [] if exit_code == 0 else [classify_build_failure(exit_code, output, timed_out)]
     variant = {
         "label": "sustained-fuzz-instrumented-build",
         "status": "pass" if not mismatches else "fail",
@@ -184,35 +164,19 @@ def run_coverage_fuzz_target(
         "-print_final_stats=1",
     ]
     started = time.perf_counter()
-    timed_out = False
-    try:
-        proc = subprocess.run(
-            argv,
-            cwd=repo_root,
-            env={**os.environ, "CARGO_NET_OFFLINE": "true"},
-            text=True,
-            capture_output=True,
-            check=False,
-            timeout=seconds + 120,
-        )
-        exit_code = proc.returncode
-        output = proc.stdout + proc.stderr
-    except FileNotFoundError as error:
-        exit_code = 127
-        output = str(error)
-    except subprocess.TimeoutExpired as error:
-        exit_code = 124
-        timed_out = True
-        output = (error.stdout or "") + (error.stderr or "")
+    exit_code, stdout, stderr = run_captured_command(
+        args=argv,
+        cwd=repo_root,
+        env={**os.environ, "CARGO_NET_OFFLINE": "true"},
+        timeout_secs=seconds + 120,
+    )
+    timed_out = exit_code == 124
+    output = stdout + stderr
     elapsed_ms = (time.perf_counter() - started) * 1000.0
     mismatches: list[str] = []
     artifacts_after = {path.name for path in artifact_dir.iterdir() if path.is_file()}
     new_artifacts = sorted(artifacts_after - artifacts_before)
-    finding = (
-        bool(new_artifacts)
-        or "ERROR: libFuzzer" in output
-        or "Test unit written to" in output
-    )
+    finding = bool(new_artifacts) or "ERROR: libFuzzer" in output or "Test unit written to" in output
     if timed_out:
         mismatches.append("target-timeout")
     elif finding:

--- a/verification/runner/sifr_verify/hardening/coverage_fuzz.py
+++ b/verification/runner/sifr_verify/hardening/coverage_fuzz.py
@@ -111,13 +111,12 @@ def build_fuzz_project(*, repo_root: Path) -> dict[str, Any]:
         "verification/fuzz",
     ]
     started = time.perf_counter()
-    exit_code, stdout, stderr = run_captured_command(
+    exit_code, stdout, stderr, timed_out = run_captured_command(
         args=argv,
         cwd=repo_root,
         env={**os.environ, "CARGO_NET_OFFLINE": "true"},
         timeout_secs=1_200,
     )
-    timed_out = exit_code == 124
     output = stdout + stderr
     elapsed_ms = (time.perf_counter() - started) * 1000.0
     mismatches = [] if exit_code == 0 else [classify_build_failure(exit_code, output, timed_out)]
@@ -164,13 +163,12 @@ def run_coverage_fuzz_target(
         "-print_final_stats=1",
     ]
     started = time.perf_counter()
-    exit_code, stdout, stderr = run_captured_command(
+    exit_code, stdout, stderr, timed_out = run_captured_command(
         args=argv,
         cwd=repo_root,
         env={**os.environ, "CARGO_NET_OFFLINE": "true"},
         timeout_secs=seconds + 120,
     )
-    timed_out = exit_code == 124
     output = stdout + stderr
     elapsed_ms = (time.perf_counter() - started) * 1000.0
     mismatches: list[str] = []

--- a/verification/runner/sifr_verify/hardening/oss_and_determinism.py
+++ b/verification/runner/sifr_verify/hardening/oss_and_determinism.py
@@ -8,10 +8,12 @@ from pathlib import Path
 from typing import Any
 
 from .core import (
+    DEFAULT_VARIANT_TIMEOUT_SECS,
     LOCAL_PINNED_REVISION_PATTERN,
     load_index,
     normalize_string,
     required_missing,
+    run_captured_command,
     run_variant,
 )
 from .fixedbugs_and_crashes import contains_internal_panic
@@ -156,7 +158,7 @@ def run_oss_suite(
                     "status": "fail",
                     "mismatches": ["pinned_revision_mismatch"],
                     "expected_pinned_revision": pinned_revision_raw,
-                    "latest_project_revision": f"local-main@{latest_sha[:len(expected_sha)]}",
+                    "latest_project_revision": f"local-main@{latest_sha[: len(expected_sha)]}",
                 }
             )
             result["cases"].append(case_result)
@@ -168,8 +170,8 @@ def run_oss_suite(
                 "status": "pass",
                 "mismatches": [],
                 "expected_pinned_revision": pinned_revision_raw,
-                "latest_project_revision": f"local-main@{latest_sha[:len(expected_sha)]}",
-                "matched_project_revision": f"local-main@{matched_sha[:len(expected_sha)]}",
+                "latest_project_revision": f"local-main@{latest_sha[: len(expected_sha)]}",
+                "matched_project_revision": f"local-main@{matched_sha[: len(expected_sha)]}",
             }
         )
 
@@ -323,22 +325,11 @@ def run_external_command(
     timeout_secs: int | None,
 ) -> tuple[int, str, str, float]:
     started = time.perf_counter()
-    try:
-        proc = subprocess.run(
-            argv,
-            cwd=repo_root,
-            text=True,
-            capture_output=True,
-            check=False,
-            timeout=timeout_secs,
-        )
-        exit_code = proc.returncode
-        stdout = proc.stdout
-        stderr = proc.stderr
-    except subprocess.TimeoutExpired as timeout_error:
-        exit_code = 124
-        stdout = timeout_error.stdout or ""
-        stderr = (timeout_error.stderr or "") + f"\ncommand timed out after {timeout_secs} seconds"
+    exit_code, stdout, stderr = run_captured_command(
+        args=argv,
+        cwd=repo_root,
+        timeout_secs=timeout_secs or DEFAULT_VARIANT_TIMEOUT_SECS,
+    )
     elapsed_ms = (time.perf_counter() - started) * 1000.0
     return exit_code, stdout, stderr, elapsed_ms
 
@@ -385,9 +376,7 @@ def run_determinism_scale_suite(
 
         if not isinstance(description, str) or not description:
             mismatches.append("description")
-        if not isinstance(command_raw, list) or not command_raw or not all(
-            isinstance(token, str) and token for token in command_raw
-        ):
+        if not isinstance(command_raw, list) or not command_raw or not all(isinstance(token, str) and token for token in command_raw):
             mismatches.append("command")
         if not isinstance(expected_exit, int):
             mismatches.append("expect_exit_code")
@@ -487,13 +476,9 @@ def load_quarantine_metadata(path: Path, suites: list[dict[str, Any]]) -> list[d
             ),
         )
         if missing:
-            raise SystemExit(
-                f"invalid quarantine entry in '{path}': missing fields {', '.join(sorted(set(missing)))}"
-            )
+            raise SystemExit(f"invalid quarantine entry in '{path}': missing fields {', '.join(sorted(set(missing)))}")
         if entry.get("suite") not in suite_names:
-            raise SystemExit(
-                f"invalid quarantine entry in '{path}': unknown suite '{entry.get('suite')}'"
-            )
+            raise SystemExit(f"invalid quarantine entry in '{path}': unknown suite '{entry.get('suite')}'")
         validated.append(entry)
     return validated
 

--- a/verification/runner/sifr_verify/hardening/oss_and_determinism.py
+++ b/verification/runner/sifr_verify/hardening/oss_and_determinism.py
@@ -325,7 +325,7 @@ def run_external_command(
     timeout_secs: int | None,
 ) -> tuple[int, str, str, float]:
     started = time.perf_counter()
-    exit_code, stdout, stderr = run_captured_command(
+    exit_code, stdout, stderr, _timed_out = run_captured_command(
         args=argv,
         cwd=repo_root,
         timeout_secs=timeout_secs or DEFAULT_VARIANT_TIMEOUT_SECS,

--- a/verification/runner/sifr_verify/hardening/property_and_fuzz.py
+++ b/verification/runner/sifr_verify/hardening/property_and_fuzz.py
@@ -598,7 +598,7 @@ def run_reproduction_command_target(*, target: dict[str, Any], repo_root: Path) 
     argv = list(target["reproduction_command"])
     timeout_seconds = int(target["timeout_seconds"])
     started = time.perf_counter()
-    exit_code, stdout, stderr = run_captured_command(
+    exit_code, stdout, stderr, timed_out = run_captured_command(
         args=argv,
         cwd=repo_root,
         env={**os.environ, "CARGO_NET_OFFLINE": "true"},
@@ -619,7 +619,7 @@ def run_reproduction_command_target(*, target: dict[str, Any], repo_root: Path) 
         stream="stderr",
     )
     mismatches: list[str] = []
-    if exit_code == 124:
+    if timed_out:
         mismatches.append("timeout")
     elif exit_code != int(target["expect_exit_code"]):
         mismatches.append("unexpected-exit")

--- a/verification/runner/sifr_verify/hardening/property_and_fuzz.py
+++ b/verification/runner/sifr_verify/hardening/property_and_fuzz.py
@@ -16,6 +16,7 @@ from .core import (
     canonicalize_output,
     load_index,
     required_missing,
+    run_captured_command,
     run_variant,
     write_text,
 )
@@ -237,9 +238,7 @@ def run_cargo_property(*, entry: dict[str, Any], repo_root: Path) -> dict[str, A
     mismatches: list[str] = []
     if proc.returncode != int(entry["expect_exit_code"]):
         mismatches.append("unexpected-exit")
-    if bool(entry.get("assert_no_panic", True)) and contains_internal_panic(
-        proc.stdout + proc.stderr
-    ):
+    if bool(entry.get("assert_no_panic", True)) and contains_internal_panic(proc.stdout + proc.stderr):
         mismatches.append("panic-signal")
     return {
         "label": "cargo-test",
@@ -258,7 +257,7 @@ def deterministic_mutations(seed_source: str, iterations: int, random_seed: int)
     corpus: list[str] = []
     for _ in range(iterations):
         if not lines:
-            lines = ["print(\"seed\")"]
+            lines = ['print("seed")']
         candidate = list(lines)
         op = rng.randint(0, 8)
         if op == 0:
@@ -269,7 +268,7 @@ def deterministic_mutations(seed_source: str, iterations: int, random_seed: int)
                     "if x > 0:",
                     "    print(str(x))",
                     "from missing_mutation_module import bad",
-                    "value: int = \"bad\"",
+                    'value: int = "bad"',
                 ]
             )
             idx = rng.randint(0, len(candidate))
@@ -319,20 +318,14 @@ def deterministic_mutations(seed_source: str, iterations: int, random_seed: int)
                 ]
             )
             if candidate:
-                signature_indices = [
-                    idx for idx, line in enumerate(candidate) if FUNCTION_SIGNATURE_PATTERN.search(line)
-                ]
+                signature_indices = [idx for idx, line in enumerate(candidate) if FUNCTION_SIGNATURE_PATTERN.search(line)]
                 if signature_indices:
                     idx = rng.choice(signature_indices)
                     replacement = signature.replace("fuzz_helper", f"fuzz_helper_{rng.randint(0, 9)}")
                     candidate[idx] = replacement
                 else:
                     insert_at = rng.randint(0, len(candidate))
-                    body = (
-                        "    return value + 1"
-                        if "-> int" in signature
-                        else '    return value + "_mut"'
-                    )
+                    body = "    return value + 1" if "-> int" in signature else '    return value + "_mut"'
                     candidate[insert_at:insert_at] = [signature, body]
             else:
                 candidate.extend([signature, "    return value"])
@@ -605,23 +598,12 @@ def run_reproduction_command_target(*, target: dict[str, Any], repo_root: Path) 
     argv = list(target["reproduction_command"])
     timeout_seconds = int(target["timeout_seconds"])
     started = time.perf_counter()
-    try:
-        proc = subprocess.run(
-            argv,
-            cwd=repo_root,
-            env={**os.environ, "CARGO_NET_OFFLINE": "true"},
-            text=True,
-            capture_output=True,
-            check=False,
-            timeout=timeout_seconds,
-        )
-        exit_code = proc.returncode
-        stdout = proc.stdout
-        stderr = proc.stderr
-    except subprocess.TimeoutExpired as timeout_error:
-        exit_code = 124
-        stdout = timeout_error.stdout or ""
-        stderr = (timeout_error.stderr or "") + f"\ncommand timed out after {timeout_seconds} seconds"
+    exit_code, stdout, stderr = run_captured_command(
+        args=argv,
+        cwd=repo_root,
+        env={**os.environ, "CARGO_NET_OFFLINE": "true"},
+        timeout_secs=timeout_seconds,
+    )
     elapsed_ms = (time.perf_counter() - started) * 1000.0
 
     stdout_norm = canonicalize_output(
@@ -705,9 +687,7 @@ def load_known_targets(repo_root: Path) -> dict[str, dict[str, Any]]:
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
     mismatches = validate_fuzz_target_rules(payload, repo_root)
     if mismatches:
-        raise SystemExit(
-            "fuzz target rules invalid: " + ", ".join(sorted(set(mismatches)))
-        )
+        raise SystemExit("fuzz target rules invalid: " + ", ".join(sorted(set(mismatches))))
     targets = payload.get("targets", [])
     return {str(target["id"]): target for target in targets}
 
@@ -806,9 +786,7 @@ def validate_target_execution_fields(target_id: object, target: dict[str, Any]) 
         if not isinstance(target.get("min_unique_cases"), int) or int(target["min_unique_cases"]) < 1:
             mismatches.append(f"{target_id}.min_unique_cases")
         allow_exit_codes = target.get("allow_exit_codes")
-        if not isinstance(allow_exit_codes, list) or not all(
-            isinstance(code, int) for code in allow_exit_codes
-        ):
+        if not isinstance(allow_exit_codes, list) or not all(isinstance(code, int) for code in allow_exit_codes):
             mismatches.append(f"{target_id}.allow_exit_codes")
         if not isinstance(target.get("assert_no_panic"), bool):
             mismatches.append(f"{target_id}.assert_no_panic")
@@ -845,9 +823,7 @@ def program_class_is_compatible(*, property_class: object, target_class: object)
 
 
 def command_list(value: object) -> bool:
-    return isinstance(value, list) and bool(value) and all(
-        isinstance(part, str) and bool(part) for part in value
-    )
+    return isinstance(value, list) and bool(value) and all(isinstance(part, str) and bool(part) for part in value)
 
 
 def validate_command_paths(target_id: object, command: object, repo_root: Path) -> list[str]:

--- a/verification/runner/sifr_verify/hardening/self_tests_and_baselines.py
+++ b/verification/runner/sifr_verify/hardening/self_tests_and_baselines.py
@@ -90,16 +90,23 @@ def run_self_tests() -> int:
         marker = deadline_root / "child-survived"
         child = f"import pathlib,time; time.sleep(0.4); pathlib.Path({str(marker)!r}).write_text('survived')"
         parent = f"import subprocess,sys,time; subprocess.Popen([sys.executable, '-c', {child!r}]); time.sleep(5)"
-        exit_code, _, stderr = run_captured_command(
+        exit_code, _, stderr, timed_out = run_captured_command(
             args=[sys.executable, "-c", parent],
             cwd=deadline_root,
             timeout_secs=0.1,
         )
-        if exit_code != 124 or "timed out" not in stderr:
+        if exit_code != 124 or not timed_out or "timed out" not in stderr:
             raise AssertionError("hardening command deadline did not report a timeout")
         time.sleep(0.5)
         if marker.exists():
             raise AssertionError("hardening command deadline left a descendant running")
+        native_124, _, _, native_timed_out = run_captured_command(
+            args=[sys.executable, "-c", "raise SystemExit(124)"],
+            cwd=deadline_root,
+            timeout_secs=1,
+        )
+        if native_124 != 124 or native_timed_out:
+            raise AssertionError("native exit 124 was confused with a command deadline")
     _external_deadline_self_test(run_external_command)
     _reproduction_deadline_self_test(run_reproduction_command_target)
     assert_self_test_failure(

--- a/verification/runner/sifr_verify/hardening/self_tests_and_baselines.py
+++ b/verification/runner/sifr_verify/hardening/self_tests_and_baselines.py
@@ -23,7 +23,11 @@ from .core import (
 )
 from .coverage_fuzz import classify_build_failure, output_tail
 
+
 def run_self_tests() -> int:
+    from .oss_and_determinism import run_external_command
+    from .property_and_fuzz import run_reproduction_command_target
+
     expected_build_classes = {
         classify_build_failure(127, "cargo not found", False): "missing tool",
         classify_build_failure(101, "offline mode prevented a download", False): "offline dependency",
@@ -84,14 +88,8 @@ def run_self_tests() -> int:
     with tempfile.TemporaryDirectory(prefix="sifr-hardening-deadline-") as tmp:
         deadline_root = Path(tmp)
         marker = deadline_root / "child-survived"
-        child = (
-            "import pathlib,time; time.sleep(0.4); "
-            f"pathlib.Path({str(marker)!r}).write_text('survived')"
-        )
-        parent = (
-            "import subprocess,sys,time; "
-            f"subprocess.Popen([sys.executable, '-c', {child!r}]); time.sleep(5)"
-        )
+        child = f"import pathlib,time; time.sleep(0.4); pathlib.Path({str(marker)!r}).write_text('survived')"
+        parent = f"import subprocess,sys,time; subprocess.Popen([sys.executable, '-c', {child!r}]); time.sleep(5)"
         exit_code, _, stderr = run_captured_command(
             args=[sys.executable, "-c", parent],
             cwd=deadline_root,
@@ -102,6 +100,8 @@ def run_self_tests() -> int:
         time.sleep(0.5)
         if marker.exists():
             raise AssertionError("hardening command deadline left a descendant running")
+    _external_deadline_self_test(run_external_command)
+    _reproduction_deadline_self_test(run_reproduction_command_target)
     assert_self_test_failure(
         "duplicate diagnostic formats",
         "lists diagnostic_format 'json' more than once",
@@ -194,6 +194,55 @@ def run_self_tests() -> int:
         assert history[0] != initial_revision
     print("verification hardening self-tests ok")
     return 0
+
+
+def _deadline_command(marker: Path) -> list[str]:
+    child = (
+        "import pathlib,signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "time.sleep(1.2); "
+        f"pathlib.Path({str(marker)!r}).write_text('survived')"
+    )
+    parent = f"import subprocess,sys,time; subprocess.Popen([sys.executable, '-c', {child!r}]); time.sleep(5)"
+    return [sys.executable, "-c", parent]
+
+
+def _assert_descendant_stopped(marker: Path, label: str) -> None:
+    time.sleep(0.5)
+    if marker.exists():
+        raise AssertionError(f"{label} left a descendant process running")
+
+
+def _external_deadline_self_test(runner: Any) -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-external-deadline-") as tmp:
+        root = Path(tmp)
+        marker = root / "child-survived"
+        exit_code, _, stderr, _ = runner(
+            repo_root=root,
+            argv=_deadline_command(marker),
+            timeout_secs=1,
+        )
+        if exit_code != 124 or "timed out" not in stderr:
+            raise AssertionError("determinism external deadline did not report timeout")
+        _assert_descendant_stopped(marker, "determinism external deadline")
+
+
+def _reproduction_deadline_self_test(runner: Any) -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-reproduction-deadline-") as tmp:
+        root = Path(tmp)
+        marker = root / "child-survived"
+        result = runner(
+            repo_root=root,
+            target={
+                "id": "deadline-self-test",
+                "reproduction_command": _deadline_command(marker),
+                "timeout_seconds": 1,
+                "expect_exit_code": 0,
+            },
+        )
+        variant = result["case"]["variants"][0]
+        if variant["actual_exit_code"] != 124 or variant["mismatches"] != ["timeout"]:
+            raise AssertionError("reproduction deadline did not classify timeout")
+        _assert_descendant_stopped(marker, "reproduction deadline")
 
 
 def run_git(repo_root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | None:
@@ -310,10 +359,7 @@ def baseline_case_result(
         else:
             missing_files = [path for path in (stdout_file, stderr_file, exit_file) if not path.is_file()]
             if missing_files:
-                mismatches.append(
-                    "missing-baseline:"
-                    + ",".join(str(path.relative_to(repo_root)) for path in missing_files)
-                )
+                mismatches.append("missing-baseline:" + ",".join(str(path.relative_to(repo_root)) for path in missing_files))
             else:
                 expected_stdout = load_text(stdout_file)
                 expected_stderr = load_text(stderr_file)

--- a/verification/runner/sifr_verify/profile_commands.py
+++ b/verification/runner/sifr_verify/profile_commands.py
@@ -19,7 +19,7 @@ from .paths import REPO_ROOT
 
 _COMMAND_DEADLINE_NS: contextvars.ContextVar[int | None] = contextvars.ContextVar("sifr_verify_command_deadline_ns", default=None)
 _ACTIVE_PROCESS_GROUPS: dict[int, subprocess.Popen[str]] = {}
-_ACTIVE_PROCESS_GROUPS_LOCK = threading.Lock()
+_ACTIVE_PROCESS_GROUPS_LOCK = threading.RLock()
 _TERMINAL_HANDLERS_INSTALLED = False
 _HANDLING_TERMINAL_SIGNAL = False
 
@@ -99,16 +99,13 @@ def _forward_terminal_signal(signum: int, _frame: object) -> None:
     if _HANDLING_TERMINAL_SIGNAL:
         raise SystemExit(128 + signum)
     _HANDLING_TERMINAL_SIGNAL = True
-    try:
-        with _ACTIVE_PROCESS_GROUPS_LOCK:
-            active = list(_ACTIVE_PROCESS_GROUPS.values())
-        for proc in active:
-            try:
-                os.killpg(proc.pid, signal.Signals(signum))
-            except ProcessLookupError:
-                pass
-    finally:
-        _HANDLING_TERMINAL_SIGNAL = False
+    with _ACTIVE_PROCESS_GROUPS_LOCK:
+        active = list(_ACTIVE_PROCESS_GROUPS.values())
+    for proc in active:
+        try:
+            os.killpg(proc.pid, signal.Signals(signum))
+        except (ProcessLookupError, PermissionError):
+            pass
     raise SystemExit(128 + signum)
 
 
@@ -181,7 +178,34 @@ def run_self_test() -> None:
     if marker.exists():
         marker.unlink()
         raise AssertionError("deadline left a descendant process running")
+    _terminal_signal_lock_self_test()
     _terminal_signal_self_test()
+
+
+def _terminal_signal_lock_self_test() -> None:
+    helper = "\n".join(
+        [
+            "import os, signal",
+            "from sifr_verify.profile_commands import _ACTIVE_PROCESS_GROUPS_LOCK, install_terminal_signal_handlers",
+            "install_terminal_signal_handlers()",
+            "with _ACTIVE_PROCESS_GROUPS_LOCK:",
+            "    os.kill(os.getpid(), signal.SIGTERM)",
+        ]
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", helper],
+        cwd=REPO_ROOT,
+        env=_self_test_environment(),
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        returncode = proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        terminate_process_group(proc)
+        raise AssertionError("terminal signal deadlocked while the process-group registry was locked") from None
+    if returncode != 128 + signal.SIGTERM:
+        raise AssertionError(f"locked terminal signal returned {returncode}, expected {128 + signal.SIGTERM}")
 
 
 def _terminal_signal_self_test() -> None:
@@ -198,14 +222,10 @@ def _terminal_signal_self_test() -> None:
             f"pathlib.Path({str(ready)!r}).write_text('ready'); "
             f"run_command([sys.executable, '-c', {child!r}])"
         )
-        helper_env = os.environ.copy()
-        runner_root = str(REPO_ROOT / "verification" / "runner")
-        existing_pythonpath = helper_env.get("PYTHONPATH")
-        helper_env["PYTHONPATH"] = f"{runner_root}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else runner_root
         proc = subprocess.Popen(
             [sys.executable, "-c", helper],
             cwd=REPO_ROOT,
-            env=helper_env,
+            env=_self_test_environment(),
             text=True,
             start_new_session=True,
         )
@@ -226,6 +246,14 @@ def _terminal_signal_self_test() -> None:
         time.sleep(0.8)
         if survived.exists():
             raise AssertionError("terminal signal left a descendant process running")
+
+
+def _self_test_environment() -> dict[str, str]:
+    helper_env = os.environ.copy()
+    runner_root = str(REPO_ROOT / "verification" / "runner")
+    existing_pythonpath = helper_env.get("PYTHONPATH")
+    helper_env["PYTHONPATH"] = f"{runner_root}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else runner_root
+    return helper_env
 
 
 def uv_area_command(*args: str) -> list[str]:

--- a/verification/runner/sifr_verify/profile_commands.py
+++ b/verification/runner/sifr_verify/profile_commands.py
@@ -8,16 +8,20 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from collections.abc import Iterator
+from pathlib import Path
 
 from .paths import REPO_ROOT
 
 
-_COMMAND_DEADLINE_NS: contextvars.ContextVar[int | None] = contextvars.ContextVar(
-    "sifr_verify_command_deadline_ns", default=None
-)
+_COMMAND_DEADLINE_NS: contextvars.ContextVar[int | None] = contextvars.ContextVar("sifr_verify_command_deadline_ns", default=None)
+_ACTIVE_PROCESS_GROUPS: dict[int, subprocess.Popen[str]] = {}
+_ACTIVE_PROCESS_GROUPS_LOCK = threading.Lock()
+_TERMINAL_HANDLERS_INSTALLED = False
+_HANDLING_TERMINAL_SIGNAL = False
 
 
 class CommandFailed(Exception):
@@ -31,9 +35,7 @@ class CommandFailed(Exception):
 @contextlib.contextmanager
 def command_deadline(budget_ms: int | None) -> Iterator[None]:
     """Apply one absolute deadline to every subprocess in a profile step."""
-    deadline_ns = (
-        None if budget_ms is None else time.monotonic_ns() + budget_ms * 1_000_000
-    )
+    deadline_ns = None if budget_ms is None else time.monotonic_ns() + budget_ms * 1_000_000
     token = _COMMAND_DEADLINE_NS.set(deadline_ns)
     try:
         yield
@@ -48,10 +50,21 @@ def remaining_deadline_seconds() -> float | None:
     return max(0.0, (deadline_ns - time.monotonic_ns()) / 1_000_000_000)
 
 
-def terminate_process_group(proc: subprocess.Popen[str]) -> None:
+def register_process_group(proc: subprocess.Popen[str]) -> None:
+    """Register a detached child so terminal signals can reach its process group."""
+    with _ACTIVE_PROCESS_GROUPS_LOCK:
+        _ACTIVE_PROCESS_GROUPS[proc.pid] = proc
+
+
+def unregister_process_group(proc: subprocess.Popen[str]) -> None:
+    with _ACTIVE_PROCESS_GROUPS_LOCK:
+        _ACTIVE_PROCESS_GROUPS.pop(proc.pid, None)
+
+
+def terminate_process_group(proc: subprocess.Popen[str], *, initial_signal: signal.Signals = signal.SIGTERM) -> None:
     """Terminate the command and descendants without leaving gate work running."""
     try:
-        os.killpg(proc.pid, signal.SIGTERM)
+        os.killpg(proc.pid, initial_signal)
     except ProcessLookupError:
         return
     try:
@@ -59,10 +72,44 @@ def terminate_process_group(proc: subprocess.Popen[str]) -> None:
     except subprocess.TimeoutExpired:
         pass
     try:
+        os.killpg(proc.pid, 0)
+    except (ProcessLookupError, PermissionError):
+        return
+    try:
         os.killpg(proc.pid, signal.SIGKILL)
-    except ProcessLookupError:
-        pass
+    except (ProcessLookupError, PermissionError):
+        return
     proc.wait()
+
+
+def install_terminal_signal_handlers() -> None:
+    """Forward terminal interruption to every live detached child group."""
+    global _TERMINAL_HANDLERS_INSTALLED
+    if _TERMINAL_HANDLERS_INSTALLED:
+        return
+    if threading.current_thread() is not threading.main_thread():
+        raise RuntimeError("terminal signal handlers must be installed on the main thread")
+    signal.signal(signal.SIGINT, _forward_terminal_signal)
+    signal.signal(signal.SIGTERM, _forward_terminal_signal)
+    _TERMINAL_HANDLERS_INSTALLED = True
+
+
+def _forward_terminal_signal(signum: int, _frame: object) -> None:
+    global _HANDLING_TERMINAL_SIGNAL
+    if _HANDLING_TERMINAL_SIGNAL:
+        raise SystemExit(128 + signum)
+    _HANDLING_TERMINAL_SIGNAL = True
+    try:
+        with _ACTIVE_PROCESS_GROUPS_LOCK:
+            active = list(_ACTIVE_PROCESS_GROUPS.values())
+        for proc in active:
+            try:
+                os.killpg(proc.pid, signal.Signals(signum))
+            except ProcessLookupError:
+                pass
+    finally:
+        _HANDLING_TERMINAL_SIGNAL = False
+    raise SystemExit(128 + signum)
 
 
 def run_command(command: list[str], *, env: dict[str, str] | None = None) -> None:
@@ -76,26 +123,30 @@ def run_command(command: list[str], *, env: dict[str, str] | None = None) -> Non
         bufsize=1,
         start_new_session=True,
     )
-    assert proc.stdout is not None
-    output_thread = threading.Thread(
-        target=_forward_output,
-        args=(proc.stdout,),
-        name="sifr-verify-output",
-        daemon=True,
-    )
-    output_thread.start()
-    timeout = remaining_deadline_seconds()
+    register_process_group(proc)
     try:
-        returncode = proc.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        terminate_process_group(proc)
-        output_thread.join(timeout=2)
-        print(
-            f"sifr_verify: subprocess deadline exceeded: {' '.join(command)}",
-            file=sys.stderr,
+        assert proc.stdout is not None
+        output_thread = threading.Thread(
+            target=_forward_output,
+            args=(proc.stdout,),
+            name="sifr-verify-output",
+            daemon=True,
         )
-        raise CommandFailed(124) from None
-    output_thread.join()
+        output_thread.start()
+        timeout = remaining_deadline_seconds()
+        try:
+            returncode = proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            terminate_process_group(proc)
+            output_thread.join(timeout=2)
+            print(
+                f"sifr_verify: subprocess deadline exceeded: {' '.join(command)}",
+                file=sys.stderr,
+            )
+            raise CommandFailed(124) from None
+        output_thread.join()
+    finally:
+        unregister_process_group(proc)
     if returncode != 0:
         raise CommandFailed(returncode)
 
@@ -110,22 +161,18 @@ def run_self_test() -> None:
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.unlink(missing_ok=True)
     child = (
-        "import pathlib,time; time.sleep(0.4); "
+        "import pathlib,signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "time.sleep(0.4); "
         f"pathlib.Path({str(marker)!r}).write_text('survived')"
     )
-    parent = (
-        "import subprocess,sys,time; "
-        f"subprocess.Popen([sys.executable, '-c', {child!r}]); time.sleep(5)"
-    )
+    parent = f"import subprocess,sys,time; subprocess.Popen([sys.executable, '-c', {child!r}]); time.sleep(5)"
     started = time.monotonic()
     try:
         with command_deadline(100):
             run_command([sys.executable, "-c", parent])
     except CommandFailed as error:
         if error.returncode != 124:
-            raise AssertionError(
-                f"deadline returned {error.returncode}, expected 124"
-            ) from error
+            raise AssertionError(f"deadline returned {error.returncode}, expected 124") from error
     else:
         raise AssertionError("deadline did not reject a hanging subprocess")
     if time.monotonic() - started > 3:
@@ -134,6 +181,51 @@ def run_self_test() -> None:
     if marker.exists():
         marker.unlink()
         raise AssertionError("deadline left a descendant process running")
+    _terminal_signal_self_test()
+
+
+def _terminal_signal_self_test() -> None:
+    with tempfile.TemporaryDirectory(prefix="sifr-terminal-signal-") as tmp:
+        root = Path(tmp)
+        ready = root / "ready"
+        survived = root / "child-survived"
+        child = f"import pathlib,time; time.sleep(0.6); pathlib.Path({str(survived)!r}).write_text('survived')"
+        helper = (
+            "import pathlib,sys; "
+            "from sifr_verify.profile_commands import "
+            "install_terminal_signal_handlers,run_command; "
+            "install_terminal_signal_handlers(); "
+            f"pathlib.Path({str(ready)!r}).write_text('ready'); "
+            f"run_command([sys.executable, '-c', {child!r}])"
+        )
+        helper_env = os.environ.copy()
+        runner_root = str(REPO_ROOT / "verification" / "runner")
+        existing_pythonpath = helper_env.get("PYTHONPATH")
+        helper_env["PYTHONPATH"] = f"{runner_root}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else runner_root
+        proc = subprocess.Popen(
+            [sys.executable, "-c", helper],
+            cwd=REPO_ROOT,
+            env=helper_env,
+            text=True,
+            start_new_session=True,
+        )
+        deadline = time.monotonic() + 3
+        while not ready.exists() and proc.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+        if not ready.exists():
+            terminate_process_group(proc)
+            raise AssertionError("terminal-signal helper did not become ready")
+        os.kill(proc.pid, signal.SIGTERM)
+        try:
+            returncode = proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            terminate_process_group(proc)
+            raise AssertionError("terminal signal did not stop the runner") from None
+        if returncode != 128 + signal.SIGTERM:
+            raise AssertionError(f"terminal signal returned {returncode}, expected {128 + signal.SIGTERM}")
+        time.sleep(0.8)
+        if survived.exists():
+            raise AssertionError("terminal signal left a descendant process running")
 
 
 def uv_area_command(*args: str) -> list[str]:


### PR DESCRIPTION
## Scope
- enforce process-group cleanup for verification hardening deadlines
- forward terminal SIGINT/SIGTERM to active detached command groups
- cover determinism, reproduction, and coverage-fuzz call sites
- add descendant-survival and terminal-signal self-tests

## Validation
- `uv run --project verification --locked ruff check verification/runner/sifr_verify`
- `python3 -m compileall -q verification/runner/sifr_verify`
- `PYTHONPATH=verification/runner python3 -m sifr_verify.hardening --self-test`
- `PYTHONPATH=verification/runner python3 -m sifr_verify --self-test`
- maintainability, file-size, HIR, driver, and method-dispatch guardrails

## Out-of-scope evidence
The real merge-profile determinism-scale suite reached the nested E2E workload and failed on an inherited M7 compiler regression: generated Rust used `Vec::append(bool)` instead of `Vec::push(bool)`. That compiler defect is tracked for the next phase item; it is not caused by this verification-only change.