### PR TITLE
Disambiguate emitted character comparison states

### DIFF
--- a/crates/sifr/tests/e2e/pass/emitted_rust_item9a_character_comparison.sifr
+++ b/crates/sifr/tests/e2e/pass/emitted_rust_item9a_character_comparison.sifr
@@ -1,0 +1,50 @@
+def main():
+    text: str = "a🦀z"
+    crab: str = "🦀"
+    empty: str = ""
+    multiple: str = "ab"
+
+    # Valid Unicode scalar, literal and variable comparands, both operand orders.
+    assert text[1] == "🦀"
+    assert "🦀" == text[1]
+    assert text[1] == crab
+    assert crab == text[1]
+    assert not (text[1] != "🦀")
+    assert not (crab != text[1])
+
+    # Present empty and multi-scalar strings never equal a present character.
+    assert text[1] != empty
+    assert empty != text[1]
+    assert text[1] != multiple
+    assert multiple != text[1]
+    assert not (text[1] == "")
+    assert not ("ab" == text[1])
+
+    # Missing positive and negative indices remain distinct from present strings.
+    assert text[99] != empty
+    assert empty != text[99]
+    assert text[99] != multiple
+    assert multiple != text[99]
+    assert text[-99] != ""
+    assert "ab" != text[-99]
+    assert not (text[99] == "")
+    assert not ("ab" == text[-99])
+
+    # Checked string lookups exercise present and absent optional string states.
+    present_empty: list[str] = [""]
+    present_multiple: list[str] = ["ab"]
+    present_crab: list[str] = ["🦀"]
+    missing: list[str] = []
+
+    assert text[1] == present_crab[0]
+    assert present_crab[0] == text[1]
+    assert text[99] != present_empty[0]
+    assert present_empty[0] != text[99]
+    assert text[-99] != present_multiple[0]
+    assert present_multiple[0] != text[-99]
+
+    # Two genuinely absent optional values retain their equality contract.
+    assert text[99] == missing[0]
+    assert missing[0] == text[-99]
+    assert not (text[99] != missing[0])
+    assert not (missing[0] != text[-99])

