### PR TITLE
fix: close residual emitted Rust flow proofs

### DIFF
--- a/crates/sifr/tests/e2e/pass/async_for_stream_result.sifr
+++ b/crates/sifr/tests/e2e/pass/async_for_stream_result.sifr
@@ -31,4 +31,18 @@ async def main() -> Result[None, StreamError]:
     assert total == 6
     assert count == 4
     assert stream.current == 4
+
+    dynamic: list[float] = []
+    seed: int = 0
+    second_stream: CounterStream = CounterStream(0, 3)
+    async for _value in second_stream:
+        try:
+            converted: float = float(seed)
+            dynamic.append(converted)
+        except FloatOverflowError as error:
+            assert False, str(error)
+        except FloatPrecisionLossError as error:
+            assert False, str(error)
+        seed = seed + 1
+    assert dynamic == [0.0, 1.0, 2.0]
     return None

--- a/crates/sifr/tests/e2e/pass/loop_integer_float_fact_invalidation.sifr
+++ b/crates/sifr/tests/e2e/pass/loop_integer_float_fact_invalidation.sifr
@@ -1,3 +1,6 @@
+SHADOWED: int = 8
+
+
 def main() -> None:
     while_values: list[str] = []
     value: int = 0
@@ -32,3 +35,31 @@ def main() -> None:
             assert False, str(error)
         value = value + 2
     assert for_values == ["2:4:6", "3:6:9", "4:8:12"]
+
+    nonlocal_values: list[float] = []
+    captured: int = 0
+    while captured < 3:
+        try:
+            converted: float = float(captured)
+            nonlocal_values.append(converted)
+        except FloatOverflowError as error:
+            assert False, str(error)
+        except FloatPrecisionLossError as error:
+            assert False, str(error)
+
+        def advance() -> None:
+            nonlocal captured
+            captured = captured + 1
+
+        advance()
+    assert nonlocal_values == [0.0, 1.0, 2.0]
+
+    SHADOWED: int = 1
+    SHADOWED = SHADOWED + 1
+    try:
+        shadowed_value: float = float(SHADOWED)
+        assert shadowed_value == 2
+    except FloatOverflowError as error:
+        assert False, str(error)
+    except FloatPrecisionLossError as error:
+        assert False, str(error)

--- a/crates/sifr_codegen/src/hir_analysis/queries.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries.rs
@@ -5,6 +5,8 @@ pub(crate) use value_liveness::*;
 #[cfg(test)]
 mod default_expression_tests;
 #[cfg(test)]
+mod python_context_flow_tests;
+#[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod type_and_operator_tests;

--- a/crates/sifr_codegen/src/hir_analysis/queries/python_context_flow_tests.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries/python_context_flow_tests.rs
@@ -1,0 +1,103 @@
+use super::*;
+use sifr_ir::{HirAsyncWithKind, HirExpr, HirStmt, HirWithItem, HirWithItemKind};
+use sifr_type_system::Type;
+
+fn python_error_type() -> Type {
+    Type::Class {
+        identity: None,
+        type_args: Vec::new(),
+        name: "PythonError".to_string(),
+        fields: vec![],
+        methods: vec![],
+        parent_class: None,
+    }
+}
+
+#[test]
+fn python_async_context_suppression_keeps_following_return_reachable() {
+    let error_type = python_error_type();
+    let stmts = vec![
+        HirStmt::AsyncWith {
+            kind: HirAsyncWithKind::Python {
+                context: HirExpr::Name {
+                    name: "manager".to_string(),
+                    binding_id: None,
+                    ty: Type::Unknown,
+                },
+                manager_class: "Manager".to_string(),
+                entered_type: Type::Unknown,
+                enter_error_type: error_type.clone(),
+                exit_error_type: error_type.clone(),
+                entered_is_opaque_borrow: false,
+                active_error_type: error_type,
+                body_may_raise: true,
+            },
+            target: None,
+            body: vec![HirStmt::Raise {
+                value: HirExpr::Name {
+                    name: "error".to_string(),
+                    binding_id: None,
+                    ty: Type::Unknown,
+                },
+            }],
+        },
+        HirStmt::Return {
+            value: Some(HirExpr::BoolLiteral(false)),
+        },
+    ];
+
+    assert_eq!(
+        block_control_flow_effect(&stmts[..1]),
+        ControlFlowEffect::FallsThrough
+    );
+    assert!(body_contains_return(&stmts));
+    assert_eq!(
+        block_control_flow_effect(&stmts),
+        ControlFlowEffect::AlwaysExits
+    );
+}
+
+#[test]
+fn python_context_return_body_still_has_a_suppression_fallthrough() {
+    let error_type = python_error_type();
+    let statements = vec![python_context_with(error_type, true)];
+
+    assert_eq!(
+        block_control_flow_effect(&statements),
+        ControlFlowEffect::FallsThrough
+    );
+    assert!(body_contains_return(&statements));
+}
+
+#[test]
+fn infallible_python_context_return_body_remains_terminal() {
+    let statements = vec![python_context_with(Type::Unknown, false)];
+
+    assert_eq!(
+        block_control_flow_effect(&statements),
+        ControlFlowEffect::AlwaysReturns
+    );
+}
+
+fn python_context_with(error_type: Type, body_may_raise: bool) -> HirStmt {
+    HirStmt::With {
+        items: vec![HirWithItem {
+            target: "value".to_string(),
+            context: HirExpr::Name {
+                name: "manager".to_string(),
+                binding_id: None,
+                ty: Type::Unknown,
+            },
+            kind: HirWithItemKind::Python {
+                entered_type: Type::Unknown,
+                enter_error_type: error_type.clone(),
+                exit_error_type: error_type,
+                entered_is_opaque_borrow: false,
+                body_may_raise,
+            },
+        }],
+        body: vec![HirStmt::Return {
+            value: Some(HirExpr::IntLiteral(1)),
+        }],
+    }
+}

