### PR TITLE
Close emitted Rust excellence item 11

### DIFF
--- a/crates/sifr/tests/e2e_support/dependency_plan_authority_tests.rs
+++ b/crates/sifr/tests/e2e_support/dependency_plan_authority_tests.rs
@@ -242,6 +242,11 @@ def repeat_text(text: str, count: int) -> str:
 
 def main():
     assert repeat_text("ab", 3) == "ababab"
+    text = "a,b,c"
+    repeated = text * 2
+    assert text == "a,b,c"
+    assert repeated == "a,b,ca,b,c"
+    assert text.split(",", 1) == ["a", "b,c"]
 "#;
     let first = tempfile::tempdir().expect("first materialization root");
     let report = sifr_driver::materialize_single_file(

--- a/crates/sifr/tests/e2e_support/dependency_plan_authority_tests.rs
+++ b/crates/sifr/tests/e2e_support/dependency_plan_authority_tests.rs
@@ -235,6 +235,73 @@ fn missing_metadata_is_not_repaired_from_generated_rust() {
 }
 
 #[test]
+fn item11_materialized_project_is_locked_portable_and_relocatable() {
+    let source = r#"
+def repeat_text(text: str, count: int) -> str:
+    return text * count
+
+def main():
+    assert repeat_text("ab", 3) == "ababab"
+"#;
+    let first = tempfile::tempdir().expect("first materialization root");
+    let report = sifr_driver::materialize_single_file(
+        source,
+        Path::new("item11_portable.sifr"),
+        first.path(),
+    )
+    .unwrap_or_else(|errors| {
+        panic!(
+            "portable materialization should succeed: {}",
+            errors
+                .iter()
+                .map(|error| error.message.as_str())
+                .collect::<Vec<_>>()
+                .join("; ")
+        )
+    });
+    let project = report.project_path();
+    let manifest = std::fs::read_to_string(project.join("Cargo.toml"))
+        .expect("portable manifest should be readable");
+    let lock = std::fs::read_to_string(project.join("Cargo.lock"))
+        .expect("portable lock should be readable");
+    let worktree = env!("CARGO_MANIFEST_DIR");
+    assert!(!manifest.contains(worktree), "{manifest}");
+    assert!(!lock.contains(worktree), "{lock}");
+    assert!(manifest.contains("git = \"https://github.com/sifr-lang/sifr.git\""));
+
+    let relocated = tempfile::tempdir().expect("relocation root");
+    let relocated_project = relocated.path().join("artifact");
+    copy_dir_recursive(project, &relocated_project);
+    let metadata = Command::new("cargo")
+        .args(["check", "--locked"])
+        .current_dir(&relocated_project)
+        .output()
+        .expect("relocated Cargo check should execute");
+    assert!(
+        metadata.status.success(),
+        "relocated Cargo check should remain locked: {}",
+        String::from_utf8_lossy(&metadata.stderr)
+    );
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).expect("destination should be created");
+    for entry in std::fs::read_dir(source).expect("source directory should be readable") {
+        let entry = entry.expect("source entry should be readable");
+        let target = destination.join(entry.file_name());
+        if entry
+            .file_type()
+            .expect("entry type should be readable")
+            .is_dir()
+        {
+            copy_dir_recursive(&entry.path(), &target);
+        } else {
+            std::fs::copy(entry.path(), target).expect("artifact file should relocate");
+        }
+    }
+}
+
+#[test]
 fn fixtures_with_different_production_plans_cannot_repair_each_other() {
     let missing = case_with_plan(
         "missing_metadata",

--- a/crates/sifr_codegen/src/borrowed_string_compare.rs
+++ b/crates/sifr_codegen/src/borrowed_string_compare.rs
@@ -321,10 +321,7 @@ impl RustEmitter {
             expr: Some(Box::new(Self::as_str_option(RustExpr::MethodCall {
                 receiver: Box::new(RustExpr::Ident("__sifr_cmp_list".to_string())),
                 method: "get".to_string(),
-                args: vec![RustExpr::Cast {
-                    expr: Box::new(RustExpr::Ident("__sifr_cmp_norm".to_string())),
-                    ty: RustType::Named("usize".to_string()),
-                }],
+                args: vec![RustExpr::Ident("__sifr_cmp_norm".to_string())],
             }))),
         }))
     }

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -77,6 +77,8 @@ mod item10_support_assembly_codegen_tests;
 #[cfg(test)]
 mod item10a_error_identity_codegen_tests;
 #[cfg(test)]
+mod item11_portable_secure_codegen_tests;
+#[cfg(test)]
 mod item8_canonical_codegen_tests;
 #[cfg(test)]
 mod item9_emitted_rust_quality_codegen_tests;

--- a/crates/sifr_codegen/src/lib_codegen_tests/item11_portable_secure_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/item11_portable_secure_codegen_tests.rs
@@ -1,0 +1,30 @@
+use super::generate_rust_from_source;
+
+#[test]
+fn item11_user_integer_widths_never_reach_panic_on_proof_usize_conversions() {
+    let generated = generate_rust_from_source(
+        r#"
+def exercise(mut values: list[int], index: int, text: str, count: int) -> tuple[list[int], str, list[str], str]:
+    values.insert(index, 7)
+    repeated = text * count
+    parts = text.split(",", count)
+    replaced = text.replace("x", "y", count)
+    return (values, repeated, parts, replaced)
+"#,
+    );
+
+    assert!(
+        generated.contains("index.clamp_slice_bound(values.len())"),
+        "{generated}"
+    );
+    assert!(
+        generated.contains("count.clamp_slice_bound("),
+        "{generated}"
+    );
+    assert!(
+        generated.contains("while &__sifr_repeat_i < &__n"),
+        "{generated}"
+    );
+    assert!(!generated.contains("to_usize_proven"), "{generated}");
+    assert!(!generated.contains(".repeat("), "{generated}");
+}

--- a/crates/sifr_codegen/src/lib_codegen_tests/item11_portable_secure_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/item11_portable_secure_codegen_tests.rs
@@ -10,6 +10,11 @@ def exercise(mut values: list[int], index: int, text: str, count: int) -> tuple[
     parts = text.split(",", count)
     replaced = text.replace("x", "y", count)
     return (values, repeated, parts, replaced)
+
+def reuse_owned_string() -> str:
+    source = "owned"
+    repeated = source * 2
+    return source + repeated
 "#,
     );
 
@@ -25,6 +30,11 @@ def exercise(mut values: list[int], index: int, text: str, count: int) -> tuple[
         generated.contains("while &__sifr_repeat_i < &__n"),
         "{generated}"
     );
+    assert!(
+        generated.contains("let __sifr_repeat_src: &str = &"),
+        "{generated}"
+    );
+    assert!(generated.contains("+ SifrInt::from_i64(1)"), "{generated}");
     assert!(!generated.contains("to_usize_proven"), "{generated}");
     assert!(!generated.contains(".repeat("), "{generated}");
 }

--- a/crates/sifr_codegen/src/methods/common.rs
+++ b/crates/sifr_codegen/src/methods/common.rs
@@ -13,16 +13,11 @@ fn exact_int_from_expr(expr: RustExpr) -> RustExpr {
     }
 }
 
-pub(super) fn exact_int_to_usize_expr(expr: RustExpr) -> RustExpr {
-    RustExpr::FnCall {
-        func: Box::new(RustExpr::Path(vec![
-            "sifr_runtime".to_string(),
-            "to_usize_proven".to_string(),
-        ])),
-        args: vec![RustExpr::Ref {
-            mutable: false,
-            expr: Box::new(expr),
-        }],
+pub(super) fn exact_int_to_bound_expr(expr: RustExpr, bound: RustExpr) -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(expr),
+        method: "clamp_slice_bound".to_string(),
+        args: vec![bound],
     }
 }
 

--- a/crates/sifr_codegen/src/methods/list.rs
+++ b/crates/sifr_codegen/src/methods/list.rs
@@ -2,7 +2,7 @@
 
 use crate::{RustExpr, RustParam, RustStmt, RustType, Type};
 
