### PR TITLE
fix(codegen): close receiver effect precision

### DIFF
--- a/crates/sifr/tests/e2e/pass/receiver_effect_setdefault_ownership.sifr
+++ b/crates/sifr/tests/e2e/pass/receiver_effect_setdefault_ownership.sifr
@@ -1,0 +1,44 @@
+def read_after_growth_and_reorder(mut values: list[int]) -> int:
+    if len(values) == 0:
+        return 0
+    values.append(4)
+    values.insert(0, 3)
+    values.extend([2, 1])
+    values.sort()
+    values.reverse()
+    return values[0]
+
+
+def read_after_value_mutation(mut values: dict[str, int]) -> int:
+    if "kept" not in values:
+        return 0
+    values.setdefault("added", 2)
+    values.update({"updated": 3})
+    return values["kept"]
+
+
+def borrowed_default(mut values: dict[str, str], key: str, default: str) -> str:
+    return values.setdefault(key, default)
+
+
+def reusable_owned_default(mut values: dict[str, str]) -> str:
+    key: str = "owned-key"
+    default: str = "owned-value"
+    selected: str = values.setdefault(key, default)
+    assert key == "owned-key"
+    assert default == "owned-value"
+    return selected
+
+
+def main():
+    numbers: list[int] = [0]
+    assert read_after_growth_and_reorder(numbers) == 4
+
+    mapped: dict[str, int] = {"kept": 7}
+    assert read_after_value_mutation(mapped) == 7
+
+    borrowed: dict[str, str] = {}
+    assert borrowed_default(borrowed, "borrowed-key", "borrowed-value") == "borrowed-value"
+
+    owned: dict[str, str] = {}
+    assert reusable_owned_default(owned) == "owned-value"

--- a/crates/sifr/tests/e2e/pass/receiver_effect_setdefault_ownership.sifr
+++ b/crates/sifr/tests/e2e/pass/receiver_effect_setdefault_ownership.sifr
@@ -30,6 +30,10 @@ def reusable_owned_default(mut values: dict[str, str]) -> str:
     return selected
 
 
+def copy_default(mut values: dict[str, bool], key: str, default: bool) -> bool:
+    return values.setdefault(key, default)
+
+
 def main():
     numbers: list[int] = [0]
     assert read_after_growth_and_reorder(numbers) == 4
@@ -42,3 +46,6 @@ def main():
 
     owned: dict[str, str] = {}
     assert reusable_owned_default(owned) == "owned-value"
+
+    flags: dict[str, bool] = {}
+    assert copy_default(flags, "enabled", True)

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/collection_methods.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/collection_methods.rs
@@ -266,7 +266,9 @@ impl RustEmitter {
                     argument,
                     lowered_arg.clone(),
                 );
