### PR TITLE
Close mutation-tail witness continuations

### DIFF
--- a/crates/sifr/tests/e2e/pass/checked_place_collection_semantics.sifr
+++ b/crates/sifr/tests/e2e/pass/checked_place_collection_semantics.sifr
@@ -51,7 +51,24 @@ def list_exit_guard_refreshes_after_mut_borrow_call() -> int:
     if len(values) == 0:
         return -1
     replace_first(values)
+    if len(values) == 0:
+        return -1
     return values[0]
+
+
+def nested_mutation_renews_outer_while_witness() -> int:
+    values: list[int] = [1]
+    if len(values) == 0:
+        return -1
+    total: int = 0
+    while values[0] < 3:
+        for index in range(1):
+            if index == 0:
+                values[0] += 1
+                total += values[0]
+    else:
+        total += 100
+    return total
 
 
 def list_witness_refreshes_on_for_back_edge() -> int:
@@ -124,6 +141,7 @@ def main():
     assert dict_exit_guard_refreshes_after_assignment() == 99
     assert positive_dict_guard_refreshes_after_assignment() == 99
     assert list_exit_guard_refreshes_after_mut_borrow_call() == 42
+    assert nested_mutation_renews_outer_while_witness() == 105
     assert list_witness_refreshes_on_for_back_edge() == 33
     assert dict_witness_refreshes_on_for_back_edge() == 101
     assert list_witness_refreshes_before_while_condition() == 3

--- a/crates/sifr_codegen/src/checked_place/control_flow.rs
+++ b/crates/sifr_codegen/src/checked_place/control_flow.rs
@@ -24,17 +24,60 @@ impl RustEmitter {
         used
     }
 
