### PR TITLE
M12H: remove delivery-plan taxonomy from flow-graph architecture

### DIFF
--- a/internal_docs/typescript_go_architecture_transfer_first_class_flow_graph.md
+++ b/internal_docs/typescript_go_architecture_transfer_first_class_flow_graph.md
@@ -57,7 +57,7 @@ This work stops at HIR and frontend propagation. Analysis and LSP code do not
 read the graph or show its fingerprint. Editor APIs therefore do not expose the
 graph rules.
 
-## M12 Retention Decision
+## Retention Decision
 
 Decision: **keep the graph as a deterministic snapshot artifact**.
 


### PR DESCRIPTION
## Summary
- remove the M12 delivery identifier from a retained architecture heading
- preserve the flow-graph retention decision and all current-state architecture text
- leave verification taxonomy enforcement unchanged

## Validation
- verification taxonomy guard and self-test
- coverage matrix readiness: 4/4
- documentation area: 3/3
- TypeScript-Go transfer guard and self-test
- file-size and whitespace guardrails