-                *lowered_arg = if matches!((object_ty, method), (Type::Set(_), "add")) {
+                *lowered_arg = if matches!((object_ty, method), (Type::Dict(_, _), "setdefault")) {
+                    lowered_arg.clone()
+                } else if matches!((object_ty, method), (Type::Set(_), "add")) {
                     self.materialize_borrowed_parameter_for_owned_boundary(
                         argument,
                         lowered_arg.clone(),

--- a/crates/sifr_codegen/src/lib_codegen_tests/ownership_quality_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/ownership_quality_codegen_tests.rs
@@ -162,6 +162,40 @@ def store(mut items: list[str], mut keys: set[str], mut defaults: dict[str, str]
 }
 
 #[test]
+fn setdefault_materializes_places_but_moves_owned_temporaries() {
+    let generated = generate_rust_from_source(
+        r#"
+def literal_default(mut defaults: dict[str, str]) -> str:
+    return defaults.setdefault("key", "value")
+
+def reusable_default(mut defaults: dict[str, str]) -> str:
+    key: str = "key"
+    value: str = "value"
+    selected: str = defaults.setdefault(key, value)
+    print(key)
+    print(value)
+    return selected
+"#,
+    );
+
+    assert!(
+        generated.contains(
+            "defaults.entry(\"key\".to_string()).or_insert(\"value\".to_string()).to_owned()"
+        ),
+        "{generated}"
+    );
+    assert!(
+        generated.contains("defaults.entry(key.to_owned()).or_insert(value.to_owned()).to_owned()"),
+        "{generated}"
+    );
+    assert!(
+        !generated.contains(".to_string().to_owned()"),
+        "{generated}"
+    );
+    assert!(!generated.contains(".to_owned().to_owned()"), "{generated}");
+}
+
+#[test]
 fn recursive_and_dynamic_programming_shapes_have_clone_budgets() {
     let generated = generate_rust_from_source(
         r#"

--- a/crates/sifr_codegen/src/lib_codegen_tests/ownership_quality_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/ownership_quality_codegen_tests.rs
@@ -196,6 +196,26 @@ def reusable_default(mut defaults: dict[str, str]) -> str:
 }
 
 #[test]
+fn setdefault_copy_values_are_moved_and_dereferenced_without_clone() {
+    let generated = generate_rust_from_source(
+        r#"
+def copy_default(mut flags: dict[str, bool], key: str, flag: bool) -> bool:
+    return flags.setdefault(key, flag)
+"#,
+    );
+
+    assert!(
+        generated.contains("*flags.entry(key.to_owned()).or_insert(flag)"),
+        "{generated}"
+    );
+    assert!(!generated.contains("flag.clone()"), "{generated}");
+    assert!(
+        !generated.contains("or_insert(flag).clone()"),
+        "{generated}"
+    );
+}
+
+#[test]
 fn recursive_and_dynamic_programming_shapes_have_clone_budgets() {
     let generated = generate_rust_from_source(
         r#"

--- a/crates/sifr_codegen/src/lower_stmt/candidate_and_validation.rs
+++ b/crates/sifr_codegen/src/lower_stmt/candidate_and_validation.rs
@@ -633,3 +633,51 @@ pub(super) fn validate_expr_lowering_shape(expr: &HirExpr) -> Result<(), Codegen
         | HirExpr::EnumVariant { .. } => Ok(()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_binding_setdefault_materializes_owned_key_and_default() {
+        let expr = HirExpr::MethodCall {
+            object: Box::new(HirExpr::Name {
+                name: "defaults".to_string(),
+                binding_id: None,
+                ty: Type::Any,
+            }),
+            method: "setdefault".to_string(),
+            args: vec![
+                HirExpr::Name {
+                    name: "key".to_string(),
+                    binding_id: None,
+                    ty: Type::Str,
+                },
+                HirExpr::Name {
+                    name: "value".to_string(),
+                    binding_id: None,
+                    ty: Type::Str,
+                },
+            ],
+            receiver_convention: Some(sifr_type_system::ReceiverConvention::MutableBorrow),
+            receiver_target: None,
+            mutable_arg_places: Vec::new(),
+            source: None,
+            ty: Type::Str,
+        };
+        let bindings = HashMap::from([(
+            "defaults".to_string(),
+            Type::Dict(Box::new(Type::Str), Box::new(Type::Str)),
+        )]);
+
+        let lowered = try_lower_expr_stmt_with_bindings(&expr, &bindings)
+            .expect("local binding method call lowers");
+        let rendered = crate::render_stmts(&lowered);
+
+        assert_eq!(
+            rendered.trim(),
+            "defaults.entry(key.to_owned()).or_insert(value.to_owned()).to_owned();"
+        );
+        assert!(!rendered.contains(".clone()"), "{rendered}");
+    }
+}

--- a/crates/sifr_codegen/src/methods/dict.rs
+++ b/crates/sifr_codegen/src/methods/dict.rs
@@ -1,6 +1,7 @@
 //! Dict method lowerers for registry lowering.
 
 use crate::{RustExpr, RustParam, RustType};
+use sifr_type_system::Type;
 
 fn is_already_borrowed_rendered_expr(arg: &RustExpr) -> bool {
     match arg {
@@ -22,6 +23,22 @@ fn render_key_arg_expr(arg: &RustExpr) -> RustExpr {
             mutable: false,
             expr: Box::new(arg.clone()),
         },
+    }
+}
+
+fn materialize_setdefault_storage_arg(ty: &Type, arg: &RustExpr) -> RustExpr {
+    let reusable_place = match arg {
+        RustExpr::Ident(_) | RustExpr::Field { .. } | RustExpr::Index { .. } => true,
+        RustExpr::Paren(inner) => matches!(
+            inner.as_ref(),
+            RustExpr::Ident(_) | RustExpr::Field { .. } | RustExpr::Index { .. }
+        ),
+        _ => false,
+    };
+    if reusable_place {
+        crate::ownership_plan::materialize_owned_value(ty, arg.clone())
+    } else {
+        arg.clone()
     }
 }
 
@@ -214,21 +231,29 @@ pub(super) fn lower_pop(object: &RustExpr, args: &[RustExpr]) -> Option<RustExpr
     }
 }
 
-pub(super) fn lower_setdefault(object: &RustExpr, args: &[RustExpr]) -> Option<RustExpr> {
+pub(super) fn lower_setdefault(
+    object: &RustExpr,
+    key_ty: &Type,
+    value_ty: &Type,
+    args: &[RustExpr],
+) -> Option<RustExpr> {
     match args {
-        [key, default] => Some(RustExpr::MethodCall {
-            receiver: Box::new(RustExpr::MethodCall {
+        [key, default] => {
+            let key = materialize_setdefault_storage_arg(key_ty, key);
+            let default = materialize_setdefault_storage_arg(value_ty, default);
+            let inserted = RustExpr::MethodCall {
                 receiver: Box::new(RustExpr::MethodCall {
                     receiver: Box::new(object.clone()),
                     method: "entry".to_string(),
-                    args: vec![key.clone()],
+                    args: vec![key],
                 }),
                 method: "or_insert".to_string(),
-                args: vec![default.clone()],
-            }),
-            method: "clone".to_string(),
-            args: vec![],
-        }),
+                args: vec![default],
+            };
+            Some(crate::ownership_plan::materialize_owned_value(
+                value_ty, inserted,
+            ))
+        }
         _ => None,
     }
 }

--- a/crates/sifr_codegen/src/methods/dict.rs
+++ b/crates/sifr_codegen/src/methods/dict.rs
@@ -27,6 +27,9 @@ fn render_key_arg_expr(arg: &RustExpr) -> RustExpr {
 }
 
 fn materialize_setdefault_storage_arg(ty: &Type, arg: &RustExpr) -> RustExpr {
+    if crate::helpers::is_copy_type_for_codegen(ty) || ty.contains_affine_resource() {
+        return arg.clone();
+    }
     let reusable_place = match arg {
         RustExpr::Ident(_) | RustExpr::Field { .. } | RustExpr::Index { .. } => true,
         RustExpr::Paren(inner) => matches!(
@@ -250,10 +253,30 @@ pub(super) fn lower_setdefault(
                 method: "or_insert".to_string(),
                 args: vec![default],
             };
-            Some(crate::ownership_plan::materialize_owned_value(
-                value_ty, inserted,
-            ))
+            Some(if crate::helpers::is_copy_type_for_codegen(value_ty) {
+                RustExpr::Deref(Box::new(inserted))
+            } else {
+                crate::ownership_plan::materialize_owned_value(value_ty, inserted)
+            })
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setdefault_storage_materialization_preserves_copy_and_affine_places() {
+        let place = RustExpr::Ident("value".to_string());
+        assert_eq!(
+            materialize_setdefault_storage_arg(&Type::Bool, &place),
+            place
+        );
+
+        let affine =
+            Type::PythonBuffer(Box::new(Type::FixedInt(sifr_type_system::FixedIntType::U8)));
+        assert_eq!(materialize_setdefault_storage_arg(&affine, &place), place);
     }
 }

--- a/crates/sifr_codegen/src/methods/mod.rs
+++ b/crates/sifr_codegen/src/methods/mod.rs
@@ -163,7 +163,7 @@ pub(crate) fn lower_method_with_context(
                 expr
             }
         }),
-        (Type::Dict(_, _), "setdefault") => dict::lower_setdefault(object, args),
+        (Type::Dict(key, value), "setdefault") => dict::lower_setdefault(object, key, value, args),
         (Type::Set(_), "add") => set::lower_add(object, args),
         (Type::Set(_), "remove") => set::lower_remove(object, args),
         (Type::Set(_), "discard") => set::lower_discard(object, args),
@@ -636,7 +636,7 @@ mod tests {
         .expect("dict setdefault lowers");
         assert_eq!(
             render_expr(&dict_setdefault.expr),
-            "d.entry(\"k\").or_insert(0).clone()"
+            "d.entry(\"k\".to_owned()).or_insert(0.clone()).clone()"
         );
 
         let set_ty = Type::Set(Box::new(Type::Int));

--- a/crates/sifr_lowering/src/lower/append_growth_shapes.rs
+++ b/crates/sifr_lowering/src/lower/append_growth_shapes.rs
@@ -34,6 +34,7 @@ fn range_anchor_sequence(for_stmt: &StmtFor, target_name: &str, ctx: &LowerCtx) 
             SequenceGuard::MinLength { .. }
             | SequenceGuard::IndexVarNonNegative { .. }
             | SequenceGuard::DictContains { .. }
+            | SequenceGuard::SubscriptAccessible { .. }
             | SequenceGuard::SubscriptPresent { .. }
             | SequenceGuard::IndexVarInRange { .. } => None,
         })

--- a/crates/sifr_lowering/src/lower/expressions/method_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_calls.rs
@@ -181,11 +181,12 @@ pub(in crate::lower) fn lower_method_call(
                 .unwrap_or(sifr_type_system::ReceiverConvention::SharedBorrow)
         },
     );
-    super::super::sequence_guards::invalidate_mutable_receiver_sequence_guards(
+    super::super::mutating_methods::apply_receiver_mutation_effect(
         ctx,
         &object,
-        Some(receiver_convention),
+        &object_ty,
         &method_name,
+        receiver_convention,
     );
     if let Some(function_type) = &method_type {
         super::super::sequence_guards::invalidate_mutable_call_sequence_guards(

--- a/crates/sifr_lowering/src/lower/guarded_index.rs
+++ b/crates/sifr_lowering/src/lower/guarded_index.rs
@@ -17,6 +17,8 @@ pub(in crate::lower) fn guarded_sequence_index_result_type(
                     Some(*value_ty.clone())
                 } else if ctx.has_subscript_guard(sequence_name.as_str(), &sub.slice) {
                     Some(remove_none_from_union(value_ty.as_ref()))
+                } else if ctx.has_subscript_access_guard(sequence_name.as_str(), &sub.slice) {
+                    Some(*value_ty.clone())
                 } else {
                     None
                 }
@@ -97,7 +99,7 @@ fn guarded_bytes_index_type(
 }
 
 fn has_guarded_sequence_index(sequence_name: &str, index_expr: &Expr, ctx: &LowerCtx) -> bool {
-    if ctx.has_subscript_guard(sequence_name, index_expr) {
+    if ctx.has_subscript_access_guard(sequence_name, index_expr) {
         return true;
     }
     if index_expr_is_safe_for_anchor(index_expr, sequence_name, 0, ctx) {

--- a/crates/sifr_lowering/src/lower/mutable_call_sequence_guard_tests.rs
+++ b/crates/sifr_lowering/src/lower/mutable_call_sequence_guard_tests.rs
@@ -121,6 +121,19 @@ def read_after_growth_and_reorder(mut values: list[int]) -> int:
 }
 
 #[test]
+fn append_preserves_non_none_subscript_fact() {
+    let source = r#"
+def read_after_append(mut values: list[int | None]) -> int:
+    if values[0] is not None:
+        values.append(None)
+        return values[0] + 1
+    return 0
+"#;
+    let result = lower_source(source);
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[test]
 fn dict_value_mutation_preserves_existing_membership_guard() {
     let source = r#"
 def read_after_setdefault(mut values: dict[str, int]) -> int:
@@ -154,4 +167,52 @@ def read_after_remove(mut values: list[int]) -> int:
         diagnostic.code == Some(DiagnosticCode::TYPE_UNSUPPORTED_OPERATOR)
             && diagnostic.message.contains("None")
     }));
+}
+
+#[test]
+fn shifting_reordering_and_value_replacement_invalidate_non_none_facts() {
+    let cases = [
+        (
+            "insert",
+            r#"
+def read_after_insert(mut values: list[int | None]) -> int:
+    if values[0] is not None:
+        values.insert(0, None)
+        return values[0] + 1
+    return 0
+"#,
+        ),
+        (
+            "reverse",
+            r#"
+def read_after_reverse(mut values: list[int | None]) -> int:
+    if values[0] is not None:
+        values.reverse()
+        return values[0] + 1
+    return 0
+"#,
+        ),
+        (
+            "dict update",
+            r#"
+def read_after_update(mut values: dict[str, int | None]) -> int:
+    if values["a"] is not None:
+        values.update({"a": None})
+        return values["a"] + 1
+    return 0
+"#,
+        ),
+    ];
+
+    for (operation, source) in cases {
+        let diagnostics = lower_source(source)
+            .expect_err(&format!("{operation} must invalidate the non-None fact"));
+        assert!(
+            diagnostics.iter().any(|diagnostic| {
+                diagnostic.code == Some(DiagnosticCode::TYPE_UNSUPPORTED_OPERATOR)
+                    && diagnostic.message.contains("None")
+            }),
+            "{operation}: {diagnostics:?}"
+        );
+    }
 }

--- a/crates/sifr_lowering/src/lower/mutable_call_sequence_guard_tests.rs
+++ b/crates/sifr_lowering/src/lower/mutable_call_sequence_guard_tests.rs
@@ -102,3 +102,56 @@ def read_after_pop(mut values: list[int]) -> int:
             && diagnostic.message.contains("None")
     }));
 }
+
+#[test]
+fn builtin_growth_and_reorder_preserve_nonempty_list_guard() {
+    let source = r#"
+def read_after_growth_and_reorder(mut values: list[int]) -> int:
+    if len(values) == 0:
+        return 0
+    values.append(4)
+    values.insert(0, 3)
+    values.extend([2, 1])
+    values.sort()
+    values.reverse()
+    return values[0] + 1
+"#;
+    let result = lower_source(source);
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[test]
+fn dict_value_mutation_preserves_existing_membership_guard() {
+    let source = r#"
+def read_after_setdefault(mut values: dict[str, int]) -> int:
+    if "a" not in values:
+        return 0
+    values.setdefault("b", 2)
+    values.update({"c": 3})
+    return values["a"] + 1
+"#;
+    let result = lower_source(source);
+    assert!(result.is_ok(), "{result:?}");
+}
+
+#[test]
+fn builtin_clear_and_remove_invalidate_sequence_guards() {
+    let source = r#"
+def read_after_clear(mut values: list[int]) -> int:
+    if len(values) == 0:
+        return 0
+    values.clear()
+    return values[0] + 1
+
+def read_after_remove(mut values: list[int]) -> int:
+    if len(values) == 0:
+        return 0
+    values.remove(values[0])
+    return values[0] + 1
+"#;
+    let diagnostics = lower_source(source).expect_err("removal must invalidate sequence guards");
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == Some(DiagnosticCode::TYPE_UNSUPPORTED_OPERATOR)
+            && diagnostic.message.contains("None")
+    }));
+}