-use super::common::exact_int_to_usize_expr;
+use super::common::exact_int_to_bound_expr;
 
 fn is_already_borrowed_rendered_expr(arg: &RustExpr) -> bool {
     match arg {
@@ -67,7 +67,17 @@ pub(super) fn lower_insert(object: &RustExpr, args: &[RustExpr]) -> Option<RustE
     Some(RustExpr::MethodCall {
         receiver: Box::new(object.clone()),
         method: "insert".to_string(),
-        args: vec![exact_int_to_usize_expr(args[0].clone()), args[1].clone()],
+        args: vec![
+            exact_int_to_bound_expr(
+                args[0].clone(),
+                RustExpr::MethodCall {
+                    receiver: Box::new(object.clone()),
+                    method: "len".to_string(),
+                    args: vec![],
+                },
+            ),
+            args[1].clone(),
+        ],
     })
 }
 

--- a/crates/sifr_codegen/src/methods/mod.rs
+++ b/crates/sifr_codegen/src/methods/mod.rs
@@ -439,7 +439,7 @@ mod tests {
         .expect("list insert lowers");
         assert_eq!(
             render_expr(&list_insert.expr),
-            "xs.insert(::sifr_runtime::to_usize_proven(&SifrInt::from_i64(0)), 1)"
+            "xs.insert(SifrInt::from_i64(0).clamp_slice_bound(xs.len()), 1)"
         );
 
         let list_copy = lower_method(&Type::List(Box::new(Type::Int)), "copy", "xs", &[])

--- a/crates/sifr_codegen/src/methods/string.rs
+++ b/crates/sifr_codegen/src/methods/string.rs
@@ -281,9 +281,15 @@ pub(super) fn lower_split(object: &RustExpr, args: &[RustExpr]) -> Option<RustEx
                                             RustExpr::Paren(Box::new(RustExpr::BinOp {
                                                 left: Box::new(maxsplit),
                                                 op: "+".to_string(),
-                                                right: Box::new(RustExpr::Literal(
-                                                    RustLiteral::Int(1),
-                                                )),
+                                                right: Box::new(RustExpr::FnCall {
+                                                    func: Box::new(RustExpr::Path(vec![
+                                                        "SifrInt".to_string(),
+                                                        "from_i64".to_string(),
+                                                    ])),
+                                                    args: vec![RustExpr::Literal(
+                                                        RustLiteral::Int(1),
+                                                    )],
+                                                }),
                                             })),
                                             replacement_or_split_limit(object),
                                         ),
@@ -337,7 +343,13 @@ pub(super) fn lower_split(object: &RustExpr, args: &[RustExpr]) -> Option<RustEx
                                         RustExpr::Paren(Box::new(RustExpr::BinOp {
                                             left: Box::new(args[1].clone()),
                                             op: "+".to_string(),
-                                            right: Box::new(RustExpr::Literal(RustLiteral::Int(1))),
+                                            right: Box::new(RustExpr::FnCall {
+                                                func: Box::new(RustExpr::Path(vec![
+                                                    "SifrInt".to_string(),
+                                                    "from_i64".to_string(),
+                                                ])),
+                                                args: vec![RustExpr::Literal(RustLiteral::Int(1))],
+                                            }),
                                         })),
                                         replacement_or_split_limit(object),
                                     ),

--- a/crates/sifr_codegen/src/methods/string.rs
+++ b/crates/sifr_codegen/src/methods/string.rs
@@ -1,8 +1,20 @@
 use crate::{RustExpr, RustLiteral, RustParam, RustStmt, RustType};
 
-use super::common::exact_int_to_usize_expr;
+use super::common::exact_int_to_bound_expr;
 
 mod search;
+
+fn replacement_or_split_limit(object: &RustExpr) -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::MethodCall {
+            receiver: Box::new(object.clone()),
+            method: "len".to_string(),
+            args: vec![],
+        }),
+        method: "saturating_add".to_string(),
+        args: vec![RustExpr::Verbatim("1usize".to_string())],
+    }
+}
 
 fn lower_zero_arg_method(object: &RustExpr, args: &[RustExpr], method: &str) -> Option<RustExpr> {
     if !args.is_empty() {
@@ -265,15 +277,16 @@ pub(super) fn lower_split(object: &RustExpr, args: &[RustExpr]) -> Option<RustEx
                                     receiver: Box::new(object.clone()),
                                     method: "splitn".to_string(),
                                     args: vec![
-                                        exact_int_to_usize_expr(RustExpr::Paren(Box::new(
-                                            RustExpr::BinOp {
+                                        exact_int_to_bound_expr(
+                                            RustExpr::Paren(Box::new(RustExpr::BinOp {
                                                 left: Box::new(maxsplit),
                                                 op: "+".to_string(),
                                                 right: Box::new(RustExpr::Literal(
                                                     RustLiteral::Int(1),
                                                 )),
-                                            },
-                                        ))),
+                                            })),
+                                            replacement_or_split_limit(object),
+                                        ),
                                         RustExpr::Closure {
                                             params: vec![RustParam::Named {
                                                 name: "c".to_string(),
@@ -320,13 +333,14 @@ pub(super) fn lower_split(object: &RustExpr, args: &[RustExpr]) -> Option<RustEx
                                 receiver: Box::new(object.clone()),
                                 method: "splitn".to_string(),
                                 args: vec![
-                                    exact_int_to_usize_expr(RustExpr::Paren(Box::new(
-                                        RustExpr::BinOp {
+                                    exact_int_to_bound_expr(
+                                        RustExpr::Paren(Box::new(RustExpr::BinOp {
                                             left: Box::new(args[1].clone()),
                                             op: "+".to_string(),
                                             right: Box::new(RustExpr::Literal(RustLiteral::Int(1))),
-                                        },
-                                    ))),
+                                        })),
+                                        replacement_or_split_limit(object),
+                                    ),
                                     string_pattern_arg(&args[0]),
                                 ],
                             }),
@@ -376,7 +390,7 @@ pub(super) fn lower_replace(object: &RustExpr, args: &[RustExpr]) -> Option<Rust
                 args: vec![
                     string_pattern_arg(old),
                     render_borrowed_arg_expr(new),
-                    exact_int_to_usize_expr(count.clone()),
+                    exact_int_to_bound_expr(count.clone(), replacement_or_split_limit(object)),
                 ],
             })),
         }),

--- a/crates/sifr_codegen/src/nested_list_element.rs
+++ b/crates/sifr_codegen/src/nested_list_element.rs
@@ -92,7 +92,7 @@ fn option_nested_list_element(
             receiver: Box::new(RustExpr::MethodCall {
                 receiver: Box::new(RustExpr::Ident("__sifr_outer_list".to_string())),
                 method: "get".to_string(),
-                args: vec![usize_cast(RustExpr::Ident("__sifr_outer_norm".to_string()))],
+                args: vec![RustExpr::Ident("__sifr_outer_norm".to_string())],
             }),
             method: "and_then".to_string(),
             args: vec![RustExpr::ClosureBlock {
@@ -120,9 +120,7 @@ fn option_nested_list_element(
                         receiver: Box::new(RustExpr::MethodCall {
                             receiver: Box::new(RustExpr::Ident("__sifr_row".to_string())),
                             method: "get".to_string(),
-                            args: vec![usize_cast(RustExpr::Ident(
-                                "__sifr_inner_norm".to_string(),
-                            ))],
+                            args: vec![RustExpr::Ident("__sifr_inner_norm".to_string())],
                         }),
                         method: projection_method.to_string(),
                         args: vec![],
@@ -132,12 +130,5 @@ fn option_nested_list_element(
                 is_async: false,
             }],
         })),
-    }
-}
-
-fn usize_cast(expr: RustExpr) -> RustExpr {
-    RustExpr::Cast {
-        expr: Box::new(expr),
-        ty: RustType::Named("usize".to_string()),
     }
 }

--- a/crates/sifr_codegen/src/rust_interop_plan.rs
+++ b/crates/sifr_codegen/src/rust_interop_plan.rs
@@ -187,6 +187,8 @@ pub enum RustInteropResolvedRoot {
         package_id: String,
         dependency_name: String,
         cargo_package_name: String,
+        cargo_version: String,
+        cargo_source: Option<String>,
         cargo_manifest_path: String,
         bridge_roots: Vec<String>,
     },