--- a/crates/sifr_codegen/src/hir_analysis/queries/queries_impl.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries/queries_impl.rs
@@ -157,23 +157,6 @@ pub(crate) fn collect_mutated_vars(
     stmts: &[HirStmt],
     func_signatures: Option<&ModuleFuncSignatures>,
 ) -> HashSet<String> {
-    fn collect_nested_assign_targets(stmts: &[HirStmt]) -> HashSet<String> {
-        let mut assigned = HashSet::new();
-        let mut on_stmt = |stmt: &HirStmt| {
-            if let HirStmt::Assign { name, .. } = stmt {
-                assigned.insert(name.clone());
-            }
-        };
-        let mut on_expr = |_expr: &HirExpr| {};
-        traversal::walk_stmts(
-            stmts,
-            TraversalConfig::LOCAL_SCOPE_ONLY,
-            &mut on_stmt,
-            &mut on_expr,
-        );
-        assigned
-    }
-
     fn canonical_mutating_call_name(func: &str) -> &str {
         let func = crate::stmt_support_emitter::canonical_plain_call_name_for_ir(func);
         func.rsplit('.').next().unwrap_or(func)
@@ -257,14 +240,9 @@ pub(crate) fn collect_mutated_vars(
                 .map(|param| param.name.clone())
                 .collect::<HashSet<_>>();
             let locally_defined = collect_locally_defined_vars(&func.body);
-            let assigned_in_nested = collect_nested_assign_targets(&func.body);
             let captured_mutated = collect_mutated_vars(&func.body, func_signatures)
                 .into_iter()
-                .filter(|name| {
-                    !param_names.contains(name)
-                        && !locally_defined.contains(name)
-                        && !assigned_in_nested.contains(name)
-                })
+                .filter(|name| !param_names.contains(name) && !locally_defined.contains(name))
                 .collect::<Vec<_>>();
             mutated.borrow_mut().extend(captured_mutated);
         }

--- a/crates/sifr_codegen/src/hir_analysis/queries/tests.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries/tests.rs
@@ -478,10 +478,18 @@ fn collect_mutated_vars_ignores_nested_function_scope() {
         name: "inner".to_string(),
         params: vec![],
         return_type: Type::None,
-        body: vec![HirStmt::Assign {
-            name: "inside".to_string(),
-            value: HirExpr::IntLiteral(1),
-        }],
+        body: vec![
+            HirStmt::Let {
+                name: "inside".to_string(),
+                ty: Type::Int,
+                value: HirExpr::IntLiteral(0),
+                is_mutable: true,
+            },
+            HirStmt::Assign {
+                name: "inside".to_string(),
+                value: HirExpr::IntLiteral(1),
+            },
+        ],
         is_async: false,
         method_kind: MethodKind::Regular,
         receiver: None,
@@ -793,56 +801,6 @@ fn body_contains_return_ignores_unreachable_return() {
         },
     ];
     assert!(!body_contains_return(&stmts));
-}
-
-#[test]
-fn python_async_context_suppression_keeps_following_return_reachable() {
-    let error_type = Type::Class {
-        identity: None,
-        type_args: Vec::new(),
-        name: "PythonError".to_string(),
-        fields: vec![],
-        methods: vec![],
-        parent_class: None,
-    };
-    let stmts = vec![
-        HirStmt::AsyncWith {
-            kind: sifr_ir::HirAsyncWithKind::Python {
-                context: HirExpr::Name {
-                    name: "manager".to_string(),
-                    binding_id: None,
-                    ty: Type::Unknown,
-                },
-                manager_class: "Manager".to_string(),
-                entered_type: Type::Unknown,
-                enter_error_type: error_type.clone(),
-                exit_error_type: error_type.clone(),
-                entered_is_opaque_borrow: false,
-                active_error_type: error_type,
-            },
-            target: None,
-            body: vec![HirStmt::Raise {
-                value: HirExpr::Name {
-                    name: "error".to_string(),
-                    binding_id: None,
-                    ty: Type::Unknown,
-                },
-            }],
-        },
-        HirStmt::Return {
-            value: Some(HirExpr::BoolLiteral(false)),
-        },
-    ];
-
-    assert_eq!(
-        block_control_flow_effect(&stmts[..1]),
-        ControlFlowEffect::FallsThrough
-    );
-    assert!(body_contains_return(&stmts));
-    assert_eq!(
-        block_control_flow_effect(&stmts),
-        ControlFlowEffect::AlwaysExits
-    );
 }
 
 #[test]

--- a/crates/sifr_codegen/src/render/render_expr_and_blocks.rs
+++ b/crates/sifr_codegen/src/render/render_expr_and_blocks.rs
@@ -648,7 +648,7 @@ impl Renderer {
             if token.is_empty() {
                 return;
             }
-            if matches!(token.as_str(), "mut" | "ref") {
+            if matches!(token.as_str(), "mut" | "ref" | "true" | "false") {
                 out.push_str(token);
             } else {
                 out.push_str(&Self::render_identifier(token));

--- a/crates/sifr_codegen/src/render/render_helpers.rs
+++ b/crates/sifr_codegen/src/render/render_helpers.rs
@@ -573,4 +573,16 @@ mod tests {
         res % r#mod;
         "###);
     }
+
+    #[test]
+    fn pattern_renderer_preserves_boolean_literals() {
+        assert_eq!(
+            Renderer::render_pattern_string("Ok(Err(false))"),
+            "Ok(Err(false))"
+        );
+        assert_eq!(
+            Renderer::render_pattern_string("Ok(Err(true))"),
+            "Ok(Err(true))"
+        );
+    }
 }

--- a/crates/sifr_codegen/src/stmt_support_emitter/async_with_and_for.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/async_with_and_for.rs
@@ -76,6 +76,7 @@ impl RustEmitter {
             exit_error_type,
             entered_is_opaque_borrow,
             active_error_type,
+            ..
         } = kind
         {
             return self.try_lower_python_async_context_for_ir(

--- a/crates/sifr_codegen/src/stmt_support_emitter/python_async_context_tests.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/python_async_context_tests.rs
@@ -70,6 +70,7 @@ fn kind(active_error_type: Type) -> sifr_ir::HirAsyncWithKind {
         exit_error_type: class_type("PythonError"),
         entered_is_opaque_borrow: false,
         active_error_type,
+        body_may_raise: false,
     }
 }
 

--- a/crates/sifr_codegen/src/stmt_support_emitter/python_context/async_context.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/python_context/async_context.rs
@@ -1,6 +1,6 @@
 use super::cancellation_scope::cleanup_scope_call;
 use super::outcome::{cause_label, cause_variant};
-use super::sync::rewrite_context_control_flow;
+use super::sync::{rewrite_context_control_flow, rust_stmts_always_exit};
 use crate::python_interop_async::{async_output_value, output_schema};
 use crate::python_interop_callbacks::failure_reconciliation_stmt;
 use crate::rust_interop_error_mapping::bridge_error_expr;
@@ -86,14 +86,16 @@ impl RustEmitter {
             })?,
             0,
         );
-        rewritten.push(RustStmt::Return(Some(RustExpr::Verbatim(
-            if can_return {
-                "Ok(Ok(None))"
-            } else {
-                "Ok(Ok(()))"
-            }
-            .to_string(),
-        ))));
+        if !rust_stmts_always_exit(&rewritten) {
+            rewritten.push(RustStmt::Return(Some(RustExpr::Verbatim(
+                if can_return {
+                    "Ok(Ok(None))"
+                } else {
+                    "Ok(Ok(()))"
+                }
+                .to_string(),
+            ))));
+        }
         let body = crate::render_stmts(&rewritten);
 
         let internal_error = mapped_internal_error(active_error_type);

--- a/crates/sifr_codegen/src/stmt_support_emitter/python_context/sync.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/python_context/sync.rs
@@ -178,10 +178,12 @@ impl RustEmitter {
         } else {
             RustExpr::Tuple(Vec::new())
         };
-        closure_body.push(RustStmt::Return(Some(call(
-            "Ok",
-            call("Ok", normal_outcome),
-        ))));
+        if !rust_stmts_always_exit(&closure_body) {
+            closure_body.push(RustStmt::Return(Some(call(
+                "Ok",
+                call("Ok", normal_outcome),
+            ))));
+        }
         let normal_outcome_type = if can_return {
             format!(
                 "Option<{}>",
@@ -705,6 +707,33 @@ pub(super) fn rewrite_context_control_flow(
             other => other,
         })
         .collect()
+}
+
+pub(super) fn rust_stmts_always_exit(stmts: &[RustStmt]) -> bool {
+    stmts.last().is_some_and(rust_stmt_always_exits)
+}
+
+fn rust_stmt_always_exits(stmt: &RustStmt) -> bool {
+    match stmt {
+        RustStmt::Return(_) => true,
+        RustStmt::If {
+            then_body,
+            else_body: Some(else_body),
+            ..
+        }
+        | RustStmt::IfLet {
+            then_body,
+            else_body: Some(else_body),
+            ..
+        } => rust_stmts_always_exit(then_body) && rust_stmts_always_exit(else_body),
+        RustStmt::Match { arms, .. } => {
+            !arms.is_empty() && arms.iter().all(|arm| rust_stmts_always_exit(&arm.body))
+        }
+        RustStmt::Block(body) => rust_stmts_always_exit(body),
+        RustStmt::TailExpr(RustExpr::Match { arms, .. })
+        | RustStmt::Expr(RustExpr::Match { arms, .. }) => arms.is_empty(),
+        _ => false,
+    }
 }
 
 fn is_error_return(expr: &RustExpr) -> bool {

--- a/crates/sifr_codegen/src/stmt_support_emitter/python_context_tests.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/python_context_tests.rs
@@ -36,6 +36,7 @@ fn python_item(target: &str, manager: &str) -> HirWithItem {
             enter_error_type: class_type("PythonError"),
             exit_error_type: class_type("PythonError"),
             entered_is_opaque_borrow: true,
+            body_may_raise: false,
         },
     }
 }
@@ -194,6 +195,14 @@ fn let_else_control_flow_is_rewritten_for_context_cleanup() {
         RustStmt::LetElse { else_body, .. }
             if matches!(else_body.as_slice(), [RustStmt::Return(Some(_))])
     ));