--- a/crates/sifr_lowering/src/lower/mutating_methods.rs
+++ b/crates/sifr_lowering/src/lower/mutating_methods.rs
@@ -3,6 +3,81 @@ use crate::hir_nodes::HirExpr;
 use ruff_text_size::TextRange;
 use sifr_type_system::{ReceiverConvention, Type};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::lower) enum ReceiverMutationEffect {
+    None,
+    Growth,
+    Removal,
+    Reorder,
+    ValueMutation,
+}
+
+pub(in crate::lower) fn receiver_mutation_effect(
+    object_ty: &Type,
+    method: &str,
+    convention: ReceiverConvention,
+) -> ReceiverMutationEffect {
+    if convention != ReceiverConvention::MutableBorrow {
+        return ReceiverMutationEffect::None;
+    }
+
+    match object_ty.resolve_alias() {
+        Type::List(_) => match method {
+            "append" | "appendleft" | "extend" | "insert" => ReceiverMutationEffect::Growth,
+            "clear" | "pop" | "popleft" | "remove" => ReceiverMutationEffect::Removal,
+            "reverse" | "sort" => ReceiverMutationEffect::Reorder,
+            _ => ReceiverMutationEffect::Removal,
+        },
+        Type::Dict(_, _) => match method {
+            "update" | "setdefault" => ReceiverMutationEffect::ValueMutation,
+            "clear" | "pop" => ReceiverMutationEffect::Removal,
+            _ => ReceiverMutationEffect::Removal,
+        },
+        Type::Set(_) => match method {
+            "add" | "update" => ReceiverMutationEffect::Growth,
+            "remove"
+            | "discard"
+            | "clear"
+            | "intersection_update"
+            | "difference_update"
+            | "symmetric_difference_update" => ReceiverMutationEffect::Removal,
+            _ => ReceiverMutationEffect::Removal,
+        },
+        Type::PythonBuffer(_) => ReceiverMutationEffect::ValueMutation,
+        Type::JoinSet(_, _) if method == "add" => ReceiverMutationEffect::Growth,
+        Type::Class { .. } | Type::Protocol { .. } => ReceiverMutationEffect::Removal,
+        _ => ReceiverMutationEffect::Removal,
+    }
+}
+
+pub(in crate::lower) fn apply_receiver_mutation_effect(
+    ctx: &mut LowerCtx,
+    receiver: &HirExpr,
+    object_ty: &Type,
+    method: &str,
+    convention: ReceiverConvention,
+) {
+    let effect = receiver_mutation_effect(object_ty, method, convention);
+    if effect == ReceiverMutationEffect::None {
+        return;
+    }
+    let Some(target) = super::sequence_guards::hir_sequence_guard_target_name(receiver) else {
+        return;
+    };
+
+    ctx.record_flow_effect(sifr_ir::FlowEffect::Mutation {
+        target: target.clone(),
+        operation: format!("method {method}"),
+    });
+    ctx.record_flow_effect(sifr_ir::FlowEffect::ClearNarrowing {
+        binding: target.clone(),
+    });
+    if effect == ReceiverMutationEffect::Removal {
+        ctx.clear_sequence_guards_for_binding(&target);
+        ctx.clear_sequence_guards_for_target(&target);
+    }
+}
+
 /// Canonical receiver convention for successfully resolved non-class methods.
 ///
 /// Class and protocol methods carry their convention in `FunctionType`.
