### PR TITLE
Synchronize Rust-interop fixture lock identities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9432,11 +9432,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -10229,6 +10229,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro 0.51.0",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen"


### PR DESCRIPTION
Closes #3655.\n\nUpdate the root Cargo lock from wasip2 1.0.2 to the vendored and fixture-canonical wasip2 1.0.3 identity, adding its exact wit-bindgen 0.57.1 dependency. This preserves source/checksum identity checks and aligns the root with all six tracked Rust-interop fixture locks.\n\nValidation:\n- Rust-interop matrix: PASS (40 fixtures)\n- Rust-interop matrix self-test: PASS (243 cases)\n- cargo check --workspace --locked: PASS\n- git diff --check: PASS\n\nOnly Cargo.lock changed; no compiler files changed, so Sifr create-PR and merge gates are intentionally skipped.