### PR TITLE
fix(codegen): preserve generic bound parameter identity

### DIFF
--- a/crates/sifr/tests/e2e/pass/protocol_bound_forwarding_conforming_typevar.sifr
+++ b/crates/sifr/tests/e2e/pass/protocol_bound_forwarding_conforming_typevar.sifr
@@ -6,8 +6,16 @@ def keep_comparable[T: Comparable](x: T) -> T:
 def relay_comparable[U: Comparable](x: U) -> U:
     return keep_comparable(x)
 
+def add_same[T: Addable](left: T, right: T) -> T:
+    return left + right
+
+def relay_add[U: Addable](left: U, right: U) -> U:
+    return add_same(left, right)
+
 def main():
     n: int = relay_comparable(7)
     s: str = relay_comparable("ok")
+    total: int = relay_add(4, 5)
     assert str(n) == '7'
     assert str(s) == 'ok'
+    assert total == 9

--- a/crates/sifr/tests/e2e/pass/string_padding_methods.sifr
+++ b/crates/sifr/tests/e2e/pass/string_padding_methods.sifr
@@ -3,6 +3,7 @@ def main():
     try:
         s: str = "x"
         centered: str = s.center(5)
+        odd_margin: str = "ab".center(5)
         left: str = s.ljust(4)
         right: str = s.rjust(4)
         zeroed: str = "7".zfill(4)
@@ -10,6 +11,7 @@ def main():
         unicode: str = "é".ljust(3)
         unchanged: str = s.center(-100)
         assert str("center = [" + centered + "]") == 'center = [  x  ]'
+        assert odd_margin == "  ab "
         assert str("ljust = [" + left + "]") == 'ljust = [x   ]'
         assert str("rjust = [" + right + "]") == 'rjust = [   x]'
         assert str("zfill = [" + zeroed + "]") == 'zfill = [0007]'