+}
+
+#[test]
+fn rewritten_terminal_context_control_does_not_require_a_dead_fallback() {
+    for statement in [RustStmt::Break, RustStmt::Continue] {
+        let rewritten = rewrite_context_control_flow(vec![statement], 0);
+        assert!(super::sync::rust_stmts_always_exit(&rewritten));
+    }
 }
 
 #[test]

--- a/crates/sifr_ir/src/hir_flow.rs
+++ b/crates/sifr_ir/src/hir_flow.rs
@@ -176,14 +176,24 @@ fn stmt_summary(stmt: &HirStmt) -> FlowSummary {
             flow_summary(body).sequence(flow_summary(finalbody))
         }
         HirStmt::With { items, body }
-            if items
-                .iter()
-                .any(|item| matches!(item.kind, HirWithItemKind::Python { .. })) =>
+            if items.iter().any(|item| {
+                matches!(
+                    item.kind,
+                    HirWithItemKind::Python {
+                        body_may_raise: true,
+                        ..
+                    }
+                )
+            }) =>
         {
             python_context_flow_summary(body)
         }
         HirStmt::AsyncWith {
-            kind: crate::HirAsyncWithKind::Python { .. },
+            kind:
+                crate::HirAsyncWithKind::Python {
+                    body_may_raise: true,
+                    ..
+                },
             body,
             ..
         } => python_context_flow_summary(body),
@@ -194,8 +204,7 @@ fn stmt_summary(stmt: &HirStmt) -> FlowSummary {
 
 fn python_context_flow_summary(body: &[HirStmt]) -> FlowSummary {
     let mut summary = flow_summary(body);
-    if summary.has_raise {
-        summary.falls_through = true;
-    }
+    // A declared Python exit can suppress an error propagated by this body.
+    summary.falls_through = true;
     summary
 }

--- a/crates/sifr_ir/src/hir_nodes.rs
+++ b/crates/sifr_ir/src/hir_nodes.rs
@@ -313,6 +313,7 @@ pub enum HirAsyncWithKind {
         exit_error_type: Type,
         entered_is_opaque_borrow: bool,
         active_error_type: Type,
+        body_may_raise: bool,
     },
 }
 
@@ -327,6 +328,7 @@ pub enum HirWithItemKind {
         enter_error_type: Type,
         exit_error_type: Type,
         entered_is_opaque_borrow: bool,
+        body_may_raise: bool,
     },
 }
 

--- a/crates/sifr_lowering/src/cfg.rs
+++ b/crates/sifr_lowering/src/cfg.rs
@@ -1,6 +1,6 @@
 //! Control-flow graph construction and flow-truth queries for HIR statement blocks.
 
