### PR TITLE
Harden emitted Rust cleanup proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7596,6 +7596,7 @@ dependencies = [
  "sifr_type_system",
  "static_assertions",
  "syn 3.0.4",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/crates/sifr_codegen/Cargo.toml
+++ b/crates/sifr_codegen/Cargo.toml
@@ -18,6 +18,7 @@ syn = { workspace = true, features = ["printing", "visit-mut"] }
 prettyplease = "0.3.0"
 proc-macro2 = { version = "1.0.107", features = ["span-locations"] }
 quote = "1.0.45"
+unicode-ident = { workspace = true }
 bigdecimal = { workspace = true }
 rust_decimal = { workspace = true }
 

--- a/crates/sifr_codegen/src/discardability.rs
+++ b/crates/sifr_codegen/src/discardability.rs
@@ -1,0 +1,64 @@
+//! Shared, conservative policy for deleting an evaluated Rust expression.
+//!
+//! Both structured-IR optimization and post-render syntax cleanup use this
+//! module. An expression is discardable only when evaluating and immediately
+//! discarding it cannot call user code, panic, allocate, or observe `Drop`.
+
+use crate::{RustExpr, RustLiteral};
+
+pub(crate) fn rust_ir_expression_is_discardable(expression: &RustExpr) -> bool {
+    match expression {
+        RustExpr::Literal(
+            RustLiteral::Int(_)
+            | RustLiteral::Float(_)
+            | RustLiteral::Bool(_)
+            | RustLiteral::StaticStr(_)
+            | RustLiteral::Char(_)
+            | RustLiteral::Unit
+            | RustLiteral::None,
+        ) => true,
+        RustExpr::Paren(inner) => rust_ir_expression_is_discardable(inner),
+        RustExpr::Tuple(elements) | RustExpr::Array(elements) => {
+            elements.iter().all(rust_ir_expression_is_discardable)
+        }
+        RustExpr::Literal(RustLiteral::Str(_))
+        | RustExpr::Verbatim(_)
+        | RustExpr::Ident(_)
+        | RustExpr::Path(_)
+        | RustExpr::MethodCall { .. }
+        | RustExpr::FnCall { .. }
+        | RustExpr::MacroCall { .. }
+        | RustExpr::FormatMacro { .. }
+        | RustExpr::BinOp { .. }
+        | RustExpr::UnaryOp { .. }
+        | RustExpr::Field { .. }
+        | RustExpr::Index { .. }
+        | RustExpr::Slice { .. }
+        | RustExpr::Ref { .. }
+        | RustExpr::Deref(_)
+        | RustExpr::Clone(_)
+        | RustExpr::Cast { .. }
+        | RustExpr::Block { .. }
+        | RustExpr::If { .. }
+        | RustExpr::Match { .. }
+        | RustExpr::Closure { .. }
+        | RustExpr::ClosureBlock { .. }
+        | RustExpr::AsyncBlock { .. }
+        | RustExpr::StructInit { .. }
+        | RustExpr::Vec(_)
+        | RustExpr::TimeoutAwait { .. }
+        | RustExpr::Try(_)
+        | RustExpr::Await(_)
+        | RustExpr::Range { .. } => false,
+    }
+}
+
+pub(crate) fn syntax_expression_is_discardable(expression: &syn::Expr) -> bool {
+    match expression {
+        syn::Expr::Lit(_) => true,
+        syn::Expr::Paren(paren) => syntax_expression_is_discardable(&paren.expr),
+        syn::Expr::Tuple(tuple) => tuple.elems.iter().all(syntax_expression_is_discardable),
+        syn::Expr::Array(array) => array.elems.iter().all(syntax_expression_is_discardable),
+        _ => false,
+    }
+}

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer.rs
@@ -8,6 +8,7 @@ use syn::visit_mut::{self, VisitMut};
 mod api_cleanup;
 mod enum_variant_cleanup;
 mod field_name_cleanup;
+mod format_capture;
 mod identifier_canonicalizer;
 mod identifier_policy;
 mod item_demand;
@@ -871,7 +872,7 @@ impl<'ast> Visit<'ast> for ScopedItemReferenceCollector<'_> {
     }
 
     fn visit_macro(&mut self, rust_macro: &'ast syn::Macro) {
-        for name in item_demand::format_capture_names(rust_macro) {
+        for name in format_capture::names(rust_macro) {
             if self.definitions.contains(&name) && !self.bindings.contains(&name) {
                 self.references.insert(name);
             }
@@ -888,6 +889,10 @@ mod tests;
 #[cfg(test)]
 #[path = "generated_rust_canonicalizer_item8_tests.rs"]
 mod item8_tests;
+
+#[cfg(test)]
+#[path = "generated_rust_canonicalizer_item8a_tests.rs"]
+mod item8a_tests;
 
 #[cfg(test)]
 #[path = "generated_rust_canonicalizer_item8_remediation_tests.rs"]

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/api_cleanup.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/api_cleanup.rs
@@ -275,7 +275,7 @@ impl<'ast> Visit<'ast> for BodyReferenceCollector {
 
     fn visit_macro(&mut self, rust_macro: &'ast syn::Macro) {
         collect_macro_identifier_tokens(rust_macro.tokens.clone(), &mut self.names);
-        collect_format_capture_identifiers(rust_macro, &mut self.names);
+        self.names.extend(super::format_capture::names(rust_macro));
         visit::visit_macro(self, rust_macro);
     }
 }
@@ -290,43 +290,6 @@ fn collect_macro_identifier_tokens(tokens: proc_macro2::TokenStream, names: &mut
                 collect_macro_identifier_tokens(group.stream(), names);
             }
             _ => {}
-        }
-    }
-}
-
-fn collect_format_capture_identifiers(rust_macro: &syn::Macro, names: &mut HashSet<String>) {
-    let Some(macro_name) = rust_macro
-        .path
-        .segments
-        .last()
-        .map(|segment| &segment.ident)
-    else {
-        return;
-    };
-    let format_index = match macro_name.to_string().as_str() {
-        "format" | "print" | "println" | "eprint" | "eprintln" => 0,
-        "write" | "writeln" => 1,
-        _ => return,
-    };
-    let Ok(arguments) = rust_macro.parse_body_with(
-        syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
-    ) else {
-        return;
-    };
-    let Some(syn::Expr::Lit(format_expression)) = arguments.iter().nth(format_index) else {
-        return;
-    };
-    let syn::Lit::Str(format_literal) = &format_expression.lit else {
-        return;
-    };
-    for field in format_literal.value().split(['{', '}']).skip(1).step_by(2) {
-        let name = field.split(':').next().unwrap_or_default();
-        if !name.is_empty()
-            && name
-                .chars()
-                .all(|character| character == '_' || character.is_ascii_alphanumeric())
-        {
-            names.insert(name.to_string());
         }
     }
 }

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/format_capture.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/format_capture.rs
@@ -1,0 +1,208 @@
+use std::collections::HashSet;
+use std::ops::Range;
+
+use quote::ToTokens;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Capture {
+    name: String,
+    range: Range<usize>,
+}
+
+pub(super) fn names(rust_macro: &syn::Macro) -> HashSet<String> {
+    format_string(rust_macro)
+        .map(|format| {
+            captures(&format)
+                .into_iter()
+                .map(|capture| capture.name)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub(super) fn rename(rust_macro: &mut syn::Macro, from: &str, to: &str) -> bool {
+    let Some(format_index) = format_argument_index(rust_macro) else {
+        return false;
+    };
+    let Ok(mut arguments) = rust_macro.parse_body_with(
+        syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
+    ) else {
+        return false;
+    };
+    let Some(syn::Expr::Lit(format_expression)) = arguments.iter_mut().nth(format_index) else {
+        return false;
+    };
+    let syn::Lit::Str(format_literal) = &mut format_expression.lit else {
+        return false;
+    };
+    let mut format = format_literal.value();
+    let replacements = captures(&format)
+        .into_iter()
+        .filter(|capture| capture.name == from)
+        .map(|capture| capture.range)
+        .collect::<Vec<_>>();
+    if replacements.is_empty() {
+        return false;
+    }
+    for range in replacements.into_iter().rev() {
+        format.replace_range(range, to);
+    }
+    *format_literal = syn::LitStr::new(&format, format_literal.span());
+    rust_macro.tokens = arguments.into_token_stream();
+    true
+}
+
+fn format_string(rust_macro: &syn::Macro) -> Option<String> {
+    let format_index = format_argument_index(rust_macro)?;
+    let arguments = rust_macro
+        .parse_body_with(syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated)
+        .ok()?;
+    let syn::Expr::Lit(format_expression) = arguments.iter().nth(format_index)? else {
+        return None;
+    };
+    let syn::Lit::Str(format_literal) = &format_expression.lit else {
+        return None;
+    };
+    Some(format_literal.value())
+}
+
+fn format_argument_index(rust_macro: &syn::Macro) -> Option<usize> {
+    let name = rust_macro.path.segments.last()?.ident.to_string();
+    match name.as_str() {
+        "format" | "format_args" | "format_args_nl" | "print" | "println" | "eprint"
+        | "eprintln" => Some(0),
+        "assert" | "write" | "writeln" => Some(1),
+        "assert_eq" | "assert_ne" => Some(2),
+        _ => None,
+    }
+}
+
+fn captures(format: &str) -> Vec<Capture> {
+    let bytes = format.as_bytes();
+    let mut captures = Vec::new();
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let Some(relative_start) = format[offset..].find('{') else {
+            break;
+        };
+        let start = offset + relative_start;
+        if bytes.get(start + 1) == Some(&b'{') {
+            offset = start + 2;
+            continue;
+        }
+        let Some(relative_end) = format[start + 1..].find('}') else {
+            break;
+        };
+        let end = start + 1 + relative_end;
+        collect_field_captures(format, start + 1, end, &mut captures);
+        offset = end + 1;
+    }
+    captures
+}
+
+fn collect_field_captures(format: &str, start: usize, end: usize, captures: &mut Vec<Capture>) {
+    let field = &format[start..end];
+    let separator = field.find(':');
+    let argument_end = separator.map_or(end, |relative| start + relative);
+    push_identifier_capture(format, start..argument_end, captures);
+
+    let Some(separator) = separator else {
+        return;
+    };
+    let spec_start = start + separator + 1;
+    let mut cursor = spec_start;
+    while cursor < end {
+        let Some(identifier_end) = identifier_end(format, cursor, end) else {
+            cursor += format[cursor..end].chars().next().map_or(1, char::len_utf8);
+            continue;
+        };
+        if format.as_bytes().get(identifier_end) == Some(&b'$') {
+            push_identifier_capture(format, cursor..identifier_end, captures);
+        }
+        cursor = identifier_end.max(cursor + 1);
+    }
+}
+
+fn push_identifier_capture(format: &str, range: Range<usize>, captures: &mut Vec<Capture>) {
+    let name = &format[range.clone()];
+    if is_identifier(name) {
+        captures.push(Capture {
+            name: name.to_string(),
+            range,
+        });
+    }
+}
+
+fn identifier_end(text: &str, start: usize, end: usize) -> Option<usize> {
+    let mut cursor = start;
+    if text[cursor..end].starts_with("r#") {
+        cursor += 2;
+    }
+    let first = text[cursor..end].chars().next()?;
+    if !is_identifier_start(first) {
+        return None;
+    }
+    cursor += first.len_utf8();
+    while cursor < end {
+        let Some(character) = text[cursor..end].chars().next() else {
+            break;
+        };
+        if !is_identifier_continue(character) {
+            break;
+        }
+        cursor += character.len_utf8();
+    }
+    Some(cursor)
+}
+
+fn is_identifier(name: &str) -> bool {
+    identifier_end(name, 0, name.len()) == Some(name.len())
+        && syn::parse_str::<syn::Ident>(name).is_ok()
+}
+
+fn is_identifier_start(character: char) -> bool {
+    character == '_' || unicode_ident::is_xid_start(character)
+}
+
+fn is_identifier_continue(character: char) -> bool {
+    character == '_' || unicode_ident::is_xid_continue(character)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collects_value_width_and_precision_captures() {
+        let rust_macro: syn::Macro = syn::parse_quote!(println!(
+            "{{escaped}} {value:>width$.precision$} {:fallback_width$}"
+        ));
+        assert_eq!(
+            names(&rust_macro),
+            HashSet::from([
+                "fallback_width".to_string(),
+                "precision".to_string(),
+                "value".to_string(),
+                "width".to_string(),
+            ])
+        );
+
+        let format_args: syn::Macro = syn::parse_quote!(format_args!("{value:width$}"));
+        assert_eq!(
+            names(&format_args),
+            HashSet::from(["value".to_string(), "width".to_string()])
+        );
+    }
+
+    #[test]
+    fn renames_every_capture_role() {
+        let mut rust_macro: syn::Macro = syn::parse_quote!(println!("{value:value$.value$}"));
+        assert!(rename(&mut rust_macro, "value", "renamed"));
+        assert!(
+            rust_macro
+                .tokens
+                .to_string()
+                .contains("{renamed:renamed$.renamed$}")
+        );
+    }
+}

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/item_demand.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/item_demand.rs
@@ -1,57 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use syn::visit::{self, Visit};
 
-pub(super) fn format_capture_names(rust_macro: &syn::Macro) -> HashSet<String> {
-    let Some(name) = rust_macro.path.segments.last() else {
-        return HashSet::new();
-    };
-    let format_index = match name.ident.to_string().as_str() {
-        "format" | "print" | "println" | "eprint" | "eprintln" => 0,
-        "assert" | "write" | "writeln" => 1,
-        "assert_eq" | "assert_ne" => 2,
-        _ => return HashSet::new(),
-    };
-    let Ok(arguments) = rust_macro.parse_body_with(
-        syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
-    ) else {
-        return HashSet::new();
-    };
-    let Some(syn::Expr::Lit(format_expression)) = arguments.iter().nth(format_index) else {
-        return HashSet::new();
-    };
-    let syn::Lit::Str(format_literal) = &format_expression.lit else {
-        return HashSet::new();
-    };
-    let format = format_literal.value();
-    let bytes = format.as_bytes();
-    let mut names = HashSet::new();
-    let mut offset = 0;
-    while offset < bytes.len() {
-        let Some(relative_start) = format[offset..].find('{') else {
-            break;
-        };
-        let start = offset + relative_start;
-        if bytes.get(start + 1) == Some(&b'{') {
-            offset = start + 2;
-            continue;
-        }
-        let Some(relative_end) = format[start + 1..].find('}') else {
-            break;
-        };
-        let end = start + 1 + relative_end;
-        let name = format[start + 1..end].split(':').next().unwrap_or_default();
-        if !name.is_empty()
-            && name
-                .chars()
-                .all(|character| character == '_' || character.is_ascii_alphanumeric())
-        {
-            names.insert(name.to_string());
-        }
-        offset = end + 1;
-    }
-    names
-}
-
 pub(super) fn concrete_trait_impl_roots(items: &[syn::Item]) -> HashSet<String> {
     let implementations = items
         .iter()

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/local_name_cleanup.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/local_name_cleanup.rs
@@ -351,60 +351,7 @@ impl LocalReferenceRenamer<'_> {
     }
 
     fn rename_format_capture(&self, rust_macro: &mut syn::Macro) {
-        let Some(macro_name) = rust_macro
-            .path
-            .segments
-            .last()
-            .map(|segment| &segment.ident)
-        else {
-            return;
-        };
-        let format_index = match macro_name.to_string().as_str() {
-            "format" | "print" | "println" | "eprint" | "eprintln" => 0,
-            "write" | "writeln" => 1,
-            _ => return,
-        };
-        let Ok(mut arguments) = rust_macro.parse_body_with(
-            syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
-        ) else {
-            return;
-        };
-        let Some(syn::Expr::Lit(format_expression)) = arguments.iter_mut().nth(format_index) else {
-            return;
-        };
-        let syn::Lit::Str(format_literal) = &mut format_expression.lit else {
-            return;
-        };
-        let format = format_literal.value();
-        let mut replacements = Vec::new();
-        let mut offset = 0;
-        while let Some(start_relative) = format[offset..].find('{') {
-            let start = offset + start_relative;
-            if format.as_bytes().get(start + 1) == Some(&b'{') {
-                offset = start + 2;
-                continue;
-            }
-            let Some(end_relative) = format[start + 1..].find('}') else {
-                break;
-            };
-            let end = start + 1 + end_relative;
-            let field_end = format[start + 1..end]
-                .find(':')
-                .map_or(end, |separator| start + 1 + separator);
-            if &format[start + 1..field_end] == self.from {
-                replacements.push((start + 1, field_end));
-            }
-            offset = end + 1;
-        }
-        if replacements.is_empty() {
-            return;
-        }
-        let mut renamed = format;
-        for (start, end) in replacements.into_iter().rev() {
-            renamed.replace_range(start..end, self.to);
-        }
-        *format_literal = syn::LitStr::new(&renamed, format_literal.span());
-        rust_macro.tokens = quote::quote!(#arguments);
+        super::format_capture::rename(rust_macro, self.from, self.to);
     }
 }
 

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/member_demand.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/member_demand.rs
@@ -3,11 +3,13 @@ use syn::visit::{self, Visit};
 use syn::visit_mut::{self, VisitMut};
 
 mod generic_cleanup;
+mod private_field_effects;
 mod wildcards;
 
 use generic_cleanup::{
     prune_item_members, prune_unconstrained_impl_generics, prune_unused_aggregate_type_parameters,
 };
+use private_field_effects::{retain_effectful_initializers, type_has_trivial_drop};
 use wildcards::rewrite_exhaustive_enum_wildcards;
 
 pub(super) fn prune_unused_members(file: &mut syn::File) {
@@ -516,14 +518,16 @@ impl VisitMut for RemovedVariantPatternCleanup<'_> {
 
 fn prune_unused_private_fields(items: &mut [syn::Item]) {
     let mut demand = FieldDemandCollector::default();
-    for item in items
-        .iter()
-        .filter(|item| !matches!(item, syn::Item::Mod(_)))
-    {
+    // Inline modules can access a parent field through `super` or a re-export.
+    // Visiting them is conservative for same-named fields and prevents a child
+    // use from deleting storage that the child still observes.
+    for item in items.iter() {
+        demand.retain_struct_initializers = matches!(item, syn::Item::Mod(_));
         demand.visit_item(item);
     }
-    let mut removed = HashMap::<String, HashSet<String>>::new();
-    for item in items.iter_mut() {
+    demand.retain_struct_initializers = false;
+    let mut candidates = HashMap::<String, HashSet<String>>::new();
+    for item in items.iter() {
         let syn::Item::Struct(struct_) = item else {
             continue;
         };
@@ -535,21 +539,42 @@ fn prune_unused_private_fields(items: &mut [syn::Item]) {
         {
             continue;
         }
-        let syn::Fields::Named(fields) = &mut struct_.fields else {
+        let syn::Fields::Named(fields) = &struct_.fields else {
             continue;
         };
         let owner = struct_.ident.to_string();
-        let owner_removed = fields
+        let owner_candidates = fields
             .named
             .iter()
             .filter_map(|field| {
                 let name = field.ident.as_ref()?.to_string();
-                (!demand.names.contains(&name)).then_some(name)
+                (!demand.names.contains(&name) && type_has_trivial_drop(&field.ty)).then_some(name)
             })
             .collect::<HashSet<_>>();
-        if owner_removed.is_empty() {
-            continue;
+        if !owner_candidates.is_empty() {
+            candidates.insert(owner, owner_candidates);
         }
+    }
+    if candidates.is_empty() {
+        return;
+    }
+
+    retain_effectful_initializers(items, &mut candidates);
+    let removed = candidates;
+    if removed.is_empty() {
+        return;
+    }
+
+    for item in items.iter_mut() {
+        let syn::Item::Struct(struct_) = item else {
+            continue;
+        };
+        let Some(owner_removed) = removed.get(&struct_.ident.to_string()) else {
+            continue;
+        };
+        let syn::Fields::Named(fields) = &mut struct_.fields else {
+            continue;
+        };
         fields.named = std::mem::take(&mut fields.named)
             .into_iter()
             .filter(|field| {
@@ -559,22 +584,20 @@ fn prune_unused_private_fields(items: &mut [syn::Item]) {
                     .is_none_or(|name| !owner_removed.contains(&name.to_string()))
             })
             .collect();
-        removed.insert(owner, owner_removed);
     }
-    if !removed.is_empty() {
-        let mut pruner = PrivateFieldPruner {
-            removed: &removed,
-            impl_owner: None,
-        };
-        for item in items {
-            pruner.visit_item_mut(item);
-        }
+    let mut pruner = PrivateFieldPruner {
+        removed: &removed,
+        impl_owner: None,
+    };
+    for item in items {
+        pruner.visit_item_mut(item);
     }
 }
 
 #[derive(Default)]
 struct FieldDemandCollector {
     names: HashSet<String>,
+    retain_struct_initializers: bool,
 }
 
 impl FieldDemandCollector {
@@ -613,6 +636,19 @@ impl<'ast> Visit<'ast> for FieldDemandCollector {
         visit::visit_field_pat(self, field);
     }
 
+    fn visit_expr_struct(&mut self, expression: &'ast syn::ExprStruct) {
+        if self.retain_struct_initializers {
+            self.names
+                .extend(expression.fields.iter().filter_map(|field| {
+                    let syn::Member::Named(name) = &field.member else {
+                        return None;
+                    };
+                    Some(name.to_string())
+                }));
+        }
+        visit::visit_expr_struct(self, expression);
+    }
+
     fn visit_macro(&mut self, rust_macro: &'ast syn::Macro) {
         self.collect_macro_tokens(rust_macro.tokens.clone());
     }
@@ -624,6 +660,10 @@ struct PrivateFieldPruner<'removed> {
 }
 
 impl VisitMut for PrivateFieldPruner<'_> {
+    fn visit_item_mod_mut(&mut self, _module: &mut syn::ItemMod) {
+        // Nested scopes compute and apply their own owner-qualified pruning.
+    }
+
     fn visit_item_impl_mut(&mut self, implementation: &mut syn::ItemImpl) {
         let previous = self.impl_owner.replace(type_name(&implementation.self_ty));
         visit_mut::visit_item_impl_mut(self, implementation);

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/member_demand/private_field_effects.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/member_demand/private_field_effects.rs
@@ -1,0 +1,118 @@
+use std::collections::{HashMap, HashSet};
+
+use syn::visit::{self, Visit};
+
+pub(super) fn type_has_trivial_drop(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Array(array) => type_has_trivial_drop(&array.elem),
+        syn::Type::Never(_) | syn::Type::Ptr(_) | syn::Type::Reference(_) => true,
+        syn::Type::Group(group) => type_has_trivial_drop(&group.elem),
+        syn::Type::Paren(paren) => type_has_trivial_drop(&paren.elem),
+        syn::Type::Tuple(tuple) => tuple.elems.iter().all(type_has_trivial_drop),
+        syn::Type::Path(path) if path.qself.is_none() && path.path.segments.len() == 1 => {
+            path.path.segments.first().is_some_and(|segment| {
+                matches!(
+                    segment.ident.to_string().as_str(),
+                    "bool"
+                        | "char"
+                        | "f32"
+                        | "f64"
+                        | "i8"
+                        | "i16"
+                        | "i32"
+                        | "i64"
+                        | "i128"
+                        | "isize"
+                        | "u8"
+                        | "u16"
+                        | "u32"
+                        | "u64"
+                        | "u128"
+                        | "usize"
+                )
+            })
+        }
+        _ => false,
+    }
+}
+
+pub(super) fn retain_effectful_initializers(
+    items: &[syn::Item],
+    candidates: &mut HashMap<String, HashSet<String>>,
+) {
+    let mut effects = FieldInitializerEffectCollector {
+        candidates,
+        unsafe_to_remove: HashSet::new(),
+        impl_owner: None,
+    };
+    for item in items
+        .iter()
+        .filter(|item| !matches!(item, syn::Item::Mod(_)))
+    {
+        effects.visit_item(item);
+    }
+    for (owner, field) in effects.unsafe_to_remove {
+        if let Some(owner_candidates) = candidates.get_mut(&owner) {
+            owner_candidates.remove(&field);
+        }
+    }
+    candidates.retain(|_, fields| !fields.is_empty());
+}
+
+struct FieldInitializerEffectCollector<'candidates> {
+    candidates: &'candidates HashMap<String, HashSet<String>>,
+    unsafe_to_remove: HashSet<(String, String)>,
+    impl_owner: Option<String>,
+}
+
+impl Visit<'_> for FieldInitializerEffectCollector<'_> {
+    fn visit_item_impl(&mut self, implementation: &syn::ItemImpl) {
+        let previous = self
+            .impl_owner
+            .replace(super::type_name(&implementation.self_ty));
+        visit::visit_item_impl(self, implementation);
+        self.impl_owner = previous;
+    }
+
+    fn visit_expr_struct(&mut self, expression: &syn::ExprStruct) {
+        let owner = expression.path.segments.last().map(|segment| {
+            if segment.ident == "Self" {
+                self.impl_owner
+                    .clone()
+                    .unwrap_or_else(|| "Self".to_string())
+            } else {
+                segment.ident.to_string()
+            }
+        });
+        let Some((owner, candidates)) = owner
+            .as_ref()
+            .and_then(|owner| self.candidates.get(owner).map(|fields| (owner, fields)))
+        else {
+            visit::visit_expr_struct(self, expression);
+            return;
+        };
+        if expression.rest.is_some() {
+            self.unsafe_to_remove.extend(
+                candidates
+                    .iter()
+                    .cloned()
+                    .map(|field| (owner.clone(), field)),
+            );
+        }
+        for field in &expression.fields {
+            let syn::Member::Named(name) = &field.member else {
+                continue;
+            };
+            let name = name.to_string();
+            if candidates.contains(&name) && !field_initializer_is_discardable(&field.expr) {
+                self.unsafe_to_remove.insert((owner.clone(), name));
+            }
+        }
+        visit::visit_expr_struct(self, expression);
+    }
+}
+
+fn field_initializer_is_discardable(expression: &syn::Expr) -> bool {
+    crate::discardability::syntax_expression_is_discardable(expression)
+        || matches!(expression, syn::Expr::Path(path) if path.qself.is_none())
+}

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup.rs
@@ -708,11 +708,7 @@ fn simple_binding_name(pattern: &syn::Pat) -> Option<String> {
 }
 
 fn expression_is_discardable(expression: &syn::Expr) -> bool {
-    match expression {
-        syn::Expr::Lit(_) => true,
-        syn::Expr::Paren(paren) => expression_is_discardable(&paren.expr),
-        _ => false,
-    }
+    crate::discardability::syntax_expression_is_discardable(expression)
 }
 
 fn expression_is_literal_unit(expression: &syn::Expr) -> bool {

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/identifier_collection.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/identifier_collection.rs
@@ -52,7 +52,10 @@ impl<'ast> Visit<'ast> for IdentifierCollector {
         } else {
             collect_token_identifiers(rust_macro.tokens.clone(), &mut self.names);
         }
-        collect_format_capture_names(rust_macro, &mut self.names);
+        self.names
+            .extend(crate::generated_rust_canonicalizer::format_capture::names(
+                rust_macro,
+            ));
     }
 }
 
@@ -84,58 +87,10 @@ impl<'ast> Visit<'ast> for ReferenceIdentifierCollector {
         } else {
             collect_token_identifiers(rust_macro.tokens.clone(), &mut self.names);
         }
-        collect_format_capture_names(rust_macro, &mut self.names);
-    }
-}
-
-fn collect_format_capture_names(rust_macro: &syn::Macro, names: &mut HashSet<String>) {
-    let Some(macro_name) = rust_macro
-        .path
-        .segments
-        .last()
-        .map(|segment| segment.ident.to_string())
-    else {
-        return;
-    };
-    let format_index = match macro_name.as_str() {
-        "format" | "print" | "println" | "eprint" | "eprintln" => 0,
-        "assert" => 1,
-        "assert_eq" | "assert_ne" => 2,
-        "write" | "writeln" => 1,
-        _ => return,
-    };
-    let Ok(arguments) = rust_macro.parse_body_with(
-        syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
-    ) else {
-        return;
-    };
-    let Some(syn::Expr::Lit(format_expression)) = arguments.iter().nth(format_index) else {
-        return;
-    };
-    let syn::Lit::Str(format_literal) = &format_expression.lit else {
-        return;
-    };
-    let format = format_literal.value();
-    let mut offset = 0;
-    while let Some(start_relative) = format[offset..].find('{') {
-        let start = offset + start_relative;
-        if format.as_bytes().get(start + 1) == Some(&b'{') {
-            offset = start + 2;
-            continue;
-        }
-        let Some(end_relative) = format[start + 1..].find('}') else {
-            break;
-        };
-        let end = start + 1 + end_relative;
-        let field = format[start + 1..end].split(':').next().unwrap_or_default();
-        if !field.is_empty()
-            && field
-                .chars()
-                .all(|character| character == '_' || character.is_ascii_alphanumeric())
-        {
-            names.insert(field.to_string());
-        }
-        offset = end + 1;
+        self.names
+            .extend(crate::generated_rust_canonicalizer::format_capture::names(
+                rust_macro,
+            ));
     }
 }
 

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/idiom_cleanup.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/idiom_cleanup.rs
@@ -18,13 +18,12 @@ use lint_cleanup::{
     fold_literal_result_bindings, fold_tail_bindings, fold_vec_push_sequences,
     group_long_float_literal, group_long_integer_literal, rewrite_assert_comparison,
     rewrite_empty_vec, rewrite_identity_constructor_closure, rewrite_literal_result_fallback,
-    rewrite_none_comparison, rewrite_option_expression, rewrite_option_match_with_if_let,
+    rewrite_option_expression, rewrite_option_match_with_if_let,
     rewrite_result_match_with_let_else, rewrite_single_element_exclusive_range,
     rewrite_single_value_format, rewrite_unwrap_or_default, terminate_known_unit_macro_tail,
 };
 use residual_cleanup::{
-    remove_explicit_unit_tail, remove_redundant_iterator_into_iter,
-    rewrite_static_format_to_string, rewrite_typed_redundant_len_closures,
+    remove_explicit_unit_tail, remove_redundant_iterator_into_iter, rewrite_static_format_to_string,
 };
 use result_control_cleanup::{rewrite_discarded_result_matches, rewrite_result_identity_match};
 use structured_control_cleanup::{
@@ -102,16 +101,6 @@ impl VisitMut for IdiomCleanup<'_> {
         terminate_known_unit_macro_tail(&mut block.stmts);
     }
 
-    fn visit_item_fn_mut(&mut self, function: &mut syn::ItemFn) {
-        rewrite_typed_redundant_len_closures(&function.sig, &mut function.block);
-        visit_mut::visit_item_fn_mut(self, function);
-    }
-
-    fn visit_impl_item_fn_mut(&mut self, method: &mut syn::ImplItemFn) {
-        rewrite_typed_redundant_len_closures(&method.sig, &mut method.block);
-        visit_mut::visit_impl_item_fn_mut(self, method);
-    }
-
     fn visit_local_mut(&mut self, local: &mut syn::Local) {
         rewrite_result_match_with_let_else(local);
         visit_mut::visit_local_mut(self, local);
@@ -160,7 +149,6 @@ impl VisitMut for IdiomCleanup<'_> {
         rewrite_single_value_format(expression);
         rewrite_option_match_with_if_let(expression);
         rewrite_option_expression(expression);
-        rewrite_none_comparison(expression);
         collapse_nested_if(expression);
         collapse_else_if(expression);
         collapse_identical_if_else_branches(expression);

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/idiom_cleanup/lint_cleanup.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/idiom_cleanup/lint_cleanup.rs
@@ -37,31 +37,6 @@ pub(super) fn rewrite_identity_constructor_closure(expression: &mut syn::Expr) {
     *expression = syn::Expr::Path(constructor.clone());
 }
 
-pub(super) fn rewrite_none_comparison(expression: &mut syn::Expr) {
-    let syn::Expr::Binary(binary) = expression else {
-        return;
-    };
-    let method = match binary.op {
-        syn::BinOp::Eq(_) => "is_none",
-        syn::BinOp::Ne(_) => "is_some",
-        _ => return,
-    };
-    let tested = if expression_is_none(&binary.left) {
-        binary.right.as_ref()
-    } else if expression_is_none(&binary.right) {
-        binary.left.as_ref()
-    } else {
-        return;
-    };
-    let method = syn::Ident::new(method, proc_macro2::Span::call_site());
-    *expression = syn::parse_quote!((#tested).#method());
-}
-
-fn expression_is_none(expression: &syn::Expr) -> bool {
-    matches!(expression, syn::Expr::Path(path)
-        if path.qself.is_none() && path.path.is_ident("None"))
-}
-
 pub(super) fn terminate_known_unit_macro_tail(statements: &mut [syn::Stmt]) {
     let Some(syn::Stmt::Expr(syn::Expr::Macro(expression_macro), semicolon @ None)) =
         statements.last_mut()

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/idiom_cleanup/residual_cleanup.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/idiom_cleanup/residual_cleanup.rs
@@ -1,7 +1,3 @@
-use std::collections::HashSet;
-
-use syn::visit_mut::{self, VisitMut};
-
 pub(super) fn remove_explicit_unit_tail(statements: &mut Vec<syn::Stmt>) {
     if matches!(
         statements.last(),
@@ -12,14 +8,6 @@ pub(super) fn remove_explicit_unit_tail(statements: &mut Vec<syn::Stmt>) {
 }
 
 pub(super) fn remove_redundant_iterator_into_iter(expression: &mut syn::Expr) {
-    if let syn::Expr::MethodCall(call) = expression
-        && matches!(call.method.to_string().as_str(), "chain" | "extend" | "zip")
-    {
-        for argument in &mut call.args {
-            strip_into_iter(argument);
-        }
-    }
-
     let syn::Expr::MethodCall(into_iter) = expression else {
         return;
     };
@@ -29,45 +17,13 @@ pub(super) fn remove_redundant_iterator_into_iter(expression: &mut syn::Expr) {
     let syn::Expr::MethodCall(producer) = into_iter.receiver.as_ref() else {
         return;
     };
-    let producer_name = producer.method.to_string();
     if !matches!(
-        producer_name.as_str(),
-        "chain"
-            | "cloned"
-            | "copied"
-            | "cycle"
-            | "enumerate"
-            | "filter"
-            | "filter_map"
-            | "flat_map"
-            | "flatten"
-            | "fuse"
-            | "inspect"
-            | "map"
-            | "map_while"
-            | "peekable"
-            | "rev"
-            | "scan"
-            | "skip"
-            | "step_by"
-            | "take"
-            | "zip"
-    ) && !matches!(
-        producer_name.as_str(),
+        producer.method.to_string().as_str(),
         "sifr_generated_iter__" | "sifr_generated_reversed__"
     ) {
         return;
     }
     *expression = syn::Expr::MethodCall(producer.clone());
-}
-
-fn strip_into_iter(expression: &mut syn::Expr) {
-    let syn::Expr::MethodCall(call) = expression else {
-        return;
-    };
-    if call.method == "into_iter" && call.args.is_empty() {
-        *expression = call.receiver.as_ref().clone();
-    }
 }
 
 pub(super) fn rewrite_static_format_to_string(expression: &mut syn::Expr) {
@@ -98,89 +54,4 @@ pub(super) fn rewrite_static_format_to_string(expression: &mut syn::Expr) {
         return;
     }
     *expression = syn::parse_quote!((#text).to_string());
-}
-
-pub(super) fn rewrite_typed_redundant_len_closures(
-    signature: &syn::Signature,
-    block: &mut syn::Block,
-) {
-    let option_vec_names = signature
-        .inputs
-        .iter()
-        .filter_map(|input| {
-            let syn::FnArg::Typed(input) = input else {
-                return None;
-            };
-            let syn::Pat::Ident(binding) = input.pat.as_ref() else {
-                return None;
-            };
-            option_contains_vec(&input.ty).then(|| binding.ident.to_string())
-        })
-        .collect();
-    TypedLenClosureCleanup { option_vec_names }.visit_block_mut(block);
-}
-
-fn option_contains_vec(ty: &syn::Type) -> bool {
-    match ty {
-        syn::Type::Reference(reference) => option_contains_vec(&reference.elem),
-        syn::Type::Paren(paren) => option_contains_vec(&paren.elem),
-        syn::Type::Group(group) => option_contains_vec(&group.elem),
-        syn::Type::Path(path) => path.path.segments.last().is_some_and(|segment| {
-            segment.ident == "Option"
-                && matches!(&segment.arguments, syn::PathArguments::AngleBracketed(arguments)
-                    if arguments.args.iter().any(|argument| matches!(argument,
-                        syn::GenericArgument::Type(syn::Type::Path(inner))
-                            if inner.path.segments.last().is_some_and(|inner| inner.ident == "Vec"))))
-        }),
-        _ => false,
-    }
-}
-
-struct TypedLenClosureCleanup {
-    option_vec_names: HashSet<String>,
-}
-
-impl VisitMut for TypedLenClosureCleanup {
-    fn visit_expr_method_call_mut(&mut self, call: &mut syn::ExprMethodCall) {
-        visit_mut::visit_expr_method_call_mut(self, call);
-        if !matches!(
-            call.method.to_string().as_str(),
-            "map" | "map_or" | "map_or_else"
-        ) || !receiver_is_known_vec_option_borrow(&call.receiver, &self.option_vec_names)
-        {
-            return;
-        }
-        for argument in &mut call.args {
-            let syn::Expr::Closure(closure) = argument else {
-                continue;
-            };
-            let [syn::Pat::Ident(binding)] = closure.inputs.iter().collect::<Vec<_>>().as_slice()
-            else {
-                continue;
-            };
-            if matches!(closure.body.as_ref(), syn::Expr::MethodCall(len)
-                if len.method == "len"
-                    && len.args.is_empty()
-                    && matches!(len.receiver.as_ref(), syn::Expr::Path(path)
-                        if path.qself.is_none() && path.path.is_ident(&binding.ident)))
-            {
-                *argument = syn::parse_quote!(::std::vec::Vec::len);
-            }
-        }
-    }
-}
-
-fn receiver_is_known_vec_option_borrow(
-    receiver: &syn::Expr,
-    option_vec_names: &HashSet<String>,
-) -> bool {
-    let syn::Expr::MethodCall(borrow) = receiver else {
-        return false;
-    };
-    matches!(borrow.method.to_string().as_str(), "as_ref" | "as_deref")
-        && borrow.args.is_empty()
-        && matches!(borrow.receiver.as_ref(), syn::Expr::Path(path)
-            if path.qself.is_none()
-                && path.path.segments.len() == 1
-                && option_vec_names.contains(&path.path.segments[0].ident.to_string()))
 }

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/idiom_cleanup/structured_control_cleanup.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/idiom_cleanup/structured_control_cleanup.rs
@@ -128,12 +128,26 @@ pub(super) fn factor_shared_if_suffix(expression: &mut syn::Expr) {
         &mut branch_bindings,
     );
     collect_statement_bindings(&else_block.block.stmts[..else_split], &mut branch_bindings);
+    // Moving the suffix outside either branch also moves it past the drop of
+    // every branch-local binding. Without resolved types, no local's `Drop`
+    // implementation can be assumed unobservable. Statement macros are also
+    // excluded because they can expand to a binding whose lexical lifetime is
+    // not visible in the parsed syntax tree.
+    let branch_prefixes_are_lifetime_transparent = branch_bindings.is_empty()
+        && branch.then_branch.stmts[..then_split]
+            .iter()
+            .chain(&else_block.block.stmts[..else_split])
+            .all(statement_cannot_introduce_branch_local);
     let mut shared_identifiers = HashSet::new();
     for statement in &shared {
         collect_statement_identifiers(statement, &mut shared_identifiers);
     }
     let condition_bindings = condition_binding_names(&branch.cond);
-    if !branch_bindings.is_disjoint(&shared_identifiers)
+    // A let-chain binding lives through the selected branch in the original
+    // expression. Hoisting any suffix would make that binding drop first.
+    if !branch_prefixes_are_lifetime_transparent
+        || !condition_bindings.is_empty()
+        || !branch_bindings.is_disjoint(&shared_identifiers)
         || !condition_bindings.is_disjoint(&shared_identifiers)
     {
         return;
@@ -158,9 +172,10 @@ struct FormatCaptureCollector<'names> {
 
 impl<'ast> Visit<'ast> for FormatCaptureCollector<'_> {
     fn visit_macro(&mut self, rust_macro: &'ast syn::Macro) {
-        self.names.extend(
-            crate::generated_rust_canonicalizer::item_demand::format_capture_names(rust_macro),
-        );
+        self.names
+            .extend(crate::generated_rust_canonicalizer::format_capture::names(
+                rust_macro,
+            ));
         syn::visit::visit_macro(self, rust_macro);
     }
 }
@@ -185,6 +200,10 @@ fn condition_binding_names(condition: &syn::Expr) -> HashSet<String> {
 }
 
 fn statement_is_movable_suffix(statement: &syn::Stmt) -> bool {
+    matches!(statement, syn::Stmt::Expr(_, Some(_)))
+}
+
+fn statement_cannot_introduce_branch_local(statement: &syn::Stmt) -> bool {
     matches!(statement, syn::Stmt::Expr(_, Some(_)))
 }
 

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/liveness.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/syntax_cleanup/liveness.rs
@@ -179,64 +179,15 @@ impl<'ast> Visit<'ast> for ReferenceCollector {
         } else {
             collect_token_names(rust_macro.tokens.clone(), &mut names);
         }
-        collect_format_capture_names(rust_macro, &mut names);
+        names.extend(crate::generated_rust_canonicalizer::format_capture::names(
+            rust_macro,
+        ));
         let free = names
             .into_iter()
             .filter(|name| !self.is_bound(name))
             .collect::<Vec<_>>();
         self.names.extend(free);
         visit::visit_macro(self, rust_macro);
-    }
-}
-
-fn collect_format_capture_names(rust_macro: &syn::Macro, names: &mut HashSet<String>) {
-    let Some(macro_name) = rust_macro
-        .path
-        .segments
-        .last()
-        .map(|segment| segment.ident.to_string())
-    else {
-        return;
-    };
-    let format_index = match macro_name.as_str() {
-        "format" | "print" | "println" | "eprint" | "eprintln" => 0,
-        "assert" => 1,
-        "assert_eq" | "assert_ne" => 2,
-        "write" | "writeln" => 1,
-        _ => return,
-    };
-    let Ok(arguments) = rust_macro.parse_body_with(
-        syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated,
-    ) else {
-        return;
-    };
-    let Some(syn::Expr::Lit(format_expression)) = arguments.iter().nth(format_index) else {
-        return;
-    };
-    let syn::Lit::Str(format_literal) = &format_expression.lit else {
-        return;
-    };
-    let format = format_literal.value();
-    let mut offset = 0;
-    while let Some(start_relative) = format[offset..].find('{') {
-        let start = offset + start_relative;
-        if format.as_bytes().get(start + 1) == Some(&b'{') {
-            offset = start + 2;
-            continue;
-        }
-        let Some(end_relative) = format[start + 1..].find('}') else {
-            break;
-        };
-        let end = start + 1 + end_relative;
-        let field = format[start + 1..end].split(':').next().unwrap_or_default();
-        if !field.is_empty()
-            && field
-                .chars()
-                .all(|character| character == '_' || character.is_ascii_alphanumeric())
-        {
-            names.insert(field.to_string());
-        }
-        offset = end + 1;
     }
 }
 

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer_item8_remediation_tests.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer_item8_remediation_tests.rs
@@ -177,7 +177,7 @@ fn folds_tail_bindings_and_empty_else_blocks() {
 }
 
 #[test]
-fn rewrites_identity_constructors_none_comparisons_and_iterator_identity() {
+fn rewrites_only_identity_constructors_with_structural_proof() {
     let source = r#"
         fn convert(value: Option<i64>, values: Vec<i64>) {
             let _ = value.map_or_else(|| Err::<i64, ()>(()), |item| Ok(item));
@@ -194,9 +194,11 @@ fn rewrites_identity_constructors_none_comparisons_and_iterator_identity() {
         canonical.contains("map_or_else(|| Err::<i64, ()>(()), Ok)"),
         "{canonical}"
     );
-    assert!(canonical.contains("value.is_some()"), "{canonical}");
-    assert!(canonical.contains("value.is_none()"), "{canonical}");
-    assert_eq!(canonical.matches(".into_iter()").count(), 1, "{canonical}");
+    assert!(canonical.contains("assert_ne!(value, None)"), "{canonical}");
+    assert!(canonical.contains("assert_eq!(None, value)"), "{canonical}");
+    assert!(!canonical.contains(".is_none()"), "{canonical}");
+    assert!(!canonical.contains(".is_some()"), "{canonical}");
+    assert_eq!(canonical.matches(".into_iter()").count(), 2, "{canonical}");
 }
 
 #[test]
@@ -289,7 +291,7 @@ fn preserves_if_let_prefix_that_reads_a_shadowing_pattern_binding() {
 }
 
 #[test]
-fn factors_shared_branch_suffix_without_leaking_branch_bindings() {
+fn retains_shared_branch_suffix_before_branch_local_drop() {
     let source = r#"
         fn advance(flag: bool, mut left: i64, mut right: i64) {
             if flag {
@@ -307,10 +309,10 @@ fn factors_shared_branch_suffix_without_leaking_branch_bindings() {
     "#;
 
     let canonical = canonicalize_generated_rust_source(source)
-        .expect("common branch suffixes should execute once after the selected branch");
+        .expect("common branch suffixes must not cross a branch-local drop boundary");
 
-    assert_eq!(canonical.matches("left += 1").count(), 1, "{canonical}");
-    assert_eq!(canonical.matches("right += 1").count(), 1, "{canonical}");
+    assert_eq!(canonical.matches("left += 1").count(), 2, "{canonical}");
+    assert_eq!(canonical.matches("right += 1").count(), 2, "{canonical}");
     assert!(canonical.contains("let detail = \"long\""), "{canonical}");
 }
 
@@ -472,7 +474,7 @@ fn removes_mutability_when_local_method_facts_prove_a_shared_receiver() {
 }
 
 #[test]
-fn removes_residual_unit_iterator_and_static_format_ceremony() {
+fn removes_only_proven_residual_unit_iterator_and_static_format_ceremony() {
     let source = r#"
         struct Generated;
         impl Generated {
@@ -493,11 +495,11 @@ fn removes_residual_unit_iterator_and_static_format_ceremony() {
         .expect("residual unit, iterator, and static-format ceremony should canonicalize");
 
     assert!(
-        !canonical.contains(".extend(vec![1, 2].into_iter())"),
+        canonical.contains(".extend(vec![1, 2].into_iter())"),
         "{canonical}"
     );
     assert!(
-        !canonical.contains(".zip(vec![2].into_iter())"),
+        canonical.contains(".zip(vec![2].into_iter())"),
         "{canonical}"
     );
     assert!(
@@ -509,7 +511,7 @@ fn removes_residual_unit_iterator_and_static_format_ceremony() {
 }
 
 #[test]
-fn rewrites_typed_vec_len_closures_and_nested_format_arguments() {
+fn leaves_post_parse_len_closures_unchanged_and_rewrites_nested_format_arguments() {
     let source = r#"
         struct Vec2 { x: i64, y: i64 }
         impl std::fmt::Display for Vec2 {
@@ -529,8 +531,7 @@ fn rewrites_typed_vec_len_closures_and_nested_format_arguments() {
     let canonical = canonicalize_generated_rust_source(source)
         .expect("typed closures and nested formatting should canonicalize");
 
-    assert!(canonical.contains("::std::vec::Vec::len"), "{canonical}");
-    assert!(!canonical.contains("|value| value.len()"), "{canonical}");
+    assert!(canonical.contains("|value| value.len()"), "{canonical}");
     assert!(
         !canonical.contains("write!(f, \"{}\", format!"),
         "{canonical}"
@@ -579,7 +580,7 @@ fn canonicalizes_source_enum_variants_without_changing_their_names() {
 }
 
 #[test]
-fn prunes_unread_private_fields_and_same_named_undemanded_methods() {
+fn retains_unread_drop_fields_and_prunes_same_named_undemanded_methods() {
     let source = r#"
         struct Config { value: i64, callback: Box<dyn Fn(i64) -> i64> }
         impl Config {
@@ -604,7 +605,7 @@ fn prunes_unread_private_fields_and_same_named_undemanded_methods() {
     let canonical = canonicalize_generated_rust_source(source)
         .expect("closed binaries should retain only demanded private members");
 
-    assert!(!canonical.contains("callback: Box"), "{canonical}");
+    assert!(canonical.contains("callback: Box"), "{canonical}");
     assert!(
         !canonical.contains("impl Base {\n    fn describe"),
         "{canonical}"

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer_item8a_tests.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer_item8a_tests.rs
@@ -1,0 +1,134 @@
+use super::canonicalize_generated_rust_source;
+
+#[test]
+fn shared_suffix_factoring_does_not_cross_branch_local_drops() {
+    let source = r#"
+        struct Guard(&'static str);
+        impl Drop for Guard {
+            fn drop(&mut self) { println!("drop {}", self.0); }
+        }
+        fn main() {
+            let choose_left = true;
+            if choose_left {
+                let _guard = Guard("left");
+                println!("left");
+                println!("shared");
+            } else {
+                let _guard = Guard("right");
+                println!("right");
+                println!("shared");
+            }
+        }
+    "#;
+
+    let canonical = canonicalize_generated_rust_source(source)
+        .expect("shared suffixes must remain before branch-local values drop");
+
+    assert_eq!(
+        canonical.matches("println!(\"shared\")").count(),
+        2,
+        "{canonical}"
+    );
+}
+
+#[test]
+fn private_field_pruning_retains_effects_and_nested_module_demand() {
+    let source = r#"
+        struct Guard;
+        impl Drop for Guard { fn drop(&mut self) { println!("drop"); } }
+        fn make_guard() -> Guard { println!("make guard"); Guard }
+        fn make_number() -> i64 { println!("make number"); 4 }
+        struct Config { live: i64, nested: i64, dead: i64, effect: i64, guard: Guard }
+        impl Config {
+            fn new() -> Self {
+                Self { live: 1, nested: 2, dead: 3, effect: make_number(), guard: make_guard() }
+            }
+        }
+        mod observer {
+            pub fn nested(config: &super::Config) -> i64 { config.nested }
+        }
+        use observer::nested;
+        fn main() {
+            let config = Config::new();
+            println!("{} {}", config.live, nested(&config));
+        }
+    "#;
+
+    let canonical = canonicalize_generated_rust_source(source)
+        .expect("field pruning must preserve effects and cross-module uses");
+
+    assert!(!canonical.contains("dead: i64"), "{canonical}");
+    assert!(canonical.contains("nested: i64"), "{canonical}");
+    assert!(canonical.contains("effect: i64"), "{canonical}");
+    assert!(canonical.contains("effect: make_number()"), "{canonical}");
+    assert!(canonical.contains("guard: Guard"), "{canonical}");
+    assert!(canonical.contains("guard: make_guard()"), "{canonical}");
+}
+
+#[test]
+fn post_parse_identity_cleanup_does_not_infer_types_from_names() {
+    let source = r#"
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum Choice { None, Value }
+        struct Custom;
+        impl Custom {
+            fn map(self, _f: impl Fn(i64) -> i64) -> Self { self }
+            fn into_iter(self) -> i64 { 7 }
+        }
+        fn main() {
+            let choice = Choice::Value;
+            assert!(choice != Choice::None);
+            let mapped = Custom.map(|value| value).into_iter();
+            let values: Option<Vec<i64>> = Some(vec![1]);
+            let deref_len = values.as_deref().map_or(0, |value| value.len());
+            println!("{mapped} {deref_len}");
+        }
+    "#;
+
+    let canonical = canonicalize_generated_rust_source(source)
+        .expect("syntax cleanup must retain expressions without resolved type provenance");
+
+    assert!(
+        canonical.contains("assert_ne!(choice, Choice::None)"),
+        "{canonical}"
+    );
+    assert!(!canonical.contains(".is_none()"), "{canonical}");
+    assert!(!canonical.contains(".is_some()"), "{canonical}");
+    assert!(
+        canonical.contains(".map(|value| value).into_iter()"),
+        "{canonical}"
+    );
+    assert!(
+        canonical.contains("as_deref().map_or(0, |value| value.len())"),
+        "{canonical}"
+    );
+}
+
+#[test]
+fn dynamic_format_captures_remain_live() {
+    let source = r#"
+        fn main() {
+            let sifr_generated_value = 1.25_f64;
+            let sifr_generated_width = 8_usize;
+            let sifr_generated_precision = 2_usize;
+            println!("{sifr_generated_value:sifr_generated_width$.sifr_generated_precision$}");
+        }
+    "#;
+
+    let canonical = canonicalize_generated_rust_source(source)
+        .expect("value, width, and precision captures must share lexical liveness");
+
+    assert!(
+        canonical
+            .contains("{sifr_generated_value:sifr_generated_width$.sifr_generated_precision$}"),
+        "{canonical}"
+    );
+    assert!(
+        canonical.contains("let sifr_generated_width"),
+        "{canonical}"
+    );
+    assert!(
+        canonical.contains("let sifr_generated_precision"),
+        "{canonical}"
+    );
+}

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/builtin_core_methods.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/builtin_core_methods.rs
@@ -628,31 +628,27 @@ impl RustEmitter {
                 let arg_count = args.len() - 1;
                 if arg_count == 1 {
                     Some(registry_box_iterator_expr(RustExpr::MethodCall {
-                        receiver: Box::new(RustExpr::MethodCall {
-                            receiver: Box::new(iter_expr),
-                            method: "map".to_string(),
-                            args: vec![RustExpr::ClosureBlock {
-                                params: vec![crate::RustParam::Named {
-                                    name: "__map_item".to_string(),
-                                    ty: crate::RustType::Named("_".to_string()),
-                                }],
-                                body: vec![crate::RustStmt::Return(Some(
-                                    registry_call_callable_with_owned_args(
-                                        self,
-                                        &args[0],
-                                        &[(
-                                            "__map_item".to_string(),
-                                            crate::resolve_alias_type_for_plain_call(args[1].ty())
-                                                .iterable_element_type()?,
-                                        )],
-                                    )?,
-                                ))],
-                                is_move: false,
-                                is_async: false,
+                        receiver: Box::new(iter_expr),
+                        method: "map".to_string(),
+                        args: vec![RustExpr::ClosureBlock {
+                            params: vec![crate::RustParam::Named {
+                                name: "__map_item".to_string(),
+                                ty: crate::RustType::Named("_".to_string()),
                             }],
-                        }),
-                        method: "into_iter".to_string(),
-                        args: vec![],
+                            body: vec![crate::RustStmt::Return(Some(
+                                registry_call_callable_with_owned_args(
+                                    self,
+                                    &args[0],
+                                    &[(
+                                        "__map_item".to_string(),
+                                        crate::resolve_alias_type_for_plain_call(args[1].ty())
+                                            .iterable_element_type()?,
+                                    )],
+                                )?,
+                            ))],
+                            is_move: false,
+                            is_async: false,
+                        }],
                     }))
                 } else {
                     let mut body = Vec::new();
@@ -677,21 +673,17 @@ impl RustEmitter {
                         registry_call_callable_with_owned_args(self, &args[0], &bindings)?,
                     )));
                     Some(registry_box_iterator_expr(RustExpr::MethodCall {
-                        receiver: Box::new(RustExpr::MethodCall {
-                            receiver: Box::new(iter_expr),
-                            method: "map".to_string(),
-                            args: vec![RustExpr::ClosureBlock {
-                                params: vec![crate::RustParam::Named {
-                                    name: "__map_item".to_string(),
-                                    ty: crate::RustType::Named("_".to_string()),
-                                }],
-                                body,
-                                is_move: false,
-                                is_async: false,
+                        receiver: Box::new(iter_expr),
+                        method: "map".to_string(),
+                        args: vec![RustExpr::ClosureBlock {
+                            params: vec![crate::RustParam::Named {
+                                name: "__map_item".to_string(),
+                                ty: crate::RustType::Named("_".to_string()),
                             }],
-                        }),
-                        method: "into_iter".to_string(),
-                        args: vec![],
+                            body,
+                            is_move: false,
+                            is_async: false,
+                        }],
                     }))
                 }
             }

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/collection_methods.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/collection_methods.rs
@@ -478,10 +478,7 @@ impl RustEmitter {
                     stmts.push(crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                         receiver: Box::new(object_expr.clone()),
                         method: "extend".to_string(),
-                        args: vec![
-                            registry_iterable_to_owned_iter_expr(self, arg)
-                                .map(|expr| crate::RustExpr::Paren(Box::new(expr)))?,
-                        ],
+                        args: vec![crate::intrinsic_method_emitters::registry_iterable_to_owned_into_iter_arg_expr(self, arg)?],
                     }));
                 }
                 return Some(crate::RustExpr::Block {
@@ -504,10 +501,7 @@ impl RustEmitter {
                     stmts.push(crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                         receiver: Box::new(crate::RustExpr::Ident("__result".to_string())),
                         method: "extend".to_string(),
-                        args: vec![
-                            registry_iterable_to_owned_iter_expr(self, arg)
-                                .map(|expr| crate::RustExpr::Paren(Box::new(expr)))?,
-                        ],
+                        args: vec![crate::intrinsic_method_emitters::registry_iterable_to_owned_into_iter_arg_expr(self, arg)?],
                     }));
                 }
                 return Some(crate::RustExpr::Block {

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/defaultdict_iterable_mutations.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/defaultdict_iterable_mutations.rs
@@ -61,11 +61,7 @@ impl RustEmitter {
                 crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::Ident(bucket_name)),
                     method: "extend".to_string(),
-                    args: vec![crate::RustExpr::MethodCall {
-                        receiver: Box::new(crate::RustExpr::Ident(items_name)),
-                        method: "into_iter".to_string(),
-                        args: vec![],
-                    }],
+                    args: vec![crate::RustExpr::Ident(items_name)],
                 }),
             ],
             expr: Some(Box::new(crate::RustExpr::Literal(crate::RustLiteral::Unit))),
@@ -126,11 +122,7 @@ impl RustEmitter {
                     stmts.push(crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                         receiver: Box::new(crate::RustExpr::Ident(bucket_name.clone())),
                         method: "extend".to_string(),
-                        args: vec![crate::RustExpr::MethodCall {
-                            receiver: Box::new(crate::RustExpr::Ident(items_name)),
-                            method: "into_iter".to_string(),
-                            args: vec![],
-                        }],
+                        args: vec![crate::RustExpr::Ident(items_name)],
                     }));
                 }
             }

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
@@ -2,6 +2,7 @@ use super::{
     HirExpr, ParamConvention, RustEmitter, RustExpr, Type,
     registry_can_construct_error_from_message, registry_is_box_new_ctor,
     registry_is_string_like_type, registry_iterable_to_vec_expr, registry_option_inner_type,
+    registry_option_none_query,
 };
 impl RustEmitter {
     pub(crate) fn flatten_option_argument_for_ir(
@@ -564,6 +565,13 @@ impl RustEmitter {
     ) -> Option<crate::RustExpr> {
         if ops.is_empty() || ops.len() != comparators.len() {
             return None;
+        }
+        if let Some((option, method)) = registry_option_none_query(self, left, ops, comparators) {
+            return Some(crate::RustExpr::MethodCall {
+                receiver: Box::new(self.try_lower_registry_expr_strict(option)?),
+                method: method.to_string(),
+                args: Vec::new(),
+            });
         }
         let mut lhs_expr = left;
         let mut chained: Option<crate::RustExpr> = None;

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/registry_helpers.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/registry_helpers.rs
@@ -63,6 +63,34 @@ pub(super) fn registry_option_inner_type(ty: &Type) -> Option<Type> {
     ty.optional_member_type()
 }
 
+pub(super) fn registry_option_none_query<'a>(
+    emitter: &RustEmitter,
+    left: &'a HirExpr,
+    ops: &[String],
+    comparators: &'a [HirExpr],
+) -> Option<(&'a HirExpr, &'static str)> {
+    let ([op], [right]) = (ops, comparators) else {
+        return None;
+    };
+    let method = match op.as_str() {
+        "is" | "==" => "is_none",
+        "is not" | "!=" => "is_some",
+        _ => return None,
+    };
+    let option = if matches!(right, HirExpr::NoneLiteral)
+        && registry_option_inner_type(&emitter.effective_registry_expr_ty(left)).is_some()
+    {
+        left
+    } else if matches!(left, HirExpr::NoneLiteral)
+        && registry_option_inner_type(&emitter.effective_registry_expr_ty(right)).is_some()
+    {
+        right
+    } else {
+        return None;
+    };
+    Some((option, method))
+}
+
 pub(super) fn registry_is_string_like_type(ty: &Type) -> bool {
     matches!(
         crate::resolve_alias_type_for_plain_call(ty),
@@ -243,6 +271,34 @@ pub(crate) fn registry_iterable_to_owned_iter_expr(
     expr: &HirExpr,
 ) -> Option<RustExpr> {
     registry_iterable_to_owned_iter_expr_with_hint(emitter, expr, None)
+}
+
+pub(crate) fn registry_iterable_to_owned_into_iter_arg_expr(
+    emitter: &mut RustEmitter,
+    expr: &HirExpr,
+) -> Option<RustExpr> {
+    let lowered = registry_iterable_to_owned_iter_expr(emitter, expr)?;
+    let plan = crate::helpers::plan_iterator_ownership(expr);
+    let can_pass_source_directly = matches!(
+        plan.source_access_mode,
+        crate::helpers::SourceAccessMode::Consume
+    ) && matches!(
+        crate::resolve_alias_type_for_plain_call(expr.ty()),
+        Type::List(_) | Type::Set(_) | Type::Iterable(_)
+    );
+    match lowered {
+        RustExpr::MethodCall {
+            receiver,
+            method,
+            args,
+        } if can_pass_source_directly && method == "into_iter" && args.is_empty() => {
+            Some(match *receiver {
+                RustExpr::Paren(expression) => *expression,
+                expression => expression,
+            })
+        }
+        expression => Some(expression),
+    }
 }
 
 pub(super) fn registry_iterable_to_owned_iter_expr_with_hint(
@@ -668,7 +724,7 @@ pub(super) fn registry_zip_iter_expr(
     let mut iter = args.iter();
     let mut acc = registry_iterable_to_owned_iter_expr(emitter, iter.next()?)?;
     for arg in iter {
-        let next_iter = registry_iterable_to_owned_iter_expr(emitter, arg)?;
+        let next_iter = registry_iterable_to_owned_into_iter_arg_expr(emitter, arg)?;
         acc = RustExpr::MethodCall {
             receiver: Box::new(acc),
             method: "zip".to_string(),

--- a/crates/sifr_codegen/src/ir_optimize/dead_bindings.rs
+++ b/crates/sifr_codegen/src/ir_optimize/dead_bindings.rs
@@ -1,4 +1,4 @@
-use crate::{RustExpr, RustItem, RustStmt};
+use crate::{RustExpr, RustItem, RustStmt, discardability::rust_ir_expression_is_discardable};
 use std::collections::HashSet;
 
 pub(crate) fn remove_unread_pure_bindings_in_items(items: &mut [RustItem]) -> usize {
@@ -41,7 +41,7 @@ fn remove_from_block(body: &mut Vec<RustStmt>) -> usize {
             RustStmt::Let { name, value, .. }
                 if name.starts_with("__sifr_")
                     && !referenced_after.contains(name)
-                    && expr_is_pure(value)
+                    && rust_ir_expression_is_discardable(value)
                     && !kept.is_empty()
         );
         if removable {
@@ -172,50 +172,6 @@ fn remove_from_stmt(stmt: &mut RustStmt) -> usize {
         | RustStmt::Return(_)
         | RustStmt::Break
         | RustStmt::Continue => 0,
-    }
-}
-
-fn expr_is_pure(expr: &RustExpr) -> bool {
-    match expr {
-        RustExpr::Literal(_) | RustExpr::Ident(_) | RustExpr::Path(_) => true,
-        RustExpr::Tuple(values) | RustExpr::Array(values) | RustExpr::Vec(values) => {
-            values.iter().all(expr_is_pure)
-        }
-        RustExpr::UnaryOp { operand, .. }
-        | RustExpr::Ref { expr: operand, .. }
-        | RustExpr::Deref(operand)
-        | RustExpr::Cast { expr: operand, .. }
-        | RustExpr::Paren(operand) => expr_is_pure(operand),
-        RustExpr::BinOp { left, right, .. }
-        | RustExpr::Range {
-            start: left,
-            end: right,
-        } => expr_is_pure(left) && expr_is_pure(right),
-        RustExpr::Field { expr, .. } => expr_is_pure(expr),
-        RustExpr::StructInit { fields, .. } => fields.iter().all(|(_, value)| expr_is_pure(value)),
-        RustExpr::FnCall { func, args }
-            if matches!(func.as_ref(), RustExpr::Path(path)
-                if path.first().is_some_and(|segment| segment == "SifrInt")) =>
-        {
-            args.iter().all(expr_is_pure)
-        }
-        RustExpr::Verbatim(_)
-        | RustExpr::MethodCall { .. }
-        | RustExpr::FnCall { .. }
-        | RustExpr::MacroCall { .. }
-        | RustExpr::FormatMacro { .. }
-        | RustExpr::Index { .. }
-        | RustExpr::Slice { .. }
-        | RustExpr::Clone(_)
-        | RustExpr::Block { .. }
-        | RustExpr::If { .. }
-        | RustExpr::Match { .. }
-        | RustExpr::Closure { .. }
-        | RustExpr::ClosureBlock { .. }
-        | RustExpr::AsyncBlock { .. }
-        | RustExpr::TimeoutAwait { .. }
-        | RustExpr::Try(_)
-        | RustExpr::Await(_) => false,
     }
 }
 
@@ -471,5 +427,38 @@ mod tests {
             &body[0],
             RustStmt::Let { name, .. } if name == "_source_dead"
         ));
+    }
+
+    #[test]
+    fn retains_unread_binary_expressions_with_unknown_operator_effects() {
+        let mut items = vec![RustItem::Fn {
+            name: "main".to_string(),
+            visibility: Visibility::Private,
+            type_params: Vec::new(),
+            params: Vec::new(),
+            ret: None,
+            body: vec![
+                RustStmt::Let {
+                    mutable: false,
+                    name: "__sifr_result".to_string(),
+                    ty: Some(RustType::I64),
+                    value: RustExpr::BinOp {
+                        left: Box::new(RustExpr::Literal(RustLiteral::Int(1))),
+                        op: "/".to_string(),
+                        right: Box::new(RustExpr::Literal(RustLiteral::Int(0))),
+                    },
+                },
+                RustStmt::Expr(RustExpr::Literal(RustLiteral::Unit)),
+            ],
+            is_async: false,
+        }];
+
+        assert_eq!(remove_unread_pure_bindings_in_items(&mut items), 0);
+        let RustItem::Fn { body, .. } = &items[0] else {
+            unreachable!();
+        };
+        assert!(
+            matches!(body.first(), Some(RustStmt::Let { name, .. }) if name == "__sifr_result")
+        );
     }
 }

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -6,6 +6,7 @@ mod lib_modules_and_codegen;
 pub use lib_modules_and_codegen::*;
 mod builtin_errors;
 pub(crate) use builtin_errors::BUILTIN_ERROR_CLASSES;
+mod discardability;
 mod generated_rust_canonicalizer;
 mod generator_runtime_needs;
 pub use generated_rust_canonicalizer::{

--- a/crates/sifr_codegen/src/lib_codegen_tests/iterators_and_generators_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/iterators_and_generators_codegen_tests.rs
@@ -809,3 +809,21 @@ fn test_structured_aug_assign_uses_string_and_list_methods() {
     assert!(!generated.rust_source.contains("s += "));
     assert!(!generated.rust_source.contains("items += "));
 }
+
+#[test]
+fn consuming_collection_into_iterator_arguments_use_the_collection_directly() {
+    let expression = HirExpr::ListLiteral {
+        elements: vec![HirExpr::IntLiteral(1), HirExpr::IntLiteral(2)],
+        ty: Type::List(Box::new(Type::Int)),
+    };
+    let lowered = crate::intrinsic_method_emitters::registry_iterable_to_owned_into_iter_arg_expr(
+        &mut RustEmitter::new(),
+        &expression,
+    )
+    .expect("a consuming list must lower as an IntoIterator argument");
+
+    assert_eq!(
+        crate::render_expr(&lowered),
+        "vec![SifrInt::from_i64(1), SifrInt::from_i64(2)]"
+    );
+}

--- a/crates/sifr_codegen/src/lib_codegen_tests/union_representation_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/union_representation_codegen_tests.rs
@@ -15,6 +15,30 @@ fn generic_option_none_comparisons_use_option_predicates_without_partial_eq() {
 }
 
 #[test]
+fn computed_option_none_comparisons_use_option_predicates() {
+    let rust_code = generate_rust_from_source(
+        r#"def missing(values: dict[str, int]) -> bool:
+    return values.get("missing") == None
+"#,
+    );
+
+    assert!(rust_code.contains(".is_none()"), "{rust_code}");
+    assert!(!rust_code.contains("== None"), "{rust_code}");
+}
+
+#[test]
+fn optional_string_length_keeps_a_payload_compatible_callback() {
+    let rust_code = generate_rust_from_source(
+        r#"def optional_length(value: str | None) -> int:
+    return len(value)
+"#,
+    );
+
+    assert!(rust_code.contains("|value| value.len()"), "{rust_code}");
+    assert!(!rust_code.contains("::std::vec::Vec::len"), "{rust_code}");
+}
+
+#[test]
 fn owned_optional_argument_widening_is_not_force_unwrapped_after_conversion() {
     let target = sifr_type_system::make_union(vec![Type::Int, Type::Str, Type::None]);
     let rust_code = generate_rust_from_source(

--- a/crates/sifr_codegen/src/methods/common.rs
+++ b/crates/sifr_codegen/src/methods/common.rs
@@ -1,6 +1,7 @@
 //! Shared method lowerers that are not container-specific.
 
 use crate::{RustExpr, RustLiteral, RustStmt, RustType};
+use sifr_type_system::Type;
 
 fn exact_int_from_expr(expr: RustExpr) -> RustExpr {
     RustExpr::FnCall {
@@ -136,10 +137,10 @@ pub(super) fn lower_tuple_index(
         stmts.push(RustStmt::If {
             cond: RustExpr::BinOp {
                 left: Box::new(RustExpr::BinOp {
-                    left: Box::new(RustExpr::BinOp {
-                        left: Box::new(RustExpr::Ident("__result".to_string())),
-                        op: "==".to_string(),
-                        right: Box::new(RustExpr::Path(vec!["None".to_string()])),
+                    left: Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident("__result".to_string())),
+                        method: "is_none".to_string(),
+                        args: Vec::new(),
                     }),
                     op: "&&".to_string(),
                     right: Box::new(RustExpr::BinOp {
@@ -203,10 +204,38 @@ pub(super) fn lower_string_char_len(object: &RustExpr, args: &[RustExpr]) -> Opt
     }))
 }
 
-pub(super) fn lower_option_len(object: &RustExpr, args: &[RustExpr]) -> Option<RustExpr> {
+pub(super) fn lower_option_len(
+    object_ty: &Type,
+    object: &RustExpr,
+    args: &[RustExpr],
+) -> Option<RustExpr> {
     if !args.is_empty() {
         return None;
     }
+    let length = if object_ty
+        .optional_member_type()
+        .is_some_and(|payload| matches!(payload.resolve_alias(), Type::List(_)))
+    {
+        RustExpr::Path(vec![
+            "std".to_string(),
+            "vec".to_string(),
+            "Vec".to_string(),
+            "len".to_string(),
+        ])
+    } else {
+        RustExpr::Closure {
+            params: vec![crate::RustParam::Named {
+                name: "value".to_string(),
+                ty: RustType::Named("_".to_string()),
+            }],
+            body: Box::new(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("value".to_string())),
+                method: "len".to_string(),
+                args: Vec::new(),
+            }),
+            is_move: false,
+        }
+    };
     Some(exact_int_from_expr(RustExpr::MethodCall {
         receiver: Box::new(RustExpr::MethodCall {
             receiver: Box::new(object.clone()),
@@ -219,18 +248,7 @@ pub(super) fn lower_option_len(object: &RustExpr, args: &[RustExpr]) -> Option<R
                 expr: Box::new(RustExpr::Literal(RustLiteral::Int(0))),
                 ty: RustType::Named("usize".to_string()),
             },
-            RustExpr::Closure {
-                params: vec![crate::RustParam::Named {
-                    name: "v".to_string(),
-                    ty: RustType::Named("_".to_string()),
-                }],
-                body: Box::new(RustExpr::MethodCall {
-                    receiver: Box::new(RustExpr::Ident("v".to_string())),
-                    method: "len".to_string(),
-                    args: vec![],
-                }),
-                is_move: false,
-            },
+            length,
         ],
     }))
 }

--- a/crates/sifr_codegen/src/methods/list.rs
+++ b/crates/sifr_codegen/src/methods/list.rs
@@ -331,10 +331,10 @@ pub(super) fn lower_index(object: &RustExpr, args: &[RustExpr]) -> Option<RustEx
                         right: Box::new(RustExpr::Ident("__stop".to_string())),
                     }),
                     op: "&&".to_string(),
-                    right: Box::new(RustExpr::BinOp {
-                        left: Box::new(RustExpr::Ident("__result".to_string())),
-                        op: "==".to_string(),
-                        right: Box::new(RustExpr::Path(vec!["None".to_string()])),
+                    right: Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident("__result".to_string())),
+                        method: "is_none".to_string(),
+                        args: Vec::new(),
                     }),
                 },
                 body: vec![

--- a/crates/sifr_codegen/src/methods/mod.rs
+++ b/crates/sifr_codegen/src/methods/mod.rs
@@ -62,7 +62,7 @@ pub(crate) fn lower_method_with_context(
         (Type::Tuple(elems), "count") => common::lower_tuple_count(elems.len(), object, args),
         (Type::Tuple(elems), "index") => common::lower_tuple_index(elems.len(), object, args),
         (Type::Str, "len") => common::lower_string_char_len(object, args),
-        (ty, "len") if is_option_type(ty) => common::lower_option_len(object, args),
+        (ty, "len") if is_option_type(ty) => common::lower_option_len(ty, object, args),
         (Type::Class { .. }, "len") if args.is_empty() => Some(RustExpr::MethodCall {
             receiver: Box::new(object.clone()),
             method: "len".to_string(),
@@ -270,7 +270,7 @@ mod tests {
         .expect("option len lowers");
         assert_eq!(
             render_expr(&option_len.expr),
-            "SifrInt::from(opt.as_ref().map_or(0_usize, |v| v.len()))"
+            "SifrInt::from(opt.as_ref().map_or(0_usize, ::std::vec::Vec::len))"
         );
 
         let generic_len = lower_method(

--- a/demos/compiler_safety/emitted.rs
+++ b/demos/compiler_safety/emitted.rs
@@ -52,14 +52,17 @@ impl ::std::fmt::Display for DBConnection {
 }
 struct Config {
     value: SifrInt,
+    callback: Box<dyn Fn(SifrInt) -> SifrInt>,
 }
 impl Config {
     fn new(value: SifrInt, callback: impl Fn(SifrInt) -> SifrInt + 'static) -> Self {
         let sifr_generated_field_value_7ce4fd9430e80cea_76616c7565: SifrInt = value.clone();
-        let _field_value_31d52eaacb529206_63616c6c6261636b: Box<dyn Fn(SifrInt) -> SifrInt> =
-            Box::new(callback);
+        let sifr_generated_field_value_31d52eaacb529206_63616c6c6261636b: Box<
+            dyn Fn(SifrInt) -> SifrInt,
+        > = Box::new(callback);
         Self {
             value: sifr_generated_field_value_7ce4fd9430e80cea_76616c7565,
+            callback: sifr_generated_field_value_31d52eaacb529206_63616c6c6261636b,
         }
     }
 }

--- a/demos/filesystem_and_archives/emitted.rs
+++ b/demos/filesystem_and_archives/emitted.rs
@@ -329,26 +329,26 @@ fn sifr_generated_match(name: &str, mut ni: SifrInt, pattern: &str, mut pi: Sifr
             if &ni >= &SifrInt::from(name.chars().count()) {
                 return false;
             }
-            {
-                if sifr_generated_shared_branch_condition {
-                } else {
-                    let nc: Option<String> = {
-                        let sifr_generated_string_source = &name;
-                        let sifr_generated_string_index = ni.clone();
-                        let sifr_generated_string_index_normalized = sifr_generated_string_index
-                            .normalize_index_or_len(sifr_generated_string_source.chars().count());
-                        sifr_generated_string_source
-                            .chars()
-                            .nth(sifr_generated_string_index_normalized)
-                    }
-                    .map(|character| character.to_string());
-                    if let Some(nc) = nc {
-                        if nc != pc {
-                            return false;
-                        }
-                    } else {
+            if sifr_generated_shared_branch_condition {
+                ni = &ni + &SifrInt::from_i64(1);
+                pi = &pi + &SifrInt::from_i64(1);
+            } else {
+                let nc: Option<String> = {
+                    let sifr_generated_string_source = &name;
+                    let sifr_generated_string_index = ni.clone();
+                    let sifr_generated_string_index_normalized = sifr_generated_string_index
+                        .normalize_index_or_len(sifr_generated_string_source.chars().count());
+                    sifr_generated_string_source
+                        .chars()
+                        .nth(sifr_generated_string_index_normalized)
+                }
+                .map(|character| character.to_string());
+                if let Some(nc) = nc {
+                    if nc != pc {
                         return false;
                     }
+                } else {
+                    return false;
                 }
                 ni = &ni + &SifrInt::from_i64(1);
                 pi = &pi + &SifrInt::from_i64(1);

--- a/demos/fnmatch/emitted.rs
+++ b/demos/fnmatch/emitted.rs
@@ -34,26 +34,26 @@ fn sifr_generated_match(name: &str, mut ni: SifrInt, pattern: &str, mut pi: Sifr
             if &ni >= &SifrInt::from(name.chars().count()) {
                 return false;
             }
-            {
-                if sifr_generated_shared_branch_condition {
-                } else {
-                    let nc: Option<String> = {
-                        let sifr_generated_string_source = &name;
-                        let sifr_generated_string_index = ni.clone();
-                        let sifr_generated_string_index_normalized = sifr_generated_string_index
-                            .normalize_index_or_len(sifr_generated_string_source.chars().count());
-                        sifr_generated_string_source
-                            .chars()
-                            .nth(sifr_generated_string_index_normalized)
-                    }
-                    .map(|character| character.to_string());
-                    if let Some(nc) = nc {
-                        if nc != pc {
-                            return false;
-                        }
-                    } else {
+            if sifr_generated_shared_branch_condition {
+                ni = &ni + &SifrInt::from_i64(1);
+                pi = &pi + &SifrInt::from_i64(1);
+            } else {
+                let nc: Option<String> = {
+                    let sifr_generated_string_source = &name;
+                    let sifr_generated_string_index = ni.clone();
+                    let sifr_generated_string_index_normalized = sifr_generated_string_index
+                        .normalize_index_or_len(sifr_generated_string_source.chars().count());
+                    sifr_generated_string_source
+                        .chars()
+                        .nth(sifr_generated_string_index_normalized)
+                }
+                .map(|character| character.to_string());
+                if let Some(nc) = nc {
+                    if nc != pc {
                         return false;
                     }
+                } else {
+                    return false;
                 }
                 ni = &ni + &SifrInt::from_i64(1);
                 pi = &pi + &SifrInt::from_i64(1);

--- a/demos/glob/emitted.rs
+++ b/demos/glob/emitted.rs
@@ -54,26 +54,26 @@ fn sifr_generated_match(name: &str, mut ni: SifrInt, pattern: &str, mut pi: Sifr
             if &ni >= &SifrInt::from(name.chars().count()) {
                 return false;
             }
-            {
-                if sifr_generated_shared_branch_condition {
-                } else {
-                    let nc: Option<String> = {
-                        let sifr_generated_string_source = &name;
-                        let sifr_generated_string_index = ni.clone();
-                        let sifr_generated_string_index_normalized = sifr_generated_string_index
-                            .normalize_index_or_len(sifr_generated_string_source.chars().count());
-                        sifr_generated_string_source
-                            .chars()
-                            .nth(sifr_generated_string_index_normalized)
-                    }
-                    .map(|character| character.to_string());
-                    if let Some(nc) = nc {
-                        if nc != pc {
-                            return false;
-                        }
-                    } else {
+            if sifr_generated_shared_branch_condition {
+                ni = &ni + &SifrInt::from_i64(1);
+                pi = &pi + &SifrInt::from_i64(1);
+            } else {
+                let nc: Option<String> = {
+                    let sifr_generated_string_source = &name;
+                    let sifr_generated_string_index = ni.clone();
+                    let sifr_generated_string_index_normalized = sifr_generated_string_index
+                        .normalize_index_or_len(sifr_generated_string_source.chars().count());
+                    sifr_generated_string_source
+                        .chars()
+                        .nth(sifr_generated_string_index_normalized)
+                }
+                .map(|character| character.to_string());
+                if let Some(nc) = nc {
+                    if nc != pc {
                         return false;
                     }
+                } else {
+                    return false;
                 }
                 ni = &ni + &SifrInt::from_i64(1);
                 pi = &pi + &SifrInt::from_i64(1);

--- a/demos/python_regressions/emitted.rs
+++ b/demos/python_regressions/emitted.rs
@@ -758,26 +758,26 @@ fn sifr_generated_match(name: &str, mut ni: SifrInt, pattern: &str, mut pi: Sifr
             if &ni >= &SifrInt::from(name.chars().count()) {
                 return false;
             }
-            {
-                if sifr_generated_shared_branch_condition {
-                } else {
-                    let nc: Option<String> = {
-                        let sifr_generated_string_source = &name;
-                        let sifr_generated_string_index = ni.clone();
-                        let sifr_generated_string_index_normalized = sifr_generated_string_index
-                            .normalize_index_or_len(sifr_generated_string_source.chars().count());
-                        sifr_generated_string_source
-                            .chars()
-                            .nth(sifr_generated_string_index_normalized)
-                    }
-                    .map(|character| character.to_string());
-                    if let Some(nc) = nc {
-                        if nc != pc {
-                            return false;
-                        }
-                    } else {
+            if sifr_generated_shared_branch_condition {
+                ni = &ni + &SifrInt::from_i64(1);
+                pi = &pi + &SifrInt::from_i64(1);
+            } else {
+                let nc: Option<String> = {
+                    let sifr_generated_string_source = &name;
+                    let sifr_generated_string_index = ni.clone();
+                    let sifr_generated_string_index_normalized = sifr_generated_string_index
+                        .normalize_index_or_len(sifr_generated_string_source.chars().count());
+                    sifr_generated_string_source
+                        .chars()
+                        .nth(sifr_generated_string_index_normalized)
+                }
+                .map(|character| character.to_string());
+                if let Some(nc) = nc {
+                    if nc != pc {
                         return false;
                     }
+                } else {
+                    return false;
                 }
                 ni = &ni + &SifrInt::from_i64(1);
                 pi = &pi + &SifrInt::from_i64(1);

--- a/demos/regex_and_filesystem/emitted.rs
+++ b/demos/regex_and_filesystem/emitted.rs
@@ -550,26 +550,26 @@ fn sifr_generated_match(name: &str, mut ni: SifrInt, pattern: &str, mut pi: Sifr
             if &ni >= &SifrInt::from(name.chars().count()) {
                 return false;
             }
-            {
-                if sifr_generated_shared_branch_condition {
-                } else {
-                    let nc: Option<String> = {
-                        let sifr_generated_string_source = &name;
-                        let sifr_generated_string_index = ni.clone();
-                        let sifr_generated_string_index_normalized = sifr_generated_string_index
-                            .normalize_index_or_len(sifr_generated_string_source.chars().count());
-                        sifr_generated_string_source
-                            .chars()
-                            .nth(sifr_generated_string_index_normalized)
-                    }
-                    .map(|character| character.to_string());
-                    if let Some(nc) = nc {
-                        if nc != pc {
-                            return false;
-                        }
-                    } else {
+            if sifr_generated_shared_branch_condition {
+                ni = &ni + &SifrInt::from_i64(1);
+                pi = &pi + &SifrInt::from_i64(1);
+            } else {
+                let nc: Option<String> = {
+                    let sifr_generated_string_source = &name;
+                    let sifr_generated_string_index = ni.clone();
+                    let sifr_generated_string_index_normalized = sifr_generated_string_index
+                        .normalize_index_or_len(sifr_generated_string_source.chars().count());
+                    sifr_generated_string_source
+                        .chars()
+                        .nth(sifr_generated_string_index_normalized)
+                }
+                .map(|character| character.to_string());
+                if let Some(nc) = nc {
+                    if nc != pc {
                         return false;
                     }
+                } else {
+                    return false;
                 }
                 ni = &ni + &SifrInt::from_i64(1);
                 pi = &pi + &SifrInt::from_i64(1);

--- a/demos/stdlib_expansion/emitted.rs
+++ b/demos/stdlib_expansion/emitted.rs
@@ -777,26 +777,26 @@ fn sifr_generated_match(name: &str, mut ni: SifrInt, pattern: &str, mut pi: Sifr
             if &ni >= &SifrInt::from(name.chars().count()) {
                 return false;
             }
-            {
-                if sifr_generated_shared_branch_condition {
-                } else {
-                    let nc: Option<String> = {
-                        let sifr_generated_string_source = &name;
-                        let sifr_generated_string_index = ni.clone();
-                        let sifr_generated_string_index_normalized = sifr_generated_string_index
-                            .normalize_index_or_len(sifr_generated_string_source.chars().count());
-                        sifr_generated_string_source
-                            .chars()
-                            .nth(sifr_generated_string_index_normalized)
-                    }
-                    .map(|character| character.to_string());
-                    if let Some(nc) = nc {
-                        if nc != pc {
-                            return false;
-                        }
-                    } else {
+            if sifr_generated_shared_branch_condition {
+                ni = &ni + &SifrInt::from_i64(1);
+                pi = &pi + &SifrInt::from_i64(1);
+            } else {
+                let nc: Option<String> = {
+                    let sifr_generated_string_source = &name;
+                    let sifr_generated_string_index = ni.clone();
+                    let sifr_generated_string_index_normalized = sifr_generated_string_index
+                        .normalize_index_or_len(sifr_generated_string_source.chars().count());
+                    sifr_generated_string_source
+                        .chars()
+                        .nth(sifr_generated_string_index_normalized)
+                }
+                .map(|character| character.to_string());
+                if let Some(nc) = nc {
+                    if nc != pc {
                         return false;
                     }
+                } else {
+                    return false;
                 }
                 ni = &ni + &SifrInt::from_i64(1);
                 pi = &pi + &SifrInt::from_i64(1);

--- a/demos/stdlib_tools/emitted.rs
+++ b/demos/stdlib_tools/emitted.rs
@@ -169,26 +169,26 @@ fn sifr_generated_match(name: &str, mut ni: SifrInt, pattern: &str, mut pi: Sifr
             if &ni >= &SifrInt::from(name.chars().count()) {
                 return false;
             }
-            {
-                if sifr_generated_shared_branch_condition {
-                } else {
-                    let nc: Option<String> = {
-                        let sifr_generated_string_source = &name;
-                        let sifr_generated_string_index = ni.clone();
-                        let sifr_generated_string_index_normalized = sifr_generated_string_index
-                            .normalize_index_or_len(sifr_generated_string_source.chars().count());
-                        sifr_generated_string_source
-                            .chars()
-                            .nth(sifr_generated_string_index_normalized)
-                    }
-                    .map(|character| character.to_string());
-                    if let Some(nc) = nc {
-                        if nc != pc {
-                            return false;
-                        }
-                    } else {
+            if sifr_generated_shared_branch_condition {
+                ni = &ni + &SifrInt::from_i64(1);
+                pi = &pi + &SifrInt::from_i64(1);
+            } else {
+                let nc: Option<String> = {
+                    let sifr_generated_string_source = &name;
+                    let sifr_generated_string_index = ni.clone();
+                    let sifr_generated_string_index_normalized = sifr_generated_string_index
+                        .normalize_index_or_len(sifr_generated_string_source.chars().count());
+                    sifr_generated_string_source
+                        .chars()
+                        .nth(sifr_generated_string_index_normalized)
+                }
+                .map(|character| character.to_string());
+                if let Some(nc) = nc {
+                    if nc != pc {
                         return false;
                     }
+                } else {
+                    return false;
                 }
                 ni = &ni + &SifrInt::from_i64(1);
                 pi = &pi + &SifrInt::from_i64(1);

--- a/demos/text_and_patterns/emitted.rs
+++ b/demos/text_and_patterns/emitted.rs
@@ -1780,26 +1780,26 @@ fn sifr_generated_match(name: &str, mut ni: SifrInt, pattern: &str, mut pi: Sifr
             if &ni >= &SifrInt::from(name.chars().count()) {
                 return false;
             }
-            {
-                if sifr_generated_shared_branch_condition {
-                } else {
-                    let nc: Option<String> = {
-                        let sifr_generated_string_source = &name;
-                        let sifr_generated_string_index = ni.clone();
-                        let sifr_generated_string_index_normalized = sifr_generated_string_index
-                            .normalize_index_or_len(sifr_generated_string_source.chars().count());
-                        sifr_generated_string_source
-                            .chars()
-                            .nth(sifr_generated_string_index_normalized)
-                    }
-                    .map(|character| character.to_string());
-                    if let Some(nc) = nc {
-                        if nc != pc {
-                            return false;
-                        }
-                    } else {
+            if sifr_generated_shared_branch_condition {
+                ni = &ni + &SifrInt::from_i64(1);
+                pi = &pi + &SifrInt::from_i64(1);
+            } else {
+                let nc: Option<String> = {
+                    let sifr_generated_string_source = &name;
+                    let sifr_generated_string_index = ni.clone();
+                    let sifr_generated_string_index_normalized = sifr_generated_string_index
+                        .normalize_index_or_len(sifr_generated_string_source.chars().count());
+                    sifr_generated_string_source
+                        .chars()
+                        .nth(sifr_generated_string_index_normalized)
+                }
+                .map(|character| character.to_string());
+                if let Some(nc) = nc {
+                    if nc != pc {
                         return false;
                     }
+                } else {
+                    return false;
                 }
                 ni = &ni + &SifrInt::from_i64(1);
                 pi = &pi + &SifrInt::from_i64(1);

--- a/verification/areas/generated_code_quality/generated_code_quality.py
+++ b/verification/areas/generated_code_quality/generated_code_quality.py
@@ -330,10 +330,13 @@ def run_command(
     *,
     cwd: Path = REPO_ROOT,
     check: bool = True,
+    cargo_target_dir: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = command_env()
     shared_root = shared_artifact_root()
-    if shared_root is not None:
+    if cargo_target_dir is not None:
+        env["CARGO_TARGET_DIR"] = str(cargo_target_dir)
+    elif shared_root is not None:
         env["CARGO_TARGET_DIR"] = str(shared_root / "cargo-target")
     result = subprocess.run(
         args,
@@ -609,6 +612,7 @@ def gate_rustfmt(entries: list[Entry], args: argparse.Namespace) -> None:
 def gate_clippy(entries: list[Entry], args: argparse.Namespace) -> None:
     run = run_id("clippy")
     run_root = TARGET_ROOT / run
+    cargo_target_dir = run_root / "cargo-target"
     records = []
     try:
         negative_seeds = {
@@ -627,6 +631,7 @@ def gate_clippy(entries: list[Entry], args: argparse.Namespace) -> None:
                     run_command,
                     STRICT_CLIPPY_ARGS,
                     parse_clippy_diagnostics,
+                    cargo_target_dir,
                 ),
             )
         debt = load_debt(QUALITY_DEBT)
@@ -640,6 +645,7 @@ def gate_clippy(entries: list[Entry], args: argparse.Namespace) -> None:
                     crate_root_inner,
                     run_command,
                     STRICT_CLIPPY_ARGS,
+                    cargo_target_dir,
                 )
                 actual = parse_clippy_diagnostics(result.stdout, crate_root_inner)
                 if result.returncode != 0 and not actual:
@@ -768,6 +774,7 @@ def authoritative_companion_entries() -> list[tuple[Path, Entry]]:
 def gate_companions(_entries: list[Entry], args: argparse.Namespace) -> None:
     run = run_id("companions")
     run_root = TARGET_ROOT / run
+    cargo_target_dir = run_root / "cargo-target"
     records = []
     summaries = []
     debt = load_debt(QUALITY_DEBT)
@@ -791,6 +798,7 @@ def gate_companions(_entries: list[Entry], args: argparse.Namespace) -> None:
                     crate_root_inner,
                     run_command,
                     STRICT_CLIPPY_ARGS,
+                    cargo_target_dir,
                 )
                 diagnostics = parse_clippy_diagnostics(result.stdout, crate_root_inner)
                 if result.returncode != 0 and not diagnostics:

--- a/verification/areas/generated_code_quality/source_quality_checks.py
+++ b/verification/areas/generated_code_quality/source_quality_checks.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 import shutil
-import tomllib
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
@@ -114,6 +113,7 @@ def assert_negative_clippy(
     run_command: Callable[..., Any],
     strict_clippy_args: Sequence[str],
     parse_diagnostics: Callable[[str, Path], dict[str, Any]],
+    cargo_target_dir: Path,
 ) -> None:
     crate_root = run_root / "negative-clippy"
     src = crate_root / "src"
@@ -134,6 +134,7 @@ def assert_negative_clippy(
             *strict_clippy_args,
         ],
         check=False,
+        cargo_target_dir=cargo_target_dir,
     )
     if result.returncode == 0:
         raise RuntimeError("negative clippy seed unexpectedly passed")
@@ -149,27 +150,12 @@ def run_strict_clippy(
     crate_root: Path,
     run_command: Callable[..., Any],
     strict_clippy_args: Sequence[str],
+    cargo_target_dir: Path,
 ) -> Any:
     manifest = crate_root / "Cargo.toml"
-    package = tomllib.loads(manifest.read_text(encoding="utf-8")).get("package")
-    package_name = package.get("name") if isinstance(package, dict) else None
-    if not isinstance(package_name, str) or not package_name:
-        raise RuntimeError(f"generated crate has no package name: {manifest}")
-
-    # Cargo does not replay diagnostics for a fresh Clippy unit. Materialized
-    # generated crates are intentionally cached, so remove only the generated
-    # package's artifacts before collecting diagnostics. Dependencies remain in
-    # the shared target directory, while every run observes the same lint set.
-    run_command(
-        [
-            "cargo",
-            "clean",
-            "--manifest-path",
-            str(manifest),
-            "--package",
-            package_name,
-        ]
-    )
+    # Each gate invocation owns a fresh target. Cargo therefore emits the same
+    # diagnostics on every run without cleaning artifacts from another process
+    # that happens to share the materialization cache.
     return run_command(
         [
             "cargo",
@@ -181,6 +167,7 @@ def run_strict_clippy(
             *strict_clippy_args,
         ],
         check=False,
+        cargo_target_dir=cargo_target_dir,
     )
 
 


### PR DESCRIPTION
Closes #3670.

## Scope

- preserve branch-local drop order during shared suffix factoring
- share a conservative discardability policy across Rust IR and syntax cleanup
- preserve private-field initializer effects and nested-module demand
- require typed or compiler-owned structural proof for iterator, length, and `None` rewrites
- consolidate format-capture parsing, including dynamic width and precision captures
- isolate generated Clippy runs in invocation-owned Cargo targets

## Validation

- `cargo test -p sifr_codegen --lib` (1,359 passed)
- `cargo test -p sifr -- --skip test_e2e_pass` (all non-ignored tests passed)
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- demo companion regeneration and freshness check
- HIR maintainability and 900-line file-size guardrails
- generated-code inventory, full panic scan, full rustfmt scan, freshness, required-demo corpus, and required-demo determinism checks
- two concurrent strict Clippy processes used distinct Cargo targets and produced identical diagnostic counts/signatures
- full E2E attempt reached 720/724; its three shared regex build failures identified the `Option<String>` length regression fixed in this SHA, and the unchanged timeout cleanup case was timing-sensitive; a post-fix targeted run of all four affected fixtures passed 4/4

The phase-specific exact-SHA Opus review and the one-shot create-PR/merge gates will follow on the frozen candidate per the phase record.
