### PR TITLE
Publish compiled SQL stdlib exports

### DIFF
--- a/docs/stdlib/public-api.mdx
+++ b/docs/stdlib/public-api.mdx
@@ -266,6 +266,16 @@ Classes: `ShutdownStream`, `Signal`, `SignalError`.
 
 Constants: `SIGINT`, `SIGTERM`.
 
+## `sifr.sql`
+
+Classes: `BoundQuery`, `CalendarInterval`, `DecodeError`, `EncodeError`, `MultiRange`, `Numeric`, `QueryTemplate`, `Range`, `SqlArray`, `SqlError`, `SqlSchema`.
+
+## `sifr.sql.migration`
+
+Functions: `migration`, `rollback`.
+
+Classes: `MigrationPlan`, `MigrationState`.
+
 ## `sifr.statistics`
 
 Functions: `correlation`, `covariance`, `geometric_mean`, `harmonic_mean`, `linear_regression`, `mean`, `median`, `median_grouped`, `median_high`, `median_low`, `mode`, `multimode`, `pstdev`, `pvariance`, `quantiles`, `stdev`, `variance`.


### PR DESCRIPTION
Closes #3649.

The SQL platform added public sifr.sql and sifr.sql.migration metadata, but the generated compiled-standard-library reference was not refreshed. This documentation-only correction uses the test-owned regeneration path and adds exactly those two sections.

Validation on exact candidate bf7ae3f49806ad669a06a4ac49ddd53b6345e1de:

- exact main baseline reproduces compiled_stdlib_exports_match_public_reference failure
- supported SIFR_UPDATE_STDLIB_PUBLIC_API regeneration passes
- no-update compiled_stdlib_exports_match_public_reference passes
- generated diff is exactly ten lines for sifr.sql and sifr.sql.migration
- file-size guard and git diff check pass

Only docs/stdlib/public-api.mdx changes. Per phase policy, compiler create-PR and merge gates do not apply.