--- a/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
+++ b/crates/sifr_codegen/src/function_emitter/generic_bounds.rs
@@ -92,8 +92,8 @@ impl RustEmitter {
                     .and_then(|by_param| by_param.get(type_param))
                     .into_iter()
                     .flatten()
+                    .map(|bound| bound.render_for(type_param))
                     .filter(|bound| !extra_bounds.contains(bound))
-                    .cloned()
                     .collect::<Vec<_>>();
                 closed_bounds.sort();
                 extra_bounds.extend(closed_bounds);

--- a/crates/sifr_codegen/src/function_generic_bounds.rs
+++ b/crates/sifr_codegen/src/function_generic_bounds.rs
@@ -1,6 +1,65 @@
 use crate::{HirExpr, HirFunction, HirModule, HirStmt, RustEmitter, Type};
 use std::collections::{HashMap, HashSet};
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum FunctionTypeParamBound {
+    Trait(String),
+    OutputSelf(&'static str),
+}
+
+pub(crate) type FunctionTypeParamBounds =
+    HashMap<String, HashMap<String, HashSet<FunctionTypeParamBound>>>;
+
+impl FunctionTypeParamBound {
+    pub(crate) fn render_for(&self, type_param: &str) -> String {
+        match self {
+            Self::Trait(bound) => bound.clone(),
+            Self::OutputSelf(trait_path) => {
+                format!("{trait_path}<Output = {type_param}>")
+            }
+        }
+    }
+}
+
+pub(crate) fn direct_type_param_bounds(
+    type_param: &str,
+    body: &[HirStmt],
+) -> Vec<FunctionTypeParamBound> {
+    let requirements =
+        crate::hir_analysis::queries::collect_typevar_operator_requirements(body, type_param);
+    let mut bounds = Vec::new();
+    if requirements.needs_add {
+        bounds.push(FunctionTypeParamBound::OutputSelf("std::ops::Add"));
+    }
+    if requirements.needs_sub {
+        bounds.push(FunctionTypeParamBound::OutputSelf("std::ops::Sub"));
+    }
+    if requirements.needs_mul {
+        bounds.push(FunctionTypeParamBound::OutputSelf("std::ops::Mul"));
+    }
+    if requirements.needs_div {
+        bounds.push(FunctionTypeParamBound::OutputSelf("std::ops::Div"));
+    }
+    if requirements.needs_rem {
+        bounds.push(FunctionTypeParamBound::OutputSelf("std::ops::Rem"));
+    }
+    if requirements.needs_neg {
+        bounds.push(FunctionTypeParamBound::OutputSelf("std::ops::Neg"));
+    }
+    if requirements.needs_partial_eq {
+        bounds.push(FunctionTypeParamBound::Trait("PartialEq".to_string()));
+    }
+    if requirements.needs_partial_ord {
+        bounds.push(FunctionTypeParamBound::Trait("PartialOrd".to_string()));
+    }
+    if requirements.needs_display {
+        bounds.push(FunctionTypeParamBound::Trait(
+            "std::fmt::Display".to_string(),
+        ));
+    }
+    bounds
+}
+
 #[derive(Debug, Clone)]
 struct GenericCallSite {
     function: String,
@@ -17,7 +76,7 @@ impl RustEmitter {
     /// parameters.
     pub(crate) fn closed_function_type_param_bounds(
         module: &HirModule,
-    ) -> HashMap<String, HashMap<String, HashSet<String>>> {
+    ) -> HashMap<String, HashMap<String, HashSet<FunctionTypeParamBound>>> {
         let functions = module
             .functions
             .iter()
@@ -32,13 +91,14 @@ impl RustEmitter {
                     .type_params
                     .iter()
                     .map(|type_param| {
-                        let mut bounds =
-                            Self::extra_bound_items_for_type_param(type_param, &function.body)
-                                .into_iter()
-                                .collect::<HashSet<_>>();
+                        let mut bounds = direct_type_param_bounds(type_param, &function.body)
+                            .into_iter()
+                            .collect::<HashSet<_>>();
                         if function_type_param_needs_hash_eq(function, type_param) {
-                            bounds.insert("std::hash::Hash".to_string());
-                            bounds.insert("Eq".to_string());
+                            bounds.insert(FunctionTypeParamBound::Trait(
+                                "std::hash::Hash".to_string(),
+                            ));
+                            bounds.insert(FunctionTypeParamBound::Trait("Eq".to_string()));
                         }
                         if let Some(declared) = module
                             .type_param_bounds
@@ -46,10 +106,7 @@ impl RustEmitter {
                             .and_then(|by_param| by_param.get(type_param))
                         {
                             for specification in declared {
-                                bounds.extend(rust_bounds_for_typevar_spec(
-                                    type_param,
-                                    specification,
-                                ));
+                                bounds.extend(rust_bounds_for_typevar_spec(specification));
                             }
                         }
                         (type_param.clone(), bounds)
@@ -98,11 +155,14 @@ impl RustEmitter {
     }
 }
 
-fn rust_bounds_for_typevar_spec(type_param: &str, specification: &str) -> Vec<String> {
+fn rust_bounds_for_typevar_spec(specification: &str) -> Vec<FunctionTypeParamBound> {
     match specification {
-        "Comparable" => vec!["PartialOrd".to_string()],
-        "Addable" => vec![format!("std::ops::Add<Output = {type_param}>")],
-        "Hashable" => vec!["std::hash::Hash".to_string(), "Eq".to_string()],
+        "Comparable" => vec![FunctionTypeParamBound::Trait("PartialOrd".to_string())],
+        "Addable" => vec![FunctionTypeParamBound::OutputSelf("std::ops::Add")],
+        "Hashable" => vec![
+            FunctionTypeParamBound::Trait("std::hash::Hash".to_string()),
+            FunctionTypeParamBound::Trait("Eq".to_string()),
+        ],
         _ => Vec::new(),
     }
 }
@@ -411,7 +471,10 @@ mod tests {
         let closed =
             RustEmitter::closed_function_type_param_bounds(&module(vec![passthrough], bounds));
 
-        assert!(closed["passthrough"]["T"].contains("PartialOrd"));
+        assert!(
+            closed["passthrough"]["T"]
+                .contains(&FunctionTypeParamBound::Trait("PartialOrd".to_string()))
+        );
     }
 
     #[test]
@@ -499,10 +562,78 @@ mod tests {
             vec![compare, display, hash, forward, outer_forward],
             HashMap::new(),
         ));
-        let outer_bounds = &closed["outer_forward"]["Outer"];
+        let outer_bounds = closed["outer_forward"]["Outer"]
+            .iter()
+            .map(|bound| bound.render_for("Outer"))
+            .collect::<HashSet<_>>();
 
         for expected in ["PartialOrd", "std::fmt::Display", "std::hash::Hash", "Eq"] {
             assert!(outer_bounds.contains(expected), "missing {expected}");
         }
+    }
+
+    #[test]
+    fn generic_call_graph_renders_output_traits_for_the_receiving_parameter() {
+        let callee_type = Type::TypeVar("T".to_string());
+        let add_same = function(
+            "add_same",
+            "T",
+            vec![
+                parameter("left", callee_type.clone()),
+                parameter("right", callee_type.clone()),
+            ],
+            callee_type.clone(),
+            vec![HirStmt::Return {
+                value: Some(HirExpr::BinOp {
+                    left: Box::new(name("left", callee_type.clone())),
+                    op: "+".to_string(),
+                    right: Box::new(name("right", callee_type.clone())),
+                    ty: callee_type,
+                }),
+            }],
+        );
+        let caller_type = Type::TypeVar("U".to_string());
+        let relay_add = function(
+            "relay_add",
+            "U",
+            vec![
+                parameter("left", caller_type.clone()),
+                parameter("right", caller_type.clone()),
+            ],
+            caller_type.clone(),
+            vec![HirStmt::Return {
+                value: Some(HirExpr::Call {
+                    func: "add_same".to_string(),
+                    args: vec![
+                        name("left", caller_type.clone()),
+                        name("right", caller_type.clone()),
+                    ],
+                    mutable_arg_places: Vec::new(),
+                    ty: caller_type,
+                }),
+            }],
+        );
+        let bounds = HashMap::from([
+            (
+                "add_same".to_string(),
+                HashMap::from([("T".to_string(), vec!["Addable".to_string()])]),
+            ),
+            (
+                "relay_add".to_string(),
+                HashMap::from([("U".to_string(), vec!["Addable".to_string()])]),
+            ),
+        ]);
+
+        let closed = RustEmitter::closed_function_type_param_bounds(&module(
+            vec![add_same, relay_add],
+            bounds,
+        ));
+        let rendered = closed["relay_add"]["U"]
+            .iter()
+            .map(|bound| bound.render_for("U"))
+            .collect::<HashSet<_>>();
+
+        assert!(rendered.contains("std::ops::Add<Output = U>"));
+        assert!(rendered.iter().all(|bound| !bound.contains("Output = T")));
     }
 }

--- a/crates/sifr_codegen/src/generic_bounds_helpers.rs
+++ b/crates/sifr_codegen/src/generic_bounds_helpers.rs
@@ -678,37 +678,10 @@ impl RustEmitter {
     }
 
     pub(crate) fn extra_bound_items_for_type_param(tp: &str, body: &[HirStmt]) -> Vec<String> {
-        let requirements =
-            crate::hir_analysis::queries::collect_typevar_operator_requirements(body, tp);
-        let mut extra = Vec::new();
-        if requirements.needs_add {
-            extra.push(format!("std::ops::Add<Output = {tp}>"));
-        }
-        if requirements.needs_sub {
-            extra.push(format!("std::ops::Sub<Output = {tp}>"));
-        }
-        if requirements.needs_mul {
-            extra.push(format!("std::ops::Mul<Output = {tp}>"));
-        }
-        if requirements.needs_div {
-            extra.push(format!("std::ops::Div<Output = {tp}>"));
-        }
-        if requirements.needs_rem {
-            extra.push(format!("std::ops::Rem<Output = {tp}>"));
-        }
-        if requirements.needs_neg {
-            extra.push(format!("std::ops::Neg<Output = {tp}>"));
-        }
-        if requirements.needs_partial_eq {
-            extra.push("PartialEq".to_string());
-        }
-        if requirements.needs_partial_ord {
-            extra.push("PartialOrd".to_string());
-        }
-        if requirements.needs_display {
-            extra.push("std::fmt::Display".to_string());
-        }
-        extra
+        crate::function_generic_bounds::direct_type_param_bounds(tp, body)
+            .iter()
+            .map(|bound| bound.render_for(tp))
+            .collect()
     }
 
     /// Rust trait requirements are transitive across calls on any instance of

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -74,7 +74,7 @@ pub struct RustEmitter {
     /// Caller-context type parameters for each structural bridge function.
     pub(crate) context_type_params: HashMap<String, HashSet<String>>,
     /// Closed Rust trait requirements for each module-level generic function.
-    pub(crate) function_type_param_bounds: HashMap<String, HashMap<String, HashSet<String>>>,
+    pub(crate) function_type_param_bounds: crate::function_generic_bounds::FunctionTypeParamBounds,
     /// Set of stdlib/intrinsic modules used (for Cargo dependency injection)
     pub used_stdlib_modules: HashSet<String>,
     /// Set of intrinsic function names (for codegen dispatch)

--- a/crates/sifr_runtime/src/string_padding.rs
+++ b/crates/sifr_runtime/src/string_padding.rs
@@ -53,7 +53,10 @@ fn checked_pad(value: &str, width: &SifrInt, alignment: Alignment) -> Result<Str
     let (left, right) = match alignment {
         Alignment::Left => (0, padding),
         Alignment::Right => (padding, 0),
-        Alignment::Center => (padding / 2, padding - (padding / 2)),
+        Alignment::Center => {
+            let left = padding / 2 + (padding & width & 1);
+            (left, padding - left)
+        }
     };
     let mut output = reserved_string(value.len(), padding)?;
     push_repeated(&mut output, ' ', left);
@@ -106,6 +109,10 @@ mod tests {
         assert_eq!(
             checked_center("x", &SifrInt::from_i64(4)),
             Ok(" x  ".into())
+        );
+        assert_eq!(
+            checked_center("ab", &SifrInt::from_i64(5)),
+            Ok("  ab ".into())
         );
         assert_eq!(
             checked_zfill("-7", &SifrInt::from_i64(4)),

--- a/demos/protocol_bounds/emitted.rs
+++ b/demos/protocol_bounds/emitted.rs
@@ -9,8 +9,17 @@ fn relay_comparable<U: Clone + 'static + PartialOrd>(x: &U) -> U {
     keep_comparable(x)
 }
 
+fn add_same<T: Clone + 'static + ::std::ops::Add<Output = T>>(left: &T, right: &T) -> T {
+    left.clone() + right.clone()
+}
+
+fn relay_add<U: Clone + 'static + ::std::ops::Add<Output = U>>(left: &U, right: &U) -> U {
+    add_same(left, right)
+}
+
 fn main() {
     println!("protocol_bounds protocol bound strictness closure demo:");
     println!("{}", relay_comparable(&SifrInt::from_i64(9)));
     println!("{}", relay_comparable(&"ok".to_string()));
+    println!("{}", relay_add(&SifrInt::from_i64(4), &SifrInt::from_i64(5)));
 }

--- a/demos/protocol_bounds/main.sifr
+++ b/demos/protocol_bounds/main.sifr
@@ -8,7 +8,14 @@ def keep_comparable[T: Comparable](x: T) -> T:
 def relay_comparable[U: Comparable](x: U) -> U:
     return keep_comparable(x)
 
+def add_same[T: Addable](left: T, right: T) -> T:
+    return left + right
+
+def relay_add[U: Addable](left: U, right: U) -> U:
+    return add_same(left, right)
+
 def main():
     print('protocol_bounds protocol bound strictness closure demo:')
     print(relay_comparable(9))
     print(relay_comparable("ok"))
+    print(relay_add(4, 5))


### PR DESCRIPTION
## Summary

- represent module-level generic operator bounds structurally as ordinary traits or self-output traits
- render self-output bounds with the receiving function's type-parameter identity during fixed-point propagation
- govern differently named `Addable` forwarding in the authoritative protocol demo and E2E fixture
- match CPython odd-margin placement in `str.center`

## Validation

Exact candidate: `aff53a422ee8c55185d0110c51483be0d600375d`

- `cargo test -p sifr_codegen`: 1,190 passed
- `cargo test -p sifr_runtime`: 89 unit + 8 exact-integer tests passed
- strict codegen/runtime Clippy passed
- both focused Sifr fixtures compiled and ran as release-native binaries
- authoritative protocol companion emitted `Add<Output = U>`, compiled as Rust metadata, and is fresh
- formatting, HIR maintainability, file-size, audit inventory, and diff checks passed