### PR TITLE
Fix SQL verification resource classification

### DIFF
--- a/verification/areas/sql_platform/manifest.json
+++ b/verification/areas/sql_platform/manifest.json
@@ -61,7 +61,7 @@
     {
       "name": "build-qualification",
       "kind": "adapter",
-      "resource_classes": ["cargo-build-exclusive"],
+      "resource_classes": ["default-local"],
       "network_mode": "offline",
       "timeout_seconds": 3600,
       "cases": [

--- a/verification/areas/sql_platform/tools/check_integrated_qualification.py
+++ b/verification/areas/sql_platform/tools/check_integrated_qualification.py
@@ -151,6 +151,10 @@ def validate_build_evidence(record: dict[str, Any]) -> None:
     suites = {str(suite.get("name")): suite for suite in manifest.get("suites", [])}
     suite = suites.get(evidence["suite"])
     require(isinstance(suite, dict), "SQL build qualification suite is absent")
+    require(
+        suite.get("resource_classes") == ["default-local"],
+        "SQL build qualification must use the schema-supported default-local resource class",
+    )
     commands = {str(case.get("command")) for case in suite.get("cases", [])}
     require(commands == {"sql-build-qualification"}, "SQL build suite command has drifted")
     workflow = (REPO_ROOT / evidence["workflow"]).read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #3657.\n\nReplace the unsupported SQL build-qualification resource class with the schema-supported default-local class and make the SQL qualification contract enforce that canonical declaration.\n\nValidation:\n- uv run --project verification --locked python -m sifr_verify --self-test\n- python3 verification/areas/sql_platform/tools/check_integrated_qualification.py\n- python3 scripts/check_file_size_guardrails.py\n- git diff --check\n\nNo compiler files changed, so Sifr create-PR and merge gates are intentionally not run.