@@ -212,6 +287,71 @@ mod tests {
         assert_eq!(
             receiver_convention_for_non_class_method(&join_set, "__sifr_join_all"),
             ReceiverConvention::Owned
+        );
+    }
+
+    #[test]
+    fn receiver_effect_registry_distinguishes_collection_mutations() {
+        let list = Type::List(Box::new(Type::Int));
+        let dict = Type::Dict(Box::new(Type::Str), Box::new(Type::Int));
+        let set = Type::Set(Box::new(Type::Int));
+
+        for method in ["append", "appendleft", "extend", "insert"] {
+            assert_eq!(
+                receiver_mutation_effect(&list, method, ReceiverConvention::MutableBorrow),
+                ReceiverMutationEffect::Growth
+            );
+        }
+        for method in ["clear", "pop", "popleft", "remove"] {
+            assert_eq!(
+                receiver_mutation_effect(&list, method, ReceiverConvention::MutableBorrow),
+                ReceiverMutationEffect::Removal
+            );
+        }
+        for method in ["reverse", "sort"] {
+            assert_eq!(
+                receiver_mutation_effect(&list, method, ReceiverConvention::MutableBorrow),
+                ReceiverMutationEffect::Reorder
+            );
+        }
+        for method in ["update", "setdefault"] {
+            assert_eq!(
+                receiver_mutation_effect(&dict, method, ReceiverConvention::MutableBorrow),
+                ReceiverMutationEffect::ValueMutation
+            );
+        }
+        for method in ["clear", "pop"] {
+            assert_eq!(
+                receiver_mutation_effect(&dict, method, ReceiverConvention::MutableBorrow),
+                ReceiverMutationEffect::Removal
+            );
+        }
+        for method in ["add", "update"] {
+            assert_eq!(
+                receiver_mutation_effect(&set, method, ReceiverConvention::MutableBorrow),
+                ReceiverMutationEffect::Growth
+            );
+        }
+        for method in [
+            "remove",
+            "discard",
+            "clear",
+            "intersection_update",
+            "difference_update",
+            "symmetric_difference_update",
+        ] {
+            assert_eq!(
+                receiver_mutation_effect(&set, method, ReceiverConvention::MutableBorrow),
+                ReceiverMutationEffect::Removal
+            );
+        }
+        assert_eq!(
+            receiver_mutation_effect(&list, "append", ReceiverConvention::SharedBorrow),
+            ReceiverMutationEffect::None
+        );
+        assert_eq!(
+            receiver_mutation_effect(&list, "future_mutator", ReceiverConvention::MutableBorrow),
+            ReceiverMutationEffect::Removal
         );
     }
 }