@@ -570,6 +572,8 @@ fn push_resolved_target(out: &mut String, target: &RustInteropResolvedTarget) {
             package_id,
             dependency_name,
             cargo_package_name,
+            cargo_version,
+            cargo_source,
             cargo_manifest_path,
             bridge_roots,
         } => {
@@ -579,6 +583,10 @@ fn push_resolved_target(out: &mut String, target: &RustInteropResolvedTarget) {
             out.push_str(dependency_name);
             out.push(':');
             out.push_str(cargo_package_name);
+            out.push('@');
+            out.push_str(cargo_version);
+            out.push(':');
+            out.push_str(cargo_source.as_deref().unwrap_or("<path>"));
             out.push(':');
             out.push_str(cargo_manifest_path);
             out.push(':');

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_binop.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_binop.rs
@@ -72,8 +72,11 @@ macro_rules! stmt_expr_binop {
                         crate::RustStmt::Let {
                             mutable: false,
                             name: "__sifr_repeat_src".to_string(),
-                            ty: None,
-                            value: string_expr,
+                            ty: Some(crate::RustType::Named("&str".to_string())),
+                            value: crate::RustExpr::Ref {
+                                mutable: false,
+                                expr: Box::new(crate::RustExpr::Paren(Box::new(string_expr))),
+                            },
                         },
                         crate::RustStmt::Let {
                             mutable: false,
@@ -145,12 +148,9 @@ macro_rules! stmt_expr_binop {
                                                 "__sifr_repeat_out".to_string(),
                                             )),
                                             method: "push_str".to_string(),
-                                            args: vec![crate::RustExpr::Ref {
-                                                mutable: false,
-                                                expr: Box::new(crate::RustExpr::Ident(
-                                                    "__sifr_repeat_src".to_string(),
-                                                )),
-                                            }],
+                                            args: vec![crate::RustExpr::Ident(
+                                                "__sifr_repeat_src".to_string(),
+                                            )],
                                         }),
                                         crate::RustStmt::AugAssign {
                                             target: crate::RustExpr::Ident(

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_binop.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_expr_binop.rs
@@ -68,12 +68,20 @@ macro_rules! stmt_expr_binop {
                     _ => return Ok(None),
                 };
                 return Ok(Some(crate::RustExpr::Block {
-                    stmts: vec![crate::RustStmt::Let {
-                        mutable: false,
-                        name: "__n".to_string(),
-                        ty: None,
-                        value: count_expr,
-                    }],
+                    stmts: vec![
+                        crate::RustStmt::Let {
+                            mutable: false,
+                            name: "__sifr_repeat_src".to_string(),
+                            ty: None,
+                            value: string_expr,
+                        },
+                        crate::RustStmt::Let {
+                            mutable: false,
+                            name: "__n".to_string(),
+                            ty: None,
+                            value: count_expr,
+                        },
+                    ],
                     expr: Some(Box::new(crate::RustExpr::If {
                         cond: Box::new(crate::RustExpr::BinOp {
                             left: Box::new(crate::RustExpr::Ident("__n".to_string())),
@@ -87,13 +95,84 @@ macro_rules! stmt_expr_binop {
                             ])),
                             args: vec![],
                         }),
-                        else_expr: Some(Box::new(crate::RustExpr::MethodCall {
-                            receiver: Box::new(crate::RustExpr::Paren(Box::new(string_expr))),
-                            method: "repeat".to_string(),
-                            args: vec![crate::RustExpr::Cast {
-                                expr: Box::new(crate::RustExpr::Ident("__n".to_string())),
-                                ty: crate::RustType::Named("usize".to_string()),
-                            }],
+                        else_expr: Some(Box::new(crate::RustExpr::Block {
+                            stmts: vec![
+                                crate::RustStmt::Let {
+                                    mutable: true,
+                                    name: "__sifr_repeat_out".to_string(),
+                                    ty: None,
+                                    value: crate::RustExpr::FnCall {
+                                        func: Box::new(crate::RustExpr::Path(vec![
+                                            "String".to_string(),
+                                            "new".to_string(),
+                                        ])),
+                                        args: vec![],
+                                    },
+                                },
+                                crate::RustStmt::Let {
+                                    mutable: true,
+                                    name: "__sifr_repeat_i".to_string(),
+                                    ty: None,
+                                    value: crate::RustExpr::FnCall {
+                                        func: Box::new(crate::RustExpr::Path(vec![
+                                            "SifrInt".to_string(),
+                                            "from_i64".to_string(),
+                                        ])),
+                                        args: vec![crate::RustExpr::Literal(
+                                            crate::RustLiteral::Int(0),
+                                        )],
+                                    },
+                                },
+                                crate::RustStmt::While {
+                                    cond: crate::RustExpr::BinOp {
+                                        left: Box::new(crate::RustExpr::Ref {
+                                            mutable: false,
+                                            expr: Box::new(crate::RustExpr::Ident(
+                                                "__sifr_repeat_i".to_string(),
+                                            )),
+                                        }),
+                                        op: "<".to_string(),
+                                        right: Box::new(crate::RustExpr::Ref {
+                                            mutable: false,
+                                            expr: Box::new(crate::RustExpr::Ident(
+                                                "__n".to_string(),
+                                            )),
+                                        }),
+                                    },
+                                    body: vec![
+                                        crate::RustStmt::Expr(crate::RustExpr::MethodCall {
+                                            receiver: Box::new(crate::RustExpr::Ident(
+                                                "__sifr_repeat_out".to_string(),
+                                            )),
+                                            method: "push_str".to_string(),
+                                            args: vec![crate::RustExpr::Ref {
+                                                mutable: false,
+                                                expr: Box::new(crate::RustExpr::Ident(
+                                                    "__sifr_repeat_src".to_string(),
+                                                )),
+                                            }],
+                                        }),
+                                        crate::RustStmt::AugAssign {
+                                            target: crate::RustExpr::Ident(
+                                                "__sifr_repeat_i".to_string(),
+                                            ),
+                                            op: "+".to_string(),
+                                            value: crate::RustExpr::FnCall {
+                                                func: Box::new(crate::RustExpr::Path(vec![
+                                                    "SifrInt".to_string(),
+                                                    "from_i64".to_string(),
+                                                ])),
+                                                args: vec![crate::RustExpr::Literal(
+                                                    crate::RustLiteral::Int(1),
+                                                )],
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                            expr: Some(Box::new(crate::RustExpr::Ident(
+                                "__sifr_repeat_out".to_string(),
+                            ))),
                         })),
                     })),
                 }));
@@ -122,57 +201,6 @@ macro_rules! stmt_expr_binop {
                     (_, (true, true)) => (lowered_right.clone(), lowered_left.clone()),
                     _ => return Ok(None),
                 };
-                if let crate::RustExpr::Vec(items) = &collection_expr {
-                    if let [item] = items.as_slice() {
-                        return Ok(Some(crate::RustExpr::Block {
-                            stmts: vec![crate::RustStmt::Let {
-                                mutable: false,
-                                name: "__sifr_repeat_n".to_string(),
-                                ty: None,
-                                value: count_expr,
-                            }],
-                            expr: Some(Box::new(crate::RustExpr::If {
-                                cond: Box::new(crate::RustExpr::BinOp {
-                                    left: Box::new(crate::RustExpr::Ident(
-                                        "__sifr_repeat_n".to_string(),
-                                    )),
-                                    op: "<=".to_string(),
-                                    right: Box::new(crate::RustExpr::FnCall {
-                                        func: Box::new(crate::RustExpr::Path(vec![
-                                            "SifrInt".to_string(),
-                                            "from_i64".to_string(),
-                                        ])),
-                                        args: vec![crate::RustExpr::Literal(
-                                            crate::RustLiteral::Int(0),
-                                        )],
-                                    }),
-                                }),
-                                then_expr: Box::new(crate::RustExpr::Vec(vec![])),
-                                else_expr: Some(Box::new(crate::RustExpr::MethodCall {
-                                    receiver: Box::new(crate::RustExpr::MethodCall {
-                                        receiver: Box::new(crate::RustExpr::FnCall {
-                                            func: Box::new(crate::RustExpr::Path(vec![
-                                                "std".to_string(),
-                                                "iter".to_string(),
-                                                "repeat".to_string(),
-                                            ])),
-                                            args: vec![item.clone()],
-                                        }),
-                                        method: "take".to_string(),
-                                        args: vec![crate::RustExpr::Cast {
-                                            expr: Box::new(crate::RustExpr::Ident(
-                                                "__sifr_repeat_n".to_string(),
-                                            )),
-                                            ty: crate::RustType::Named("usize".to_string()),
-                                        }],
-                                    }),
-                                    method: "collect::<Vec<_>>".to_string(),
-                                    args: vec![],
-                                })),
-                            })),
-                        }));
-                    }
-                }
                 return Ok(Some(crate::RustExpr::Block {
                     stmts: vec![
                         crate::RustStmt::Let {
@@ -211,18 +239,38 @@ macro_rules! stmt_expr_binop {
                                     ty: None,
                                     value: crate::RustExpr::Vec(vec![]),
                                 },
-                                crate::RustStmt::For {
-                                    var: "_".to_string(),
-                                    iter: crate::RustExpr::Range {
-                                        start: Box::new(crate::RustExpr::Literal(
+                                crate::RustStmt::Let {
+                                    mutable: true,
+                                    name: "__sifr_repeat_i".to_string(),
+                                    ty: None,
+                                    value: crate::RustExpr::FnCall {
+                                        func: Box::new(crate::RustExpr::Path(vec![
+                                            "SifrInt".to_string(),
+                                            "from_i64".to_string(),
+                                        ])),
+                                        args: vec![crate::RustExpr::Literal(
                                             crate::RustLiteral::Int(0),
-                                        )),
-                                        end: Box::new(crate::RustExpr::Ident(
-                                            "__sifr_repeat_n".to_string(),
-                                        )),
+                                        )],
                                     },
-                                    body: vec![crate::RustStmt::Expr(
-                                        crate::RustExpr::MethodCall {
+                                },
+                                crate::RustStmt::While {
+                                    cond: crate::RustExpr::BinOp {
+                                        left: Box::new(crate::RustExpr::Ref {
+                                            mutable: false,
+                                            expr: Box::new(crate::RustExpr::Ident(
+                                                "__sifr_repeat_i".to_string(),
+                                            )),
+                                        }),
+                                        op: "<".to_string(),
+                                        right: Box::new(crate::RustExpr::Ref {
+                                            mutable: false,
+                                            expr: Box::new(crate::RustExpr::Ident(
+                                                "__sifr_repeat_n".to_string(),
+                                            )),
+                                        }),
+                                    },
+                                    body: vec![
+                                        crate::RustStmt::Expr(crate::RustExpr::MethodCall {
                                             receiver: Box::new(crate::RustExpr::Ident(
                                                 "__sifr_repeat_out".to_string(),
                                             )),
@@ -240,8 +288,23 @@ macro_rules! stmt_expr_binop {
                                                 method: "cloned".to_string(),
                                                 args: vec![],
                                             }],
+                                        }),
+                                        crate::RustStmt::AugAssign {
+                                            target: crate::RustExpr::Ident(
+                                                "__sifr_repeat_i".to_string(),
+                                            ),
+                                            op: "+".to_string(),
+                                            value: crate::RustExpr::FnCall {
+                                                func: Box::new(crate::RustExpr::Path(vec![
+                                                    "SifrInt".to_string(),
+                                                    "from_i64".to_string(),
+                                                ])),
+                                                args: vec![crate::RustExpr::Literal(
+                                                    crate::RustLiteral::Int(1),
+                                                )],
+                                            },
                                         },
-                                    )],
+                                    ],
                                 },
                             ],
                             expr: Some(Box::new(crate::RustExpr::Ident(

--- a/crates/sifr_driver/src/build/cargo_manifest.rs
+++ b/crates/sifr_driver/src/build/cargo_manifest.rs
@@ -26,6 +26,15 @@ pub(crate) fn generate_dependency_cargo_toml_with_interop(
     render_dependency_cargo_toml(project_name, dependency_plan, interop)
 }
 
+pub(crate) fn generate_portable_dependency_cargo_toml_with_interop(
+    project_name: &str,
+    dependency_plan: &SysrootDependencyPlan,
+    interop: &InteropBuildPlan,
+    sifr_revision: &str,
+) -> Result<String, String> {
+    render_portable_dependency_cargo_toml(project_name, dependency_plan, interop, sifr_revision)
+}
+
 pub fn try_generate_standalone_dependency_plan(
     stdlib_modules: &HashSet<String>,
     required_features: &HashSet<StdlibFeature>,
@@ -117,6 +126,145 @@ edition = "2024"
     }
 
     cargo_toml
+}
+
+fn render_portable_dependency_cargo_toml(
+    project_name: &str,
+    dependency_plan: &SysrootDependencyPlan,
+    interop: &InteropBuildPlan,
+    sifr_revision: &str,
+) -> Result<String, String> {
+    if sifr_revision.len() != 40 || !sifr_revision.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(
+            "portable generated Cargo projects require an exact 40-character Sifr revision"
+                .to_string(),
+        );
+    }
+    let mut cargo_toml = format!(
+        r#"[package]
+name = "{project_name}"
+version = "0.1.0"
+edition = "2024"
+
+[workspace]
+"#
+    );
+    let mut dependencies = dependency_plan
+        .crates
+        .iter()
+        .map(|dependency| portable_sysroot_dependency_line(dependency, sifr_revision))
+        .collect::<Vec<_>>();
+    dependencies.extend(dependency_plan.retained_direct_dependencies.iter().cloned());
+    dependencies.extend(portable_rust_interop_dependencies(interop)?);
+    if !dependencies.is_empty() {
+        cargo_toml.push_str("\n[dependencies]\n");
+        for dependency in dependencies {
+            cargo_toml.push_str(&dependency);
+            cargo_toml.push('\n');
+        }
+    }
+    Ok(cargo_toml)
+}
+
+fn portable_sysroot_dependency_line(
+    dependency: &SysrootCrateDependency,
+    sifr_revision: &str,
+) -> String {
+    let package = dependency.krate.package_name();
+    let mut fields = vec![
+        format!("git = {}", toml_quote_string(SIFR_GIT_SOURCE)),
+        format!("rev = {}", toml_quote_string(sifr_revision)),
+        "default-features = false".to_string(),
+    ];
+    if !dependency.features.is_empty() {
+        fields.push(format!(
+            "features = [{}]",
+            dependency
+                .features
+                .iter()
+                .map(|feature| toml_quote_string(feature))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    format!("{package} = {{ {} }}", fields.join(", "))
+}
+
+fn portable_rust_interop_dependencies(interop: &InteropBuildPlan) -> Result<Vec<String>, String> {
+    let mut dependencies = BTreeMap::new();
+    for target in &interop.rust.resolved_targets {
+        let fields = match &target.root {
+            RustInteropResolvedRoot::DirectCargoDependency {
+                dependency_name,
+                cargo_package_name,
+                cargo_version,
+                cargo_source,
+                ..
+            }
+            | RustInteropResolvedRoot::PackageBridge {
+                dependency_name,
+                cargo_package_name,
+                cargo_version,
+                cargo_source,
+                ..
+            } => Some((
+                dependency_name,
+                portable_dependency_line(
+                    dependency_name,
+                    cargo_package_name,
+                    cargo_version,
+                    cargo_source.as_deref(),
+                )?,
+            )),
+            RustInteropResolvedRoot::SysrootCrate { .. }
+            | RustInteropResolvedRoot::SelfMethod { .. } => None,
+        };
+        if let Some((name, line)) = fields {
+            dependencies.insert(name.clone(), line);
+        }
+    }
+    Ok(dependencies.into_values().collect())
+}
+
+fn portable_dependency_line(
+    dependency_name: &str,
+    cargo_package_name: &str,
+    cargo_version: &str,
+    cargo_source: Option<&str>,
+) -> Result<String, String> {
+    let package = (dependency_name != cargo_package_name)
+        .then(|| format!("package = {}, ", toml_quote_string(cargo_package_name)))
+        .unwrap_or_default();
+    let Some(source) = cargo_source else {
+        return Err(format!(
+            "local Rust dependency `{dependency_name}` cannot be included in a portable generated project; publish it through an exact registry or Git source"
+        ));
+    };
+    if source.starts_with("registry+") {
+        return Ok(format!(
+            "{dependency_name} = {{ {package}version = {} }}",
+            toml_quote_string(&format!("={cargo_version}"))
+        ));
+    }
+    let Some(git) = source.strip_prefix("git+") else {
+        return Err(format!(
+            "Rust dependency `{dependency_name}` uses unsupported Cargo source `{source}`"
+        ));
+    };
+    let (location, revision) = git.rsplit_once('#').ok_or_else(|| {
+        format!("Git dependency `{dependency_name}` has no exact locked revision")
+    })?;
+    let url = location.split('?').next().unwrap_or(location);
+    if revision.len() != 40 || !revision.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(format!(
+            "Git dependency `{dependency_name}` has no exact 40-character locked revision"
+        ));
+    }
+    Ok(format!(
+        "{dependency_name} = {{ {package}git = {}, rev = {} }}",
+        toml_quote_string(url),
+        toml_quote_string(revision)
+    ))
 }
 
 fn rust_interop_path_dependencies(interop: &InteropBuildPlan) -> BTreeMap<String, String> {
@@ -444,6 +592,8 @@ mod tests {
                 package_id: "local-blake3-bridge@0.1.0#path".to_string(),
                 dependency_name: "__sifr_bridge_package_local_blake3_bridge".to_string(),
                 cargo_package_name: "local-blake3-bridge".to_string(),
+                cargo_version: "0.1.0".to_string(),
+                cargo_source: None,
                 cargo_manifest_path: "/ws/local_blake3_bridge/Cargo.toml".to_string(),
                 bridge_roots: vec!["src/bridges".to_string()],
             },
@@ -496,6 +646,32 @@ sifr_stdlib = { path = "/opt/sifr/crates/sifr_stdlib", default-features = false,
 serde_json = { version = "1.0.151", features = ["preserve_order"] }
 "#
         );
+    }
+
+    #[test]
+    fn item11_portable_manifest_replaces_host_paths_with_exact_sources() {
+        let mut dependency_plan = test_dependency_plan(
+            CargoVendorMode::SysrootOnly,
+            PathBuf::from("/host/sysroot/vendor"),
+        );
+        dependency_plan.crates = vec![SysrootCrateDependency {
+            krate: SysrootCrate::SifrRuntime,
+            path: PathBuf::from("/host/sysroot/crates/sifr_runtime"),
+            features: BTreeSet::new(),
+        }];
+        let revision = "0123456789abcdef0123456789abcdef01234567";
+
+        let manifest = generate_portable_dependency_cargo_toml_with_interop(
+            "sifr_output",
+            &dependency_plan,
+            &InteropBuildPlan::default(),
+            revision,
+        )
+        .expect("portable manifest should render");
+
+        assert!(!manifest.contains("/host/"), "{manifest}");
+        assert!(manifest.contains("git = \"https://github.com/sifr-lang/sifr.git\""));
+        assert!(manifest.contains(&format!("rev = \"{revision}\"")));
     }
 
     fn test_dependency_plan(

--- a/crates/sifr_driver/src/build/cargo_resolution.rs
+++ b/crates/sifr_driver/src/build/cargo_resolution.rs
@@ -181,7 +181,11 @@ fn prepare_lockfile_from_authority(
     policy: &CargoResolutionPolicy,
     cargo_prefix_args: &[String],
 ) -> Result<(), Vec<RenderedDiagnostic>> {
-    seed_lockfile_from_authorities(&project_dir.join("Cargo.lock"), &policy.authoritative_locks)?;
+    seed_lockfile_for_resolution(
+        &project_dir.join("Cargo.lock"),
+        &policy.authoritative_locks,
+        cargo_prefix_args,
+    )?;
     let mut command = Command::new("cargo");
     command
         .args(cargo_prefix_args)
@@ -205,6 +209,27 @@ fn prepare_lockfile_from_authority(
         policy.lock_mode.as_str(),
         bounded_excerpt(&stderr)
     ))])
+}
+
+fn seed_lockfile_for_resolution(
+    destination: &Path,
+    authoritative_locks: &[PathBuf],
+    cargo_prefix_args: &[String],
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    if cargo_prefix_args.is_empty() {
+        return seed_lockfile_from_authorities(destination, authoritative_locks);
+    }
+
+    // A release sysroot's vendored source is itself an immutable authority.
+    // Start from an empty lock so Cargo selects only versions actually present
+    // in that source; importing a newer workspace lock can otherwise pin a
+    // package absent from the release vendor directory.
+    std::fs::write(destination, "version = 4\n").map_err(|error| {
+        vec![cargo_resolution_error(format!(
+            "failed to initialize generated Cargo lockfile at '{}': {error}",
+            destination.display()
+        ))]
+    })
 }
 
 fn seed_lockfile_from_authorities(
@@ -326,7 +351,7 @@ fn prepared_lock_path(
     cargo_prefix_args: &[String],
 ) -> Result<PathBuf, Vec<RenderedDiagnostic>> {
     let mut input = Vec::new();
-    push_cache_bytes(&mut input, "sifr-cargo-resolution-v6");
+    push_cache_bytes(&mut input, "sifr-cargo-resolution-v7");
     push_cache_bytes(&mut input, &normalized_manifest_cache_input(project_dir)?);
     for argument in cargo_prefix_args {
         push_cache_bytes(&mut input, argument);
@@ -515,7 +540,8 @@ mod tests {
     use super::{
         CargoResolutionPolicy, CargoVendorMode, PREPARED_LOCK_NONCE,
         normalized_manifest_cache_input, registry_entries, registry_version_compatibility_family,
-        seed_lockfile_from_authorities, validate_authoritative_registry_entries,
+        seed_lockfile_for_resolution, seed_lockfile_from_authorities,
+        validate_authoritative_registry_entries,
     };
     use sifr_package::CargoLockMode;
     use std::collections::BTreeSet;
@@ -532,6 +558,36 @@ mod tests {
             trusted_vendor_dirs: Vec::new(),
         };
         assert!(!package_owned.uses_sysroot_vendor());
+    }
+
+    #[test]
+    fn item11_vendor_resolution_does_not_import_unavailable_workspace_pins() {
+        let root = std::env::temp_dir().join(format!(
+            "sifr_item11_vendor_seed_{}_{}",
+            std::process::id(),
+            PREPARED_LOCK_NONCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&root).expect("test root should be created");
+        let authority = root.join("authority.lock");
+        let destination = root.join("Cargo.lock");
+        std::fs::write(
+            &authority,
+            "version = 4\n\n[[package]]\nname = \"newer-than-vendor\"\nversion = \"9.9.9\"\n",
+        )
+        .expect("authority should be written");
+
+        seed_lockfile_for_resolution(
+            &destination,
+            &[authority],
+            &["--config".to_string(), "source replacement".to_string()],
+        )
+        .expect("vendor seed should initialize");
+
+        assert_eq!(
+            std::fs::read_to_string(&destination).expect("seed should be readable"),
+            "version = 4\n"
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/sifr_driver/src/build/entrypoint.rs
+++ b/crates/sifr_driver/src/build/entrypoint.rs
@@ -247,6 +247,7 @@ pub(crate) fn materialize_rooted_entrypoint_rust_project(
     let mode = entrypoint.build_mode();
     let plan = RootedEntrypointPlan::from_entrypoint(entrypoint)?;
     let frontend_diagnostics = plan.frontend_diagnostics();
+    let cargo_resolution = plan.cargo_resolution.clone();
     let generated_project = plan.into_generated_binary_project()?;
     let requested_vendor_mode = super::entrypoint_resolution::requested_vendor_mode_for_build(mode);
     let project_path = materialize_binary_project_sources(
@@ -254,6 +255,7 @@ pub(crate) fn materialize_rooted_entrypoint_rust_project(
         "sifr_output",
         generated_project,
         requested_vendor_mode,
+        &cargo_resolution,
     )?;
     Ok(MaterializedRustProjectReport::new(
         project_path,

--- a/crates/sifr_driver/src/build/entrypoint_resolution.rs
+++ b/crates/sifr_driver/src/build/entrypoint_resolution.rs
@@ -9,14 +9,13 @@ pub(super) fn package_cargo_resolution_policy(
     entrypoint: Option<&PackageEntrypoint>,
     stdlib: &StdlibCompiled,
 ) -> CargoResolutionPolicy {
-    let Some(entrypoint) = entrypoint else {
-        return CargoResolutionPolicy::normal();
-    };
     let mut authoritative_locks = Vec::new();
     let mut trusted_vendor_dirs = Vec::new();
-    if let Some(package) = entrypoint.graph.packages.get(&entrypoint.package_id) {
-        if let Some(lock) = nearest_ancestor_file(&package.package_root, "Cargo.lock") {
-            authoritative_locks.push(lock);
+    if let Some(entrypoint) = entrypoint {
+        if let Some(package) = entrypoint.graph.packages.get(&entrypoint.package_id) {
+            if let Some(lock) = nearest_ancestor_file(&package.package_root, "Cargo.lock") {
+                authoritative_locks.push(lock);
+            }
         }
     }
     if let Some(lock) = stdlib
@@ -38,8 +37,12 @@ pub(super) fn package_cargo_resolution_policy(
         trusted_vendor_dirs.push(vendor_dir);
     }
     CargoResolutionPolicy {
-        lock_mode: entrypoint.lock_mode,
-        cargo_vendor_mode: CargoVendorMode::PackageOwned,
+        lock_mode: entrypoint.map_or(sifr_package::CargoLockMode::Locked, |entrypoint| {
+            entrypoint.lock_mode
+        }),
+        cargo_vendor_mode: entrypoint.map_or(CargoVendorMode::SysrootOnly, |_| {
+            CargoVendorMode::PackageOwned
+        }),
         authoritative_locks,
         trusted_vendor_dirs,
     }

--- a/crates/sifr_driver/src/build/materialize.rs
+++ b/crates/sifr_driver/src/build/materialize.rs
@@ -61,6 +61,7 @@ pub(super) fn materialize_binary_project_sources(
     project_name: &str,
     generated_project: GeneratedBinaryProject,
     requested_vendor_mode: CargoVendorMode,
+    cargo_resolution: &CargoResolutionPolicy,
 ) -> Result<PathBuf, Vec<RenderedDiagnostic>> {
     let project_path = output_dir.join(project_name);
     let dependency_plan = try_generate_sysroot_dependency_plan(
@@ -70,13 +71,38 @@ pub(super) fn materialize_binary_project_sources(
         requested_vendor_mode,
     )
     .map_err(|error| vec![build_error(error.boundary_message())])?;
-    materialize_binary_project_files(
-        &project_path,
-        project_name,
-        generated_project,
-        &dependency_plan,
-    )?;
-    Ok(project_path)
+    let interop = generated_project.interop.clone();
+    let local_project_path =
+        super::portable_project::local_resolution_project_path(output_dir, project_name);
+    let result = (|| {
+        materialize_binary_project_files(
+            &local_project_path,
+            project_name,
+            generated_project,
+            &dependency_plan,
+        )?;
+        let cargo_prefix_args = sysroot_cargo_config_args(&dependency_plan);
+        let prepared_resolution =
+            prepare_cargo_resolution(&local_project_path, cargo_resolution, &cargo_prefix_args)?;
+        prepared_resolution.assert_unchanged()?;
+        super::portable_project::prepare_portable_project_metadata(
+            &local_project_path,
+            project_name,
+            &dependency_plan,
+            &interop,
+            cargo_resolution,
+        )?;
+        super::portable_project::publish_portable_project(&local_project_path, &project_path)?;
+        Ok(project_path)
+    })();
+    let cleanup = std::fs::remove_dir_all(&local_project_path);
+    match (result, cleanup) {
+        (Ok(path), Ok(())) => Ok(path),
+        (Ok(_), Err(error)) => Err(vec![build_error(format!(
+            "failed to remove ephemeral local Cargo resolution state: {error}"
+        ))]),
+        (Err(errors), _) => Err(errors),
+    }
 }
 
 pub(super) fn materialize_cached_binary_project_with_report(
@@ -295,8 +321,10 @@ fn canonical_rust_module_path(path: &Path) -> Result<PathBuf, Vec<RenderedDiagno
     let mut canonical = PathBuf::new();
     for component in path.components() {
         let std::path::Component::Normal(component) = component else {
-            canonical.push(component);
-            continue;
+            return Err(vec![build_error(format!(
+                "generated Rust module path must be relative and cannot escape its project: {}",
+                path.display()
+            ))]);
         };
         let component = Path::new(component);
         if component
@@ -559,7 +587,7 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet, HashSet};
 
     #[test]
-    fn generated_module_paths_use_the_source_identifier_mapping() {
+    fn item11_generated_module_paths_are_relative_and_cannot_escape() {
         let bridge = canonical_rust_module_path(std::path::Path::new("__sifr_bridge/_sifr_fs.rs"));
         assert!(matches!(
             bridge.as_deref(),
@@ -570,6 +598,8 @@ mod tests {
             public.as_deref(),
             Ok(path) if path == std::path::Path::new("public/mod.rs")
         ));
+        assert!(canonical_rust_module_path(std::path::Path::new("../escape.rs")).is_err());
+        assert!(canonical_rust_module_path(std::path::Path::new("/escape.rs")).is_err());
     }
 
     #[test]

--- a/crates/sifr_driver/src/build/mod.rs
+++ b/crates/sifr_driver/src/build/mod.rs
@@ -8,6 +8,7 @@ mod entrypoint_resolution;
 mod entrypoint_single_file;
 mod entrypoint_stages;
 mod materialize;
+mod portable_project;
 mod project_codegen;
 mod python_bridges;
 mod python_certification;

--- a/crates/sifr_driver/src/build/portable_project.rs
+++ b/crates/sifr_driver/src/build/portable_project.rs
@@ -1,0 +1,462 @@
+use super::cargo_manifest::generate_portable_dependency_cargo_toml_with_interop;
+use super::cargo_resolution::CargoResolutionPolicy;
+use crate::diagnostics::{RenderedDiagnostic, diagnostic_with_code};
+use sifr_codegen::{InteropBuildPlan, RustInteropResolvedRoot};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_stdlib_manifest::{SysrootCrate, SysrootDependencyPlan};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static LOCAL_RESOLUTION_NONCE: AtomicU64 = AtomicU64::new(0);
+
+pub(super) fn local_resolution_project_path(output_dir: &Path, project_name: &str) -> PathBuf {
+    let nonce = LOCAL_RESOLUTION_NONCE.fetch_add(1, Ordering::Relaxed);
+    output_dir.join(format!(
+        ".{project_name}.sifr-local-resolution-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+pub(super) fn publish_portable_project(
+    local_project: &Path,
+    project_path: &Path,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    std::fs::create_dir_all(project_path).map_err(|error| {
+        vec![portable_error(format!(
+            "failed to create portable project directory: {error}"
+        ))]
+    })?;
+    let destination_src = project_path.join("src");
+    if destination_src.exists() {
+        std::fs::remove_dir_all(&destination_src).map_err(|error| {
+            vec![portable_error(format!(
+                "failed to reset portable generated source directory: {error}"
+            ))]
+        })?;
+    }
+    copy_tree(&local_project.join("src"), &destination_src)?;
+    for file_name in ["Cargo.toml", "Cargo.lock"] {
+        let destination = project_path.join(file_name);
+        if destination.exists() {
+            std::fs::remove_file(&destination).map_err(|error| {
+                vec![portable_error(format!(
+                    "failed to replace portable {file_name}: {error}"
+                ))]
+            })?;
+        }
+        std::fs::copy(local_project.join(file_name), &destination).map_err(|error| {
+            vec![portable_error(format!(
+                "failed to publish portable {file_name}: {error}"
+            ))]
+        })?;
+    }
+    Ok(())
+}
+
+fn copy_tree(source: &Path, destination: &Path) -> Result<(), Vec<RenderedDiagnostic>> {
+    std::fs::create_dir_all(destination).map_err(|error| {
+        vec![portable_error(format!(
+            "failed to create portable source directory: {error}"
+        ))]
+    })?;
+    let entries = std::fs::read_dir(source).map_err(|error| {
+        vec![portable_error(format!(
+            "failed to read generated source directory: {error}"
+        ))]
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            vec![portable_error(format!(
+                "failed to read generated source entry: {error}"
+            ))]
+        })?;
+        let destination = destination.join(entry.file_name());
+        if entry
+            .file_type()
+            .map_err(|error| vec![portable_error(error.to_string())])?
+            .is_dir()
+        {
+            copy_tree(&entry.path(), &destination)?;
+        } else {
+            std::fs::copy(entry.path(), destination).map_err(|error| {
+                vec![portable_error(format!(
+                    "failed to publish generated source file: {error}"
+                ))]
+            })?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn prepare_portable_project_metadata(
+    project_path: &Path,
+    project_name: &str,
+    dependency_plan: &SysrootDependencyPlan,
+    interop: &InteropBuildPlan,
+    cargo_resolution: &CargoResolutionPolicy,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let revision = exact_sysroot_revision(dependency_plan)?;
+    let manifest = generate_portable_dependency_cargo_toml_with_interop(
+        project_name,
+        dependency_plan,
+        interop,
+        &revision,
+    )
+    .map_err(|message| vec![portable_error(message)])?;
+
+    // Publish the portable manifest before rewriting the lock. If lock
+    // finalization fails, no retained artifact exposes the temporary local
+    // dependency paths used to resolve the compiler-owned build.
+    std::fs::write(project_path.join("Cargo.toml"), manifest).map_err(|error| {
+        vec![portable_error(format!(
+            "failed to write portable generated Cargo manifest: {error}"
+        ))]
+    })?;
+    rewrite_lock_sources(
+        &project_path.join("Cargo.lock"),
+        dependency_plan,
+        interop,
+        cargo_resolution,
+        &revision,
+    )
+}
+
+fn exact_sysroot_revision(
+    dependency_plan: &SysrootDependencyPlan,
+) -> Result<String, Vec<RenderedDiagnostic>> {
+    let manifest_path = dependency_plan.sysroot_root.join("sysroot.toml");
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .ok()
+        .and_then(|source| sifr_sysroot::parse_sysroot_manifest(&source).ok());
+    if let Some(revision) = manifest
+        .as_ref()
+        .map(|manifest| manifest.built_by_compiler_commit.as_str())
+        .filter(|revision| exact_revision(revision))
+    {
+        return Ok(revision.to_ascii_lowercase());
+    }
+
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", "HEAD^{commit}"])
+        .current_dir(&dependency_plan.sysroot_root)
+        .output()
+        .map_err(|error| {
+            vec![portable_error(format!(
+                "failed to resolve the development sysroot revision: {error}"
+            ))]
+        })?;
+    let revision = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !output.status.success() || !exact_revision(&revision) {
+        return Err(vec![portable_error(
+            "portable generated projects require a sysroot built from one exact Git commit",
+        )]);
+    }
+    Ok(revision.to_ascii_lowercase())
+}
+
+fn exact_revision(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[derive(Clone)]
+struct PortableSource {
+    name: String,
+    version: String,
+    source: String,
+}
+
+fn rewrite_lock_sources(
+    lock_path: &Path,
+    dependency_plan: &SysrootDependencyPlan,
+    interop: &InteropBuildPlan,
+    cargo_resolution: &CargoResolutionPolicy,
+    sifr_revision: &str,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let source = std::fs::read_to_string(lock_path).map_err(|error| {
+        vec![portable_error(format!(
+            "failed to read resolved generated Cargo lockfile: {error}"
+        ))]
+    })?;
+    let mut lock = source.parse::<toml::Table>().map_err(|error| {
+        vec![portable_error(format!(
+            "failed to parse resolved generated Cargo lockfile: {error}"
+        ))]
+    })?;
+    let mut requirements = dependency_plan
+        .crates
+        .iter()
+        .map(|dependency| PortableSource {
+            name: dependency.krate.package_name().to_string(),
+            version: "0.0.0".to_string(),
+            source: format!(
+                "git+https://github.com/sifr-lang/sifr.git?rev={sifr_revision}#{sifr_revision}"
+            ),
+        })
+        .collect::<Vec<_>>();
+    if dependency_plan
+        .crates
+        .iter()
+        .any(|dependency| dependency.krate == SysrootCrate::SifrStdlib)
+        && !requirements
+            .iter()
+            .any(|requirement| requirement.name == "sifr_runtime")
+    {
+        requirements.push(PortableSource {
+            name: "sifr_runtime".to_string(),
+            version: "0.0.0".to_string(),
+            source: format!(
+                "git+https://github.com/sifr-lang/sifr.git?rev={sifr_revision}#{sifr_revision}"
+            ),
+        });
+    }
+    requirements.extend(interop_sources(interop)?);
+
+    let authority = authority_packages(&cargo_resolution.authoritative_locks)?;
+    let packages = lock
+        .get_mut("package")
+        .and_then(toml::Value::as_array_mut)
+        .ok_or_else(|| {
+            vec![portable_error(
+                "generated Cargo lockfile has no package array",
+            )]
+        })?;
+    for requirement in requirements {
+        let package = packages
+            .iter_mut()
+            .find_map(|package| {
+                let table = package.as_table_mut()?;
+                (table.get("name")?.as_str()? == requirement.name
+                    && table.get("version")?.as_str()? == requirement.version
+                    && table.get("source").is_none())
+                .then_some(table)
+            })
+            .ok_or_else(|| {
+                vec![portable_error(format!(
+                    "resolved generated Cargo lockfile is missing local package {} {}",
+                    requirement.name, requirement.version
+                ))]
+            })?;
+        package.insert(
+            "source".to_string(),
+            toml::Value::String(requirement.source.clone()),
+        );
+        package.remove("checksum");
+        if requirement.source.starts_with("registry+") {
+            let key = (
+                requirement.name.clone(),
+                requirement.version.clone(),
+                requirement.source.clone(),
+            );
+            let checksum = authority.get(&key).ok_or_else(|| {
+                vec![portable_error(format!(
+                    "portable dependency {} {} is absent from every authoritative lockfile",
+                    requirement.name, requirement.version
+                ))]
+            })?;
+            package.insert(
+                "checksum".to_string(),
+                toml::Value::String(checksum.clone()),
+            );
+        }
+    }
+    let rendered = toml::to_string(&lock).map_err(|error| {
+        vec![portable_error(format!(
+            "failed to serialize portable generated Cargo lockfile: {error}"
+        ))]
+    })?;
+    std::fs::write(lock_path, rendered).map_err(|error| {
+        vec![portable_error(format!(
+            "failed to write portable generated Cargo lockfile: {error}"
+        ))]
+    })
+}
+
+fn interop_sources(
+    interop: &InteropBuildPlan,
+) -> Result<Vec<PortableSource>, Vec<RenderedDiagnostic>> {
+    let mut sources = BTreeMap::new();
+    for target in &interop.rust.resolved_targets {
+        let values = match &target.root {
+            RustInteropResolvedRoot::DirectCargoDependency {
+                cargo_package_name,
+                cargo_version,
+                cargo_source: Some(cargo_source),
+                ..
+            }
+            | RustInteropResolvedRoot::PackageBridge {
+                cargo_package_name,
+                cargo_version,
+                cargo_source: Some(cargo_source),
+                ..
+            } => Some((cargo_package_name, cargo_version, cargo_source)),
+            _ => None,
+        };
+        if let Some((name, version, source)) = values {
+            let source = portable_lock_source(name, source)?;
+            sources.insert(
+                (name.clone(), version.clone(), source.clone()),
+                PortableSource {
+                    name: name.clone(),
+                    version: version.clone(),
+                    source,
+                },
+            );
+        }
+    }
+    Ok(sources.into_values().collect())
+}
+
+fn portable_lock_source(
+    dependency_name: &str,
+    source: &str,
+) -> Result<String, Vec<RenderedDiagnostic>> {
+    if source.starts_with("registry+") {
+        return Ok(source.to_string());
+    }
+    let Some(git) = source.strip_prefix("git+") else {
+        return Err(vec![portable_error(format!(
+            "Rust dependency `{dependency_name}` uses unsupported Cargo source `{source}`"
+        ))]);
+    };
+    let (location, revision) = git.rsplit_once('#').ok_or_else(|| {
+        vec![portable_error(format!(
+            "Git dependency `{dependency_name}` has no exact locked revision"
+        ))]
+    })?;
+    if !exact_revision(revision) {
+        return Err(vec![portable_error(format!(
+            "Git dependency `{dependency_name}` has no exact 40-character locked revision"
+        ))]);
+    }
+    let url = location.split('?').next().unwrap_or(location);
+    Ok(format!("git+{url}?rev={revision}#{revision}"))
+}
+
+fn authority_packages(
+    paths: &[PathBuf],
+) -> Result<BTreeMap<(String, String, String), String>, Vec<RenderedDiagnostic>> {
+    let mut packages = BTreeMap::new();
+    for path in paths {
+        let source = std::fs::read_to_string(path).map_err(|error| {
+            vec![portable_error(format!(
+                "failed to read authoritative Cargo lockfile '{}': {error}",
+                path.display()
+            ))]
+        })?;
+        let lock = source.parse::<toml::Table>().map_err(|error| {
+            vec![portable_error(format!(
+                "failed to parse authoritative Cargo lockfile '{}': {error}",
+                path.display()
+            ))]
+        })?;
+        for package in lock
+            .get("package")
+            .and_then(toml::Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(toml::Value::as_table)
+        {
+            let Some((name, version, source, checksum)) = package
+                .get("name")
+                .and_then(toml::Value::as_str)
+                .zip(package.get("version").and_then(toml::Value::as_str))
+                .zip(package.get("source").and_then(toml::Value::as_str))
+                .zip(package.get("checksum").and_then(toml::Value::as_str))
+                .map(|(((name, version), source), checksum)| (name, version, source, checksum))
+            else {
+                continue;
+            };
+            packages.insert(
+                (name.to_string(), version.to_string(), source.to_string()),
+                checksum.to_string(),
+            );
+        }
+    }
+    Ok(packages)
+}
+
+fn portable_error(message: impl Into<String>) -> RenderedDiagnostic {
+    diagnostic_with_code(
+        message.into(),
+        DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sifr_stdlib_manifest::{CargoVendorMode, SysrootCrateDependency};
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn item11_portable_lock_rewrites_local_sysroot_packages_to_exact_git_sources() {
+        let root = std::env::temp_dir().join(format!(
+            "sifr_item11_portable_lock_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time should move forward")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).expect("test root should be created");
+        let lock_path = root.join("Cargo.lock");
+        std::fs::write(
+            &lock_path,
+            "version = 4\n\n[[package]]\nname = \"sifr_runtime\"\nversion = \"0.0.0\"\n",
+        )
+        .expect("test lock should be written");
+        let revision = "0123456789abcdef0123456789abcdef01234567";
+        let plan = SysrootDependencyPlan {
+            stdlib_modules: BTreeSet::new(),
+            required_features: BTreeSet::new(),
+            sysroot_root: PathBuf::from("/private/host/sysroot"),
+            toolchain_id: "test".to_string(),
+            sysroot_content_sha256: "content".to_string(),
+            cargo_config: PathBuf::from("/private/host/sysroot/.cargo/config.toml"),
+            vendor_dir: PathBuf::from("/private/host/sysroot/vendor"),
+            crates: vec![SysrootCrateDependency {
+                krate: SysrootCrate::SifrRuntime,
+                path: PathBuf::from("/private/host/sysroot/crates/sifr_runtime"),
+                features: BTreeSet::new(),
+            }],
+            retained_direct_dependencies: Vec::new(),
+            cargo_vendor_mode: CargoVendorMode::SysrootOnly,
+            cache_fingerprint: "test".to_string(),
+        };
+        let policy = CargoResolutionPolicy {
+            lock_mode: sifr_package::CargoLockMode::Locked,
+            cargo_vendor_mode: CargoVendorMode::SysrootOnly,
+            authoritative_locks: Vec::new(),
+            trusted_vendor_dirs: Vec::new(),
+        };
+
+        rewrite_lock_sources(
+            &lock_path,
+            &plan,
+            &InteropBuildPlan::default(),
+            &policy,
+            revision,
+        )
+        .expect("portable lock should render");
+        let lock = std::fs::read_to_string(&lock_path).expect("portable lock should be readable");
+        assert!(!lock.contains("/private/host"), "{lock}");
+        assert!(lock.contains(&format!(
+            "source = \"git+https://github.com/sifr-lang/sifr.git?rev={revision}#{revision}\""
+        )));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn item11_git_lock_sources_match_the_portable_exact_revision_manifest() {
+        let revision = "0123456789abcdef0123456789abcdef01234567";
+        let source = format!("git+https://example.com/dependency.git?branch=main#{revision}");
+
+        assert_eq!(
+            portable_lock_source("dependency", &source).expect("exact Git source should normalize"),
+            format!("git+https://example.com/dependency.git?rev={revision}#{revision}")
+        );
+    }
+}

--- a/crates/sifr_driver/src/build/rust_interop.rs
+++ b/crates/sifr_driver/src/build/rust_interop.rs
@@ -353,6 +353,8 @@ impl<'a> RustInteropResolver<'a> {
                     dependency_name
                 },
                 cargo_package_name: package.cargo_package_name.clone(),
+                cargo_version: package.cargo_version.clone(),
+                cargo_source: package.cargo_source.clone(),
                 cargo_manifest_path: package
                     .package_root
                     .join("Cargo.toml")

--- a/crates/sifr_stdlib/src/process.rs
+++ b/crates/sifr_stdlib/src/process.rs
@@ -464,4 +464,17 @@ mod tests {
                 .contains("process timeout must be finite and non-negative")
         );
     }
+
+    #[test]
+    fn item11_process_arguments_remain_distinct_without_implicit_shell_parsing() {
+        let payload = "$(printf injected); spaced * argument".to_string();
+        let args = vec!["%s".to_string(), payload.clone()];
+        let handle = process_output_text("printf", &args, &empty(), "", false, b"", false, "utf-8")
+            .expect("printf should execute directly");
+        assert_eq!(
+            process_output_stdout_text(&handle).expect("stdout text"),
+            payload
+        );
+        process_output_close(&handle);
+    }
 }

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -492,7 +492,17 @@ large-file check and a representative project check.
   is a structured build diagnostic, never an unformatted fallback.
   Materialization repeats this fail-closed check for synthetic namespace and
   bridge files that do not exist at the earlier emit boundary.
-- Both shapes materialize through the same generated-binary-project path and the same Cargo manifest generation helper.
+- Both shapes materialize through the same generated-binary-project path. Native
+  build state uses local sysroot and package paths only while Cargo resolves and
+  builds it. The source-only materialization boundary then replaces that local
+  manifest with exact Git or registry dependencies and rewrites the generated
+  lock to the same portable sources; local Rust interop dependencies that have
+  no publishable source fail closed instead of leaking a host path.
+- Single-file and non-package projects resolve from the immutable sysroot vendor
+  source into a cached lock before compilation. The vendor inventory, rather
+  than a potentially newer development-workspace lock entry, selects available
+  versions; every result must still belong to an authoritative lock or trusted
+  vendor source and remains byte-stable during the Cargo invocation.
 - Rematerialization replaces the generated `src` tree as one owned output set so
   removed support or bridge modules cannot survive from an earlier build. The
   Cargo `target` directory remains outside that replacement boundary and retains

--- a/verification/areas/core_language/fixtures/static_class_adapter/negative/non_string_leaf_rejected/Cargo.lock
+++ b/verification/areas/core_language/fixtures/static_class_adapter/negative/non_string_leaf_rejected/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -103,6 +103,12 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-bigint"
@@ -149,6 +155,7 @@ version = "0.0.0"
 dependencies = [
  "encoding_rs",
  "indexmap",
+ "memchr",
  "num-bigint",
  "num-traits",
  "sifr_structural_identity",


### PR DESCRIPTION
## Summary
- separate ephemeral local Cargo resolution from portable source-only artifacts
- pin emitted manifests and locks to exact Git/registry sources and resolve normal projects against the compatible sysroot vendor inventory
- preserve direct process argv boundaries, reject generated path escapes, and remove panic-on-proof conversions from user-controlled insert/split/replace/repeat paths
- refresh the static class-adapter negative fixture lock (closes #3685)

## Focused evidence
- cargo test -p sifr_codegen item11_ -- --nocapture
- cargo test -p sifr_driver item11_ -- --nocapture
- cargo test -p sifr_stdlib --features process item11_ -- --nocapture
- cargo test -p sifr_driver tests::attached_api_codegen::non_string_leaf_negative_is_package_compilable -- --exact --nocapture
- cargo test -p sifr --test e2e item11_materialized_project_is_locked_portable_and_relocatable -- --nocapture
- cargo fmt --check
- python3 scripts/check_file_size_guardrails.py
- python3 scripts/check_hir_maintainability_guardrails.py
- python3 scripts/check_sifr_driver_maintainability_guardrails.py

Exact candidate: 4e24b61bb0c06315afb51d92b42f3ae19e364c68