### PR TITLE
M12C: harden verification command lifecycles

### DIFF
--- a/verification/areas/fuzz_property/property_manifest.json
+++ b/verification/areas/fuzz_property/property_manifest.json
@@ -136,6 +136,7 @@
       "diagnostic_format": "none",
       "expect_exit_code": 0,
       "repeat_runs": 1,
+      "timeout_seconds": 600,
       "assert_no_panic": true,
       "reproduction_command": [
         "cargo",
@@ -160,6 +161,7 @@
       "diagnostic_format": "none",
       "expect_exit_code": 0,
       "repeat_runs": 1,
+      "timeout_seconds": 600,
       "assert_no_panic": true,
       "reproduction_command": [
         "cargo",
@@ -185,6 +187,7 @@
       "diagnostic_format": "none",
       "expect_exit_code": 0,
       "repeat_runs": 1,
+      "timeout_seconds": 600,
       "assert_no_panic": true,
       "reproduction_command": [
         "cargo",
@@ -209,6 +212,7 @@
       "diagnostic_format": "none",
       "expect_exit_code": 0,
       "repeat_runs": 1,
+      "timeout_seconds": 600,
       "assert_no_panic": true,
       "reproduction_command": [
         "cargo",

--- a/verification/runner/sifr_verify/hardening/property_and_fuzz.py
+++ b/verification/runner/sifr_verify/hardening/property_and_fuzz.py
@@ -4,7 +4,6 @@ import hashlib
 import json
 import os
 import random
-import subprocess
 import time
 from pathlib import Path
 from typing import Any
@@ -110,10 +109,7 @@ def run_property_suite(
         if not isinstance(diagnostic_format, str) or not diagnostic_format:
             mismatches.append("diagnostic_format")
         if command_name == "cargo-test":
-            if not isinstance(entry.get("cargo_package"), str) or not entry["cargo_package"]:
-                mismatches.append("cargo_package")
-            if not isinstance(entry.get("test_filter"), str) or not entry["test_filter"]:
-                mismatches.append("test_filter")
+            mismatches.extend(validate_cargo_property_metadata(entry))
 
         if mismatches:
             result["total_variants"] += 1
@@ -214,6 +210,17 @@ def run_property_suite(
     return result
 
 
+def validate_cargo_property_metadata(entry: dict[str, Any]) -> list[str]:
+    mismatches: list[str] = []
+    if not isinstance(entry.get("cargo_package"), str) or not entry["cargo_package"]:
+        mismatches.append("cargo_package")
+    if not isinstance(entry.get("test_filter"), str) or not entry["test_filter"]:
+        mismatches.append("test_filter")
+    if not isinstance(entry.get("timeout_seconds"), int) or entry["timeout_seconds"] < 1:
+        mismatches.append("timeout_seconds")
+    return mismatches
+
+
 def run_cargo_property(*, entry: dict[str, Any], repo_root: Path) -> dict[str, Any]:
     argv = [
         "cargo",
@@ -226,26 +233,26 @@ def run_cargo_property(*, entry: dict[str, Any], repo_root: Path) -> dict[str, A
         "--nocapture",
     ]
     started = time.perf_counter()
-    proc = subprocess.run(
-        argv,
+    exit_code, stdout, stderr, timed_out = run_captured_command(
+        args=argv,
         cwd=repo_root,
         env={**os.environ, "CARGO_NET_OFFLINE": "true"},
-        text=True,
-        capture_output=True,
-        check=False,
+        timeout_secs=int(entry["timeout_seconds"]),
     )
     elapsed_ms = (time.perf_counter() - started) * 1000.0
     mismatches: list[str] = []
-    if proc.returncode != int(entry["expect_exit_code"]):
+    if timed_out:
+        mismatches.append("timeout")
+    elif exit_code != int(entry["expect_exit_code"]):
         mismatches.append("unexpected-exit")
-    if bool(entry.get("assert_no_panic", True)) and contains_internal_panic(proc.stdout + proc.stderr):
+    if bool(entry.get("assert_no_panic", True)) and contains_internal_panic(stdout + stderr):
         mismatches.append("panic-signal")
     return {
         "label": "cargo-test",
         "status": "pass" if not mismatches else "fail",
         "mismatches": mismatches,
         "expected_exit_code": int(entry["expect_exit_code"]),
-        "actual_exit_code": proc.returncode,
+        "actual_exit_code": exit_code,
         "duration_ms": round(elapsed_ms, 3),
         "argv": argv,
     }

--- a/verification/runner/sifr_verify/hardening/self_tests_and_baselines.py
+++ b/verification/runner/sifr_verify/hardening/self_tests_and_baselines.py
@@ -25,6 +25,7 @@ from .coverage_fuzz import classify_build_failure, output_tail
 
 
 def run_self_tests() -> int:
+    from . import property_and_fuzz
     from .oss_and_determinism import run_external_command
     from .property_and_fuzz import run_reproduction_command_target
 
@@ -109,6 +110,7 @@ def run_self_tests() -> int:
             raise AssertionError("native exit 124 was confused with a command deadline")
     _external_deadline_self_test(run_external_command)
     _reproduction_deadline_self_test(run_reproduction_command_target)
+    _cargo_property_deadline_self_test(property_and_fuzz)
     assert_self_test_failure(
         "duplicate diagnostic formats",
         "lists diagnostic_format 'json' more than once",
@@ -211,6 +213,28 @@ def _deadline_command(marker: Path) -> list[str]:
     )
     parent = f"import subprocess,sys,time; subprocess.Popen([sys.executable, '-c', {child!r}]); time.sleep(5)"
     return [sys.executable, "-c", parent]
+
+
+def _cargo_property_deadline_self_test(property_module: Any) -> None:
+    original_runner = property_module.run_captured_command
+    entry = {
+        "cargo_package": "fake-package",
+        "test_filter": "fake-test",
+        "expect_exit_code": 124,
+        "timeout_seconds": 1,
+        "assert_no_panic": True,
+    }
+    try:
+        property_module.run_captured_command = lambda **_kwargs: (124, "", "", True)
+        timeout_result = property_module.run_cargo_property(entry=entry, repo_root=Path("/tmp"))
+        property_module.run_captured_command = lambda **_kwargs: (124, "", "", False)
+        native_result = property_module.run_cargo_property(entry=entry, repo_root=Path("/tmp"))
+    finally:
+        property_module.run_captured_command = original_runner
+    if timeout_result["mismatches"] != ["timeout"]:
+        raise AssertionError("cargo property timeout lost its explicit classification")
+    if native_result["mismatches"]:
+        raise AssertionError("cargo property native exit 124 was confused with a timeout")
 
 
 def _assert_descendant_stopped(marker: Path, label: str) -> None:

--- a/verification/runner/sifr_verify/profile_commands.py
+++ b/verification/runner/sifr_verify/profile_commands.py
@@ -22,6 +22,7 @@ _ACTIVE_PROCESS_GROUPS: dict[int, subprocess.Popen[str]] = {}
 _ACTIVE_PROCESS_GROUPS_LOCK = threading.RLock()
 _TERMINAL_HANDLERS_INSTALLED = False
 _HANDLING_TERMINAL_SIGNAL = False
+_TERMINAL_SIGNAL_GRACE_SECONDS = 0.1
 
 
 class CommandFailed(Exception):
@@ -100,13 +101,35 @@ def _forward_terminal_signal(signum: int, _frame: object) -> None:
         raise SystemExit(128 + signum)
     _HANDLING_TERMINAL_SIGNAL = True
     with _ACTIVE_PROCESS_GROUPS_LOCK:
-        active = list(_ACTIVE_PROCESS_GROUPS.values())
-    for proc in active:
+        process_group_ids = tuple(_ACTIVE_PROCESS_GROUPS)
+    received_signal = signal.Signals(signum)
+    for process_group_id in process_group_ids:
         try:
-            os.killpg(proc.pid, signal.Signals(signum))
+            os.killpg(process_group_id, received_signal)
         except (ProcessLookupError, PermissionError):
             pass
+    if process_group_ids:
+        threading.Thread(
+            target=_escalate_forwarded_process_groups,
+            args=(process_group_ids,),
+            name="sifr-verify-signal-escalation",
+            daemon=False,
+        ).start()
     raise SystemExit(128 + signum)
+
+
+def _escalate_forwarded_process_groups(process_group_ids: tuple[int, ...]) -> None:
+    """Kill groups that remain live after a forwarded terminal signal."""
+    time.sleep(_TERMINAL_SIGNAL_GRACE_SECONDS)
+    for process_group_id in process_group_ids:
+        try:
+            os.killpg(process_group_id, 0)
+        except (ProcessLookupError, PermissionError):
+            continue
+        try:
+            os.killpg(process_group_id, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
 
 
 def run_command(command: list[str], *, env: dict[str, str] | None = None) -> None:
@@ -213,13 +236,18 @@ def _terminal_signal_self_test() -> None:
         root = Path(tmp)
         ready = root / "ready"
         survived = root / "child-survived"
-        child = f"import pathlib,time; time.sleep(0.6); pathlib.Path({str(survived)!r}).write_text('survived')"
+        child = (
+            "import pathlib,signal,time; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            f"pathlib.Path({str(ready)!r}).write_text('ready'); "
+            "time.sleep(0.6); "
+            f"pathlib.Path({str(survived)!r}).write_text('survived')"
+        )
         helper = (
-            "import pathlib,sys; "
+            "import sys; "
             "from sifr_verify.profile_commands import "
             "install_terminal_signal_handlers,run_command; "
             "install_terminal_signal_handlers(); "
-            f"pathlib.Path({str(ready)!r}).write_text('ready'); "
             f"run_command([sys.executable, '-c', {child!r}])"
         )
         proc = subprocess.Popen(

--- a/verification/runner/sifr_verify/profile_commands.py
+++ b/verification/runner/sifr_verify/profile_commands.py
@@ -100,6 +100,8 @@ def _forward_terminal_signal(signum: int, _frame: object) -> None:
     if _HANDLING_TERMINAL_SIGNAL:
         raise SystemExit(128 + signum)
     _HANDLING_TERMINAL_SIGNAL = True
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
     with _ACTIVE_PROCESS_GROUPS_LOCK:
         process_group_ids = tuple(_ACTIVE_PROCESS_GROUPS)
     received_signal = signal.Signals(signum)
@@ -202,7 +204,8 @@ def run_self_test() -> None:
         marker.unlink()
         raise AssertionError("deadline left a descendant process running")
     _terminal_signal_lock_self_test()
-    _terminal_signal_self_test()
+    _terminal_signal_self_test(signal.SIGTERM)
+    _terminal_signal_self_test(signal.SIGINT)
 
 
 def _terminal_signal_lock_self_test() -> None:
@@ -231,14 +234,14 @@ def _terminal_signal_lock_self_test() -> None:
         raise AssertionError(f"locked terminal signal returned {returncode}, expected {128 + signal.SIGTERM}")
 
 
-def _terminal_signal_self_test() -> None:
+def _terminal_signal_self_test(terminal_signal: signal.Signals) -> None:
     with tempfile.TemporaryDirectory(prefix="sifr-terminal-signal-") as tmp:
         root = Path(tmp)
         ready = root / "ready"
         survived = root / "child-survived"
         child = (
             "import pathlib,signal,time; "
-            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            f"signal.signal({int(terminal_signal)}, signal.SIG_IGN); "
             f"pathlib.Path({str(ready)!r}).write_text('ready'); "
             "time.sleep(0.6); "
             f"pathlib.Path({str(survived)!r}).write_text('survived')"
@@ -263,14 +266,15 @@ def _terminal_signal_self_test() -> None:
         if not ready.exists():
             terminate_process_group(proc)
             raise AssertionError("terminal-signal helper did not become ready")
-        os.kill(proc.pid, signal.SIGTERM)
+        os.kill(proc.pid, terminal_signal)
         try:
             returncode = proc.wait(timeout=3)
         except subprocess.TimeoutExpired:
             terminate_process_group(proc)
             raise AssertionError("terminal signal did not stop the runner") from None
-        if returncode != 128 + signal.SIGTERM:
-            raise AssertionError(f"terminal signal returned {returncode}, expected {128 + signal.SIGTERM}")
+        expected_returncode = 128 + terminal_signal
+        if returncode != expected_returncode:
+            raise AssertionError(f"terminal signal returned {returncode}, expected {expected_returncode}")
         time.sleep(0.8)
         if survived.exists():
             raise AssertionError("terminal signal left a descendant process running")


### PR DESCRIPTION
## Summary
- escalate forwarded terminal signals for live process groups without re-entering Popen waits
- cover SIGTERM/SIGINT-ignoring descendants and repeated terminal signals
- give Cargo property checks finite group-aware deadlines with explicit timeout classification

## Validation
- runner and hardening self-tests
- fuzz_property property suite: 19 variants, 0 failures
- Ruff and compileall
- maintainability, file-size, HIR, driver, and whitespace guardrails

## Review
Exact-SHA Opus review and the one permitted remediation review both returned SATISFIED. Human review is deferred by current phase direction.