### PR TITLE
M12G: register lowering intrinsic transport owner

### DIFF
--- a/internal_docs/stdlib_retained_compiler_intrinsics.toml
+++ b/internal_docs/stdlib_retained_compiler_intrinsics.toml
@@ -140,6 +140,7 @@ issue = "stdlib-native-boundary-completion"
 evidence_links = ["stdlib-native-boundary-completion"]
 reason = "Typed compiler identity transport and dispatch are shared language glue; these files may carry CompilerIntrinsicId but may not infer identity from callable names."
 lowering_files = [
+  "crates/sifr_lowering/src/lib.rs",
   "crates/sifr_lowering/src/lower/compiler_intrinsics.rs",
   "crates/sifr_lowering/src/lower/external_defs.rs",
   "crates/sifr_lowering/src/lower/imported_defaults.rs",


### PR DESCRIPTION
## Summary
- register the consolidated lowering facade as a typed intrinsic transport owner
- preserve the explicit HIR re-export and existing scanner authority

## Validation
- stdlib native intrinsic allowlist guard and self-test
- stdlib manifest schema guard and self-test
- documentation area
- file-size guardrail
- exact-SHA Opus review: SATISFIED