### PR TITLE
feat(codegen): close stdlib emitted semantics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ rust_decimal = { version = "1.42.1", features = ["maths", "serde-with-str"] }
 rustc-hash = { version = "2.1.3" }
 schemars = { version = "1.2.2" }
 serde = { version = "1.0.229", features = ["derive"] }
-serde_json = "1.0.151"
+serde_json = { version = "1.0.151", features = ["preserve_order"] }
 semver = { version = "1.0.28", features = ["serde"] }
 serde_test = { version = "1.0.177" }
 sha1 = { version = "0.11.0" }

--- a/crates/sifr/tests/e2e/pass/cpython_itertools.sifr
+++ b/crates/sifr/tests/e2e/pass/cpython_itertools.sifr
@@ -17,9 +17,21 @@ def is_even(x: int) -> bool:
 def add2(a: int, b: int) -> int:
     return a + b
 
-def collect_islice(own data: Iterator[int], start_or_stop: int, stop: int | None = None, step: int = 1) -> list[int]:
+def optional_int(value: int) -> int | None:
+    return value
+
+def collect_islice(own data: Iterator[int], stop: int) -> list[int]:
     try:
-        sliced: Iterator[int] = islice(iter(data), start_or_stop, stop, step)
+        sliced: Iterator[int] = islice(iter(data), stop)
+        return list(sliced)
+    except ValueError as e:
+        _message: str = e.message
+        assert_true(False)
+        return []
+
+def collect_islice_range(own data: Iterator[int], start: int, stop: int | None, step: int | None = 1) -> list[int]:
+    try:
+        sliced: Iterator[int] = islice(iter(data), start, stop, step)
         return list(sliced)
     except ValueError as e:
         _message: str = e.message
@@ -74,9 +86,11 @@ def main():
 
     # islice validates invalid arguments at construction and consumes its source lazily.
     assert_true(str(collect_islice(iter([0, 1, 2, 3, 4]), 3)) == "[0, 1, 2]")
-    assert_true(str(collect_islice(iter([0, 1, 2, 3, 4]), 1, 4)) == "[1, 2, 3]")
-    assert_true(str(collect_islice(iter([0, 1, 2, 3, 4]), 1, 5, 2)) == "[1, 3]")
-    assert_true(str(collect_islice(iter([0, 1, 2, 3, 4]), 10, 110, 3)) == "[]")
+    assert_true(str(collect_islice_range(iter([0, 1, 2, 3, 4]), 1, 4)) == "[1, 2, 3]")
+    assert_true(str(collect_islice_range(iter([0, 1, 2, 3, 4]), 1, 5, 2)) == "[1, 3]")
+    assert_true(str(collect_islice_range(iter([0, 1, 2, 3, 4]), 10, 110, 3)) == "[]")
+    assert_true(str(collect_islice_range(iter([0, 1, 2, 3, 4]), 2, None)) == "[2, 3, 4]")
+    assert_true(str(collect_islice_range(iter([0, 1, 2, 3, 4]), 2, None, None)) == "[2, 3, 4]")
     invalid_zero_step: bool = False
     try:
         _zero_step: Iterator[int] = islice(iter([10, 20, 30]), 0, 3, 0)
@@ -143,6 +157,17 @@ def main():
     # cycle (intentional finite signature adaptation: cycle(data, n))
     empty_cycle: list[int] = []
     assert_true(str(list(cycle(iter([1, 2, 3]), 10))) == "[1, 2, 3, 1, 2, 3, 1, 2, 3, 1]")
+    optional_cycle: list[int | None] = []
+    optional_cycle.append(optional_int(1))
+    optional_cycle.append(None)
+    optional_cycle.append(optional_int(2))
+    optional_cycle_expected: list[int | None] = []
+    optional_cycle_expected.append(optional_int(1))
+    optional_cycle_expected.append(None)
+    optional_cycle_expected.append(optional_int(2))
+    optional_cycle_expected.append(optional_int(1))
+    optional_cycle_expected.append(None)
+    assert_true(list(cycle(iter(optional_cycle), 5)) == optional_cycle_expected)
     assert_true(str(list(cycle(iter(empty_cycle), 10))) == "[]")
     assert_true(str(list(cycle(iter([1, 2, 3]), 0))) == "[]")
 

--- a/crates/sifr/tests/e2e/pass/cpython_itertools_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/cpython_itertools_subset.sifr
@@ -8,9 +8,19 @@ def lt3(x: int) -> bool:
 def add2(a: int, b: int) -> int:
     return a + b
 
-def collect_islice(own data: Iterator[int], start_or_stop: int, stop: int | None = None, step: int = 1) -> list[int]:
+def optional_int(value: int) -> int | None:
+    return value
+
+def collect_islice(own data: Iterator[int], stop: int) -> list[int]:
     try:
-        sliced: Iterator[int] = islice(iter(data), start_or_stop, stop, step)
+        sliced: Iterator[int] = islice(iter(data), stop)
+        return list(sliced)
+    except ValueError:
+        return []
+
+def collect_islice_range(own data: Iterator[int], start: int, stop: int | None, step: int | None = 1) -> list[int]:
+    try:
+        sliced: Iterator[int] = islice(iter(data), start, stop, step)
         return list(sliced)
     except ValueError:
         return []
@@ -32,6 +42,8 @@ def collect_core_actual() -> list[bool]:
     actual.append(batched_ok)
 
     actual.append(str(collect_islice(iter([10, 20, 30, 40]), 3)) == "[10, 20, 30]")
+    actual.append(str(collect_islice_range(iter([10, 20, 30, 40]), 1, None)) == "[20, 30, 40]")
+    actual.append(str(collect_islice_range(iter([10, 20, 30, 40]), 1, None, None)) == "[20, 30, 40]")
     actual.append(str(list(accumulate(iter([1, 2, 3, 4])))) == "[1, 3, 6, 10]")
     actual.append(str(list(accumulate(iter([1, 2, 3]), initial=0))) == "[0, 1, 3, 6]")
     actual.append(str(list(compress(iter([1, 2, 3]), iter([True, False, True])))) == "[1, 3]")
@@ -47,6 +59,17 @@ def collect_core_actual() -> list[bool]:
     c3: int | None = next(ctr)
     actual.append(c0 == 5 and c1 == 7 and c2 == 9 and c3 == 11)
     actual.append(str(list(cycle(iter([1, 2, 3]), 5))) == "[1, 2, 3, 1, 2]")
+    optional_values: list[int | None] = []
+    optional_values.append(optional_int(1))
+    optional_values.append(None)
+    optional_values.append(optional_int(2))
+    optional_expected: list[int | None] = []
+    optional_expected.append(optional_int(1))
+    optional_expected.append(None)
+    optional_expected.append(optional_int(2))
+    optional_expected.append(optional_int(1))
+    optional_expected.append(None)
+    actual.append(list(cycle(iter(optional_values), 5)) == optional_expected)
     actual.append(str(list(product([1, 2], [3, 4]))) == "[[1, 3], [1, 4], [2, 3], [2, 4]]")
     actual.append(str(list(product([1, 2], repeat=-1))) == "[]")
     actual.append(str(list(permutations(iter([1, 2, 3]), 2))) == "[[1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]")
@@ -95,7 +118,8 @@ def main():
         True, True, True, True, True, True, True, True,
         True, True, True, True, True, True, True, True,
         True, True, True, True, True, True, True, True,
-        True, True, True, True, True, True
+        True, True, True, True, True, True, True, True,
+        True
     ]
     actual: list[bool] = []
     append_all(actual, collect_core_actual())

--- a/crates/sifr/tests/e2e/pass/cpython_json_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/cpython_json_subset.sifr
@@ -10,12 +10,14 @@ def main() -> None:
         bval: JsonValue = loads("true")
         nval: JsonValue = loads("null")
         sval: JsonValue = loads("\"hi\"")
+        ordered: JsonValue = loads("{\"z\":1,\"a\":2,\"m\":3}")
         assert str(obj) == "{\"a\":1}"
         assert str(arr) == "[1,2,3]"
         assert str(num) == "42"
         assert str(bval) == "true"
         assert str(nval) == "null"
         assert str(sval) == "\"hi\""
+        assert str(ordered) == "{\"z\":1,\"a\":2,\"m\":3}"
     except JSONDecodeError as e:
         assert False
 

--- a/crates/sifr/tests/e2e/pass/exact_integer_bounded_and_float_results.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_integer_bounded_and_float_results.sifr
@@ -42,6 +42,9 @@ def main():
         quotient: float = exact_divide(3, divisor)
         assert quotient == 1.5
 
+        negative_zero: float = exact_divide(0, -2)
+        assert str(negative_zero).startswith("-")
+
         mixed: float = mixed_add(fitting, 0.5)
         assert mixed == 9007199254740992.0
     except Error:

--- a/crates/sifr/tests/e2e/pass/in_memory_streams.sifr
+++ b/crates/sifr/tests/e2e/pass/in_memory_streams.sifr
@@ -14,6 +14,7 @@ def main() -> None:
     bytesio_closed_rejects: bool = False
     bytesio_negative_seek_rejects: bool = False
     binary_file_ok: bool = False
+    binary_error_kind_ok: bool = False
     cleanup_ok: bool = False
 
     path: str = "/tmp/sifr_in_memory_streams_binary.bin"
@@ -74,14 +75,28 @@ def main() -> None:
         _seed: None = write_text(path, "")
         writer: BinaryFileHandle = open_binary(path, "wb")
         _w_file: None = writer.write_bytes(b"memory-stream-sample")
+        _flush_file: None = writer.flush()
         writer.close()
 
         reader: BinaryFileHandle = open_binary(path, "rb")
-        loaded: bytes = reader.read_bytes()
+        head_file: bytes = reader.read_bytes(6)
+        first_position: int = reader.tell()
+        stream_position: int = reader.seek(7)
+        middle_file: bytes = reader.read_bytes(6)
+        tail_position: int = reader.seek(-6, 2)
+        tail_file: bytes = reader.read_bytes()
         reader.close()
-        binary_file_ok = loaded == b"memory-stream-sample"
+        binary_file_ok = head_file == b"memory" and first_position == 6 and stream_position == 7 and middle_file == b"stream" and tail_position == 14 and tail_file == b"sample" and reader.closed()
     except IOError as e:
         _ = str(e.message)
+
+    try:
+        missing: BinaryFileHandle = open_binary(path + ".missing", "rb")
+        missing.close()
+    except FileNotFoundError:
+        binary_error_kind_ok = True
+    except IOError:
+        binary_error_kind_ok = False
 
     try:
         if exists(path):
@@ -97,7 +112,8 @@ def main() -> None:
     actual.append(bytesio_closed_rejects)
     actual.append(bytesio_negative_seek_rejects)
     actual.append(binary_file_ok)
+    actual.append(binary_error_kind_ok)
     actual.append(cleanup_ok)
 
-    expected: list[bool] = [True, True, True, True, True, True, True, True]
+    expected: list[bool] = [True, True, True, True, True, True, True, True, True]
     assert_bool_vector_eq(actual, expected)

--- a/crates/sifr/tests/e2e/pass/string_padding_methods.sifr
+++ b/crates/sifr/tests/e2e/pass/string_padding_methods.sifr
@@ -1,7 +1,27 @@
 
 def main():
-    s: str = "x"
-    assert str("center = [" + s.center(5) + "]") == 'center = [  x  ]'
-    assert str("ljust = [" + s.ljust(4) + "]") == 'ljust = [x   ]'
-    assert str("rjust = [" + s.rjust(4) + "]") == 'rjust = [   x]'
-    assert str("zfill = [" + "7".zfill(4) + "]") == 'zfill = [0007]'
+    try:
+        s: str = "x"
+        centered: str = s.center(5)
+        left: str = s.ljust(4)
+        right: str = s.rjust(4)
+        zeroed: str = "7".zfill(4)
+        signed: str = "-7".zfill(4)
+        unicode: str = "é".ljust(3)
+        unchanged: str = s.center(-100)
+        assert str("center = [" + centered + "]") == 'center = [  x  ]'
+        assert str("ljust = [" + left + "]") == 'ljust = [x   ]'
+        assert str("rjust = [" + right + "]") == 'rjust = [   x]'
+        assert str("zfill = [" + zeroed + "]") == 'zfill = [0007]'
+        assert signed == "-007"
+        assert unicode == "é  "
+        assert unchanged == "x"
+    except OverflowError:
+        assert False
+
+    try:
+        impossible: str = "x".center(100000000000000000000000000000000000000)
+        _ = impossible
+        assert False
+    except OverflowError as error:
+        assert len(error.message) > 0

--- a/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
+++ b/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
@@ -85,7 +85,19 @@ impl RustEmitter {
                 } else {
                     base
                 };