-use crate::{HirExpr, HirStmt};
+use crate::{HirAsyncWithKind, HirExpr, HirStmt, HirWithItemKind};
 use sifr_ir::{
     CfgBlock, CfgBlockId, CfgBlockLabel, CfgInvariantError, CfgTerminator, ControlFlowGraph,
     FlowExitEffect, FlowFacts,
@@ -229,10 +229,39 @@ impl CfgBuilder {
                 self.set_terminator(block, CfgTerminator::Goto(body_entry));
                 block
             }
-            HirStmt::With { body, .. } => {
+            HirStmt::With { items, body } => {
                 let body_entry = self.build_stmt_list(body, next, loop_targets, false);
                 let block = self.new_block(CfgBlockLabel::Statement("with"), top_level_stmt_index);
-                self.set_terminator(block, CfgTerminator::Goto(body_entry));
+                if items.iter().any(|item| {
+                    matches!(
+                        item.kind,
+                        HirWithItemKind::Python {
+                            body_may_raise: true,
+                            ..
+                        }
+                    )
+                }) {
+                    self.set_terminator(block, CfgTerminator::Branch(vec![body_entry, next]));
+                } else {
+                    self.set_terminator(block, CfgTerminator::Goto(body_entry));
+                }
+                block
+            }
+            HirStmt::AsyncWith { kind, body, .. } => {
+                let body_entry = self.build_stmt_list(body, next, loop_targets, false);
+                let block =
+                    self.new_block(CfgBlockLabel::Statement("async_with"), top_level_stmt_index);
+                if matches!(
+                    kind,
+                    HirAsyncWithKind::Python {
+                        body_may_raise: true,
+                        ..
+                    }
+                ) {
+                    self.set_terminator(block, CfgTerminator::Branch(vec![body_entry, next]));
+                } else {
+                    self.set_terminator(block, CfgTerminator::Goto(body_entry));
+                }
                 block
             }
             _ => {
@@ -431,6 +460,67 @@ mod tests {
 
         let facts = valid_flow_facts(&stmts);
         assert_eq!(facts.reachable_return_types(), &[Type::Int]);
+    }
+
+    #[test]
+    fn suppressible_python_context_return_body_does_not_close_cfg_fallthrough() {
+        let statements = vec![HirStmt::With {
+            items: vec![sifr_ir::HirWithItem {
+                target: "value".to_string(),
+                context: HirExpr::Name {
+                    name: "manager".to_string(),
+                    binding_id: None,
+                    ty: Type::Unknown,
+                },
+                kind: HirWithItemKind::Python {
+                    entered_type: Type::Unknown,
+                    enter_error_type: Type::Unknown,
+                    exit_error_type: Type::Unknown,
+                    entered_is_opaque_borrow: false,
+                    body_may_raise: true,
+                },
+            }],
+            body: vec![HirStmt::Return {
+                value: Some(HirExpr::IntLiteral(1)),
+            }],
+        }];
+
+        let facts = valid_flow_facts(&statements);
+        assert_eq!(facts.exit_effect(), FlowExitEffect::FallsThrough);
+        assert!(facts.has_reachable_return());
+    }
+
+    #[test]
+    fn suppressible_python_async_context_return_body_keeps_following_code_reachable() {
+        let statements = vec![
+            HirStmt::AsyncWith {
+                kind: HirAsyncWithKind::Python {
+                    context: HirExpr::Name {
+                        name: "manager".to_string(),
+                        binding_id: None,
+                        ty: Type::Unknown,
+                    },
+                    manager_class: "Manager".to_string(),
+                    entered_type: Type::Unknown,
+                    enter_error_type: Type::Unknown,
+                    exit_error_type: Type::Unknown,
+                    entered_is_opaque_borrow: false,
+                    active_error_type: Type::Unknown,
+                    body_may_raise: true,
+                },
+                target: None,
+                body: vec![HirStmt::Return {
+                    value: Some(HirExpr::IntLiteral(1)),
+                }],
+            },
+            HirStmt::Return {
+                value: Some(HirExpr::IntLiteral(2)),
+            },
+        ];
+
+        let facts = valid_flow_facts(&statements);
+        assert_eq!(facts.reachable_top_level_stmt_indices(), &[0, 1]);
+        assert_eq!(facts.exit_effect(), FlowExitEffect::AlwaysReturns);
     }
 
     #[test]

--- a/crates/sifr_lowering/src/hir_snapshot_expr_projection.rs
+++ b/crates/sifr_lowering/src/hir_snapshot_expr_projection.rs
@@ -476,6 +476,7 @@ pub(super) fn async_with_kind_name(kind: &HirAsyncWithKind) -> Value {
             exit_error_type,
             entered_is_opaque_borrow,
             active_error_type,
+            body_may_raise,
         } => json!({
             "kind": "Python",
             "context": project_expr(context),
@@ -485,6 +486,7 @@ pub(super) fn async_with_kind_name(kind: &HirAsyncWithKind) -> Value {
             "exit_error_type": type_name(exit_error_type),
             "entered_is_opaque_borrow": entered_is_opaque_borrow,
             "active_error_type": type_name(active_error_type),
+            "body_may_raise": body_may_raise,
         }),
     }
 }

--- a/crates/sifr_lowering/src/hir_snapshot_tests.rs
+++ b/crates/sifr_lowering/src/hir_snapshot_tests.rs
@@ -393,12 +393,14 @@ fn project_stmt(stmt: &HirStmt) -> Value {
                             enter_error_type,
                             exit_error_type,
                             entered_is_opaque_borrow,
+                            body_may_raise,
                         } => json!({
                             "kind": "Python",
                             "entered_type": type_name(entered_type),
                             "enter_error_type": type_name(enter_error_type),
                             "exit_error_type": type_name(exit_error_type),
                             "entered_is_opaque_borrow": entered_is_opaque_borrow,
+                            "body_may_raise": body_may_raise,
                         }),
                     };
                     json!({

--- a/crates/sifr_lowering/src/lower/expression_operators/integer_semantics.rs
+++ b/crates/sifr_lowering/src/lower/expression_operators/integer_semantics.rs
@@ -326,19 +326,12 @@ pub(in crate::lower) fn proven_exact_integer_value(
         HirExpr::UnaryOp { op, operand, .. } if op == "-" => {
             proven_exact_integer_value(operand, ctx).map(|value| -value)
         }
-        HirExpr::Name {
-            name, binding_id, ..
-        } => ctx.scope.const_integer_value(name).cloned().or_else(|| {
-            binding_id
-                .and_then(|id| ctx.scope.retained_binding(id))
-                .filter(|binding| {
-                    matches!(
-                        binding.binding_kind,
-                        crate::scope::BindingKind::ModuleConstant
-                    )
-                })
-                .and_then(|_| ctx.const_integer_values.get(name))
-                .cloned()
+        HirExpr::Name { name, .. } => ctx.scope.const_integer_value(name).cloned().or_else(|| {
+            if ctx.scope.resolves_to_module_binding(name) {
+                ctx.const_integer_values.get(name).cloned()
+            } else {
+                None
+            }
         }),
         _ => None,
     }

--- a/crates/sifr_lowering/src/lower/expression_operators/integer_semantics.rs
+++ b/crates/sifr_lowering/src/lower/expression_operators/integer_semantics.rs
@@ -326,11 +326,20 @@ pub(in crate::lower) fn proven_exact_integer_value(
         HirExpr::UnaryOp { op, operand, .. } if op == "-" => {
             proven_exact_integer_value(operand, ctx).map(|value| -value)
         }
-        HirExpr::Name { name, .. } => ctx
-            .scope
-            .const_integer_value(name)
-            .or_else(|| ctx.const_integer_values.get(name))
-            .cloned(),
+        HirExpr::Name {
+            name, binding_id, ..
+        } => ctx.scope.const_integer_value(name).cloned().or_else(|| {
+            binding_id
+                .and_then(|id| ctx.scope.retained_binding(id))
+                .filter(|binding| {
+                    matches!(
+                        binding.binding_kind,
+                        crate::scope::BindingKind::ModuleConstant
+                    )
+                })
+                .and_then(|_| ctx.const_integer_values.get(name))
+                .cloned()
+        }),
         _ => None,
     }
 }

--- a/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
@@ -238,6 +238,13 @@ pub(super) fn lower_regular_call(
                 &func_name,
                 ctx,
             );
+        if function_binding_id.is_some() {
+            super::super::integer_const_facts::invalidate_nested_function_call_const_integer_facts(
+                ctx, &func_name,
+            );
+        } else {
+            super::super::integer_const_facts::invalidate_aliased_nested_function_call_const_integer_facts(ctx);
+        }
         return Some(HirExpr::Call {
             mutable_arg_places,
             func: func_name,

--- a/crates/sifr_lowering/src/lower/expressions_tests.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests.rs
@@ -6,7 +6,7 @@ pub(crate) use sifr_python_ast::{
 };
 pub(crate) use sifr_type_system::{FixedIntType, FunctionType, Type};
 pub(crate) use support::{
-    function_let_value, function_nested_let_value, lower_source,
+    function_let_value, function_nested_let_value, lower_source, lower_source_with_externals,
     lower_source_with_stdlib_collections, range_for, range_for_after, range_for_after_anchor,
 };
 

--- a/crates/sifr_lowering/src/lower/expressions_tests/loop_const_fact_invalidation.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/loop_const_fact_invalidation.rs
@@ -1,4 +1,5 @@
 use super::*;
+use num_bigint::BigInt;
 
 fn assert_loop_numeric_operations_require_typed_handling(source: &str) {
     let errors = lower_source(source)
@@ -172,4 +173,29 @@ def main() -> None:
         value = value + 1
 ",
     );
+}
+
+#[test]
+fn imported_integer_constant_retains_exact_value_proof() {
+    let mut externals = crate::ExternalDefs::default();
+    externals
+        .constants
+        .entry("settings".to_string())
+        .or_default()
+        .insert("LIMIT".to_string(), Type::Int);
+    externals
+        .constant_integer_values
+        .entry("settings".to_string())
+        .or_default()
+        .insert("LIMIT".to_string(), BigInt::from(8));
+
+    let source = "\
+from settings import LIMIT
+
+def main() -> None:
+    value: float = float(LIMIT)
+";
+
+    lower_source_with_externals(source, &externals)
+        .expect("an imported integer constant should retain its exact value proof");
 }

--- a/crates/sifr_lowering/src/lower/expressions_tests/loop_const_fact_invalidation.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/loop_const_fact_invalidation.rs
@@ -45,3 +45,131 @@ def main() -> None:
 ",
     );
 }
+
+#[test]
+fn async_for_body_assignment_invalidates_pre_loop_integer_fact() {
+    assert_loop_numeric_operations_require_typed_handling(
+        "\
+class StreamError(Error):
+    pass
+
+class CounterStream:
+    current: int
+
+    def __init__(self):
+        self.current = 0
+
+    async def anext(mut self) -> Result[Option[int], StreamError]:
+        if self.current >= 1:
+            return None
+        self.current = self.current + 1
+        value: Option[int] = self.current
+        return value
+
+async def main() -> Result[None, StreamError]:
+    value: int = 4
+    stream: CounterStream = CounterStream()
+    async for iteration in stream:
+        divided: float = value / 2
+        converted: float = float(value)
+        mixed: float = value * 1.5
+        value = value + iteration
+    return None
+",
+    );
+}
+
+#[test]
+fn called_nonlocal_mutator_invalidates_loop_carried_integer_fact() {
+    assert_loop_numeric_operations_require_typed_handling(
+        "\
+def main() -> None:
+    value: int = 0
+    def advance() -> None:
+        nonlocal value
+        value = value + 1
+    while value < 3:
+        divided: float = value / 2
+        converted: float = float(value)
+        mixed: float = value * 1.5
+        advance()
+",
+    );
+}
+
+#[test]
+fn nonlocal_mutator_declared_in_loop_invalidates_pre_lowering_integer_fact() {
+    assert_loop_numeric_operations_require_typed_handling(
+        "\
+def main() -> None:
+    value: int = 0
+    while value < 3:
+        divided: float = value / 2
+        converted: float = float(value)
+        mixed: float = value * 1.5
+        def advance() -> None:
+            nonlocal value
+            value = value + 1
+        advance()
+",
+    );
+}
+
+#[test]
+fn transitive_nonlocal_mutator_invalidates_loop_carried_integer_fact() {
+    assert_loop_numeric_operations_require_typed_handling(
+        "\
+def main() -> None:
+    value: int = 0
+    def tick() -> None:
+        nonlocal value
+        value = value + 1
+    def advance() -> None:
+        tick()
+    while value < 3:
+        divided: float = value / 2
+        converted: float = float(value)
+        mixed: float = value * 1.5
+        advance()
+",
+    );
+}
+
+#[test]
+fn callable_alias_effect_propagates_through_nested_helper() {
+    assert_loop_numeric_operations_require_typed_handling(
+        "\
+def main() -> None:
+    value: int = 0
+    def tick() -> None:
+        nonlocal value
+        value = value + 1
+    alias: Callable[[], None] = tick
+    def advance() -> None:
+        alias()
+    while value < 3:
+        divided: float = value / 2
+        converted: float = float(value)
+        mixed: float = value * 1.5
+        advance()
+",
+    );
+}
+
+#[test]
+fn cleared_local_fact_does_not_fall_back_to_shadowed_module_constant() {
+    assert_loop_numeric_operations_require_typed_handling(
+        "\
+value: int = 8
+
+def main() -> None:
+    value: int = 1
+    value = value + 1
+    while value < 4:
+        divided: float = value / 2
+        converted: float = float(value)
+        mixed: float = value * 1.5
+        value = value + 1
+",
+    );
+}

--- a/crates/sifr_lowering/src/lower/expressions_tests/support.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/support.rs
@@ -10,6 +10,14 @@ pub(crate) fn lower_source(source: &str) -> Result<HirModule, Vec<HirDiagnostic>
     lower_module(parsed.suite()).map(|r| r.module)
 }
 
+pub(crate) fn lower_source_with_externals(
+    source: &str,
+    externals: &ExternalDefs,
+) -> Result<HirModule, Vec<HirDiagnostic>> {
+    let parsed = parse_module(source).expect("parse failed");
+    lower_module_with_externals(parsed.suite(), externals).map(|r| r.module)
+}
+
 pub(crate) fn lower_source_with_stdlib_collections(
     source: &str,
 ) -> Result<HirModule, Vec<HirDiagnostic>> {

--- a/crates/sifr_lowering/src/lower/integer_const_facts.rs
+++ b/crates/sifr_lowering/src/lower/integer_const_facts.rs
@@ -1,7 +1,9 @@
 use crate::hir_nodes::HirExpr;
 use crate::scope::ConstIntegerSnapshot;
 use num_bigint::BigInt;
-use sifr_python_ast::Stmt;
+use sifr_python_ast::visitor::{self, Visitor};
+use sifr_python_ast::{Expr, Stmt};
+use sifr_type_system::Type;
 use std::collections::HashSet;
 
 use super::LowerCtx;
@@ -38,8 +40,91 @@ pub(in crate::lower) fn invalidate_loop_body_const_integer_facts(
         body,
         &mut assigned_names,
     );
+    assigned_names
+        .extend(super::nested_function_inference::collect_nested_function_mutated_nonlocals(body));
     for name in assigned_names {
         ctx.scope.clear_const_integer_value(&name);
+    }
+
+    let mut calls = NestedFunctionCallCollector::default();
+    for stmt in body {
+        calls.visit_stmt(stmt);
+    }
+    let may_call_aliased_nested_function = calls.called.iter().any(|function| {
+        !ctx.nested_function_mutated_captures.contains_key(function)
+            && ctx.scope.lookup(function).is_some_and(|binding| {
+                matches!(
+                    binding.effective_type().resolve_alias(),
+                    Type::Callable(..) | Type::AsyncCallable(..)
+                )
+            })
+    });
+    let mutated_captures = if may_call_aliased_nested_function {
+        all_nested_function_mutated_captures(ctx)
+    } else {
+        calls
+            .called
+            .iter()
+            .filter_map(|function| ctx.nested_function_mutated_captures.get(function))
+            .flatten()
+            .cloned()
+            .collect()
+    };
+    for name in mutated_captures {
+        ctx.scope.clear_const_integer_value(&name);
+    }
+}
+
+pub(in crate::lower) fn invalidate_aliased_nested_function_call_const_integer_facts(
+    ctx: &mut LowerCtx,
+) {
+    for name in all_nested_function_mutated_captures(ctx) {
+        ctx.scope.clear_const_integer_value(&name);
+    }
+}
+
+fn all_nested_function_mutated_captures(ctx: &LowerCtx) -> HashSet<String> {
+    ctx.nested_function_mutated_captures
+        .values()
+        .flatten()
+        .cloned()
+        .collect()
+}
+
+pub(in crate::lower) fn invalidate_nested_function_call_const_integer_facts(
+    ctx: &mut LowerCtx,
+    function: &str,
+) {
+    let mutated_captures = ctx
+        .nested_function_mutated_captures
+        .get(function)
+        .cloned()
+        .unwrap_or_default();
+    for name in mutated_captures {
+        ctx.scope.clear_const_integer_value(&name);
+    }
+}
+
+#[derive(Default)]
+struct NestedFunctionCallCollector {
+    called: HashSet<String>,
+}
+
+impl<'ast> Visitor<'ast> for NestedFunctionCallCollector {
+    fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+        if matches!(stmt, Stmt::FunctionDef(_)) {
+            return;
+        }
+        visitor::walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &'ast Expr) {
+        if let Expr::Call(call) = expr
+            && let Expr::Name(function) = call.func.as_ref()
+        {
+            self.called.insert(function.id.to_string());
+        }
+        visitor::walk_expr(self, expr);
     }
 }
 

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -144,6 +144,8 @@ mod python_buffer_contract_tests;
 #[cfg(test)]
 mod python_context_expression_tests;
 #[cfg(test)]
+mod python_context_flow_tests;
+#[cfg(test)]
 mod python_coroutine_contract_tests;
 #[cfg(test)]
 mod python_dlpack_contract_tests;

--- a/crates/sifr_lowering/src/lower/nested_function_inference.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference.rs
@@ -5,6 +5,7 @@ use sifr_python_ast::{CmpOp, Expr, ExprCall, Operator};
 use sifr_type_system::{FunctionType, Type, type_check_binary_op};
 use std::collections::HashMap;
 
+mod call_effects;
 mod state_collection;
 pub(in crate::lower) use state_collection::*;
 mod expression_inference;
@@ -37,3 +38,4 @@ use compound_statement_inference::{
 mod capture_collection;
 pub(in crate::lower) use capture_collection::collect_referenced_names_in_expr;
 mod mutation_collection;
+pub(in crate::lower) use mutation_collection::collect_nested_function_mutated_nonlocals;

--- a/crates/sifr_lowering/src/lower/nested_function_inference/call_effects.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/call_effects.rs
@@ -1,0 +1,74 @@
+use super::state_collection::{LocalFunctionState, ParamState};
+use sifr_python_ast::visitor::{self, Visitor};
+use sifr_python_ast::{Expr, Stmt};
+use sifr_type_system::Type;
+use std::collections::{HashMap, HashSet};
+
+pub(super) struct NestedFunctionCallEffects {
+    pub(super) called_functions: Vec<String>,
+    pub(super) may_call_nested_alias: bool,
+}
+
+pub(super) fn nested_function_call_effects(
+    body: &[Stmt],
+    states: &HashMap<String, LocalFunctionState<'_>>,
+    captures: &[(String, Type)],
+    params: &[ParamState],
+) -> NestedFunctionCallEffects {
+    let mut visitor = DirectNestedCallVisitor {
+        nested_names: states.keys().map(String::as_str).collect(),
+        callable_aliases: captures
+            .iter()
+            .map(|(name, ty)| (name.as_str(), ty))
+            .chain(params.iter().map(|param| (param.name.as_str(), &param.ty)))
+            .filter_map(|(name, ty)| {
+                matches!(
+                    ty.resolve_alias(),
+                    Type::Callable(..) | Type::AsyncCallable(..)
+                )
+                .then_some(name)
+            })
+            .collect(),
+        called: HashSet::new(),
+        may_call_nested_alias: false,
+    };
+    for stmt in body {
+        visitor.visit_stmt(stmt);
+    }
+    let mut called_functions = visitor.called.into_iter().collect::<Vec<_>>();
+    called_functions.sort();
+    NestedFunctionCallEffects {
+        called_functions,
+        may_call_nested_alias: visitor.may_call_nested_alias,
+    }
+}
+
+struct DirectNestedCallVisitor<'a> {
+    nested_names: HashSet<&'a str>,
+    callable_aliases: HashSet<&'a str>,
+    called: HashSet<String>,
+    may_call_nested_alias: bool,
+}
+
+impl<'ast> Visitor<'ast> for DirectNestedCallVisitor<'_> {
+    fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+        if matches!(stmt, Stmt::FunctionDef(_)) {
+            return;
+        }
+        visitor::walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &'ast Expr) {
+        if let Expr::Call(call) = expr
+            && let Expr::Name(function) = call.func.as_ref()
+        {
+            let function = function.id.as_str();
+            if self.nested_names.contains(function) {
+                self.called.insert(function.to_string());
+            } else if self.callable_aliases.contains(function) {
+                self.may_call_nested_alias = true;
+            }
+        }
+        visitor::walk_expr(self, expr);
+    }
+}

