### PR TITLE
fix(lowering): close receiver fact ownership gaps

### DIFF
--- a/crates/sifr/tests/e2e/fail/python_buffer_setdefault_owner_conflict.sifr
+++ b/crates/sifr/tests/e2e/fail/python_buffer_setdefault_owner_conflict.sifr
@@ -1,0 +1,6 @@
+# expect-error: SIFR-PYZC-0001
+def select(
+    mut values: dict[str, python.Buffer[uint8]],
+    own fallback: python.Buffer[uint8],
+) -> python.Buffer[uint8]:
+    return values.setdefault("key", fallback)

--- a/crates/sifr/tests/e2e/pass/receiver_effect_setdefault_ownership.sifr
+++ b/crates/sifr/tests/e2e/pass/receiver_effect_setdefault_ownership.sifr
@@ -34,6 +34,10 @@ def copy_default(mut values: dict[str, bool], key: str, default: bool) -> bool:
     return values.setdefault(key, default)
 
 
+def existing_default(mut values: dict[str, str], default: str) -> str:
+    return values.setdefault("key", default)
+
+
 def main():
     numbers: list[int] = [0]
     assert read_after_growth_and_reorder(numbers) == 4
@@ -49,3 +53,6 @@ def main():
 
     flags: dict[str, bool] = {}
     assert copy_default(flags, "enabled", True)
+
+    existing: dict[str, str] = {"key": "stored"}
+    assert existing_default(existing, "unused") == "stored"