-                let extra = Self::extra_bound_items_for_type_param(type_param, &func.body)
+                let mut extra_bounds = Self::extra_bound_items_for_type_param(type_param, &func.body);
+                let mut closed_bounds = self
+                    .function_type_param_bounds
+                    .get(&func.name)
+                    .and_then(|by_param| by_param.get(type_param))
+                    .into_iter()
+                    .flatten()
+                    .filter(|bound| !extra_bounds.contains(bound))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                closed_bounds.sort();
+                extra_bounds.extend(closed_bounds);
+                let extra = extra_bounds
                     .into_iter()
                     .filter(|bound| !base.split(" + ").any(|existing| existing == bound))
                     .fold(String::new(), |mut rendered, bound| {

--- a/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
+++ b/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
@@ -59,9 +59,9 @@ impl RustEmitter {
                 } else if attached_storage {
                     "Clone + 'static".to_string()
                 } else if needs_hash_eq {
-                    "Clone + std::fmt::Display + PartialOrd + std::hash::Hash + Eq + 'static".to_string()
+                    "Clone + std::hash::Hash + Eq + 'static".to_string()
                 } else {
-                    "Clone + std::fmt::Display + PartialOrd + 'static".to_string()
+                    "Clone + 'static".to_string()
                 };
                 if Self::returns_borrowed_type_param(func, type_param) {
                     Self::append_bound(&mut base, "Clone");

--- a/crates/sifr_codegen/src/function_emitter/tests.rs
+++ b/crates/sifr_codegen/src/function_emitter/tests.rs
@@ -31,6 +31,39 @@ fn regular_int_function(params: Vec<HirParam>, body: Vec<HirStmt>) -> HirFunctio
     }
 }
 
+#[test]
+fn unconstrained_generic_functions_emit_only_ownership_bounds() {
+    let function = HirFunction {
+        name: "forward".to_string(),
+        params: vec![HirParam {
+            name: "value".to_string(),
+            ty: Type::TypeVar("T".to_string()),
+            default: None,
+            keyword_only: false,
+            convention: ParamConvention::own(),
+        }],
+        return_type: Type::TypeVar("T".to_string()),
+        body: vec![HirStmt::Return {
+            value: Some(HirExpr::Name {
+                name: "value".to_string(),
+                binding_id: None,
+                ty: Type::TypeVar("T".to_string()),
+            }),
+        }],
+        is_async: false,
+        method_kind: MethodKind::Regular,
+        receiver: None,
+        decorators: vec![],
+        rust_interop: Vec::new(),
+        python_interop: Vec::new(),
+        compiler_intrinsic: None,
+        type_params: vec!["T".to_string()],
+    };
+
+    let bounds = RustEmitter::new().lower_function_type_params(&function);
+    assert_eq!(bounds[0].bounds, vec!["Clone + 'static"]);
+}
+
 fn helper_returning_name(name: &str) -> HirFunction {
     HirFunction {
         name: "helper".to_string(),

--- a/crates/sifr_codegen/src/function_generic_bounds.rs
+++ b/crates/sifr_codegen/src/function_generic_bounds.rs
@@ -1,0 +1,508 @@
+use crate::{HirExpr, HirFunction, HirModule, HirStmt, RustEmitter, Type};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone)]
+struct GenericCallSite {
+    function: String,
+    explicit_type_args: Vec<Type>,
+    argument_types: Vec<Type>,
+    result_type: Type,
+}
+
+impl RustEmitter {
+    /// Compute the least fixed point of Rust trait requirements for module-level
+    /// generic functions. Source-declared protocol bounds are authoritative,
+    /// direct operations add their concrete Rust traits, and forwarding calls
+    /// propagate the callee requirements onto the corresponding caller type
+    /// parameters.
+    pub(crate) fn closed_function_type_param_bounds(
+        module: &HirModule,
+    ) -> HashMap<String, HashMap<String, HashSet<String>>> {
+        let functions = module
+            .functions
+            .iter()
+            .map(|function| (function.name.as_str(), function))
+            .collect::<HashMap<_, _>>();
+        let mut requirements = module
+            .functions
+            .iter()
+            .filter(|function| !function.type_params.is_empty())
+            .map(|function| {
+                let by_param = function
+                    .type_params
+                    .iter()
+                    .map(|type_param| {
+                        let mut bounds =
+                            Self::extra_bound_items_for_type_param(type_param, &function.body)
+                                .into_iter()
+                                .collect::<HashSet<_>>();
+                        if function_type_param_needs_hash_eq(function, type_param) {
+                            bounds.insert("std::hash::Hash".to_string());
+                            bounds.insert("Eq".to_string());
+                        }
+                        if let Some(declared) = module
+                            .type_param_bounds
+                            .get(&function.name)
+                            .and_then(|by_param| by_param.get(type_param))
+                        {
+                            for specification in declared {
+                                bounds.extend(rust_bounds_for_typevar_spec(
+                                    type_param,
+                                    specification,
+                                ));
+                            }
+                        }
+                        (type_param.clone(), bounds)
+                    })
+                    .collect::<HashMap<_, _>>();
+                (function.name.clone(), by_param)
+            })
+            .collect::<HashMap<_, _>>();
+
+        loop {
+            let mut changed = false;
+            for caller in module
+                .functions
+                .iter()
+                .filter(|function| !function.type_params.is_empty())
+            {
+                for call in collect_generic_call_sites(&caller.body) {
+                    let Some(callee) = functions.get(call.function.as_str()) else {
+                        continue;
+                    };
+                    let Some(callee_requirements) = requirements.get(&callee.name).cloned() else {
+                        continue;
+                    };
+                    for (callee_type_param, bounds) in callee_requirements {
+                        let forwarded =
+                            forwarded_caller_type_params(caller, callee, &call, &callee_type_param);
+                        for caller_type_param in forwarded {
+                            let target = requirements
+                                .entry(caller.name.clone())
+                                .or_default()
+                                .entry(caller_type_param)
+                                .or_default();
+                            let before = target.len();
+                            target.extend(bounds.iter().cloned());
+                            changed |= target.len() != before;
+                        }
+                    }
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+
+        requirements
+    }
+}
+
+fn rust_bounds_for_typevar_spec(type_param: &str, specification: &str) -> Vec<String> {
+    match specification {
+        "Comparable" => vec!["PartialOrd".to_string()],
+        "Addable" => vec![format!("std::ops::Add<Output = {type_param}>")],
+        "Hashable" => vec!["std::hash::Hash".to_string(), "Eq".to_string()],
+        _ => Vec::new(),
+    }
+}
+
+fn function_type_param_needs_hash_eq(function: &HirFunction, type_param: &str) -> bool {
+    function
+        .params
+        .iter()
+        .any(|param| type_contains_hash_key_param(&param.ty, type_param))
+        || type_contains_hash_key_param(&function.return_type, type_param)
+}
+
+fn type_contains_hash_key_param(ty: &Type, type_param: &str) -> bool {
+    match ty.resolve_alias() {
+        Type::Dict(key, value) => {
+            RustEmitter::type_mentions_type_param(key, type_param)
+                || type_contains_hash_key_param(value, type_param)
+        }
+        Type::Set(value) => RustEmitter::type_mentions_type_param(value, type_param),
+        Type::List(value)
+        | Type::Iterable(value)
+        | Type::Iterator(value)
+        | Type::Newtype { inner: value, .. } => type_contains_hash_key_param(value, type_param),
+        Type::Tuple(values) | Type::Union(values) | Type::Intersection(values) => values
+            .iter()
+            .any(|value| type_contains_hash_key_param(value, type_param)),
+        _ => false,
+    }
+}
+
+fn collect_generic_call_sites(body: &[HirStmt]) -> Vec<GenericCallSite> {
+    let mut calls = Vec::new();
+    let mut on_stmt = |_stmt: &HirStmt| {};
+    let mut on_expr = |expr: &HirExpr| match expr {
+        HirExpr::Call { func, args, ty, .. } => calls.push(GenericCallSite {
+            function: func.clone(),
+            explicit_type_args: Vec::new(),
+            argument_types: args.iter().map(|argument| argument.ty().clone()).collect(),
+            result_type: ty.clone(),
+        }),
+        HirExpr::GenericCall {
+            func,
+            type_args,
+            args,
+            ty,
+            ..
+        } => calls.push(GenericCallSite {
+            function: func.clone(),
+            explicit_type_args: type_args.clone(),
+            argument_types: args.iter().map(|argument| argument.ty().clone()).collect(),
+            result_type: ty.clone(),
+        }),
+        _ => {}
+    };
+    crate::hir_analysis::traversal::walk_stmts(
+        body,
+        crate::hir_analysis::traversal::TraversalConfig::LOCAL_SCOPE_ONLY,
+        &mut on_stmt,
+        &mut on_expr,
+    );
+    calls
+}
+
+fn forwarded_caller_type_params(
+    caller: &HirFunction,
+    callee: &HirFunction,
+    call: &GenericCallSite,
+    callee_type_param: &str,
+) -> HashSet<String> {
+    let mut forwarded = HashSet::new();
+    if let Some(index) = callee
+        .type_params
+        .iter()
+        .position(|candidate| candidate == callee_type_param)
+        && let Some(actual) = call.explicit_type_args.get(index)
+    {
+        collect_actual_caller_params(actual, &caller.type_params, &mut forwarded);
+    }
+    for (formal, actual) in callee.params.iter().zip(&call.argument_types) {
+        collect_corresponding_type_params(
+            &formal.ty,
+            actual,
+            callee_type_param,
+            &caller.type_params,
+            &mut forwarded,
+        );
+    }
+    collect_corresponding_type_params(
+        &callee.return_type,
+        &call.result_type,
+        callee_type_param,
+        &caller.type_params,
+        &mut forwarded,
+    );
+    forwarded
+}
+
+fn collect_corresponding_type_params(
+    formal: &Type,
+    actual: &Type,
+    callee_type_param: &str,
+    caller_type_params: &[String],
+    forwarded: &mut HashSet<String>,
+) {
+    let formal = formal.resolve_alias();
+    let actual = actual.resolve_alias();
+    if matches!(formal, Type::TypeVar(name) if name == callee_type_param) {
+        collect_actual_caller_params(actual, caller_type_params, forwarded);
+        return;
+    }
+
+    match (formal, actual) {
+        (Type::List(left), Type::List(right))
+        | (Type::Set(left), Type::Set(right))
+        | (Type::Iterable(left), Type::Iterable(right))
+        | (Type::Iterator(left), Type::Iterator(right))
+        | (Type::PythonBuffer(left), Type::PythonBuffer(right))
+        | (Type::PythonDlpackTensor(left), Type::PythonDlpackTensor(right))
+        | (Type::Awaitable(left), Type::Awaitable(right))
+        | (Type::Failure(left), Type::Failure(right))
+        | (Type::TimeoutResult(left), Type::TimeoutResult(right))
+        | (Type::Newtype { inner: left, .. }, Type::Newtype { inner: right, .. }) => {
+            collect_corresponding_type_params(
+                left,
+                right,
+                callee_type_param,
+                caller_type_params,
+                forwarded,
+            );
+        }
+        (Type::Dict(lk, lv), Type::Dict(rk, rv))
+        | (Type::Result(lk, lv), Type::Result(rk, rv))
+        | (Type::Task(lk, lv), Type::Task(rk, rv))
+        | (Type::TaskResult(lk, lv), Type::TaskResult(rk, rv))
+        | (Type::Coroutine(lk, lv), Type::Coroutine(rk, rv))
+        | (Type::Select2(lk, lv), Type::Select2(rk, rv))
+        | (Type::BlockingTask(lk, lv), Type::BlockingTask(rk, rv))
+        | (Type::JoinSet(lk, lv), Type::JoinSet(rk, rv))
+        | (Type::AsyncIterator(lk, lv), Type::AsyncIterator(rk, rv))
+        | (Type::AsyncGenerator(lk, lv), Type::AsyncGenerator(rk, rv)) => {
+            collect_corresponding_type_params(
+                lk,
+                rk,
+                callee_type_param,
+                caller_type_params,
+                forwarded,
+            );
+            collect_corresponding_type_params(
+                lv,
+                rv,
+                callee_type_param,
+                caller_type_params,
+                forwarded,
+            );
+        }
+        (Type::Tuple(left), Type::Tuple(right))
+        | (Type::Union(left), Type::Union(right))
+        | (Type::Intersection(left), Type::Intersection(right))
+            if left.len() == right.len() =>
+        {
+            for (formal, actual) in left.iter().zip(right) {
+                collect_corresponding_type_params(
+                    formal,
+                    actual,
+                    callee_type_param,
+                    caller_type_params,
+                    forwarded,
+                );
+            }
+        }
+        (
+            Type::Class {
+                identity: left_identity,
+                type_args: left,
+                name: left_name,
+                ..
+            },
+            Type::Class {
+                identity: right_identity,
+                type_args: right,
+                name: right_name,
+                ..
+            },
+        ) if left_identity.as_ref().unwrap_or(left_name)
+            == right_identity.as_ref().unwrap_or(right_name)
+            && left.len() == right.len() =>
+        {
+            for (formal, actual) in left.iter().zip(right) {
+                collect_corresponding_type_params(
+                    formal,
+                    actual,
+                    callee_type_param,
+                    caller_type_params,
+                    forwarded,
+                );
+            }
+        }
+        _ if RustEmitter::type_mentions_type_param(formal, callee_type_param) => {
+            collect_actual_caller_params(actual, caller_type_params, forwarded);
+        }
+        _ => {}
+    }
+}
+
+fn collect_actual_caller_params(
+    actual: &Type,
+    caller_type_params: &[String],
+    forwarded: &mut HashSet<String>,
+) {
+    forwarded.extend(
+        caller_type_params
+            .iter()
+            .filter(|candidate| RustEmitter::type_mentions_type_param(actual, candidate))
+            .cloned(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sifr_ir::{HirParam, MethodKind};
+    use sifr_type_system::ParamConvention;
+
+    fn parameter(name: &str, ty: Type) -> HirParam {
+        HirParam {
+            name: name.to_string(),
+            ty,
+            default: None,
+            keyword_only: false,
+            convention: ParamConvention::own(),
+        }
+    }
+
+    fn function(
+        name: &str,
+        type_param: &str,
+        params: Vec<HirParam>,
+        return_type: Type,
+        body: Vec<HirStmt>,
+    ) -> HirFunction {
+        HirFunction {
+            name: name.to_string(),
+            params,
+            return_type,
+            body,
+            is_async: false,
+            method_kind: MethodKind::Regular,
+            receiver: None,
+            decorators: Vec::new(),
+            rust_interop: Vec::new(),
+            python_interop: Vec::new(),
+            compiler_intrinsic: None,
+            type_params: vec![type_param.to_string()],
+        }
+    }
+
+    fn name(name: &str, ty: Type) -> HirExpr {
+        HirExpr::Name {
+            name: name.to_string(),
+            binding_id: None,
+            ty,
+        }
+    }
+
+    fn call(function: &str, args: Vec<HirExpr>, ty: Type) -> HirStmt {
+        HirStmt::Expr {
+            expr: HirExpr::Call {
+                func: function.to_string(),
+                args,
+                mutable_arg_places: Vec::new(),
+                ty,
+            },
+        }
+    }
+
+    fn module(
+        functions: Vec<HirFunction>,
+        type_param_bounds: HashMap<String, HashMap<String, Vec<String>>>,
+    ) -> HirModule {
+        HirModule {
+            functions,
+            classes: Vec::new(),
+            imports: Vec::new(),
+            constants: Vec::new(),
+            generic_functions: HashMap::new(),
+            type_param_bounds,
+        }
+    }
+
+    #[test]
+    fn source_protocol_bounds_survive_without_local_operator_use() {
+        let passthrough = function(
+            "passthrough",
+            "T",
+            vec![parameter("value", Type::TypeVar("T".to_string()))],
+            Type::TypeVar("T".to_string()),
+            vec![HirStmt::Return {
+                value: Some(name("value", Type::TypeVar("T".to_string()))),
+            }],
+        );
+        let bounds = HashMap::from([(
+            "passthrough".to_string(),
+            HashMap::from([("T".to_string(), vec!["Comparable".to_string()])]),
+        )]);
+
+        let closed =
+            RustEmitter::closed_function_type_param_bounds(&module(vec![passthrough], bounds));
+
+        assert!(closed["passthrough"]["T"].contains("PartialOrd"));
+    }
+
+    #[test]
+    fn generic_call_graph_closes_operator_display_and_hash_requirements() {
+        let compared = Type::TypeVar("Compared".to_string());
+        let compare = function(
+            "compare",
+            "Compared",
+            vec![
+                parameter("left", compared.clone()),
+                parameter("right", compared.clone()),
+            ],
+            Type::Bool,
+            vec![HirStmt::Return {
+                value: Some(HirExpr::Compare {
+                    left: Box::new(name("left", compared.clone())),
+                    ops: vec!["<".to_string()],
+                    comparators: vec![name("right", compared.clone())],
+                    ty: Type::Bool,
+                }),
+            }],
+        );
+        let displayed = Type::TypeVar("Displayed".to_string());
+        let display = function(
+            "display",
+            "Displayed",
+            vec![parameter("value", displayed.clone())],
+            Type::None,
+            vec![call("print", vec![name("value", displayed)], Type::None)],
+        );
+        let keyed = Type::TypeVar("Key".to_string());
+        let key_map = Type::Dict(Box::new(keyed), Box::new(Type::Int));
+        let hash = function(
+            "hash",
+            "Key",
+            vec![parameter("values", key_map)],
+            Type::None,
+            vec![HirStmt::Pass],
+        );
+        let forwarded = Type::TypeVar("Forwarded".to_string());
+        let forwarded_map = Type::Dict(Box::new(forwarded.clone()), Box::new(Type::Int));
+        let forward = function(
+            "forward",
+            "Forwarded",
+            vec![
+                parameter("value", forwarded.clone()),
+                parameter("values", forwarded_map.clone()),
+            ],
+            Type::None,
+            vec![
+                call(
+                    "compare",
+                    vec![
+                        name("value", forwarded.clone()),
+                        name("value", forwarded.clone()),
+                    ],
+                    Type::Bool,
+                ),
+                call(
+                    "display",
+                    vec![name("value", forwarded.clone())],
+                    Type::None,
+                ),
+                call("hash", vec![name("values", forwarded_map)], Type::None),
+            ],
+        );
+        let outer = Type::TypeVar("Outer".to_string());
+        let outer_map = Type::Dict(Box::new(outer.clone()), Box::new(Type::Int));
+        let outer_forward = function(
+            "outer_forward",
+            "Outer",
+            vec![
+                parameter("value", outer.clone()),
+                parameter("values", outer_map.clone()),
+            ],
+            Type::None,
+            vec![call(
+                "forward",
+                vec![name("value", outer), name("values", outer_map)],
+                Type::None,
+            )],
+        );
+
+        let closed = RustEmitter::closed_function_type_param_bounds(&module(
+            vec![compare, display, hash, forward, outer_forward],
+            HashMap::new(),
+        ));
+        let outer_bounds = &closed["outer_forward"]["Outer"];
+
+        for expected in ["PartialOrd", "std::fmt::Display", "std::hash::Hash", "Eq"] {
+            assert!(outer_bounds.contains(expected), "missing {expected}");
+        }
+    }
+}

--- a/crates/sifr_codegen/src/generic_bounds_helpers.rs
+++ b/crates/sifr_codegen/src/generic_bounds_helpers.rs
@@ -705,6 +705,9 @@ impl RustEmitter {
         if requirements.needs_partial_ord {
             extra.push("PartialOrd".to_string());
         }
+        if requirements.needs_display {
+            extra.push("std::fmt::Display".to_string());
+        }
         extra
     }
 

--- a/crates/sifr_codegen/src/helpers/collection_storage.rs
+++ b/crates/sifr_codegen/src/helpers/collection_storage.rs
@@ -48,7 +48,13 @@ pub(crate) fn adapt_collection_value_for_target(
     source_expr: &HirExpr,
     value: RustExpr,
 ) -> RustExpr {
-    flatten_option_value_for_target(target, source_expr.ty(), value)
+    let flattened = flatten_option_value_for_target(target, source_expr.ty(), value);
+    crate::RustEmitter::wrap_option_local_value_for_ir(
+        target,
+        source_expr,
+        source_expr.ty(),
+        flattened,
+    )
 }
 
 /// Adapt representation-significant optional wrappers inside an owned collection value.

--- a/crates/sifr_codegen/src/helpers/tests.rs
+++ b/crates/sifr_codegen/src/helpers/tests.rs
@@ -635,6 +635,18 @@ fn collection_target_coercion_does_not_flatten_a_simple_optional_index() {
 }
 
 #[test]
+fn collection_target_coercion_wraps_a_plain_value_for_optional_storage() {
+    let target = sifr_type_system::make_union(vec![Type::Int, Type::None]);
+    let expr = HirExpr::IntLiteral(3);
+    let rendered = crate::render_expr(&adapt_collection_value_for_target(
+        &target,
+        &expr,
+        RustExpr::Ident("value".to_string()),
+    ));
+    assert_eq!(rendered, "Some(value)");
+}
+
+#[test]
 fn collection_storage_coercion_maps_nested_optional_elements() {
     let target_element = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
     let source_element = Type::Union(vec![target_element.clone(), Type::None]);

--- a/crates/sifr_codegen/src/hir_analysis/queries/queries_impl.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries/queries_impl.rs
@@ -530,6 +530,7 @@ pub(crate) struct TypeVarOpRequirements {
     pub needs_neg: bool,
     pub needs_partial_eq: bool,
     pub needs_partial_ord: bool,
+    pub needs_display: bool,
 }
 
 fn type_mentions_type_var(ty: &Type, type_param_name: &str) -> bool {
@@ -598,7 +599,8 @@ pub(crate) fn collect_typevar_operator_requirements(
 ) -> TypeVarOpRequirements {
     let mut requirements = TypeVarOpRequirements::default();
     let mut on_stmt = |_stmt: &HirStmt| {};
-    let mut on_expr = |expr: &HirExpr| match expr {
+    let mut on_expr = |expr: &HirExpr| {
+        match expr {
         HirExpr::BinOp {
             left,
             op,
@@ -646,7 +648,23 @@ pub(crate) fn collect_typevar_operator_requirements(
                 requirements.needs_partial_ord = true;
             }
         }
+        HirExpr::Call { func, args, .. }
+            if matches!(func.as_str(), "print" | "str")
+                && args
+                    .iter()
+                    .any(|arg| type_mentions_type_var(arg.ty(), type_param_name)) =>
+        {
+            requirements.needs_display = true;
+        }
+        HirExpr::FString { parts, .. }
+            if parts.iter().any(|part| {
+                matches!(part, sifr_ir::HirFStringPart::Expr(value) if type_mentions_type_var(value.ty(), type_param_name))
+            }) =>
+        {
+            requirements.needs_display = true;
+        }
         _ => {}
+    }
     };
     traversal::walk_stmts(
         stmts,

--- a/crates/sifr_codegen/src/hir_analysis/queries/type_and_operator_tests.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries/type_and_operator_tests.rs
@@ -68,6 +68,25 @@ fn collect_typevar_operator_requirements_detects_equality() {
 }
 
 #[test]
+fn collect_typevar_operator_requirements_detects_display_calls() {
+    let stmts = vec![HirStmt::Expr {
+        expr: HirExpr::Call {
+            mutable_arg_places: Vec::new(),
+            func: "str".to_string(),
+            args: vec![HirExpr::Name {
+                name: "value".to_string(),
+                binding_id: None,
+                ty: Type::TypeVar("T".to_string()),
+            }],
+            ty: Type::Str,
+        },
+    }];
+
+    let req = collect_typevar_operator_requirements(&stmts, "T");
+    assert!(req.needs_display);
+}
+
+#[test]
 fn collect_let_declared_types_covers_nested_blocks() {
     let stmts = vec![HirStmt::If {
         condition: HirExpr::BoolLiteral(true),

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -54,6 +54,7 @@ mod expr_ref_emitter;
 mod expr_render_helpers;
 mod field_analysis_helpers;
 mod function_emitter;
+mod function_generic_bounds;
 mod function_like_lowering;
 mod generic_bounds_helpers;
 mod helpers;

--- a/crates/sifr_codegen/src/lib_codegen_tests/union_representation_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/union_representation_codegen_tests.rs
@@ -1,6 +1,20 @@
 use super::*;
 
 #[test]
+fn generic_option_none_comparisons_use_option_predicates_without_partial_eq() {
+    let rust_code = generate_rust_from_source(
+        r#"def both_missing[T](left: T | None, right: T | None) -> bool:
+    return left is None and right == None
+"#,
+    );
+
+    assert!(rust_code.contains("left.is_none()"), "{rust_code}");
+    assert!(rust_code.contains("right.is_none()"), "{rust_code}");
+    assert!(!rust_code.contains("Option<T> == None"), "{rust_code}");
+    assert!(!rust_code.contains("T: PartialEq"), "{rust_code}");
+}
+
+#[test]
 fn owned_optional_argument_widening_is_not_force_unwrapped_after_conversion() {
     let target = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
     let rust_code = generate_rust_from_source(

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -73,6 +73,8 @@ pub struct RustEmitter {
     pub(crate) method_slot_type_params: HashMap<String, HashSet<String>>,
     /// Caller-context type parameters for each structural bridge function.
     pub(crate) context_type_params: HashMap<String, HashSet<String>>,
+    /// Closed Rust trait requirements for each module-level generic function.
+    pub(crate) function_type_param_bounds: HashMap<String, HashMap<String, HashSet<String>>>,
     /// Set of stdlib/intrinsic modules used (for Cargo dependency injection)
     pub used_stdlib_modules: HashSet<String>,
     /// Set of intrinsic function names (for codegen dispatch)
@@ -278,6 +280,7 @@ impl RustEmitter {
             string_structural_type_params: HashMap::new(),
             method_slot_type_params: HashMap::new(),
             context_type_params: HashMap::new(),
+            function_type_param_bounds: HashMap::new(),
             used_stdlib_modules: HashSet::new(),
             intrinsic_functions: HashSet::new(),
             intrinsic_registry_features: HashSet::new(),

--- a/crates/sifr_codegen/src/methods/mod.rs
+++ b/crates/sifr_codegen/src/methods/mod.rs
@@ -379,11 +379,10 @@ mod tests {
         )
         .expect("center lowers");
         let center_rendered = render_expr(&center.expr);
-        assert!(
-            center_rendered
-                .contains("let _w = ::sifr_runtime::to_usize_proven(&SifrInt::from_i64(5))"),
-            "{center_rendered}"
-        );
+        assert!(center_rendered.contains("sifr_runtime::checked_center"));
+        assert!(center_rendered.contains("map_err"));
+        assert!(center_rendered.contains("OverflowError::new"));
+        assert!(!center_rendered.contains("to_usize"));
 
         let ljust = lower_method(
             &Type::Str,
@@ -392,10 +391,10 @@ mod tests {
             &["SifrInt::from_i64(5)".to_string()],
         )
         .expect("ljust lowers");
-        assert_eq!(
-            render_expr(&ljust.expr),
-            "format!(\"{:<1$}\", s, ::sifr_runtime::to_usize_proven(&SifrInt::from_i64(5)))"
-        );
+        let ljust_rendered = render_expr(&ljust.expr);
+        assert!(ljust_rendered.contains("sifr_runtime::checked_ljust"));
+        assert!(ljust_rendered.contains("OverflowError::new"));
+        assert!(!ljust_rendered.contains("to_usize"));
 
         let rjust = lower_method(
             &Type::Str,
@@ -404,10 +403,10 @@ mod tests {
             &["SifrInt::from_i64(5)".to_string()],
         )
         .expect("rjust lowers");
-        assert_eq!(
-            render_expr(&rjust.expr),
-            "format!(\"{:>1$}\", s, ::sifr_runtime::to_usize_proven(&SifrInt::from_i64(5)))"
-        );
+        let rjust_rendered = render_expr(&rjust.expr);
+        assert!(rjust_rendered.contains("sifr_runtime::checked_rjust"));
+        assert!(rjust_rendered.contains("OverflowError::new"));
+        assert!(!rjust_rendered.contains("to_usize"));
 
         let zfill = lower_method(
             &Type::Str,
@@ -416,10 +415,10 @@ mod tests {
             &["SifrInt::from_i64(5)".to_string()],
         )
         .expect("zfill lowers");
-        assert_eq!(
-            render_expr(&zfill.expr),
-            "format!(\"{:0>1$}\", s, ::sifr_runtime::to_usize_proven(&SifrInt::from_i64(5)))"
-        );
+        let zfill_rendered = render_expr(&zfill.expr);
+        assert!(zfill_rendered.contains("sifr_runtime::checked_zfill"));
+        assert!(zfill_rendered.contains("OverflowError::new"));
+        assert!(!zfill_rendered.contains("to_usize"));
 
         let list_clear = lower_method(&Type::List(Box::new(Type::Int)), "clear", "xs", &[])
             .expect("list clear lowers");
@@ -799,12 +798,22 @@ mod tests {
         let big_quantize =
             lower_method(&Type::BigDecimal, "quantize", "bd", &["digits".to_string()])
                 .expect("bigdecimal quantize lowers");
-        assert!(render_expr(&big_quantize.expr).contains("round_decimal_ref"));
+        let big_quantize_rendered = render_expr(&big_quantize.expr);
+        assert!(big_quantize_rendered.contains("round_decimal_ref"));
+        assert!(big_quantize_rendered.contains("bigdecimal::Context::new"));
+        assert!(big_quantize_rendered.contains("NonZeroU64::MIN.saturating_add(27)"));
+        assert!(!big_quantize_rendered.contains("unwrap_or_else"));
+        assert!(!big_quantize_rendered.contains("with_prec"));
 
         let big_sqrt =
             lower_method(&Type::BigDecimal, "sqrt", "bd", &[]).expect("bigdecimal sqrt lowers");
-        assert!(render_expr(&big_sqrt.expr).contains("sqrt_with_context"));
-        assert!(render_expr(&big_sqrt.expr).contains("DecimalConversionError"));
+        let big_sqrt_rendered = render_expr(&big_sqrt.expr);
+        assert!(big_sqrt_rendered.contains("sqrt_with_context"));
+        assert!(big_sqrt_rendered.contains("DecimalConversionError"));
+        assert!(big_sqrt_rendered.contains("bigdecimal::Context::new"));
+        assert!(big_sqrt_rendered.contains("NonZeroU64::MIN.saturating_add(27)"));
+        assert!(!big_sqrt_rendered.contains("unwrap_or_else"));
+        assert!(!big_sqrt_rendered.contains("with_prec"));
 
         let big_round =
             lower_method(&Type::BigDecimal, "round", "bd", &[]).expect("bigdecimal round lowers");

--- a/crates/sifr_codegen/src/methods/string.rs
+++ b/crates/sifr_codegen/src/methods/string.rs
@@ -717,133 +717,50 @@ pub(super) fn lower_islower(object: &RustExpr, args: &[RustExpr]) -> Option<Rust
 }
 
 pub(super) fn lower_center(object: &RustExpr, args: &[RustExpr]) -> Option<RustExpr> {
-    if args.len() != 1 {
-        return None;
-    }
-    Some(RustExpr::Block {
-        stmts: vec![
-            RustStmt::Let {
-                mutable: false,
-                name: "_s".to_string(),
-                ty: None,
-                value: RustExpr::Clone(Box::new(object.clone())),
-            },
-            RustStmt::Let {
-                mutable: false,
-                name: "_w".to_string(),
-                ty: None,
-                value: exact_int_to_usize_expr(args[0].clone()),
-            },
-            RustStmt::Let {
-                mutable: false,
-                name: "_len".to_string(),
-                ty: None,
-                value: RustExpr::MethodCall {
-                    receiver: Box::new(RustExpr::MethodCall {
-                        receiver: Box::new(RustExpr::Ident("_s".to_string())),
-                        method: "chars".to_string(),
-                        args: vec![],
-                    }),
-                    method: "count".to_string(),
-                    args: vec![],
-                },
-            },
-        ],
-        expr: Some(Box::new(RustExpr::If {
-            cond: Box::new(RustExpr::BinOp {
-                left: Box::new(RustExpr::Ident("_len".to_string())),
-                op: ">=".to_string(),
-                right: Box::new(RustExpr::Ident("_w".to_string())),
-            }),
-            then_expr: Box::new(RustExpr::Ident("_s".to_string())),
-            else_expr: Some(Box::new(RustExpr::Block {
-                stmts: vec![
-                    RustStmt::Let {
-                        mutable: false,
-                        name: "_pad".to_string(),
-                        ty: None,
-                        value: RustExpr::BinOp {
-                            left: Box::new(RustExpr::Ident("_w".to_string())),
-                            op: "-".to_string(),
-                            right: Box::new(RustExpr::Ident("_len".to_string())),
-                        },
-                    },
-                    RustStmt::Let {
-                        mutable: false,
-                        name: "_left".to_string(),
-                        ty: None,
-                        value: RustExpr::BinOp {
-                            left: Box::new(RustExpr::Ident("_pad".to_string())),
-                            op: "/".to_string(),
-                            right: Box::new(RustExpr::Literal(RustLiteral::Int(2))),
-                        },
-                    },
-                    RustStmt::Let {
-                        mutable: false,
-                        name: "_right".to_string(),
-                        ty: None,
-                        value: RustExpr::BinOp {
-                            left: Box::new(RustExpr::Ident("_pad".to_string())),
-                            op: "-".to_string(),
-                            right: Box::new(RustExpr::Ident("_left".to_string())),
-                        },
-                    },
-                ],
-                expr: Some(Box::new(RustExpr::FormatMacro {
-                    name: "format".to_string(),
-                    format_str: "{}{}{}".to_string(),
-                    args: vec![
-                        RustExpr::MethodCall {
-                            receiver: Box::new(RustExpr::Literal(RustLiteral::Str(
-                                " ".to_string(),
-                            ))),
-                            method: "repeat".to_string(),
-                            args: vec![RustExpr::Ident("_left".to_string())],
-                        },
-                        RustExpr::Ident("_s".to_string()),
-                        RustExpr::MethodCall {
-                            receiver: Box::new(RustExpr::Literal(RustLiteral::Str(
-                                " ".to_string(),
-                            ))),
-                            method: "repeat".to_string(),
-                            args: vec![RustExpr::Ident("_right".to_string())],
-                        },
-                    ],
-                })),
-            })),
-        })),
-    })
+    lower_checked_padding(object, args, "checked_center")
 }
 
 pub(super) fn lower_ljust(object: &RustExpr, args: &[RustExpr]) -> Option<RustExpr> {
-    if args.len() != 1 {
-        return None;
-    }
-    Some(RustExpr::FormatMacro {
-        name: "format".to_string(),
-        format_str: "{:<1$}".to_string(),
-        args: vec![object.clone(), exact_int_to_usize_expr(args[0].clone())],
-    })
+    lower_checked_padding(object, args, "checked_ljust")
 }
 
 pub(super) fn lower_rjust(object: &RustExpr, args: &[RustExpr]) -> Option<RustExpr> {
-    if args.len() != 1 {
-        return None;
-    }
-    Some(RustExpr::FormatMacro {
-        name: "format".to_string(),
-        format_str: "{:>1$}".to_string(),
-        args: vec![object.clone(), exact_int_to_usize_expr(args[0].clone())],
-    })
+    lower_checked_padding(object, args, "checked_rjust")
 }
 
 pub(super) fn lower_zfill(object: &RustExpr, args: &[RustExpr]) -> Option<RustExpr> {
+    lower_checked_padding(object, args, "checked_zfill")
+}
+
+fn lower_checked_padding(object: &RustExpr, args: &[RustExpr], helper: &str) -> Option<RustExpr> {
     if args.len() != 1 {
         return None;
     }
-    Some(RustExpr::FormatMacro {
-        name: "format".to_string(),
-        format_str: "{:0>1$}".to_string(),
-        args: vec![object.clone(), exact_int_to_usize_expr(args[0].clone())],
+    Some(RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec![
+                "sifr_runtime".to_string(),
+                helper.to_string(),
+            ])),
+            args: vec![
+                render_borrowed_arg_expr(object),
+                render_borrowed_arg_expr(&args[0]),
+            ],
+        }),
+        method: "map_err".to_string(),
+        args: vec![RustExpr::Closure {
+            params: vec![RustParam::Named {
+                name: "__padding_error".to_string(),
+                ty: RustType::Named("_".to_string()),
+            }],
+            body: Box::new(RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec![
+                    "OverflowError".to_string(),
+                    "new".to_string(),
+                ])),
+                args: vec![RustExpr::Ident("__padding_error".to_string())],
+            }),
+            is_move: false,
+        }],
     })
 }

--- a/crates/sifr_codegen/src/module_prescan.rs
+++ b/crates/sifr_codegen/src/module_prescan.rs
@@ -51,6 +51,7 @@ impl RustEmitter {
         self.static_program_type_params = static_program;
         self.method_slot_type_params = method_slots;
         self.context_type_params = context;
+        self.function_type_param_bounds = Self::closed_function_type_param_bounds(module);
     }
 
     pub(crate) fn collect_import_metadata(&mut self, module: &HirModule) {

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_wrappers_and_compare.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_wrappers_and_compare.rs
@@ -604,6 +604,54 @@ macro_rules! stmt_expr_contains_unary_compare_bool {
                         "is not" => "!=".to_string(),
                         _ => return Ok(None),
                     };
+                    let left_none_like = matches!(lhs_expr, HirExpr::NoneLiteral)
+                        || matches!(
+                            crate::resolve_alias_type_for_plain_call(lhs_expr.ty()),
+                            Type::None
+                        );
+                    let right_none_like = matches!(rhs_expr, HirExpr::NoneLiteral)
+                        || matches!(
+                            crate::resolve_alias_type_for_plain_call(rhs_expr.ty()),
+                            Type::None
+                        );
+                    let option_expr = if left_none_like
+                        && crate::helpers::is_option_type(rhs_expr.ty())
+                    {
+                        Some(rhs_expr)
+                    } else if right_none_like && crate::helpers::is_option_type(lhs_expr.ty()) {
+                        Some(lhs_expr)
+                    } else {
+                        None
+                    };
+                    if matches!(lowered_op.as_str(), "==" | "!=")
+                        && let Some(option_expr) = option_expr
+                    {
+                        let Some(lowered_option) =
+                            $emitter.lower_stmt_expr_for_ir(option_expr)?
+                        else {
+                            return Ok(None);
+                        };
+                        let lowered_cmp = crate::RustExpr::MethodCall {
+                            receiver: Box::new(lowered_option),
+                            method: if lowered_op == "==" {
+                                "is_none".to_string()
+                            } else {
+                                "is_some".to_string()
+                            },
+                            args: Vec::new(),
+                        };
+                        lowered_chain = Some(if let Some(existing) = lowered_chain {
+                            crate::RustExpr::BinOp {
+                                left: Box::new(existing),
+                                op: "&&".to_string(),
+                                right: Box::new(lowered_cmp),
+                            }
+                        } else {
+                            lowered_cmp
+                        });
+                        lhs_expr = rhs_expr;
+                        continue;
+                    }
                     if matches!(lowered_op.as_str(), "==" | "!=") {
                         let borrowed_left =
                             $emitter.try_lower_borrowed_string_lookup_for_compare(lhs_expr)?;
@@ -684,16 +732,6 @@ macro_rules! stmt_expr_contains_unary_compare_bool {
                         && right_witness_ty.is_none())
                         || crate::stmt_support_emitter::compiler_verified_pop_lowers_as_option_for_ir(
                             rhs_expr,
-                        );
-                    let left_none_like = matches!(lhs_expr, HirExpr::NoneLiteral)
-                        || matches!(
-                            crate::resolve_alias_type_for_plain_call(lhs_expr.ty()),
-                            Type::None
-                        );
-                    let right_none_like = matches!(rhs_expr, HirExpr::NoneLiteral)
-                        || matches!(
-                            crate::resolve_alias_type_for_plain_call(rhs_expr.ty()),
-                            Type::None
                         );
                     let left_ty = crate::resolve_alias_type_for_plain_call(
                         left_witness_ty.as_ref().unwrap_or_else(|| lhs_expr.ty()),

--- a/crates/sifr_lowering/src/lower/expressions/call_shadowable_builtins.rs
+++ b/crates/sifr_lowering/src/lower/expressions/call_shadowable_builtins.rs
@@ -56,6 +56,17 @@ fn prefer_complete_class_surface(fallback: Type, candidate: Option<Type>) -> Typ
     })
 }
 
+fn register_compiler_open_handle_defaults(ctx: &mut LowerCtx, class_name: &str) {
+    ctx.function_defaults
+        .entry(format!("{class_name}.seek"))
+        .or_insert_with(|| vec![(1, HirExpr::IntLiteral(0))]);
+    if class_name == "FileHandle" {
+        ctx.function_defaults
+            .entry("FileHandle.read_bytes".to_string())
+            .or_insert_with(|| vec![(0, HirExpr::NoneLiteral)]);
+    }
+}
+
 fn string_literal_value(expr: &Expr) -> Option<String> {
     match expr {
         Expr::StringLiteral(literal) => Some(literal.value.to_str().to_string()),
@@ -301,6 +312,7 @@ pub(super) fn lower_shadowable_builtin_call(
                 class_type_with_identity(ctx, TEXT_FILE_HANDLE_IDENTITY),
             );
             fill_file_handle_receiver_conventions(&mut text_handle_ty);
+            register_compiler_open_handle_defaults(ctx, "TextFileHandle");
             if let Some(error_ty) = ctx.class_types.get("IOError") {
                 ctx.try_block_error_types.insert(error_ty.clone());
             }
@@ -383,7 +395,10 @@ pub(super) fn lower_shadowable_builtin_call(
                 (
                     "read_bytes".to_string(),
                     FunctionType::all_borrow(
-                        vec![],
+                        vec![(
+                            "size".to_string(),
+                            sifr_type_system::make_union(vec![Type::Int, Type::None]),
+                        )],
                         Type::Result(Box::new(Type::Bytes), Box::new(io_err_ty.clone())),
                     ),
                 ),
@@ -423,6 +438,7 @@ pub(super) fn lower_shadowable_builtin_call(
             class_type_with_identity(ctx, FILE_HANDLE_IDENTITY),
         );
         fill_file_handle_receiver_conventions(&mut file_handle_ty);
+        register_compiler_open_handle_defaults(ctx, "FileHandle");
         // Register IOError as a possible exception from this call
         if let Some(error_ty) = ctx.class_types.get("IOError") {
             ctx.try_block_error_types.insert(error_ty.clone());

--- a/crates/sifr_lowering/src/lower/expressions/method_type_objects.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_type_objects.rs
@@ -1,8 +1,9 @@
 use super::{
     DiagnosticCode, FunctionType, HirExpr, LowerCtx, TextRange, Type,
     canonicalize_class_surface_type, coroutine_result_type, expression_diagnostics,
-    method_count_range, reject_exact_method_arg_count, reject_method_arg_count,
-    reject_no_method_args, resolve_method_type, resolve_str_encode_method_type, str,
+    expression_operators, method_count_range, reject_exact_method_arg_count,
+    reject_method_arg_count, reject_no_method_args, resolve_method_type,
+    resolve_str_encode_method_type, str,
 };
 pub(super) fn resolve_str_method_type(
     method: &str,
@@ -123,7 +124,25 @@ pub(super) fn resolve_str_method_type(
                 );
                 return None;
             }
-            Some(Type::Str)
+            if args[0].ty() != &Type::Int {
+                expression_diagnostics::type_mismatch(
+                    ctx,
+                    format!(
+                        "str.{method}() width must be 'int', got '{}'",
+                        args[0].ty().display_name()
+                    ),
+                    arg_ranges[0],
+                );
+            }
+            Some(Type::Result(
+                Box::new(Type::Str),
+                Box::new(expression_operators::builtin_error_type(
+                    ctx,
+                    "OverflowError",
+                    "Error",
+                    vec![],
+                )),
+            ))
         }
         "find" | "rfind" => {
             if args.len() != 1 {

--- a/crates/sifr_lowering/src/lower/expressions_tests/control_flow_and_strings.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/control_flow_and_strings.rs
@@ -1,4 +1,35 @@
 use super::*;
+
+#[test]
+pub(super) fn test_string_padding_methods_expose_typed_allocation_failure() {
+    let result = lower_source(
+        "def pad(value: str, width: int) -> Result[str, OverflowError]:\n    return value.center(width)\n",
+    );
+
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[test]
+pub(super) fn test_string_padding_width_requires_exact_integer() {
+    let source = "def main():\n    padded = \"x\".ljust(3.5)\n";
+    let errors = lower_source(source).expect_err("float padding width should be rejected");
+
+    assert!(errors.iter().any(|error| {
+        error.message.contains("str.ljust() width must be 'int'")
+            && error.code == Some(DiagnosticCode::TYPE_MISMATCH)
+            && error.primary_range == Some(range_for(source, "3.5"))
+    }));
+}
+
+#[test]
+pub(super) fn test_varargs_adopt_declared_optional_element_type() {
+    let result = lower_source(
+        "def count_values(*values: int | None) -> int:\n    return len(values)\n\ndef main():\n    count: int = count_values(1, 2)\n",
+    );
+
+    assert!(result.is_ok(), "{result:?}");
+}
+
 #[test]
 pub(super) fn test_duplicate_optional_method_keyword_is_rejected() {
     let source = "def main():\n    data: dict[str, int] = {\"x\": 1}\n    value: int = data.get(\"x\", 1, default=2)\n";

--- a/crates/sifr_lowering/src/lower/method_call_args.rs
+++ b/crates/sifr_lowering/src/lower/method_call_args.rs
@@ -522,9 +522,23 @@ fn lower_vararg_function_call_args(
     };
     let vararg_ty = ft.params.get(vararg_index).map(|(_, ty, _)| ty.clone());
     let vararg_elem_ty = if vararg_elements.is_empty() {
-        match vararg_ty {
+        match vararg_ty.clone() {
             Some(Type::List(elem_ty)) => *elem_ty,
             Some(_) | None => Type::Any,
+        }
+    } else if let Some(Type::List(expected_elem_ty)) = vararg_ty.as_ref() {
+        if vararg_elements
+            .iter()
+            .all(|element| element.ty().is_assignable_to(expected_elem_ty))
+        {
+            expected_elem_ty.as_ref().clone()
+        } else {
+            make_union(
+                vararg_elements
+                    .iter()
+                    .map(|element| element.ty().clone())
+                    .collect(),
+            )
         }
     } else {
         make_union(

--- a/crates/sifr_lowering/src/lower/name_import_diagnostics_tests.rs
+++ b/crates/sifr_lowering/src/lower/name_import_diagnostics_tests.rs
@@ -325,6 +325,40 @@ fn builtin_open_preserves_an_aliased_imported_binary_handle_identity() {
 }
 
 #[test]
+fn builtin_binary_open_supplies_the_read_bytes_size_default() {
+    let source = "from sifr.io import FileHandle as Handle\n\ndef main():\n    handle: Handle = open(\"out.bin\", \"rb\")\n    payload: bytes = handle.read_bytes()\n";
+    let parsed = parse_module(source).expect("parse failed");
+    let mut externals = ExternalDefs::default();
+    externals.classes.insert(
+        "sifr.io".to_string(),
+        HashMap::from([(
+            "FileHandle".to_string(),
+            Type::Class {
+                identity: Some("sifr.io.FileHandle".to_string()),
+                type_args: Vec::new(),
+                name: "FileHandle".to_string(),
+                fields: Vec::new(),
+                methods: vec![(
+                    "read_bytes".to_string(),
+                    FunctionType::all_borrow(
+                        vec![(
+                            "size".to_string(),
+                            sifr_type_system::make_union(vec![Type::Int, Type::None]),
+                        )],
+                        Type::Bytes,
+                    )
+                    .with_receiver(sifr_type_system::ReceiverConvention::MutableBorrow),
+                )],
+                parent_class: None,
+            },
+        )]),
+    );
+
+    lower_module_with_externals(parsed.suite(), &externals)
+        .expect("compiler-special binary open should retain the no-size read_bytes form");
+}
+
+#[test]
 fn builtin_open_never_reuses_a_local_same_basename_handle() {
     for source in [
         "class TextFileHandle:\n    value: int\n\ndef main():\n    handle: TextFileHandle = open(\"out.txt\", \"w\", encoding=\"utf-8\")\n",

--- a/crates/sifr_runtime/src/int.rs
+++ b/crates/sifr_runtime/src/int.rs
@@ -602,7 +602,11 @@ fn exact_bigint_ratio_to_f64(
     denominator: &BigInt,
 ) -> Result<f64, IntegerDivisionError> {
     if numerator.is_zero() {
-        return Ok(0.0);
+        return Ok(if denominator.sign() == Sign::Minus {
+            -0.0
+        } else {
+            0.0
+        });
     }
     let negative = numerator.sign() != denominator.sign();
     let mut numerator = numerator.abs();

--- a/crates/sifr_runtime/src/int_tests.rs
+++ b/crates/sifr_runtime/src/int_tests.rs
@@ -210,6 +210,16 @@ fn exact_integer_converts_to_fitting_fixed_width_targets() {
 }
 
 #[test]
+fn exact_zero_divided_by_negative_integer_preserves_negative_zero() {
+    let quotient = SifrInt::from_i64(0)
+        .checked_true_div(&SifrInt::from_i64(-2))
+        .expect("nonzero exact divisor should succeed");
+
+    assert_eq!(quotient, 0.0);
+    assert!(quotient.is_sign_negative());
+}
+
+#[test]
 fn exact_integer_conversion_reports_typed_range_errors() {
     let too_large = SifrInt::parse_decimal(
         "340282366920938463463374607431768211456",

--- a/crates/sifr_runtime/src/lib.rs
+++ b/crates/sifr_runtime/src/lib.rs
@@ -20,6 +20,7 @@ mod nonempty_vec;
 pub mod python;
 mod range;
 mod slice;
+mod string_padding;
 #[cfg(any(feature = "net", feature = "tls", feature = "http", test))]
 mod timeouts;
 #[cfg(feature = "tls")]
@@ -38,3 +39,4 @@ pub use int::{
 pub use nonempty_vec::SifrNonEmptyVec;
 pub use range::SifrRange;
 pub use slice::SifrSliceIndices;
+pub use string_padding::{checked_center, checked_ljust, checked_rjust, checked_zfill};

--- a/crates/sifr_runtime/src/string_padding.rs
+++ b/crates/sifr_runtime/src/string_padding.rs
@@ -1,0 +1,128 @@
+use crate::SifrInt;
+
+const WIDTH_RANGE_ERROR: &str = "requested string width exceeds the addressable platform range";
+const CAPACITY_ERROR: &str = "requested string width cannot be allocated";
+
+pub fn checked_ljust(value: &str, width: &SifrInt) -> Result<String, String> {
+    checked_pad(value, width, Alignment::Left)
+}
+
+pub fn checked_rjust(value: &str, width: &SifrInt) -> Result<String, String> {
+    checked_pad(value, width, Alignment::Right)
+}
+
+pub fn checked_center(value: &str, width: &SifrInt) -> Result<String, String> {
+    checked_pad(value, width, Alignment::Center)
+}
+
+pub fn checked_zfill(value: &str, width: &SifrInt) -> Result<String, String> {
+    let width = normalized_width(width)?;
+    let character_count = value.chars().count();
+    let padding = width.saturating_sub(character_count);
+    if padding == 0 {
+        return checked_copy(value);
+    }
+
+    let mut output = reserved_string(value.len(), padding)?;
+    let mut chars = value.chars();
+    if let Some(sign @ ('+' | '-')) = chars.next() {
+        output.push(sign);
+        push_repeated(&mut output, '0', padding);
+        output.extend(chars);
+    } else {
+        push_repeated(&mut output, '0', padding);
+        output.push_str(value);
+    }
+    Ok(output)
+}
+
+#[derive(Clone, Copy)]
+enum Alignment {
+    Left,
+    Right,
+    Center,
+}
+
+fn checked_pad(value: &str, width: &SifrInt, alignment: Alignment) -> Result<String, String> {
+    let width = normalized_width(width)?;
+    let padding = width.saturating_sub(value.chars().count());
+    if padding == 0 {
+        return checked_copy(value);
+    }
+
+    let (left, right) = match alignment {
+        Alignment::Left => (0, padding),
+        Alignment::Right => (padding, 0),
+        Alignment::Center => (padding / 2, padding - (padding / 2)),
+    };
+    let mut output = reserved_string(value.len(), padding)?;
+    push_repeated(&mut output, ' ', left);
+    output.push_str(value);
+    push_repeated(&mut output, ' ', right);
+    Ok(output)
+}
+
+fn normalized_width(width: &SifrInt) -> Result<usize, String> {
+    if width.is_negative() {
+        return Ok(0);
+    }
+    width
+        .try_to_usize()
+        .map_err(|_| WIDTH_RANGE_ERROR.to_string())
+}
+
+fn checked_copy(value: &str) -> Result<String, String> {
+    let mut output = reserved_string(value.len(), 0)?;
+    output.push_str(value);
+    Ok(output)
+}
+
+fn reserved_string(value_bytes: usize, padding: usize) -> Result<String, String> {
+    let capacity = value_bytes
+        .checked_add(padding)
+        .ok_or_else(|| CAPACITY_ERROR.to_string())?;
+    let mut output = String::new();
+    output
+        .try_reserve_exact(capacity)
+        .map_err(|_| CAPACITY_ERROR.to_string())?;
+    Ok(output)
+}
+
+fn push_repeated(output: &mut String, value: char, count: usize) {
+    for _ in 0..count {
+        output.push(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{checked_center, checked_ljust, checked_rjust, checked_zfill};
+    use crate::SifrInt;
+
+    #[test]
+    fn padding_preserves_python_width_and_sign_semantics() {
+        assert_eq!(checked_ljust("x", &SifrInt::from_i64(4)), Ok("x   ".into()));
+        assert_eq!(checked_rjust("x", &SifrInt::from_i64(4)), Ok("   x".into()));
+        assert_eq!(
+            checked_center("x", &SifrInt::from_i64(4)),
+            Ok(" x  ".into())
+        );
+        assert_eq!(
+            checked_zfill("-7", &SifrInt::from_i64(4)),
+            Ok("-007".into())
+        );
+        assert_eq!(
+            checked_zfill("+7", &SifrInt::from_i64(4)),
+            Ok("+007".into())
+        );
+        assert_eq!(checked_ljust("é", &SifrInt::from_i64(3)), Ok("é  ".into()));
+        assert_eq!(checked_ljust("x", &SifrInt::from_i64(-1)), Ok("x".into()));
+    }
+
+    #[test]
+    fn out_of_range_width_is_typed_failure() {
+        let width = SifrInt::parse_decimal("100000000000000000000000000000", 40)
+            .expect("fixture integer parses");
+        assert!(checked_center("x", &width).is_err());
+    }
+}

--- a/crates/sifr_stdlib/src/fs.rs
+++ b/crates/sifr_stdlib/src/fs.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fs::{self, DirEntry, File, OpenOptions},
-    io::{BufRead as _, BufReader, BufWriter, Read as _, Write as _},
+    io::{BufRead as _, BufReader, BufWriter, Read as _, Seek as _, SeekFrom, Write as _},
     path::{Path, PathBuf},
     process::Command,
     sync::{
@@ -10,7 +10,7 @@ use std::{
     },
 };
 
-use sifr_runtime::interop::SifrIntBridge;
+use sifr_runtime::{SifrInt, interop::SifrIntBridge};
 
 enum FileHandleEntry {
     TextRead(BufReader<File>),
@@ -106,16 +106,61 @@ pub fn file_close(handle: &str) {
     file_handles().remove(handle);
 }
 
-pub fn file_read_bytes(handle: &str) -> Result<Vec<u8>, std::io::Error> {
+pub fn file_read_bytes(
+    handle: &str,
+    size: Option<SifrIntBridge>,
+) -> Result<Vec<u8>, std::io::Error> {
     with_binary_reader(handle, |reader| {
-        let mut bytes = Vec::new();
-        reader.read_to_end(&mut bytes)?;
-        Ok(bytes)
+        read_bytes_with_limit(reader, read_size_limit(size.as_ref()))
     })
 }
 
 pub fn file_write_bytes(handle: &str, data: &[u8]) -> Result<(), std::io::Error> {
     with_binary_writer(handle, |writer| writer.write_all(data))
+}
+
+pub fn file_flush(handle: &str) -> Result<(), std::io::Error> {
+    let mut handles = file_handles();
+    match handles.get_mut(handle) {
+        Some(FileHandleEntry::TextWrite(writer)) | Some(FileHandleEntry::BinaryWrite(writer)) => {
+            writer.flush()
+        }
+        Some(FileHandleEntry::TextRead(_) | FileHandleEntry::BinaryRead(_)) => Ok(()),
+        None => Err(std::io::Error::other("unknown file handle")),
+    }
+}
+
+pub fn file_seek(
+    handle: &str,
+    offset: SifrIntBridge,
+    whence: SifrIntBridge,
+) -> Result<SifrIntBridge, std::io::Error> {
+    let seek_from = seek_from(&offset, &whence)?;
+    let mut handles = file_handles();
+    let position = match handles.get_mut(handle) {
+        Some(FileHandleEntry::TextRead(reader)) | Some(FileHandleEntry::BinaryRead(reader)) => {
+            reader.seek(seek_from)
+        }
+        Some(FileHandleEntry::TextWrite(writer)) | Some(FileHandleEntry::BinaryWrite(writer)) => {
+            writer.seek(seek_from)
+        }
+        None => Err(std::io::Error::other("unknown file handle")),
+    }?;
+    Ok(SifrIntBridge::from(SifrInt::from(position)))
+}
+
+pub fn file_tell(handle: &str) -> Result<SifrIntBridge, std::io::Error> {
+    let mut handles = file_handles();
+    let position = match handles.get_mut(handle) {
+        Some(FileHandleEntry::TextRead(reader)) | Some(FileHandleEntry::BinaryRead(reader)) => {
+            reader.stream_position()
+        }
+        Some(FileHandleEntry::TextWrite(writer)) | Some(FileHandleEntry::BinaryWrite(writer)) => {
+            writer.stream_position()
+        }
+        None => Err(std::io::Error::other("unknown file handle")),
+    }?;
+    Ok(SifrIntBridge::from(SifrInt::from(position)))
 }
 
 pub fn getcwd() -> Result<String, std::io::Error> {
@@ -377,6 +422,68 @@ fn with_binary_writer<T>(
     match handles.get_mut(handle) {
         Some(FileHandleEntry::BinaryWrite(writer)) => write(writer),
         _ => Err(std::io::Error::other("file not open for binary writing")),
+    }
+}
+
+fn read_size_limit(size: Option<&SifrIntBridge>) -> Option<u64> {
+    let size = size?;
+    if size.as_sifr_int() < &SifrInt::from_i64(0) {
+        return None;
+    }
+    Some(size.try_to_u64().unwrap_or(u64::MAX))
+}
+
+fn read_bytes_with_limit(
+    reader: &mut BufReader<File>,
+    limit: Option<u64>,
+) -> Result<Vec<u8>, std::io::Error> {
+    const CHUNK_SIZE: usize = 8 * 1024;
+    const CHUNK_SIZE_U64: u64 = 8 * 1024;
+
+    let mut bytes = Vec::new();
+    let mut remaining = limit.unwrap_or(u64::MAX);
+    while remaining > 0 {
+        let chunk_len = usize::try_from(remaining.min(CHUNK_SIZE_U64)).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid read size")
+        })?;
+        let mut chunk = [0_u8; CHUNK_SIZE];
+        let read = reader.read(&mut chunk[..chunk_len])?;
+        if read == 0 {
+            break;
+        }
+        bytes.try_reserve(read).map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::OutOfMemory,
+                format!("unable to allocate binary read buffer: {error}"),
+            )
+        })?;
+        bytes.extend_from_slice(&chunk[..read]);
+        let read_u64 = u64::try_from(read).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid read length")
+        })?;
+        remaining -= read_u64;
+    }
+    Ok(bytes)
+}
+
+fn seek_from(offset: &SifrIntBridge, whence: &SifrIntBridge) -> Result<SeekFrom, std::io::Error> {
+    let whence = whence.try_to_i64().map_err(|error| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+    })?;
+    match whence {
+        0 => offset.try_to_u64().map(SeekFrom::Start).map_err(|error| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+        }),
+        1 => offset.try_to_i64().map(SeekFrom::Current).map_err(|error| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+        }),
+        2 => offset.try_to_i64().map(SeekFrom::End).map_err(|error| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+        }),
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid whence: {whence}"),
+        )),
     }
 }
 

--- a/crates/sifr_stdlib/tests/api_behavior.rs
+++ b/crates/sifr_stdlib/tests/api_behavior.rs
@@ -501,15 +501,46 @@ fn fs_native_file_handles_match_text_and_binary_surfaces() {
         sifr_stdlib::fs::open_file(&binary_path, "wb").expect("binary writer should open");
     sifr_stdlib::fs::file_write_bytes(&binary_writer, b"bytes")
         .expect("binary writer should write");
+    sifr_stdlib::fs::file_flush(&binary_writer).expect("binary writer should flush");
     assert!(sifr_stdlib::fs::file_write(&binary_writer, "text").is_err());
     sifr_stdlib::fs::file_close(&binary_writer);
 
     let binary_reader =
         sifr_stdlib::fs::open_file(&binary_path, "rb").expect("binary reader should open");
     assert_eq!(
-        sifr_stdlib::fs::file_read_bytes(&binary_reader).expect("binary reader should read"),
-        b"bytes".to_vec()
+        sifr_stdlib::fs::file_read_bytes(&binary_reader, Some(2_i64.into()))
+            .expect("bounded binary read should succeed"),
+        b"by".to_vec()
     );
+    assert_eq!(
+        sifr_stdlib::fs::file_tell(&binary_reader)
+            .expect("binary position should be available")
+            .to_i64_saturating(),
+        2
+    );
+    assert_eq!(
+        sifr_stdlib::fs::file_seek(&binary_reader, 1_i64.into(), 1_i64.into())
+            .expect("relative seek should succeed")
+            .to_i64_saturating(),
+        3
+    );
+    assert_eq!(
+        sifr_stdlib::fs::file_read_bytes(&binary_reader, Some(1_i64.into()))
+            .expect("second bounded read should succeed"),
+        b"e".to_vec()
+    );
+    assert_eq!(
+        sifr_stdlib::fs::file_seek(&binary_reader, (-2_i64).into(), 2_i64.into())
+            .expect("end-relative seek should succeed")
+            .to_i64_saturating(),
+        3
+    );
+    assert_eq!(
+        sifr_stdlib::fs::file_read_bytes(&binary_reader, None)
+            .expect("unbounded binary read should succeed"),
+        b"es".to_vec()
+    );
+    assert!(sifr_stdlib::fs::file_seek(&binary_reader, 0_i64.into(), 3_i64.into()).is_err());
     sifr_stdlib::fs::file_close(&binary_reader);
 
     let invalid = sifr_stdlib::fs::open_file(&binary_path, "q")

--- a/demos/additional_modules/emitted.rs
+++ b/demos/additional_modules/emitted.rs
@@ -180,14 +180,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -204,7 +233,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -230,14 +259,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1477,7 +1522,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1525,14 +1570,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1548,14 +1593,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1570,7 +1619,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1628,19 +1677,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1656,14 +1704,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1678,7 +1730,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1770,7 +1822,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1822,7 +1874,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1862,6 +1914,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2472,7 +2534,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2493,7 +2555,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2532,7 +2594,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3298,7 +3360,7 @@ mod __sifr_project_nominals {
                     .map(|__kv| (__kv.0.clone(), __kv.1.clone()))
                     .collect::<Vec<_>>()
                 {
-                    if (value == None) {
+                    if (value.is_none()) {
                         lines.push(key.clone());
                     } else {
                         if let Some(value) = value {
@@ -3320,7 +3382,7 @@ mod __sifr_project_nominals {
                     .map(|__kv| (__kv.0.clone(), __kv.1.clone()))
                     .collect::<Vec<_>>()
                 {
-                    if (value == None) {
+                    if (value.is_none()) {
                         lines.push(key.clone());
                     } else {
                         if let Some(value) = value {
@@ -3338,7 +3400,7 @@ mod __sifr_project_nominals {
                         .normalize_index_or_len(__sifr_index_list.len());
                     __sifr_index_list.get(__sifr_index_norm).cloned()
                 };
-                if (maybe_last != None) && (maybe_last == Some("".to_string())) {
+                if (maybe_last.is_some()) && (maybe_last == Some("".to_string())) {
                     if let Some(_) = lines.pop() {}
                 }
             }
@@ -3637,7 +3699,7 @@ mod __sifr_project_nominals {
                             merged,
                             &normalized_key,
                         );
-                        if (replacement == None) {
+                        if (replacement.is_none()) {
                             result.push_str("%(");
                             result.push_str((key).as_str());
                             result.push_str(")s");
@@ -4285,14 +4347,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -4306,7 +4394,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4325,14 +4413,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -5170,7 +5274,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5191,7 +5295,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5230,7 +5334,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5501,7 +5605,7 @@ fn _resolve_interpolation(
                         merged,
                         &normalized_key,
                     );
-                    if (replacement == None) {
+                    if (replacement.is_none()) {
                         result.push_str("%(");
                         result.push_str((key).as_str());
                         result.push_str(")s");
@@ -5633,10 +5737,7 @@ fn lt(a: SifrInt, b: SifrInt) -> bool {
 fn eq(a: SifrInt, b: SifrInt) -> bool {
     &a == &b
 }
-fn getitem<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    items: &Vec<T>,
-    index: SifrInt,
-) -> Option<T> {
+fn getitem<T: Clone + 'static>(items: &Vec<T>, index: SifrInt) -> Option<T> {
     {
         let __sifr_checked_read_collection = &items;
         let __sifr_checked_read_index = index.clone();
@@ -5645,10 +5746,7 @@ fn getitem<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         __sifr_checked_read_collection.get(__sifr_checked_read_normalized).cloned()
     }
 }
-fn itemgetter<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    items: &Vec<T>,
-    index: SifrInt,
-) -> Option<T> {
+fn itemgetter<T: Clone + 'static>(items: &Vec<T>, index: SifrInt) -> Option<T> {
     getitem(items, (index).clone())
 }
 fn run_command(cmd: &String) -> Result<String, IOError> {

--- a/demos/advanced_class_libraries/emitted.rs
+++ b/demos/advanced_class_libraries/emitted.rs
@@ -687,14 +687,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -711,7 +740,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -737,14 +766,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1984,7 +2029,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -2032,14 +2077,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -2055,14 +2100,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -2077,7 +2126,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -2135,19 +2184,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2163,14 +2211,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2185,7 +2237,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2277,7 +2329,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -2329,7 +2381,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -2369,6 +2421,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2979,7 +3041,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3000,7 +3062,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3039,7 +3101,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -6228,7 +6290,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -6249,7 +6311,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -6270,7 +6332,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -6893,14 +6955,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -6914,7 +7002,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6933,14 +7021,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -7778,7 +7882,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -7799,7 +7903,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -7838,7 +7942,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -9543,7 +9647,7 @@ fn _iterdir_to_iter(path: &String) -> Result<Box<dyn Iterator<Item = String>>, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -9564,7 +9668,7 @@ fn _glob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -9585,7 +9689,7 @@ fn _rglob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/binary_files/emitted.rs
+++ b/demos/binary_files/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1297,7 +1342,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1345,14 +1390,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1368,14 +1413,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1390,7 +1439,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1413,9 +1462,6 @@ mod __sifr_project_nominals {
     }
     pub fn _closed_stream_error() -> String {
         "I/O operation on closed stream".to_string()
-    }
-    pub fn _unsupported_seek_tell_error() -> String {
-        "seek/tell is unsupported for this stream".to_string()
     }
     pub fn _mode_is_readable(mode: &String) -> bool {
         mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
@@ -1874,14 +1920,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -1895,7 +1967,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1914,14 +1986,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -2607,9 +2695,6 @@ fn encode(
 fn _closed_stream_error() -> String {
     "I/O operation on closed stream".to_string()
 }
-fn _unsupported_seek_tell_error() -> String {
-    "seek/tell is unsupported for this stream".to_string()
-}
 fn _mode_is_readable(mode: &String) -> bool {
     mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
 }
@@ -2739,7 +2824,7 @@ fn main() {
                 ),
             )
         })()?;
-        let loaded: Vec<u8> = reader.read_bytes()?;
+        let loaded: Vec<u8> = reader.read_bytes(&None)?;
         reader.close();
         payload_ok = (loaded
             == vec![

--- a/demos/binary_hashing/emitted.rs
+++ b/demos/binary_hashing/emitted.rs
@@ -251,14 +251,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -275,7 +304,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -301,14 +330,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -869,14 +914,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -890,7 +961,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -909,14 +980,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/binary_storage/emitted.rs
+++ b/demos/binary_storage/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1297,7 +1342,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1345,14 +1390,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1368,14 +1413,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1390,7 +1439,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1413,9 +1462,6 @@ mod __sifr_project_nominals {
     }
     pub fn _closed_stream_error() -> String {
         "I/O operation on closed stream".to_string()
-    }
-    pub fn _unsupported_seek_tell_error() -> String {
-        "seek/tell is unsupported for this stream".to_string()
     }
     pub fn _mode_is_readable(mode: &String) -> bool {
         mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
@@ -1874,14 +1920,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -1895,7 +1967,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1914,14 +1986,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -2607,9 +2695,6 @@ fn encode(
 fn _closed_stream_error() -> String {
     "I/O operation on closed stream".to_string()
 }
-fn _unsupported_seek_tell_error() -> String {
-    "seek/tell is unsupported for this stream".to_string()
-}
 fn _mode_is_readable(mode: &String) -> bool {
     mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
 }
@@ -2870,7 +2955,7 @@ fn main() {
                 ),
             )
         })()?;
-        let loaded: Vec<u8> = reader.read_bytes()?;
+        let loaded: Vec<u8> = reader.read_bytes(&None)?;
         reader.close();
         io_ok = (((loaded == payload))
             && ((format!(

--- a/demos/bisect/emitted.rs
+++ b/demos/bisect/emitted.rs
@@ -98,7 +98,7 @@ fn bisect_right<T: Clone + 'static + PartialOrd>(
     }
     left.clone()
 }
-fn insort_left<T: Clone + 'static>(
+fn insort_left<T: Clone + 'static + PartialOrd>(
     a: &mut Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -107,7 +107,7 @@ fn insort_left<T: Clone + 'static>(
     let pos: SifrInt = bisect_left(a, x, (lo).clone(), (hi).clone());
     a.insert(::sifr_runtime::to_usize_proven(&pos), x.clone());
 }
-fn insort_right<T: Clone + 'static>(
+fn insort_right<T: Clone + 'static + PartialOrd>(
     a: &mut Vec<T>,
     x: &T,
     lo: SifrInt,

--- a/demos/bisect/emitted.rs
+++ b/demos/bisect/emitted.rs
@@ -2,7 +2,7 @@
 use ::sifr_runtime::SifrInt;
 
 // --- stdlib: sifr.bisect ---
-fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn bisect_left<T: Clone + 'static + PartialOrd>(
     a: &Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -13,7 +13,7 @@ fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         left = SifrInt::from_i64(0);
     }
     let mut right: SifrInt = SifrInt::from(a.len());
-    if (hi == None) {
+    if (hi.is_none()) {
         right = SifrInt::from(a.len());
     } else {
         if let Some(hi) = hi.clone() {
@@ -50,7 +50,7 @@ fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     left.clone()
 }
-fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn bisect_right<T: Clone + 'static + PartialOrd>(
     a: &Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -61,7 +61,7 @@ fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         left = SifrInt::from_i64(0);
     }
     let mut right: SifrInt = SifrInt::from(a.len());
-    if (hi == None) {
+    if (hi.is_none()) {
         right = SifrInt::from(a.len());
     } else {
         if let Some(hi) = hi.clone() {
@@ -98,7 +98,7 @@ fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     left.clone()
 }
-fn insort_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn insort_left<T: Clone + 'static>(
     a: &mut Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -107,7 +107,7 @@ fn insort_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     let pos: SifrInt = bisect_left(a, x, (lo).clone(), (hi).clone());
     a.insert(::sifr_runtime::to_usize_proven(&pos), x.clone());
 }
-fn insort_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn insort_right<T: Clone + 'static>(
     a: &mut Vec<T>,
     x: &T,
     lo: SifrInt,

--- a/demos/builtin_callables/emitted.rs
+++ b/demos/builtin_callables/emitted.rs
@@ -20,9 +20,7 @@ pub use __sifr_project_nominals::ValueError;
 use ::std::collections::HashMap;
 use ::sifr_runtime::SifrInt;
 use ::sifr_runtime::SifrRange;
-fn assert_ok<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    value: Result<T, Error>,
-) {
+fn assert_ok<T: Clone + 'static>(value: Result<T, Error>) {
     let __sifr_try_res: Result<(), Error> = (|| {
         let out: T = value?;
         Ok(())
@@ -31,9 +29,7 @@ fn assert_ok<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         assert!(false);
     }
 }
-fn assert_err<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    value: Result<T, Error>,
-) {
+fn assert_err<T: Clone + 'static>(value: Result<T, Error>) {
     let __sifr_try_res: Result<(), Error> = (|| {
         let out: T = value?;
         assert!(false);

--- a/demos/bytes_file_io/emitted.rs
+++ b/demos/bytes_file_io/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1297,7 +1342,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1345,14 +1390,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1368,14 +1413,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1390,7 +1439,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1413,9 +1462,6 @@ mod __sifr_project_nominals {
     }
     pub fn _closed_stream_error() -> String {
         "I/O operation on closed stream".to_string()
-    }
-    pub fn _unsupported_seek_tell_error() -> String {
-        "seek/tell is unsupported for this stream".to_string()
     }
     pub fn _mode_is_readable(mode: &String) -> bool {
         mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
@@ -1874,14 +1920,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -1895,7 +1967,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1914,14 +1986,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -2607,9 +2695,6 @@ fn encode(
 fn _closed_stream_error() -> String {
     "I/O operation on closed stream".to_string()
 }
-fn _unsupported_seek_tell_error() -> String {
-    "seek/tell is unsupported for this stream".to_string()
-}
 fn _mode_is_readable(mode: &String) -> bool {
     mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
 }
@@ -2739,7 +2824,7 @@ fn main() {
                 ),
             )
         })()?;
-        let loaded: Vec<u8> = reader.read_bytes()?;
+        let loaded: Vec<u8> = reader.read_bytes(&None)?;
         reader.close();
         loaded_ok = (loaded
             == vec![

--- a/demos/class_libraries/emitted.rs
+++ b/demos/class_libraries/emitted.rs
@@ -487,7 +487,7 @@ mod __sifr_project_nominals {
                     .normalize_index_or_len(__sifr_checked_read_collection.len());
                 __sifr_checked_read_collection.get(__sifr_checked_read_normalized).cloned()
             };
-            if (current != None) && (current == Some((*node).clone())) {
+            if (current.is_some()) && (current == Some((*node).clone())) {
                 self._next_index = &self._next_index.clone() + &SifrInt::from_i64(1);
             }
         }
@@ -814,14 +814,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -838,7 +867,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -864,14 +893,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -2119,7 +2164,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -2167,14 +2212,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -2190,14 +2235,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -2212,7 +2261,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -2270,19 +2319,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2298,14 +2346,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2320,7 +2372,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2412,7 +2464,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -2464,7 +2516,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -2504,6 +2556,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -3114,7 +3176,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3135,7 +3197,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3174,7 +3236,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -4213,7 +4275,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -4234,7 +4296,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -4255,7 +4317,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -5295,14 +5357,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -5316,7 +5404,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5335,14 +5423,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -6188,7 +6292,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6209,7 +6313,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6248,7 +6352,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6656,7 +6760,7 @@ fn _iterdir_to_iter(path: &String) -> Result<Box<dyn Iterator<Item = String>>, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6677,7 +6781,7 @@ fn _glob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6698,7 +6802,7 @@ fn _rglob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/code_generation/emitted.rs
+++ b/demos/code_generation/emitted.rs
@@ -13,7 +13,7 @@ fn main() {
     println!("Division 10/2: {}", result);
     assert!((format!("{}", format!("Division 10/2: {}", result)) == "Division 10/2: 5"));
     let val: Option<SifrInt> = None;
-    if (val == None) {
+    if (val.is_none()) {
         println!("None value: None");
     } else {
         if let Some(val) = val.clone() {

--- a/demos/codegen_preamble/emitted.rs
+++ b/demos/codegen_preamble/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1476,7 +1521,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1524,14 +1569,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1547,14 +1592,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1569,7 +1618,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1627,19 +1676,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1655,14 +1703,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1677,7 +1729,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1769,7 +1821,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1821,7 +1873,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1861,6 +1913,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2471,7 +2533,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2492,7 +2554,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2531,7 +2593,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3527,14 +3589,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3548,7 +3636,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3567,14 +3655,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4412,7 +4516,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4433,7 +4537,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4472,7 +4576,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/collections/emitted.rs
+++ b/demos/collections/emitted.rs
@@ -752,9 +752,9 @@ use ::std::collections::HashMap;
 use ::std::collections::HashSet;
 use ::std::collections::VecDeque;
 use ::sifr_runtime::SifrInt;
-fn from_list<
-    T: Clone + ::std::fmt::Display + PartialOrd + ::std::hash::Hash + Eq + 'static,
->(items: &Vec<T>) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
+fn from_list<T: Clone + ::std::hash::Hash + Eq + 'static>(
+    items: &Vec<T>,
+) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
     let mut counts: HashMap<T, SifrInt> = HashMap::from([]);
     for item in items.iter().cloned() {
         let val: Option<SifrInt> = counts.get(&item).cloned();

--- a/demos/collections_and_argparse/emitted.rs
+++ b/demos/collections_and_argparse/emitted.rs
@@ -951,7 +951,7 @@ mod __sifr_project_nominals {
                 __sifr_chars_token.get(__sifr_string_index_normalized)
             })
                 .map(|c| c.to_string());
-            if (ch != None) && (ch == Some("=".to_string())) {
+            if (ch.is_some()) && (ch == Some("=".to_string())) {
                 let mut value: String = "".to_string();
                 let mut j: SifrInt = &i + &SifrInt::from_i64(1);
                 while (&j < &SifrInt::from(__sifr_chars_token.len())) {
@@ -1671,7 +1671,7 @@ fn _split_inline_option(token: &String) -> (bool, String, String) {
             __sifr_chars_token.get(__sifr_string_index_normalized)
         })
             .map(|c| c.to_string());
-        if (ch != None) && (ch == Some("=".to_string())) {
+        if (ch.is_some()) && (ch == Some("=".to_string())) {
             let mut value: String = "".to_string();
             let mut j: SifrInt = &i + &SifrInt::from_i64(1);
             while (&j < &SifrInt::from(__sifr_chars_token.len())) {

--- a/demos/config_json_csv/emitted.rs
+++ b/demos/config_json_csv/emitted.rs
@@ -182,14 +182,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -206,7 +235,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -232,14 +261,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1479,7 +1524,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1527,14 +1572,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1550,14 +1595,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1572,7 +1621,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1630,19 +1679,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1658,14 +1706,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1680,7 +1732,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1772,7 +1824,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1824,7 +1876,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1864,6 +1916,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2474,7 +2536,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2495,7 +2557,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2534,7 +2596,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3300,7 +3362,7 @@ mod __sifr_project_nominals {
                     .map(|__kv| (__kv.0.clone(), __kv.1.clone()))
                     .collect::<Vec<_>>()
                 {
-                    if (value == None) {
+                    if (value.is_none()) {
                         lines.push(key.clone());
                     } else {
                         if let Some(value) = value {
@@ -3322,7 +3384,7 @@ mod __sifr_project_nominals {
                     .map(|__kv| (__kv.0.clone(), __kv.1.clone()))
                     .collect::<Vec<_>>()
                 {
-                    if (value == None) {
+                    if (value.is_none()) {
                         lines.push(key.clone());
                     } else {
                         if let Some(value) = value {
@@ -3340,7 +3402,7 @@ mod __sifr_project_nominals {
                         .normalize_index_or_len(__sifr_index_list.len());
                     __sifr_index_list.get(__sifr_index_norm).cloned()
                 };
-                if (maybe_last != None) && (maybe_last == Some("".to_string())) {
+                if (maybe_last.is_some()) && (maybe_last == Some("".to_string())) {
                     if let Some(_) = lines.pop() {}
                 }
             }
@@ -3639,7 +3701,7 @@ mod __sifr_project_nominals {
                             merged,
                             &normalized_key,
                         );
-                        if (replacement == None) {
+                        if (replacement.is_none()) {
                             result.push_str("%(");
                             result.push_str((key).as_str());
                             result.push_str(")s");
@@ -4932,7 +4994,7 @@ mod __sifr_project_nominals {
         tokens.push(format!("{}{}", value.kind.clone(), ""));
         if (value.kind.clone() == "bool") {
             let bool_value: Option<bool> = value.bool_value;
-            if (bool_value == None) {
+            if (bool_value.is_none()) {
                 tokens.push("false".to_string());
             } else {
                 if let Some(bool_value) = bool_value {
@@ -4942,7 +5004,7 @@ mod __sifr_project_nominals {
         } else {
             if (value.kind.clone() == "int") {
                 let int_value: Option<SifrInt> = value.int_value.clone();
-                if (int_value == None) {
+                if (int_value.is_none()) {
                     tokens.push("0".to_string());
                 } else {
                     if let Some(int_value) = int_value.clone() {
@@ -4952,7 +5014,7 @@ mod __sifr_project_nominals {
             } else {
                 if (value.kind.clone() == "float") {
                     let float_value: Option<f64> = value.float_value;
-                    if (float_value == None) {
+                    if (float_value.is_none()) {
                         tokens.push("0.0".to_string());
                     } else {
                         if let Some(float_value) = float_value {
@@ -4962,7 +5024,7 @@ mod __sifr_project_nominals {
                 } else {
                     if (value.kind.clone() == "str") {
                         let str_value: Option<String> = value.as_str();
-                        if (str_value == None) {
+                        if (str_value.is_none()) {
                             tokens.push("".to_string());
                         } else {
                             if let Some(str_value) = str_value {
@@ -5520,14 +5582,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -5541,7 +5629,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5560,14 +5648,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -6405,7 +6509,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6426,7 +6530,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6465,7 +6569,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6736,7 +6840,7 @@ fn _resolve_interpolation(
                         merged,
                         &normalized_key,
                     );
-                    if (replacement == None) {
+                    if (replacement.is_none()) {
                         result.push_str("%(");
                         result.push_str((key).as_str());
                         result.push_str(")s");
@@ -7527,7 +7631,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -7537,7 +7641,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -7547,7 +7651,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -7557,7 +7661,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {

--- a/demos/constrained_typevars/emitted.rs
+++ b/demos/constrained_typevars/emitted.rs
@@ -1,11 +1,11 @@
 // src/main.rs
 use ::sifr_runtime::SifrInt;
 
-fn echo<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(x: &T) -> T {
+fn echo<T: Clone + 'static>(x: &T) -> T {
     x.clone()
 }
 
-fn smallest<U: Clone + ::std::fmt::Display + PartialOrd + 'static>(a: &U, b: &U) -> U {
+fn smallest<U: Clone + 'static + PartialOrd>(a: &U, b: &U) -> U {
     if *a < *b {
         return a.clone();
     }

--- a/demos/core_libraries/emitted.rs
+++ b/demos/core_libraries/emitted.rs
@@ -1295,14 +1295,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -1319,7 +1348,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -1345,14 +1374,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -2641,14 +2686,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -2662,7 +2733,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2681,14 +2752,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/core_stdlib/emitted.rs
+++ b/demos/core_stdlib/emitted.rs
@@ -181,14 +181,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -205,7 +234,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -231,14 +260,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1515,7 +1560,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1563,14 +1608,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1586,14 +1631,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1608,7 +1657,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1666,19 +1715,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1694,14 +1742,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1716,7 +1768,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1808,7 +1860,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1860,7 +1912,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1900,6 +1952,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2510,7 +2572,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2531,7 +2593,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2570,7 +2632,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2892,7 +2954,7 @@ mod __sifr_project_nominals {
         tokens.push(format!("{}{}", value.kind.clone(), ""));
         if (value.kind.clone() == "bool") {
             let bool_value: Option<bool> = value.bool_value;
-            if (bool_value == None) {
+            if (bool_value.is_none()) {
                 tokens.push("false".to_string());
             } else {
                 if let Some(bool_value) = bool_value {
@@ -2902,7 +2964,7 @@ mod __sifr_project_nominals {
         } else {
             if (value.kind.clone() == "int") {
                 let int_value: Option<SifrInt> = value.int_value.clone();
-                if (int_value == None) {
+                if (int_value.is_none()) {
                     tokens.push("0".to_string());
                 } else {
                     if let Some(int_value) = int_value.clone() {
@@ -2912,7 +2974,7 @@ mod __sifr_project_nominals {
             } else {
                 if (value.kind.clone() == "float") {
                     let float_value: Option<f64> = value.float_value;
-                    if (float_value == None) {
+                    if (float_value.is_none()) {
                         tokens.push("0.0".to_string());
                     } else {
                         if let Some(float_value) = float_value {
@@ -2922,7 +2984,7 @@ mod __sifr_project_nominals {
                 } else {
                     if (value.kind.clone() == "str") {
                         let str_value: Option<String> = value.as_str();
-                        if (str_value == None) {
+                        if (str_value.is_none()) {
                             tokens.push("".to_string());
                         } else {
                             if let Some(str_value) = str_value {
@@ -3399,14 +3461,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3420,7 +3508,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3439,14 +3527,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4284,7 +4388,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4305,7 +4409,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4344,7 +4448,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4848,7 +4952,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -4858,7 +4962,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -4868,7 +4972,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -4878,7 +4982,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {

--- a/demos/csv/emitted.rs
+++ b/demos/csv/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1476,7 +1521,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1524,14 +1569,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1547,14 +1592,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1569,7 +1618,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1627,19 +1676,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1655,14 +1703,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1677,7 +1729,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1769,7 +1821,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1821,7 +1873,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1861,6 +1913,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2471,7 +2533,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2492,7 +2554,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2531,7 +2593,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3492,14 +3554,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3513,7 +3601,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3532,14 +3620,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4377,7 +4481,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4398,7 +4502,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4437,7 +4541,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/decimal_conversions/emitted.rs
+++ b/demos/decimal_conversions/emitted.rs
@@ -197,14 +197,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -218,7 +244,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -237,14 +263,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -1519,7 +1561,7 @@ impl __SifrIoFileHandle {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
-        Ok(())
+        file_flush(&self._handle)
     }
 }
 impl __SifrIoFileHandle {
@@ -1567,14 +1609,14 @@ impl __SifrIoFileHandle {
     }
 }
 impl __SifrIoFileHandle {
-    fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+    fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
         if !self.readable() {
             return Err(IOError::new("stream is not readable".to_string()));
         }
-        file_read_bytes(&self._handle)
+        file_read_bytes(&self._handle, (size.clone()).clone())
     }
 }
 impl __SifrIoFileHandle {
@@ -1590,14 +1632,18 @@ impl __SifrIoFileHandle {
 }
 impl __SifrIoFileHandle {
     fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-        let _ = offset.clone();
-        let _ = whence.clone();
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
     }
 }
 impl __SifrIoFileHandle {
     fn tell(&self) -> Result<SifrInt, IOError> {
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_tell(&self._handle)
     }
 }
 impl __SifrIoFileHandle {
@@ -1612,7 +1658,7 @@ impl __SifrIoFileHandle {
 }
 impl __SifrIoFileHandle {
     fn seekable(&self) -> bool {
-        false
+        !(self._closed)
     }
 }
 impl __SifrIoFileHandle {
@@ -1670,19 +1716,18 @@ impl __SifrIoBinaryFileHandle {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
-        Ok(())
+        file_flush(&self._handle)
     }
 }
 impl __SifrIoBinaryFileHandle {
     fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-        let _ = (size).clone();
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
         if !self.readable() {
             return Err(IOError::new("stream is not readable".to_string()));
         }
-        file_read_bytes(&self._handle)
+        file_read_bytes(&self._handle, (size.clone()).clone())
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -1698,14 +1743,18 @@ impl __SifrIoBinaryFileHandle {
 }
 impl __SifrIoBinaryFileHandle {
     fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-        let _ = offset.clone();
-        let _ = whence.clone();
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
     }
 }
 impl __SifrIoBinaryFileHandle {
     fn tell(&self) -> Result<SifrInt, IOError> {
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_tell(&self._handle)
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -1720,7 +1769,7 @@ impl __SifrIoBinaryFileHandle {
 }
 impl __SifrIoBinaryFileHandle {
     fn seekable(&self) -> bool {
-        false
+        !(self._closed)
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -1812,7 +1861,7 @@ impl __SifrIoTextFileHandle {
                         __sifr_try_variant_error,
                     ) => {
                         let e = __sifr_try_variant_error.clone();
-                        return Err(IOError::new(e.message.clone()));
+                        return Err(e);
                     }
                     __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                         __sifr_try_variant_error,
@@ -1864,7 +1913,7 @@ impl __SifrIoTextFileHandle {
                         __sifr_try_variant_error,
                     ) => {
                         let e = __sifr_try_variant_error.clone();
-                        return Err(IOError::new(e.message.clone()));
+                        return Err(e);
                     }
                     __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                         __sifr_try_variant_error,
@@ -1904,6 +1953,16 @@ impl __SifrIoTextFileHandle {
                     .to_string(),
             ),
         )
+    }
+}
+impl __SifrIoTextFileHandle {
+    fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+        self._binary.seek(offset, whence)
+    }
+}
+impl __SifrIoTextFileHandle {
+    fn tell(&self) -> Result<SifrInt, IOError> {
+        self._binary.tell()
     }
 }
 impl __SifrIoTextFileHandle {
@@ -2506,7 +2565,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2527,7 +2586,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2566,7 +2625,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2888,7 +2947,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -2898,7 +2957,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -2908,7 +2967,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -2918,7 +2977,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {

--- a/demos/decimal_verification/emitted.rs
+++ b/demos/decimal_verification/emitted.rs
@@ -258,14 +258,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -279,7 +305,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -298,14 +324,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -1580,7 +1622,7 @@ impl __SifrIoFileHandle {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
-        Ok(())
+        file_flush(&self._handle)
     }
 }
 impl __SifrIoFileHandle {
@@ -1628,14 +1670,14 @@ impl __SifrIoFileHandle {
     }
 }
 impl __SifrIoFileHandle {
-    fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+    fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
         if !self.readable() {
             return Err(IOError::new("stream is not readable".to_string()));
         }
-        file_read_bytes(&self._handle)
+        file_read_bytes(&self._handle, (size.clone()).clone())
     }
 }
 impl __SifrIoFileHandle {
@@ -1651,14 +1693,18 @@ impl __SifrIoFileHandle {
 }
 impl __SifrIoFileHandle {
     fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-        let _ = offset.clone();
-        let _ = whence.clone();
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
     }
 }
 impl __SifrIoFileHandle {
     fn tell(&self) -> Result<SifrInt, IOError> {
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_tell(&self._handle)
     }
 }
 impl __SifrIoFileHandle {
@@ -1673,7 +1719,7 @@ impl __SifrIoFileHandle {
 }
 impl __SifrIoFileHandle {
     fn seekable(&self) -> bool {
-        false
+        !(self._closed)
     }
 }
 impl __SifrIoFileHandle {
@@ -1731,19 +1777,18 @@ impl __SifrIoBinaryFileHandle {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
-        Ok(())
+        file_flush(&self._handle)
     }
 }
 impl __SifrIoBinaryFileHandle {
     fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-        let _ = (size).clone();
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
         if !self.readable() {
             return Err(IOError::new("stream is not readable".to_string()));
         }
-        file_read_bytes(&self._handle)
+        file_read_bytes(&self._handle, (size.clone()).clone())
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -1759,14 +1804,18 @@ impl __SifrIoBinaryFileHandle {
 }
 impl __SifrIoBinaryFileHandle {
     fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-        let _ = offset.clone();
-        let _ = whence.clone();
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
     }
 }
 impl __SifrIoBinaryFileHandle {
     fn tell(&self) -> Result<SifrInt, IOError> {
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_tell(&self._handle)
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -1781,7 +1830,7 @@ impl __SifrIoBinaryFileHandle {
 }
 impl __SifrIoBinaryFileHandle {
     fn seekable(&self) -> bool {
-        false
+        !(self._closed)
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -1873,7 +1922,7 @@ impl __SifrIoTextFileHandle {
                         __sifr_try_variant_error,
                     ) => {
                         let e = __sifr_try_variant_error.clone();
-                        return Err(IOError::new(e.message.clone()));
+                        return Err(e);
                     }
                     __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                         __sifr_try_variant_error,
@@ -1925,7 +1974,7 @@ impl __SifrIoTextFileHandle {
                         __sifr_try_variant_error,
                     ) => {
                         let e = __sifr_try_variant_error.clone();
-                        return Err(IOError::new(e.message.clone()));
+                        return Err(e);
                     }
                     __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                         __sifr_try_variant_error,
@@ -1965,6 +2014,16 @@ impl __SifrIoTextFileHandle {
                     .to_string(),
             ),
         )
+    }
+}
+impl __SifrIoTextFileHandle {
+    fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+        self._binary.seek(offset, whence)
+    }
+}
+impl __SifrIoTextFileHandle {
+    fn tell(&self) -> Result<SifrInt, IOError> {
+        self._binary.tell()
     }
 }
 impl __SifrIoTextFileHandle {
@@ -2567,7 +2626,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2588,7 +2647,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2627,7 +2686,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2949,7 +3008,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -2959,7 +3018,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -2969,7 +3028,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -2979,7 +3038,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {

--- a/demos/dependency_manifest/emitted.rs
+++ b/demos/dependency_manifest/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1483,7 +1528,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1531,14 +1576,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1554,14 +1599,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1576,7 +1625,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1634,19 +1683,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1662,14 +1710,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1684,7 +1736,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1776,7 +1828,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1828,7 +1880,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1868,6 +1920,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2478,7 +2540,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2499,7 +2561,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2538,7 +2600,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3073,14 +3135,43 @@ pub fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 pub fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+pub fn _file_read_bytes(
+    handle: &String,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+pub fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 pub fn open_file(
@@ -3097,7 +3188,7 @@ pub fn open_file(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3123,14 +3214,30 @@ pub fn file_readlines(
 pub fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+pub fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 pub fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+pub fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 pub fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -3975,7 +4082,7 @@ pub fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError>
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3996,7 +4103,7 @@ pub fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4035,7 +4142,7 @@ pub fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/error_subclasses/emitted.rs
+++ b/demos/error_subclasses/emitted.rs
@@ -181,14 +181,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -205,7 +234,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -231,14 +260,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1515,7 +1560,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1563,14 +1608,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1586,14 +1631,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1608,7 +1657,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1666,19 +1715,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1694,14 +1742,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1716,7 +1768,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1808,7 +1860,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1860,7 +1912,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1900,6 +1952,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2510,7 +2572,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2531,7 +2593,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2570,7 +2632,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2892,7 +2954,7 @@ mod __sifr_project_nominals {
         tokens.push(format!("{}{}", value.kind.clone(), ""));
         if (value.kind.clone() == "bool") {
             let bool_value: Option<bool> = value.bool_value;
-            if (bool_value == None) {
+            if (bool_value.is_none()) {
                 tokens.push("false".to_string());
             } else {
                 if let Some(bool_value) = bool_value {
@@ -2902,7 +2964,7 @@ mod __sifr_project_nominals {
         } else {
             if (value.kind.clone() == "int") {
                 let int_value: Option<SifrInt> = value.int_value.clone();
-                if (int_value == None) {
+                if (int_value.is_none()) {
                     tokens.push("0".to_string());
                 } else {
                     if let Some(int_value) = int_value.clone() {
@@ -2912,7 +2974,7 @@ mod __sifr_project_nominals {
             } else {
                 if (value.kind.clone() == "float") {
                     let float_value: Option<f64> = value.float_value;
-                    if (float_value == None) {
+                    if (float_value.is_none()) {
                         tokens.push("0.0".to_string());
                     } else {
                         if let Some(float_value) = float_value {
@@ -2922,7 +2984,7 @@ mod __sifr_project_nominals {
                 } else {
                     if (value.kind.clone() == "str") {
                         let str_value: Option<String> = value.as_str();
-                        if (str_value == None) {
+                        if (str_value.is_none()) {
                             tokens.push("".to_string());
                         } else {
                             if let Some(str_value) = str_value {
@@ -3392,14 +3454,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3413,7 +3501,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3432,14 +3520,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4277,7 +4381,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4298,7 +4402,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4337,7 +4441,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4841,7 +4945,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -4851,7 +4955,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -4861,7 +4965,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -4871,7 +4975,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {
@@ -5284,7 +5388,7 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
 fn has_match(pattern: &String, text: &String) -> Result<bool, RegexError> {
     let __sifr_try_res: Result<Result<bool, RegexError>, RegexError> = (|| {
         let found: Option<String> = search(pattern, text)?;
-        Ok(Ok((found != None)))
+        Ok(Ok((found.is_some())))
     })();
     match __sifr_try_res {
         Ok(__sifr_ret_val) => {

--- a/demos/extended_collections/emitted.rs
+++ b/demos/extended_collections/emitted.rs
@@ -692,9 +692,9 @@ pub use __sifr_project_nominals::__SifrStdlib_sifr_x2ecollections_x2eCounter;
 use ::std::collections::HashMap;
 use ::std::collections::HashSet;
 use ::sifr_runtime::SifrInt;
-fn from_list<
-    T: Clone + ::std::fmt::Display + PartialOrd + ::std::hash::Hash + Eq + 'static,
->(items: &Vec<T>) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
+fn from_list<T: Clone + ::std::hash::Hash + Eq + 'static>(
+    items: &Vec<T>,
+) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
     let mut counts: HashMap<T, SifrInt> = HashMap::from([]);
     for item in items.iter().cloned() {
         let val: Option<SifrInt> = counts.get(&item).cloned();

--- a/demos/extended_itertools/emitted.rs
+++ b/demos/extended_itertools/emitted.rs
@@ -96,16 +96,14 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn _collect_iterator<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    data: Box<dyn Iterator<Item = T>>,
-) -> Vec<T> {
+fn _collect_iterator<T: Clone + 'static>(data: Box<dyn Iterator<Item = T>>) -> Vec<T> {
     let mut collected: Vec<T> = vec![];
     for item in data {
         collected.push(item.clone());
     }
     collected
 }
-fn product<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn product<T: Clone + 'static>(
     iterables: &Vec<Vec<T>>,
     repeat: SifrInt,
 ) -> Box<dyn Iterator<Item = Vec<T>>> {
@@ -277,7 +275,7 @@ fn product<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn permutations<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn permutations<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     r: Option<SifrInt>,
 ) -> Box<dyn Iterator<Item = Vec<T>>> {
@@ -588,7 +586,7 @@ fn permutations<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn combinations<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn combinations<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     r: SifrInt,
 ) -> Box<dyn Iterator<Item = Vec<T>>> {
@@ -733,7 +731,7 @@ fn combinations<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn combinations_with_replacement<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn combinations_with_replacement<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     r: SifrInt,
 ) -> Box<dyn Iterator<Item = Vec<T>>> {
@@ -844,11 +842,7 @@ fn combinations_with_replacement<T: Clone + ::std::fmt::Display + PartialOrd + '
         }),
     )
 }
-fn starmap<
-    A: Clone + ::std::fmt::Display + PartialOrd + 'static,
-    B: Clone + ::std::fmt::Display + PartialOrd + 'static,
-    R: Clone + ::std::fmt::Display + PartialOrd + 'static,
->(
+fn starmap<A: Clone + 'static, B: Clone + 'static, R: Clone + 'static>(
     func: impl Fn(&A, &B) -> R + Send + Sync + 'static,
     pairs: Box<dyn Iterator<Item = (A, B)>>,
 ) -> Box<dyn Iterator<Item = R>> {
@@ -860,9 +854,10 @@ fn starmap<
         }),
     )
 }
-fn accumulate<
-    T: Clone + ::std::fmt::Display + PartialOrd + 'static + ::std::ops::Add<Output = T>,
->(data: Box<dyn Iterator<Item = T>>, initial: Option<T>) -> Box<dyn Iterator<Item = T>> {
+fn accumulate<T: Clone + 'static + ::std::ops::Add<Output = T>>(
+    data: Box<dyn Iterator<Item = T>>,
+    initial: Option<T>,
+) -> Box<dyn Iterator<Item = T>> {
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
             let mut state: Vec<T> = vec![];
@@ -938,7 +933,7 @@ fn accumulate<
         }),
     )
 }
-fn compress<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn compress<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     selectors: Box<dyn Iterator<Item = bool>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -954,7 +949,7 @@ fn compress<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn dropwhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn dropwhile<T: Clone + 'static>(
     pred: impl Fn(&T) -> bool + Send + Sync + 'static,
     data: Box<dyn Iterator<Item = T>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -974,7 +969,7 @@ fn dropwhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn takewhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn takewhile<T: Clone + 'static>(
     pred: impl Fn(&T) -> bool + Send + Sync + 'static,
     data: Box<dyn Iterator<Item = T>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -989,7 +984,7 @@ fn takewhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn filterfalse<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn filterfalse<T: Clone + 'static>(
     pred: impl Fn(&T) -> bool + Send + Sync + 'static,
     data: Box<dyn Iterator<Item = T>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -1003,7 +998,7 @@ fn filterfalse<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn zip_longest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn zip_longest<T: Clone + 'static>(
     a: Box<dyn Iterator<Item = T>>,
     b: Box<dyn Iterator<Item = T>>,
     fill: &T,
@@ -1016,7 +1011,7 @@ fn zip_longest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             loop {
                 let left_value: Option<T> = left.next();
                 let right_value: Option<T> = right.next();
-                if (left_value == None) && (right_value == None) {
+                if (left_value.is_none()) && (right_value.is_none()) {
                     return;
                 }
                 let mut pair: Vec<T> = vec![];
@@ -1035,7 +1030,7 @@ fn zip_longest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn cycle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn cycle<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     n: SifrInt,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -1048,38 +1043,22 @@ fn cycle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             }
             for value in data {
                 saved.push(value.clone());
-                let current: Option<T> = {
-                    let __sifr_index_list = &saved;
-                    let __sifr_index_i = SifrInt::from(saved.len())
-                        - SifrInt::from_i64(1);
-                    let __sifr_index_norm = __sifr_index_i
-                        .normalize_index_or_len(__sifr_index_list.len());
-                    __sifr_index_list.get(__sifr_index_norm).cloned()
-                };
-                if let Some(current) = current {
-                    __sifr_yielder.suspend(current.clone()).await;
+                __sifr_yielder.suspend(value.clone()).await;
+                emitted = &emitted + &SifrInt::from_i64(1);
+                if (&emitted >= &n) {
+                    return;
+                }
+            }
+            while (&emitted < &n)
+                && (&SifrInt::from(saved.len()) > &SifrInt::from_i64(0))
+            {
+                for repeated in saved.iter().cloned() {
+                    __sifr_yielder.suspend(repeated.clone()).await;
                     emitted = &emitted + &SifrInt::from_i64(1);
                     if (&emitted >= &n) {
                         return;
                     }
                 }
-            }
-            let size: SifrInt = SifrInt::from(saved.len());
-            while (&emitted < &n) && (&size > &SifrInt::from_i64(0)) {
-                let index: SifrInt = emitted.floor_mod_known_nonzero(&size);
-                let repeated: Option<T> = {
-                    let __sifr_checked_read_collection = &saved;
-                    let __sifr_checked_read_index = index.clone();
-                    let __sifr_checked_read_normalized = __sifr_checked_read_index
-                        .normalize_index_or_len(__sifr_checked_read_collection.len());
-                    __sifr_checked_read_collection
-                        .get(__sifr_checked_read_normalized)
-                        .cloned()
-                };
-                if let Some(repeated) = repeated {
-                    __sifr_yielder.suspend(repeated.clone()).await;
-                }
-                emitted = &emitted + &SifrInt::from_i64(1);
             }
         }),
     )

--- a/demos/extended_stdlib/emitted.rs
+++ b/demos/extended_stdlib/emitted.rs
@@ -308,14 +308,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -329,7 +355,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -348,14 +374,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -1204,7 +1246,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eRandom {
         }
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -1842,7 +1884,7 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
 fn has_match(pattern: &String, text: &String) -> Result<bool, RegexError> {
     let __sifr_try_res: Result<Result<bool, RegexError>, RegexError> = (|| {
         let found: Option<String> = search(pattern, text)?;
-        Ok(Ok((found != None)))
+        Ok(Ok((found.is_some())))
     })();
     match __sifr_try_res {
         Ok(__sifr_ret_val) => {

--- a/demos/file_streams/emitted.rs
+++ b/demos/file_streams/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1297,7 +1342,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1345,14 +1390,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1368,14 +1413,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1390,7 +1439,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1413,9 +1462,6 @@ mod __sifr_project_nominals {
     }
     pub fn _closed_stream_error() -> String {
         "I/O operation on closed stream".to_string()
-    }
-    pub fn _unsupported_seek_tell_error() -> String {
-        "seek/tell is unsupported for this stream".to_string()
     }
     pub fn _mode_is_readable(mode: &String) -> bool {
         mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
@@ -1874,14 +1920,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -1895,7 +1967,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1914,14 +1986,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -2607,9 +2695,6 @@ fn encode(
 fn _closed_stream_error() -> String {
     "I/O operation on closed stream".to_string()
 }
-fn _unsupported_seek_tell_error() -> String {
-    "seek/tell is unsupported for this stream".to_string()
-}
 fn _mode_is_readable(mode: &String) -> bool {
     mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
 }
@@ -2763,7 +2848,7 @@ fn main() {
                 ),
             )
         })()?;
-        let payload: Vec<u8> = rb.read_bytes()?;
+        let payload: Vec<u8> = rb.read_bytes(&None)?;
         rb.close();
         binary_ok = (payload
             == vec![114u8, 97u8, 119u8, 45u8, 98u8, 121u8, 116u8, 101u8, 115u8]);

--- a/demos/filesystem_and_archives/emitted.rs
+++ b/demos/filesystem_and_archives/emitted.rs
@@ -70,14 +70,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -94,7 +123,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -120,14 +149,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -744,7 +789,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -765,7 +810,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -786,7 +831,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -1187,14 +1232,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -1208,7 +1279,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1227,14 +1298,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -3048,7 +3135,7 @@ fn _iterdir_to_iter(path: &String) -> Result<Box<dyn Iterator<Item = String>>, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3069,7 +3156,7 @@ fn _glob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3090,7 +3177,7 @@ fn _rglob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3374,7 +3461,7 @@ fn mkstemp(prefix: &String) -> Result<String, IOError> {
                     attempts = &attempts + &SifrInt::from_i64(1);
                     continue;
                 }
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3409,7 +3496,7 @@ fn mkdtemp(prefix: &String) -> Result<String, IOError> {
                     attempts = &attempts + &SifrInt::from_i64(1);
                     continue;
                 }
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }

--- a/demos/generic_functions_and_iterators/emitted.rs
+++ b/demos/generic_functions_and_iterators/emitted.rs
@@ -279,13 +279,10 @@ impl Printable for Product {
         Product::display(self)
     }
 }
-fn identity<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(x: &T) -> T {
+fn identity<T: Clone + 'static>(x: &T) -> T {
     x.clone()
 }
-fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    x: &T,
-    n: SifrInt,
-) -> Vec<T> {
+fn repeat<T: Clone + 'static>(x: &T, n: SifrInt) -> Vec<T> {
     let mut result: Vec<T> = vec![];
     let mut i: SifrInt = SifrInt::from_i64(0);
     while (&i < &n) {

--- a/demos/generic_stdlib/emitted.rs
+++ b/demos/generic_stdlib/emitted.rs
@@ -751,9 +751,9 @@ pub use __sifr_project_nominals::__SifrStdlib_sifr_x2ecollections_x2edeque;
 use ::std::collections::HashMap;
 use ::std::collections::VecDeque;
 use ::sifr_runtime::SifrInt;
-fn from_list<
-    T: Clone + ::std::fmt::Display + PartialOrd + ::std::hash::Hash + Eq + 'static,
->(items: &Vec<T>) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
+fn from_list<T: Clone + ::std::hash::Hash + Eq + 'static>(
+    items: &Vec<T>,
+) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
     let mut counts: HashMap<T, SifrInt> = HashMap::from([]);
     for item in items.iter().cloned() {
         let val: Option<SifrInt> = counts.get(&item).cloned();
@@ -777,17 +777,18 @@ fn from_list<
     }
     __SifrStdlib_sifr_x2ecollections_x2eCounter::new(Some(counts), None)
 }
-fn reduce<
-    T: Clone + ::std::fmt::Display + PartialOrd + 'static,
-    U: Clone + ::std::fmt::Display + PartialOrd + 'static,
->(func: impl Fn(&U, &T) -> U, data: &Vec<T>, initial: &U) -> U {
+fn reduce<T: Clone + 'static, U: Clone + 'static>(
+    func: impl Fn(&U, &T) -> U,
+    data: &Vec<T>,
+    initial: &U,
+) -> U {
     let mut result: U = (initial).clone();
     for val in data.iter().cloned() {
         result = func(&result, &val);
     }
     result
 }
-fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _sift_down<T: Clone + 'static + PartialOrd>(
     data: &mut Vec<T>,
     mut pos: SifrInt,
     n: SifrInt,
@@ -910,7 +911,7 @@ fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -920,9 +921,7 @@ fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-) -> Option<T> {
+fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -963,10 +962,7 @@ fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     top
 }
-fn nsmallest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut heap: Vec<T> = data.clone();
     heapify(&mut heap);
     let mut result: Vec<T> = vec![];
@@ -983,10 +979,7 @@ fn nsmallest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     result
 }
-fn nlargest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn nlargest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     if &n <= &SifrInt::from_i64(0) {
         return vec![];
     }
@@ -1122,9 +1115,7 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    iterables: &Vec<Vec<T>>,
-) -> Box<dyn Iterator<Item = T>> {
+fn chain<T: Clone + 'static>(iterables: &Vec<Vec<T>>) -> Box<dyn Iterator<Item = T>> {
     let iterables = iterables.clone();
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
@@ -1136,10 +1127,7 @@ fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    value: T,
-    times: SifrInt,
-) -> Box<dyn Iterator<Item = T>> {
+fn repeat<T: Clone + 'static>(value: T, times: SifrInt) -> Box<dyn Iterator<Item = T>> {
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
             let holder: Vec<T> = vec![value.clone()];
@@ -1166,10 +1154,7 @@ fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn take<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn take<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut result: Vec<T> = vec![];
     let mut count: SifrInt = SifrInt::from_i64(0);
     for item in data.iter().cloned() {
@@ -1181,9 +1166,7 @@ fn take<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     result
 }
-fn flatten<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    lists: &Vec<Vec<T>>,
-) -> Vec<T> {
+fn flatten<T: Clone + 'static>(lists: &Vec<Vec<T>>) -> Vec<T> {
     let mut result: Vec<T> = vec![];
     for inner in lists.iter().cloned() {
         for val in inner.iter().cloned() {
@@ -1192,9 +1175,7 @@ fn flatten<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     result
 }
-fn pairwise<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    data: &Vec<T>,
-) -> Vec<Vec<T>> {
+fn pairwise<T: Clone + 'static>(data: &Vec<T>) -> Vec<Vec<T>> {
     let mut result: Vec<Vec<T>> = vec![];
     let mut prev_values: Vec<T> = vec![];
     for value in data.iter().cloned() {
@@ -1238,10 +1219,11 @@ fn pairwise<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     result
 }
-fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _islice_impl<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start: SifrInt,
     stop: SifrInt,
+    unbounded: bool,
     step: SifrInt,
 ) -> Box<dyn Iterator<Item = T>> {
     Box::new(
@@ -1249,7 +1231,7 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             let mut index: SifrInt = SifrInt::from_i64(0);
             let mut next_yield: SifrInt = start.clone();
             for value in data {
-                if &index >= &stop {
+                if !unbounded && (&index >= &stop) {
                     return;
                 }
                 if &index == &next_yield {
@@ -1261,23 +1243,47 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn islice<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start_or_stop: SifrInt,
-    stop: Option<SifrInt>,
-    step: SifrInt,
+    slice_args: &Vec<Option<SifrInt>>,
 ) -> Result<Box<dyn Iterator<Item = T>>, ValueError> {
+    if (&SifrInt::from(slice_args.len()) > &SifrInt::from_i64(2)) {
+        return Err(
+            ValueError::new(
+                "islice: expected at most stop and step after start".to_string(),
+            ),
+        );
+    }
     let mut actual_start: SifrInt = SifrInt::from_i64(0);
     let mut actual_stop: SifrInt = start_or_stop.clone();
-    if let Some(stop) = stop.clone() {
-        actual_start = start_or_stop.clone();
-        actual_stop = stop.clone();
+    let mut unbounded: bool = false;
+    let mut actual_step: SifrInt = SifrInt::from_i64(1);
+    let mut argument_index: SifrInt = SifrInt::from_i64(0);
+    for argument in slice_args.iter().cloned() {
+        if (&argument_index == &SifrInt::from_i64(0)) {
+            actual_start = start_or_stop.clone();
+            if (argument.is_none()) {
+                unbounded = true;
+            } else {
+                if let Some(argument) = argument.clone() {
+                    actual_stop = argument.clone();
+                }
+            }
+        } else {
+            if let Some(argument) = argument.clone() {
+                actual_step = argument.clone();
+            }
+        }
+        argument_index = &argument_index + &SifrInt::from_i64(1);
     }
-    if (&actual_start < &SifrInt::from_i64(0)) || (&actual_stop < &SifrInt::from_i64(0))
-    {
+    if (&actual_start < &SifrInt::from_i64(0)) {
         return Err(ValueError::new("islice: indices must be non-negative".to_string()));
     }
-    if (&step <= &SifrInt::from_i64(0)) {
+    if !unbounded && (&actual_stop < &SifrInt::from_i64(0)) {
+        return Err(ValueError::new("islice: indices must be non-negative".to_string()));
+    }
+    if (&actual_step <= &SifrInt::from_i64(0)) {
         return Err(
             ValueError::new("islice: step must be greater than zero".to_string()),
         );
@@ -1287,13 +1293,15 @@ fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             Box::new(data),
             (actual_start).clone(),
             (actual_stop).clone(),
-            (step).clone(),
+            unbounded,
+            (actual_step).clone(),
         ),
     )
 }
-fn accumulate<
-    T: Clone + ::std::fmt::Display + PartialOrd + 'static + ::std::ops::Add<Output = T>,
->(data: Box<dyn Iterator<Item = T>>, initial: Option<T>) -> Box<dyn Iterator<Item = T>> {
+fn accumulate<T: Clone + 'static + ::std::ops::Add<Output = T>>(
+    data: Box<dyn Iterator<Item = T>>,
+    initial: Option<T>,
+) -> Box<dyn Iterator<Item = T>> {
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
             let mut state: Vec<T> = vec![];
@@ -1369,7 +1377,7 @@ fn accumulate<
         }),
     )
 }
-fn compress<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn compress<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     selectors: Box<dyn Iterator<Item = bool>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -1385,7 +1393,7 @@ fn compress<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn dropwhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn dropwhile<T: Clone + 'static>(
     pred: impl Fn(&T) -> bool + Send + Sync + 'static,
     data: Box<dyn Iterator<Item = T>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -1405,7 +1413,7 @@ fn dropwhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn takewhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn takewhile<T: Clone + 'static>(
     pred: impl Fn(&T) -> bool + Send + Sync + 'static,
     data: Box<dyn Iterator<Item = T>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -1420,7 +1428,7 @@ fn takewhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn filterfalse<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn filterfalse<T: Clone + 'static>(
     pred: impl Fn(&T) -> bool + Send + Sync + 'static,
     data: Box<dyn Iterator<Item = T>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -1434,7 +1442,7 @@ fn filterfalse<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn zip_longest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn zip_longest<T: Clone + 'static>(
     a: Box<dyn Iterator<Item = T>>,
     b: Box<dyn Iterator<Item = T>>,
     fill: &T,
@@ -1447,7 +1455,7 @@ fn zip_longest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             loop {
                 let left_value: Option<T> = left.next();
                 let right_value: Option<T> = right.next();
-                if (left_value == None) && (right_value == None) {
+                if (left_value.is_none()) && (right_value.is_none()) {
                     return;
                 }
                 let mut pair: Vec<T> = vec![];
@@ -1466,7 +1474,7 @@ fn zip_longest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn cycle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn cycle<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     n: SifrInt,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -1479,38 +1487,22 @@ fn cycle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             }
             for value in data {
                 saved.push(value.clone());
-                let current: Option<T> = {
-                    let __sifr_index_list = &saved;
-                    let __sifr_index_i = SifrInt::from(saved.len())
-                        - SifrInt::from_i64(1);
-                    let __sifr_index_norm = __sifr_index_i
-                        .normalize_index_or_len(__sifr_index_list.len());
-                    __sifr_index_list.get(__sifr_index_norm).cloned()
-                };
-                if let Some(current) = current {
-                    __sifr_yielder.suspend(current.clone()).await;
+                __sifr_yielder.suspend(value.clone()).await;
+                emitted = &emitted + &SifrInt::from_i64(1);
+                if (&emitted >= &n) {
+                    return;
+                }
+            }
+            while (&emitted < &n)
+                && (&SifrInt::from(saved.len()) > &SifrInt::from_i64(0))
+            {
+                for repeated in saved.iter().cloned() {
+                    __sifr_yielder.suspend(repeated.clone()).await;
                     emitted = &emitted + &SifrInt::from_i64(1);
                     if (&emitted >= &n) {
                         return;
                     }
                 }
-            }
-            let size: SifrInt = SifrInt::from(saved.len());
-            while (&emitted < &n) && (&size > &SifrInt::from_i64(0)) {
-                let index: SifrInt = emitted.floor_mod_known_nonzero(&size);
-                let repeated: Option<T> = {
-                    let __sifr_checked_read_collection = &saved;
-                    let __sifr_checked_read_index = index.clone();
-                    let __sifr_checked_read_normalized = __sifr_checked_read_index
-                        .normalize_index_or_len(__sifr_checked_read_collection.len());
-                    __sifr_checked_read_collection
-                        .get(__sifr_checked_read_normalized)
-                        .cloned()
-                };
-                if let Some(repeated) = repeated {
-                    __sifr_yielder.suspend(repeated.clone()).await;
-                }
-                emitted = &emitted + &SifrInt::from_i64(1);
             }
         }),
     )
@@ -2247,7 +2239,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eRandom {
         }
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -2514,7 +2506,7 @@ fn _module_random() -> __SifrStdlib_sifr_x2erandom_x2eRandom {
 fn _sync_module_random(generator: &mut __SifrStdlib_sifr_x2erandom_x2eRandom) {
     _store_state_into_module_storage(&generator.getstate());
 }
-fn shuffle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(items: &mut Vec<T>) {
+fn shuffle<T: Clone + 'static>(items: &mut Vec<T>) {
     let mut generator: __SifrStdlib_sifr_x2erandom_x2eRandom = _module_random();
     let n: SifrInt = SifrInt::from(items.len());
     if (&n > &SifrInt::from_i64(1)) {

--- a/demos/generic_stdlib/emitted.rs
+++ b/demos/generic_stdlib/emitted.rs
@@ -911,7 +911,7 @@ fn _sift_down<T: Clone + 'static + PartialOrd>(
         }
     }
 }
-fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static + PartialOrd>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -921,7 +921,7 @@ fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
+fn heappop<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -962,7 +962,7 @@ fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     }
     top
 }
-fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
+fn nsmallest<T: Clone + 'static + PartialOrd>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut heap: Vec<T> = data.clone();
     heapify(&mut heap);
     let mut result: Vec<T> = vec![];
@@ -979,7 +979,7 @@ fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     }
     result
 }
-fn nlargest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
+fn nlargest<T: Clone + 'static + PartialOrd>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     if &n <= &SifrInt::from_i64(0) {
         return vec![];
     }

--- a/demos/generics_impl/emitted.rs
+++ b/demos/generics_impl/emitted.rs
@@ -1,11 +1,11 @@
 // src/main.rs
 use ::sifr_runtime::SifrInt;
 
-fn identity<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(x: &T) -> T {
+fn identity<T: Clone + 'static>(x: &T) -> T {
     x.clone()
 }
 
-fn first<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(items: &Vec<T>) -> Option<T> {
+fn first<T: Clone + 'static>(items: &Vec<T>) -> Option<T> {
     {
     let __sifr_checked_read_collection = &items;
     let __sifr_checked_read_index = SifrInt::from_i64(0);
@@ -51,7 +51,7 @@ fn main() {
         println!("{}", first_word);
     }
     let missing_word: Option<String> = first(&empty_words);
-    if (missing_word == None) {
+    if (missing_word.is_none()) {
         println!("empty list -> None");
     } else {
         if let Some(missing_word) = missing_word {

--- a/demos/glob/emitted.rs
+++ b/demos/glob/emitted.rs
@@ -111,14 +111,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -132,7 +158,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -151,14 +177,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/hashlib/emitted.rs
+++ b/demos/hashlib/emitted.rs
@@ -251,14 +251,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -275,7 +304,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -301,14 +330,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -817,14 +862,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -838,7 +909,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -857,14 +928,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -1181,7 +1268,7 @@ fn file_digest(
         }
     };
     let __sifr_try_res: Result<(Vec<u8>,), IOError> = (|| {
-        let data: Vec<u8> = file_read_bytes(&handle)?;
+        let data: Vec<u8> = file_read_bytes(&handle, None)?;
         Ok((data,))
     })();
     let (data,) = match __sifr_try_res {

--- a/demos/heap_option_drain/emitted.rs
+++ b/demos/heap_option_drain/emitted.rs
@@ -2,7 +2,7 @@
 use ::sifr_runtime::SifrInt;
 
 // --- stdlib: sifr.heapq ---
-fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _sift_down<T: Clone + 'static + PartialOrd>(
     data: &mut Vec<T>,
     mut pos: SifrInt,
     n: SifrInt,
@@ -125,10 +125,7 @@ fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    mut pos: SifrInt,
-) {
+fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt) {
     let mut done: bool = false;
     while !done {
         if (&pos <= &SifrInt::from_i64(0)) {
@@ -200,18 +197,13 @@ fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn heappush<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    item: &T,
-) {
+fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-) -> Option<T> {
+fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -274,6 +266,6 @@ fn main() {
     let mut heap: Vec<SifrInt> = vec![];
     heappush(&mut heap, &SifrInt::from_i64(7));
     assert!((heappop(&mut heap) == Some(SifrInt::from_i64(7))));
-    assert!((heappop(&mut heap) == None));
+    assert!((heappop(&mut heap).is_none()));
     println!("heap_option_drain: ok");
 }

--- a/demos/heap_option_drain/emitted.rs
+++ b/demos/heap_option_drain/emitted.rs
@@ -197,13 +197,13 @@ fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt
         }
     }
 }
-fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
+fn heappush<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
+fn heappop<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());

--- a/demos/heapq/emitted.rs
+++ b/demos/heapq/emitted.rs
@@ -2,7 +2,7 @@
 use ::sifr_runtime::SifrInt;
 
 // --- stdlib: sifr.heapq ---
-fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _sift_down<T: Clone + 'static + PartialOrd>(
     data: &mut Vec<T>,
     mut pos: SifrInt,
     n: SifrInt,
@@ -125,10 +125,7 @@ fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    mut pos: SifrInt,
-) {
+fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt) {
     let mut done: bool = false;
     while !done {
         if (&pos <= &SifrInt::from_i64(0)) {
@@ -200,7 +197,7 @@ fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -210,18 +207,13 @@ fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappush<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    item: &T,
-) {
+fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-) -> Option<T> {
+fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -262,10 +254,7 @@ fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     top
 }
-fn nsmallest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut heap: Vec<T> = data.clone();
     heapify(&mut heap);
     let mut result: Vec<T> = vec![];
@@ -282,10 +271,7 @@ fn nsmallest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     result
 }
-fn nlargest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn nlargest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     if &n <= &SifrInt::from_i64(0) {
         return vec![];
     }

--- a/demos/heapq/emitted.rs
+++ b/demos/heapq/emitted.rs
@@ -197,7 +197,7 @@ fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt
         }
     }
 }
-fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static + PartialOrd>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -207,13 +207,13 @@ fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
+fn heappush<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
+fn heappop<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -254,7 +254,7 @@ fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     }
     top
 }
-fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
+fn nsmallest<T: Clone + 'static + PartialOrd>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut heap: Vec<T> = data.clone();
     heapify(&mut heap);
     let mut result: Vec<T> = vec![];
@@ -271,7 +271,7 @@ fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     }
     result
 }
-fn nlargest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
+fn nlargest<T: Clone + 'static + PartialOrd>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     if &n <= &SifrInt::from_i64(0) {
         return vec![];
     }

--- a/demos/html_and_textwrap/emitted.rs
+++ b/demos/html_and_textwrap/emitted.rs
@@ -465,8 +465,8 @@ mod __sifr_project_nominals {
                         })
                             .map(|c| c.to_string());
                     }
-                    if (next_opt != None) && (next_opt == Some(" ".to_string())) {
-                        if (next2_opt == None) || (next2_opt != Some(" ".to_string())) {
+                    if (next_opt.is_some()) && (next_opt == Some(" ".to_string())) {
+                        if (next2_opt.is_none()) || (next2_opt != Some(" ".to_string())) {
                             result.push(' ');
                         }
                     }
@@ -963,8 +963,8 @@ fn _apply_sentence_endings_line(text: &String) -> String {
                     })
                         .map(|c| c.to_string());
                 }
-                if (next_opt != None) && (next_opt == Some(" ".to_string())) {
-                    if (next2_opt == None) || (next2_opt != Some(" ".to_string())) {
+                if (next_opt.is_some()) && (next_opt == Some(" ".to_string())) {
+                    if (next2_opt.is_none()) || (next2_opt != Some(" ".to_string())) {
                         result.push(' ');
                     }
                 }

--- a/demos/in_memory_streams/emitted.rs
+++ b/demos/in_memory_streams/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1297,19 +1342,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1325,14 +1369,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1347,7 +1395,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1777,9 +1825,6 @@ mod __sifr_project_nominals {
             __sifr_concat
         }
     }
-    pub fn _unsupported_seek_tell_error() -> String {
-        "seek/tell is unsupported for this stream".to_string()
-    }
     pub fn _mode_is_readable(mode: &String) -> bool {
         mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
     }
@@ -2045,14 +2090,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -2066,7 +2137,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2085,14 +2156,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -2794,9 +2881,6 @@ fn _negative_seek_error(offset: SifrInt) -> String {
         __sifr_concat
     }
 }
-fn _unsupported_seek_tell_error() -> String {
-    "seek/tell is unsupported for this stream".to_string()
-}
 fn _mode_is_readable(mode: &String) -> bool {
     mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
 }
@@ -2821,7 +2905,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/io/emitted.rs
+++ b/demos/io/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1361,19 +1406,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1389,14 +1433,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1411,7 +1459,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1503,7 +1551,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1555,7 +1603,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1598,6 +1646,16 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
+        }
+    }
+    impl __SifrIoTextFileHandle {
         pub fn readable(&self) -> bool {
             self._binary.readable()
         }
@@ -1633,9 +1691,6 @@ mod __sifr_project_nominals {
     }
     pub fn _closed_stream_error() -> String {
         "I/O operation on closed stream".to_string()
-    }
-    pub fn _unsupported_seek_tell_error() -> String {
-        "seek/tell is unsupported for this stream".to_string()
     }
     pub fn _mode_is_readable(mode: &String) -> bool {
         mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
@@ -2095,14 +2150,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -2116,7 +2197,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2135,14 +2216,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -2891,9 +2988,6 @@ for __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencod
 }
 fn _closed_stream_error() -> String {
     "I/O operation on closed stream".to_string()
-}
-fn _unsupported_seek_tell_error() -> String {
-    "seek/tell is unsupported for this stream".to_string()
 }
 fn _mode_is_readable(mode: &String) -> bool {
     mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())

--- a/demos/io_safety/emitted.rs
+++ b/demos/io_safety/emitted.rs
@@ -220,14 +220,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -241,7 +267,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -260,14 +286,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/iterator_basics/emitted.rs
+++ b/demos/iterator_basics/emitted.rs
@@ -112,18 +112,14 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn _collect_iterator<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    data: Box<dyn Iterator<Item = T>>,
-) -> Vec<T> {
+fn _collect_iterator<T: Clone + 'static>(data: Box<dyn Iterator<Item = T>>) -> Vec<T> {
     let mut collected: Vec<T> = vec![];
     for item in data {
         collected.push(item.clone());
     }
     collected
 }
-fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    iterables: &Vec<Vec<T>>,
-) -> Box<dyn Iterator<Item = T>> {
+fn chain<T: Clone + 'static>(iterables: &Vec<Vec<T>>) -> Box<dyn Iterator<Item = T>> {
     let iterables = iterables.clone();
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
@@ -135,10 +131,7 @@ fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    value: T,
-    times: SifrInt,
-) -> Box<dyn Iterator<Item = T>> {
+fn repeat<T: Clone + 'static>(value: T, times: SifrInt) -> Box<dyn Iterator<Item = T>> {
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
             let holder: Vec<T> = vec![value.clone()];
@@ -165,10 +158,11 @@ fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _islice_impl<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start: SifrInt,
     stop: SifrInt,
+    unbounded: bool,
     step: SifrInt,
 ) -> Box<dyn Iterator<Item = T>> {
     Box::new(
@@ -176,7 +170,7 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             let mut index: SifrInt = SifrInt::from_i64(0);
             let mut next_yield: SifrInt = start.clone();
             for value in data {
-                if &index >= &stop {
+                if !unbounded && (&index >= &stop) {
                     return;
                 }
                 if &index == &next_yield {
@@ -188,23 +182,47 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn islice<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start_or_stop: SifrInt,
-    stop: Option<SifrInt>,
-    step: SifrInt,
+    slice_args: &Vec<Option<SifrInt>>,
 ) -> Result<Box<dyn Iterator<Item = T>>, ValueError> {
+    if (&SifrInt::from(slice_args.len()) > &SifrInt::from_i64(2)) {
+        return Err(
+            ValueError::new(
+                "islice: expected at most stop and step after start".to_string(),
+            ),
+        );
+    }
     let mut actual_start: SifrInt = SifrInt::from_i64(0);
     let mut actual_stop: SifrInt = start_or_stop.clone();
-    if let Some(stop) = stop.clone() {
-        actual_start = start_or_stop.clone();
-        actual_stop = stop.clone();
+    let mut unbounded: bool = false;
+    let mut actual_step: SifrInt = SifrInt::from_i64(1);
+    let mut argument_index: SifrInt = SifrInt::from_i64(0);
+    for argument in slice_args.iter().cloned() {
+        if (&argument_index == &SifrInt::from_i64(0)) {
+            actual_start = start_or_stop.clone();
+            if (argument.is_none()) {
+                unbounded = true;
+            } else {
+                if let Some(argument) = argument.clone() {
+                    actual_stop = argument.clone();
+                }
+            }
+        } else {
+            if let Some(argument) = argument.clone() {
+                actual_step = argument.clone();
+            }
+        }
+        argument_index = &argument_index + &SifrInt::from_i64(1);
     }
-    if (&actual_start < &SifrInt::from_i64(0)) || (&actual_stop < &SifrInt::from_i64(0))
-    {
+    if (&actual_start < &SifrInt::from_i64(0)) {
         return Err(ValueError::new("islice: indices must be non-negative".to_string()));
     }
-    if (&step <= &SifrInt::from_i64(0)) {
+    if !unbounded && (&actual_stop < &SifrInt::from_i64(0)) {
+        return Err(ValueError::new("islice: indices must be non-negative".to_string()));
+    }
+    if (&actual_step <= &SifrInt::from_i64(0)) {
         return Err(
             ValueError::new("islice: step must be greater than zero".to_string()),
         );
@@ -214,7 +232,8 @@ fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             Box::new(data),
             (actual_start).clone(),
             (actual_stop).clone(),
-            (step).clone(),
+            unbounded,
+            (actual_step).clone(),
         ),
     )
 }
@@ -229,7 +248,7 @@ fn count(start: SifrInt, step: SifrInt) -> Box<dyn Iterator<Item = SifrInt>> {
         }),
     )
 }
-fn product<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn product<T: Clone + 'static>(
     iterables: &Vec<Vec<T>>,
     repeat: SifrInt,
 ) -> Box<dyn Iterator<Item = Vec<T>>> {
@@ -401,7 +420,7 @@ fn product<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn combinations<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn combinations<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     r: SifrInt,
 ) -> Box<dyn Iterator<Item = Vec<T>>> {
@@ -593,7 +612,7 @@ fn main() {
     assert!((odd_it.next() == Some(SifrInt::from_i64(1))));
     assert!((odd_it.next() == Some(SifrInt::from_i64(3))));
     assert!((odd_it.next() == Some(SifrInt::from_i64(5))));
-    assert!((odd_it.next() == None));
+    assert!((odd_it.next().is_none()));
     assert!(
         (format!("{:?}", Box::new((vec![SifrInt::from_i64(1), SifrInt::from_i64(2)])
         .into_iter().zip((vec!["a".to_string(), "b".to_string()]).into_iter()).map(|
@@ -628,8 +647,7 @@ fn main() {
                     .into_iter(),
             ),
             SifrInt::from_i64(1),
-            Some(SifrInt::from_i64(5)),
-            SifrInt::from_i64(2),
+            &vec![Some(SifrInt::from_i64(5)), Some(SifrInt::from_i64(2))],
         )?;
         assert!((format!("{:?}", sliced.collect::< Vec < _ >> ()) == "[20, 40]"));
         Ok(())

--- a/demos/iterator_integration/emitted.rs
+++ b/demos/iterator_integration/emitted.rs
@@ -70,14 +70,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -94,7 +123,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -120,14 +149,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -744,7 +789,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -765,7 +810,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -786,7 +831,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -1377,14 +1422,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -1398,7 +1469,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1417,14 +1488,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -2542,10 +2629,11 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _islice_impl<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start: SifrInt,
     stop: SifrInt,
+    unbounded: bool,
     step: SifrInt,
 ) -> Box<dyn Iterator<Item = T>> {
     Box::new(
@@ -2553,7 +2641,7 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             let mut index: SifrInt = SifrInt::from_i64(0);
             let mut next_yield: SifrInt = start.clone();
             for value in data {
-                if &index >= &stop {
+                if !unbounded && (&index >= &stop) {
                     return;
                 }
                 if &index == &next_yield {
@@ -2565,23 +2653,47 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn islice<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start_or_stop: SifrInt,
-    stop: Option<SifrInt>,
-    step: SifrInt,
+    slice_args: &Vec<Option<SifrInt>>,
 ) -> Result<Box<dyn Iterator<Item = T>>, ValueError> {
+    if (&SifrInt::from(slice_args.len()) > &SifrInt::from_i64(2)) {
+        return Err(
+            ValueError::new(
+                "islice: expected at most stop and step after start".to_string(),
+            ),
+        );
+    }
     let mut actual_start: SifrInt = SifrInt::from_i64(0);
     let mut actual_stop: SifrInt = start_or_stop.clone();
-    if let Some(stop) = stop.clone() {
-        actual_start = start_or_stop.clone();
-        actual_stop = stop.clone();
+    let mut unbounded: bool = false;
+    let mut actual_step: SifrInt = SifrInt::from_i64(1);
+    let mut argument_index: SifrInt = SifrInt::from_i64(0);
+    for argument in slice_args.iter().cloned() {
+        if (&argument_index == &SifrInt::from_i64(0)) {
+            actual_start = start_or_stop.clone();
+            if (argument.is_none()) {
+                unbounded = true;
+            } else {
+                if let Some(argument) = argument.clone() {
+                    actual_stop = argument.clone();
+                }
+            }
+        } else {
+            if let Some(argument) = argument.clone() {
+                actual_step = argument.clone();
+            }
+        }
+        argument_index = &argument_index + &SifrInt::from_i64(1);
     }
-    if (&actual_start < &SifrInt::from_i64(0)) || (&actual_stop < &SifrInt::from_i64(0))
-    {
+    if (&actual_start < &SifrInt::from_i64(0)) {
         return Err(ValueError::new("islice: indices must be non-negative".to_string()));
     }
-    if (&step <= &SifrInt::from_i64(0)) {
+    if !unbounded && (&actual_stop < &SifrInt::from_i64(0)) {
+        return Err(ValueError::new("islice: indices must be non-negative".to_string()));
+    }
+    if (&actual_step <= &SifrInt::from_i64(0)) {
         return Err(
             ValueError::new("islice: step must be greater than zero".to_string()),
         );
@@ -2591,7 +2703,8 @@ fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             Box::new(data),
             (actual_start).clone(),
             (actual_stop).clone(),
-            (step).clone(),
+            unbounded,
+            (actual_step).clone(),
         ),
     )
 }
@@ -2915,7 +3028,7 @@ fn _iterdir_to_iter(path: &String) -> Result<Box<dyn Iterator<Item = String>>, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2936,7 +3049,7 @@ fn _glob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2957,7 +3070,7 @@ fn _rglob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3506,8 +3619,10 @@ fn main() {
         let sliced_entries: Box<dyn Iterator<Item = String>> = (islice(
             Box::new(entries_it),
             SifrInt::from_i64(2),
-            None,
-            SifrInt::from_i64(1),
+            &({
+                let __sifr_empty_list_literal: Vec<Option<SifrInt>> = vec![];
+                __sifr_empty_list_literal
+            }),
         ))
             .map_err(|__e| __SifrUnion_8_x3asequence5_x3aunion1_x3a223_x3a5_x3aclass10_x3aValueError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass10_x3aValueError1_x3a0(
                 __e,

--- a/demos/iterators_and_randomness/emitted.rs
+++ b/demos/iterators_and_randomness/emitted.rs
@@ -112,18 +112,14 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn _collect_iterator<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    data: Box<dyn Iterator<Item = T>>,
-) -> Vec<T> {
+fn _collect_iterator<T: Clone + 'static>(data: Box<dyn Iterator<Item = T>>) -> Vec<T> {
     let mut collected: Vec<T> = vec![];
     for item in data {
         collected.push(item.clone());
     }
     collected
 }
-fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    iterables: &Vec<Vec<T>>,
-) -> Box<dyn Iterator<Item = T>> {
+fn chain<T: Clone + 'static>(iterables: &Vec<Vec<T>>) -> Box<dyn Iterator<Item = T>> {
     let iterables = iterables.clone();
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
@@ -135,10 +131,11 @@ fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _islice_impl<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start: SifrInt,
     stop: SifrInt,
+    unbounded: bool,
     step: SifrInt,
 ) -> Box<dyn Iterator<Item = T>> {
     Box::new(
@@ -146,7 +143,7 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             let mut index: SifrInt = SifrInt::from_i64(0);
             let mut next_yield: SifrInt = start.clone();
             for value in data {
-                if &index >= &stop {
+                if !unbounded && (&index >= &stop) {
                     return;
                 }
                 if &index == &next_yield {
@@ -158,23 +155,47 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn islice<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start_or_stop: SifrInt,
-    stop: Option<SifrInt>,
-    step: SifrInt,
+    slice_args: &Vec<Option<SifrInt>>,
 ) -> Result<Box<dyn Iterator<Item = T>>, ValueError> {
+    if (&SifrInt::from(slice_args.len()) > &SifrInt::from_i64(2)) {
+        return Err(
+            ValueError::new(
+                "islice: expected at most stop and step after start".to_string(),
+            ),
+        );
+    }
     let mut actual_start: SifrInt = SifrInt::from_i64(0);
     let mut actual_stop: SifrInt = start_or_stop.clone();
-    if let Some(stop) = stop.clone() {
-        actual_start = start_or_stop.clone();
-        actual_stop = stop.clone();
+    let mut unbounded: bool = false;
+    let mut actual_step: SifrInt = SifrInt::from_i64(1);
+    let mut argument_index: SifrInt = SifrInt::from_i64(0);
+    for argument in slice_args.iter().cloned() {
+        if (&argument_index == &SifrInt::from_i64(0)) {
+            actual_start = start_or_stop.clone();
+            if (argument.is_none()) {
+                unbounded = true;
+            } else {
+                if let Some(argument) = argument.clone() {
+                    actual_stop = argument.clone();
+                }
+            }
+        } else {
+            if let Some(argument) = argument.clone() {
+                actual_step = argument.clone();
+            }
+        }
+        argument_index = &argument_index + &SifrInt::from_i64(1);
     }
-    if (&actual_start < &SifrInt::from_i64(0)) || (&actual_stop < &SifrInt::from_i64(0))
-    {
+    if (&actual_start < &SifrInt::from_i64(0)) {
         return Err(ValueError::new("islice: indices must be non-negative".to_string()));
     }
-    if (&step <= &SifrInt::from_i64(0)) {
+    if !unbounded && (&actual_stop < &SifrInt::from_i64(0)) {
+        return Err(ValueError::new("islice: indices must be non-negative".to_string()));
+    }
+    if (&actual_step <= &SifrInt::from_i64(0)) {
         return Err(
             ValueError::new("islice: step must be greater than zero".to_string()),
         );
@@ -184,11 +205,12 @@ fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             Box::new(data),
             (actual_start).clone(),
             (actual_stop).clone(),
-            (step).clone(),
+            unbounded,
+            (actual_step).clone(),
         ),
     )
 }
-fn product<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn product<T: Clone + 'static>(
     iterables: &Vec<Vec<T>>,
     repeat: SifrInt,
 ) -> Box<dyn Iterator<Item = Vec<T>>> {
@@ -360,7 +382,7 @@ fn product<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn permutations<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn permutations<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     r: Option<SifrInt>,
 ) -> Box<dyn Iterator<Item = Vec<T>>> {
@@ -671,7 +693,7 @@ fn permutations<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn combinations<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn combinations<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     r: SifrInt,
 ) -> Box<dyn Iterator<Item = Vec<T>>> {
@@ -816,11 +838,7 @@ fn combinations<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn starmap<
-    A: Clone + ::std::fmt::Display + PartialOrd + 'static,
-    B: Clone + ::std::fmt::Display + PartialOrd + 'static,
-    R: Clone + ::std::fmt::Display + PartialOrd + 'static,
->(
+fn starmap<A: Clone + 'static, B: Clone + 'static, R: Clone + 'static>(
     func: impl Fn(&A, &B) -> R + Send + Sync + 'static,
     pairs: Box<dyn Iterator<Item = (A, B)>>,
 ) -> Box<dyn Iterator<Item = R>> {
@@ -1564,7 +1582,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eRandom {
         }
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -1794,7 +1812,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
     ) -> Result<SifrInt, ValueError> {
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -2026,9 +2044,7 @@ fn gauss(mu: f64, sigma: f64) -> f64 {
     _sync_module_random(&mut generator);
     value
 }
-fn choice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    items: &Vec<T>,
-) -> Result<T, ValueError> {
+fn choice<T: Clone + 'static>(items: &Vec<T>) -> Result<T, ValueError> {
     let item_count: SifrInt = SifrInt::from(items.len());
     if (&item_count == &SifrInt::from_i64(0)) {
         return Err(ValueError::new("choice: items must not be empty".to_string()));
@@ -2048,7 +2064,7 @@ fn choice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     Err(ValueError::new("choice: index out of range".to_string()))
 }
-fn choices<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn choices<T: Clone + 'static>(
     items: &Vec<T>,
     k: SifrInt,
 ) -> Result<Vec<T>, ValueError> {
@@ -2081,10 +2097,7 @@ fn choices<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     _sync_module_random(&mut generator);
     Ok(result)
 }
-fn sample<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    items: &Vec<T>,
-    k: SifrInt,
-) -> Result<Vec<T>, ValueError> {
+fn sample<T: Clone + 'static>(items: &Vec<T>, k: SifrInt) -> Result<Vec<T>, ValueError> {
     if (&k < &SifrInt::from_i64(0)) {
         return Err(ValueError::new("sample: k must be >= 0".to_string()));
     }
@@ -2146,7 +2159,7 @@ fn sample<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     _sync_module_random(&mut generator);
     Ok(result)
 }
-fn shuffle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(items: &mut Vec<T>) {
+fn shuffle<T: Clone + 'static>(items: &mut Vec<T>) {
     let mut generator: __SifrStdlib_sifr_x2erandom_x2eRandom = _module_random();
     let n: SifrInt = SifrInt::from(items.len());
     if (&n > &SifrInt::from_i64(1)) {
@@ -2326,8 +2339,7 @@ fn main() {
                     .into_iter(),
             ),
             SifrInt::from_i64(1),
-            Some(SifrInt::from_i64(5)),
-            SifrInt::from_i64(2),
+            &vec![Some(SifrInt::from_i64(5)), Some(SifrInt::from_i64(2))],
         )?;
         println!(
             "{}", { let mut __sifr_concat : String = String::with_capacity(28usize +

--- a/demos/itertools/emitted.rs
+++ b/demos/itertools/emitted.rs
@@ -112,9 +112,7 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    iterables: &Vec<Vec<T>>,
-) -> Box<dyn Iterator<Item = T>> {
+fn chain<T: Clone + 'static>(iterables: &Vec<Vec<T>>) -> Box<dyn Iterator<Item = T>> {
     let iterables = iterables.clone();
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
@@ -126,9 +124,7 @@ fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn pairwise<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    data: &Vec<T>,
-) -> Vec<Vec<T>> {
+fn pairwise<T: Clone + 'static>(data: &Vec<T>) -> Vec<Vec<T>> {
     let mut result: Vec<Vec<T>> = vec![];
     let mut prev_values: Vec<T> = vec![];
     for value in data.iter().cloned() {
@@ -172,7 +168,7 @@ fn pairwise<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     result
 }
-fn batched<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn batched<T: Clone + 'static>(
     data: &Vec<T>,
     n: SifrInt,
 ) -> Result<Vec<Vec<T>>, ValueError> {
@@ -193,9 +189,10 @@ fn batched<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     Ok(result)
 }
-fn accumulate<
-    T: Clone + ::std::fmt::Display + PartialOrd + 'static + ::std::ops::Add<Output = T>,
->(data: Box<dyn Iterator<Item = T>>, initial: Option<T>) -> Box<dyn Iterator<Item = T>> {
+fn accumulate<T: Clone + 'static + ::std::ops::Add<Output = T>>(
+    data: Box<dyn Iterator<Item = T>>,
+    initial: Option<T>,
+) -> Box<dyn Iterator<Item = T>> {
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
             let mut state: Vec<T> = vec![];
@@ -271,7 +268,7 @@ fn accumulate<
         }),
     )
 }
-fn cycle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn cycle<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     n: SifrInt,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -284,38 +281,22 @@ fn cycle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             }
             for value in data {
                 saved.push(value.clone());
-                let current: Option<T> = {
-                    let __sifr_index_list = &saved;
-                    let __sifr_index_i = SifrInt::from(saved.len())
-                        - SifrInt::from_i64(1);
-                    let __sifr_index_norm = __sifr_index_i
-                        .normalize_index_or_len(__sifr_index_list.len());
-                    __sifr_index_list.get(__sifr_index_norm).cloned()
-                };
-                if let Some(current) = current {
-                    __sifr_yielder.suspend(current.clone()).await;
+                __sifr_yielder.suspend(value.clone()).await;
+                emitted = &emitted + &SifrInt::from_i64(1);
+                if (&emitted >= &n) {
+                    return;
+                }
+            }
+            while (&emitted < &n)
+                && (&SifrInt::from(saved.len()) > &SifrInt::from_i64(0))
+            {
+                for repeated in saved.iter().cloned() {
+                    __sifr_yielder.suspend(repeated.clone()).await;
                     emitted = &emitted + &SifrInt::from_i64(1);
                     if (&emitted >= &n) {
                         return;
                     }
                 }
-            }
-            let size: SifrInt = SifrInt::from(saved.len());
-            while (&emitted < &n) && (&size > &SifrInt::from_i64(0)) {
-                let index: SifrInt = emitted.floor_mod_known_nonzero(&size);
-                let repeated: Option<T> = {
-                    let __sifr_checked_read_collection = &saved;
-                    let __sifr_checked_read_index = index.clone();
-                    let __sifr_checked_read_normalized = __sifr_checked_read_index
-                        .normalize_index_or_len(__sifr_checked_read_collection.len());
-                    __sifr_checked_read_collection
-                        .get(__sifr_checked_read_normalized)
-                        .cloned()
-                };
-                if let Some(repeated) = repeated {
-                    __sifr_yielder.suspend(repeated.clone()).await;
-                }
-                emitted = &emitted + &SifrInt::from_i64(1);
             }
         }),
     )

--- a/demos/itertools_iterables/emitted.rs
+++ b/demos/itertools_iterables/emitted.rs
@@ -70,14 +70,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -94,7 +123,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -120,14 +149,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -744,7 +789,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -765,7 +810,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -786,7 +831,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -1057,14 +1102,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -1078,7 +1149,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1097,14 +1168,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -2222,10 +2309,11 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _islice_impl<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start: SifrInt,
     stop: SifrInt,
+    unbounded: bool,
     step: SifrInt,
 ) -> Box<dyn Iterator<Item = T>> {
     Box::new(
@@ -2233,7 +2321,7 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             let mut index: SifrInt = SifrInt::from_i64(0);
             let mut next_yield: SifrInt = start.clone();
             for value in data {
-                if &index >= &stop {
+                if !unbounded && (&index >= &stop) {
                     return;
                 }
                 if &index == &next_yield {
@@ -2245,23 +2333,47 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn islice<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start_or_stop: SifrInt,
-    stop: Option<SifrInt>,
-    step: SifrInt,
+    slice_args: &Vec<Option<SifrInt>>,
 ) -> Result<Box<dyn Iterator<Item = T>>, ValueError> {
+    if (&SifrInt::from(slice_args.len()) > &SifrInt::from_i64(2)) {
+        return Err(
+            ValueError::new(
+                "islice: expected at most stop and step after start".to_string(),
+            ),
+        );
+    }
     let mut actual_start: SifrInt = SifrInt::from_i64(0);
     let mut actual_stop: SifrInt = start_or_stop.clone();
-    if let Some(stop) = stop.clone() {
-        actual_start = start_or_stop.clone();
-        actual_stop = stop.clone();
+    let mut unbounded: bool = false;
+    let mut actual_step: SifrInt = SifrInt::from_i64(1);
+    let mut argument_index: SifrInt = SifrInt::from_i64(0);
+    for argument in slice_args.iter().cloned() {
+        if (&argument_index == &SifrInt::from_i64(0)) {
+            actual_start = start_or_stop.clone();
+            if (argument.is_none()) {
+                unbounded = true;
+            } else {
+                if let Some(argument) = argument.clone() {
+                    actual_stop = argument.clone();
+                }
+            }
+        } else {
+            if let Some(argument) = argument.clone() {
+                actual_step = argument.clone();
+            }
+        }
+        argument_index = &argument_index + &SifrInt::from_i64(1);
     }
-    if (&actual_start < &SifrInt::from_i64(0)) || (&actual_stop < &SifrInt::from_i64(0))
-    {
+    if (&actual_start < &SifrInt::from_i64(0)) {
         return Err(ValueError::new("islice: indices must be non-negative".to_string()));
     }
-    if (&step <= &SifrInt::from_i64(0)) {
+    if !unbounded && (&actual_stop < &SifrInt::from_i64(0)) {
+        return Err(ValueError::new("islice: indices must be non-negative".to_string()));
+    }
+    if (&actual_step <= &SifrInt::from_i64(0)) {
         return Err(
             ValueError::new("islice: step must be greater than zero".to_string()),
         );
@@ -2271,13 +2383,15 @@ fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             Box::new(data),
             (actual_start).clone(),
             (actual_stop).clone(),
-            (step).clone(),
+            unbounded,
+            (actual_step).clone(),
         ),
     )
 }
-fn accumulate<
-    T: Clone + ::std::fmt::Display + PartialOrd + 'static + ::std::ops::Add<Output = T>,
->(data: Box<dyn Iterator<Item = T>>, initial: Option<T>) -> Box<dyn Iterator<Item = T>> {
+fn accumulate<T: Clone + 'static + ::std::ops::Add<Output = T>>(
+    data: Box<dyn Iterator<Item = T>>,
+    initial: Option<T>,
+) -> Box<dyn Iterator<Item = T>> {
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
             let mut state: Vec<T> = vec![];
@@ -2353,7 +2467,7 @@ fn accumulate<
         }),
     )
 }
-fn compress<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn compress<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     selectors: Box<dyn Iterator<Item = bool>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -2369,7 +2483,7 @@ fn compress<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn takewhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn takewhile<T: Clone + 'static>(
     pred: impl Fn(&T) -> bool + Send + Sync + 'static,
     data: Box<dyn Iterator<Item = T>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -2704,7 +2818,7 @@ fn _iterdir_to_iter(path: &String) -> Result<Box<dyn Iterator<Item = String>>, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2725,7 +2839,7 @@ fn _glob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2746,7 +2860,7 @@ fn _rglob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2849,8 +2963,7 @@ fn main() {
         let sliced: Box<dyn Iterator<Item = SifrInt>> = islice(
             Box::new(nums.clone().into_iter()),
             SifrInt::from_i64(1),
-            Some(SifrInt::from_i64(4)),
-            SifrInt::from_i64(2),
+            &vec![Some(SifrInt::from_i64(4)), Some(SifrInt::from_i64(2))],
         )?;
         println!("{:?}", sliced.collect::< Vec < _ >> ());
         Ok(())
@@ -2907,8 +3020,10 @@ fn main() {
         let sliced_entries: Box<dyn Iterator<Item = String>> = (islice(
             Box::new(entries_it),
             SifrInt::from_i64(1),
-            None,
-            SifrInt::from_i64(1),
+            &({
+                let __sifr_empty_list_literal: Vec<Option<SifrInt>> = vec![];
+                __sifr_empty_list_literal
+            }),
         ))
             .map_err(|__e| __SifrUnion_8_x3asequence5_x3aunion1_x3a223_x3a5_x3aclass10_x3aValueError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass10_x3aValueError1_x3a0(
                 __e,

--- a/demos/itertools_iterators/emitted.rs
+++ b/demos/itertools_iterators/emitted.rs
@@ -112,9 +112,7 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    iterables: &Vec<Vec<T>>,
-) -> Box<dyn Iterator<Item = T>> {
+fn chain<T: Clone + 'static>(iterables: &Vec<Vec<T>>) -> Box<dyn Iterator<Item = T>> {
     let iterables = iterables.clone();
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
@@ -126,10 +124,7 @@ fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    value: T,
-    times: SifrInt,
-) -> Box<dyn Iterator<Item = T>> {
+fn repeat<T: Clone + 'static>(value: T, times: SifrInt) -> Box<dyn Iterator<Item = T>> {
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
             let holder: Vec<T> = vec![value.clone()];
@@ -156,10 +151,11 @@ fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _islice_impl<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start: SifrInt,
     stop: SifrInt,
+    unbounded: bool,
     step: SifrInt,
 ) -> Box<dyn Iterator<Item = T>> {
     Box::new(
@@ -167,7 +163,7 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             let mut index: SifrInt = SifrInt::from_i64(0);
             let mut next_yield: SifrInt = start.clone();
             for value in data {
-                if &index >= &stop {
+                if !unbounded && (&index >= &stop) {
                     return;
                 }
                 if &index == &next_yield {
@@ -179,23 +175,47 @@ fn _islice_impl<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn islice<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     start_or_stop: SifrInt,
-    stop: Option<SifrInt>,
-    step: SifrInt,
+    slice_args: &Vec<Option<SifrInt>>,
 ) -> Result<Box<dyn Iterator<Item = T>>, ValueError> {
+    if (&SifrInt::from(slice_args.len()) > &SifrInt::from_i64(2)) {
+        return Err(
+            ValueError::new(
+                "islice: expected at most stop and step after start".to_string(),
+            ),
+        );
+    }
     let mut actual_start: SifrInt = SifrInt::from_i64(0);
     let mut actual_stop: SifrInt = start_or_stop.clone();
-    if let Some(stop) = stop.clone() {
-        actual_start = start_or_stop.clone();
-        actual_stop = stop.clone();
+    let mut unbounded: bool = false;
+    let mut actual_step: SifrInt = SifrInt::from_i64(1);
+    let mut argument_index: SifrInt = SifrInt::from_i64(0);
+    for argument in slice_args.iter().cloned() {
+        if (&argument_index == &SifrInt::from_i64(0)) {
+            actual_start = start_or_stop.clone();
+            if (argument.is_none()) {
+                unbounded = true;
+            } else {
+                if let Some(argument) = argument.clone() {
+                    actual_stop = argument.clone();
+                }
+            }
+        } else {
+            if let Some(argument) = argument.clone() {
+                actual_step = argument.clone();
+            }
+        }
+        argument_index = &argument_index + &SifrInt::from_i64(1);
     }
-    if (&actual_start < &SifrInt::from_i64(0)) || (&actual_stop < &SifrInt::from_i64(0))
-    {
+    if (&actual_start < &SifrInt::from_i64(0)) {
         return Err(ValueError::new("islice: indices must be non-negative".to_string()));
     }
-    if (&step <= &SifrInt::from_i64(0)) {
+    if !unbounded && (&actual_stop < &SifrInt::from_i64(0)) {
+        return Err(ValueError::new("islice: indices must be non-negative".to_string()));
+    }
+    if (&actual_step <= &SifrInt::from_i64(0)) {
         return Err(
             ValueError::new("islice: step must be greater than zero".to_string()),
         );
@@ -205,7 +225,8 @@ fn islice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             Box::new(data),
             (actual_start).clone(),
             (actual_stop).clone(),
-            (step).clone(),
+            unbounded,
+            (actual_step).clone(),
         ),
     )
 }
@@ -242,8 +263,7 @@ fn main() {
                     .into_iter(),
             ),
             SifrInt::from_i64(1),
-            Some(SifrInt::from_i64(5)),
-            SifrInt::from_i64(2),
+            &vec![Some(SifrInt::from_i64(5)), Some(SifrInt::from_i64(2))],
         )?;
         println!("{:?}", sliced.collect::< Vec < _ >> ());
         Ok(())

--- a/demos/json/emitted.rs
+++ b/demos/json/emitted.rs
@@ -181,14 +181,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -205,7 +234,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -231,14 +260,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1515,7 +1560,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1563,14 +1608,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1586,14 +1631,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1608,7 +1657,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1666,19 +1715,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1694,14 +1742,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1716,7 +1768,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1808,7 +1860,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1860,7 +1912,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1900,6 +1952,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2510,7 +2572,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2531,7 +2593,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2570,7 +2632,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2892,7 +2954,7 @@ mod __sifr_project_nominals {
         tokens.push(format!("{}{}", value.kind.clone(), ""));
         if (value.kind.clone() == "bool") {
             let bool_value: Option<bool> = value.bool_value;
-            if (bool_value == None) {
+            if (bool_value.is_none()) {
                 tokens.push("false".to_string());
             } else {
                 if let Some(bool_value) = bool_value {
@@ -2902,7 +2964,7 @@ mod __sifr_project_nominals {
         } else {
             if (value.kind.clone() == "int") {
                 let int_value: Option<SifrInt> = value.int_value.clone();
-                if (int_value == None) {
+                if (int_value.is_none()) {
                     tokens.push("0".to_string());
                 } else {
                     if let Some(int_value) = int_value.clone() {
@@ -2912,7 +2974,7 @@ mod __sifr_project_nominals {
             } else {
                 if (value.kind.clone() == "float") {
                     let float_value: Option<f64> = value.float_value;
-                    if (float_value == None) {
+                    if (float_value.is_none()) {
                         tokens.push("0.0".to_string());
                     } else {
                         if let Some(float_value) = float_value {
@@ -2922,7 +2984,7 @@ mod __sifr_project_nominals {
                 } else {
                     if (value.kind.clone() == "str") {
                         let str_value: Option<String> = value.as_str();
-                        if (str_value == None) {
+                        if (str_value.is_none()) {
                             tokens.push("".to_string());
                         } else {
                             if let Some(str_value) = str_value {
@@ -3346,14 +3408,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3367,7 +3455,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3386,14 +3474,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4266,7 +4370,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4287,7 +4391,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4326,7 +4430,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4795,7 +4899,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -4805,7 +4909,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -4815,7 +4919,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -4825,7 +4929,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {

--- a/demos/json_values/emitted.rs
+++ b/demos/json_values/emitted.rs
@@ -181,14 +181,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -205,7 +234,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -231,14 +260,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1515,7 +1560,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1563,14 +1608,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1586,14 +1631,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1608,7 +1657,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1666,19 +1715,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1694,14 +1742,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1716,7 +1768,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1808,7 +1860,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1860,7 +1912,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1900,6 +1952,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2510,7 +2572,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2531,7 +2593,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2570,7 +2632,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2892,7 +2954,7 @@ mod __sifr_project_nominals {
         tokens.push(format!("{}{}", value.kind.clone(), ""));
         if (value.kind.clone() == "bool") {
             let bool_value: Option<bool> = value.bool_value;
-            if (bool_value == None) {
+            if (bool_value.is_none()) {
                 tokens.push("false".to_string());
             } else {
                 if let Some(bool_value) = bool_value {
@@ -2902,7 +2964,7 @@ mod __sifr_project_nominals {
         } else {
             if (value.kind.clone() == "int") {
                 let int_value: Option<SifrInt> = value.int_value.clone();
-                if (int_value == None) {
+                if (int_value.is_none()) {
                     tokens.push("0".to_string());
                 } else {
                     if let Some(int_value) = int_value.clone() {
@@ -2912,7 +2974,7 @@ mod __sifr_project_nominals {
             } else {
                 if (value.kind.clone() == "float") {
                     let float_value: Option<f64> = value.float_value;
-                    if (float_value == None) {
+                    if (float_value.is_none()) {
                         tokens.push("0.0".to_string());
                     } else {
                         if let Some(float_value) = float_value {
@@ -2922,7 +2984,7 @@ mod __sifr_project_nominals {
                 } else {
                     if (value.kind.clone() == "str") {
                         let str_value: Option<String> = value.as_str();
-                        if (str_value == None) {
+                        if (str_value.is_none()) {
                             tokens.push("".to_string());
                         } else {
                             if let Some(str_value) = str_value {
@@ -3346,14 +3408,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3367,7 +3455,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3386,14 +3474,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4266,7 +4370,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4287,7 +4391,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4326,7 +4430,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4840,7 +4944,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -4850,7 +4954,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -4860,7 +4964,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -4870,7 +4974,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {

--- a/demos/lazy_iterators_basics/emitted.rs
+++ b/demos/lazy_iterators_basics/emitted.rs
@@ -96,9 +96,7 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    iterables: &Vec<Vec<T>>,
-) -> Box<dyn Iterator<Item = T>> {
+fn chain<T: Clone + 'static>(iterables: &Vec<Vec<T>>) -> Box<dyn Iterator<Item = T>> {
     let iterables = iterables.clone();
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {

--- a/demos/logging/emitted.rs
+++ b/demos/logging/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1484,7 +1529,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1532,14 +1577,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1555,14 +1600,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1577,7 +1626,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1635,19 +1684,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1663,14 +1711,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1685,7 +1737,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1777,7 +1829,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1829,7 +1881,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1869,6 +1921,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2479,7 +2541,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2500,7 +2562,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2539,7 +2601,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3333,14 +3395,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3354,7 +3442,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3373,14 +3461,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4218,7 +4322,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4239,7 +4343,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4278,7 +4382,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/logging_and_timers/emitted.rs
+++ b/demos/logging_and_timers/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1484,7 +1529,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1532,14 +1577,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1555,14 +1600,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1577,7 +1626,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1635,19 +1684,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1663,14 +1711,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1685,7 +1737,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1777,7 +1829,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1829,7 +1881,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1869,6 +1921,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2479,7 +2541,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2500,7 +2562,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2539,7 +2601,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3807,14 +3869,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3828,7 +3916,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3847,14 +3935,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4692,7 +4796,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4713,7 +4817,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4752,7 +4856,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/max_heap/emitted.rs
+++ b/demos/max_heap/emitted.rs
@@ -2,7 +2,7 @@
 use ::sifr_runtime::SifrInt;
 
 // --- stdlib: sifr.heapq ---
-fn _sift_down_max<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _sift_down_max<T: Clone + 'static + PartialOrd>(
     data: &mut Vec<T>,
     mut pos: SifrInt,
     n: SifrInt,
@@ -125,9 +125,7 @@ fn _sift_down_max<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn _heapify_max<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    data: &mut Vec<T>,
-) {
+fn _heapify_max<T: Clone + 'static>(data: &mut Vec<T>) {
     "Convert list to a max-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -137,9 +135,7 @@ fn _heapify_max<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn _heappop_max<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-) -> Option<T> {
+fn _heappop_max<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the largest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -180,10 +176,7 @@ fn _heappop_max<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     top
 }
-fn _heapreplace_max<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    item: T,
-) -> Option<T> {
+fn _heapreplace_max<T: Clone + 'static>(heap: &mut Vec<T>, item: T) -> Option<T> {
     "Pop and return the largest item, then push item onto the heap.\n    Returns None if the heap is empty. O(log n) time."
         .to_string();
     if &SifrInt::from(heap.len()) == &SifrInt::from_i64(0) {

--- a/demos/max_heap/emitted.rs
+++ b/demos/max_heap/emitted.rs
@@ -125,7 +125,7 @@ fn _sift_down_max<T: Clone + 'static + PartialOrd>(
         }
     }
 }
-fn _heapify_max<T: Clone + 'static>(data: &mut Vec<T>) {
+fn _heapify_max<T: Clone + 'static + PartialOrd>(data: &mut Vec<T>) {
     "Convert list to a max-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -135,7 +135,7 @@ fn _heapify_max<T: Clone + 'static>(data: &mut Vec<T>) {
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn _heappop_max<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
+fn _heappop_max<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the largest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -176,7 +176,10 @@ fn _heappop_max<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     }
     top
 }
-fn _heapreplace_max<T: Clone + 'static>(heap: &mut Vec<T>, item: T) -> Option<T> {
+fn _heapreplace_max<T: Clone + 'static + PartialOrd>(
+    heap: &mut Vec<T>,
+    item: T,
+) -> Option<T> {
     "Pop and return the largest item, then push item onto the heap.\n    Returns None if the heap is empty. O(log n) time."
         .to_string();
     if &SifrInt::from(heap.len()) == &SifrInt::from_i64(0) {

--- a/demos/no_runtime_panics/emitted.rs
+++ b/demos/no_runtime_panics/emitted.rs
@@ -181,14 +181,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -205,7 +234,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -231,14 +260,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1515,7 +1560,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1563,14 +1608,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1586,14 +1631,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1608,7 +1657,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1666,19 +1715,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1694,14 +1742,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1716,7 +1768,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1808,7 +1860,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1860,7 +1912,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1900,6 +1952,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2510,7 +2572,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2531,7 +2593,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2570,7 +2632,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2892,7 +2954,7 @@ mod __sifr_project_nominals {
         tokens.push(format!("{}{}", value.kind.clone(), ""));
         if (value.kind.clone() == "bool") {
             let bool_value: Option<bool> = value.bool_value;
-            if (bool_value == None) {
+            if (bool_value.is_none()) {
                 tokens.push("false".to_string());
             } else {
                 if let Some(bool_value) = bool_value {
@@ -2902,7 +2964,7 @@ mod __sifr_project_nominals {
         } else {
             if (value.kind.clone() == "int") {
                 let int_value: Option<SifrInt> = value.int_value.clone();
-                if (int_value == None) {
+                if (int_value.is_none()) {
                     tokens.push("0".to_string());
                 } else {
                     if let Some(int_value) = int_value.clone() {
@@ -2912,7 +2974,7 @@ mod __sifr_project_nominals {
             } else {
                 if (value.kind.clone() == "float") {
                     let float_value: Option<f64> = value.float_value;
-                    if (float_value == None) {
+                    if (float_value.is_none()) {
                         tokens.push("0.0".to_string());
                     } else {
                         if let Some(float_value) = float_value {
@@ -2922,7 +2984,7 @@ mod __sifr_project_nominals {
                 } else {
                     if (value.kind.clone() == "str") {
                         let str_value: Option<String> = value.as_str();
-                        if (str_value == None) {
+                        if (str_value.is_none()) {
                             tokens.push("".to_string());
                         } else {
                             if let Some(str_value) = str_value {
@@ -3542,14 +3604,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3563,7 +3651,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3582,14 +3670,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4427,7 +4531,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4448,7 +4552,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4487,7 +4591,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4521,7 +4625,7 @@ fn is_valid_ipv4(addr: &String) -> bool {
                 __sifr_chars_part.get(__sifr_string_index_normalized)
             })
                 .map(|c| c.to_string());
-            if (first_digit != None) && (first_digit == Some("0".to_string())) {
+            if (first_digit.is_some()) && (first_digit == Some("0".to_string())) {
                 return false;
             }
         }
@@ -5120,7 +5224,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -5130,7 +5234,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -5140,7 +5244,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -5150,7 +5254,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {
@@ -5980,7 +6084,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eRandom {
         }
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -6825,7 +6929,7 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
 fn has_match(pattern: &String, text: &String) -> Result<bool, RegexError> {
     let __sifr_try_res: Result<Result<bool, RegexError>, RegexError> = (|| {
         let found: Option<String> = search(pattern, text)?;
-        Ok(Ok((found != None)))
+        Ok(Ok((found.is_some())))
     })();
     match __sifr_try_res {
         Ok(__sifr_ret_val) => {

--- a/demos/optional_arithmetic/emitted.rs
+++ b/demos/optional_arithmetic/emitted.rs
@@ -20,7 +20,7 @@ fn main() {
         }
     }
     let missing_total: Option<SifrInt> = None;
-    if (missing_total == None) {
+    if (missing_total.is_none()) {
         println!("{}", SifrInt::from_i64(0));
     }
 }

--- a/demos/ordered_collections/emitted.rs
+++ b/demos/ordered_collections/emitted.rs
@@ -799,7 +799,7 @@ fn bisect_right<T: Clone + 'static + PartialOrd>(
     }
     left.clone()
 }
-fn insort_right<T: Clone + 'static>(
+fn insort_right<T: Clone + 'static + PartialOrd>(
     a: &mut Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -1029,7 +1029,7 @@ fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt
         }
     }
 }
-fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static + PartialOrd>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -1039,13 +1039,13 @@ fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
+fn heappush<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
+fn heappop<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -1086,7 +1086,10 @@ fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     }
     top
 }
-fn heapreplace<T: Clone + 'static>(heap: &mut Vec<T>, item: T) -> Option<T> {
+fn heapreplace<T: Clone + 'static + PartialOrd>(
+    heap: &mut Vec<T>,
+    item: T,
+) -> Option<T> {
     if &SifrInt::from(heap.len()) == &SifrInt::from_i64(0) {
         return None;
     }
@@ -1111,7 +1114,10 @@ fn heapreplace<T: Clone + 'static>(heap: &mut Vec<T>, item: T) -> Option<T> {
     _sift_down(heap, SifrInt::from_i64(0), (heap_len).clone());
     top
 }
-fn heappushpop<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) -> Option<T> {
+fn heappushpop<T: Clone + 'static + PartialOrd>(
+    heap: &mut Vec<T>,
+    item: &T,
+) -> Option<T> {
     heappush(heap, item);
     heappop(heap)
 }

--- a/demos/ordered_collections/emitted.rs
+++ b/demos/ordered_collections/emitted.rs
@@ -751,7 +751,7 @@ pub use __sifr_project_nominals::__SifrStdlib_sifr_x2ecollections_x2edeque;
 use ::std::collections::HashMap;
 use ::std::collections::VecDeque;
 use ::sifr_runtime::SifrInt;
-fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn bisect_right<T: Clone + 'static + PartialOrd>(
     a: &Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -762,7 +762,7 @@ fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         left = SifrInt::from_i64(0);
     }
     let mut right: SifrInt = SifrInt::from(a.len());
-    if (hi == None) {
+    if (hi.is_none()) {
         right = SifrInt::from(a.len());
     } else {
         if let Some(hi) = hi.clone() {
@@ -799,7 +799,7 @@ fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     left.clone()
 }
-fn insort_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn insort_right<T: Clone + 'static>(
     a: &mut Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -808,9 +808,9 @@ fn insort_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     let pos: SifrInt = bisect_right(a, x, (lo).clone(), (hi).clone());
     a.insert(::sifr_runtime::to_usize_proven(&pos), x.clone());
 }
-fn from_list<
-    T: Clone + ::std::fmt::Display + PartialOrd + ::std::hash::Hash + Eq + 'static,
->(items: &Vec<T>) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
+fn from_list<T: Clone + ::std::hash::Hash + Eq + 'static>(
+    items: &Vec<T>,
+) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
     let mut counts: HashMap<T, SifrInt> = HashMap::from([]);
     for item in items.iter().cloned() {
         let val: Option<SifrInt> = counts.get(&item).cloned();
@@ -834,7 +834,7 @@ fn from_list<
     }
     __SifrStdlib_sifr_x2ecollections_x2eCounter::new(Some(counts), None)
 }
-fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _sift_down<T: Clone + 'static + PartialOrd>(
     data: &mut Vec<T>,
     mut pos: SifrInt,
     n: SifrInt,
@@ -957,10 +957,7 @@ fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    mut pos: SifrInt,
-) {
+fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt) {
     let mut done: bool = false;
     while !done {
         if (&pos <= &SifrInt::from_i64(0)) {
@@ -1032,7 +1029,7 @@ fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -1042,18 +1039,13 @@ fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappush<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    item: &T,
-) {
+fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-) -> Option<T> {
+fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -1094,10 +1086,7 @@ fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     top
 }
-fn heapreplace<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    item: T,
-) -> Option<T> {
+fn heapreplace<T: Clone + 'static>(heap: &mut Vec<T>, item: T) -> Option<T> {
     if &SifrInt::from(heap.len()) == &SifrInt::from_i64(0) {
         return None;
     }
@@ -1122,10 +1111,7 @@ fn heapreplace<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     _sift_down(heap, SifrInt::from_i64(0), (heap_len).clone());
     top
 }
-fn heappushpop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    item: &T,
-) -> Option<T> {
+fn heappushpop<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) -> Option<T> {
     heappush(heap, item);
     heappop(heap)
 }

--- a/demos/ordering_rules/emitted.rs
+++ b/demos/ordering_rules/emitted.rs
@@ -181,14 +181,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -205,7 +234,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -231,14 +260,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1515,7 +1560,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1563,14 +1608,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1586,14 +1631,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1608,7 +1657,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1666,19 +1715,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1694,14 +1742,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1716,7 +1768,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1808,7 +1860,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1860,7 +1912,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1900,6 +1952,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2510,7 +2572,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2531,7 +2593,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2570,7 +2632,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2892,7 +2954,7 @@ mod __sifr_project_nominals {
         tokens.push(format!("{}{}", value.kind.clone(), ""));
         if (value.kind.clone() == "bool") {
             let bool_value: Option<bool> = value.bool_value;
-            if (bool_value == None) {
+            if (bool_value.is_none()) {
                 tokens.push("false".to_string());
             } else {
                 if let Some(bool_value) = bool_value {
@@ -2902,7 +2964,7 @@ mod __sifr_project_nominals {
         } else {
             if (value.kind.clone() == "int") {
                 let int_value: Option<SifrInt> = value.int_value.clone();
-                if (int_value == None) {
+                if (int_value.is_none()) {
                     tokens.push("0".to_string());
                 } else {
                     if let Some(int_value) = int_value.clone() {
@@ -2912,7 +2974,7 @@ mod __sifr_project_nominals {
             } else {
                 if (value.kind.clone() == "float") {
                     let float_value: Option<f64> = value.float_value;
-                    if (float_value == None) {
+                    if (float_value.is_none()) {
                         tokens.push("0.0".to_string());
                     } else {
                         if let Some(float_value) = float_value {
@@ -2922,7 +2984,7 @@ mod __sifr_project_nominals {
                 } else {
                     if (value.kind.clone() == "str") {
                         let str_value: Option<String> = value.as_str();
-                        if (str_value == None) {
+                        if (str_value.is_none()) {
                             tokens.push("".to_string());
                         } else {
                             if let Some(str_value) = str_value {
@@ -3305,9 +3367,7 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    iterables: &Vec<Vec<T>>,
-) -> Box<dyn Iterator<Item = T>> {
+fn chain<T: Clone + 'static>(iterables: &Vec<Vec<T>>) -> Box<dyn Iterator<Item = T>> {
     let iterables = iterables.clone();
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
@@ -3319,10 +3379,7 @@ fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    value: T,
-    times: SifrInt,
-) -> Box<dyn Iterator<Item = T>> {
+fn repeat<T: Clone + 'static>(value: T, times: SifrInt) -> Box<dyn Iterator<Item = T>> {
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
             let holder: Vec<T> = vec![value.clone()];
@@ -3349,10 +3406,7 @@ fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn take<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn take<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut result: Vec<T> = vec![];
     let mut count: SifrInt = SifrInt::from_i64(0);
     for item in data.iter().cloned() {
@@ -3524,14 +3578,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3545,7 +3625,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3564,14 +3644,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4444,7 +4540,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4465,7 +4561,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4504,7 +4600,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4973,7 +5069,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -4983,7 +5079,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -4993,7 +5089,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -5003,7 +5099,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {

--- a/demos/os/emitted.rs
+++ b/demos/os/emitted.rs
@@ -220,14 +220,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -241,7 +267,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -260,14 +286,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/parse_safety/emitted.rs
+++ b/demos/parse_safety/emitted.rs
@@ -181,14 +181,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -205,7 +234,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -231,14 +260,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1478,7 +1523,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1526,14 +1571,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1549,14 +1594,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1571,7 +1620,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1629,19 +1678,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1657,14 +1705,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1679,7 +1731,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1771,7 +1823,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1823,7 +1875,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1863,6 +1915,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2473,7 +2535,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2494,7 +2556,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2533,7 +2595,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3287,7 +3349,7 @@ mod __sifr_project_nominals {
         tokens.push(format!("{}{}", value.kind.clone(), ""));
         if (value.kind.clone() == "bool") {
             let bool_value: Option<bool> = value.bool_value;
-            if (bool_value == None) {
+            if (bool_value.is_none()) {
                 tokens.push("false".to_string());
             } else {
                 if let Some(bool_value) = bool_value {
@@ -3297,7 +3359,7 @@ mod __sifr_project_nominals {
         } else {
             if (value.kind.clone() == "int") {
                 let int_value: Option<SifrInt> = value.int_value.clone();
-                if (int_value == None) {
+                if (int_value.is_none()) {
                     tokens.push("0".to_string());
                 } else {
                     if let Some(int_value) = int_value.clone() {
@@ -3307,7 +3369,7 @@ mod __sifr_project_nominals {
             } else {
                 if (value.kind.clone() == "float") {
                     let float_value: Option<f64> = value.float_value;
-                    if (float_value == None) {
+                    if (float_value.is_none()) {
                         tokens.push("0.0".to_string());
                     } else {
                         if let Some(float_value) = float_value {
@@ -3317,7 +3379,7 @@ mod __sifr_project_nominals {
                 } else {
                     if (value.kind.clone() == "str") {
                         let str_value: Option<String> = value.as_str();
-                        if (str_value == None) {
+                        if (str_value.is_none()) {
                             tokens.push("".to_string());
                         } else {
                             if let Some(str_value) = str_value {
@@ -4346,14 +4408,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -4367,7 +4455,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4386,14 +4474,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -5266,7 +5370,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5287,7 +5391,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5326,7 +5430,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5795,7 +5899,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -5805,7 +5909,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -5815,7 +5919,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -5825,7 +5929,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {
@@ -6646,7 +6750,7 @@ fn _load_json(
 fn has_match(pattern: &String, text: &String) -> Result<bool, RegexError> {
     let __sifr_try_res: Result<Result<bool, RegexError>, RegexError> = (|| {
         let found: Option<String> = search(pattern, text)?;
-        Ok(Ok((found != None)))
+        Ok(Ok((found.is_some())))
     })();
     match __sifr_try_res {
         Ok(__sifr_ret_val) => {

--- a/demos/pathlib/emitted.rs
+++ b/demos/pathlib/emitted.rs
@@ -70,14 +70,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -94,7 +123,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -120,14 +149,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -744,7 +789,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -765,7 +810,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -786,7 +831,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -886,14 +931,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -907,7 +978,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -926,14 +997,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -1449,7 +1536,7 @@ fn _iterdir_to_iter(path: &String) -> Result<Box<dyn Iterator<Item = String>>, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1470,7 +1557,7 @@ fn _glob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1491,7 +1578,7 @@ fn _rglob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/pattern_matching/emitted.rs
+++ b/demos/pattern_matching/emitted.rs
@@ -206,14 +206,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -227,7 +253,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -246,14 +272,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/protocol_bounds/emitted.rs
+++ b/demos/protocol_bounds/emitted.rs
@@ -1,11 +1,11 @@
 // src/main.rs
 use ::sifr_runtime::SifrInt;
 
-fn keep_comparable<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(x: &T) -> T {
+fn keep_comparable<T: Clone + 'static>(x: &T) -> T {
     x.clone()
 }
 
-fn relay_comparable<U: Clone + ::std::fmt::Display + PartialOrd + 'static>(x: &U) -> U {
+fn relay_comparable<U: Clone + 'static>(x: &U) -> U {
     keep_comparable(x)
 }
 

--- a/demos/protocol_bounds/emitted.rs
+++ b/demos/protocol_bounds/emitted.rs
@@ -1,11 +1,11 @@
 // src/main.rs
 use ::sifr_runtime::SifrInt;
 
-fn keep_comparable<T: Clone + 'static>(x: &T) -> T {
+fn keep_comparable<T: Clone + 'static + PartialOrd>(x: &T) -> T {
     x.clone()
 }
 
-fn relay_comparable<U: Clone + 'static>(x: &U) -> U {
+fn relay_comparable<U: Clone + 'static + PartialOrd>(x: &U) -> U {
     keep_comparable(x)
 }
 

--- a/demos/pure_sifr_stdlib/emitted.rs
+++ b/demos/pure_sifr_stdlib/emitted.rs
@@ -469,14 +469,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -490,7 +516,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -509,14 +535,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/pure_stdlib/emitted.rs
+++ b/demos/pure_stdlib/emitted.rs
@@ -495,9 +495,9 @@ pub use __sifr_project_nominals::ValueError;
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2ecollections_x2eCounter;
 use ::std::collections::HashMap;
 use ::sifr_runtime::SifrInt;
-fn from_list<
-    T: Clone + ::std::fmt::Display + PartialOrd + ::std::hash::Hash + Eq + 'static,
->(items: &Vec<T>) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
+fn from_list<T: Clone + ::std::hash::Hash + Eq + 'static>(
+    items: &Vec<T>,
+) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
     let mut counts: HashMap<T, SifrInt> = HashMap::from([]);
     for item in items.iter().cloned() {
         let val: Option<SifrInt> = counts.get(&item).cloned();
@@ -521,10 +521,11 @@ fn from_list<
     }
     __SifrStdlib_sifr_x2ecollections_x2eCounter::new(Some(counts), None)
 }
-fn reduce<
-    T: Clone + ::std::fmt::Display + PartialOrd + 'static,
-    U: Clone + ::std::fmt::Display + PartialOrd + 'static,
->(func: impl Fn(&U, &T) -> U, data: &Vec<T>, initial: &U) -> U {
+fn reduce<T: Clone + 'static, U: Clone + 'static>(
+    func: impl Fn(&U, &T) -> U,
+    data: &Vec<T>,
+    initial: &U,
+) -> U {
     let mut result: U = (initial).clone();
     for val in data.iter().cloned() {
         result = func(&result, &val);
@@ -636,9 +637,10 @@ fn count(start: SifrInt, step: SifrInt) -> Box<dyn Iterator<Item = SifrInt>> {
         }),
     )
 }
-fn accumulate<
-    T: Clone + ::std::fmt::Display + PartialOrd + 'static + ::std::ops::Add<Output = T>,
->(data: Box<dyn Iterator<Item = T>>, initial: Option<T>) -> Box<dyn Iterator<Item = T>> {
+fn accumulate<T: Clone + 'static + ::std::ops::Add<Output = T>>(
+    data: Box<dyn Iterator<Item = T>>,
+    initial: Option<T>,
+) -> Box<dyn Iterator<Item = T>> {
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
             let mut state: Vec<T> = vec![];
@@ -714,7 +716,7 @@ fn accumulate<
         }),
     )
 }
-fn compress<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn compress<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     selectors: Box<dyn Iterator<Item = bool>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -730,7 +732,7 @@ fn compress<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn dropwhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn dropwhile<T: Clone + 'static>(
     pred: impl Fn(&T) -> bool + Send + Sync + 'static,
     data: Box<dyn Iterator<Item = T>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -750,7 +752,7 @@ fn dropwhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn takewhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn takewhile<T: Clone + 'static>(
     pred: impl Fn(&T) -> bool + Send + Sync + 'static,
     data: Box<dyn Iterator<Item = T>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -765,7 +767,7 @@ fn takewhile<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn filterfalse<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn filterfalse<T: Clone + 'static>(
     pred: impl Fn(&T) -> bool + Send + Sync + 'static,
     data: Box<dyn Iterator<Item = T>>,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -779,7 +781,7 @@ fn filterfalse<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn zip_longest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn zip_longest<T: Clone + 'static>(
     a: Box<dyn Iterator<Item = T>>,
     b: Box<dyn Iterator<Item = T>>,
     fill: &T,
@@ -792,7 +794,7 @@ fn zip_longest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             loop {
                 let left_value: Option<T> = left.next();
                 let right_value: Option<T> = right.next();
-                if (left_value == None) && (right_value == None) {
+                if (left_value.is_none()) && (right_value.is_none()) {
                     return;
                 }
                 let mut pair: Vec<T> = vec![];
@@ -828,7 +830,7 @@ fn count_from(
         }),
     )
 }
-fn cycle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn cycle<T: Clone + 'static>(
     data: Box<dyn Iterator<Item = T>>,
     n: SifrInt,
 ) -> Box<dyn Iterator<Item = T>> {
@@ -841,38 +843,22 @@ fn cycle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
             }
             for value in data {
                 saved.push(value.clone());
-                let current: Option<T> = {
-                    let __sifr_index_list = &saved;
-                    let __sifr_index_i = SifrInt::from(saved.len())
-                        - SifrInt::from_i64(1);
-                    let __sifr_index_norm = __sifr_index_i
-                        .normalize_index_or_len(__sifr_index_list.len());
-                    __sifr_index_list.get(__sifr_index_norm).cloned()
-                };
-                if let Some(current) = current {
-                    __sifr_yielder.suspend(current.clone()).await;
+                __sifr_yielder.suspend(value.clone()).await;
+                emitted = &emitted + &SifrInt::from_i64(1);
+                if (&emitted >= &n) {
+                    return;
+                }
+            }
+            while (&emitted < &n)
+                && (&SifrInt::from(saved.len()) > &SifrInt::from_i64(0))
+            {
+                for repeated in saved.iter().cloned() {
+                    __sifr_yielder.suspend(repeated.clone()).await;
                     emitted = &emitted + &SifrInt::from_i64(1);
                     if (&emitted >= &n) {
                         return;
                     }
                 }
-            }
-            let size: SifrInt = SifrInt::from(saved.len());
-            while (&emitted < &n) && (&size > &SifrInt::from_i64(0)) {
-                let index: SifrInt = emitted.floor_mod_known_nonzero(&size);
-                let repeated: Option<T> = {
-                    let __sifr_checked_read_collection = &saved;
-                    let __sifr_checked_read_index = index.clone();
-                    let __sifr_checked_read_normalized = __sifr_checked_read_index
-                        .normalize_index_or_len(__sifr_checked_read_collection.len());
-                    __sifr_checked_read_collection
-                        .get(__sifr_checked_read_normalized)
-                        .cloned()
-                };
-                if let Some(repeated) = repeated {
-                    __sifr_yielder.suspend(repeated.clone()).await;
-                }
-                emitted = &emitted + &SifrInt::from_i64(1);
             }
         }),
     )
@@ -1609,7 +1595,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eRandom {
         }
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -1892,10 +1878,7 @@ fn gauss(mu: f64, sigma: f64) -> f64 {
     _sync_module_random(&mut generator);
     value
 }
-fn sample<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    items: &Vec<T>,
-    k: SifrInt,
-) -> Result<Vec<T>, ValueError> {
+fn sample<T: Clone + 'static>(items: &Vec<T>, k: SifrInt) -> Result<Vec<T>, ValueError> {
     if (&k < &SifrInt::from_i64(0)) {
         return Err(ValueError::new("sample: k must be >= 0".to_string()));
     }
@@ -1957,7 +1940,7 @@ fn sample<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     _sync_module_random(&mut generator);
     Ok(result)
 }
-fn shuffle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(items: &mut Vec<T>) {
+fn shuffle<T: Clone + 'static>(items: &mut Vec<T>) {
     let mut generator: __SifrStdlib_sifr_x2erandom_x2eRandom = _module_random();
     let n: SifrInt = SifrInt::from(items.len());
     if (&n > &SifrInt::from_i64(1)) {

--- a/demos/python_regressions/emitted.rs
+++ b/demos/python_regressions/emitted.rs
@@ -4665,7 +4665,7 @@ fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt
         }
     }
 }
-fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static + PartialOrd>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -4675,13 +4675,13 @@ fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
+fn heappush<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
+fn heappop<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());

--- a/demos/python_regressions/emitted.rs
+++ b/demos/python_regressions/emitted.rs
@@ -930,14 +930,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -954,7 +983,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -980,14 +1009,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -2264,7 +2309,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -2312,14 +2357,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -2335,14 +2380,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -2357,7 +2406,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -2415,19 +2464,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2443,14 +2491,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2465,7 +2517,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2557,7 +2609,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -2609,7 +2661,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -2649,6 +2701,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -3259,7 +3321,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3280,7 +3342,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3319,7 +3381,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3641,7 +3703,7 @@ mod __sifr_project_nominals {
         tokens.push(format!("{}{}", value.kind.clone(), ""));
         if (value.kind.clone() == "bool") {
             let bool_value: Option<bool> = value.bool_value;
-            if (bool_value == None) {
+            if (bool_value.is_none()) {
                 tokens.push("false".to_string());
             } else {
                 if let Some(bool_value) = bool_value {
@@ -3651,7 +3713,7 @@ mod __sifr_project_nominals {
         } else {
             if (value.kind.clone() == "int") {
                 let int_value: Option<SifrInt> = value.int_value.clone();
-                if (int_value == None) {
+                if (int_value.is_none()) {
                     tokens.push("0".to_string());
                 } else {
                     if let Some(int_value) = int_value.clone() {
@@ -3661,7 +3723,7 @@ mod __sifr_project_nominals {
             } else {
                 if (value.kind.clone() == "float") {
                     let float_value: Option<f64> = value.float_value;
-                    if (float_value == None) {
+                    if (float_value.is_none()) {
                         tokens.push("0.0".to_string());
                     } else {
                         if let Some(float_value) = float_value {
@@ -3671,7 +3733,7 @@ mod __sifr_project_nominals {
                 } else {
                     if (value.kind.clone() == "str") {
                         let str_value: Option<String> = value.as_str();
-                        if (str_value == None) {
+                        if (str_value.is_none()) {
                             tokens.push("".to_string());
                         } else {
                             if let Some(str_value) = str_value {
@@ -4096,7 +4158,7 @@ use ::std::collections::HashSet;
 use ::rust_decimal::Decimal;
 use ::bigdecimal::BigDecimal;
 use ::sifr_runtime::SifrInt;
-fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn bisect_left<T: Clone + 'static + PartialOrd>(
     a: &Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -4107,7 +4169,7 @@ fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         left = SifrInt::from_i64(0);
     }
     let mut right: SifrInt = SifrInt::from(a.len());
-    if (hi == None) {
+    if (hi.is_none()) {
         right = SifrInt::from(a.len());
     } else {
         if let Some(hi) = hi.clone() {
@@ -4144,7 +4206,7 @@ fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     left.clone()
 }
-fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn bisect_right<T: Clone + 'static + PartialOrd>(
     a: &Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -4155,7 +4217,7 @@ fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         left = SifrInt::from_i64(0);
     }
     let mut right: SifrInt = SifrInt::from(a.len());
-    if (hi == None) {
+    if (hi.is_none()) {
         right = SifrInt::from(a.len());
     } else {
         if let Some(hi) = hi.clone() {
@@ -4192,9 +4254,9 @@ fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     left.clone()
 }
-fn from_list<
-    T: Clone + ::std::fmt::Display + PartialOrd + ::std::hash::Hash + Eq + 'static,
->(items: &Vec<T>) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
+fn from_list<T: Clone + ::std::hash::Hash + Eq + 'static>(
+    items: &Vec<T>,
+) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
     let mut counts: HashMap<T, SifrInt> = HashMap::from([]);
     for item in items.iter().cloned() {
         let val: Option<SifrInt> = counts.get(&item).cloned();
@@ -4408,7 +4470,7 @@ fn filter(names: &Vec<String>, pattern: &String) -> Vec<String> {
     }
     result
 }
-fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _sift_down<T: Clone + 'static + PartialOrd>(
     data: &mut Vec<T>,
     mut pos: SifrInt,
     n: SifrInt,
@@ -4531,10 +4593,7 @@ fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    mut pos: SifrInt,
-) {
+fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt) {
     let mut done: bool = false;
     while !done {
         if (&pos <= &SifrInt::from_i64(0)) {
@@ -4606,7 +4665,7 @@ fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -4616,18 +4675,13 @@ fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappush<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    item: &T,
-) {
+fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-) -> Option<T> {
+fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -4762,9 +4816,7 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    iterables: &Vec<Vec<T>>,
-) -> Box<dyn Iterator<Item = T>> {
+fn chain<T: Clone + 'static>(iterables: &Vec<Vec<T>>) -> Box<dyn Iterator<Item = T>> {
     let iterables = iterables.clone();
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
@@ -4776,10 +4828,7 @@ fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    value: T,
-    times: SifrInt,
-) -> Box<dyn Iterator<Item = T>> {
+fn repeat<T: Clone + 'static>(value: T, times: SifrInt) -> Box<dyn Iterator<Item = T>> {
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
             let holder: Vec<T> = vec![value.clone()];
@@ -4806,10 +4855,7 @@ fn repeat<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn take<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn take<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut result: Vec<T> = vec![];
     let mut count: SifrInt = SifrInt::from_i64(0);
     for item in data.iter().cloned() {
@@ -4821,9 +4867,7 @@ fn take<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     result
 }
-fn flatten<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    lists: &Vec<Vec<T>>,
-) -> Vec<T> {
+fn flatten<T: Clone + 'static>(lists: &Vec<Vec<T>>) -> Vec<T> {
     let mut result: Vec<T> = vec![];
     for inner in lists.iter().cloned() {
         for val in inner.iter().cloned() {
@@ -4992,14 +5036,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -5013,7 +5083,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5032,14 +5102,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -5912,7 +5998,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5933,7 +6019,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5972,7 +6058,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6441,7 +6527,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -6451,7 +6537,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -6461,7 +6547,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -6471,7 +6557,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {
@@ -7947,7 +8033,7 @@ fn __io_err<E: ::std::fmt::Display + 'static>(e: E) -> IOError {
 fn has_match(pattern: &String, text: &String) -> Result<bool, RegexError> {
     let __sifr_try_res: Result<Result<bool, RegexError>, RegexError> = (|| {
         let found: Option<String> = search(pattern, text)?;
-        Ok(Ok((found != None)))
+        Ok(Ok((found.is_some())))
     })();
     match __sifr_try_res {
         Ok(__sifr_ret_val) => {

--- a/demos/random_hashing/emitted.rs
+++ b/demos/random_hashing/emitted.rs
@@ -251,14 +251,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -275,7 +304,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -301,14 +330,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -961,14 +1006,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -982,7 +1053,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1001,14 +1072,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -1805,7 +1892,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eRandom {
         }
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {

--- a/demos/random_state/emitted.rs
+++ b/demos/random_state/emitted.rs
@@ -733,7 +733,7 @@ mod __sifr_project_nominals {
             }
             let mut actual_start: SifrInt = start.clone();
             let mut actual_stop: SifrInt = start.clone();
-            if (stop.clone() == None) {
+            if (stop.is_none()) {
                 actual_start = SifrInt::from_i64(0);
             } else {
                 if let Some(stop) = stop.as_ref() {

--- a/demos/readonly_bytes/emitted.rs
+++ b/demos/readonly_bytes/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1297,7 +1342,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1345,14 +1390,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1368,14 +1413,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1390,7 +1439,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1413,9 +1462,6 @@ mod __sifr_project_nominals {
     }
     pub fn _closed_stream_error() -> String {
         "I/O operation on closed stream".to_string()
-    }
-    pub fn _unsupported_seek_tell_error() -> String {
-        "seek/tell is unsupported for this stream".to_string()
     }
     pub fn _mode_is_readable(mode: &String) -> bool {
         mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
@@ -1874,14 +1920,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -1895,7 +1967,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1914,14 +1986,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -2607,9 +2695,6 @@ fn encode(
 fn _closed_stream_error() -> String {
     "I/O operation on closed stream".to_string()
 }
-fn _unsupported_seek_tell_error() -> String {
-    "seek/tell is unsupported for this stream".to_string()
-}
 fn _mode_is_readable(mode: &String) -> bool {
     mode.contains(&"r".to_string()) || mode.contains(&"+".to_string())
 }
@@ -2783,7 +2868,7 @@ fn main() {
                 ),
             )
         })()?;
-        let loaded: Vec<u8> = reader.read_bytes()?;
+        let loaded: Vec<u8> = reader.read_bytes(&None)?;
         reader.close();
         io_ok = (((loaded == payload))
             && ((format!(

--- a/demos/regex/emitted.rs
+++ b/demos/regex/emitted.rs
@@ -305,7 +305,7 @@ fn assert_bool_vector_eq(actual: &Vec<bool>, expected: &Vec<bool>) {
 fn has_match(pattern: &String, text: &String) -> Result<bool, RegexError> {
     let __sifr_try_res: Result<Result<bool, RegexError>, RegexError> = (|| {
         let found: Option<String> = search(pattern, text)?;
-        Ok(Ok((found != None)))
+        Ok(Ok((found.is_some())))
     })();
     match __sifr_try_res {
         Ok(__sifr_ret_val) => {
@@ -352,7 +352,7 @@ fn collect_primary_actual() -> Vec<bool> {
             &"HELLO".to_string(),
             __const_IGNORECASE(),
         )?;
-        case_fold_ok = (case_fold != None);
+        case_fold_ok = (case_fold.is_some());
         Ok(())
     })();
     if let Err(__sifr_try_err) = __sifr_try_res {

--- a/demos/regex_and_filesystem/emitted.rs
+++ b/demos/regex_and_filesystem/emitted.rs
@@ -307,14 +307,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -331,7 +360,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -357,14 +386,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -981,7 +1026,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -1002,7 +1047,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -1023,7 +1068,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -1392,14 +1437,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -1413,7 +1484,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1432,14 +1503,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -3226,7 +3313,7 @@ fn _iterdir_to_iter(path: &String) -> Result<Box<dyn Iterator<Item = String>>, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3247,7 +3334,7 @@ fn _glob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3268,7 +3355,7 @@ fn _rglob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3706,7 +3793,7 @@ fn main() {
         if let Some(second) = second {
             assert!((second.group() == "22"));
         }
-        assert!((digits.next() == None));
+        assert!((digits.next().is_none()));
         let pat: __SifrStdlib_sifr_x2ere_x2ePattern = compile(&"[a-z]+".to_string())?;
         let mut words: Vec<String> = vec![];
         let word_it: Box<dyn Iterator<Item = __SifrStdlib_sifr_x2ere_x2eMatch>> = pat

--- a/demos/safe_edge_cases/emitted.rs
+++ b/demos/safe_edge_cases/emitted.rs
@@ -2156,7 +2156,7 @@ fn is_valid_ipv4(addr: &String) -> bool {
                 __sifr_chars_part.get(__sifr_string_index_normalized)
             })
                 .map(|c| c.to_string());
-            if (first_digit != None) && (first_digit == Some("0".to_string())) {
+            if (first_digit.is_some()) && (first_digit == Some("0".to_string())) {
                 return false;
             }
         }
@@ -2255,7 +2255,7 @@ fn ip_to_int(addr: &String) -> Result<SifrInt, ValueError> {
     }
     Ok(_ip_to_int_raw(addr))
 }
-fn batched<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn batched<T: Clone + 'static>(
     data: &Vec<T>,
     n: SifrInt,
 ) -> Result<Vec<Vec<T>>, ValueError> {
@@ -3008,7 +3008,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eRandom {
         }
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -3238,7 +3238,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
     ) -> Result<SifrInt, ValueError> {
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -3470,9 +3470,7 @@ fn gauss(mu: f64, sigma: f64) -> f64 {
     _sync_module_random(&mut generator);
     value
 }
-fn choice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    items: &Vec<T>,
-) -> Result<T, ValueError> {
+fn choice<T: Clone + 'static>(items: &Vec<T>) -> Result<T, ValueError> {
     let item_count: SifrInt = SifrInt::from(items.len());
     if (&item_count == &SifrInt::from_i64(0)) {
         return Err(ValueError::new("choice: items must not be empty".to_string()));
@@ -3492,7 +3490,7 @@ fn choice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     Err(ValueError::new("choice: index out of range".to_string()))
 }
-fn choices<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn choices<T: Clone + 'static>(
     items: &Vec<T>,
     k: SifrInt,
 ) -> Result<Vec<T>, ValueError> {
@@ -3525,10 +3523,7 @@ fn choices<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     _sync_module_random(&mut generator);
     Ok(result)
 }
-fn sample<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    items: &Vec<T>,
-    k: SifrInt,
-) -> Result<Vec<T>, ValueError> {
+fn sample<T: Clone + 'static>(items: &Vec<T>, k: SifrInt) -> Result<Vec<T>, ValueError> {
     if (&k < &SifrInt::from_i64(0)) {
         return Err(ValueError::new("sample: k must be >= 0".to_string()));
     }
@@ -3590,7 +3585,7 @@ fn sample<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     _sync_module_random(&mut generator);
     Ok(result)
 }
-fn shuffle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(items: &mut Vec<T>) {
+fn shuffle<T: Clone + 'static>(items: &mut Vec<T>) {
     let mut generator: __SifrStdlib_sifr_x2erandom_x2eRandom = _module_random();
     let n: SifrInt = SifrInt::from(items.len());
     if (&n > &SifrInt::from_i64(1)) {

--- a/demos/shutil/emitted.rs
+++ b/demos/shutil/emitted.rs
@@ -220,14 +220,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -241,7 +267,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -260,14 +286,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/stdlib/emitted.rs
+++ b/demos/stdlib/emitted.rs
@@ -1223,14 +1223,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -1247,7 +1276,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -1273,14 +1302,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -2527,7 +2572,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -2575,14 +2620,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -2598,14 +2643,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -2620,7 +2669,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -2678,19 +2727,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2706,14 +2754,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2728,7 +2780,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2820,7 +2872,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -2872,7 +2924,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -2912,6 +2964,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -3522,7 +3584,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3543,7 +3605,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3582,7 +3644,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -5668,7 +5730,7 @@ fn is_valid_ipv4(addr: &String) -> bool {
                 __sifr_chars_part.get(__sifr_string_index_normalized)
             })
                 .map(|c| c.to_string());
-            if (first_digit != None) && (first_digit == Some("0".to_string())) {
+            if (first_digit.is_some()) && (first_digit == Some("0".to_string())) {
                 return false;
             }
         }
@@ -6080,14 +6142,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -6101,7 +6189,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6120,14 +6208,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -6973,7 +7077,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6994,7 +7098,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -7033,7 +7137,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/stdlib_classes/emitted.rs
+++ b/demos/stdlib_classes/emitted.rs
@@ -479,9 +479,9 @@ mod __sifr_project_nominals {
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2ecollections_x2eCounter;
 use ::std::collections::HashMap;
 use ::sifr_runtime::SifrInt;
-fn from_list<
-    T: Clone + ::std::fmt::Display + PartialOrd + ::std::hash::Hash + Eq + 'static,
->(items: &Vec<T>) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
+fn from_list<T: Clone + ::std::hash::Hash + Eq + 'static>(
+    items: &Vec<T>,
+) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
     let mut counts: HashMap<T, SifrInt> = HashMap::from([]);
     for item in items.iter().cloned() {
         let val: Option<SifrInt> = counts.get(&item).cloned();

--- a/demos/stdlib_expansion/emitted.rs
+++ b/demos/stdlib_expansion/emitted.rs
@@ -3741,7 +3741,7 @@ fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt
         }
     }
 }
-fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static + PartialOrd>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -3751,13 +3751,13 @@ fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
+fn heappush<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
+fn heappop<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -3798,7 +3798,7 @@ fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     }
     top
 }
-fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
+fn nsmallest<T: Clone + 'static + PartialOrd>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut heap: Vec<T> = data.clone();
     heapify(&mut heap);
     let mut result: Vec<T> = vec![];

--- a/demos/stdlib_expansion/emitted.rs
+++ b/demos/stdlib_expansion/emitted.rs
@@ -235,7 +235,7 @@ fn _split_inline_option(token: &String) -> (bool, String, String) {
             __sifr_chars_token.get(__sifr_string_index_normalized)
         })
             .map(|c| c.to_string());
-        if (ch != None) && (ch == Some("=".to_string())) {
+        if (ch.is_some()) && (ch == Some("=".to_string())) {
             let mut value: String = "".to_string();
             let mut j: SifrInt = &i + &SifrInt::from_i64(1);
             while (&j < &SifrInt::from(__sifr_chars_token.len())) {
@@ -334,7 +334,7 @@ fn parse_option(args: &Vec<String>, name: &String, default: &String) -> String {
         __sifr_concat
     }
 }
-fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn bisect_left<T: Clone + 'static + PartialOrd>(
     a: &Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -345,7 +345,7 @@ fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         left = SifrInt::from_i64(0);
     }
     let mut right: SifrInt = SifrInt::from(a.len());
-    if (hi == None) {
+    if (hi.is_none()) {
         right = SifrInt::from(a.len());
     } else {
         if let Some(hi) = hi.clone() {
@@ -558,14 +558,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -579,7 +605,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -598,14 +624,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -1845,7 +1887,7 @@ impl __SifrIoFileHandle {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
-        Ok(())
+        file_flush(&self._handle)
     }
 }
 impl __SifrIoFileHandle {
@@ -1893,14 +1935,14 @@ impl __SifrIoFileHandle {
     }
 }
 impl __SifrIoFileHandle {
-    fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+    fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
         if !self.readable() {
             return Err(IOError::new("stream is not readable".to_string()));
         }
-        file_read_bytes(&self._handle)
+        file_read_bytes(&self._handle, (size.clone()).clone())
     }
 }
 impl __SifrIoFileHandle {
@@ -1916,14 +1958,18 @@ impl __SifrIoFileHandle {
 }
 impl __SifrIoFileHandle {
     fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-        let _ = offset.clone();
-        let _ = whence.clone();
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
     }
 }
 impl __SifrIoFileHandle {
     fn tell(&self) -> Result<SifrInt, IOError> {
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_tell(&self._handle)
     }
 }
 impl __SifrIoFileHandle {
@@ -1938,7 +1984,7 @@ impl __SifrIoFileHandle {
 }
 impl __SifrIoFileHandle {
     fn seekable(&self) -> bool {
-        false
+        !(self._closed)
     }
 }
 impl __SifrIoFileHandle {
@@ -1996,19 +2042,18 @@ impl __SifrIoBinaryFileHandle {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
-        Ok(())
+        file_flush(&self._handle)
     }
 }
 impl __SifrIoBinaryFileHandle {
     fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-        let _ = (size).clone();
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
         if !self.readable() {
             return Err(IOError::new("stream is not readable".to_string()));
         }
-        file_read_bytes(&self._handle)
+        file_read_bytes(&self._handle, (size.clone()).clone())
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -2024,14 +2069,18 @@ impl __SifrIoBinaryFileHandle {
 }
 impl __SifrIoBinaryFileHandle {
     fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-        let _ = offset.clone();
-        let _ = whence.clone();
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
     }
 }
 impl __SifrIoBinaryFileHandle {
     fn tell(&self) -> Result<SifrInt, IOError> {
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_tell(&self._handle)
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -2046,7 +2095,7 @@ impl __SifrIoBinaryFileHandle {
 }
 impl __SifrIoBinaryFileHandle {
     fn seekable(&self) -> bool {
-        false
+        !(self._closed)
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -2138,7 +2187,7 @@ impl __SifrIoTextFileHandle {
                         __sifr_try_variant_error,
                     ) => {
                         let e = __sifr_try_variant_error.clone();
-                        return Err(IOError::new(e.message.clone()));
+                        return Err(e);
                     }
                     __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                         __sifr_try_variant_error,
@@ -2190,7 +2239,7 @@ impl __SifrIoTextFileHandle {
                         __sifr_try_variant_error,
                     ) => {
                         let e = __sifr_try_variant_error.clone();
-                        return Err(IOError::new(e.message.clone()));
+                        return Err(e);
                     }
                     __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                         __sifr_try_variant_error,
@@ -2230,6 +2279,16 @@ impl __SifrIoTextFileHandle {
                     .to_string(),
             ),
         )
+    }
+}
+impl __SifrIoTextFileHandle {
+    fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+        self._binary.seek(offset, whence)
+    }
+}
+impl __SifrIoTextFileHandle {
+    fn tell(&self) -> Result<SifrInt, IOError> {
+        self._binary.tell()
     }
 }
 impl __SifrIoTextFileHandle {
@@ -2832,7 +2891,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2853,7 +2912,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2892,7 +2951,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3476,17 +3535,18 @@ fn filter(names: &Vec<String>, pattern: &String) -> Vec<String> {
     }
     result
 }
-fn reduce<
-    T: Clone + ::std::fmt::Display + PartialOrd + 'static,
-    U: Clone + ::std::fmt::Display + PartialOrd + 'static,
->(func: impl Fn(&U, &T) -> U, data: &Vec<T>, initial: &U) -> U {
+fn reduce<T: Clone + 'static, U: Clone + 'static>(
+    func: impl Fn(&U, &T) -> U,
+    data: &Vec<T>,
+    initial: &U,
+) -> U {
     let mut result: U = (initial).clone();
     for val in data.iter().cloned() {
         result = func(&result, &val);
     }
     result
 }
-fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _sift_down<T: Clone + 'static + PartialOrd>(
     data: &mut Vec<T>,
     mut pos: SifrInt,
     n: SifrInt,
@@ -3609,10 +3669,7 @@ fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    mut pos: SifrInt,
-) {
+fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt) {
     let mut done: bool = false;
     while !done {
         if (&pos <= &SifrInt::from_i64(0)) {
@@ -3684,7 +3741,7 @@ fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -3694,18 +3751,13 @@ fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappush<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    item: &T,
-) {
+fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-) -> Option<T> {
+fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -3746,10 +3798,7 @@ fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     top
 }
-fn nsmallest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut heap: Vec<T> = data.clone();
     heapify(&mut heap);
     let mut result: Vec<T> = vec![];
@@ -3860,9 +3909,7 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    iterables: &Vec<Vec<T>>,
-) -> Box<dyn Iterator<Item = T>> {
+fn chain<T: Clone + 'static>(iterables: &Vec<Vec<T>>) -> Box<dyn Iterator<Item = T>> {
     let iterables = iterables.clone();
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {
@@ -3874,10 +3921,7 @@ fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }),
     )
 }
-fn take<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn take<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut result: Vec<T> = vec![];
     let mut count: SifrInt = SifrInt::from_i64(0);
     for item in data.iter().cloned() {
@@ -3889,9 +3933,7 @@ fn take<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     result
 }
-fn flatten<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    lists: &Vec<Vec<T>>,
-) -> Vec<T> {
+fn flatten<T: Clone + 'static>(lists: &Vec<Vec<T>>) -> Vec<T> {
     let mut result: Vec<T> = vec![];
     for inner in lists.iter().cloned() {
         for val in inner.iter().cloned() {
@@ -4632,7 +4674,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eRandom {
         }
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -4862,7 +4904,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eSystemRandom {
     ) -> Result<SifrInt, ValueError> {
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -5094,9 +5136,7 @@ fn gauss(mu: f64, sigma: f64) -> f64 {
     _sync_module_random(&mut generator);
     value
 }
-fn choice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    items: &Vec<T>,
-) -> Result<T, ValueError> {
+fn choice<T: Clone + 'static>(items: &Vec<T>) -> Result<T, ValueError> {
     let item_count: SifrInt = SifrInt::from(items.len());
     if (&item_count == &SifrInt::from_i64(0)) {
         return Err(ValueError::new("choice: items must not be empty".to_string()));
@@ -5116,7 +5156,7 @@ fn choice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     Err(ValueError::new("choice: index out of range".to_string()))
 }
-fn choices<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn choices<T: Clone + 'static>(
     items: &Vec<T>,
     k: SifrInt,
 ) -> Result<Vec<T>, ValueError> {
@@ -5149,10 +5189,7 @@ fn choices<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     _sync_module_random(&mut generator);
     Ok(result)
 }
-fn sample<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    items: &Vec<T>,
-    k: SifrInt,
-) -> Result<Vec<T>, ValueError> {
+fn sample<T: Clone + 'static>(items: &Vec<T>, k: SifrInt) -> Result<Vec<T>, ValueError> {
     if (&k < &SifrInt::from_i64(0)) {
         return Err(ValueError::new("sample: k must be >= 0".to_string()));
     }
@@ -5214,7 +5251,7 @@ fn sample<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     _sync_module_random(&mut generator);
     Ok(result)
 }
-fn shuffle<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(items: &mut Vec<T>) {
+fn shuffle<T: Clone + 'static>(items: &mut Vec<T>) {
     let mut generator: __SifrStdlib_sifr_x2erandom_x2eRandom = _module_random();
     let n: SifrInt = SifrInt::from(items.len());
     if (&n > &SifrInt::from_i64(1)) {

--- a/demos/stdlib_fixes/emitted.rs
+++ b/demos/stdlib_fixes/emitted.rs
@@ -416,14 +416,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -440,7 +469,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -466,14 +495,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1713,7 +1758,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1761,14 +1806,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1784,14 +1829,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1806,7 +1855,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1864,19 +1913,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1892,14 +1940,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1914,7 +1966,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -2006,7 +2058,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -2058,7 +2110,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -2098,6 +2150,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2708,7 +2770,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2729,7 +2791,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2768,7 +2830,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3713,7 +3775,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrStdlib_sifr_x2edatetime_x2etime {
         pub fn is_aware(&self) -> bool {
-            (self._tz_offset.clone() != None)
+            (self._tz_offset.clone().is_some())
         }
     }
     impl __SifrStdlib_sifr_x2edatetime_x2etime {
@@ -5344,7 +5406,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -5365,7 +5427,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -5386,7 +5448,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -6151,14 +6213,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -6172,7 +6260,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6191,14 +6279,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -7036,7 +7140,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -7057,7 +7161,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -7096,7 +7200,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -8927,7 +9031,7 @@ fn _iterdir_to_iter(path: &String) -> Result<Box<dyn Iterator<Item = String>>, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -8948,7 +9052,7 @@ fn _glob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -8969,7 +9073,7 @@ fn _rglob_to_iter(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -9705,7 +9809,7 @@ impl __SifrStdlib_sifr_x2erandom_x2eRandom {
         }
         let mut actual_start: SifrInt = start.clone();
         let mut actual_stop: SifrInt = start.clone();
-        if (stop.clone() == None) {
+        if (stop.is_none()) {
             actual_start = SifrInt::from_i64(0);
         } else {
             if let Some(stop) = stop.as_ref() {
@@ -9972,9 +10076,7 @@ fn _module_random() -> __SifrStdlib_sifr_x2erandom_x2eRandom {
 fn _sync_module_random(generator: &mut __SifrStdlib_sifr_x2erandom_x2eRandom) {
     _store_state_into_module_storage(&generator.getstate());
 }
-fn choice<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    items: &Vec<T>,
-) -> Result<T, ValueError> {
+fn choice<T: Clone + 'static>(items: &Vec<T>) -> Result<T, ValueError> {
     let item_count: SifrInt = SifrInt::from(items.len());
     if (&item_count == &SifrInt::from_i64(0)) {
         return Err(ValueError::new("choice: items must not be empty".to_string()));

--- a/demos/stdlib_functions/emitted.rs
+++ b/demos/stdlib_functions/emitted.rs
@@ -18,7 +18,7 @@ mod __sifr_project_nominals {
 }
 pub use __sifr_project_nominals::ValueError;
 use ::sifr_runtime::SifrInt;
-fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn bisect_left<T: Clone + 'static + PartialOrd>(
     a: &Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -29,7 +29,7 @@ fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         left = SifrInt::from_i64(0);
     }
     let mut right: SifrInt = SifrInt::from(a.len());
-    if (hi == None) {
+    if (hi.is_none()) {
         right = SifrInt::from(a.len());
     } else {
         if let Some(hi) = hi.clone() {
@@ -66,9 +66,7 @@ fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     left.clone()
 }
-fn pairwise<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    data: &Vec<T>,
-) -> Vec<Vec<T>> {
+fn pairwise<T: Clone + 'static>(data: &Vec<T>) -> Vec<Vec<T>> {
     let mut result: Vec<Vec<T>> = vec![];
     let mut prev_values: Vec<T> = vec![];
     for value in data.iter().cloned() {
@@ -112,7 +110,7 @@ fn pairwise<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     result
 }
-fn batched<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn batched<T: Clone + 'static>(
     data: &Vec<T>,
     n: SifrInt,
 ) -> Result<Vec<Vec<T>>, ValueError> {
@@ -597,14 +595,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -618,7 +642,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -637,14 +661,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/stdlib_intrinsics/emitted.rs
+++ b/demos/stdlib_intrinsics/emitted.rs
@@ -500,14 +500,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -521,7 +547,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -540,14 +566,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/stdlib_modules/emitted.rs
+++ b/demos/stdlib_modules/emitted.rs
@@ -393,14 +393,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -414,7 +440,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -433,14 +459,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -1715,7 +1757,7 @@ impl __SifrIoFileHandle {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
-        Ok(())
+        file_flush(&self._handle)
     }
 }
 impl __SifrIoFileHandle {
@@ -1763,14 +1805,14 @@ impl __SifrIoFileHandle {
     }
 }
 impl __SifrIoFileHandle {
-    fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+    fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
         if !self.readable() {
             return Err(IOError::new("stream is not readable".to_string()));
         }
-        file_read_bytes(&self._handle)
+        file_read_bytes(&self._handle, (size.clone()).clone())
     }
 }
 impl __SifrIoFileHandle {
@@ -1786,14 +1828,18 @@ impl __SifrIoFileHandle {
 }
 impl __SifrIoFileHandle {
     fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-        let _ = offset.clone();
-        let _ = whence.clone();
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
     }
 }
 impl __SifrIoFileHandle {
     fn tell(&self) -> Result<SifrInt, IOError> {
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_tell(&self._handle)
     }
 }
 impl __SifrIoFileHandle {
@@ -1808,7 +1854,7 @@ impl __SifrIoFileHandle {
 }
 impl __SifrIoFileHandle {
     fn seekable(&self) -> bool {
-        false
+        !(self._closed)
     }
 }
 impl __SifrIoFileHandle {
@@ -1866,19 +1912,18 @@ impl __SifrIoBinaryFileHandle {
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
-        Ok(())
+        file_flush(&self._handle)
     }
 }
 impl __SifrIoBinaryFileHandle {
     fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-        let _ = (size).clone();
         if self._closed {
             return Err(IOError::new(_closed_stream_error()));
         }
         if !self.readable() {
             return Err(IOError::new("stream is not readable".to_string()));
         }
-        file_read_bytes(&self._handle)
+        file_read_bytes(&self._handle, (size.clone()).clone())
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -1894,14 +1939,18 @@ impl __SifrIoBinaryFileHandle {
 }
 impl __SifrIoBinaryFileHandle {
     fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-        let _ = offset.clone();
-        let _ = whence.clone();
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
     }
 }
 impl __SifrIoBinaryFileHandle {
     fn tell(&self) -> Result<SifrInt, IOError> {
-        Err(IOError::new(_unsupported_seek_tell_error()))
+        if self._closed {
+            return Err(IOError::new(_closed_stream_error()));
+        }
+        file_tell(&self._handle)
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -1916,7 +1965,7 @@ impl __SifrIoBinaryFileHandle {
 }
 impl __SifrIoBinaryFileHandle {
     fn seekable(&self) -> bool {
-        false
+        !(self._closed)
     }
 }
 impl __SifrIoBinaryFileHandle {
@@ -2008,7 +2057,7 @@ impl __SifrIoTextFileHandle {
                         __sifr_try_variant_error,
                     ) => {
                         let e = __sifr_try_variant_error.clone();
-                        return Err(IOError::new(e.message.clone()));
+                        return Err(e);
                     }
                     __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                         __sifr_try_variant_error,
@@ -2060,7 +2109,7 @@ impl __SifrIoTextFileHandle {
                         __sifr_try_variant_error,
                     ) => {
                         let e = __sifr_try_variant_error.clone();
-                        return Err(IOError::new(e.message.clone()));
+                        return Err(e);
                     }
                     __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                         __sifr_try_variant_error,
@@ -2100,6 +2149,16 @@ impl __SifrIoTextFileHandle {
                     .to_string(),
             ),
         )
+    }
+}
+impl __SifrIoTextFileHandle {
+    fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+        self._binary.seek(offset, whence)
+    }
+}
+impl __SifrIoTextFileHandle {
+    fn tell(&self) -> Result<SifrInt, IOError> {
+        self._binary.tell()
     }
 }
 impl __SifrIoTextFileHandle {
@@ -2702,7 +2761,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2723,7 +2782,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2762,7 +2821,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3084,7 +3143,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -3094,7 +3153,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -3104,7 +3163,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -3114,7 +3173,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {

--- a/demos/stdlib_ownership/emitted.rs
+++ b/demos/stdlib_ownership/emitted.rs
@@ -479,7 +479,7 @@ mod __sifr_project_nominals {
 pub use __sifr_project_nominals::__SifrStdlib_sifr_x2ecollections_x2eCounter;
 use ::std::collections::HashMap;
 use ::sifr_runtime::SifrInt;
-fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn bisect_left<T: Clone + 'static + PartialOrd>(
     a: &Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -490,7 +490,7 @@ fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         left = SifrInt::from_i64(0);
     }
     let mut right: SifrInt = SifrInt::from(a.len());
-    if (hi == None) {
+    if (hi.is_none()) {
         right = SifrInt::from(a.len());
     } else {
         if let Some(hi) = hi.clone() {
@@ -527,7 +527,7 @@ fn bisect_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     left.clone()
 }
-fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn bisect_right<T: Clone + 'static + PartialOrd>(
     a: &Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -538,7 +538,7 @@ fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         left = SifrInt::from_i64(0);
     }
     let mut right: SifrInt = SifrInt::from(a.len());
-    if (hi == None) {
+    if (hi.is_none()) {
         right = SifrInt::from(a.len());
     } else {
         if let Some(hi) = hi.clone() {
@@ -575,7 +575,7 @@ fn bisect_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     left.clone()
 }
-fn insort_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn insort_left<T: Clone + 'static>(
     a: &mut Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -584,7 +584,7 @@ fn insort_left<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     let pos: SifrInt = bisect_left(a, x, (lo).clone(), (hi).clone());
     a.insert(::sifr_runtime::to_usize_proven(&pos), x.clone());
 }
-fn insort_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn insort_right<T: Clone + 'static>(
     a: &mut Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -593,9 +593,9 @@ fn insort_right<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     let pos: SifrInt = bisect_right(a, x, (lo).clone(), (hi).clone());
     a.insert(::sifr_runtime::to_usize_proven(&pos), x.clone());
 }
-fn from_list<
-    T: Clone + ::std::fmt::Display + PartialOrd + ::std::hash::Hash + Eq + 'static,
->(items: &Vec<T>) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
+fn from_list<T: Clone + ::std::hash::Hash + Eq + 'static>(
+    items: &Vec<T>,
+) -> __SifrStdlib_sifr_x2ecollections_x2eCounter<T> {
     let mut counts: HashMap<T, SifrInt> = HashMap::from([]);
     for item in items.iter().cloned() {
         let val: Option<SifrInt> = counts.get(&item).cloned();
@@ -619,7 +619,7 @@ fn from_list<
     }
     __SifrStdlib_sifr_x2ecollections_x2eCounter::new(Some(counts), None)
 }
-fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
+fn _sift_down<T: Clone + 'static + PartialOrd>(
     data: &mut Vec<T>,
     mut pos: SifrInt,
     n: SifrInt,
@@ -742,10 +742,7 @@ fn _sift_down<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    mut pos: SifrInt,
-) {
+fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt) {
     let mut done: bool = false;
     while !done {
         if (&pos <= &SifrInt::from_i64(0)) {
@@ -817,7 +814,7 @@ fn _sift_up<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         }
     }
 }
-fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -827,18 +824,13 @@ fn heapify<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(data: &mut Vec
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappush<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-    item: &T,
-) {
+fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    heap: &mut Vec<T>,
-) -> Option<T> {
+fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -879,10 +871,7 @@ fn heappop<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     top
 }
-fn nsmallest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut heap: Vec<T> = data.clone();
     heapify(&mut heap);
     let mut result: Vec<T> = vec![];
@@ -899,10 +888,7 @@ fn nsmallest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
     }
     result
 }
-fn nlargest<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    n: SifrInt,
-    data: &Vec<T>,
-) -> Vec<T> {
+fn nlargest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     if &n <= &SifrInt::from_i64(0) {
         return vec![];
     }
@@ -1038,9 +1024,7 @@ impl<T> Iterator for __SifrGenerator<T> {
         yielded
     }
 }
-fn chain<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    iterables: &Vec<Vec<T>>,
-) -> Box<dyn Iterator<Item = T>> {
+fn chain<T: Clone + 'static>(iterables: &Vec<Vec<T>>) -> Box<dyn Iterator<Item = T>> {
     let iterables = iterables.clone();
     Box::new(
         __SifrGenerator::new(async move |__sifr_yielder: __SifrYielder<T>| {

--- a/demos/stdlib_ownership/emitted.rs
+++ b/demos/stdlib_ownership/emitted.rs
@@ -575,7 +575,7 @@ fn bisect_right<T: Clone + 'static + PartialOrd>(
     }
     left.clone()
 }
-fn insort_left<T: Clone + 'static>(
+fn insort_left<T: Clone + 'static + PartialOrd>(
     a: &mut Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -584,7 +584,7 @@ fn insort_left<T: Clone + 'static>(
     let pos: SifrInt = bisect_left(a, x, (lo).clone(), (hi).clone());
     a.insert(::sifr_runtime::to_usize_proven(&pos), x.clone());
 }
-fn insort_right<T: Clone + 'static>(
+fn insort_right<T: Clone + 'static + PartialOrd>(
     a: &mut Vec<T>,
     x: &T,
     lo: SifrInt,
@@ -814,7 +814,7 @@ fn _sift_up<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, mut pos: SifrInt
         }
     }
 }
-fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
+fn heapify<T: Clone + 'static + PartialOrd>(data: &mut Vec<T>) {
     "Convert list to a min-heap in-place. O(n) time.".to_string();
     let n: SifrInt = SifrInt::from(data.len());
     let mut i: SifrInt = &n.floor_div_known_nonzero(&SifrInt::from_i64(2))
@@ -824,13 +824,13 @@ fn heapify<T: Clone + 'static>(data: &mut Vec<T>) {
         i = &i - &SifrInt::from_i64(1);
     }
 }
-fn heappush<T: Clone + 'static>(heap: &mut Vec<T>, item: &T) {
+fn heappush<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>, item: &T) {
     "Push item onto the heap in-place. O(log n) time.".to_string();
     heap.push(item.clone());
     let pos: SifrInt = &SifrInt::from(heap.len()) - &SifrInt::from_i64(1);
     _sift_up(heap, (pos).clone());
 }
-fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
+fn heappop<T: Clone + 'static + PartialOrd>(heap: &mut Vec<T>) -> Option<T> {
     "Pop and return the smallest item. Heap is modified in-place. O(log n) time.\n    Returns None if the heap is empty."
         .to_string();
     let n: SifrInt = SifrInt::from(heap.len());
@@ -871,7 +871,7 @@ fn heappop<T: Clone + 'static>(heap: &mut Vec<T>) -> Option<T> {
     }
     top
 }
-fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
+fn nsmallest<T: Clone + 'static + PartialOrd>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     let mut heap: Vec<T> = data.clone();
     heapify(&mut heap);
     let mut result: Vec<T> = vec![];
@@ -888,7 +888,7 @@ fn nsmallest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     }
     result
 }
-fn nlargest<T: Clone + 'static>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
+fn nlargest<T: Clone + 'static + PartialOrd>(n: SifrInt, data: &Vec<T>) -> Vec<T> {
     if &n <= &SifrInt::from_i64(0) {
         return vec![];
     }

--- a/demos/stdlib_tools/emitted.rs
+++ b/demos/stdlib_tools/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1483,7 +1528,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1531,14 +1576,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1554,14 +1599,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1576,7 +1625,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1634,19 +1683,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1662,14 +1710,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1684,7 +1736,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1776,7 +1828,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1828,7 +1880,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1868,6 +1920,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2478,7 +2540,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2499,7 +2561,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2538,7 +2600,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2940,14 +3002,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -2961,7 +3049,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -2980,14 +3068,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4149,7 +4253,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4170,7 +4274,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4209,7 +4313,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4891,7 +4995,7 @@ fn main() {
         )?;
         let key_value: Option<__SifrStdlib_sifr_x2etomllib_x2eTomlValue> = inline
             .get(&"key".to_string());
-        println!("{}", (key_value != None));
+        println!("{}", (key_value.is_some()));
         Ok(())
     })();
     if let Err(__sifr_try_err) = __sifr_try_res {

--- a/demos/structured_parsing_serialization/emitted.rs
+++ b/demos/structured_parsing_serialization/emitted.rs
@@ -182,14 +182,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -206,7 +235,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -232,14 +261,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1479,7 +1524,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1527,14 +1572,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1550,14 +1595,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1572,7 +1621,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1630,19 +1679,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1658,14 +1706,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1680,7 +1732,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1772,7 +1824,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1824,7 +1876,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1864,6 +1916,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2474,7 +2536,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2495,7 +2557,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2534,7 +2596,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3300,7 +3362,7 @@ mod __sifr_project_nominals {
                     .map(|__kv| (__kv.0.clone(), __kv.1.clone()))
                     .collect::<Vec<_>>()
                 {
-                    if (value == None) {
+                    if (value.is_none()) {
                         lines.push(key.clone());
                     } else {
                         if let Some(value) = value {
@@ -3322,7 +3384,7 @@ mod __sifr_project_nominals {
                     .map(|__kv| (__kv.0.clone(), __kv.1.clone()))
                     .collect::<Vec<_>>()
                 {
-                    if (value == None) {
+                    if (value.is_none()) {
                         lines.push(key.clone());
                     } else {
                         if let Some(value) = value {
@@ -3340,7 +3402,7 @@ mod __sifr_project_nominals {
                         .normalize_index_or_len(__sifr_index_list.len());
                     __sifr_index_list.get(__sifr_index_norm).cloned()
                 };
-                if (maybe_last != None) && (maybe_last == Some("".to_string())) {
+                if (maybe_last.is_some()) && (maybe_last == Some("".to_string())) {
                     if let Some(_) = lines.pop() {}
                 }
             }
@@ -3639,7 +3701,7 @@ mod __sifr_project_nominals {
                             merged,
                             &normalized_key,
                         );
-                        if (replacement == None) {
+                        if (replacement.is_none()) {
                             result.push_str("%(");
                             result.push_str((key).as_str());
                             result.push_str(")s");
@@ -4956,7 +5018,7 @@ mod __sifr_project_nominals {
         tokens.push(format!("{}{}", value.kind.clone(), ""));
         if (value.kind.clone() == "bool") {
             let bool_value: Option<bool> = value.bool_value;
-            if (bool_value == None) {
+            if (bool_value.is_none()) {
                 tokens.push("false".to_string());
             } else {
                 if let Some(bool_value) = bool_value {
@@ -4966,7 +5028,7 @@ mod __sifr_project_nominals {
         } else {
             if (value.kind.clone() == "int") {
                 let int_value: Option<SifrInt> = value.int_value.clone();
-                if (int_value == None) {
+                if (int_value.is_none()) {
                     tokens.push("0".to_string());
                 } else {
                     if let Some(int_value) = int_value.clone() {
@@ -4976,7 +5038,7 @@ mod __sifr_project_nominals {
             } else {
                 if (value.kind.clone() == "float") {
                     let float_value: Option<f64> = value.float_value;
-                    if (float_value == None) {
+                    if (float_value.is_none()) {
                         tokens.push("0.0".to_string());
                     } else {
                         if let Some(float_value) = float_value {
@@ -4986,7 +5048,7 @@ mod __sifr_project_nominals {
                 } else {
                     if (value.kind.clone() == "str") {
                         let str_value: Option<String> = value.as_str();
-                        if (str_value == None) {
+                        if (str_value.is_none()) {
                             tokens.push("".to_string());
                         } else {
                             if let Some(str_value) = str_value {
@@ -5753,14 +5815,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -5774,7 +5862,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -5793,14 +5881,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -6638,7 +6742,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6659,7 +6763,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6698,7 +6802,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -6969,7 +7073,7 @@ fn _resolve_interpolation(
                         merged,
                         &normalized_key,
                     );
-                    if (replacement == None) {
+                    if (replacement.is_none()) {
                         result.push_str("%(");
                         result.push_str((key).as_str());
                         result.push_str(")s");
@@ -8092,7 +8196,7 @@ fn _json_append_tokens(
     tokens.push(format!("{}{}", value.kind.clone(), ""));
     if (value.kind.clone() == "bool") {
         let bool_value: Option<bool> = value.bool_value;
-        if (bool_value == None) {
+        if (bool_value.is_none()) {
             tokens.push("false".to_string());
         } else {
             if let Some(bool_value) = bool_value {
@@ -8102,7 +8206,7 @@ fn _json_append_tokens(
     } else {
         if (value.kind.clone() == "int") {
             let int_value: Option<SifrInt> = value.int_value.clone();
-            if (int_value == None) {
+            if (int_value.is_none()) {
                 tokens.push("0".to_string());
             } else {
                 if let Some(int_value) = int_value.clone() {
@@ -8112,7 +8216,7 @@ fn _json_append_tokens(
         } else {
             if (value.kind.clone() == "float") {
                 let float_value: Option<f64> = value.float_value;
-                if (float_value == None) {
+                if (float_value.is_none()) {
                     tokens.push("0.0".to_string());
                 } else {
                     if let Some(float_value) = float_value {
@@ -8122,7 +8226,7 @@ fn _json_append_tokens(
             } else {
                 if (value.kind.clone() == "str") {
                     let str_value: Option<String> = value.as_str();
-                    if (str_value == None) {
+                    if (str_value.is_none()) {
                         tokens.push("".to_string());
                     } else {
                         if let Some(str_value) = str_value {

--- a/demos/subprocess/emitted.rs
+++ b/demos/subprocess/emitted.rs
@@ -111,14 +111,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -132,7 +158,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -151,14 +177,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/demos/system_tools/emitted.rs
+++ b/demos/system_tools/emitted.rs
@@ -179,14 +179,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -203,7 +232,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -229,14 +258,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -1484,7 +1529,7 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1532,14 +1577,14 @@ mod __sifr_project_nominals {
         }
     }
     impl __SifrIoFileHandle {
-        pub fn read_bytes(&self) -> Result<Vec<u8>, IOError> {
+        pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
@@ -1555,14 +1600,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoFileHandle {
@@ -1577,7 +1626,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoFileHandle {
@@ -1635,19 +1684,18 @@ mod __sifr_project_nominals {
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
-            Ok(())
+            file_flush(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn read_bytes(&self, size: &Option<SifrInt>) -> Result<Vec<u8>, IOError> {
-            let _ = (size).clone();
             if self._closed {
                 return Err(IOError::new(_closed_stream_error()));
             }
             if !self.readable() {
                 return Err(IOError::new("stream is not readable".to_string()));
             }
-            file_read_bytes(&self._handle)
+            file_read_bytes(&self._handle, (size.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1663,14 +1711,18 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
-            let _ = offset.clone();
-            let _ = whence.clone();
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_seek(&self._handle, (offset.clone()).clone(), (whence.clone()).clone())
         }
     }
     impl __SifrIoBinaryFileHandle {
         pub fn tell(&self) -> Result<SifrInt, IOError> {
-            Err(IOError::new(_unsupported_seek_tell_error()))
+            if self._closed {
+                return Err(IOError::new(_closed_stream_error()));
+            }
+            file_tell(&self._handle)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1685,7 +1737,7 @@ mod __sifr_project_nominals {
     }
     impl __SifrIoBinaryFileHandle {
         pub fn seekable(&self) -> bool {
-            false
+            !(self._closed)
         }
     }
     impl __SifrIoBinaryFileHandle {
@@ -1777,7 +1829,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eDecodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1829,7 +1881,7 @@ mod __sifr_project_nominals {
                             __sifr_try_variant_error,
                         ) => {
                             let e = __sifr_try_variant_error.clone();
-                            return Err(IOError::new(e.message.clone()));
+                            return Err(e);
                         }
                         __SifrUnion_8_x3asequence5_x3aunion1_x3a238_x3a5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a019_x3a5_x3aclass7_x3aIOError1_x3a0::__SifrUnionVariant_5_x3aclass25_x3asifr_x2eencoding_x2eEncodeError1_x3a0(
                             __sifr_try_variant_error,
@@ -1869,6 +1921,16 @@ mod __sifr_project_nominals {
                         .to_string(),
                 ),
             )
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn seek(&self, offset: &SifrInt, whence: &SifrInt) -> Result<SifrInt, IOError> {
+            self._binary.seek(offset, whence)
+        }
+    }
+    impl __SifrIoTextFileHandle {
+        pub fn tell(&self) -> Result<SifrInt, IOError> {
+            self._binary.tell()
         }
     }
     impl __SifrIoTextFileHandle {
@@ -2479,7 +2541,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2500,7 +2562,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -2539,7 +2601,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -3397,14 +3459,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -3418,7 +3506,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -3437,14 +3525,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -4290,7 +4394,7 @@ fn open(path: &String, mode: &String) -> Result<__SifrIoFileHandle, IOError> {
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4311,7 +4415,7 @@ fn open_binary(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -4350,7 +4454,7 @@ fn open_text(
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }

--- a/demos/tempfile/emitted.rs
+++ b/demos/tempfile/emitted.rs
@@ -220,14 +220,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -241,7 +267,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -260,14 +286,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -1682,7 +1724,7 @@ fn mkstemp(prefix: &String) -> Result<String, IOError> {
                     attempts = &attempts + &SifrInt::from_i64(1);
                     continue;
                 }
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -1717,7 +1759,7 @@ fn mkdtemp(prefix: &String) -> Result<String, IOError> {
                     attempts = &attempts + &SifrInt::from_i64(1);
                     continue;
                 }
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }

--- a/demos/tempfiles_and_zip/emitted.rs
+++ b/demos/tempfiles_and_zip/emitted.rs
@@ -522,14 +522,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -543,7 +569,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -562,14 +588,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()
@@ -1914,7 +1956,7 @@ fn mkstemp(prefix: &String) -> Result<String, IOError> {
                     attempts = &attempts + &SifrInt::from_i64(1);
                     continue;
                 }
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -1949,7 +1991,7 @@ fn mkdtemp(prefix: &String) -> Result<String, IOError> {
                     attempts = &attempts + &SifrInt::from_i64(1);
                     continue;
                 }
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }

--- a/demos/test_assertions/emitted.rs
+++ b/demos/test_assertions/emitted.rs
@@ -409,21 +409,19 @@ fn assert_not_almost_eq(actual: f64, expected: f64, tolerance: f64) {
     }
     assert!(diff > tolerance);
 }
-fn assert_ge<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(a: &T, b: &T) {
+fn assert_ge<T: Clone + 'static + PartialOrd>(a: &T, b: &T) {
     assert!(* a >= * b);
 }
-fn assert_le<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(a: &T, b: &T) {
+fn assert_le<T: Clone + 'static + PartialOrd>(a: &T, b: &T) {
     assert!(* a <= * b);
 }
-fn assert_some<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(value: Option<T>) {
+fn assert_some<T: Clone + 'static>(value: Option<T>) {
     assert!(value.is_some());
 }
-fn assert_none<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(value: Option<T>) {
+fn assert_none<T: Clone + 'static>(value: Option<T>) {
     assert!(value.is_none());
 }
-fn assert_ok<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    value: Result<T, Error>,
-) {
+fn assert_ok<T: Clone + 'static>(value: Result<T, Error>) {
     let __sifr_try_res: Result<(), Error> = (|| {
         let out: T = value?;
         Ok(())
@@ -432,9 +430,7 @@ fn assert_ok<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
         assert!(false);
     }
 }
-fn assert_err<T: Clone + ::std::fmt::Display + PartialOrd + 'static>(
-    value: Result<T, Error>,
-) {
+fn assert_err<T: Clone + 'static>(value: Result<T, Error>) {
     let __sifr_try_res: Result<(), Error> = (|| {
         let out: T = value?;
         assert!(false);

--- a/demos/text_and_patterns/emitted.rs
+++ b/demos/text_and_patterns/emitted.rs
@@ -164,7 +164,7 @@ mod __sifr_project_nominals {
             })
                 .map(|c| c.to_string());
             let mut next_value: String = "".to_string();
-            if (next_ch == None) {
+            if (next_ch.is_none()) {
                 if safe {
                     result.push('$');
                     i = &i + &SifrInt::from_i64(1);
@@ -320,7 +320,7 @@ mod __sifr_project_nominals {
                 }
                 let mapped_value: Option<String> = _mapping_lookup(mapping, &name);
                 let mut mapped_value_text: String = "".to_string();
-                if (mapped_value == None) {
+                if (mapped_value.is_none()) {
                     if safe {
                         result.push_str("${");
                         result.push_str((name).as_str());
@@ -391,7 +391,7 @@ mod __sifr_project_nominals {
             }
             let mapped_value2: Option<String> = _mapping_lookup(mapping, &name2);
             let mut mapped_value2_text: String = "".to_string();
-            if (mapped_value2 == None) {
+            if (mapped_value2.is_none()) {
                 if safe {
                     result.push('$');
                     result.push_str((name2).as_str());
@@ -454,7 +454,7 @@ mod __sifr_project_nominals {
                         __sifr_chars_format_string.get(__sifr_string_index_normalized)
                     })
                         .map(|c| c.to_string());
-                    if (escaped_next != None) && (escaped_next == Some("{".to_string())) {
+                    if (escaped_next.is_some()) && (escaped_next == Some("{".to_string())) {
                         result.push('{');
                         i = &i + &SifrInt::from_i64(2);
                         continue;
@@ -530,7 +530,8 @@ mod __sifr_project_nominals {
                         __sifr_chars_format_string.get(__sifr_string_index_normalized)
                     })
                         .map(|c| c.to_string());
-                    if (escaped_next2 != None) && (escaped_next2 == Some("}".to_string())) {
+                    if (escaped_next2.is_some()) && (escaped_next2 == Some("}".to_string()))
+                    {
                         result.push('}');
                         i = &i + &SifrInt::from_i64(2);
                         continue;
@@ -1009,8 +1010,8 @@ mod __sifr_project_nominals {
                         })
                             .map(|c| c.to_string());
                     }
-                    if (next_opt != None) && (next_opt == Some(" ".to_string())) {
-                        if (next2_opt == None) || (next2_opt != Some(" ".to_string())) {
+                    if (next_opt.is_some()) && (next_opt == Some(" ".to_string())) {
+                        if (next2_opt.is_none()) || (next2_opt != Some(" ".to_string())) {
                             result.push(' ');
                         }
                     }
@@ -2243,7 +2244,7 @@ fn _template_substitute_impl(
         })
             .map(|c| c.to_string());
         let mut next_value: String = "".to_string();
-        if (next_ch == None) {
+        if (next_ch.is_none()) {
             if safe {
                 result.push('$');
                 i = &i + &SifrInt::from_i64(1);
@@ -2399,7 +2400,7 @@ fn _template_substitute_impl(
             }
             let mapped_value: Option<String> = _mapping_lookup(mapping, &name);
             let mut mapped_value_text: String = "".to_string();
-            if (mapped_value == None) {
+            if (mapped_value.is_none()) {
                 if safe {
                     result.push_str("${");
                     result.push_str((name).as_str());
@@ -2470,7 +2471,7 @@ fn _template_substitute_impl(
         }
         let mapped_value2: Option<String> = _mapping_lookup(mapping, &name2);
         let mut mapped_value2_text: String = "".to_string();
-        if (mapped_value2 == None) {
+        if (mapped_value2.is_none()) {
             if safe {
                 result.push('$');
                 result.push_str((name2).as_str());
@@ -2533,7 +2534,7 @@ fn _formatter_format_impl(
                     __sifr_chars_format_string.get(__sifr_string_index_normalized)
                 })
                     .map(|c| c.to_string());
-                if (escaped_next != None) && (escaped_next == Some("{".to_string())) {
+                if (escaped_next.is_some()) && (escaped_next == Some("{".to_string())) {
                     result.push('{');
                     i = &i + &SifrInt::from_i64(2);
                     continue;
@@ -2609,7 +2610,8 @@ fn _formatter_format_impl(
                     __sifr_chars_format_string.get(__sifr_string_index_normalized)
                 })
                     .map(|c| c.to_string());
-                if (escaped_next2 != None) && (escaped_next2 == Some("}".to_string())) {
+                if (escaped_next2.is_some()) && (escaped_next2 == Some("}".to_string()))
+                {
                     result.push('}');
                     i = &i + &SifrInt::from_i64(2);
                     continue;
@@ -2960,8 +2962,8 @@ fn _apply_sentence_endings_line(text: &String) -> String {
                     })
                         .map(|c| c.to_string());
                 }
-                if (next_opt != None) && (next_opt == Some(" ".to_string())) {
-                    if (next2_opt == None) || (next2_opt != Some(" ".to_string())) {
+                if (next_opt.is_some()) && (next_opt == Some(" ".to_string())) {
+                    if (next2_opt.is_none()) || (next2_opt != Some(" ".to_string())) {
                         result.push(' ');
                     }
                 }

--- a/demos/text_and_statistics/emitted.rs
+++ b/demos/text_and_statistics/emitted.rs
@@ -465,8 +465,8 @@ mod __sifr_project_nominals {
                         })
                             .map(|c| c.to_string());
                     }
-                    if (next_opt != None) && (next_opt == Some(" ".to_string())) {
-                        if (next2_opt == None) || (next2_opt != Some(" ".to_string())) {
+                    if (next_opt.is_some()) && (next_opt == Some(" ".to_string())) {
+                        if (next2_opt.is_none()) || (next2_opt != Some(" ".to_string())) {
                             result.push(' ');
                         }
                     }
@@ -1551,8 +1551,8 @@ fn _apply_sentence_endings_line(text: &String) -> String {
                     })
                         .map(|c| c.to_string());
                 }
-                if (next_opt != None) && (next_opt == Some(" ".to_string())) {
-                    if (next2_opt == None) || (next2_opt != Some(" ".to_string())) {
+                if (next_opt.is_some()) && (next_opt == Some(" ".to_string())) {
+                    if (next2_opt.is_none()) || (next2_opt != Some(" ".to_string())) {
                         result.push(' ');
                     }
                 }

--- a/demos/utility_classes/emitted.rs
+++ b/demos/utility_classes/emitted.rs
@@ -950,7 +950,7 @@ mod __sifr_project_nominals {
                 __sifr_chars_token.get(__sifr_string_index_normalized)
             })
                 .map(|c| c.to_string());
-            if (ch != None) && (ch == Some("=".to_string())) {
+            if (ch.is_some()) && (ch == Some("=".to_string())) {
                 let mut value: String = "".to_string();
                 let mut j: SifrInt = &i + &SifrInt::from_i64(1);
                 while (&j < &SifrInt::from(__sifr_chars_token.len())) {
@@ -1355,7 +1355,7 @@ mod __sifr_project_nominals {
                     .normalize_index_or_len(__sifr_checked_read_collection.len());
                 __sifr_checked_read_collection.get(__sifr_checked_read_normalized).cloned()
             };
-            if (current != None) && (current == Some((*node).clone())) {
+            if (current.is_some()) && (current == Some((*node).clone())) {
                 self._next_index = &self._next_index.clone() + &SifrInt::from_i64(1);
             }
         }
@@ -1634,7 +1634,7 @@ mod __sifr_project_nominals {
                     __sifr_chars_part.get(__sifr_string_index_normalized)
                 })
                     .map(|c| c.to_string());
-                if (first_digit != None) && (first_digit == Some("0".to_string())) {
+                if (first_digit.is_some()) && (first_digit == Some("0".to_string())) {
                     return false;
                 }
             }
@@ -2193,7 +2193,7 @@ fn _split_inline_option(token: &String) -> (bool, String, String) {
             __sifr_chars_token.get(__sifr_string_index_normalized)
         })
             .map(|c| c.to_string());
-        if (ch != None) && (ch == Some("=".to_string())) {
+        if (ch.is_some()) && (ch == Some("=".to_string())) {
             let mut value: String = "".to_string();
             let mut j: SifrInt = &i + &SifrInt::from_i64(1);
             while (&j < &SifrInt::from(__sifr_chars_token.len())) {
@@ -2582,7 +2582,7 @@ fn is_valid_ipv4(addr: &String) -> bool {
                 __sifr_chars_part.get(__sifr_string_index_normalized)
             })
                 .map(|c| c.to_string());
-            if (first_digit != None) && (first_digit == Some("0".to_string())) {
+            if (first_digit.is_some()) && (first_digit == Some("0".to_string())) {
                 return false;
             }
         }

--- a/demos/zipfile_io/emitted.rs
+++ b/demos/zipfile_io/emitted.rs
@@ -251,14 +251,43 @@ mod __sifr_project_nominals {
     pub fn _file_close(handle: &String) {
         ::sifr_stdlib::fs::file_close(handle);
     }
-    pub fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-        ::sifr_stdlib::fs::file_read_bytes(handle)
+    pub fn _file_read_bytes(
+        handle: &String,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        ::sifr_stdlib::fs::file_read_bytes(
+                handle,
+                size.map(::sifr_runtime::interop::SifrIntBridge::from),
+            )
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
         ::sifr_stdlib::fs::file_write_bytes(handle, data)
             .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_flush(handle: &String) -> Result<(), IOError> {
+        ::sifr_stdlib::fs::file_flush(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_seek(
+        handle: &String,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_seek(
+                handle,
+                ::sifr_runtime::interop::SifrIntBridge::from(offset),
+                ::sifr_runtime::interop::SifrIntBridge::from(whence),
+            )
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+            .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+    }
+    pub fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+        ::sifr_stdlib::fs::file_tell(handle)
+            .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
             .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
     }
     pub fn open_file(
@@ -275,7 +304,7 @@ mod __sifr_project_nominals {
             }
             Err(__sifr_try_err) => {
                 let e = __sifr_try_err.clone();
-                return Err(IOError::new(e.message.clone()));
+                return Err(e);
             }
         }
     }
@@ -301,14 +330,30 @@ mod __sifr_project_nominals {
     pub fn file_close(handle: &__SifrIoNativeFileHandle) {
         _file_close(&handle._id.clone());
     }
-    pub fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-        _file_read_bytes(&handle._id.clone())
+    pub fn file_read_bytes(
+        handle: &__SifrIoNativeFileHandle,
+        size: Option<SifrInt>,
+    ) -> Result<Vec<u8>, IOError> {
+        _file_read_bytes(&handle._id.clone(), (size).clone())
     }
     pub fn file_write_bytes(
         handle: &__SifrIoNativeFileHandle,
         data: &Vec<u8>,
     ) -> Result<(), IOError> {
         _file_write_bytes(&handle._id.clone(), data)
+    }
+    pub fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+        _file_flush(&handle._id.clone())
+    }
+    pub fn file_seek(
+        handle: &__SifrIoNativeFileHandle,
+        offset: SifrInt,
+        whence: SifrInt,
+    ) -> Result<SifrInt, IOError> {
+        _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+    }
+    pub fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+        _file_tell(&handle._id.clone())
     }
     pub fn getcwd() -> Result<String, IOError> {
         ::sifr_stdlib::fs::getcwd()
@@ -481,7 +526,7 @@ mod __sifr_project_nominals {
                 })();
                 if let Err(__sifr_try_err) = __sifr_try_res {
                     let e = __sifr_try_err.clone();
-                    return Err(IOError::new(e.message.clone()));
+                    return Err(e);
                 }
             }
             self._cleaned = true;
@@ -1112,14 +1157,40 @@ fn _file_readlines(handle: &String) -> Result<Vec<String>, IOError> {
 fn _file_close(handle: &String) {
     ::sifr_stdlib::fs::file_close(handle);
 }
-fn _file_read_bytes(handle: &String) -> Result<Vec<u8>, IOError> {
-    ::sifr_stdlib::fs::file_read_bytes(handle)
+fn _file_read_bytes(handle: &String, size: Option<SifrInt>) -> Result<Vec<u8>, IOError> {
+    ::sifr_stdlib::fs::file_read_bytes(
+            handle,
+            size.map(::sifr_runtime::interop::SifrIntBridge::from),
+        )
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn _file_write_bytes(handle: &String, data: &Vec<u8>) -> Result<(), IOError> {
     ::sifr_stdlib::fs::file_write_bytes(handle, data)
         .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_flush(handle: &String) -> Result<(), IOError> {
+    ::sifr_stdlib::fs::file_flush(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok)
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_seek(
+    handle: &String,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_seek(
+            handle,
+            ::sifr_runtime::interop::SifrIntBridge::from(offset),
+            ::sifr_runtime::interop::SifrIntBridge::from(whence),
+        )
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
+        .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
+}
+fn _file_tell(handle: &String) -> Result<SifrInt, IOError> {
+    ::sifr_stdlib::fs::file_tell(handle)
+        .map(|__sifr_bridge_ok| __sifr_bridge_ok.into_sifr_int())
         .map_err(|__sifr_bridge_error| __io_err(__sifr_bridge_error))
 }
 fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, IOError> {
@@ -1133,7 +1204,7 @@ fn open_file(path: &String, mode: &String) -> Result<__SifrIoNativeFileHandle, I
         }
         Err(__sifr_try_err) => {
             let e = __sifr_try_err.clone();
-            return Err(IOError::new(e.message.clone()));
+            return Err(e);
         }
     }
 }
@@ -1152,14 +1223,30 @@ fn file_readlines(handle: &__SifrIoNativeFileHandle) -> Result<Vec<String>, IOEr
 fn file_close(handle: &__SifrIoNativeFileHandle) {
     _file_close(&handle._id.clone());
 }
-fn file_read_bytes(handle: &__SifrIoNativeFileHandle) -> Result<Vec<u8>, IOError> {
-    _file_read_bytes(&handle._id.clone())
+fn file_read_bytes(
+    handle: &__SifrIoNativeFileHandle,
+    size: Option<SifrInt>,
+) -> Result<Vec<u8>, IOError> {
+    _file_read_bytes(&handle._id.clone(), (size).clone())
 }
 fn file_write_bytes(
     handle: &__SifrIoNativeFileHandle,
     data: &Vec<u8>,
 ) -> Result<(), IOError> {
     _file_write_bytes(&handle._id.clone(), data)
+}
+fn file_flush(handle: &__SifrIoNativeFileHandle) -> Result<(), IOError> {
+    _file_flush(&handle._id.clone())
+}
+fn file_seek(
+    handle: &__SifrIoNativeFileHandle,
+    offset: SifrInt,
+    whence: SifrInt,
+) -> Result<SifrInt, IOError> {
+    _file_seek(&handle._id.clone(), (offset).clone(), (whence).clone())
+}
+fn file_tell(handle: &__SifrIoNativeFileHandle) -> Result<SifrInt, IOError> {
+    _file_tell(&handle._id.clone())
 }
 fn getcwd() -> Result<String, IOError> {
     ::sifr_stdlib::fs::getcwd()

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -328,6 +328,12 @@ Several stdlib functions intentionally diverge from CPython names due to Rust ke
 | `sifr.itertools.take` | — (no CPython equivalent) | Sifr extension; returns first N elements from an `Iterable[T]`. Kept for ergonomics. |
 | `sifr.itertools.flatten` | `itertools.chain.from_iterable` | Sifr extension; flattens `Iterable[Iterable[T]]`. Simpler API than CPython's `chain.from_iterable`. |
 
+Iterator-taking `sifr.itertools` APIs own their `Iterator[T]` inputs. Callers
+that start with an iterable use an explicit `iter(...)` conversion, making
+single-pass consumption visible at the call site. `islice(data, stop)` treats
+the second argument as the stop bound, while `islice(data, start, None)` is
+unbounded and an explicit `None` step has the canonical unit-step meaning.
+
 **Removed type-specific duplicates (type-system architecture — stdlib generic rewrite):** `chain_str`, `chain_float`, `accumulate_float`, `accumulate_str`, `counter_add`, `counter_sub`, and other monomorphic variants have been deleted. All stdlib functions are now generic — e.g., `chain[T]`, `accumulate[T: Addable]`, `Counter[T: Hashable]`, `deque[T]`, `heapq` functions with `[T: Comparable]` bounds, `reduce[T, U]`, `shuffle[T]`, `sample[T]`.
 
 ## Compiler Pipeline

--- a/stdlib/_sifr/fs.sifr
+++ b/stdlib/_sifr/fs.sifr
@@ -63,7 +63,7 @@ def _file_close(handle: str) -> None:
 
 
 @rust(sifr_stdlib.fs.file_read_bytes)
-def _file_read_bytes(handle: str) -> Result[bytes, IOError]:
+def _file_read_bytes(handle: str, size: int | None) -> Result[bytes, IOError]:
     ...
 
 
@@ -72,12 +72,27 @@ def _file_write_bytes(handle: str, data: bytes) -> Result[None, IOError]:
     ...
 
 
+@rust(sifr_stdlib.fs.file_flush)
+def _file_flush(handle: str) -> Result[None, IOError]:
+    ...
+
+
+@rust(sifr_stdlib.fs.file_seek)
+def _file_seek(handle: str, offset: int, whence: int) -> Result[int, IOError]:
+    ...
+
+
+@rust(sifr_stdlib.fs.file_tell)
+def _file_tell(handle: str) -> Result[int, IOError]:
+    ...
+
+
 def open_file(path: str, mode: str) -> Result[NativeFileHandle, IOError]:
     try:
         handle_id: str = _open_file(path, mode)
         return NativeFileHandle(handle_id)
     except IOError as e:
-        raise IOError(e.message)
+        raise e
 
 
 def file_read(handle: NativeFileHandle) -> Result[str, IOError]:
@@ -100,12 +115,24 @@ def file_close(handle: NativeFileHandle) -> None:
     _file_close(handle._id)
 
 
-def file_read_bytes(handle: NativeFileHandle) -> Result[bytes, IOError]:
-    return _file_read_bytes(handle._id)
+def file_read_bytes(handle: NativeFileHandle, size: int | None = None) -> Result[bytes, IOError]:
+    return _file_read_bytes(handle._id, size)
 
 
 def file_write_bytes(handle: NativeFileHandle, data: bytes) -> Result[None, IOError]:
     return _file_write_bytes(handle._id, data)
+
+
+def file_flush(handle: NativeFileHandle) -> Result[None, IOError]:
+    return _file_flush(handle._id)
+
+
+def file_seek(handle: NativeFileHandle, offset: int, whence: int = 0) -> Result[int, IOError]:
+    return _file_seek(handle._id, offset, whence)
+
+
+def file_tell(handle: NativeFileHandle) -> Result[int, IOError]:
+    return _file_tell(handle._id)
 
 
 @rust(sifr_stdlib.fs.getcwd)

--- a/stdlib/sifr/io.sifr
+++ b/stdlib/sifr/io.sifr
@@ -1,6 +1,6 @@
 # sifr.io — File and stream I/O surfaces
 # Provides open(), open_binary(), file handle classes, and in-memory stream wrappers.
-from _sifr.fs import NativeFileHandle, open_file, file_read, file_write, file_readline, file_readlines, file_close, file_read_bytes, file_write_bytes
+from _sifr.fs import NativeFileHandle, open_file, file_read, file_write, file_readline, file_readlines, file_close, file_read_bytes, file_write_bytes, file_flush, file_seek, file_tell
 from _sifr.fs import read_text as _read_text_impl
 from _sifr.fs import write_text as _write_text_impl
 from _sifr.fs import exists as _exists_impl
@@ -129,7 +129,7 @@ class FileHandle:
     def flush(self) -> Result[None, IOError]:
         if self._closed:
             raise IOError(_closed_stream_error())
-        return None
+        return file_flush(self._handle)
 
     def read(self) -> Result[str, IOError]:
         if self._closed:
@@ -159,12 +159,12 @@ class FileHandle:
             raise IOError("stream is not readable")
         return file_readlines(self._handle)
 
-    def read_bytes(self) -> Result[bytes, IOError]:
+    def read_bytes(self, size: int | None = None) -> Result[bytes, IOError]:
         if self._closed:
             raise IOError(_closed_stream_error())
         if not self.readable():
             raise IOError("stream is not readable")
-        return file_read_bytes(self._handle)
+        return file_read_bytes(self._handle, size)
 
     def write_bytes(self, data: bytes) -> Result[None, IOError]:
         if self._closed:
@@ -174,12 +174,14 @@ class FileHandle:
         return file_write_bytes(self._handle, data)
 
     def seek(self, offset: int, whence: int = 0) -> Result[int, IOError]:
-        _ = offset
-        _ = whence
-        raise IOError(_unsupported_seek_tell_error())
+        if self._closed:
+            raise IOError(_closed_stream_error())
+        return file_seek(self._handle, offset, whence)
 
     def tell(self) -> Result[int, IOError]:
-        raise IOError(_unsupported_seek_tell_error())
+        if self._closed:
+            raise IOError(_closed_stream_error())
+        return file_tell(self._handle)
 
     def readable(self) -> bool:
         return _mode_is_readable(self._mode)
@@ -188,7 +190,7 @@ class FileHandle:
         return _mode_is_writable(self._mode)
 
     def seekable(self) -> bool:
-        return False
+        return not self._closed
 
     def __enter__(self) -> FileHandle:
         return self
@@ -219,15 +221,14 @@ class BinaryFileHandle:
     def flush(self) -> Result[None, IOError]:
         if self._closed:
             raise IOError(_closed_stream_error())
-        return None
+        return file_flush(self._handle)
 
     def read_bytes(self, size: int | None = None) -> Result[bytes, IOError]:
-        _ = size
         if self._closed:
             raise IOError(_closed_stream_error())
         if not self.readable():
             raise IOError("stream is not readable")
-        return file_read_bytes(self._handle)
+        return file_read_bytes(self._handle, size)
 
     def write_bytes(self, data: bytes) -> Result[None, IOError]:
         if self._closed:
@@ -237,12 +238,14 @@ class BinaryFileHandle:
         return file_write_bytes(self._handle, data)
 
     def seek(self, offset: int, whence: int = 0) -> Result[int, IOError]:
-        _ = offset
-        _ = whence
-        raise IOError(_unsupported_seek_tell_error())
+        if self._closed:
+            raise IOError(_closed_stream_error())
+        return file_seek(self._handle, offset, whence)
 
     def tell(self) -> Result[int, IOError]:
-        raise IOError(_unsupported_seek_tell_error())
+        if self._closed:
+            raise IOError(_closed_stream_error())
+        return file_tell(self._handle)
 
     def readable(self) -> bool:
         return _mode_is_readable(self._mode)
@@ -251,7 +254,7 @@ class BinaryFileHandle:
         return _mode_is_writable(self._mode)
 
     def seekable(self) -> bool:
-        return False
+        return not self._closed
 
     def __enter__(self) -> BinaryFileHandle:
         return self
@@ -315,7 +318,7 @@ class TextFileHandle:
             text: str = decode(data, self._encoding, self._decode_errors)
             return text
         except IOError as e:
-            raise IOError(e.message)
+            raise e
         except DecodeError as e:
             raise IOError("text decode failed: " + e.message)
 
@@ -327,13 +330,19 @@ class TextFileHandle:
         except EncodeError as e:
             raise IOError("text encode failed: " + e.message)
         except IOError as e:
-            raise IOError(e.message)
+            raise e
 
     def readline(self) -> Result[str | None, IOError]:
         raise IOError("TextFileHandle.readline is deferred; use read().split(\"\\n\")")
 
     def readlines(self) -> Result[list[str], IOError]:
         raise IOError("TextFileHandle.readlines is deferred; use read().split(\"\\n\")")
+
+    def seek(self, offset: int, whence: int = 0) -> Result[int, IOError]:
+        return self._binary.seek(offset, whence)
+
+    def tell(self) -> Result[int, IOError]:
+        return self._binary.tell()
 
     def readable(self) -> bool:
         return self._binary.readable()
@@ -569,7 +578,7 @@ def open(path: str, mode: str = "r") -> Result[FileHandle, IOError]:
         handle: NativeFileHandle = open_file(path, mode)
         return FileHandle(handle, mode)
     except IOError as e:
-        raise IOError(e.message)
+        raise e
 
 
 def open_binary(path: str, mode: str = "rb") -> Result[BinaryFileHandle, IOError]:
@@ -579,7 +588,7 @@ def open_binary(path: str, mode: str = "rb") -> Result[BinaryFileHandle, IOError
         handle: NativeFileHandle = open_file(path, mode)
         return BinaryFileHandle(handle, mode)
     except IOError as e:
-        raise IOError(e.message)
+        raise e
 
 
 def open_text(path: str, mode: str = "r", encoding: Encoding | None = None, errors: DecodeErrorHandler | None = None) -> Result[TextFileHandle, IOError]:
@@ -591,4 +600,4 @@ def open_text(path: str, mode: str = "r", encoding: Encoding | None = None, erro
         binary: BinaryFileHandle = open_binary(path, binary_mode)
         return TextFileHandle(binary, text_encoding, decode_errors, encode_errors)
     except IOError as e:
-        raise IOError(e.message)
+        raise e

--- a/stdlib/sifr/itertools.sifr
+++ b/stdlib/sifr/itertools.sifr
@@ -84,11 +84,11 @@ def batched(data: Iterable[T], n: int) -> Result[list[list[T]], ValueError]:
     return result
 
 
-def _islice_impl[T](own data: Iterator[T], start: int, stop: int, step: int) -> Iterator[T]:
+def _islice_impl[T](own data: Iterator[T], start: int, stop: int, unbounded: bool, step: int) -> Iterator[T]:
     index: int = 0
     next_yield: int = start.clone()
     for value in data:
-        if index >= stop:
+        if not unbounded and index >= stop:
             return
         if index == next_yield:
             yield value
@@ -96,17 +96,32 @@ def _islice_impl[T](own data: Iterator[T], start: int, stop: int, step: int) -> 
         index = index + 1
 
 
-def islice(own data: Iterator[T], start_or_stop: int, stop: int | None = None, step: int = 1) -> Result[Iterator[T], ValueError]:
+def islice(own data: Iterator[T], start_or_stop: int, *slice_args: int | None) -> Result[Iterator[T], ValueError]:
+    if len(slice_args) > 2:
+        raise ValueError("islice: expected at most stop and step after start")
     actual_start: int = 0
     actual_stop: int = start_or_stop.clone()
-    if stop is not None:
-        actual_start = start_or_stop.clone()
-        actual_stop = stop.clone()
-    if actual_start < 0 or actual_stop < 0:
+    unbounded: bool = False
+    actual_step: int = 1
+    argument_index: int = 0
+    for argument in slice_args:
+        if argument_index == 0:
+            actual_start = start_or_stop.clone()
+            if argument is None:
+                unbounded = True
+            else:
+                actual_stop = argument.clone()
+        else:
+            if argument is not None:
+                actual_step = argument.clone()
+        argument_index = argument_index + 1
+    if actual_start < 0:
         raise ValueError("islice: indices must be non-negative")
-    if step <= 0:
+    if not unbounded and actual_stop < 0:
+        raise ValueError("islice: indices must be non-negative")
+    if actual_step <= 0:
         raise ValueError("islice: step must be greater than zero")
-    return _islice_impl(data, actual_start, actual_stop, step)
+    return _islice_impl(data, actual_start, actual_stop, unbounded, actual_step)
 
 def count(start: int = 0, step: int = 1) -> Iterator[int]:
     current: int = start.clone()
@@ -459,16 +474,13 @@ def cycle(own data: Iterator[T], n: int) -> Iterator[T]:
         return
     for value in data:
         saved.append(value)
-        current: T | None = saved[len(saved) - 1]
-        if current is not None:
-            yield current
+        yield value
+        emitted = emitted + 1
+        if emitted >= n:
+            return
+    while emitted < n and len(saved) > 0:
+        for repeated in saved:
+            yield repeated
             emitted = emitted + 1
             if emitted >= n:
                 return
-    size: int = len(saved)
-    while emitted < n and size > 0:
-        index: int = emitted % size
-        repeated: T | None = saved[index]
-        if repeated is not None:
-            yield repeated
-        emitted = emitted + 1

--- a/stdlib/sifr/pathlib.sifr
+++ b/stdlib/sifr/pathlib.sifr
@@ -109,7 +109,7 @@ def _iterdir_to_iter(path: str) -> Result[Iterator[str], IOError]:
         entries: list[str] = _iterdir_list(path)
         return _iter_list_str(entries)
     except IOError as e:
-        raise IOError(e.message)
+        raise e
 
 
 def _glob_to_iter(path: str, pattern: str) -> Result[Iterator[str], IOError]:
@@ -117,7 +117,7 @@ def _glob_to_iter(path: str, pattern: str) -> Result[Iterator[str], IOError]:
         entries: list[str] = _glob_list(path, pattern)
         return _iter_list_str(entries)
     except IOError as e:
-        raise IOError(e.message)
+        raise e
 
 
 def _rglob_to_iter(path: str, pattern: str) -> Result[Iterator[str], IOError]:
@@ -125,7 +125,7 @@ def _rglob_to_iter(path: str, pattern: str) -> Result[Iterator[str], IOError]:
         entries: list[str] = _rglob_list(path, pattern)
         return _iter_list_str(entries)
     except IOError as e:
-        raise IOError(e.message)
+        raise e
 
 class Path:
     _path: str

--- a/stdlib/sifr/tempfile.sifr
+++ b/stdlib/sifr/tempfile.sifr
@@ -54,7 +54,7 @@ def mkstemp(prefix: str) -> Result[str, IOError]:
             if exists(path_for_check):
                 attempts = attempts + 1
                 continue
-            raise IOError(e.message)
+            raise e
     raise IOError(_collision_message("mkstemp", max_attempts))
 
 
@@ -74,7 +74,7 @@ def mkdtemp(prefix: str) -> Result[str, IOError]:
             if exists(path_for_check):
                 attempts = attempts + 1
                 continue
-            raise IOError(e.message)
+            raise e
     raise IOError(_collision_message("mkdtemp", max_attempts))
 
 
@@ -110,7 +110,7 @@ class NamedTemporaryFile:
             try:
                 _rm_done: None = remove_file(self._path)
             except IOError as e:
-                raise IOError(e.message)
+                raise e
         self._cleaned = True
         return None
 
@@ -167,7 +167,7 @@ class TemporaryDirectory:
             try:
                 _rm_tree_done: None = rmdir_all(self._path)
             except IOError as e:
-                raise IOError(e.message)
+                raise e
         self._cleaned = True
         self._closed = True
         return None

--- a/verification/areas/generated_code_quality/emitted_rust_audit_inventory.json
+++ b/verification/areas/generated_code_quality/emitted_rust_audit_inventory.json
@@ -219,7 +219,7 @@
       "owner_item": 6,
       "mechanism": "ljust, rjust, zfill, and center lower signed widths through unchecked usize conversion before allocation.",
       "evidence": ["crates/sifr_codegen/src/methods/string.rs"],
-      "semantic_anchor": {"kind": "text", "revision": "current", "path": "crates/sifr_codegen/src/methods/string.rs", "contains": "value: exact_int_to_usize_expr(args[0].clone())"},
+      "semantic_anchor": {"kind": "text", "revision": "baseline", "path": "crates/sifr_codegen/src/methods/string.rs", "contains": "name: \"_w\".to_string()"},
       "sources": ["internal", "external"]
     },
     {
@@ -229,8 +229,8 @@
       "severity": "blocking",
       "owner_item": 6,
       "mechanism": "Generated try/except and IO adapters reconstruct IOError with a generic category instead of preserving the source kind.",
-      "evidence": ["crates/sifr_codegen/src/preamble/io_file_handles.rs", "crates/sifr_codegen/src/class_error_emitter.rs"],
-      "semantic_anchor": {"kind": "text", "revision": "current", "path": "crates/sifr_codegen/src/preamble/io_file_handles.rs", "contains": "Some(::std::io::ErrorKind::{kind})"},
+      "evidence": ["stdlib/_sifr/fs.sifr", "stdlib/sifr/io.sifr", "stdlib/sifr/pathlib.sifr", "stdlib/sifr/tempfile.sifr"],
+      "semantic_anchor": {"kind": "text", "revision": "baseline", "path": "stdlib/sifr/io.sifr", "contains": "raise IOError(e.message)"},
       "sources": ["internal", "external"]
     },
     {
@@ -240,8 +240,8 @@
       "severity": "blocking",
       "owner_item": 6,
       "mechanism": "The generated file-handle read_bytes adapter can consume the full remaining stream regardless of the requested size.",
-      "evidence": ["crates/sifr_codegen/src/preamble/io_bytes_methods.rs"],
-      "semantic_anchor": {"kind": "text", "revision": "current", "path": "crates/sifr_codegen/src/preamble/io_bytes_methods.rs", "contains": "\"read_to_end\".to_string()"},
+      "evidence": ["crates/sifr_stdlib/src/fs.rs", "stdlib/_sifr/fs.sifr", "stdlib/sifr/io.sifr"],
+      "semantic_anchor": {"kind": "text", "revision": "baseline", "path": "stdlib/sifr/io.sifr", "contains": "_ = size"},
       "sources": ["internal", "external"]
     },
     {
@@ -385,9 +385,9 @@
       "disposition": "confirmed",
       "severity": "blocking",
       "owner_item": 11,
-      "mechanism": "Generated allocation widths, offsets, and capacity arithmetic use unchecked casts or arithmetic that can wrap, abort, or become target-width dependent.",
-      "evidence": ["crates/sifr_codegen/src/methods/string.rs", "crates/sifr_codegen/src/preamble", "demos/**/emitted.rs"],
-      "semantic_anchor": {"kind": "text", "revision": "current", "path": "crates/sifr_codegen/src/methods/string.rs", "contains": "value: exact_int_to_usize_expr(args[0].clone())"},
+      "mechanism": "Remaining generated indices and allocation counts can reach a panic-on-invalid-proof usize conversion without a local typed range boundary.",
+      "evidence": ["crates/sifr_codegen/src/methods/list.rs", "crates/sifr_codegen/src/preamble", "demos/**/emitted.rs"],
+      "semantic_anchor": {"kind": "text", "revision": "current", "path": "crates/sifr_codegen/src/methods/list.rs", "contains": "args: vec![exact_int_to_usize_expr(args[0].clone()), args[1].clone()]"},
       "sources": ["internal", "external"]
     }
   ]


### PR DESCRIPTION
Closes Item 6 of the Emitted Rust Excellence phase.\n\nImplements full stdlib emitted-semantics closure: checked string padding, signed-zero exact division, ordered JSON, sized/seekable I/O with error-kind preservation, iterator optional-value and islice parity, demand-driven generic bounds, and generated regressions/companions.\n\nValidation and exact-SHA Opus evidence will be added before readiness.