### PR TITLE
Support callable structural-record fields

### DIFF
--- a/crates/sifr_codegen/src/intrinsic_method_emitters/collection_methods.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/collection_methods.rs
@@ -346,23 +346,17 @@ impl RustEmitter {
             }
         }
 
-        if let Type::Class {
-            fields, methods, ..
-        } = crate::resolve_alias_type_for_plain_call(object_ty)
-        {
-            let is_callable_field = !methods.iter().any(|(name, _)| name == method)
-                && fields
-                    .iter()
-                    .any(|(name, ty)| name == method && matches!(ty, Type::Callable(..)));
-            if is_callable_field {
-                return Some(crate::RustExpr::FnCall {
-                    func: Box::new(crate::RustExpr::Paren(Box::new(crate::RustExpr::Field {
-                        expr: Box::new(object_expr),
-                        field: method.to_string(),
-                    }))),
-                    args: arg_exprs,
-                });
+        if object_ty.callable_field_type(method).is_some() {
+            if let Some(method_params) = method_params.as_deref() {
+                self.apply_registry_method_arg_conventions(args, method_params, &mut arg_exprs);
             }
+            return Some(crate::RustExpr::FnCall {
+                func: Box::new(crate::RustExpr::Paren(Box::new(crate::RustExpr::Field {
+                    expr: Box::new(object_expr),
+                    field: method.to_string(),
+                }))),
+                args: arg_exprs,
+            });
         }
 
         if matches!(object_ty, Type::List(_)) && method == "extend" && args.len() == 1 {

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
@@ -512,54 +512,48 @@ impl RustEmitter {
         object_ty: &Type,
         method: &str,
     ) -> Option<Vec<(Type, ParamConvention)>> {
-        let Type::Class {
-            name,
-            fields,
-            methods,
-            ..
-        } = crate::resolve_alias_type_for_plain_call(object_ty)
-        else {
-            return None;
-        };
-        self.func_signatures
-            .get(&format!("{name}::{method}"))
-            .map(|(params, _)| params.clone())
-            .or_else(|| {
-                methods
-                    .iter()
-                    .find(|(method_name, _)| method_name == method)
-                    .map(|(_, fty)| {
-                        fty.params
-                            .iter()
-                            .map(|(_, ty, conv)| (ty.clone(), *conv))
-                            .collect::<Vec<_>>()
-                    })
-            })
-            .or_else(|| {
-                fields
-                    .iter()
-                    .find(|(field_name, _)| field_name == method)
-                    .and_then(|(_, field_ty)| match field_ty.resolve_alias() {
-                        Type::Callable(params, conventions, _)
-                        | Type::AsyncCallable(params, conventions, _) => Some(
-                            params
+        let nominal_params = match crate::resolve_alias_type_for_plain_call(object_ty) {
+            Type::Class { name, methods, .. } => self
+                .func_signatures
+                .get(&format!("{name}::{method}"))
+                .map(|(params, _)| params.clone())
+                .or_else(|| {
+                    methods
+                        .iter()
+                        .find(|(method_name, _)| method_name == method)
+                        .map(|(_, fty)| {
+                            fty.params
                                 .iter()
-                                .cloned()
-                                .enumerate()
-                                .map(|(index, param)| {
-                                    (
-                                        param,
-                                        conventions
-                                            .get(index)
-                                            .copied()
-                                            .unwrap_or_else(ParamConvention::own),
-                                    )
-                                })
-                                .collect(),
-                        ),
-                        _ => None,
+                                .map(|(_, ty, convention)| (ty.clone(), *convention))
+                                .collect()
+                        })
+                }),
+            _ => None,
+        };
+        nominal_params.or_else(|| {
+            let field_ty = object_ty.callable_field_type(method)?;
+            let (params, conventions) = match field_ty.resolve_alias() {
+                Type::Callable(params, conventions, _)
+                | Type::AsyncCallable(params, conventions, _) => (params, conventions),
+                _ => return None,
+            };
+            Some(
+                params
+                    .iter()
+                    .cloned()
+                    .enumerate()
+                    .map(|(index, param)| {
+                        (
+                            param,
+                            conventions
+                                .get(index)
+                                .copied()
+                                .unwrap_or_else(ParamConvention::borrow),
+                        )
                     })
-            })
+                    .collect(),
+            )
+        })
     }
 
     pub(crate) fn try_lower_registry_compare_expr(

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/recursive_exprs.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/recursive_exprs.rs
@@ -195,25 +195,21 @@ impl RustEmitter {
                         arg_exprs[0] = Self::clone_owned_append_arg_expr_for_ir(&args[0], adjusted);
                     }
                 }
-                if let Type::Class {
-                    fields, methods, ..
-                } = crate::resolve_alias_type_for_plain_call(&effective_object_ty)
-                {
-                    let is_callable_field = !methods.iter().any(|(name, _)| name == method)
-                        && fields
-                            .iter()
-                            .any(|(name, ty)| name == method && matches!(ty, Type::Callable(..)));
-                    if is_callable_field {
-                        return Some(crate::RustExpr::FnCall {
-                            func: Box::new(crate::RustExpr::Paren(Box::new(
-                                crate::RustExpr::Field {
-                                    expr: Box::new(object_expr),
-                                    field: method.clone(),
-                                },
-                            ))),
-                            args: arg_exprs,
-                        });
+                if effective_object_ty.callable_field_type(method).is_some() {
+                    if let Some(method_params) = method_params.as_deref() {
+                        self.apply_registry_method_arg_conventions(
+                            args,
+                            method_params,
+                            &mut arg_exprs,
+                        );
                     }
+                    return Some(crate::RustExpr::FnCall {
+                        func: Box::new(crate::RustExpr::Paren(Box::new(crate::RustExpr::Field {
+                            expr: Box::new(object_expr),
+                            field: method.clone(),
+                        }))),
+                        args: arg_exprs,
+                    });
                 }
                 if let Some(lowered) = methods::lower_method_with_context(
                     &effective_object_ty,

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/registry_method_arg_conventions.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/registry_method_arg_conventions.rs
@@ -1,6 +1,25 @@
 use super::{HirExpr, ParamConvention, RustEmitter, Type};
 
 impl RustEmitter {
+    pub(crate) fn apply_registry_method_arg_conventions(
+        &self,
+        args: &[HirExpr],
+        params: &[(Type, ParamConvention)],
+        lowered_args: &mut [crate::RustExpr],
+    ) {
+        for (index, lowered_arg) in lowered_args.iter_mut().enumerate() {
+            if let (Some(arg), Some((param_ty, convention))) = (args.get(index), params.get(index))
+            {
+                *lowered_arg = self.apply_registry_method_arg_convention(
+                    arg,
+                    param_ty,
+                    *convention,
+                    lowered_arg.clone(),
+                );
+            }
+        }
+    }
+
     pub(crate) fn apply_registry_method_arg_convention(
         &self,
         arg: &HirExpr,

--- a/crates/sifr_codegen/src/lib_codegen_tests/structural_record_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structural_record_codegen_tests.rs
@@ -138,3 +138,66 @@ def main():
     assert!(rust.contains("value(count.clone())"), "{rust}");
     syn::parse_file(&rust).expect("logical-copy record should produce valid Rust syntax");
 }
+
+#[test]
+fn callable_record_field_emits_a_parenthesized_field_call() {
+    let rust = generate_rust_from_source(
+        r#"
+type Transform = {apply: Callable[[int], int]}
+
+def increment(value: int) -> int:
+    return value + 1
+
+def main():
+    transform: Transform = Transform(apply=increment)
+    assert transform.apply(4) == 5
+"#,
+    );
+    assert!(rust.contains("(transform.apply)("), "{rust}");
+    assert!(!rust.contains("transform.apply("), "{rust}");
+    syn::parse_file(&rust).expect("callable record-field codegen should produce valid Rust syntax");
+}
+
+#[test]
+fn callable_record_field_applies_shared_borrow_conventions() {
+    let rust = generate_rust_from_source(
+        r#"
+type Transform = {apply: Callable[[str], str]}
+
+def identity(value: str) -> str:
+    return value.clone()
+
+def main():
+    transform: Transform = Transform(apply=identity)
+    text: str = "value"
+    assert transform.apply(text) == "value"
+    assert text == "value"
+"#,
+    );
+    assert!(rust.contains("(transform.apply)(&text)"), "{rust}");
+    syn::parse_file(&rust)
+        .expect("borrowed callable record-field codegen should produce valid Rust syntax");
+}
+
+#[test]
+fn async_callable_record_field_emits_an_awaited_field_call() {
+    let rust = generate_rust_from_source(
+        r#"
+type Runner = {apply: AsyncCallable[[str], str]}
+
+async def echo(own value: str) -> str:
+    await task.sleep(0.0)
+    return value
+
+async def main() -> None:
+    runner: Runner = Runner(apply=echo)
+    text: str = "value"
+    result: str = await runner.apply(text)
+    assert result == "value"
+    return None
+"#,
+    );
+    assert!(rust.contains("(runner.apply)(text).await"), "{rust}");
+    syn::parse_file(&rust)
+        .expect("async callable record-field codegen should produce valid Rust syntax");
+}

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_method_and_question_mark.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_method_and_question_mark.rs
@@ -268,19 +268,14 @@ macro_rules! stmt_expr_method_call {
                 };
                 lowered_args[0] = crate::RustExpr::Literal(crate::RustLiteral::Int(scale));
             }
-            let is_callable_field = match crate::resolve_alias_type_for_plain_call(
-                &effective_object_ty,
-            ) {
-                Type::Class { fields, .. } => fields.iter().any(|(field_name, field_ty)| {
-                    field_name == method
-                        && matches!(
-                            crate::resolve_alias_type_for_plain_call(field_ty),
-                            Type::Callable(..) | Type::AsyncCallable(..)
-                        )
-                }),
-                _ => false,
-            };
-            if is_callable_field {
+            if effective_object_ty.callable_field_type(method).is_some() {
+                if let Some(method_params) = method_params.as_deref() {
+                    $emitter.apply_registry_method_arg_conventions(
+                        args,
+                        method_params,
+                        &mut lowered_args,
+                    );
+                }
                 return Ok(Some(crate::RustExpr::FnCall {
                     func: Box::new(crate::RustExpr::Paren(Box::new(crate::RustExpr::Field {
                         expr: Box::new(lowered_object),

--- a/crates/sifr_lowering/src/lower/callable_fields.rs
+++ b/crates/sifr_lowering/src/lower/callable_fields.rs
@@ -1,0 +1,45 @@
+use sifr_type_system::{FunctionType, ParamConvention, Type};
+
+pub(super) fn callable_field_function_type(
+    object_ty: &Type,
+    field_name: &str,
+) -> Option<FunctionType> {
+    let field_ty = object_ty.callable_field_type(field_name)?;
+    let (params, conventions, return_type) = match field_ty.resolve_alias() {
+        Type::Callable(params, conventions, return_type)
+        | Type::AsyncCallable(params, conventions, return_type) => {
+            (params, conventions, return_type)
+        }
+        _ => return None,
+    };
+    Some(FunctionType {
+        receiver: None,
+        params: params
+            .iter()
+            .enumerate()
+            .map(|(index, ty)| {
+                (
+                    format!("arg{index}"),
+                    ty.clone(),
+                    conventions
+                        .get(index)
+                        .copied()
+                        .unwrap_or_else(ParamConvention::borrow),
+                )
+            })
+            .collect(),
+        return_type: return_type.clone(),
+    })
+}
+
+pub(super) fn callable_argument_is_assignable(
+    source: &Type,
+    target: &Type,
+    convention: ParamConvention,
+) -> bool {
+    if convention.is_shared_borrow() {
+        source.is_shared_borrow_assignable_to(target)
+    } else {
+        source.is_assignable_to(target)
+    }
+}

--- a/crates/sifr_lowering/src/lower/expressions.rs
+++ b/crates/sifr_lowering/src/lower/expressions.rs
@@ -109,7 +109,8 @@ use method_type_collections::{
 mod method_type_objects;
 use method_type_objects::{
     resolve_class_method_on_type, resolve_enum_method_type, resolve_newtype_method_type,
-    resolve_protocol_method_type, resolve_str_method_type, resolve_tuple_method_type,
+    resolve_protocol_method_type, resolve_str_method_type, resolve_structural_record_method_type,
+    resolve_tuple_method_type,
 };
 mod python_buffer_methods;
 use python_buffer_methods::{

--- a/crates/sifr_lowering/src/lower/expressions/method_argument_ownership.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_argument_ownership.rs
@@ -8,7 +8,13 @@ pub(super) fn method_function_type(ty: &Type, method_name: &str) -> Option<Funct
         Type::Class { methods, .. } | Type::Protocol { methods, .. } => methods
             .iter()
             .find(|(candidate, _)| candidate == method_name)
-            .map(|(_, function_type)| function_type.clone()),
+            .map(|(_, function_type)| function_type.clone())
+            .or_else(|| {
+                super::super::callable_fields::callable_field_function_type(ty, method_name)
+            }),
+        Type::StructuralRecord(_) => {
+            super::super::callable_fields::callable_field_function_type(ty, method_name)
+        }
         _ => None,
     }
 }

--- a/crates/sifr_lowering/src/lower/expressions/method_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_calls.rs
@@ -11,8 +11,8 @@ use super::{
     resolve_enum_method_type, resolve_fixed_width_method_type, resolve_list_method_type,
     resolve_newtype_method_type, resolve_protocol_method_type, resolve_python_arrow_method_type,
     resolve_python_buffer_method_type, resolve_python_dlpack_method_type, resolve_set_method_type,
-    resolve_str_method_type, resolve_tuple_method_type, str, try_lower_class_method_call,
-    try_lower_super_method_call, tsc,
+    resolve_str_method_type, resolve_structural_record_method_type, resolve_tuple_method_type, str,
+    try_lower_class_method_call, try_lower_super_method_call, tsc,
 };
 use super::{method_call_arguments, python_raw_object_methods};
 use crate::lower::python_interop::callback_method_arg_ranges;
@@ -439,6 +439,16 @@ pub(in crate::lower) fn resolve_method_type(
     }
     if matches!(object_ty, Type::AsyncGenerator(_, _)) {
         return super::async_generator_methods::resolve_async_generator_method_type(
+            object_ty,
+            method,
+            args,
+            arg_ranges,
+            method_range,
+            ctx,
+        );
+    }
+    if matches!(object_ty.resolve_alias(), Type::StructuralRecord(_)) {
+        return resolve_structural_record_method_type(
             object_ty,
             method,
             args,

--- a/crates/sifr_lowering/src/lower/expressions/method_type_objects.rs
+++ b/crates/sifr_lowering/src/lower/expressions/method_type_objects.rs
@@ -3,7 +3,7 @@ use super::{
     canonicalize_class_surface_type, coroutine_result_type, expression_diagnostics,
     expression_operators, method_count_range, reject_exact_method_arg_count,
     reject_method_arg_count, reject_no_method_args, resolve_method_type,
-    resolve_str_encode_method_type, str,
+    resolve_str_encode_method_type, str, validate_borrowed_structural_coercion,
 };
 pub(super) fn resolve_str_method_type(
     method: &str,
@@ -400,46 +400,19 @@ pub(super) fn resolve_class_method_type(
         }
         Some(canonicalize_class_surface_type(&ft.return_type))
     } else if let Some((_, field_ty)) = class.fields.iter().find(|(n, _)| n == method) {
-        // Callable fields use method-call syntax; async callable fields produce a coroutine.
-        if let Type::Callable(param_types, _, ret_type)
-        | Type::AsyncCallable(param_types, _, ret_type) = field_ty
-        {
-            if args.len() != param_types.len() {
-                expression_diagnostics::call_not_callable_or_arity(
-                    ctx,
-                    format!(
-                        "{}.{}() (callable field) takes {} argument(s), got {}",
-                        class.name,
-                        method,
-                        param_types.len(),
-                        args.len()
-                    ),
-                    method_count_range(args.len(), param_types.len(), arg_ranges, method_range),
-                );
-                return None;
-            }
-            for (i, (arg, param_ty)) in args.iter().zip(param_types.iter()).enumerate() {
-                if !arg.ty().is_assignable_to(param_ty) {
-                    expression_diagnostics::type_mismatch(
-                        ctx,
-                        format!(
-                            "argument {} of {}.{}(): expected '{}', got '{}'",
-                            i + 1,
-                            class.name,
-                            method,
-                            param_ty.display_name(),
-                            arg.ty().display_name()
-                        ),
-                        arg_ranges.get(i).copied().unwrap_or(method_range),
-                    );
-                }
-            }
-            let return_type = canonicalize_class_surface_type(ret_type);
-            if matches!(field_ty, Type::AsyncCallable(..)) {
-                Some(coroutine_result_type(&return_type))
-            } else {
-                Some(return_type)
-            }
+        if matches!(
+            field_ty.resolve_alias(),
+            Type::Callable(..) | Type::AsyncCallable(..)
+        ) {
+            resolve_callable_field_call(
+                class.name,
+                method,
+                field_ty,
+                args,
+                arg_ranges,
+                method_range,
+                ctx,
+            )
         } else {
             expression_diagnostics::call_not_callable_or_arity(
                 ctx,
@@ -460,6 +433,118 @@ pub(super) fn resolve_class_method_type(
             method_range,
         );
         None
+    }
+}
+
+pub(super) fn resolve_structural_record_method_type(
+    object_ty: &Type,
+    method: &str,
+    args: &[HirExpr],
+    arg_ranges: &[TextRange],
+    method_range: TextRange,
+    ctx: &mut LowerCtx,
+) -> Option<Type> {
+    let Type::StructuralRecord(record) = object_ty.resolve_alias() else {
+        return None;
+    };
+    let Some(field) = record.field(method) else {
+        ctx.error_with_code_at(
+            DiagnosticCode::CLASS_MISSING_MEMBER,
+            format!(
+                "record type '{}' has no field '{method}'",
+                object_ty.display_name()
+            ),
+            method_range,
+        );
+        return None;
+    };
+    let field_ty = field.ty();
+    if !matches!(
+        field_ty.resolve_alias(),
+        Type::Callable(..) | Type::AsyncCallable(..)
+    ) {
+        expression_diagnostics::call_not_callable_or_arity(
+            ctx,
+            format!(
+                "field '{method}' of record type '{}' is not callable (type: '{}')",
+                object_ty.display_name(),
+                field_ty.display_name()
+            ),
+            method_range,
+        );
+        return None;
+    }
+    resolve_callable_field_call(
+        &object_ty.display_name(),
+        method,
+        field_ty,
+        args,
+        arg_ranges,
+        method_range,
+        ctx,
+    )
+}
+
+fn resolve_callable_field_call(
+    owner: &str,
+    field_name: &str,
+    field_ty: &Type,
+    args: &[HirExpr],
+    arg_ranges: &[TextRange],
+    method_range: TextRange,
+    ctx: &mut LowerCtx,
+) -> Option<Type> {
+    let (param_types, conventions, return_type, is_async) = match field_ty.resolve_alias() {
+        Type::Callable(param_types, conventions, return_type) => {
+            (param_types, conventions, return_type, false)
+        }
+        Type::AsyncCallable(param_types, conventions, return_type) => {
+            (param_types, conventions, return_type, true)
+        }
+        _ => return None,
+    };
+    if args.len() != param_types.len() {
+        expression_diagnostics::call_not_callable_or_arity(
+            ctx,
+            format!(
+                "{owner}.{field_name}() (callable field) takes {} argument(s), got {}",
+                param_types.len(),
+                args.len()
+            ),
+            method_count_range(args.len(), param_types.len(), arg_ranges, method_range),
+        );
+        return None;
+    }
+    for (index, (arg, param_ty)) in args.iter().zip(param_types).enumerate() {
+        let convention = conventions
+            .get(index)
+            .copied()
+            .unwrap_or_else(sifr_type_system::ParamConvention::borrow);
+        let range = arg_ranges.get(index).copied().unwrap_or(method_range);
+        if super::super::callable_fields::callable_argument_is_assignable(
+            arg.ty(),
+            param_ty,
+            convention,
+        ) {
+            validate_borrowed_structural_coercion(arg.ty(), param_ty, convention, range, ctx);
+        } else {
+            expression_diagnostics::type_mismatch(
+                ctx,
+                format!(
+                    "argument {} of {owner}.{field_name}(): expected '{}', got '{}'",
+                    index + 1,
+                    param_ty.display_name(),
+                    arg.ty().display_name()
+                ),
+                range,
+            );
+        }
+    }
+    let return_type = canonicalize_class_surface_type(return_type);
+    if is_async {
+        Some(coroutine_result_type(&return_type))
+    } else {
+        Some(return_type)
     }
 }
 

--- a/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
+++ b/crates/sifr_lowering/src/lower/expressions/regular_calls.rs
@@ -188,7 +188,11 @@ pub(super) fn lower_regular_call(
                 .get(i)
                 .copied()
                 .unwrap_or(ParamConvention::borrow());
-            if !argument_is_assignable(arg.ty(), param_ty, convention) {
+            if !super::super::callable_fields::callable_argument_is_assignable(
+                arg.ty(),
+                param_ty,
+                convention,
+            ) {
                 expression_diagnostics::type_mismatch(
                     ctx,
                     format!(
@@ -521,7 +525,11 @@ pub(super) fn lower_regular_call(
                 .copied()
                 .flatten()
                 .unwrap_or_else(|| call.range());
-            if argument_is_assignable(arg.ty(), param_ty, *convention) {
+            if super::super::callable_fields::callable_argument_is_assignable(
+                arg.ty(),
+                param_ty,
+                *convention,
+            ) {
                 validate_borrowed_structural_coercion(
                     arg.ty(),
                     param_ty,
@@ -641,7 +649,11 @@ pub(super) fn lower_regular_call(
                     }
                     continue;
                 }
-                if argument_is_assignable(arg.ty(), &concrete_param_ty, *convention) {
+                if super::super::callable_fields::callable_argument_is_assignable(
+                    arg.ty(),
+                    &concrete_param_ty,
+                    *convention,
+                ) {
                     let primary_range = arg_ranges
                         .get(i)
                         .copied()
@@ -790,14 +802,6 @@ pub(super) fn lower_regular_call(
             args,
             ty: call_type,
         })
-    }
-}
-
-fn argument_is_assignable(source: &Type, target: &Type, convention: ParamConvention) -> bool {
-    if convention.is_shared_borrow() {
-        source.is_shared_borrow_assignable_to(target)
-    } else {
-        source.is_assignable_to(target)
     }
 }
 

--- a/crates/sifr_lowering/src/lower/expressions_tests/structural_records.rs
+++ b/crates/sifr_lowering/src/lower/expressions_tests/structural_records.rs
@@ -1,4 +1,5 @@
 use super::{HirExpr, HirStmt, Type, lower_source};
+use sifr_type_system::ReceiverConvention;
 
 #[test]
 fn record_constructor_and_field_access_lower_with_exact_types() {
@@ -232,4 +233,141 @@ def main():
             .message
             .contains("branches cannot infer 'value' as a union")
     }));
+}
+
+#[test]
+fn callable_record_field_lowers_as_a_shared_receiver_call() {
+    let module = lower_source(
+        r#"
+type Transform = {apply: Callable[[int], int]}
+
+def apply(transform: Transform, value: int) -> int:
+    return transform.apply(value)
+"#,
+    )
+    .expect("callable structural-record fields should lower");
+    let HirStmt::Return {
+        value:
+            Some(HirExpr::MethodCall {
+                method,
+                receiver_convention,
+                ty,
+                ..
+            }),
+    } = &module.functions[0].body[0]
+    else {
+        panic!("expected callable field method call");
+    };
+    assert_eq!(method, "apply");
+    assert_eq!(*receiver_convention, Some(ReceiverConvention::SharedBorrow));
+    assert_eq!(ty, &Type::Int);
+}
+
+#[test]
+fn async_callable_record_field_lowers_to_a_coroutine() {
+    let module = lower_source(
+        r#"
+type Runner = {apply: AsyncCallable[[str], str]}
+
+async def apply(runner: Runner, own value: str) -> str:
+    return await runner.apply(value)
+"#,
+    )
+    .expect("async callable structural-record fields should lower");
+    let HirStmt::Return {
+        value: Some(HirExpr::Await { value, .. }),
+    } = &module.functions[0].body[0]
+    else {
+        panic!("expected awaited callable field");
+    };
+    assert!(matches!(
+        value.as_ref(),
+        HirExpr::MethodCall {
+            method,
+            ty: Type::Coroutine(ok, _),
+            ..
+        } if method == "apply" && ok.as_ref() == &Type::Str
+    ));
+}
+
+#[test]
+fn callable_record_field_validates_arity_and_argument_types() {
+    let arity_errors = lower_source(
+        r#"
+type Transform = {apply: Callable[[int], int]}
+
+def apply(transform: Transform) -> int:
+    return transform.apply()
+"#,
+    )
+    .expect_err("callable record-field arity must be checked");
+    assert!(arity_errors.iter().any(|error| {
+        error
+            .message
+            .contains("(callable field) takes 1 argument(s), got 0")
+    }));
+
+    let type_errors = lower_source(
+        r#"
+type Transform = {apply: Callable[[int], int]}
+
+def apply(transform: Transform) -> int:
+    return transform.apply("wrong")
+"#,
+    )
+    .expect_err("callable record-field argument types must be checked");
+    assert!(type_errors.iter().any(|error| {
+        error.message.contains("argument 1 of")
+            && error
+                .message
+                .contains(".apply(): expected 'int', got 'str'")
+    }));
+}
+
+#[test]
+fn record_field_call_distinguishes_missing_and_non_callable_fields() {
+    let missing = lower_source(
+        r#"
+type Transform = {apply: Callable[[int], int]}
+
+def apply(transform: Transform) -> int:
+    return transform.missing(1)
+"#,
+    )
+    .expect_err("missing record fields must be diagnosed");
+    assert!(
+        missing
+            .iter()
+            .any(|error| error.message.contains("has no field 'missing'"))
+    );
+
+    let non_callable = lower_source(
+        r#"
+type Value = {number: int}
+
+def read(value: Value) -> int:
+    return value.number()
+"#,
+    )
+    .expect_err("non-callable record fields must be diagnosed");
+    assert!(non_callable.iter().any(|error| {
+        error.message.contains("field 'number' of record type")
+            && error.message.contains("is not callable (type: 'int')")
+    }));
+}
+
+#[test]
+fn async_callable_record_field_consumes_owned_arguments() {
+    let errors = lower_source(
+        r#"
+type Runner = {apply: AsyncCallable[[str], str]}
+
+async def apply(runner: Runner, own value: str) -> str:
+    result: str = await runner.apply(value)
+    print(value)
+    return result
+"#,
+    )
+    .expect_err("async callable record fields must consume owned arguments");
+    assert!(errors.iter().any(|error| error.message.contains("moved")));
 }

--- a/crates/sifr_lowering/src/lower/method_receiver_analysis.rs
+++ b/crates/sifr_lowering/src/lower/method_receiver_analysis.rs
@@ -454,7 +454,8 @@ pub(super) fn method_signature(
             methods,
             method,
             class_types,
-        ),
+        )
+        .or_else(|| super::callable_fields::callable_field_function_type(ty, method)),
         Type::Protocol {
             identity,
             name,
@@ -467,6 +468,9 @@ pub(super) fn method_signature(
             class_types,
         ),
         Type::Enum { name, .. } => functions.get(&format!("{name}.{method}")).cloned(),
+        Type::StructuralRecord(_) => {
+            super::callable_fields::callable_field_function_type(ty, method)
+        }
         Type::Alias { body, .. } => method_signature(body, method, class_types, functions),
         Type::TypeVar(name) => class_types
             .get(name)

--- a/crates/sifr_lowering/src/lower/mod.rs
+++ b/crates/sifr_lowering/src/lower/mod.rs
@@ -24,6 +24,7 @@ mod builtin_calls;
 mod bytes_methods;
 mod call_argument_ranges;
 mod call_iterable_validation;
+mod callable_fields;
 mod class_field_inference;
 #[cfg(test)]
 mod class_inheritance_defaults_tests;

--- a/crates/sifr_lowering/src/lower/mutating_methods.rs
+++ b/crates/sifr_lowering/src/lower/mutating_methods.rs
@@ -241,11 +241,17 @@ pub(in crate::lower) fn reject_immutable_method_mut_borrow_arguments(
     args: &[HirExpr],
     arg_ranges: &[TextRange],
 ) -> bool {
-    let methods = match object_ty.resolve_alias() {
-        Type::Class { methods, .. } | Type::Protocol { methods, .. } => methods,
-        _ => return false,
+    let signature = match object_ty.resolve_alias() {
+        Type::Class { methods, .. } | Type::Protocol { methods, .. } => methods
+            .iter()
+            .find_map(|(name, signature)| (name == method).then(|| signature.clone()))
+            .or_else(|| super::callable_fields::callable_field_function_type(object_ty, method)),
+        Type::StructuralRecord(_) => {
+            super::callable_fields::callable_field_function_type(object_ty, method)
+        }
+        _ => None,
     };
-    let Some((_, signature)) = methods.iter().find(|(name, _)| name == method) else {
+    let Some(signature) = signature else {
         return false;
     };
 

--- a/crates/sifr_type_system/src/types/type_queries.rs
+++ b/crates/sifr_type_system/src/types/type_queries.rs
@@ -6,6 +6,33 @@ pub(super) fn parent_chain_contains(parent_class: Option<&str>, ancestor: &str) 
 }
 
 impl Type {
+    /// Return a callable field exposed through method-call syntax.
+    ///
+    /// Declared class methods shadow same-named fields. Structural records have
+    /// no methods, so their field namespace is unambiguous.
+    #[must_use]
+    pub fn callable_field_type(&self, field_name: &str) -> Option<&Self> {
+        let field_ty = match self.resolve_alias() {
+            Self::Class {
+                fields, methods, ..
+            } => {
+                if methods.iter().any(|(name, _)| name == field_name) {
+                    return None;
+                }
+                fields
+                    .iter()
+                    .find_map(|(name, ty)| (name == field_name).then_some(ty))?
+            }
+            Self::StructuralRecord(record) => record.field(field_name)?.ty(),
+            _ => return None,
+        };
+        matches!(
+            field_ty.resolve_alias(),
+            Self::Callable(..) | Self::AsyncCallable(..)
+        )
+        .then_some(field_ty)
+    }
+
     /// Stable recursion key for a nominal class representation. The declaring
     /// identity distinguishes same-named imports, while concrete arguments
     /// distinguish specializations whose emitted trait capabilities can differ.


### PR DESCRIPTION
Closes #3656.\n\nImplement callable and async-callable structural-record field invocation across type resolution, ownership/move analysis, receiver-place validation, and all Rust emission paths. Centralize callable-field lookup in the type system and preserve class-method shadowing. Add focused lowering and codegen regressions for success, diagnostics, shared borrows, async awaits, and owned moves.\n\nFocused validation on the implementation (unchanged by the #3657 base rebase):\n- cargo test -p sifr_lowering structural_records -- --nocapture: PASS (15)\n- cargo test -p sifr_codegen callable_record_field -- --nocapture: PASS (3)\n- cargo clippy -p sifr_type_system -p sifr_lowering -p sifr_codegen --lib -- -D warnings: PASS\n- cargo fmt --all -- --check: PASS\n- HIR maintainability, file-size, and diff guards: PASS\n- direct sifr check of structural_records.sifr: PASS\n- emitted panic-surface sweep advanced past structural_records.sifr and failed only later on separately owned numeric_sentinels behavior\n\nThe one permitted create-PR gate was run on equivalent implementation SHA 0412cfed980c3c2850fe6054d1728e7e3159a886. It stopped solely at the pre-existing unsupported SQL verification resource class, recorded as #3657 and fixed/merged independently by PR #3658. Per the user rule, the create-PR gate is not rerun. The single merge gate will run on final SHA 1f0be9e65f4b2ece77724aaed12712504b1f9e88 after exact-SHA review.