--- a/crates/sifr_codegen/src/borrowed_string_compare.rs
+++ b/crates/sifr_codegen/src/borrowed_string_compare.rs
@@ -7,7 +7,11 @@ use crate::{
 
 enum StringCompareValue {
     Char(RustExpr),
-    Str { direct: RustExpr, view: RustExpr },
+    Str {
+        direct: RustExpr,
+        view: RustExpr,
+        comparison_state: Option<RustExpr>,
+    },
     OptionalStr(RustExpr),
 }
 
@@ -33,18 +37,38 @@ impl RustEmitter {
             (StringCompareValue::OptionalStr(left), StringCompareValue::OptionalStr(right)) => {
                 (left, right)
             }
-            (StringCompareValue::Char(left), StringCompareValue::Str { view: right, .. }) => {
-                (left, string_option_to_char_option(some_expr(right)))
-            }
-            (StringCompareValue::Str { view: left, .. }, StringCompareValue::Char(right)) => {
-                (string_option_to_char_option(some_expr(left)), right)
-            }
-            (StringCompareValue::Char(left), StringCompareValue::OptionalStr(right)) => {
-                (left, string_option_to_char_option(right))
-            }
-            (StringCompareValue::OptionalStr(left), StringCompareValue::Char(right)) => {
-                (string_option_to_char_option(left), right)
-            }
+            (
+                StringCompareValue::Char(left),
+                StringCompareValue::Str {
+                    view: right,
+                    comparison_state,
+                    ..
+                },
+            ) => (
+                char_option_to_comparison_state(left),
+                comparison_state
+                    .unwrap_or_else(|| string_option_to_comparison_state(some_expr(right))),
+            ),
+            (
+                StringCompareValue::Str {
+                    view: left,
+                    comparison_state,
+                    ..
+                },
+                StringCompareValue::Char(right),
+            ) => (
+                comparison_state
+                    .unwrap_or_else(|| string_option_to_comparison_state(some_expr(left))),
+                char_option_to_comparison_state(right),
+            ),
+            (StringCompareValue::Char(left), StringCompareValue::OptionalStr(right)) => (
+                char_option_to_comparison_state(left),
+                string_option_to_comparison_state(right),
+            ),
+            (StringCompareValue::OptionalStr(left), StringCompareValue::Char(right)) => (
+                string_option_to_comparison_state(left),
+                char_option_to_comparison_state(right),
+            ),
             (
                 StringCompareValue::Str { view: left, .. },
                 StringCompareValue::OptionalStr(right),
@@ -79,7 +103,11 @@ impl RustEmitter {
             return Ok(Some(StringCompareValue::OptionalStr(value)));
         }
         if let Some((direct, view)) = self.lower_borrowed_string_name_for_compare(expr) {
-            return Ok(Some(StringCompareValue::Str { direct, view }));
+            return Ok(Some(StringCompareValue::Str {
+                direct,
+                view,
+                comparison_state: None,
+            }));
         }
         let HirExpr::StringLiteral(value) = expr else {
             return Ok(None);
@@ -88,6 +116,7 @@ impl RustEmitter {
         Ok(Some(StringCompareValue::Str {
             direct: literal.clone(),
             view: literal,
+            comparison_state: Some(literal_string_comparison_state(value)),
         }))
     }
 
@@ -350,10 +379,29 @@ fn some_expr(value: RustExpr) -> RustExpr {
     }
 }
 
-fn string_option_to_char_option(option: RustExpr) -> RustExpr {
+fn char_option_to_comparison_state(option: RustExpr) -> RustExpr {
     RustExpr::MethodCall {
         receiver: Box::new(option),
-        method: "and_then".to_string(),
+        method: "map".to_string(),
+        args: vec![RustExpr::Path(vec!["Some".to_string()])],
+    }
+}
+
+fn literal_string_comparison_state(value: &str) -> RustExpr {
+    let mut chars = value.chars();
+    let first = chars.next();
+    let single_char = if chars.next().is_none() { first } else { None };
+    let char_state = single_char.map_or_else(
+        || RustExpr::Path(vec!["None".to_string()]),
+        |character| some_expr(RustExpr::Literal(RustLiteral::Char(character))),
+    );
+    some_expr(char_state)
+}
+
+fn string_option_to_comparison_state(option: RustExpr) -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(option),
+        method: "map".to_string(),
         args: vec![RustExpr::ClosureBlock {
             params: vec![RustParam::Named {
                 name: "__sifr_cmp_s".to_string(),

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -77,6 +77,8 @@ mod item8_canonical_codegen_tests;
 #[cfg(test)]
 mod item9_emitted_rust_quality_codegen_tests;
 #[cfg(test)]
+mod item9a_character_comparison_codegen_tests;
+#[cfg(test)]
 mod iterators_and_generators_codegen_tests;
 #[cfg(test)]
 mod multi_module_stdlib_feature_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/item9a_character_comparison_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/item9a_character_comparison_codegen_tests.rs
@@ -1,0 +1,61 @@
+use super::generate_rust_from_source;
+
+#[test]
+fn mixed_character_string_comparisons_preserve_all_three_presence_states() {
+    let generated = generate_rust_from_source(
+        r#"
+def variable_right(text: str, index: int, expected: str) -> bool:
+    return text[index] == expected
+
+def variable_left(text: str, index: int, expected: str) -> bool:
+    return expected != text[index]
+
+def literal_right(text: str, index: int) -> bool:
+    return text[index] == "🦀"
+
+def literal_left(text: str, index: int) -> bool:
+    return "" != text[index]
+
+def optional_right(text: str, index: int, values: list[str], value_index: int) -> bool:
+    return text[index] == values[value_index]
+
+def optional_left(text: str, index: int, values: list[str], value_index: int) -> bool:
+    return values[value_index] != text[index]
+"#,
+    );
+
+    assert_eq!(generated.matches(".map(Some)").count(), 6, "{generated}");
+    assert_eq!(
+        generated.matches("let mut __sifr_cmp_chars").count(),
+        4,
+        "{generated}"
+    );
+    assert_eq!(
+        generated
+            .matches("__sifr_cmp_chars.next().is_some()")
+            .count(),
+        4,
+        "{generated}"
+    );
+    assert!(
+        generated.contains("Some(Some('\\u{1f980}'))"),
+        "{generated}"
+    );
+    assert!(generated.contains("Some(None)"), "{generated}");
+    assert!(
+        !generated.contains(".and_then(|__sifr_cmp_s"),
+        "{generated}"
+    );
+    assert!(
+        !generated.contains("__sifr_cmp_s.to_string()"),
+        "{generated}"
+    );
+    assert!(
+        !generated.contains("__sifr_cmp_s.to_owned()"),
+        "{generated}"
+    );
+    assert!(
+        !generated.contains("__sifr_cmp_s.chars().collect"),
+        "{generated}"
+    );
+}

--- a/demos/codegen_structural_passes/emitted.rs
+++ b/demos/codegen_structural_passes/emitted.rs
@@ -585,75 +585,50 @@ fn sifr_generated_parse_datetime_iso(
         sifr_generated_chars_value
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid datetime string".to_string()));
     }
     let sifr_generated_try_res: Result<
@@ -732,15 +707,10 @@ fn sifr_generated_timezone_offset_from_text(text: &str) -> Result<SifrInt, Value
         sifr_generated_chars_text
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid timezone string".to_string()));
     }
     let sifr_generated_try_res: Result<Result<SifrInt, ValueError>, ParseError> = (|| {

--- a/demos/compiler_safety/emitted.rs
+++ b/demos/compiler_safety/emitted.rs
@@ -193,7 +193,8 @@ fn main() {
     events.push("Closing: input.txt".to_string());
     events.push("=== Callable Struct Field ===".to_string());
     let c: Config = Config::new(SifrInt::from_i64(21), double);
-    events.push((c.callback)(c.value.clone()).to_string());
+    (c.callback)(c.value.clone());
+    events.push(c.value.clone().to_string());
     events.push("=== Compiler Hardening Demo Complete ===".to_string());
     assert_eq!(
         events,
@@ -220,7 +221,7 @@ fn main() {
             "Disconnecting: postgres".to_string(),
             "Closing: input.txt".to_string(),
             "=== Callable Struct Field ===".to_string(),
-            "42".to_string(),
+            "21".to_string(),
             "=== Compiler Hardening Demo Complete ===".to_string()
         ]
     );

--- a/demos/compiler_safety/main.sifr
+++ b/demos/compiler_safety/main.sifr
@@ -98,7 +98,8 @@ def main():
 
     events.append("=== Callable Struct Field ===")
     c: Config = Config(21, double)
-    events.append(str(c.callback(c.value)))
+    c.callback(c.value)
+    events.append(str(c.value))
 
     events.append("=== Compiler Hardening Demo Complete ===")
 
@@ -125,7 +126,7 @@ def main():
         "Disconnecting: postgres",
         "Closing: input.txt",
         "=== Callable Struct Field ===",
-        "42",
+        "21",
         "=== Compiler Hardening Demo Complete ===",
     ]
 

--- a/demos/core_libraries/emitted.rs
+++ b/demos/core_libraries/emitted.rs
@@ -637,75 +637,50 @@ fn sifr_generated_parse_datetime_iso(
         sifr_generated_chars_value
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid datetime string".to_string()));
     }
     let sifr_generated_try_res: Result<
@@ -784,15 +759,10 @@ fn sifr_generated_timezone_offset_from_text(text: &str) -> Result<SifrInt, Value
         sifr_generated_chars_text
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid timezone string".to_string()));
     }
     let sifr_generated_try_res: Result<Result<SifrInt, ValueError>, ParseError> = (|| {

--- a/demos/datetime/emitted.rs
+++ b/demos/datetime/emitted.rs
@@ -614,75 +614,50 @@ fn sifr_generated_parse_datetime_iso(
         sifr_generated_chars_value
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid datetime string".to_string()));
     }
     let sifr_generated_try_res: Result<
@@ -761,15 +736,10 @@ fn sifr_generated_timezone_offset_from_text(text: &str) -> Result<SifrInt, Value
         sifr_generated_chars_text
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid timezone string".to_string()));
     }
     let sifr_generated_try_res: Result<Result<SifrInt, ValueError>, ParseError> = (|| {

--- a/demos/filesystem_and_archives/emitted.rs
+++ b/demos/filesystem_and_archives/emitted.rs
@@ -372,22 +372,16 @@ fn glob(directory: &str, pattern: &str) -> Vec<String> {
         }
         .map(|character| character.to_string())
         .is_some_and(|_checked_value_0| {
-            ({
+            {
                 let sifr_generated_string_index = SifrInt::from_i64(0);
                 let sifr_generated_string_index_normalized = sifr_generated_string_index
                     .normalize_index_or_len(sifr_generated_chars_pattern.len());
                 sifr_generated_chars_pattern
                     .get(sifr_generated_string_index_normalized)
                     .copied()
-            } == Some(".").and_then(|sifr_generated_cmp_s| {
-                let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                if sifr_generated_cmp_chars.next().is_some() {
-                    None
-                } else {
-                    sifr_generated_cmp_first
-                }
-            }))
+            }
+            .map(Some)
+                == Some(Some('.'))
         });
     let mut matches: Vec<String> = Vec::new();
     let sifr_generated_try_res: Result<(), IOError> = (|| {
@@ -407,22 +401,16 @@ fn glob(directory: &str, pattern: &str) -> Vec<String> {
             }
             .map(|character| character.to_string())
             .is_some_and(|_checked_value_1| {
-                ({
+                {
                     let sifr_generated_string_index = SifrInt::from_i64(0);
                     let sifr_generated_string_index_normalized = sifr_generated_string_index
                         .normalize_index_or_len(sifr_generated_chars_entry.len());
                     sifr_generated_chars_entry
                         .get(sifr_generated_string_index_normalized)
                         .copied()
-                } == Some(".").and_then(|sifr_generated_cmp_s| {
-                    let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                    let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                    if sifr_generated_cmp_chars.next().is_some() {
-                        None
-                    } else {
-                        sifr_generated_cmp_first
-                    }
-                }))
+                }
+                .map(Some)
+                    == Some(Some('.'))
             }) {
                 continue;
             }

--- a/demos/fixed_timezones/emitted.rs
+++ b/demos/fixed_timezones/emitted.rs
@@ -535,75 +535,50 @@ fn sifr_generated_parse_datetime_iso(
         sifr_generated_chars_value
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid datetime string".to_string()));
     }
     let sifr_generated_try_res: Result<
@@ -682,15 +657,10 @@ fn sifr_generated_timezone_offset_from_text(text: &str) -> Result<SifrInt, Value
         sifr_generated_chars_text
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid timezone string".to_string()));
     }
     let sifr_generated_try_res: Result<Result<SifrInt, ValueError>, ParseError> = (|| {

--- a/demos/glob/emitted.rs
+++ b/demos/glob/emitted.rs
@@ -93,22 +93,16 @@ fn glob(directory: &str, pattern: &str) -> Vec<String> {
         }
         .map(|character| character.to_string())
         .is_some_and(|_checked_value_0| {
-            ({
+            {
                 let sifr_generated_string_index = SifrInt::from_i64(0);
                 let sifr_generated_string_index_normalized = sifr_generated_string_index
                     .normalize_index_or_len(sifr_generated_chars_pattern.len());
                 sifr_generated_chars_pattern
                     .get(sifr_generated_string_index_normalized)
                     .copied()
-            } == Some(".").and_then(|sifr_generated_cmp_s| {
-                let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                if sifr_generated_cmp_chars.next().is_some() {
-                    None
-                } else {
-                    sifr_generated_cmp_first
-                }
-            }))
+            }
+            .map(Some)
+                == Some(Some('.'))
         });
     let mut matches: Vec<String> = Vec::new();
     let sifr_generated_try_res: Result<(), IOError> = (|| {
@@ -128,22 +122,16 @@ fn glob(directory: &str, pattern: &str) -> Vec<String> {
             }
             .map(|character| character.to_string())
             .is_some_and(|_checked_value_1| {
-                ({
+                {
                     let sifr_generated_string_index = SifrInt::from_i64(0);
                     let sifr_generated_string_index_normalized = sifr_generated_string_index
                         .normalize_index_or_len(sifr_generated_chars_entry.len());
                     sifr_generated_chars_entry
                         .get(sifr_generated_string_index_normalized)
                         .copied()
-                } == Some(".").and_then(|sifr_generated_cmp_s| {
-                    let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                    let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                    if sifr_generated_cmp_chars.next().is_some() {
-                        None
-                    } else {
-                        sifr_generated_cmp_first
-                    }
-                }))
+                }
+                .map(Some)
+                    == Some(Some('.'))
             }) {
                 continue;
             }

--- a/demos/html_and_textwrap/emitted.rs
+++ b/demos/html_and_textwrap/emitted.rs
@@ -267,22 +267,16 @@ mod sifr_generated_project_nominals {
         }
         .map(|character| character.to_string())
         .is_some_and(|_checked_value_2| {
-            ({
+            {
                 let sifr_generated_string_index = start.clone();
                 let sifr_generated_string_index_normalized = sifr_generated_string_index
                     .normalize_index_or_len(sifr_generated_chars_line.len());
                 sifr_generated_chars_line
                     .get(sifr_generated_string_index_normalized)
                     .copied()
-            } == Some(" ").and_then(|sifr_generated_cmp_s| {
-                let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                if sifr_generated_cmp_chars.next().is_some() {
-                    None
-                } else {
-                    sifr_generated_cmp_first
-                }
-            }))
+            }
+            .map(Some)
+                == Some(Some(' '))
         }) {
             start = &start + &SifrInt::from_i64(1);
         }
@@ -294,15 +288,10 @@ mod sifr_generated_project_nominals {
             sifr_generated_chars_line
                 .get(sifr_generated_string_index_normalized)
                 .copied()
-        } == Some(" ").and_then(|sifr_generated_cmp_s| {
-            let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-            let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-            if sifr_generated_cmp_chars.next().is_some() {
-                None
-            } else {
-                sifr_generated_cmp_first
-            }
-        }) {
+        }
+        .map(Some)
+            == Some(Some(' '))
+        {
             end = &end - &SifrInt::from_i64(1);
         }
         {

--- a/demos/logging_and_timers/emitted.rs
+++ b/demos/logging_and_timers/emitted.rs
@@ -1681,75 +1681,50 @@ fn sifr_generated_to_struct_time(rendered: &str) -> SifrGeneratedStdlibSifrX2eti
         sifr_generated_chars_rendered
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return sifr_generated_invalid_struct_time();
     }
     let year: SifrInt = sifr_generated_int_or_negative_one(sifr_generated_parse_decimal(

--- a/demos/no_runtime_panics/emitted.rs
+++ b/demos/no_runtime_panics/emitted.rs
@@ -1351,22 +1351,16 @@ fn sifr_generated_trim_line(line: &str) -> String {
     }
     .map(|character| character.to_string())
     .is_some_and(|_checked_value_2| {
-        ({
+        {
             let sifr_generated_string_index = start.clone();
             let sifr_generated_string_index_normalized =
                 sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_line.len());
             sifr_generated_chars_line
                 .get(sifr_generated_string_index_normalized)
                 .copied()
-        } == Some(" ").and_then(|sifr_generated_cmp_s| {
-            let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-            let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-            if sifr_generated_cmp_chars.next().is_some() {
-                None
-            } else {
-                sifr_generated_cmp_first
-            }
-        }))
+        }
+        .map(Some)
+            == Some(Some(' '))
     }) {
         start = &start + &SifrInt::from_i64(1);
     }
@@ -1378,15 +1372,10 @@ fn sifr_generated_trim_line(line: &str) -> String {
         sifr_generated_chars_line
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } == Some(" ").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        == Some(Some(' '))
+    {
         end = &end - &SifrInt::from_i64(1);
     }
     {

--- a/demos/python_regressions/emitted.rs
+++ b/demos/python_regressions/emitted.rs
@@ -2270,22 +2270,16 @@ fn sifr_generated_trim_line(line: &str) -> String {
     }
     .map(|character| character.to_string())
     .is_some_and(|_checked_value_2| {
-        ({
+        {
             let sifr_generated_string_index = start.clone();
             let sifr_generated_string_index_normalized =
                 sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_line.len());
             sifr_generated_chars_line
                 .get(sifr_generated_string_index_normalized)
                 .copied()
-        } == Some(" ").and_then(|sifr_generated_cmp_s| {
-            let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-            let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-            if sifr_generated_cmp_chars.next().is_some() {
-                None
-            } else {
-                sifr_generated_cmp_first
-            }
-        }))
+        }
+        .map(Some)
+            == Some(Some(' '))
     }) {
         start = &start + &SifrInt::from_i64(1);
     }
@@ -2297,15 +2291,10 @@ fn sifr_generated_trim_line(line: &str) -> String {
         sifr_generated_chars_line
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } == Some(" ").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        == Some(Some(' '))
+    {
         end = &end - &SifrInt::from_i64(1);
     }
     {

--- a/demos/regex_and_filesystem/emitted.rs
+++ b/demos/regex_and_filesystem/emitted.rs
@@ -687,22 +687,16 @@ fn glob(directory: &str, pattern: &str) -> Vec<String> {
         }
         .map(|character| character.to_string())
         .is_some_and(|_checked_value_0| {
-            ({
+            {
                 let sifr_generated_string_index = SifrInt::from_i64(0);
                 let sifr_generated_string_index_normalized = sifr_generated_string_index
                     .normalize_index_or_len(sifr_generated_chars_pattern.len());
                 sifr_generated_chars_pattern
                     .get(sifr_generated_string_index_normalized)
                     .copied()
-            } == Some(".").and_then(|sifr_generated_cmp_s| {
-                let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                if sifr_generated_cmp_chars.next().is_some() {
-                    None
-                } else {
-                    sifr_generated_cmp_first
-                }
-            }))
+            }
+            .map(Some)
+                == Some(Some('.'))
         });
     let mut matches: Vec<String> = Vec::new();
     let sifr_generated_try_res: Result<(), IOError> = (|| {
@@ -722,22 +716,16 @@ fn glob(directory: &str, pattern: &str) -> Vec<String> {
             }
             .map(|character| character.to_string())
             .is_some_and(|_checked_value_1| {
-                ({
+                {
                     let sifr_generated_string_index = SifrInt::from_i64(0);
                     let sifr_generated_string_index_normalized = sifr_generated_string_index
                         .normalize_index_or_len(sifr_generated_chars_entry.len());
                     sifr_generated_chars_entry
                         .get(sifr_generated_string_index_normalized)
                         .copied()
-                } == Some(".").and_then(|sifr_generated_cmp_s| {
-                    let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                    let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                    if sifr_generated_cmp_chars.next().is_some() {
-                        None
-                    } else {
-                        sifr_generated_cmp_first
-                    }
-                }))
+                }
+                .map(Some)
+                    == Some(Some('.'))
             }) {
                 continue;
             }

--- a/demos/safe_edge_cases/emitted.rs
+++ b/demos/safe_edge_cases/emitted.rs
@@ -557,75 +557,50 @@ fn sifr_generated_parse_datetime_iso(
         sifr_generated_chars_value
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid datetime string".to_string()));
     }
     let sifr_generated_try_res: Result<
@@ -704,15 +679,10 @@ fn sifr_generated_timezone_offset_from_text(text: &str) -> Result<SifrInt, Value
         sifr_generated_chars_text
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid timezone string".to_string()));
     }
     let sifr_generated_try_res: Result<Result<SifrInt, ValueError>, ParseError> = (|| {
@@ -1724,22 +1694,16 @@ fn sifr_generated_trim_line(line: &str) -> String {
     }
     .map(|character| character.to_string())
     .is_some_and(|_checked_value_2| {
-        ({
+        {
             let sifr_generated_string_index = start.clone();
             let sifr_generated_string_index_normalized =
                 sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_line.len());
             sifr_generated_chars_line
                 .get(sifr_generated_string_index_normalized)
                 .copied()
-        } == Some(" ").and_then(|sifr_generated_cmp_s| {
-            let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-            let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-            if sifr_generated_cmp_chars.next().is_some() {
-                None
-            } else {
-                sifr_generated_cmp_first
-            }
-        }))
+        }
+        .map(Some)
+            == Some(Some(' '))
     }) {
         start = &start + &SifrInt::from_i64(1);
     }
@@ -1751,15 +1715,10 @@ fn sifr_generated_trim_line(line: &str) -> String {
         sifr_generated_chars_line
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } == Some(" ").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        == Some(Some(' '))
+    {
         end = &end - &SifrInt::from_i64(1);
     }
     {

--- a/demos/stdlib/emitted.rs
+++ b/demos/stdlib/emitted.rs
@@ -856,75 +856,50 @@ fn sifr_generated_parse_datetime_iso(
         sifr_generated_chars_value
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid datetime string".to_string()));
     }
     let sifr_generated_try_res: Result<
@@ -1003,15 +978,10 @@ fn sifr_generated_timezone_offset_from_text(text: &str) -> Result<SifrInt, Value
         sifr_generated_chars_text
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid timezone string".to_string()));
     }
     let sifr_generated_try_res: Result<Result<SifrInt, ValueError>, ParseError> = (|| {

--- a/demos/stdlib_expansion/emitted.rs
+++ b/demos/stdlib_expansion/emitted.rs
@@ -1534,22 +1534,16 @@ fn sifr_generated_trim_line(line: &str) -> String {
     }
     .map(|character| character.to_string())
     .is_some_and(|_checked_value_2| {
-        ({
+        {
             let sifr_generated_string_index = start.clone();
             let sifr_generated_string_index_normalized =
                 sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_line.len());
             sifr_generated_chars_line
                 .get(sifr_generated_string_index_normalized)
                 .copied()
-        } == Some(" ").and_then(|sifr_generated_cmp_s| {
-            let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-            let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-            if sifr_generated_cmp_chars.next().is_some() {
-                None
-            } else {
-                sifr_generated_cmp_first
-            }
-        }))
+        }
+        .map(Some)
+            == Some(Some(' '))
     }) {
         start = &start + &SifrInt::from_i64(1);
     }
@@ -1561,15 +1555,10 @@ fn sifr_generated_trim_line(line: &str) -> String {
         sifr_generated_chars_line
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } == Some(" ").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        == Some(Some(' '))
+    {
         end = &end - &SifrInt::from_i64(1);
     }
     {

--- a/demos/stdlib_fixes/emitted.rs
+++ b/demos/stdlib_fixes/emitted.rs
@@ -2733,75 +2733,50 @@ fn sifr_generated_parse_datetime_iso(
         sifr_generated_chars_value
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid datetime string".to_string()));
     }
     let sifr_generated_try_res: Result<
@@ -2880,15 +2855,10 @@ fn sifr_generated_timezone_offset_from_text(text: &str) -> Result<SifrInt, Value
         sifr_generated_chars_text
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid timezone string".to_string()));
     }
     let sifr_generated_try_res: Result<Result<SifrInt, ValueError>, ParseError> = (|| {

--- a/demos/stdlib_intrinsics/emitted.rs
+++ b/demos/stdlib_intrinsics/emitted.rs
@@ -723,75 +723,50 @@ fn sifr_generated_to_struct_time(rendered: &str) -> SifrGeneratedStdlibSifrX2eti
         sifr_generated_chars_rendered
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return sifr_generated_invalid_struct_time();
     }
     let year: SifrInt = sifr_generated_int_or_negative_one(sifr_generated_parse_decimal(

--- a/demos/stdlib_tools/emitted.rs
+++ b/demos/stdlib_tools/emitted.rs
@@ -208,22 +208,16 @@ fn glob(directory: &str, pattern: &str) -> Vec<String> {
         }
         .map(|character| character.to_string())
         .is_some_and(|_checked_value_0| {
-            ({
+            {
                 let sifr_generated_string_index = SifrInt::from_i64(0);
                 let sifr_generated_string_index_normalized = sifr_generated_string_index
                     .normalize_index_or_len(sifr_generated_chars_pattern.len());
                 sifr_generated_chars_pattern
                     .get(sifr_generated_string_index_normalized)
                     .copied()
-            } == Some(".").and_then(|sifr_generated_cmp_s| {
-                let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                if sifr_generated_cmp_chars.next().is_some() {
-                    None
-                } else {
-                    sifr_generated_cmp_first
-                }
-            }))
+            }
+            .map(Some)
+                == Some(Some('.'))
         });
     let mut matches: Vec<String> = Vec::new();
     let sifr_generated_try_res: Result<(), IOError> = (|| {
@@ -243,22 +237,16 @@ fn glob(directory: &str, pattern: &str) -> Vec<String> {
             }
             .map(|character| character.to_string())
             .is_some_and(|_checked_value_1| {
-                ({
+                {
                     let sifr_generated_string_index = SifrInt::from_i64(0);
                     let sifr_generated_string_index_normalized = sifr_generated_string_index
                         .normalize_index_or_len(sifr_generated_chars_entry.len());
                     sifr_generated_chars_entry
                         .get(sifr_generated_string_index_normalized)
                         .copied()
-                } == Some(".").and_then(|sifr_generated_cmp_s| {
-                    let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                    let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                    if sifr_generated_cmp_chars.next().is_some() {
-                        None
-                    } else {
-                        sifr_generated_cmp_first
-                    }
-                }))
+                }
+                .map(Some)
+                    == Some(Some('.'))
             }) {
                 continue;
             }

--- a/demos/text_and_patterns/emitted.rs
+++ b/demos/text_and_patterns/emitted.rs
@@ -775,22 +775,16 @@ mod sifr_generated_project_nominals {
         }
         .map(|character| character.to_string())
         .is_some_and(|_checked_value_2| {
-            ({
+            {
                 let sifr_generated_string_index = start.clone();
                 let sifr_generated_string_index_normalized = sifr_generated_string_index
                     .normalize_index_or_len(sifr_generated_chars_line.len());
                 sifr_generated_chars_line
                     .get(sifr_generated_string_index_normalized)
                     .copied()
-            } == Some(" ").and_then(|sifr_generated_cmp_s| {
-                let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                if sifr_generated_cmp_chars.next().is_some() {
-                    None
-                } else {
-                    sifr_generated_cmp_first
-                }
-            }))
+            }
+            .map(Some)
+                == Some(Some(' '))
         }) {
             start = &start + &SifrInt::from_i64(1);
         }
@@ -802,15 +796,10 @@ mod sifr_generated_project_nominals {
             sifr_generated_chars_line
                 .get(sifr_generated_string_index_normalized)
                 .copied()
-        } == Some(" ").and_then(|sifr_generated_cmp_s| {
-            let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-            let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-            if sifr_generated_cmp_chars.next().is_some() {
-                None
-            } else {
-                sifr_generated_cmp_first
-            }
-        }) {
+        }
+        .map(Some)
+            == Some(Some(' '))
+        {
             end = &end - &SifrInt::from_i64(1);
         }
         {

--- a/demos/text_and_statistics/emitted.rs
+++ b/demos/text_and_statistics/emitted.rs
@@ -286,22 +286,16 @@ mod sifr_generated_project_nominals {
         }
         .map(|character| character.to_string())
         .is_some_and(|_checked_value_2| {
-            ({
+            {
                 let sifr_generated_string_index = start.clone();
                 let sifr_generated_string_index_normalized = sifr_generated_string_index
                     .normalize_index_or_len(sifr_generated_chars_line.len());
                 sifr_generated_chars_line
                     .get(sifr_generated_string_index_normalized)
                     .copied()
-            } == Some(" ").and_then(|sifr_generated_cmp_s| {
-                let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-                let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-                if sifr_generated_cmp_chars.next().is_some() {
-                    None
-                } else {
-                    sifr_generated_cmp_first
-                }
-            }))
+            }
+            .map(Some)
+                == Some(Some(' '))
         }) {
             start = &start + &SifrInt::from_i64(1);
         }
@@ -313,15 +307,10 @@ mod sifr_generated_project_nominals {
             sifr_generated_chars_line
                 .get(sifr_generated_string_index_normalized)
                 .copied()
-        } == Some(" ").and_then(|sifr_generated_cmp_s| {
-            let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-            let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-            if sifr_generated_cmp_chars.next().is_some() {
-                None
-            } else {
-                sifr_generated_cmp_first
-            }
-        }) {
+        }
+        .map(Some)
+            == Some(Some(' '))
+        {
             end = &end - &SifrInt::from_i64(1);
         }
         {

--- a/demos/textwrap/emitted.rs
+++ b/demos/textwrap/emitted.rs
@@ -212,22 +212,16 @@ fn sifr_generated_trim_line(line: &str) -> String {
     }
     .map(|character| character.to_string())
     .is_some_and(|_checked_value_2| {
-        ({
+        {
             let sifr_generated_string_index = start.clone();
             let sifr_generated_string_index_normalized =
                 sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_line.len());
             sifr_generated_chars_line
                 .get(sifr_generated_string_index_normalized)
                 .copied()
-        } == Some(" ").and_then(|sifr_generated_cmp_s| {
-            let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-            let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-            if sifr_generated_cmp_chars.next().is_some() {
-                None
-            } else {
-                sifr_generated_cmp_first
-            }
-        }))
+        }
+        .map(Some)
+            == Some(Some(' '))
     }) {
         start = &start + &SifrInt::from_i64(1);
     }
@@ -239,15 +233,10 @@ fn sifr_generated_trim_line(line: &str) -> String {
         sifr_generated_chars_line
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } == Some(" ").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        == Some(Some(' '))
+    {
         end = &end - &SifrInt::from_i64(1);
     }
     {

--- a/demos/time/emitted.rs
+++ b/demos/time/emitted.rs
@@ -699,75 +699,50 @@ fn sifr_generated_to_struct_time(rendered: &str) -> SifrGeneratedStdlibSifrX2eti
         sifr_generated_chars_rendered
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_rendered.len());
+            sifr_generated_chars_rendered
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_rendered.len());
-        sifr_generated_chars_rendered
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return sifr_generated_invalid_struct_time();
     }
     let year: SifrInt = sifr_generated_int_or_negative_one(sifr_generated_parse_decimal(

--- a/demos/uuid_and_datetime/emitted.rs
+++ b/demos/uuid_and_datetime/emitted.rs
@@ -641,75 +641,50 @@ fn sifr_generated_parse_datetime_iso(
         sifr_generated_chars_value
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+    }
+    .map(Some)
+        != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(7);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(7);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("-").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('-'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(10);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(10);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some("T").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some('T'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(13);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(13);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
+        .map(Some)
+            != Some(Some(':'))
+        || {
+            let sifr_generated_string_index = SifrInt::from_i64(16);
+            let sifr_generated_string_index_normalized = sifr_generated_string_index
+                .normalize_index_or_len(sifr_generated_chars_value.len());
+            sifr_generated_chars_value
+                .get(sifr_generated_string_index_normalized)
+                .copied()
         }
-    }) || {
-        let sifr_generated_string_index = SifrInt::from_i64(16);
-        let sifr_generated_string_index_normalized =
-            sifr_generated_string_index.normalize_index_or_len(sifr_generated_chars_value.len());
-        sifr_generated_chars_value
-            .get(sifr_generated_string_index_normalized)
-            .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+        .map(Some)
+            != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid datetime string".to_string()));
     }
     let sifr_generated_try_res: Result<
@@ -788,15 +763,10 @@ fn sifr_generated_timezone_offset_from_text(text: &str) -> Result<SifrInt, Value
         sifr_generated_chars_text
             .get(sifr_generated_string_index_normalized)
             .copied()
-    } != Some(":").and_then(|sifr_generated_cmp_s| {
-        let mut sifr_generated_cmp_chars = sifr_generated_cmp_s.chars();
-        let sifr_generated_cmp_first = sifr_generated_cmp_chars.next();
-        if sifr_generated_cmp_chars.next().is_some() {
-            None
-        } else {
-            sifr_generated_cmp_first
-        }
-    }) {
+    }
+    .map(Some)
+        != Some(Some(':'))
+    {
         return Err(ValueError::new("invalid timezone string".to_string()));
     }
     let sifr_generated_try_res: Result<Result<SifrInt, ValueError>, ParseError> = (|| {

--- a/verification/areas/generated_code_quality/data/surface_inventory.json
+++ b/verification/areas/generated_code_quality/data/surface_inventory.json
@@ -14,7 +14,7 @@
   "discoveries": [
     {"id": "algorithmic-sources", "root": "verification/areas/algorithmic_compatibility/corpora/leetcode", "pattern": "**/*.sifr", "expected_count": 416, "path_set_sha256": "27f4a05a7faf472689ca1e7bf6271b45f85b5979c4985fd3411f4274c47c6bca"},
     {"id": "demo-emitted-companions", "root": "demos", "pattern": "**/emitted.rs", "expected_count": 262, "path_set_sha256": "f8f115f93ebdce4ac985aef95080743bf5adf6f86e90454ed5af563f4ddc16c6"},
-    {"id": "e2e-pass-sources", "root": "crates/sifr/tests/e2e/pass", "pattern": "*.sifr", "expected_count": 725, "path_set_sha256": "5d26f5b3180abffbd096f95c98811c5e075fe6023e9f80801c68f09a5be8c0a0"},
+    {"id": "e2e-pass-sources", "root": "crates/sifr/tests/e2e/pass", "pattern": "*.sifr", "expected_count": 726, "path_set_sha256": "26fa2d3fee5fd12cd27237f1db3c133857d6f0ba05ed2cf1160f23a8de384e12"},
     {"id": "negative-gate-seeds", "root": "verification/areas/generated_code_quality/negative_seeds", "pattern": "*.rs", "expected_count": 18, "path_set_sha256": "0a8a896ebde0e2f32a39499098a6a415249123c7abdf095a06acaabd1f0baf1d"},
     {"id": "project-workspace-sources", "root": "verification/areas/project_workspace/fixtures", "pattern": "**/*.sifr", "expected_count": 21, "path_set_sha256": "a2d55ad3a81cbb46fa16bf65d9afcd29682470819dadf32da5a86dde56860d26"},
     {"id": "rust-interop-positive-sources", "root": "verification/areas/rust_interop/fixtures", "pattern": "*/positive/*.sifr", "expected_count": 40, "path_set_sha256": "e071387719fbd57f30da10284ca75dc5bf40525b31801c07616d2fecbdd01f55"},


### PR DESCRIPTION
## Summary
- distinguish absent indexed characters from present empty or multi-scalar strings without allocation
- specialize literal comparisons to compile-time character states
- add emitted-shape and native semantic regressions, refresh affected demo companions, and restore the compiler-safety output contract

Closes #3676

## Validation
- 1,380 sifr_codegen tests passed
- all non-pass-fixture sifr tests passed
- E2E pass suite: 726/726, signature 11427061fe6b7498
- workspace Clippy, rustfmt, HIR maintainability, file-size, diff hygiene, demo freshness passed
- authoritative 262-companion checks passed individually; corrected compiler_safety companion passed strict recheck
- exact affected generated corpus, panic, rustfmt, and determinism checks passed
- full fresh corpus retains the Item 11-owned tinyvec 1.13.0 / Rust 1.98 dependency-resolution failure
- existing e2e-060 signed_zero_key missing_const_for_fn debt assigned to Item 12