--- a/crates/sifr_lowering/src/lower/mutating_methods.rs
+++ b/crates/sifr_lowering/src/lower/mutating_methods.rs
@@ -12,16 +12,32 @@ pub(in crate::lower) enum ReceiverMutationEffect {
     ValueMutation,
 }
 
-pub(in crate::lower) fn receiver_mutation_effect(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReceiverFactInvalidation {
+    None,
+    SubscriptPresence,
+    All,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::lower) struct ReceiverMutationSummary {
+    effect: ReceiverMutationEffect,
+    fact_invalidation: ReceiverFactInvalidation,
+}
+
+pub(in crate::lower) fn receiver_mutation_summary(
     object_ty: &Type,
     method: &str,
     convention: ReceiverConvention,
-) -> ReceiverMutationEffect {
+) -> ReceiverMutationSummary {
     if convention != ReceiverConvention::MutableBorrow {
-        return ReceiverMutationEffect::None;
+        return ReceiverMutationSummary {
+            effect: ReceiverMutationEffect::None,
+            fact_invalidation: ReceiverFactInvalidation::None,
+        };
     }
 
-    match object_ty.resolve_alias() {
+    let effect = match object_ty.resolve_alias() {
         Type::List(_) => match method {
             "append" | "appendleft" | "extend" | "insert" => ReceiverMutationEffect::Growth,
             "clear" | "pop" | "popleft" | "remove" => ReceiverMutationEffect::Removal,
@@ -47,6 +63,29 @@ pub(in crate::lower) fn receiver_mutation_effect(
         Type::JoinSet(_, _) if method == "add" => ReceiverMutationEffect::Growth,
         Type::Class { .. } | Type::Protocol { .. } => ReceiverMutationEffect::Removal,
         _ => ReceiverMutationEffect::Removal,
+    };
+    let fact_invalidation = match effect {
+        ReceiverMutationEffect::None => ReceiverFactInvalidation::None,
+        ReceiverMutationEffect::Removal => ReceiverFactInvalidation::All,
+        ReceiverMutationEffect::Reorder => ReceiverFactInvalidation::SubscriptPresence,
+        ReceiverMutationEffect::Growth
+            if matches!(object_ty.resolve_alias(), Type::List(_))
+                && matches!(method, "insert" | "appendleft") =>
+        {
+            ReceiverFactInvalidation::SubscriptPresence
+        }
+        ReceiverMutationEffect::ValueMutation
+            if matches!(object_ty.resolve_alias(), Type::Dict(_, _)) && method == "update" =>
+        {
+            ReceiverFactInvalidation::SubscriptPresence
+        }
+        ReceiverMutationEffect::Growth | ReceiverMutationEffect::ValueMutation => {
+            ReceiverFactInvalidation::None
+        }
+    };
+    ReceiverMutationSummary {
+        effect,
+        fact_invalidation,
     }
 }
 
@@ -57,8 +96,8 @@ pub(in crate::lower) fn apply_receiver_mutation_effect(
     method: &str,
     convention: ReceiverConvention,
 ) {
-    let effect = receiver_mutation_effect(object_ty, method, convention);
-    if effect == ReceiverMutationEffect::None {
+    let summary = receiver_mutation_summary(object_ty, method, convention);
+    if summary.effect == ReceiverMutationEffect::None {
         return;
     }
     let Some(target) = super::sequence_guards::hir_sequence_guard_target_name(receiver) else {
@@ -72,9 +111,15 @@ pub(in crate::lower) fn apply_receiver_mutation_effect(
     ctx.record_flow_effect(sifr_ir::FlowEffect::ClearNarrowing {
         binding: target.clone(),
     });
-    if effect == ReceiverMutationEffect::Removal {
-        ctx.clear_sequence_guards_for_binding(&target);
-        ctx.clear_sequence_guards_for_target(&target);
+    match summary.fact_invalidation {
+        ReceiverFactInvalidation::None => {}
+        ReceiverFactInvalidation::SubscriptPresence => {
+            ctx.clear_subscript_presence_guards_for_target(&target);
+        }
+        ReceiverFactInvalidation::All => {
+            ctx.clear_sequence_guards_for_binding(&target);
+            ctx.clear_sequence_guards_for_target(&target);
+        }
     }
 }
 
@@ -295,40 +340,43 @@ mod tests {
         let list = Type::List(Box::new(Type::Int));
         let dict = Type::Dict(Box::new(Type::Str), Box::new(Type::Int));
         let set = Type::Set(Box::new(Type::Int));
+        let effect = |ty: &Type, method: &str, convention| {
+            receiver_mutation_summary(ty, method, convention).effect
+        };
 
         for method in ["append", "appendleft", "extend", "insert"] {
             assert_eq!(
-                receiver_mutation_effect(&list, method, ReceiverConvention::MutableBorrow),
+                effect(&list, method, ReceiverConvention::MutableBorrow),
                 ReceiverMutationEffect::Growth
             );
         }
         for method in ["clear", "pop", "popleft", "remove"] {
             assert_eq!(
-                receiver_mutation_effect(&list, method, ReceiverConvention::MutableBorrow),
+                effect(&list, method, ReceiverConvention::MutableBorrow),
                 ReceiverMutationEffect::Removal
             );
         }
         for method in ["reverse", "sort"] {
             assert_eq!(
-                receiver_mutation_effect(&list, method, ReceiverConvention::MutableBorrow),
+                effect(&list, method, ReceiverConvention::MutableBorrow),
                 ReceiverMutationEffect::Reorder
             );
         }
         for method in ["update", "setdefault"] {
             assert_eq!(
-                receiver_mutation_effect(&dict, method, ReceiverConvention::MutableBorrow),
+                effect(&dict, method, ReceiverConvention::MutableBorrow),
                 ReceiverMutationEffect::ValueMutation
             );
         }
         for method in ["clear", "pop"] {
             assert_eq!(
-                receiver_mutation_effect(&dict, method, ReceiverConvention::MutableBorrow),
+                effect(&dict, method, ReceiverConvention::MutableBorrow),
                 ReceiverMutationEffect::Removal
             );
         }
         for method in ["add", "update"] {
             assert_eq!(
-                receiver_mutation_effect(&set, method, ReceiverConvention::MutableBorrow),
+                effect(&set, method, ReceiverConvention::MutableBorrow),
                 ReceiverMutationEffect::Growth
             );
         }
@@ -341,17 +389,50 @@ mod tests {
             "symmetric_difference_update",
         ] {
             assert_eq!(
-                receiver_mutation_effect(&set, method, ReceiverConvention::MutableBorrow),
+                effect(&set, method, ReceiverConvention::MutableBorrow),
                 ReceiverMutationEffect::Removal
             );
         }
         assert_eq!(
-            receiver_mutation_effect(&list, "append", ReceiverConvention::SharedBorrow),
+            effect(&list, "append", ReceiverConvention::SharedBorrow),
             ReceiverMutationEffect::None
         );
         assert_eq!(
-            receiver_mutation_effect(&list, "future_mutator", ReceiverConvention::MutableBorrow),
+            effect(&list, "future_mutator", ReceiverConvention::MutableBorrow),
             ReceiverMutationEffect::Removal
+        );
+    }
+
+    #[test]
+    fn receiver_summary_invalidates_only_falsified_sequence_facts() {
+        let optional_int = Type::Union(vec![Type::Int, Type::None]);
+        let list = Type::List(Box::new(optional_int.clone()));
+        let dict = Type::Dict(Box::new(Type::Str), Box::new(optional_int));
+        let summary = |ty: &Type, method: &str| {
+            receiver_mutation_summary(ty, method, ReceiverConvention::MutableBorrow)
+        };
+
+        assert_eq!(
+            summary(&list, "append").fact_invalidation,
+            ReceiverFactInvalidation::None
+        );
+        for method in ["insert", "appendleft", "reverse", "sort"] {
+            assert_eq!(
+                summary(&list, method).fact_invalidation,
+                ReceiverFactInvalidation::SubscriptPresence
+            );
+        }
+        assert_eq!(
+            summary(&dict, "setdefault").fact_invalidation,
+            ReceiverFactInvalidation::None
+        );
+        assert_eq!(
+            summary(&dict, "update").fact_invalidation,
+            ReceiverFactInvalidation::SubscriptPresence
+        );
+        assert_eq!(
+            summary(&list, "pop").fact_invalidation,
+            ReceiverFactInvalidation::All
         );
     }
 }

--- a/crates/sifr_lowering/src/lower/sequence_guard_detection.rs
+++ b/crates/sifr_lowering/src/lower/sequence_guard_detection.rs
@@ -258,10 +258,16 @@ fn subscript_present_guard(expr: &Expr) -> Vec<SequenceGuard> {
     let Some(index_expr_debug) = key_guard_token(subscript.slice.as_ref()) else {
         return Vec::new();
     };
-    vec![SequenceGuard::SubscriptPresent {
-        sequence,
-        index_expr_debug,
-    }]
+    vec![
+        SequenceGuard::SubscriptAccessible {
+            sequence: sequence.clone(),
+            index_expr_debug: index_expr_debug.clone(),
+        },
+        SequenceGuard::SubscriptPresent {
+            sequence,
+            index_expr_debug,
+        },
+    ]
 }
 
 fn dict_contains_guard(key_expr: &Expr, haystack_expr: &Expr) -> Vec<SequenceGuard> {

--- a/crates/sifr_lowering/src/lower/sequence_guards.rs
+++ b/crates/sifr_lowering/src/lower/sequence_guards.rs
@@ -21,6 +21,10 @@ pub(in crate::lower) enum SequenceGuard {
         dict: String,
         key_expr_debug: String,
     },
+    SubscriptAccessible {
+        sequence: String,
+        index_expr_debug: String,
+    },
     SubscriptPresent {
         sequence: String,
         index_expr_debug: String,
@@ -123,6 +127,27 @@ impl LowerCtx {
                     index_expr_debug,
                 });
             }
+            SequenceGuard::SubscriptAccessible {
+                sequence,
+                index_expr_debug,
+            } => {
+                if self.sequence_guards.iter().any(|existing| {
+                    matches!(
+                        existing,
+                        SequenceGuard::SubscriptAccessible {
+                            sequence: existing_sequence,
+                            index_expr_debug: existing_index,
+                        } if existing_sequence == &sequence && existing_index == &index_expr_debug
+                    )
+                }) {
+                    return;
+                }
+                self.sequence_guards
+                    .push(SequenceGuard::SubscriptAccessible {
+                        sequence,
+                        index_expr_debug,
+                    });
+            }
         }
     }
 
@@ -142,6 +167,16 @@ impl LowerCtx {
     pub(in crate::lower) fn clear_sequence_guards_for_target(&mut self, target: &str) {
         self.sequence_guards
             .retain(|guard| !guard_depends_on_target(guard, target));
+    }
+
+    pub(in crate::lower) fn clear_subscript_presence_guards_for_target(&mut self, target: &str) {
+        self.sequence_guards.retain(|guard| {
+            !matches!(
+                guard,
+                SequenceGuard::SubscriptPresent { sequence, .. }
+                    if path_depends_on_target(sequence, target)
+            )
+        });
     }
 
     pub(in crate::lower) fn min_length_guard(&self, sequence: &str) -> usize {
@@ -221,6 +256,25 @@ impl LowerCtx {
             )
         })
     }
+
+    pub(in crate::lower) fn has_subscript_access_guard(
+        &self,
+        sequence: &str,
+        index_expr: &Expr,
+    ) -> bool {
+        let Some(index_expr_debug) = key_guard_token(index_expr) else {
+            return false;
+        };
+        self.sequence_guards.iter().any(|guard| {
+            matches!(
+                guard,
+                SequenceGuard::SubscriptAccessible {
+                    sequence: guard_sequence,
+                    index_expr_debug: guard_index,
+                } if guard_sequence == sequence && guard_index == &index_expr_debug
+            )
+        })
+    }
 }
 
 fn guard_depends_on_binding(guard: &SequenceGuard, binding: &str) -> bool {
@@ -236,7 +290,11 @@ fn guard_depends_on_binding(guard: &SequenceGuard, binding: &str) -> bool {
             dict,
             key_expr_debug,
         } => path_depends_on_binding(dict, binding) || token_mentions_name(key_expr_debug, binding),
-        SequenceGuard::SubscriptPresent {
+        SequenceGuard::SubscriptAccessible {
+            sequence,
+            index_expr_debug,
+        }
+        | SequenceGuard::SubscriptPresent {
             sequence,
             index_expr_debug,
         } => {
@@ -250,6 +308,7 @@ fn guard_depends_on_target(guard: &SequenceGuard, target: &str) -> bool {
     match guard {
         SequenceGuard::MinLength { sequence, .. }
         | SequenceGuard::IndexVarInRange { sequence, .. }
+        | SequenceGuard::SubscriptAccessible { sequence, .. }
         | SequenceGuard::SubscriptPresent { sequence, .. } => {
             path_depends_on_target(sequence, target)
         }

--- a/crates/sifr_lowering/src/lower/sequence_guards.rs
+++ b/crates/sifr_lowering/src/lower/sequence_guards.rs
@@ -298,29 +298,6 @@ pub(in crate::lower) fn invalidate_mutable_call_sequence_guards(
     }
 }
 
-pub(in crate::lower) fn invalidate_mutable_receiver_sequence_guards(
-    ctx: &mut LowerCtx,
-    receiver: &HirExpr,
-    convention: Option<sifr_type_system::ReceiverConvention>,
-    method: &str,
-) {
-    if convention != Some(sifr_type_system::ReceiverConvention::MutableBorrow) {
-        return;
-    }
-    let Some(target) = hir_sequence_guard_target_name(receiver) else {
-        return;
-    };
-    ctx.record_flow_effect(sifr_ir::FlowEffect::Mutation {
-        target: target.clone(),
-        operation: format!("method {method}"),
-    });
-    ctx.record_flow_effect(sifr_ir::FlowEffect::ClearNarrowing {
-        binding: target.clone(),
-    });
-    ctx.clear_sequence_guards_for_binding(&target);
-    ctx.clear_sequence_guards_for_target(&target);
-}
-
 pub(in crate::lower) fn key_guard_token(expr: &Expr) -> Option<String> {
     match expr {
         Expr::Name(name) => Some(format!("name:{}", name.id)),


### PR DESCRIPTION
Completes Emitted Rust Excellence Item 7A. Introduces fact-granular mutable-receiver summaries, separates subscript accessibility from non-None value facts, and centralizes ownership-safe dict.setdefault emission across all entrypoints. Adds lowering, emitted-shape, fallback, Copy/affine, and native regressions.\n\nExact reviewed candidate: e77bf60695f27cee1fa71a1e3eea2e8facad1b75.\n\nKnown unrelated failures remain assigned to Item 8 (numeric_sentinels) and Item 12 (SQL profile composition).