### PR TITLE
Preserve module-scoped builtin error identities

### DIFF
--- a/crates/sifr_codegen/src/builtin_errors.rs
+++ b/crates/sifr_codegen/src/builtin_errors.rs
@@ -37,3 +37,9 @@ pub(crate) const BUILTIN_ERROR_CLASSES: &[&str] = &[
     "WorkerRuntimeError",
     "WorkerError",
 ];
+
+pub(crate) fn builtin_error_identity(name: &str) -> Option<String> {
+    BUILTIN_ERROR_CLASSES
+        .contains(&name)
+        .then(|| format!("sifr.builtin.{name}"))
+}

--- a/crates/sifr_codegen/src/generated_rust_canonicalizer/project_support_pruning.rs
+++ b/crates/sifr_codegen/src/generated_rust_canonicalizer/project_support_pruning.rs
@@ -50,7 +50,7 @@ pub(crate) fn prune_generated_support_for_consumers(
         consumer_roots.extend(crate::stdlib_filter::rust_source_required_trait_names(
             source,
             support_source,
-        ));
+        )?);
         let file = syn::parse_file(source)
             .map_err(|error| format!("failed to parse generated support consumer: {error}"))?;
         consumer_items.extend(file.items);

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -5,7 +5,7 @@
 mod lib_modules_and_codegen;
 pub use lib_modules_and_codegen::*;
 mod builtin_errors;
-pub(crate) use builtin_errors::BUILTIN_ERROR_CLASSES;
+pub(crate) use builtin_errors::{BUILTIN_ERROR_CLASSES, builtin_error_identity};
 mod discardability;
 mod generated_dependency_metadata;
 mod generated_rust_canonicalizer;

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -75,6 +75,8 @@ mod generic_inheritance_codegen_tests;
 #[cfg(test)]
 mod item10_support_assembly_codegen_tests;
 #[cfg(test)]
+mod item10a_error_identity_codegen_tests;
+#[cfg(test)]
 mod item8_canonical_codegen_tests;
 #[cfg(test)]
 mod item9_emitted_rust_quality_codegen_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/item10a_error_identity_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/item10a_error_identity_codegen_tests.rs
@@ -1,0 +1,24 @@
+use super::*;
+
+#[test]
+fn item10a_single_file_user_error_shadow_keeps_one_local_identity() {
+    let generated = generate_rust_from_source(
+        r#"
+class ValueError(Error):
+    message: str
+
+def message() -> str:
+    try:
+        raise ValueError("local")
+    except ValueError as error:
+        return error.message
+"#,
+    );
+
+    assert_eq!(
+        generated.matches("struct ValueError").count(),
+        1,
+        "{generated}"
+    );
+    assert!(generated.contains("Err(ValueError::new(\"local\".to_string()))"));
+}

--- a/crates/sifr_codegen/src/lib_codegen_tests/item10a_error_identity_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/item10a_error_identity_codegen_tests.rs
@@ -6,12 +6,17 @@ fn item10a_single_file_user_error_shadow_keeps_one_local_identity() {
         r#"
 class ValueError(Error):
     message: str
+    detail: str
+
+    def __init__(self, message: str, detail: str):
+        self.message = message
+        self.detail = detail
 
 def message() -> str:
     try:
-        raise ValueError("local")
+        raise ValueError("local", "single-file-detail")
     except ValueError as error:
-        return error.message
+        return error.detail
 "#,
     );
 
@@ -20,5 +25,6 @@ def message() -> str:
         1,
         "{generated}"
     );