--- a/crates/sifr_lowering/src/lower/nested_function_inference/mutation_collection.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/mutation_collection.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::lower::mutating_methods::{
     is_collection_mutating_method, is_potential_collection_mutating_method,
 };
+use sifr_python_ast::visitor::{self, Visitor};
 use sifr_python_ast::{
     ExceptHandler, Expr, InterpolatedStringElement, Parameters, Stmt, StmtFunctionDef,
 };
@@ -26,6 +27,39 @@ pub(super) fn collect_mutated_binding_names(
         collect_mutated_binding_names_in_stmt(stmt, candidate_names, &mut mutated);
     }
     mutated
+}
+
+pub(in crate::lower) fn collect_nested_function_mutated_nonlocals(
+    stmts: &[Stmt],
+) -> HashSet<String> {
+    let mut collector = NestedFunctionNonlocalMutationCollector::default();
+    for stmt in stmts {
+        collector.visit_stmt(stmt);
+    }
+    collector.mutated
+}
+
+#[derive(Default)]
+struct NestedFunctionNonlocalMutationCollector {
+    mutated: HashSet<String>,
+}
+
+impl<'ast> Visitor<'ast> for NestedFunctionNonlocalMutationCollector {
+    fn visit_stmt(&mut self, stmt: &'ast Stmt) {
+        let Stmt::FunctionDef(func) = stmt else {
+            visitor::walk_stmt(self, stmt);
+            return;
+        };
+
+        let mut nonlocal_names = HashSet::new();
+        collect_nonlocal_names(&func.body, &mut nonlocal_names);
+        let candidates = nonlocal_names
+            .into_iter()
+            .map(|name| (name, MutationCandidate::InferFromUsage))
+            .collect();
+        self.mutated
+            .extend(collect_mutated_binding_names(&func.body, &candidates));
+    }
 }
 
 fn collect_mutated_binding_names_in_stmt(

--- a/crates/sifr_lowering/src/lower/nested_function_inference/state_collection.rs
+++ b/crates/sifr_lowering/src/lower/nested_function_inference/state_collection.rs
@@ -261,7 +261,7 @@ fn infer_function_types(
     };
     analyze_block(stmts, &mut env, &mut states, None, ctx);
     let function_captures = collect_nested_function_captures(stmts, &env, &states);
-    let function_mutated_captures = states
+    let mut function_mutated_captures: HashMap<String, Vec<String>> = states
         .iter()
         .map(|(name, state)| {
             let candidate_names = function_captures
@@ -277,6 +277,41 @@ fn infer_function_types(
             (name.clone(), mutated)
         })
         .collect();
+    let call_graph = states
+        .iter()
+        .map(|(name, state)| {
+            (
+                name.clone(),
+                super::call_effects::nested_function_call_effects(
+                    &state.func.body,
+                    &states,
+                    function_captures
+                        .get(name)
+                        .map(Vec::as_slice)
+                        .unwrap_or_default(),
+                    &state.params,
+                ),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    loop {
+        let previous = function_mutated_captures.clone();
+        for (name, call_effects) in &call_graph {
+            let mut mutations = previous.get(name).cloned().unwrap_or_default();
+            for called in &call_effects.called_functions {
+                mutations.extend(previous.get(called).into_iter().flatten().cloned());
+            }
+            if call_effects.may_call_nested_alias {
+                mutations.extend(previous.values().flatten().cloned());
+            }
+            mutations.sort();
+            mutations.dedup();
+            function_mutated_captures.insert(name.clone(), mutations);
+        }
+        if function_mutated_captures == previous {
+            break;
+        }
+    }
 
     NestedFunctionInference {
         function_types: finalize_nested_function_types(&mut states, ctx),

--- a/crates/sifr_lowering/src/lower/python_context_flow_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_context_flow_tests.rs
@@ -1,0 +1,59 @@
+use super::python_interop_tests::lower_ok;
+use crate::{HirStmt, hir_nodes::HirWithItemKind};
+
+#[test]
+fn python_with_infallible_return_body_remains_terminal() {
+    let source = r#"
+class PythonError(Error):
+    message: str
+    kind: str
+    exception_type: str
+    traceback: str
+    context: str
+
+class ExitCause:
+    pass
+
+class ExitDecision:
+    pass
+
+@python.opaque(type=pkg.Counter, cleanup=context)
+class Counter:
+    @python.context.enter(Self.__enter__)
+    def __enter__(self) -> Result[int, PythonError]: ...
+
+    @python.context.exit(Self.__exit__)
+    def __exit__(own self, cause: ExitCause) -> Result[ExitDecision, PythonError]: ...
+
+@python(pkg.Counter)
+def make_counter() -> Result[Counter, PythonError]: ...
+
+def use_counter() -> Result[int, PythonError]:
+    try:
+        with make_counter() as value:
+            copied: int = value
+            return copied
+    except PythonError as error:
+        raise error
+"#;
+    let module = lower_ok(source);
+    let function = module
+        .functions
+        .iter()
+        .find(|function| function.name == "use_counter")
+        .expect("function");
+    let HirStmt::TryExcept { body, .. } = &function.body[0] else {
+        panic!("function should retain try body");
+    };
+    let HirStmt::With { items, .. } = &body[0] else {
+        panic!("body should retain with statement");
+    };
+    assert!(matches!(
+        items[0].kind,
+        HirWithItemKind::Python {
+            entered_is_opaque_borrow: false,
+            body_may_raise: false,
+            ..
+        }
+    ));
+}

--- a/crates/sifr_lowering/src/lower/python_interop/context/async_with.rs
+++ b/crates/sifr_lowering/src/lower/python_interop/context/async_with.rs
@@ -213,7 +213,8 @@ fn lower_python_async_with(
             ));
         }
     }
-    let body = crate::lower::statements::lower_stmts(&with_stmt.body, func_type, ctx);
+    let (body, body_may_raise) =
+        crate::lower::statements::lower_python_context_body(&with_stmt.body, func_type, ctx);
     if let Some((name, previous)) = previous_borrow {
         if let Some(range) = previous {
             ctx.python_context_borrows.insert(name, range);
@@ -230,6 +231,7 @@ fn lower_python_async_with(
             exit_error_type: metadata.exit_error_type,
             entered_is_opaque_borrow: metadata.entered_is_opaque_borrow,
             active_error_type: active_error_type.as_ref().clone(),
+            body_may_raise,
         },
         target,
         body,

--- a/crates/sifr_lowering/src/lower/python_interop/context/declarations.rs
+++ b/crates/sifr_lowering/src/lower/python_interop/context/declarations.rs
@@ -62,6 +62,7 @@ pub(in crate::lower) fn python_context_item_kind(
         enter_error_type: enter_error_type.as_ref().clone(),
         exit_error_type: exit_error_type.as_ref().clone(),
         entered_is_opaque_borrow,
+        body_may_raise: false,
     })
 }
 

--- a/crates/sifr_lowering/src/lower/python_interop_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_interop_tests.rs
@@ -5,7 +5,7 @@ use sifr_ir::{
 };
 use sifr_python_parser::parse_module;
 
-fn lower_ok(source: &str) -> HirModule {
+pub(super) fn lower_ok(source: &str) -> HirModule {
     let parsed = parse_module(source).expect("source should parse");
     lower_module(parsed.suite())
         .map(|result| result.module)
@@ -374,6 +374,7 @@ fn python_with_retains_dedicated_hir_and_scoped_opaque_borrow() {
         enter_error_type,
         exit_error_type,
         entered_is_opaque_borrow,
+        body_may_raise,
     } = &items[0].kind
     else {
         panic!("item should use dedicated Python context HIR");
@@ -382,6 +383,7 @@ fn python_with_retains_dedicated_hir_and_scoped_opaque_borrow() {
     assert_eq!(enter_error_type.display_name(), "PythonError");
     assert_eq!(exit_error_type.display_name(), "PythonError");
     assert!(*entered_is_opaque_borrow);
+    assert!(!body_may_raise);
 }
 
 #[test]
@@ -415,59 +417,17 @@ fn python_with_supports_multiple_context_items_with_distinct_borrows() {
             ..
         }
     )));
-}
-
-#[test]
-fn python_with_nonopaque_entered_value_is_ordinary_owned_data() {
-    let source = r#"
-class PythonError(Error):
-    message: str
-    kind: str
-    exception_type: str
-    traceback: str
-    context: str
-
-class ExitCause:
-    pass
-
-class ExitDecision:
-    pass
-
-@python.opaque(type=pkg.Counter, cleanup=context)
-class Counter:
-    @python.context.enter(Self.__enter__)
-    def __enter__(self) -> Result[int, PythonError]: ...
-
-    @python.context.exit(Self.__exit__)
-    def __exit__(own self, cause: ExitCause) -> Result[ExitDecision, PythonError]: ...
-
-@python(pkg.Counter)
-def make_counter() -> Result[Counter, PythonError]: ...
-
-def use_counter() -> Result[int, PythonError]:
-    try:
-        with make_counter() as value:
-            copied: int = value
-            return copied
-    except PythonError as error:
-        raise error
-"#;
-    let module = lower_ok(source);
-    let function = module
-        .functions
-        .iter()
-        .find(|function| function.name == "use_counter")
-        .expect("function");
-    let HirStmt::TryExcept { body, .. } = &function.body[0] else {
-        panic!("function should retain try body");
-    };
-    let HirStmt::With { items, .. } = &body[0] else {
-        panic!("body should retain with statement");
-    };
     assert!(matches!(
-        items[0].kind,
+        &items[0].kind,
         HirWithItemKind::Python {
-            entered_is_opaque_borrow: false,
+            body_may_raise: true,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &items[1].kind,
+        HirWithItemKind::Python {
+            body_may_raise: false,
             ..
         }
     ));

--- a/crates/sifr_lowering/src/lower/statements.rs
+++ b/crates/sifr_lowering/src/lower/statements.rs
@@ -88,3 +88,21 @@ pub(in crate::lower) fn record_try_error_types(ctx: &mut LowerCtx, error_type: &
         _ => {}
     }
 }
+
+pub(in crate::lower) fn lower_python_context_body(
+    stmts: &[sifr_python_ast::Stmt],
+    func_type: &FunctionType,
+    ctx: &mut LowerCtx,
+) -> (Vec<HirStmt>, bool) {
+    let enclosing_errors = std::mem::take(&mut ctx.try_block_error_types);
+    let body = lower_stmts(stmts, func_type, ctx);
+    let propagated_errors = std::mem::take(&mut ctx.try_block_error_types);
+
+    let mut explicit_errors = std::collections::HashSet::new();
+    diagnostics::collect_raise_error_types(&body, &mut explicit_errors);
+    let body_may_raise = !propagated_errors.is_empty() || !explicit_errors.is_empty();
+
+    ctx.try_block_error_types = enclosing_errors;
+    ctx.try_block_error_types.extend(propagated_errors);
+    (body, body_may_raise)
+}

--- a/crates/sifr_lowering/src/lower/statements/statement_dispatch.rs
+++ b/crates/sifr_lowering/src/lower/statements/statement_dispatch.rs
@@ -454,7 +454,19 @@ pub(in crate::lower) fn lower_stmt(
                         },
                     });
                 }
