### PR TITLE
Restore canonical list method fallback lowering

### DIFF
--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -7,6 +7,7 @@ pub(crate) use registry_helpers::*;
 mod borrowing_call_args;
 mod builtin_core_methods;
 mod builtin_numeric;
+mod collection_method_args;
 mod collection_methods;
 mod collection_type_resolution;
 mod defaultdict_iterable_mutations;

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/collection_method_args.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/collection_method_args.rs
@@ -1,0 +1,60 @@
+use super::{HirExpr, RustEmitter, RustExpr, Type};
+
+impl RustEmitter {
+    pub(crate) fn adapt_collection_method_args_for_ir(
+        &self,
+        object_ty: &Type,
+        method: &str,
+        args: &[HirExpr],
+        arg_exprs: &mut [RustExpr],
+    ) {
+        let object_ty = crate::resolve_alias_type_for_plain_call(object_ty);
+        let collection_element_target = match (object_ty, method) {
+            (Type::List(element_ty), "append" | "appendleft") => Some((0, element_ty.as_ref())),
+            (Type::List(element_ty), "insert") => Some((1, element_ty.as_ref())),
+            (Type::Set(element_ty), "add") => Some((0, element_ty.as_ref())),
+            (Type::Dict(_, value_ty), "setdefault") => Some((1, value_ty.as_ref())),
+            _ => None,
+        };
+        if let Some((index, target_ty)) = collection_element_target {
+            if let (Some(argument), Some(lowered_arg)) = (args.get(index), arg_exprs.get_mut(index))
+            {
+                *lowered_arg = self.coerce_collection_element_for_registry(
+                    target_ty,
+                    argument,
+                    lowered_arg.clone(),
+                );
+            }
+        }
+
+        if matches!(object_ty, Type::List(_))
+            && matches!(method, "append" | "appendleft")
+            && let (Some(argument), Some(lowered_arg)) = (args.first(), arg_exprs.first_mut())
+        {
+            if matches!(argument.ty(), Type::TypeVar(_)) {
+                *lowered_arg = RustExpr::MethodCall {
+                    receiver: Box::new(lowered_arg.clone()),
+                    method: "clone".to_string(),
+                    args: vec![],
+                };
+            }
+            *lowered_arg = Self::clone_owned_append_arg_expr_for_ir(argument, lowered_arg.clone());
+        }
+
+        if matches!(object_ty, Type::List(_)) && method == "insert" && args.len() >= 2 {
+            let Some(HirExpr::Name { name, ty, .. }) = args.get(1) else {
+                return;
+            };
+            let needs_clone = (self.borrowed_params.contains(name.as_str())
+                || self.mut_borrowed_params.contains(name.as_str()))
+                && ty.ownership() != sifr_type_system::OwnershipKind::Copy;
+            if needs_clone && let Some(lowered_arg) = arg_exprs.get_mut(1) {
+                *lowered_arg = RustExpr::MethodCall {
+                    receiver: Box::new(lowered_arg.clone()),
+                    method: "clone".to_string(),
+                    args: vec![],
+                };
+            }
+        }
+    }
+}

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/collection_methods.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/collection_methods.rs
@@ -223,60 +223,12 @@ impl RustEmitter {
             );
         }
 