-    assert!(generated.contains("Err(ValueError::new(\"local\".to_string()))"));
+    assert!(generated.contains("detail: String"), "{generated}");
+    assert!(generated.contains("\"single-file-detail\".to_string()"));
 }

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -372,7 +372,7 @@ pub fn generate_rust_multi_with_metadata(
         let union_imports =
             render_project_union_imports(module_name, &used_unions, &crate_root_modules);
         let module_support_demand = codegen_result.support_demand.clone();
-        project_support_demand.merge(&module_support_demand);
+        project_support_demand.merge_project_module(&module_support_demand);
         module_support_demands.insert((*module_name).to_string(), module_support_demand);
         let mut rust_source = relocate_project_stdlib_nominals(
             &codegen_result.module_body_source,
@@ -460,7 +460,8 @@ pub fn generate_rust_multi_with_metadata(
         let prelude_support_traits = crate::stdlib_filter::rust_source_required_trait_names(
             &project_union_prelude,
             &visible_support,
-        );
+        )
+        .unwrap_or_else(|error| panic!("invalid generated project support trait layout: {error}"));
         if !prelude_support_refs.is_empty() || !prelude_support_traits.is_empty() {
             project_union_prelude =
                 crate::import_generated_support_in_project_nominals(&project_union_prelude)
@@ -475,7 +476,10 @@ pub fn generate_rust_multi_with_metadata(
             let body_support_refs =
                 crate::stdlib_filter::rust_source_referenced_item_names(source, &support_names);
             let body_support_traits =
-                crate::stdlib_filter::rust_source_required_trait_names(source, &visible_support);
+                crate::stdlib_filter::rust_source_required_trait_names(source, &visible_support)
+                    .unwrap_or_else(|error| {
+                        panic!("invalid generated project support trait layout: {error}")
+                    });
             if module_needs_support
                 && (!body_support_refs.is_empty() || !body_support_traits.is_empty())
             {

--- a/crates/sifr_codegen/src/lib_test_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_test_project_codegen.rs
@@ -119,7 +119,7 @@ pub fn generate_rust_test_project_with_metadata(
         .collect::<Vec<_>>()
         .join("\n");
         let module_demand = generated.support_demand.clone();
-        project_support_demand.merge(&module_demand);
+        project_support_demand.merge_project_module(&module_demand);
         support_module_demands.insert((*module_name).to_string(), module_demand);
         let source = if imports.is_empty() {
             generated.module_body_source
@@ -159,7 +159,7 @@ pub fn generate_rust_test_project_with_metadata(
             SupportEmission::Deferred,
         );
         let module_demand = generated.support_demand.clone();
-        project_support_demand.merge(&module_demand);
+        project_support_demand.merge_project_module(&module_demand);
         test_module_demands.insert((*module_name).to_string(), module_demand);
         test_rust_files.insert((*module_name).to_string(), generated.module_body_source);
         used_stdlib_modules.extend(generated.used_stdlib_modules);
@@ -224,7 +224,10 @@ pub fn generate_rust_test_project_with_metadata(
         let prelude_support_traits = crate::stdlib_filter::rust_source_required_trait_names(
             &project_union_prelude,
             &visible_support,
-        );
+        )
+        .unwrap_or_else(|error| {
+            panic!("invalid generated test-project support trait layout: {error}")
+        });
         if !prelude_support_refs.is_empty() || !prelude_support_traits.is_empty() {
             project_union_prelude =
                 crate::import_generated_support_in_project_nominals(&project_union_prelude)
@@ -238,7 +241,10 @@ pub fn generate_rust_test_project_with_metadata(
             let body_support_refs =
                 crate::stdlib_filter::rust_source_referenced_item_names(source, &support_names);
             let body_support_traits =
-                crate::stdlib_filter::rust_source_required_trait_names(source, &visible_support);
+                crate::stdlib_filter::rust_source_required_trait_names(source, &visible_support)
+                    .unwrap_or_else(|error| {
+                        panic!("invalid generated test-project support trait layout: {error}")
+                    });
             if support_module_demands
                 .get(module_name)
                 .is_some_and(ModuleSupportDemand::needs_support)
@@ -254,7 +260,10 @@ pub fn generate_rust_test_project_with_metadata(
             let body_support_refs =
                 crate::stdlib_filter::rust_source_referenced_item_names(source, &support_names);
             let body_support_traits =
-                crate::stdlib_filter::rust_source_required_trait_names(source, &visible_support);
+                crate::stdlib_filter::rust_source_required_trait_names(source, &visible_support)
+                    .unwrap_or_else(|error| {
+                        panic!("invalid generated test-project support trait layout: {error}")
+                    });
             test_module_demands
                 .get(module_name)
                 .is_some_and(ModuleSupportDemand::needs_support)

--- a/crates/sifr_codegen/src/project_stdlib_nominals.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals.rs
@@ -40,6 +40,12 @@ impl ProjectNominalRegistry {
         self.shared_rust_names.remove(&rust_name);
         self.crate_root_rust_names.insert(rust_name);
     }
+
+    fn register_builtin(&mut self, name: &str, rust_name: String) {
+        let identity = crate::builtin_error_identity(name)
+            .expect("project builtin registration requires a builtin error name");
+        self.register_shared(identity, rust_name);
+    }
 }
 
 impl ProjectStdlibNominalPlan {
@@ -115,6 +121,12 @@ pub(crate) fn project_stdlib_nominal_plan(
     }
     for (_, module) in modules {
         collect_module_nominals(module, &mut declarations, &mut builtin_types);
+        let local_error_names = module
+            .classes
+            .iter()
+            .filter(|class| class.is_error_type)
+            .map(|class| class.name.as_str())
+            .collect::<HashSet<_>>();
         let intrinsic_functions =
             crate::error_refs::collect_module_intrinsic_function_names(module);
         for name in crate::error_refs::collect_referenced_builtin_error_classes(
@@ -124,7 +136,9 @@ pub(crate) fn project_stdlib_nominal_plan(
             false,
             crate::BUILTIN_ERROR_CLASSES,
         ) {
-            if sifr_type_system::io_error_kind(&name).is_some() {
+            if local_error_names.contains(name.as_str())
+                || sifr_type_system::io_error_kind(&name).is_some()
+            {
                 continue;
             }
             builtin_types
@@ -154,6 +168,10 @@ pub(crate) fn project_stdlib_nominal_plan(
     }
     for (name, ty) in builtin_types {
         let rust_name = class_rust_name(None, &name);
+        debug_assert!(
+            matches!(&ty, Type::Class { identity, .. } if is_compiler_builtin_error(identity.as_deref(), &name)),
+            "project builtin registry accepted a non-builtin nominal identity"
+        );
         if let Type::Class {
             identity: Some(identity),
             ..
@@ -161,7 +179,7 @@ pub(crate) fn project_stdlib_nominal_plan(
         {
             registry.register_shared(identity.clone(), rust_name.clone());
         }
-        registry.register_shared(name, rust_name);
+        registry.register_builtin(&name, rust_name);
     }
     for identity in SHARED_MODULE_CRATE_ROOT_NOMINAL_IDENTITIES {
         if let Some((_, name)) = identity.rsplit_once('.') {
@@ -308,7 +326,7 @@ fn register_emitted_builtin_nominals(shared_source: &str, registry: &mut Project
         if sifr_type_system::io_error_kind(name).is_some() || !defined_names.contains(*name) {
             continue;
         }
-        registry.register_shared((*name).to_string(), class_rust_name(None, name));
+        registry.register_builtin(name, class_rust_name(None, name));
     }
 }
 
@@ -704,11 +722,43 @@ mod tests {
 
         assert!(registry.shared_rust_names.contains("ParseError"));
         assert_eq!(
-            registry.rust_paths.get("ParseError"),
+            registry.rust_paths.get("sifr.builtin.ParseError"),
             Some(&"crate::__sifr_project_nominals::ParseError".to_string())
         );
+        assert!(!registry.rust_paths.contains_key("ParseError"));
         assert!(!registry.shared_rust_names.contains("FileNotFoundError"));
         assert!(!registry.rust_paths.contains_key("FileNotFoundError"));
+    }
+
+    #[test]
+    fn item10a_builtin_registry_identity_does_not_replace_a_module_qualified_shadow() {
+        let mut paths = HashMap::from([
+            (
+                "shadow.ValueError".to_string(),
+                "crate::shadow::ValueError".to_string(),
+            ),
+            (
+                "ValueError".to_string(),
+                "crate::shadow::ValueError".to_string(),
+            ),
+        ]);
+        let mut registry = ProjectNominalRegistry::default();
+        registry.register_builtin("ValueError", "ValueError".to_string());
+
+        paths.extend(registry.rust_paths);
+
+        assert_eq!(
+            paths.get("shadow.ValueError"),
+            Some(&"crate::shadow::ValueError".to_string())
+        );
+        assert_eq!(
+            paths.get("ValueError"),
+            Some(&"crate::shadow::ValueError".to_string())
+        );
+        assert_eq!(
+            paths.get("sifr.builtin.ValueError"),
+            Some(&"crate::__sifr_project_nominals::ValueError".to_string())
+        );
     }
 
     #[test]

--- a/crates/sifr_codegen/src/project_stdlib_nominals.rs
+++ b/crates/sifr_codegen/src/project_stdlib_nominals.rs
@@ -89,7 +89,11 @@ pub(crate) fn relocate_project_stdlib_nominals_owned_by(
     if owned_names.is_empty() {
         return source.to_string();
     }
-    let names = owned_names.iter().map(String::as_str).collect();
+    let relocatable_names = owned_names
+        .iter()
+        .filter(|name| !local_class_rust_names.contains(*name))
+        .collect::<HashSet<_>>();
+    let names = relocatable_names.iter().map(|name| name.as_str()).collect();
     let stripped = strip_relocated_rust_items_by_name(source, &names, local_class_rust_names);
     if crate_root_modules.contains(module_name) {
         return stripped;
@@ -98,6 +102,9 @@ pub(crate) fn relocate_project_stdlib_nominals_owned_by(
     ordered_names.sort();
     let mut imports = String::new();
     for name in ordered_names {
+        if local_class_rust_names.contains(name) {
+            continue;
+        }
         if !rust_source_references_item_name(&stripped, name) {
             continue;
         }
@@ -759,6 +766,17 @@ mod tests {
             paths.get("sifr.builtin.ValueError"),
             Some(&"crate::__sifr_project_nominals::ValueError".to_string())
         );
+
+        let relocated = relocate_project_stdlib_nominals_owned_by(
+            "struct ValueError { message: String, detail: String }\nfn detail(error: ValueError) -> String { error.detail }\n",
+            "shadow",
+            &HashSet::from(["main"]),
+            &HashSet::from(["ValueError".to_string()]),
+            &HashSet::from(["ValueError".to_string()]),
+        );
+        assert!(relocated.contains("struct ValueError"), "{relocated}");
+        assert!(relocated.contains("error.detail"), "{relocated}");
+        assert!(!relocated.contains("use crate::ValueError"), "{relocated}");
     }
 
     #[test]

--- a/crates/sifr_codegen/src/stdlib_filter/external_refs.rs
+++ b/crates/sifr_codegen/src/stdlib_filter/external_refs.rs
@@ -69,37 +69,62 @@ impl<'ast> Visit<'ast> for ExternalItemRefCollector<'_> {
 pub(crate) fn rust_source_required_trait_names(
     consumer_source: &str,
     support_source: &str,
-) -> HashSet<String> {
-    let (Ok(consumer), Ok(support)) = (
-        syn::parse_file(consumer_source),
-        syn::parse_file(support_source),
-    ) else {
-        return HashSet::new();
-    };
+) -> Result<HashSet<String>, String> {
+    let consumer = syn::parse_file(consumer_source)
+        .map_err(|error| format!("failed to parse generated support consumer: {error}"))?;
+    let support = syn::parse_file(support_source).map_err(|error| {
+        format!("failed to parse generated support while collecting traits: {error}")
+    })?;
     let mut method_traits = HashMap::<String, HashSet<String>>::new();
-    for item in support.items {
-        let syn::Item::Trait(trait_) = item else {
-            continue;
-        };
-        let trait_name = trait_.ident.to_string();
-        for item in trait_.items {
-            if let syn::TraitItem::Fn(method) = item {
-                method_traits
-                    .entry(method.sig.ident.to_string())
-                    .or_default()
-                    .insert(trait_name.clone());
+    for item in &support.items {
+        match item {
+            syn::Item::Trait(trait_) => {
+                let trait_name = trait_.ident.to_string();
+                for item in &trait_.items {
+                    if let syn::TraitItem::Fn(method) = item {
+                        method_traits
+                            .entry(method.sig.ident.to_string())
+                            .or_default()
+                            .insert(trait_name.clone());
+                    }
+                }
             }
+            syn::Item::Mod(module) => {
+                if let Some(trait_name) = nested_trait_name(module) {
+                    return Err(format!(
+                        "generated support trait `{trait_name}` is nested in module `{}`; support traits must be top-level items",
+                        module.ident
+                    ));
+                }
+            }
+            _ => {}
         }
     }
     if method_traits.is_empty() {
-        return HashSet::new();
+        return Ok(HashSet::new());
     }
     let mut collector = MethodCallCollector {
         method_traits: &method_traits,
         required_traits: HashSet::new(),
     };
     collector.visit_file(&consumer);
-    collector.required_traits
+    Ok(collector.required_traits)
+}
+
+fn nested_trait_name(module: &syn::ItemMod) -> Option<String> {
+    let (_, items) = module.content.as_ref()?;
+    for item in items {
+        match item {
+            syn::Item::Trait(trait_) => return Some(trait_.ident.to_string()),
+            syn::Item::Mod(nested) => {
+                if let Some(name) = nested_trait_name(nested) {
+                    return Some(name);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 struct MethodCallCollector<'a> {
@@ -137,8 +162,21 @@ mod tests {
         let required = rust_source_required_trait_names(
             "fn run(value: Wrapper) { value.render(); }",
             "trait RenderSupport { fn render(&self); }",
-        );
+        )
+        .expect("flat support traits should be accepted");
 
         assert_eq!(required, HashSet::from(["RenderSupport".to_string()]));
+    }
+
+    #[test]
+    fn item10a_nested_support_traits_violate_the_flat_owner_invariant() {
+        let error = rust_source_required_trait_names(
+            "fn run(value: Wrapper) { value.render(); }",
+            "mod nested { trait RenderSupport { fn render(&self); } }",
+        )
+        .expect_err("nested support traits must fail closed");
+
+        assert!(error.contains("support traits must be top-level items"));
+        assert!(error.contains("RenderSupport"));
     }
 }

--- a/crates/sifr_codegen/src/support_plan.rs
+++ b/crates/sifr_codegen/src/support_plan.rs
@@ -39,7 +39,7 @@ pub(crate) struct ModuleSupportDemand {
     directly_used_stdlib_modules: HashSet<String>,
     imported_stdlib_names: HashMap<String, HashSet<String>>,
     suppressed_union_definitions: HashSet<String>,
-    suppressed_error_classes: HashSet<String>,
+    locally_shadowed_error_classes: HashSet<String>,
     referenced_error_classes: HashSet<String>,
     python_error_rust_types: BTreeSet<String>,
     required_features: HashSet<StdlibFeature>,
@@ -74,7 +74,7 @@ impl ModuleSupportDemand {
             directly_used_stdlib_modules: emitter.used_stdlib_modules.clone(),
             imported_stdlib_names: emitter.imported_stdlib_names.clone(),
             suppressed_union_definitions: emitter.union_enums.keys().cloned().collect(),
-            suppressed_error_classes: user_defined_error_classes
+            locally_shadowed_error_classes: user_defined_error_classes
                 .into_iter()
                 .map(str::to_string)
                 .collect(),
@@ -92,7 +92,16 @@ impl ModuleSupportDemand {
         }
     }
 
-    pub(crate) fn merge(&mut self, other: &Self) {
+    /// Merge one named module into a crate-level support owner.
+    ///
+    /// Error-class shadows are deliberately module-local. The shared owner
+    /// must retain builtins required by a sibling module or by compiler-owned
+    /// runtime and stdlib support.
+    pub(crate) fn merge_project_module(&mut self, other: &Self) {
+        assert!(
+            self.locally_shadowed_error_classes.is_empty(),
+            "project support demand must start from the unshadowed aggregate identity"
+        );
         self.runtime.merge(&other.runtime);
         self.runtime_needs.merge(&other.runtime_needs);
         self.intrinsic_functions
@@ -107,8 +116,6 @@ impl ModuleSupportDemand {
         }
         self.suppressed_union_definitions
             .extend(other.suppressed_union_definitions.iter().cloned());
-        self.suppressed_error_classes
-            .extend(other.suppressed_error_classes.iter().cloned());
         self.referenced_error_classes
             .extend(other.referenced_error_classes.iter().cloned());
         self.python_error_rust_types
@@ -138,23 +145,6 @@ impl ModuleSupportDemand {
         }
         features
     }
-
-    pub(crate) fn referenced_error_classes_with_source(
-        &self,
-        source: &str,
-        needs_file_handles: bool,
-    ) -> HashSet<String> {
-        let mut referenced = self.referenced_error_classes.clone();
-        referenced.extend(collect_source_builtin_error_classes(
-            source,
-            BUILTIN_ERROR_CLASSES,
-        ));
-        if needs_file_handles {
-            referenced.insert("IOError".to_string());
-        }
-        referenced.retain(|name| !self.suppressed_error_classes.contains(name));
-        referenced
-    }
 }
 
 pub(crate) struct RenderedSupport {
@@ -179,7 +169,7 @@ pub(crate) fn render_support(
         referenced_error_classes.insert("IOError".to_string());
     }
     add_runtime_error_classes(&demand.runtime, &mut referenced_error_classes);
-    referenced_error_classes.retain(|name| !demand.suppressed_error_classes.contains(name));
+    referenced_error_classes.retain(|name| !demand.locally_shadowed_error_classes.contains(name));
 
     let stdlib_emits_task_context = stdlib.source.contains("__sifr_task_current_context")
         || stdlib.source.contains("__SIFR_TASK_CONTEXT_LABEL");
@@ -603,14 +593,15 @@ fn use_item(path: &[&str]) -> RustItem {
 #[cfg(test)]
 mod tests {
     use super::{ModuleSupportDemand, render_support};
-    use crate::StdlibCode;
+    use crate::{StdlibCode, StdlibRustSource};
+    use std::collections::HashSet;
 
     #[test]
-    fn user_error_classes_suppress_late_runtime_error_demand() {
+    fn item10a_single_file_user_error_suppresses_late_runtime_demand() {
         let mut demand = ModuleSupportDemand::default();
         demand.runtime.task_scope = true;
         demand
-            .suppressed_error_classes
+            .locally_shadowed_error_classes
             .insert("SecondaryError".to_string());
 
         let rendered = render_support(&demand, &StdlibCode::default());
@@ -619,17 +610,32 @@ mod tests {
     }
 
     #[test]
-    fn user_error_classes_suppress_late_source_error_demand() {
-        let mut demand = ModuleSupportDemand::default();
-        demand
-            .suppressed_error_classes
+    fn item10a_project_merge_does_not_promote_a_module_shadow_to_a_crate_veto() {
+        let mut module = ModuleSupportDemand::default();
+        module
+            .locally_shadowed_error_classes
             .insert("ValueError".to_string());
+        module
+            .directly_used_stdlib_modules
+            .insert("sifr.fixture".to_string());
 
-        let referenced = demand.referenced_error_classes_with_source(
-            "fn operation() -> Result<(), ValueError> { Ok(()) }",
-            false,
+        let mut project = ModuleSupportDemand::default();
+        project.merge_project_module(&module);
+
+        let mut stdlib = StdlibCode::default();
+        stdlib.module_rust_code.insert(
+            "sifr.fixture".to_string(),
+            StdlibRustSource {
+                module: "sifr.fixture".to_string(),
+                source_path: "stdlib/sifr/fixture.sifr".to_string(),
+                source_sha256: "item-10a-fixture".to_string(),
+                nominal_types: HashSet::new(),
+                rust: "fn operation() -> Result<(), ValueError> { Ok(()) }\n".to_string(),
+            },
         );
 
-        assert!(!referenced.contains("ValueError"));
+        let rendered = render_support(&project, &stdlib);
+
+        assert!(rendered.source.contains("struct ValueError"));
     }
 }

--- a/crates/sifr_codegen/src/union_type_helpers.rs
+++ b/crates/sifr_codegen/src/union_type_helpers.rs
@@ -11,7 +11,11 @@ impl RustEmitter {
         if self.project_nominal_type_paths.is_empty() {
             return None;
         }
-        let key = identity.unwrap_or(name);
+        let builtin_identity = identity
+            .is_none()
+            .then(|| crate::builtin_error_identity(name))
+            .flatten();
+        let key = identity.or(builtin_identity.as_deref()).unwrap_or(name);
         if let Some(path) = self.project_nominal_type_paths.get(key) {
             return Some(path);
         }

--- a/crates/sifr_driver/src/tests/project_build_check.rs
+++ b/crates/sifr_driver/src/tests/project_build_check.rs
@@ -16,6 +16,48 @@ pub(super) fn mktemp_dir(name: &str) -> std::path::PathBuf {
 }
 
 #[test]
+fn item10a_build_project_preserves_module_scoped_builtin_error_shadow_identities() {
+    let dir = mktemp_dir("module_scoped_builtin_error_shadow");
+    let main_file = dir.join("main.sifr");
+    let build_out = dir.join("build_out");
+    std::fs::write(
+        &main_file,
+        "from shadow import shadow_message\nfrom builtin_user import builtin_message\n\ndef main():\n    assert shadow_message() == \"shadow\"\n    assert builtin_message() == \"builtin\"\n    print(\"module-error-identities-ok\")\n",
+    )
+    .expect("main module should be written");
+    std::fs::write(
+        dir.join("shadow.sifr"),
+        "class ValueError(Error):\n    message: str\n\ndef shadow_message() -> str:\n    try:\n        raise ValueError(\"shadow\")\n    except ValueError as error:\n        return error.message\n",
+    )
+    .expect("shadow module should be written");
+    std::fs::write(
+        dir.join("builtin_user.sifr"),
+        "def builtin_message() -> str:\n    try:\n        raise ValueError(\"builtin\")\n    except ValueError as error:\n        return error.message\n",
+    )
+    .expect("builtin user module should be written");
+
+    let binary = build_project(
+        &main_file,
+        &build_out,
+        &mut sifr_frontend::DiskSourceProvider::new(),
+    )
+    .expect("project with distinct local and builtin ValueError identities should build");
+    let output = std::process::Command::new(&binary)
+        .output()
+        .expect("generated project binary should run");
+
+    assert!(
+        output.status.success(),
+        "generated binary failed: {output:?}"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "module-error-identities-ok"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 fn test_check_project_resolves_valid_local_imports() {
     let dir = mktemp_dir("check_positive");
     std::fs::write(

--- a/crates/sifr_driver/src/tests/project_build_check.rs
+++ b/crates/sifr_driver/src/tests/project_build_check.rs
@@ -22,12 +22,12 @@ fn item10a_build_project_preserves_module_scoped_builtin_error_shadow_identities
     let build_out = dir.join("build_out");
     std::fs::write(
         &main_file,
-        "from shadow import shadow_message\nfrom builtin_user import builtin_message\n\ndef main():\n    assert shadow_message() == \"shadow\"\n    assert builtin_message() == \"builtin\"\n    print(\"module-error-identities-ok\")\n",
+        "from shadow import shadow_detail\nfrom builtin_user import builtin_message\n\ndef main():\n    assert shadow_detail() == \"shadow-detail\"\n    assert builtin_message() == \"builtin\"\n    print(\"module-error-identities-ok\")\n",
     )
     .expect("main module should be written");
     std::fs::write(
         dir.join("shadow.sifr"),
-        "class ValueError(Error):\n    message: str\n\ndef shadow_message() -> str:\n    try:\n        raise ValueError(\"shadow\")\n    except ValueError as error:\n        return error.message\n",
+        "class ValueError(Error):\n    message: str\n    detail: str\n\n    def __init__(self, message: str, detail: str):\n        self.message = message\n        self.detail = detail\n\ndef shadow_detail() -> str:\n    try:\n        raise ValueError(\"shadow\", \"shadow-detail\")\n    except ValueError as error:\n        return error.detail\n",
     )
     .expect("shadow module should be written");
     std::fs::write(

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -9,6 +9,36 @@ use std::path::PathBuf;
 use std::sync::{Arc, Barrier};
 
 #[test]
+fn item10a_test_project_preserves_module_scoped_builtin_error_shadow_identities() {
+    let unique = format!(
+        "sifr_test_module_error_identity_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos()
+    );
+    let test_dir = std::env::temp_dir().join(unique);
+    std::fs::create_dir_all(&test_dir).expect("test dir should be created");
+    std::fs::write(
+        test_dir.join("shadow.sifr"),
+        "class ValueError(Error):\n    message: str\n\ndef shadow_message() -> str:\n    try:\n        raise ValueError(\"shadow\")\n    except ValueError as error:\n        return error.message\n",
+    )
+    .expect("shadow support module should be written");
+    std::fs::write(
+        test_dir.join("test_error_identities.sifr"),
+        "from shadow import shadow_message\n\ndef builtin_message() -> str:\n    try:\n        raise ValueError(\"builtin\")\n    except ValueError as error:\n        return error.message\n\ndef test_module_error_identities():\n    assert shadow_message() == \"shadow\"\n    assert builtin_message() == \"builtin\"\n",
+    )
+    .expect("test module should be written");
+
+    let result = run_tests(&test_dir, &mut DiskSourceProvider::new())
+        .expect("test project with distinct local and builtin ValueError identities should run");
+
+    assert!(result, "generated Sifr test project should succeed");
+    let _ = std::fs::remove_dir_all(&test_dir);
+}
+
+#[test]
 fn test_run_tests_resolves_local_imports_and_constants() {
     let unique = format!(
         "sifr_test_import_parity_{}_{}",

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -22,12 +22,12 @@ fn item10a_test_project_preserves_module_scoped_builtin_error_shadow_identities(
     std::fs::create_dir_all(&test_dir).expect("test dir should be created");
     std::fs::write(
         test_dir.join("shadow.sifr"),
-        "class ValueError(Error):\n    message: str\n\ndef shadow_message() -> str:\n    try:\n        raise ValueError(\"shadow\")\n    except ValueError as error:\n        return error.message\n",
+        "class ValueError(Error):\n    message: str\n    detail: str\n\n    def __init__(self, message: str, detail: str):\n        self.message = message\n        self.detail = detail\n\ndef shadow_detail() -> str:\n    try:\n        raise ValueError(\"shadow\", \"shadow-detail\")\n    except ValueError as error:\n        return error.detail\n",
     )
     .expect("shadow support module should be written");
     std::fs::write(
         test_dir.join("test_error_identities.sifr"),
-        "from shadow import shadow_message\n\ndef builtin_message() -> str:\n    try:\n        raise ValueError(\"builtin\")\n    except ValueError as error:\n        return error.message\n\ndef test_module_error_identities():\n    assert shadow_message() == \"shadow\"\n    assert builtin_message() == \"builtin\"\n",
+        "from shadow import shadow_detail\n\ndef builtin_message() -> str:\n    try:\n        raise ValueError(\"builtin\")\n    except ValueError as error:\n        return error.message\n\ndef test_module_error_identities():\n    assert shadow_detail() == \"shadow-detail\"\n    assert builtin_message() == \"builtin\"\n",
     )
     .expect("test module should be written");
 


### PR DESCRIPTION
Closes #3682

## Summary
- keep user-defined error shadows local while aggregating builtin support demand per project
- key shared builtin nominals by canonical sifr.builtin.* identity without replacing module-qualified user paths
- preserve local shadow definitions during project nominal relocation
- fail closed when generated support traits violate the flat top-level ownership invariant
- cover single-file, normal project, and generated test-project paths with a distinct local field shape

## Exact candidate
- base: 5017ddb9f73089febc461affe597350ba6d695ae
- candidate: c9d0fb34331c32fb90342debf1eea28a0c6ee7e1

## Validation
- cargo test -p sifr_codegen item10a_ -- --nocapture (5 passed)
- cargo test -p sifr_driver item10a_ -- --nocapture (2 passed, including project and test-project native compile/run)
- python3 scripts/check_file_size_guardrails.py (3,751 files passed)
- cargo fmt --all -- --check (passed)
- sole merge-profile gate reached and passed generated-demo freshness, HIR/file-size/ownership/dependency/resource/stdlib/driver/verification guardrails, and the complete Rust-interop area; it then stopped only on unchanged SQL coverage/taxonomy readiness debt already owned by Item 12. The gate was not repeated.

## Review
- Exact-SHA Opus review: SATISFIED, no blocking findings: https://github.com/sifr-lang/sifr/pull/3684#issuecomment-5538828920
- No remediation review required.
- Pre-existing fixture lock drift found by review is recorded separately in #3685.