--- a/crates/sifr_codegen/src/methods/dict.rs
+++ b/crates/sifr_codegen/src/methods/dict.rs
@@ -27,7 +27,7 @@ fn render_key_arg_expr(arg: &RustExpr) -> RustExpr {
 }
 
 fn materialize_setdefault_storage_arg(ty: &Type, arg: &RustExpr) -> RustExpr {
-    if crate::helpers::is_copy_type_for_codegen(ty) || ty.contains_affine_resource() {
+    if crate::helpers::is_copy_type_for_codegen(ty) {
         return arg.clone();
     }
     let reusable_place = match arg {
@@ -240,6 +240,9 @@ pub(super) fn lower_setdefault(
     value_ty: &Type,
     args: &[RustExpr],
 ) -> Option<RustExpr> {
+    if key_ty.contains_affine_resource() || value_ty.contains_affine_resource() {
+        return None;
+    }
     match args {
         [key, default] => {
             let key = materialize_setdefault_storage_arg(key_ty, key);
@@ -268,15 +271,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn setdefault_storage_materialization_preserves_copy_and_affine_places() {
+    fn setdefault_storage_materialization_preserves_copy_places() {
         let place = RustExpr::Ident("value".to_string());
         assert_eq!(
             materialize_setdefault_storage_arg(&Type::Bool, &place),
             place
         );
+    }
 
+    #[test]
+    fn setdefault_defensively_rejects_affine_key_and_value_types() {
+        let object = RustExpr::Ident("values".to_string());
+        let key = RustExpr::Ident("key".to_string());
+        let value = RustExpr::Ident("value".to_string());
         let affine =
             Type::PythonBuffer(Box::new(Type::FixedInt(sifr_type_system::FixedIntType::U8)));
-        assert_eq!(materialize_setdefault_storage_arg(&affine, &place), place);
+        assert!(
+            lower_setdefault(&object, &Type::Str, &affine, &[key.clone(), value.clone()]).is_none()
+        );
+        assert!(lower_setdefault(&object, &affine, &Type::Int, &[key, value]).is_none());
     }
 }

--- a/crates/sifr_lowering/src/lower/expressions/method_type_collections.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_type_collections.rs
@@ -318,6 +318,15 @@ pub(super) fn resolve_dict_method_type(
         method,
         "values" | "items" | "update" | "copy" | "get" | "setdefault"
     );
+    if method == "setdefault" && val_ty.contains_affine_resource() {
+        ctx.error_with_code_at(
+            DiagnosticCode::PYZC_INVALID_DECLARATION,
+            "dict.setdefault() is unavailable for values containing affine Python resources: insertion transfers the default into the dict, while returning the selected stored value would require a second owner"
+                .to_string(),
+            method_range,
+        );
+        return None;
+    }
     if requires_reusable_values
         && !unresolved_empty_get
         && !val_ty.supports_derived_clone()

--- a/crates/sifr_lowering/src/lower/mutable_call_sequence_guard_tests.rs
+++ b/crates/sifr_lowering/src/lower/mutable_call_sequence_guard_tests.rs
@@ -134,6 +134,45 @@ def read_after_append(mut values: list[int | None]) -> int:
 }
 
 #[test]
+fn append_and_extend_invalidate_end_relative_non_none_subscript_facts() {
+    let cases = [
+        (
+            "append",
+            r#"
+def read_after_append(mut values: list[int | None]) -> int:
+    if values[-1] is not None:
+        values.append(None)
+        return values[-1] + 1
+    return 0
+"#,
+        ),
+        (
+            "extend",
+            r#"
+def read_after_extend(mut values: list[int | None]) -> int:
+    if values[-1] is not None:
+        values.extend([None])
+        return values[-1] + 1
+    return 0
+"#,
+        ),
+    ];
+
+    for (operation, source) in cases {
+        let diagnostics = lower_source(source).expect_err(&format!(
+            "{operation} must invalidate an end-relative non-None fact"
+        ));
+        assert!(
+            diagnostics.iter().any(|diagnostic| {
+                diagnostic.code == Some(DiagnosticCode::TYPE_UNSUPPORTED_OPERATOR)
+                    && diagnostic.message.contains("None")
+            }),
+            "{operation}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
 fn dict_value_mutation_preserves_existing_membership_guard() {
     let source = r#"
 def read_after_setdefault(mut values: dict[str, int]) -> int:

--- a/crates/sifr_lowering/src/lower/mutating_methods.rs
+++ b/crates/sifr_lowering/src/lower/mutating_methods.rs
@@ -15,13 +15,21 @@ pub(in crate::lower) enum ReceiverMutationEffect {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReceiverFactInvalidation {
     None,
+    GrowthSensitiveSubscriptPresence,
     SubscriptPresence,
     All,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReceiverFactDomain {
+    RelevantSequenceFacts,
+    NoRelevantSequenceFacts,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::lower) struct ReceiverMutationSummary {
     effect: ReceiverMutationEffect,
+    fact_domain: ReceiverFactDomain,
     fact_invalidation: ReceiverFactInvalidation,
 }
 
@@ -33,6 +41,7 @@ pub(in crate::lower) fn receiver_mutation_summary(
     if convention != ReceiverConvention::MutableBorrow {
         return ReceiverMutationSummary {
             effect: ReceiverMutationEffect::None,
+            fact_domain: receiver_fact_domain(object_ty),
             fact_invalidation: ReceiverFactInvalidation::None,
         };
     }
@@ -64,28 +73,44 @@ pub(in crate::lower) fn receiver_mutation_summary(
         Type::Class { .. } | Type::Protocol { .. } => ReceiverMutationEffect::Removal,
         _ => ReceiverMutationEffect::Removal,
     };
-    let fact_invalidation = match effect {
-        ReceiverMutationEffect::None => ReceiverFactInvalidation::None,
-        ReceiverMutationEffect::Removal => ReceiverFactInvalidation::All,
-        ReceiverMutationEffect::Reorder => ReceiverFactInvalidation::SubscriptPresence,
-        ReceiverMutationEffect::Growth
+    let fact_domain = receiver_fact_domain(object_ty);
+    let fact_invalidation = match (fact_domain, effect) {
+        (ReceiverFactDomain::NoRelevantSequenceFacts, _) => ReceiverFactInvalidation::None,
+        (_, ReceiverMutationEffect::None) => ReceiverFactInvalidation::None,
+        (_, ReceiverMutationEffect::Removal) => ReceiverFactInvalidation::All,
+        (_, ReceiverMutationEffect::Reorder) => ReceiverFactInvalidation::SubscriptPresence,
+        (_, ReceiverMutationEffect::Growth)
             if matches!(object_ty.resolve_alias(), Type::List(_))
                 && matches!(method, "insert" | "appendleft") =>
         {
             ReceiverFactInvalidation::SubscriptPresence
         }
-        ReceiverMutationEffect::ValueMutation
+        (_, ReceiverMutationEffect::Growth)
+            if matches!(object_ty.resolve_alias(), Type::List(_))
+                && matches!(method, "append" | "extend") =>
+        {
+            ReceiverFactInvalidation::GrowthSensitiveSubscriptPresence
+        }
+        (_, ReceiverMutationEffect::ValueMutation)
             if matches!(object_ty.resolve_alias(), Type::Dict(_, _)) && method == "update" =>
         {
             ReceiverFactInvalidation::SubscriptPresence
         }
-        ReceiverMutationEffect::Growth | ReceiverMutationEffect::ValueMutation => {
+        (_, ReceiverMutationEffect::Growth | ReceiverMutationEffect::ValueMutation) => {
             ReceiverFactInvalidation::None
         }
     };
     ReceiverMutationSummary {
         effect,
+        fact_domain,
         fact_invalidation,
+    }
+}
+
+fn receiver_fact_domain(object_ty: &Type) -> ReceiverFactDomain {
+    match object_ty.resolve_alias() {
+        Type::PythonBuffer(_) | Type::JoinSet(_, _) => ReceiverFactDomain::NoRelevantSequenceFacts,
+        _ => ReceiverFactDomain::RelevantSequenceFacts,
     }
 }
 
@@ -113,6 +138,9 @@ pub(in crate::lower) fn apply_receiver_mutation_effect(
     });
     match summary.fact_invalidation {
         ReceiverFactInvalidation::None => {}
+        ReceiverFactInvalidation::GrowthSensitiveSubscriptPresence => {
+            ctx.clear_growth_sensitive_subscript_presence_guards_for_target(&target);
+        }
         ReceiverFactInvalidation::SubscriptPresence => {
             ctx.clear_subscript_presence_guards_for_target(&target);
         }
@@ -414,7 +442,7 @@ mod tests {
 
         assert_eq!(
             summary(&list, "append").fact_invalidation,
-            ReceiverFactInvalidation::None
+            ReceiverFactInvalidation::GrowthSensitiveSubscriptPresence
         );
         for method in ["insert", "appendleft", "reverse", "sort"] {
             assert_eq!(
@@ -433,6 +461,21 @@ mod tests {
         assert_eq!(
             summary(&list, "pop").fact_invalidation,
             ReceiverFactInvalidation::All
+        );
+
+        let buffer =
+            Type::PythonBuffer(Box::new(Type::FixedInt(sifr_type_system::FixedIntType::U8)));
+        assert_eq!(
+            summary(&buffer, "write").fact_domain,
+            ReceiverFactDomain::NoRelevantSequenceFacts
+        );
+        assert_eq!(
+            summary(&buffer, "write").fact_invalidation,
+            ReceiverFactInvalidation::None
+        );
+        assert_eq!(
+            summary(&list, "append").fact_domain,
+            ReceiverFactDomain::RelevantSequenceFacts
         );
     }
 }

--- a/crates/sifr_lowering/src/lower/python_buffer_contract_tests.rs
+++ b/crates/sifr_lowering/src/lower/python_buffer_contract_tests.rs
@@ -443,6 +443,24 @@ fn affine_buffer_collection_capabilities_are_rejected_before_codegen() {
 }
 
 #[test]
+fn affine_buffer_setdefault_rejects_insertion_and_return_owner_conflict() {
+    let errors = lower_errors(
+        "def select(mut values: dict[str, python.Buffer[uint8]], own fallback: python.Buffer[uint8]) -> python.Buffer[uint8]:\n    return values.setdefault(\"key\", fallback)\n",
+    );
+    assert!(
+        errors.iter().any(|error| {
+            error.code == Some(DiagnosticCode::PYZC_INVALID_DECLARATION)
+                && error.message.contains("insertion transfers the default")
+                && error
+                    .message
+                    .contains("returning the selected stored value")
+                && error.message.contains("second owner")
+        }),
+        "{errors:?}"
+    );
+}
+
+#[test]
 fn affine_buffer_collection_insertion_consumes_the_source() {
     for source in [
         "def pack(own view: python.Buffer[uint8]) -> None:\n    values: list[python.Buffer[uint8]] = []\n    values.append(view)\n    print(view.length())\n",

--- a/crates/sifr_lowering/src/lower/sequence_guard_detection.rs
+++ b/crates/sifr_lowering/src/lower/sequence_guard_detection.rs
@@ -1,5 +1,5 @@
 use super::LowerCtx;
-use super::sequence_guards::{SequenceGuard, key_guard_token};
+use super::sequence_guards::{SequenceGuard, SubscriptReferenceStability, key_guard_token};
 use sifr_python_ast::visitor::{self, Visitor};
 use sifr_python_ast::{
     BoolOp, CmpOp, Expr, Number, Operator, Stmt, StmtAssign, StmtAugAssign, StmtFor, StmtWhile,
@@ -266,8 +266,17 @@ fn subscript_present_guard(expr: &Expr) -> Vec<SequenceGuard> {
         SequenceGuard::SubscriptPresent {
             sequence,
             index_expr_debug,
+            reference_stability: subscript_reference_stability(subscript.slice.as_ref()),
         },
     ]
+}
+
+fn subscript_reference_stability(index: &Expr) -> SubscriptReferenceStability {
+    if literal_int(index).is_some_and(|value| value >= 0) {
+        SubscriptReferenceStability::StableAcrossGrowth
+    } else {
+        SubscriptReferenceStability::MayChangeOnGrowth
+    }
 }
 
 fn dict_contains_guard(key_expr: &Expr, haystack_expr: &Expr) -> Vec<SequenceGuard> {

--- a/crates/sifr_lowering/src/lower/sequence_guards.rs
+++ b/crates/sifr_lowering/src/lower/sequence_guards.rs
@@ -3,6 +3,12 @@ use crate::hir_nodes::HirExpr;
 use sifr_python_ast::{Expr, Number, Operator, UnaryOp};
 use sifr_type_system::ParamConvention;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::lower) enum SubscriptReferenceStability {
+    StableAcrossGrowth,
+    MayChangeOnGrowth,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::lower) enum SequenceGuard {
     MinLength {
@@ -28,6 +34,7 @@ pub(in crate::lower) enum SequenceGuard {
     SubscriptPresent {
         sequence: String,
         index_expr_debug: String,
+        reference_stability: SubscriptReferenceStability,
     },
 }
 
@@ -110,6 +117,7 @@ impl LowerCtx {
             SequenceGuard::SubscriptPresent {
                 sequence,
                 index_expr_debug,
+                reference_stability,
             } => {
                 if self.sequence_guards.iter().any(|existing| {
                     matches!(
@@ -117,7 +125,10 @@ impl LowerCtx {
                         SequenceGuard::SubscriptPresent {
                             sequence: existing_sequence,
                             index_expr_debug: existing_index,
-                        } if existing_sequence == &sequence && existing_index == &index_expr_debug
+                            reference_stability: existing_stability,
+                        } if existing_sequence == &sequence
+                            && existing_index == &index_expr_debug
+                            && existing_stability == &reference_stability
                     )
                 }) {
                     return;
@@ -125,6 +136,7 @@ impl LowerCtx {
                 self.sequence_guards.push(SequenceGuard::SubscriptPresent {
                     sequence,
                     index_expr_debug,
+                    reference_stability,
                 });
             }
             SequenceGuard::SubscriptAccessible {
@@ -175,6 +187,22 @@ impl LowerCtx {
                 guard,
                 SequenceGuard::SubscriptPresent { sequence, .. }
                     if path_depends_on_target(sequence, target)
+            )
+        });
+    }
+
+    pub(in crate::lower) fn clear_growth_sensitive_subscript_presence_guards_for_target(
+        &mut self,
+        target: &str,
+    ) {
+        self.sequence_guards.retain(|guard| {
+            !matches!(
+                guard,
+                SequenceGuard::SubscriptPresent {
+                    sequence,
+                    reference_stability: SubscriptReferenceStability::MayChangeOnGrowth,
+                    ..
+                } if path_depends_on_target(sequence, target)
             )
         });
     }
@@ -252,6 +280,7 @@ impl LowerCtx {
                 SequenceGuard::SubscriptPresent {
                     sequence: guard_sequence,
                     index_expr_debug: guard_index,
+                    ..
                 } if guard_sequence == sequence && guard_index == &index_expr_debug
             )
         })
@@ -297,6 +326,7 @@ fn guard_depends_on_binding(guard: &SequenceGuard, binding: &str) -> bool {
         | SequenceGuard::SubscriptPresent {
             sequence,
             index_expr_debug,
+            ..
         } => {
             path_depends_on_binding(sequence, binding)
                 || token_mentions_name(index_expr_debug, binding)


### PR DESCRIPTION
## Summary

- classify subscript non-None facts by whether sequence growth can change their referent
- invalidate negative and otherwise potentially end-relative facts on append/extend while preserving absolute facts
- make affine dict.setdefault ownership rejection explicit at lowering and defensive at codegen
- encode the no-relevant-sequence-facts domain for mutable Python buffers and join sets

## Validation

- 1,103 lowering tests passed; 1 ignored
- 1,218 codegen tests passed
- 569 E2E fail fixtures passed
- focused release-native receiver/setdefault fixture passed
- full E2E: 718 passed; only unchanged Item 8 numeric_sentinels failed
- workspace Clippy, rustfmt, diff, HIR, file-size, audit inventory, and exact demo freshness passed

Exact candidate: `5b6c68d0508c5e79b0ddfc8d598480314ef8ef14`.