-        let collection_element_target = match (object_ty, method) {
-            (Type::List(element_ty), "append" | "appendleft") => Some((0, element_ty.as_ref())),
-            (Type::List(element_ty), "insert") => Some((1, element_ty.as_ref())),
-            (Type::Set(element_ty), "add") => Some((0, element_ty.as_ref())),
-            (Type::Dict(_, value_ty), "setdefault") => Some((1, value_ty.as_ref())),
-            _ => None,
-        };
-        if let Some((index, target_ty)) = collection_element_target {
-            if let (Some(argument), Some(lowered_arg)) = (args.get(index), arg_exprs.get_mut(index))
-            {
-                *lowered_arg = self.coerce_collection_element_for_registry(
-                    target_ty,
-                    argument,
-                    lowered_arg.clone(),
-                );
-            }
-        }
-
-        if matches!(object_ty, Type::List(_))
-            && matches!(method, "append" | "appendleft")
-            && !args.is_empty()
-            && matches!(args[0].ty(), Type::TypeVar(_))
-        {
-            // Clone TypeVar list args to avoid move issues.
-            arg_exprs[0] = crate::RustExpr::MethodCall {
-                receiver: Box::new(arg_exprs[0].clone()),
-                method: "clone".to_string(),
-                args: vec![],
-            };
-        }
-        if matches!(object_ty, Type::List(_))
-            && matches!(method, "append" | "appendleft")
-            && !args.is_empty()
-        {
-            arg_exprs[0] = Self::clone_owned_append_arg_expr_for_ir(&args[0], arg_exprs[0].clone());
-        }
-
-        if matches!(object_ty, Type::List(_)) && method == "insert" && args.len() >= 2 {
-            // Clone borrowed/mut-borrowed move-owned values.
-            let needs_clone = if let HirExpr::Name { name, ty, .. } = &args[1] {
-                (self.borrowed_params.contains(name.as_str())
-                    || self.mut_borrowed_params.contains(name.as_str()))
-                    && ty.ownership() != sifr_type_system::OwnershipKind::Copy
-            } else {
-                false
-            };
-            if needs_clone {
-                arg_exprs[1] = crate::RustExpr::MethodCall {
-                    receiver: Box::new(arg_exprs[1].clone()),
-                    method: "clone".to_string(),
-                    args: vec![],
-                };
-            }
-        }
+        self.adapt_collection_method_args_for_ir(
+            &effective_object_ty,
+            method,
+            args,
+            &mut arg_exprs,
+        );
 
         if matches!(object_ty, Type::Dict(key_ty, _) if matches!(crate::resolve_alias_type_for_plain_call(key_ty.as_ref()), Type::Str | Type::LiteralStr(_)))
             && matches!(method, "get" | "contains" | "remove" | "pop")

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_method_and_question_mark.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_method_and_question_mark.rs
@@ -216,6 +216,12 @@ macro_rules! stmt_expr_method_call {
                 };
                 lowered_args.push(lowered_arg);
             }
+            $emitter.adapt_collection_method_args_for_ir(
+                &effective_object_ty,
+                method,
+                args,
+                &mut lowered_args,
+            );
             let is_callable_field = match crate::resolve_alias_type_for_plain_call(
                 &effective_object_ty,
             ) {
@@ -281,6 +287,21 @@ macro_rules! stmt_expr_method_call {
                         );
                     }
                 }