-                let body = lower_stmts(&with_stmt.body, func_type, ctx);
+                let (body, body_may_raise) =
+                    super::lower_python_context_body(&with_stmt.body, func_type, ctx);
+                let mut later_python_enter_may_raise = false;
+                for item in items.iter_mut().rev() {
+                    if let HirWithItemKind::Python {
+                        body_may_raise: item_body_may_raise,
+                        ..
+                    } = &mut item.kind
+                    {
+                        *item_body_may_raise = body_may_raise || later_python_enter_may_raise;
+                        later_python_enter_may_raise = true;
+                    }
+                }
                 for (name, previous) in previous_context_borrows.into_iter().rev() {
                     if let Some(range) = previous {
                         ctx.python_context_borrows.insert(name, range);

--- a/verification/areas/python_interop/fixtures/sqlite_context/context_codegen_smoke.sifr
+++ b/verification/areas/python_interop/fixtures/sqlite_context/context_codegen_smoke.sifr
@@ -37,6 +37,8 @@ def return_from_transaction() -> Result[int, PythonError]:
             return changes + 7
     except PythonError as error:
         raise error
+    # A declared Python context may suppress a body error before the return.
+    return 7
 
 
 def break_from_transaction() -> Result[int, PythonError]:


### PR DESCRIPTION
## Summary

Closes Item 3A of the emitted-Rust excellence phase:

- model suppressible Python context body errors as typed continuation paths in HIR flow and CFG analysis without weakening infallible-return precision
- remove dead context closure fallbacks and preserve boolean literal patterns
- make exact-integer proof lookup binding-aware across module-constant shadowing
- invalidate loop and expression facts for direct, transitive, and callable-alias nested-function mutation effects
- emit captured nonlocal rebindings with mutable outer storage
- add sync/async context, while/for/async-for, shadowing, and nested mutation regressions

## Validation

- `cargo test -p sifr_ir`
- `cargo test -p sifr_lowering -p sifr_codegen`
- `cargo test -p sifr -- --skip test_e2e_pass`
- focused runtime execution of `loop_integer_float_fact_invalidation.sifr`
- focused runtime execution of `async_for_stream_result.sifr`
- focused compiled SQLite Python-context example (`total=71` marker observed)
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `python3 scripts/check_file_size_guardrails.py`
- Item-owned Clippy passes with only three untouched workspace failures relaxed; strict workspace Clippy currently stops on pre-existing `needless_borrows_for_generic_args` in `annotation_resolution.rs` and `needless_pass_by_value`/`expect_used` in `structural_record_codegen.rs`.

Exact-SHA Opus review and the single create-PR/merge gates will be attached before ready-for-review/merge.