+    fn checked_place_witness_is_invalidated_by_stmt(
+        witness: &super::CheckedPlaceReadWitness,
+        stmt: &crate::HirStmt,
+    ) -> bool {
+        let mut invalidated = false;
+        crate::hir_analysis::traversal::walk_stmts(
+            std::slice::from_ref(stmt),
+            crate::hir_analysis::traversal::TraversalConfig::LOCAL_SCOPE_ONLY,
+            &mut |_| {},
+            &mut |expr| {
+                let (args, mutable_arg_places) = match expr {
+                    crate::HirExpr::Call {
+                        args,
+                        mutable_arg_places,
+                        ..
+                    }
+                    | crate::HirExpr::GenericCall {
+                        args,
+                        mutable_arg_places,
+                        ..
+                    }
+                    | crate::HirExpr::MethodCall {
+                        args,
+                        mutable_arg_places,
+                        ..
+                    } => (args, mutable_arg_places),
+                    _ => return,
+                };
+                for (arg, target) in args.iter().zip(mutable_arg_places) {
+                    if target.is_none() {
+                        continue;
+                    }
+                    crate::hir_analysis::traversal::walk_expr(arg, &mut |candidate| {
+                        if matches!(candidate, crate::HirExpr::Name { name, .. }
+                            if witness.dependencies.contains(name))
+                        {
+                            invalidated = true;
+                        }
+                    });
+                }
+            },
+        );
+        invalidated
+    }
+
     fn checked_place_witnesses_affected_by_stmts(
         &self,
         stmts: &[crate::HirStmt],
-        require_missing_body: bool,
     ) -> Vec<(String, super::CheckedPlaceReadWitness)> {
         let mutated =
             crate::hir_analysis::queries::collect_mutated_vars(stmts, Some(&self.func_signatures));
         let mut affected = self
             .checked_place_read_witnesses
             .iter()
-            .filter(|(_, witness)| !require_missing_body || witness.missing.is_some())
             .filter(|(_, witness)| {
                 witness
                     .dependencies
@@ -50,12 +93,47 @@ impl RustEmitter {
     fn checked_place_witnesses_affected_by_stmt(
         &self,
         stmt: &crate::HirStmt,
-        require_missing_body: bool,
     ) -> Vec<(String, super::CheckedPlaceReadWitness)> {
-        self.checked_place_witnesses_affected_by_stmts(
-            std::slice::from_ref(stmt),
-            require_missing_body,
-        )
+        self.checked_place_witnesses_affected_by_stmts(std::slice::from_ref(stmt))
+    }
+
+    pub(crate) fn prepare_checked_place_witnesses_for_mutation(
+        &mut self,
+        stmt: &crate::HirStmt,
+        following: Option<&[crate::HirStmt]>,
+    ) -> Vec<RustStmt> {
+        let Some(following) = following else {
+            return Vec::new();
+        };
+        let mut preparations = Vec::new();
+        for (key, mut witness) in self.checked_place_witnesses_affected_by_stmt(stmt) {
+            if !witness.borrowed
+                || Self::checked_place_witness_is_invalidated_by_stmt(&witness, stmt)
+                || !Self::checked_place_read_is_used(&key, following)
+            {
+                continue;
+            }
+            preparations.push(RustStmt::Let {
+                mutable: false,
+                name: witness.binding.clone(),
+                ty: None,
+                value: crate::RustExpr::MethodCall {
+                    receiver: Box::new(crate::RustExpr::Paren(Box::new(crate::RustExpr::Deref(
+                        Box::new(crate::RustExpr::Ident(witness.binding.clone())),
+                    )))),
+                    method: "clone".to_string(),
+                    args: Vec::new(),
+                },
+            });
+            witness.borrowed = false;
+            witness.option = crate::RustExpr::MethodCall {
+                receiver: Box::new(witness.option),
+                method: "cloned".to_string(),
+                args: Vec::new(),
+            };
+            self.checked_place_read_witnesses.insert(key, witness);
+        }
+        preparations
     }
 
     pub(crate) fn checked_place_loop_condition_refreshes_for_ir(
@@ -75,7 +153,7 @@ impl RustEmitter {
                 })
                 .collect::<std::collections::BTreeSet<_>>();
         let refreshed = self
-            .checked_place_witnesses_affected_by_stmts(body, false)
+            .checked_place_witnesses_affected_by_stmts(body)
             .into_iter()
             .filter(|(key, _)| condition_reads.contains(key))
             .collect::<Vec<_>>();
@@ -121,22 +199,26 @@ impl RustEmitter {
         stmt: &crate::HirStmt,
         following: Option<&[crate::HirStmt]>,
     ) -> Vec<RustStmt> {
-        let affected = self.checked_place_witnesses_affected_by_stmt(stmt, true);
+        let affected = self.checked_place_witnesses_affected_by_stmt(stmt);
         let mut refreshes = Vec::new();
         for (key, witness) in affected {
             self.checked_place_read_witnesses.remove(&key);
-            if !following.is_some_and(|tail| Self::checked_place_read_is_used(&key, tail)) {
+            if Self::checked_place_witness_is_invalidated_by_stmt(&witness, stmt)
+                || !following.is_some_and(|tail| Self::checked_place_read_is_used(&key, tail))
+            {
                 continue;
             }
-            let Some(missing) = witness.missing.clone() else {
-                continue;
-            };
             self.checked_place_read_witnesses
                 .insert(key, witness.clone());
-            refreshes.push(RustStmt::LetElse {
-                pattern: format!("Some({})", witness.binding),
-                value: witness.option,
-                else_body: missing,
+            refreshes.push(RustStmt::Let {
+                mutable: false,
+                name: witness.binding.clone(),
+                ty: None,
+                value: crate::RustExpr::MethodCall {
+                    receiver: Box::new(witness.option),
+                    method: "unwrap_or".to_string(),
+                    args: vec![crate::RustExpr::Ident(witness.binding)],
+                },
             });
         }
         refreshes
@@ -153,7 +235,9 @@ impl RustEmitter {
             return Ok(None);
         }
 
-        let affected = self.checked_place_witnesses_affected_by_stmt(stmt, false);
+        let mut preparations =
+            self.prepare_checked_place_witnesses_for_mutation(stmt, Some(following));
+        let affected = self.checked_place_witnesses_affected_by_stmt(stmt);
         if affected.is_empty() {
             return Ok(None);
         }
@@ -162,46 +246,45 @@ impl RustEmitter {
         self.checked_place_refresh_suppressed_depth = Some(self.stmt_block_depth + 1);
         let lowered_stmt = self.try_lower_stmt_block_for_ir(std::slice::from_ref(stmt));
         self.checked_place_refresh_suppressed_depth = previous_suppressed_depth;
-        let Some(mut lowered) = lowered_stmt? else {
+        let Some(lowered_stmt) = lowered_stmt? else {
             return Err(crate::CodegenError::new(
                 "codegen invariant violated: mutation under a checked-place witness was not structurally lowered",
             ));
         };
+        preparations.extend(lowered_stmt);
+        let mut lowered = preparations;
 
         for (key, _) in &affected {
             self.checked_place_read_witnesses.remove(key);
         }
         let refreshed = affected
             .into_iter()
-            .filter(|(key, _)| Self::checked_place_read_is_used(key, following))
+            .filter(|(key, witness)| {
+                !Self::checked_place_witness_is_invalidated_by_stmt(witness, stmt)
+                    && Self::checked_place_read_is_used(key, following)
+            })
             .collect::<Vec<_>>();
         for (key, witness) in &refreshed {
             self.checked_place_read_witnesses
                 .insert(key.clone(), witness.clone());
         }
-        let Some(mut tail) = self.try_lower_stmt_block_for_ir(following)? else {
+        for (_, witness) in &refreshed {
+            lowered.push(RustStmt::Let {
+                mutable: false,
+                name: witness.binding.clone(),
+                ty: None,
+                value: crate::RustExpr::MethodCall {
+                    receiver: Box::new(witness.option.clone()),
+                    method: "unwrap_or".to_string(),
+                    args: vec![crate::RustExpr::Ident(witness.binding.clone())],
+                },
+            });
+        }
+        let Some(tail) = self.try_lower_stmt_block_for_ir(following)? else {
             return Err(crate::CodegenError::new(
                 "codegen invariant violated: tail after checked-place witness refresh was not structurally lowered",
             ));
         };
-        for (_, witness) in refreshed.into_iter().rev() {
-            tail = if let Some(missing) = witness.missing {
-                let mut guarded = vec![RustStmt::LetElse {
-                    pattern: format!("Some({})", witness.binding),
-                    value: witness.option,
-                    else_body: missing,
-                }];
-                guarded.extend(tail);
-                guarded
-            } else {
-                vec![RustStmt::IfLet {
-                    pattern: format!("Some({})", witness.binding),
-                    expr: witness.option,
-                    then_body: tail,
-                    else_body: None,
-                }]
-            };
-        }
         lowered.extend(tail);
         Ok(Some(lowered))
     }
@@ -409,7 +492,7 @@ impl RustEmitter {
             .map(|guard| guard.key.as_str())
             .collect::<std::collections::BTreeSet<_>>();
         let loop_carried_candidates = self
-            .checked_place_witnesses_affected_by_stmts(body, false)
+            .checked_place_witnesses_affected_by_stmts(body)
             .into_iter()
             .filter(|(key, _)| {
                 !guard_keys.contains(key.as_str())
@@ -422,10 +505,8 @@ impl RustEmitter {
             .map(|guard| {
                 (
                     guard.key.clone(),
-                    self.checked_place_read_witnesses.insert(
-                        guard.key.clone(),
-                        guard.witness_with_missing(vec![missing.clone()]),
-                    ),
+                    self.checked_place_read_witnesses
+                        .insert(guard.key.clone(), guard.witness()),
                 )
             })
             .collect::<Vec<_>>();
@@ -581,10 +662,8 @@ impl RustEmitter {
         let Some(absent_body) = self.lower_checked_read_branch(then_body, &guard, false)? else {
             return Ok(None);
         };
-        self.checked_place_read_witnesses.insert(
-            guard.key.clone(),
-            guard.witness_with_missing(absent_body.clone()),
-        );
+        self.checked_place_read_witnesses
+            .insert(guard.key.clone(), guard.witness());
         Ok(Some(RustStmt::LetElse {
             pattern: format!("Some({})", guard.binding),
             value: guard.option,
@@ -661,10 +740,8 @@ impl RustEmitter {
             });
         }
         for guard in guards {
-            self.checked_place_read_witnesses.insert(
-                guard.key.clone(),
-                guard.witness_with_missing(absent_body.clone()),
-            );
+            self.checked_place_read_witnesses
+                .insert(guard.key.clone(), guard.witness());
             lowered.push(RustStmt::LetElse {
                 pattern: format!("Some({})", guard.binding),
                 value: guard.option,

--- a/crates/sifr_codegen/src/checked_place/witnesses.rs
+++ b/crates/sifr_codegen/src/checked_place/witnesses.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use crate::{RustExpr, RustStmt};
+use crate::RustExpr;
 
 pub(super) fn checked_place_expr_token(expr: &crate::HirExpr) -> Option<String> {
     match expr {
@@ -82,7 +82,6 @@ pub(crate) struct CheckedPlaceReadWitness {
     pub(super) binding: String,
     pub(super) borrowed: bool,
     pub(super) option: RustExpr,
-    pub(super) missing: Option<Vec<RustStmt>>,
     pub(super) dependencies: Vec<String>,
     pub(super) order: usize,
 }
@@ -93,16 +92,8 @@ impl CheckedDictReadGuard {
             binding: self.binding.clone(),
             borrowed: self.borrowed,
             option: self.option.clone(),
-            missing: None,
             dependencies: self.dependencies.clone(),
             order: self.order,
-        }
-    }
-
-    pub(super) fn witness_with_missing(&self, missing: Vec<RustStmt>) -> CheckedPlaceReadWitness {
-        CheckedPlaceReadWitness {
-            missing: Some(missing),
-            ..self.witness()
         }
     }
 }

--- a/crates/sifr_codegen/src/lib_codegen_tests/checked_place_read_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/checked_place_read_codegen_tests.rs
@@ -269,8 +269,16 @@ def dict_value(mut mapping: dict[str, int], key: str) -> int:
     return mapping[key]
 "#,
     );
+    assert_eq!(
+        generated.matches("let Some(__sifr_checked_value_").count(),
+        2,
+        "{generated}"
+    );
     assert!(
-        generated.matches("let Some(__sifr_checked_value_").count() >= 4,
+        generated
+            .matches(".unwrap_or(__sifr_checked_value_")
+            .count()
+            >= 2,
         "{generated}"
     );
     assert!(generated.matches("mapping.get(key)").count() >= 2);
@@ -302,11 +310,18 @@ def dict_value(mut mapping: dict[str, int], key: str) -> int:
     return -1
 "#,
     );
-    assert!(
+    assert_eq!(
         generated
             .matches("if let Some(__sifr_checked_value_")
+            .count(),
+        2,
+        "{generated}"
+    );
+    assert!(
+        generated
+            .matches(".unwrap_or(__sifr_checked_value_")
             .count()
-            >= 4
+            >= 2
     );
     assert!(generated.matches("mapping.get(key)").count() >= 2);
     assert!(!generated.contains("mapping["), "{generated}");
@@ -327,6 +342,8 @@ def value_after_call(mut values: list[int]) -> int:
     if len(values) == 0:
         return -1
     replace_first(values)
+    if len(values) == 0:
+        return -1
     return values[0]
 "#,
     );
@@ -340,13 +357,82 @@ def value_after_call(mut values: list[int]) -> int:
         panic!("{generated}");
     };
     let Some(returned) = generated[refreshed..]
-        .find("__sifr_checked_value_0.clone()")
+        .find("\n    __sifr_checked_value_")
         .map(|offset| refreshed + offset)
     else {
         panic!("{generated}");
     };
     assert!(call < refreshed && refreshed < returned, "{generated}");
     assert!(!generated.contains("values["), "{generated}");
+    assert!(!generated.contains("compile_error!"), "{generated}");
+}
+
+#[test]
+fn nested_mutation_renews_outer_witness_without_replaying_loop_exit() {
+    let generated = generate_rust_from_source(
+        r#"
+def nested_value(mut values: list[int]) -> int:
+    if len(values) == 0:
+        return -1
+    total: int = 0
+    while values[0] < 3:
+        for index in range(1):
+            if index == 0:
+                values[0] += 1
+                total += values[0]
+    else:
+        total += 100
+    return total
+"#,
+    );
+    assert!(
+        generated
+            .matches(".unwrap_or(__sifr_checked_value_")
+            .count()
+            >= 1,
+        "{generated}"
+    );
+    assert!(!generated.contains("compile_error!"), "{generated}");
+}
+
+#[test]
+fn condition_refresh_uses_current_while_else_break_marker() {
+    let generated = generate_rust_from_source(
+        r#"
+def count_down(mut values: list[int]) -> int:
+    if len(values) == 0:
+        return -1
+    result: int = 0
+    while values[0] > 0:
+        values[0] -= 1
+    else:
+        result = 7
+    return result
+"#,
+    );
+    assert_eq!(
+        generated.matches("_broke = true;").count(),
+        1,
+        "{generated}"
+    );
+    let marker = generated.find("_broke = true;").expect("loop-else marker");
+    let condition = generated[marker..]
+        .find("if !(")
+        .map(|offset| marker + offset)
+        .expect("natural condition exit");
+    let natural_break = generated[condition..]
+        .find("break;")
+        .map(|offset| condition + offset)
+        .expect("natural condition break");
+    let loop_else = generated[natural_break..]
+        .find("if !(_broke)")
+        .map(|offset| natural_break + offset)
+        .expect("loop-else dispatch");
+    assert!(marker < condition && condition < natural_break && natural_break < loop_else);
+    assert!(
+        !generated[condition..natural_break].contains("_broke = true;"),
+        "{generated}"
+    );
     assert!(!generated.contains("compile_error!"), "{generated}");
 }
 
@@ -364,7 +450,7 @@ def neighbor_min_cost(mut cost: list[int]) -> int:
     );
     assert_eq!(
         generated.matches("let Some(__sifr_checked_value_").count(),
-        7,
+        5,
         "{generated}"
     );
     assert!(!generated.contains("to_usize_proven"), "{generated}");

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -29,6 +29,7 @@ pub(crate) use candidate_and_validation::{
     is_simple_stmt_candidate, try_lower_simple_stmt_with_scope_result_and_bindings,
 };
 mod simple_dispatch_and_bindings;
+pub(crate) use simple_dispatch_and_bindings::lower_loop_break_stmt;
 #[cfg(test)]
 use simple_dispatch_and_bindings::try_lower_simple_stmt_with_ctx;
 use simple_dispatch_and_bindings::try_lower_simple_stmt_with_ctx_and_bindings;

--- a/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
+++ b/crates/sifr_codegen/src/lower_stmt/simple_dispatch_and_bindings.rs
@@ -32,6 +32,20 @@ pub(crate) fn try_lower_simple_stmt_with_ctx(
     )
 }
 
+pub(crate) fn lower_loop_break_stmt(in_loop_with_else: bool) -> RustStmt {
+    if in_loop_with_else {
+        RustStmt::Block(vec![
+            RustStmt::Assign {
+                target: crate::RustExpr::Ident("_broke".to_string()),
+                value: crate::RustExpr::Literal(crate::RustLiteral::Bool(true)),
+            },
+            RustStmt::Break,
+        ])
+    } else {
+        RustStmt::Break
+    }
+}
+
 pub(super) fn try_lower_simple_stmt_with_ctx_and_bindings(
     stmt: &HirStmt,
     in_loop_with_else: bool,
@@ -292,19 +306,10 @@ pub(super) fn try_lower_simple_stmt_with_ctx_and_bindings(
         HirStmt::TryFinally { .. } => None,
         HirStmt::Pass => Some(vec![]),
         HirStmt::Continue => Some(vec![RustStmt::Continue]),
-        HirStmt::Break => {
-            if in_loop_with_else {
-                Some(vec![
-                    RustStmt::Assign {
-                        target: crate::RustExpr::Ident("_broke".to_string()),
-                        value: crate::RustExpr::Literal(crate::RustLiteral::Bool(true)),
-                    },
-                    RustStmt::Break,
-                ])
-            } else {
-                Some(vec![RustStmt::Break])
-            }
-        }
+        HirStmt::Break => Some(match lower_loop_break_stmt(in_loop_with_else) {
+            RustStmt::Block(stmts) => stmts,
+            stmt => vec![stmt],
+        }),
         _ => None,
     }
 }

--- a/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/loops_try_finally.rs
@@ -8,17 +8,8 @@ mod try_except;
 
 impl RustEmitter {
     pub(crate) fn lower_loop_break_for_ir(&self) -> RustStmt {
-        if self.loop_else_stack.last().copied().unwrap_or(false) {
-            RustStmt::Block(vec![
-                RustStmt::Assign {
-                    target: RustExpr::Ident("_broke".to_string()),
-                    value: RustExpr::Literal(crate::RustLiteral::Bool(true)),
-                },
-                RustStmt::Break,
-            ])
-        } else {
-            RustStmt::Break
-        }
+        let in_loop_with_else = self.loop_else_stack.last().copied().unwrap_or(false);
+        crate::lower_loop_break_stmt(in_loop_with_else)
     }
 
     pub(crate) fn lower_loop_control_stmt_for_ir(&self, stmt: &HirStmt) -> Option<RustStmt> {

--- a/crates/sifr_codegen/src/structured_stmt_entrypoints.rs
+++ b/crates/sifr_codegen/src/structured_stmt_entrypoints.rs
@@ -14,6 +14,10 @@ impl RustEmitter {
         if is_simple_stmt_candidate(stmt) {
             self.lowering_stats.stmt_candidate_total += 1;
         }
+        for preparation in self.prepare_checked_place_witnesses_for_mutation(stmt, following_stmts)
+        {
+            self.push_captured_stmt(&preparation);
+        }
         match self.try_lower_structured_stmt_with_following(stmt, following_stmts) {
             Ok(true) => {
                 for refresh in

--- a/crates/sifr_lowering/src/lower/expressions/attached_api_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/attached_api_calls.rs
@@ -143,6 +143,14 @@ fn lower_call(
         &binding.emitted_function,
         ctx,
     );
+    super::super::sequence_guards::invalidate_mutable_call_sequence_guards(
+        ctx,
+        &args,
+        full_type
+            .params
+            .iter()
+            .map(|(_, _, convention)| *convention),
+    );
     for (index, argument) in args.iter().enumerate() {
         if full_type
             .params

--- a/crates/sifr_lowering/src/lower/expressions/method_argument_ownership.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_argument_ownership.rs
@@ -106,6 +106,14 @@ pub(super) fn try_lower_super_method_call(
         return Some(None);
     };
     consume_owned_method_arguments(&args, call, &function_type, ctx);
+    super::super::sequence_guards::invalidate_mutable_call_sequence_guards(
+        ctx,
+        &args,
+        function_type
+            .params
+            .iter()
+            .map(|(_, _, convention)| *convention),
+    );
     let return_type = *function_type.return_type;
     Some(Some(HirExpr::SuperCall {
         parent_class: defining_name,
@@ -165,6 +173,14 @@ pub(super) fn try_lower_class_method_call(
         return Some(None);
     };
     consume_owned_method_arguments(&args, call, &function_type, ctx);
+    super::super::sequence_guards::invalidate_mutable_call_sequence_guards(
+        ctx,
+        &args,
+        function_type
+            .params
+            .iter()
+            .map(|(_, _, convention)| *convention),
+    );
     Some(Some(HirExpr::Call {
         mutable_arg_places: Vec::new(),
         func: format!("{class_name}::{method_name}"),

--- a/crates/sifr_lowering/src/lower/expressions/method_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_calls.rs
@@ -153,6 +153,14 @@ pub(in crate::lower) fn lower_method_call(
     )?;
     if let Some(function_type) = &method_type {
         consume_owned_method_arguments(&args, call, function_type, ctx);
+        super::super::sequence_guards::invalidate_mutable_call_sequence_guards(
+            ctx,
+            &args,
+            function_type
+                .params
+                .iter()
+                .map(|(_, _, convention)| *convention),
+        );
     }
     consume_affine_collection_method_arguments(
         &object_ty,

--- a/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
@@ -238,6 +238,14 @@ pub(super) fn lower_regular_call(
                 &func_name,
                 ctx,
             );
+        super::super::sequence_guards::invalidate_mutable_call_sequence_guards(
+            ctx,
+            &args,
+            signature
+                .params
+                .iter()
+                .map(|(_, _, convention)| *convention),
+        );
         if function_binding_id.is_some() {
             super::super::integer_const_facts::invalidate_nested_function_call_const_integer_facts(
                 ctx, &func_name,
@@ -280,6 +288,11 @@ pub(super) fn lower_regular_call(
         let args =
             lower_signature_call_args(call, &format!("{func_name}.__call__"), &call_ft, None, ctx)?;
         consume_owned_method_arguments(&args, call, &call_ft, ctx);
+        super::super::sequence_guards::invalidate_mutable_call_sequence_guards(
+            ctx,
+            &args,
+            call_ft.params.iter().map(|(_, _, convention)| *convention),
+        );
         return Some(HirExpr::MethodCall {
             object: Box::new(object),
             method: "__call__".to_string(),
@@ -540,6 +553,11 @@ pub(super) fn lower_regular_call(
         call.range(),
         &func_name,
         ctx,
+    );
+    super::super::sequence_guards::invalidate_mutable_call_sequence_guards(
+        ctx,
+        &args,
+        ft.params.iter().map(|(_, _, convention)| *convention),
     );
 
     // Track ownership: only mark arguments as moved when the parameter convention is Own

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -112,6 +112,8 @@ mod module_constants_lowering;
 mod module_function_inference;
 mod module_function_registry;
 mod must_use_obligations;
+#[cfg(test)]
+mod mutable_call_sequence_guard_tests;
 mod mutating_methods;
 mod name_diagnostics;
 #[cfg(test)]

--- a/crates/sifr_lowering/src/lower/mutable_call_sequence_guard_tests.rs
+++ b/crates/sifr_lowering/src/lower/mutable_call_sequence_guard_tests.rs
@@ -1,0 +1,66 @@
+use super::expressions_tests::lower_source;
+use sifr_diagnostics::DiagnosticCode;
+
+#[test]
+fn mutable_call_invalidates_straight_line_sequence_guard() {
+    let source = r#"
+def clear_values(mut values: list[int]) -> None:
+    values.clear()
+
+def read_after_call(mut values: list[int]) -> int:
+    if len(values) == 0:
+        return 0
+    clear_values(values)
+    return values[0] + 1
+"#;
+    let diagnostics = lower_source(source).expect_err("mutable call must invalidate the guard");
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == Some(DiagnosticCode::TYPE_UNSUPPORTED_OPERATOR)
+            && diagnostic.message.contains("None")
+    }));
+}
+
+#[test]
+fn nested_mutable_call_uses_current_optional_contract() {
+    let source = r#"
+def clear_values(mut values: list[int]) -> None:
+    values.clear()
+
+def read_in_nested_region(mut values: list[int]) -> int:
+    if len(values) == 0:
+        return 0
+    total: int = 0
+    while values[0] > 0:
+        for index in range(1):
+            if index == 0:
+                clear_values(values)
+                total += values[0]
+    else:
+        total += 1
+    return total
+"#;
+    let diagnostics = lower_source(source).expect_err("nested call must invalidate the guard");
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == Some(DiagnosticCode::TYPE_UNSUPPORTED_OPERATOR)
+            && diagnostic.message.contains("None")
+    }));
+}
+
+#[test]
+fn explicit_reguard_after_mutable_call_restores_checked_read() {
+    let source = r#"
+def replace_first(mut values: list[int]) -> None:
+    if len(values) > 0:
+        values[0] = 42
+
+def read_after_reguard(mut values: list[int]) -> int:
+    if len(values) == 0:
+        return 0
+    replace_first(values)
+    if len(values) == 0:
+        return 0
+    return values[0]
+"#;
+    let result = lower_source(source);
+    assert!(result.is_ok(), "{result:?}");
+}

--- a/crates/sifr_lowering/src/lower/sequence_guards.rs
+++ b/crates/sifr_lowering/src/lower/sequence_guards.rs
@@ -1,6 +1,7 @@
 use super::LowerCtx;
 use crate::hir_nodes::HirExpr;
 use sifr_python_ast::{Expr, Number, Operator, UnaryOp};
+use sifr_type_system::ParamConvention;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::lower) enum SequenceGuard {
@@ -277,6 +278,23 @@ pub(in crate::lower) fn hir_sequence_guard_target_name(expr: &HirExpr) -> Option
             Some(format!("{base}.{field}"))
         }
         _ => None,
+    }
+}
+
+pub(in crate::lower) fn invalidate_mutable_call_sequence_guards(
+    ctx: &mut LowerCtx,
+    args: &[HirExpr],
+    conventions: impl IntoIterator<Item = ParamConvention>,
+) {
+    for (arg, convention) in args.iter().zip(conventions) {
+        if !convention.is_mut_borrow() {
+            continue;
+        }
+        let Some(target) = hir_sequence_guard_target_name(arg) else {
+            continue;
+        };
+        ctx.clear_sequence_guards_for_binding(&target);
+        ctx.clear_sequence_guards_for_target(&target);
     }
 }
 


### PR DESCRIPTION
## Summary
- remove stored witness missing-action continuations and renew straight-line witnesses without replaying outer control flow
- invalidate mutable-call sequence guards during lowering and require explicit re-guarding before checked reads
- share one canonical loop-break constructor and add nested/native/codegen regressions

## Validation
- `cargo test -p sifr_lowering -p sifr_codegen`
- `cargo test -p sifr_codegen checked_place_read_codegen_tests`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/checked_place_collection_semantics.sifr`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- touched source files remain below 900 lines

The non-E2E Sifr sweep reaches the pre-existing `numeric_sentinels.sifr` type diagnostic; exact base SHA `6862b4a21e` reproduces the same failure.