+            }
+            if let Some(lowered) = crate::methods::lower_method_with_context(
+                &effective_object_ty,
+                method,
+                &lowered_object,
+                &lowered_args,
+                $emitter.is_deque_data_field(object),
+            ) {
+                return Ok(Some(unwrap_compiler_verified_nonempty_pop_result_for_ir(
+                    &effective_object_ty,
+                    method,
+                    args,
+                    $expr.ty(),
+                    lowered.expr,
+                )));
             }
             let lowered_method = crate::RustExpr::MethodCall {
                 receiver: Box::new(lowered_object),
@@ -482,72 +503,5 @@ impl RustEmitter {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn list_method_call(method: &str, args: Vec<HirExpr>, result_ty: Type) -> HirExpr {
-        let list_ty = Type::List(Box::new(Type::Int));
-        HirExpr::MethodCall {
-            object: Box::new(HirExpr::Name {
-                name: "items".to_string(),
-                binding_id: Some(sifr_ir::BindingId(1)),
-                ty: list_ty,
-            }),
-            method: method.to_string(),
-            args,
-            receiver_convention: Some(if method == "append" {
-                sifr_type_system::ReceiverConvention::MutableBorrow
-            } else {
-                sifr_type_system::ReceiverConvention::SharedBorrow
-            }),
-            receiver_target: (method == "append").then(|| {
-                sifr_ir::MutableReceiverTarget::Place(sifr_ir::Place {
-                    root: sifr_ir::BindingId(1),
-                    projections: Vec::new(),
-                })
-            }),
-            mutable_arg_places: vec![None; usize::from(method == "append")],
-            source: None,
-            ty: result_ty,
-        }
-    }
-
-    #[test]
-    fn generic_imported_project_calls_use_the_canonical_function_name() {
-        let expression = HirExpr::GenericCall {
-            func: "load::<i64>".to_string(),
-            type_args: vec![Type::Int],
-            args: Vec::new(),
-            mutable_arg_places: Vec::new(),
-            ty: Type::None,
-        };
-        let imported = std::collections::HashSet::from(["load".to_string()]);
-
-        assert!(is_imported_project_call_for_ir(&expression, &imported));
-    }
-
-    #[test]
-    fn statement_list_methods_use_registry_authority_after_legacy_fallback_removal() {
-        let mut emitter = RustEmitter::new();
-        let append = list_method_call("append", vec![HirExpr::IntLiteral(1)], Type::None);
-        let cloned = list_method_call("cloned", Vec::new(), Type::List(Box::new(Type::Int)));
-
-        let lowered_append = emitter
-            .lower_stmt_expr_for_ir(&append)
-            .expect("append lowering must not error")
-            .expect("append must be accepted by registry authority");
-        let lowered_cloned = emitter
-            .lower_stmt_expr_for_ir(&cloned)
-            .expect("cloned lowering must not error")
-            .expect("cloned must be accepted by registry authority");
-
-        assert!(matches!(
-            lowered_append,
-            crate::RustExpr::MethodCall { method, .. } if method == "push"
-        ));
-        assert!(matches!(
-            lowered_cloned,
-            crate::RustExpr::MethodCall { method, .. } if method == "clone"
-        ));
-    }
-}
+#[path = "stmt_expr_method_and_question_mark_tests.rs"]
+mod tests;

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_method_and_question_mark_tests.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_method_and_question_mark_tests.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+fn list_method_call(method: &str, args: Vec<HirExpr>, result_ty: Type) -> HirExpr {
+    let list_ty = Type::List(Box::new(Type::Int));
+    HirExpr::MethodCall {
+        object: Box::new(HirExpr::Name {
+            name: "items".to_string(),
+            binding_id: Some(sifr_ir::BindingId(1)),
+            ty: list_ty,
+        }),
+        method: method.to_string(),
+        args,
+        receiver_convention: Some(if method == "append" {
+            sifr_type_system::ReceiverConvention::MutableBorrow
+        } else {
+            sifr_type_system::ReceiverConvention::SharedBorrow
+        }),
+        receiver_target: (method == "append").then(|| {
+            sifr_ir::MutableReceiverTarget::Place(sifr_ir::Place {
+                root: sifr_ir::BindingId(1),
+                projections: Vec::new(),
+            })
+        }),
+        mutable_arg_places: vec![None; usize::from(method == "append")],
+        source: None,
+        ty: result_ty,
+    }
+}
+
+#[test]
+fn generic_imported_project_calls_use_the_canonical_function_name() {
+    let expression = HirExpr::GenericCall {
+        func: "load::<i64>".to_string(),
+        type_args: vec![Type::Int],
+        args: Vec::new(),
+        mutable_arg_places: Vec::new(),
+        ty: Type::None,
+    };
+    let imported = std::collections::HashSet::from(["load".to_string()]);
+
+    assert!(is_imported_project_call_for_ir(&expression, &imported));
+}
+
+#[test]
+fn statement_list_methods_use_registry_authority_after_legacy_fallback_removal() {
+    let mut emitter = RustEmitter::new();
+    let append = list_method_call("append", vec![HirExpr::IntLiteral(1)], Type::None);
+    let cloned = list_method_call("cloned", Vec::new(), Type::List(Box::new(Type::Int)));
+
+    let lowered_append = emitter
+        .lower_stmt_expr_for_ir(&append)
+        .expect("append lowering must not error")
+        .expect("append must be accepted by registry authority");
+    let lowered_cloned = emitter
+        .lower_stmt_expr_for_ir(&cloned)
+        .expect("cloned lowering must not error")
+        .expect("cloned must be accepted by registry authority");
+
+    assert!(matches!(
+        lowered_append,
+        crate::RustExpr::MethodCall { method, .. } if method == "push"
+    ));
+    assert!(matches!(
+        lowered_cloned,
+        crate::RustExpr::MethodCall { method, .. } if method == "clone"
+    ));
+}
+
+#[test]
+fn structured_fallback_uses_registry_authority_after_strict_argument_decline() {
+    let mut emitter = RustEmitter::new();
+    let append = list_method_call(
+        "append",
+        vec![HirExpr::Call {
+            func: "predicate".to_string(),
+            args: Vec::new(),
+            mutable_arg_places: Vec::new(),
+            ty: Type::Int,
+        }],
+        Type::None,
+    );
+
+    let lowered = emitter
+        .lower_stmt_expr_for_ir(&append)
+        .expect("append lowering must not error")
+        .expect("structured fallback must lower the append");
+
+    assert!(matches!(
+        lowered,
+        crate::RustExpr::MethodCall { method, args, .. }
+            if method == "push"
+                && matches!(args.first(), Some(crate::RustExpr::FnCall { .. }))
+    ));
+}

--- a/verification/policy/method_dispatch_authority.json
+++ b/verification/policy/method_dispatch_authority.json
@@ -31,14 +31,16 @@
         "try_lower_registry_method_call_expr_unchecked:compare:len#1",
         "try_lower_registry_method_call_expr_unchecked:match:get|len#1",
         "try_lower_registry_method_call_expr_unchecked:compare:len#2",
-        "try_lower_registry_method_call_expr_unchecked:match:append|appendleft|insert|add|setdefault#1",
-        "try_lower_registry_method_call_expr_unchecked:compare:insert#1",
         "try_lower_registry_method_call_expr_unchecked:match:extend#1",
         "try_lower_registry_method_call_expr_unchecked:compare:extend#1",
         "try_lower_registry_set_method_call_expr:match:update|extend|union|intersection|difference|intersection_update|difference_update|contains|symmetric_difference|symmetric_difference_update|cloned#1",
         "try_lower_defaultdict_index_method_call_expr:compare:extend#1",
         "try_lower_defaultdict_index_method_call_expr:compare:extend#2",
         "try_lower_defaultdict_index_method_call_expr:match:append|add|insert|remove|discard#1"
+      ],
+      "crates/sifr_codegen/src/intrinsic_method_emitters/collection_method_args.rs": [
+        "adapt_collection_method_args_for_ir:match:append|appendleft|insert|add|setdefault#1",
+        "adapt_collection_method_args_for_ir:compare:insert#1"
       ],
       "crates/sifr_codegen/src/intrinsic_method_emitters/defaultdict_iterable_mutations.rs": [
         "try_lower_defaultdict_set_update_expr:compare:symmetric_difference_update#1",


### PR DESCRIPTION
## Scope
- route structured method fallback through the canonical method authority
- share collection argument ownership/conversion adaptation with strict registry lowering
- reproduce strict-registry argument decline without restoring an ad hoc name fallback
- split statement-method tests to preserve the maintainability ratchet

## Validation
- focused strict-decline regression: passed
- six no-cache process fixtures from the failed determinism batch: 6/6 passed
- complete `sifr_codegen` suite: 1,163 passed
- workspace Clippy with warnings denied: passed
- formatting, codegen invariant, maintainability, HIR, method authority, file-size, and whitespace guards: passed

## Gate policy
This item changes compiler files. Per the phase execution rule, the one create-PR and one merge gate remain reserved for the final implementation SHA after the later items; they are not repeated per item.