### PR TITLE
M12I: restore Python interop gate budget integrity

### DIFF
--- a/verification/profiles/create-pr.json
+++ b/verification/profiles/create-pr.json
@@ -96,8 +96,8 @@
       "enforcement": "blocking"
     },
     "area_python_interop": {
-      "warm_budget_ms": 600000,
-      "cold_budget_ms": 1200000,
+      "warm_budget_ms": 2400000,
+      "cold_budget_ms": 2700000,
       "cache_classifier": "successful-input-receipt",
       "enforcement": "blocking"
     },

--- a/verification/profiles/merge.json
+++ b/verification/profiles/merge.json
@@ -14,6 +14,12 @@
     "cargo_cache_setup": {
       "budget_ms": 300000,
       "enforcement": "blocking"
+    },
+    "area_python_interop": {
+      "warm_budget_ms": 2400000,
+      "cold_budget_ms": 4500000,
+      "cache_classifier": "successful-input-receipt",
+      "enforcement": "blocking"
     }
   },
   "resource_policy": {

--- a/verification/profiles/nightly.json
+++ b/verification/profiles/nightly.json
@@ -18,6 +18,12 @@
     "area_fuzz_property": {
       "budget_ms": 2400000,
       "enforcement": "blocking"
+    },
+    "area_python_interop": {
+      "warm_budget_ms": 2400000,
+      "cold_budget_ms": 4500000,
+      "cache_classifier": "successful-input-receipt",
+      "enforcement": "blocking"
     }
   },
   "resource_policy": {

--- a/verification/profiles/release.json
+++ b/verification/profiles/release.json
@@ -18,6 +18,12 @@
     "area_fuzz_property": {
       "budget_ms": 2400000,
       "enforcement": "blocking"
+    },
+    "area_python_interop": {
+      "warm_budget_ms": 2400000,
+      "cold_budget_ms": 4500000,
+      "cache_classifier": "successful-input-receipt",
+      "enforcement": "blocking"
     }
   },
   "resource_policy": {

--- a/verification/runner/sifr_verify/profile_policy_selftest.py
+++ b/verification/runner/sifr_verify/profile_policy_selftest.py
@@ -90,17 +90,8 @@ def profile_schema_self_test() -> None:
             raise AssertionError(
                 f"{profile_name} has a noncanonical Cargo setup budget: {setup_budget}"
             )
+    _python_interop_budget_policy_self_test(profiles)
     create_pr_step_budgets = profiles["create-pr"].get("step_budgets", {})
-    python_interop_budget = create_pr_step_budgets.get("area_python_interop")
-    if python_interop_budget != {
-        "warm_budget_ms": 600_000,
-        "cold_budget_ms": 1_200_000,
-        "cache_classifier": "successful-input-receipt",
-        "enforcement": "blocking",
-    }:
-        raise AssertionError(
-            f"create-pr Python interop cache budget drifted: {python_interop_budget}"
-        )
     rust_interop_budget = create_pr_step_budgets.get("area_rust_interop")
     if rust_interop_budget != {
         "budget_ms": 20_000,
@@ -131,6 +122,34 @@ def profile_schema_self_test() -> None:
                 f"create-pr step budget is not blocking/positive: {step}={budget}"
             )
     _profile_coverage_self_test(profiles)
+
+
+def _python_interop_budget_policy_self_test(
+    profiles: dict[str, dict[str, Any]],
+) -> None:
+    expected_budgets = {
+        "create-pr": (2_400_000, 2_700_000),
+        "merge": (2_400_000, 4_500_000),
+        "nightly": (2_400_000, 4_500_000),
+        "release": (2_400_000, 4_500_000),
+    }
+    for profile_name, (warm_budget_ms, cold_budget_ms) in (
+        expected_budgets.items()
+    ):
+        python_interop_budget = profiles[profile_name].get("step_budgets", {}).get(
+            "area_python_interop"
+        )
+        expected_budget = {
+            "warm_budget_ms": warm_budget_ms,
+            "cold_budget_ms": cold_budget_ms,
+            "cache_classifier": "successful-input-receipt",
+            "enforcement": "blocking",
+        }
+        if python_interop_budget != expected_budget:
+            raise AssertionError(
+                f"{profile_name} Python interop cache budget drifted: "
+                f"{python_interop_budget}"
+            )
 
 
 def _profile_coverage_self_test(profiles: dict[str, dict[str, Any]]) -> None:

--- a/verification/runner/sifr_verify/step_budgets.py
+++ b/verification/runner/sifr_verify/step_budgets.py
@@ -92,7 +92,7 @@ def prepare_step_budget(
         required_cache_paths=required_paths,
     )
     env["SIFR_VERIFY_STEP_CACHE_STATE"] = state
-    if name == "python_interop":
+    if area_name_for_step(name) == "python_interop":
         env["SIFR_PYTHON_INTEROP_CACHE_STATE"] = state
     print(
         f"[sifr-lane-step-cache] name={name} state={state} reason={reason} fingerprint={fingerprint[:16]}"
@@ -203,9 +203,8 @@ def input_fingerprint(
         "python": sys.version,
         "sifr_binary_sha256": binary_digest,
     }
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return (
-        hashlib.sha256(encoded).hexdigest(),
+        fingerprint_digest(payload),
         eligible,
         "eligible"
         if eligible
@@ -215,8 +214,17 @@ def input_fingerprint(
     )
 
 
+def fingerprint_digest(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def area_name_for_step(step_name: str) -> str:
+    return step_name.removeprefix("area_")
+
+
 def selected_suites(profile: dict[str, Any], step_name: str) -> list[str]:
-    area = "python_interop" if step_name == "python_interop" else step_name
+    area = area_name_for_step(step_name)
     return [
         str(suite)
         for selection in profile.get("selected_areas", [])
@@ -228,7 +236,7 @@ def selected_suites(profile: dict[str, Any], step_name: str) -> list[str]:
 def required_cache_paths(
     repo_root: Path, step_name: str, binary: Path
 ) -> tuple[Path, ...]:
-    if step_name == "python_interop":
+    if area_name_for_step(step_name) == "python_interop":
         return (binary, repo_root / "target" / "python" / "debug")
     return (binary,)
 
@@ -341,22 +349,60 @@ def run_self_test() -> None:
             overrun_status = enforce_step_budget(context, 1_200_001)
         if overrun_status != 124:
             raise AssertionError("cold blocking budget did not reject an overrun")
-        from .reports import parse_log
+        report_cache_classification_self_test(root)
+        suite_fingerprint_self_test()
 
-        log = root / "lane.log"
-        log.write_text(
-            "[sifr-lane-step-cache] name=python_interop state=cold "
-            "reason=receipt-missing fingerprint=aaaaaaaaaaaaaaaa\n"
-            "[sifr-lane-step] name=python_interop elapsed_ms=900000 status=pass\n"
-            "[sifr-lane-step-budget] name=python_interop elapsed_ms=900000 "
-            "budget_ms=1200000 enforcement=blocking status=pass\n",
-            encoding="utf-8",
+
+def report_cache_classification_self_test(root: Path) -> None:
+    from .reports import parse_log
+
+    log = root / "lane.log"
+    log.write_text(
+        "[sifr-lane-step-cache] name=python_interop state=cold "
+        "reason=receipt-missing fingerprint=aaaaaaaaaaaaaaaa\n"
+        "[sifr-lane-step] name=python_interop elapsed_ms=900000 status=pass\n"
+        "[sifr-lane-step-budget] name=python_interop elapsed_ms=900000 "
+        "budget_ms=1200000 enforcement=blocking status=pass\n",
+        encoding="utf-8",
+    )
+    parsed = parse_log(log)
+    expected_cache = {
+        "state": "cold",
+        "reason": "receipt-missing",
+        "fingerprint": "aaaaaaaaaaaaaaaa",
+    }
+    if parsed["lane_step_cache"].get("python_interop") != expected_cache:
+        raise AssertionError("lane report lost the cache classification")
+
+
+def suite_fingerprint_self_test() -> None:
+    profile = {
+        "selected_areas": [
+            {
+                "area": "python_interop",
+                "suites": ["self-test", "callback-examples"],
+            }
+        ]
+    }
+    suites = selected_suites(profile, "area_python_interop")
+    if suites != ["self-test", "callback-examples"]:
+        raise AssertionError("area Python interop step did not bind its selected suites")
+    fingerprint_inputs = {
+        "profile": "create-pr",
+        "step": "area_python_interop",
+        "source_commit": "candidate",
+        "tracked_state": "",
+        "suites": suites,
+        "cargo_lock_sha256": "lock",
+        "rustc": "rustc",
+        "python": "python",
+        "sifr_binary_sha256": "binary",
+    }
+    original_fingerprint = fingerprint_digest(fingerprint_inputs)
+    changed_fingerprint = fingerprint_digest(
+        {**fingerprint_inputs, "suites": [*suites, "buffer-examples"]}
+    )
+    if original_fingerprint == changed_fingerprint:
+        raise AssertionError(
+            "changed Python interop suite selection did not change the fingerprint"
         )
-        parsed = parse_log(log)
-        expected_cache = {
-            "state": "cold",
-            "reason": "receipt-missing",
-            "fingerprint": "aaaaaaaaaaaaaaaa",
-        }
-        if parsed["lane_step_cache"].get("python_interop") != expected_cache:
-            raise AssertionError("lane report lost the cache classification")


### PR DESCRIPTION
## Summary
- bind Python-interop cache identity to the actual selected suite list
- apply Python-specific cache classification to canonical area step names
- set measured, blocking cache-aware budgets for authoritative delivery profiles
- add deterministic runner and profile-policy self-tests

## Validation
- full create-PR Python-interop selection: 24/24 pass, 2026.34s
- full merge Python-interop selection: 30/30 pass, 1792.99s
- verification runner self-test
- profile schema check and create-pr/merge/nightly/release plans
- maintainability and file-size guardrails
- git diff --check